### PR TITLE
changed default connection-factory value to 'rabbitConnectionFactory' to 

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AbstractAmqpInboundAdapterParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AbstractAmqpInboundAdapterParser.java
@@ -111,7 +111,7 @@ abstract class AbstractAmqpInboundAdapterParser extends AbstractSingleBeanDefini
 				"org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer");
 		String connectionFactoryRef = element.getAttribute("connection-factory");
 		if (!StringUtils.hasText(connectionFactoryRef)) {
-			connectionFactoryRef = "connectionFactory";
+			connectionFactoryRef = "rabbitConnectionFactory";
 		}
 		builder.addConstructorArgReference(connectionFactoryRef);
 		for (String attributeName : CONTAINER_VALUE_ATTRIBUTES) {


### PR DESCRIPTION
changed default connection-factory value to 'rabbitConnectionFactory' to be consistent with the Spring AMQP listener-container

/cc @olegz @ghillert
