### PR TITLE
INT-2011 fixed ReseqencerParserTests that was broken due to the change in

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/config/resequencerParserTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/resequencerParserTests.xml
@@ -53,7 +53,7 @@
 	<resequencer id="resequencerWithReleaseStrategy"
 		input-channel="inputChannel6"
 		release-strategy="pojoReleaseStrategy"
-		release-strategy-method="checkCompleteness"/>
+		release-strategy-method="checkCompletenessAsList"/>
 
 	<beans:bean id="testComparator"
 		class="org.springframework.integration.config.ResequencerParserTests$TestComparator"/>


### PR DESCRIPTION
INT-2011 fixed ReseqencerParserTests that was broken due to the change in method names in MaxValueReleaseStrategy
