### PR TITLE
fixed jms outbound-gateway timeout attributes

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
@@ -74,6 +74,7 @@ public class JmsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "extract-request-payload");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "extract-reply-payload");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "receive-timeout");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "send-timeout");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "request-pub-sub-domain");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-pub-sub-domain");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "time-to-live");

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.1.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.1.xsd
@@ -725,8 +725,20 @@
 					</xsd:appinfo>
 				</xsd:annotation>
 			</xsd:attribute>
-			<xsd:attribute name="request-timeout" type="xsd:string"/>
-			<xsd:attribute name="reply-timeout" type="xsd:string"/>
+			<xsd:attribute name="receive-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Timeout for the JMS MessageConsumer to receive the JMS reply Message. Default is 5 seconds. 
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="send-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Timeout for sending the mapped integration Message to this gateway's reply-channel. Default is indefinite.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="request-destination" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>
@@ -847,7 +859,6 @@
 			</xsd:attribute>
 			<xsd:attribute name="extract-request-payload" type="xsd:string" default="true"/>
 			<xsd:attribute name="extract-reply-payload" type="xsd:string" default="true"/>
-			<xsd:attribute name="receive-timeout" type="xsd:string"/>
 			<xsd:attribute name="delivery-mode" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[


### PR DESCRIPTION
I'm not completely sure about this one. Typical confusion over receive, send, request, and reply terminology. The two values in question are (names as used in this pull request):
1. receive-timeout: the one that affects the JMS MessageConsumer receive() call
2. send-timeout: the one that affects the sending of a fully mapped SI Message to the reply-channel of this gateway
