### PR TITLE
INT-2094 removed  deprecated use of task-executor @markfisher

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
@@ -59,7 +59,7 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport {
 
 
 	public ImapIdleChannelAdapter(ImapMailReceiver mailReceiver) {
-		Assert.notNull(mailReceiver, "mailReceiver must not be null");
+		Assert.notNull(mailReceiver, "'mailReceiver' must not be null");
 		this.mailReceiver = mailReceiver;
 	}
 

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParser.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParser.java
@@ -58,7 +58,6 @@ public class ImapIdleChannelAdapterParser extends AbstractSingleBeanDefinitionPa
 		builder.addConstructorArgValue(this.parseImapMailReceiver(element, parserContext));
 		builder.addPropertyReference("outputChannel", channel);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel", "errorChannel");
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "task-executor");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-startup");
 	}
 

--- a/spring-integration-mail/src/main/resources/org/springframework/integration/mail/config/spring-integration-mail-2.1.xsd
+++ b/spring-integration-mail/src/main/resources/org/springframework/integration/mail/config/spring-integration-mail-2.1.xsd
@@ -104,18 +104,6 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="inboundMailAdapterType">
-					<xsd:attribute name="task-executor" type="xsd:string">
-						<xsd:annotation>
-							<xsd:documentation>
-	[DEPRECATED as of 2.0.5]
-							</xsd:documentation>
-							<xsd:appinfo>
-								<tool:annotation kind="ref">
-									<tool:expected-type type="org.springframework.core.task.TaskExecutor"/>
-								</tool:annotation>
-							</xsd:appinfo>
-						</xsd:annotation>
-					</xsd:attribute>
 					<xsd:attribute name="error-channel" type="xsd:string">
 						<xsd:annotation>
 							<xsd:appinfo>

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests-context.xml
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests-context.xml
@@ -63,8 +63,7 @@
 			channel="channel"
 			auto-startup="false"
 			java-mail-properties="javaMailProperties"
-			should-delete-messages="${mail.delete}"
-			task-executor="executor"/>
+			should-delete-messages="${mail.delete}"/>
 
 	<util:properties id="javaMailProperties">
 		<prop key="foo">bar</prop>

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests.java
@@ -129,9 +129,7 @@ public class ImapIdleChannelAdapterParserTests {
 		assertEquals(ImapIdleChannelAdapter.class, adapter.getClass());
 		DirectFieldAccessor adapterAccessor = new DirectFieldAccessor(adapter);
 		Object channel = context.getBean("channel");
-		Object executor = context.getBean("executor");
 		assertSame(channel, adapterAccessor.getPropertyValue("outputChannel"));
-		assertSame(executor, adapterAccessor.getPropertyValue("taskExecutor"));
 		assertEquals(Boolean.FALSE, adapterAccessor.getPropertyValue("autoStartup"));
 		Object receiver = adapterAccessor.getPropertyValue("mailReceiver");
 		assertEquals(ImapMailReceiver.class, receiver.getClass());


### PR DESCRIPTION
Mark, there is more refactoring that could be done based on what we have discovered when we deprecated task-executor, but that would be the whole other issue so I only address the removal of the deprecated  part.
