### PR TITLE
INT-2009 fixed related classes to ensure that POJO-based release strategy

### DIFF
--- a/docs/src/reference/docbook/aggregator.xml
+++ b/docs/src/reference/docbook/aggregator.xml
@@ -231,6 +231,28 @@
           aggregation, and false otherwise.</para>
         </listitem>
       </itemizedlist>
+      
+      For example:
+      
+      <programlisting language="java"><![CDATA[public class MyReleaseStrategy{
+
+    @ReleaseStrategy 
+    public boolean canMessagesBeReleased(List<Message<?>>){..}
+}]]></programlisting>
+
+<programlisting language="java"><![CDATA[public class MyReleaseStrategy{
+
+    @ReleaseStrategy 
+    public boolean canMessagesBeReleased(List<String>){..}
+}]]></programlisting>
+
+<para>
+As you can see based on the above signatures the POJO-based Release Strategy will be passed a <classname>Collection</classname> of unmarked Messages 
+if you need access to the whole <classname>Message</classname> or <classname>Collection</classname> of payload objects if the type parameter is 
+anything other than <classname>Message</classname>. Typically this would satisfy the majority of the use cases. However if 
+you need complete access to the <classname>MessageGroup</classname> which gives you access to <code>unmarked</code> and <code>marked</code> Messages 
+than provide the implementation of the <classname>ReleaseStrategy</classname>.
+</para>
 
       <para>When the group is released for aggregation, all its unmarked
       messages are processed and then marked so they will not be processed


### PR DESCRIPTION
INT-2009 fixed related classes to ensure that POJO-based release strategy can have raw MessageGroup in its signature
