### PR TITLE
INT-2012 added warning messages regarding missing Reaper

### DIFF
--- a/docs/src/reference/docbook/aggregator.xml
+++ b/docs/src/reference/docbook/aggregator.xml
@@ -397,9 +397,16 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
       </callout>
       
       <callout arearefs="aggxml08">
-        <para>Indicates if partially aggregated messages should be released when their storage time has expired
-        (see <code>MessageGroupStore.expireMessageGroups(long)</code>).
+        <para>
+        Indicates that partially aggregated messages should be sent to the 'output-channel' or 'replyChannel' 
+		once the particular <classname>MessageGroup</classname> had expired (see <code>MessageGroupStore.expireMessageGroups(long)</code>). One of the ways of expiring <classname>MessageGroup</classname>s is by 
+		configuring <classname>MessageGroupStoreReaper</classname>. However since <classname>MessageGroup</classname>s are expired by calling 
+		<code>MessageGroupStore.expireMessageGroup(groupId)</code>, <classname>MessageGroupStoreReaper</classname> is not the only option and can be 
+		accomplished via <classname>ControlBus</classname> or by simply invoking a method on <classname>MessageGroupStore</classname> if you have reference to its instance.
+		Otherwise by itself this attribute has no behavior. It only serves as an indicator of what to do (drop or send to the output/reply channel) with Messages that are 
+		still in the <classname>MessageGroup</classname> that is about to be expired.
         <emphasis>Optional</emphasis>.</para>
+        <para><emphasis>Default - 'false'</emphasis>.</para>
       </callout>
       
        <callout arearefs="aggxml09">

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageHandler.java
@@ -16,6 +16,8 @@ package org.springframework.integration.aggregator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessageHeaders;
@@ -26,6 +28,7 @@ import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.store.*;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
@@ -129,6 +132,18 @@ public class CorrelatingMessageHandler extends AbstractMessageHandler implements
 		BeanFactory beanFactory = this.getBeanFactory();
 		if (beanFactory != null) {
 			this.messagingTemplate.setBeanFactory(beanFactory);
+		}
+		if (this.sendPartialResultOnExpiry){
+			if (beanFactory instanceof ListableBeanFactory){
+				if (CollectionUtils.isEmpty(BeanFactoryUtils.beansOfTypeIncludingAncestors((ListableBeanFactory)beanFactory, MessageGroupStoreReaper.class))){
+					logger.warn("'send-partial-result-on-expiry' has been set to 'true' but no MessageGroupStoreReaper was configured. " +
+							"Unless MessageGroups are expired manually (e.g., via ControlBus - messageGroupStore.expireMessageGroups(..) ) this attribute carries no behavior");
+				}
+			}
+			else {
+				logger.warn("'send-partial-result-on-expiry' has been set to 'true' but no MessageGroupStoreReaper was located. " +
+						"Unless MessageGroups are expired manually (e.g., via ControlBus - messageGroupStore.expireMessageGroups(..) ) this attribute carries no behavior");
+			}
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageHandler.java
@@ -13,11 +13,13 @@
 
 package org.springframework.integration.aggregator;
 
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryUtils;
-import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessageHeaders;
@@ -26,13 +28,12 @@ import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.handler.AbstractMessageHandler;
-import org.springframework.integration.store.*;
+import org.springframework.integration.store.MessageGroup;
+import org.springframework.integration.store.MessageGroupCallback;
+import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.integration.store.MessageStore;
+import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
-
-import java.util.Collection;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * Message handler that holds a buffer of correlated messages in a
@@ -132,18 +133,6 @@ public class CorrelatingMessageHandler extends AbstractMessageHandler implements
 		BeanFactory beanFactory = this.getBeanFactory();
 		if (beanFactory != null) {
 			this.messagingTemplate.setBeanFactory(beanFactory);
-		}
-		if (this.sendPartialResultOnExpiry){
-			if (beanFactory instanceof ListableBeanFactory){
-				if (CollectionUtils.isEmpty(BeanFactoryUtils.beansOfTypeIncludingAncestors((ListableBeanFactory)beanFactory, MessageGroupStoreReaper.class))){
-					logger.warn("'send-partial-result-on-expiry' has been set to 'true' but no MessageGroupStoreReaper was configured. " +
-							"Unless MessageGroups are expired manually (e.g., via ControlBus - messageGroupStore.expireMessageGroups(..) ) this attribute carries no behavior");
-				}
-			}
-			else {
-				logger.warn("'send-partial-result-on-expiry' has been set to 'true' but no MessageGroupStoreReaper was located. " +
-						"Unless MessageGroups are expired manually (e.g., via ControlBus - messageGroupStore.expireMessageGroups(..) ) this attribute carries no behavior");
-			}
 		}
 	}
 

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.0.xsd
@@ -2511,8 +2511,11 @@ Name of the header whose value will be used to route messages
 				<xsd:attribute name="send-partial-result-on-expiry" type="xsd:string">
 					<xsd:annotation>
 						<xsd:documentation>
-						Tells if partially aggregated messages should be released when their storage time had expired (see
-						MessageGroupStore.expireMessageGroups(long))
+						Tells that partially aggregated messages should be sent to the 'output-channel' or 'replyChannel' 
+						once the particular MessageGroup had expired. One of the ways of expiring MessageGroups is by 
+						configuring MessageGroupStoreReaper. However since MessageGroups are expired by calling 
+						MessageGroupStore.expireMessageGroup(groupId), MessageGroupStoreReaper is not the only option and can be 
+						accomplished via ControlBus or by simply invoking a method on MessageGroupStore if you have reference to its instance.
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
@@ -2499,8 +2499,11 @@ Name of the header whose value will be used to route messages
 				<xsd:attribute name="send-partial-result-on-expiry" type="xsd:string">
 					<xsd:annotation>
 						<xsd:documentation>
-						Tells if partially aggregated messages should be released when their storage time had expired (see
-						MessageGroupStore.expireMessageGroups(long))
+						Tells that partially aggregated messages should be sent to the 'output-channel' or 'replyChannel' 
+						once the particular MessageGroup had expired. One of the ways of expiring MessageGroups is by 
+						configuring MessageGroupStoreReaper. However since MessageGroups are expired by calling 
+						MessageGroupStore.expireMessageGroup(groupId), MessageGroupStoreReaper is not the only option and can be 
+						accomplished via ControlBus or by simply invoking a method on MessageGroupStore if you have reference to its instance.
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>


### PR DESCRIPTION
Actually looking further send-partial-result-on-expiry is not all that meaningless without the reaper since MessageGroups could be expired via ControlBus call (e.g., messageGroupStore.expireMessageGroups(..) )

So i think this is really an issue of WARNING/INFORMING users that we could not find a reaper if this attribute is set to true and letting them know that unless they execute the manual call this attribute has no value/behavior
