### PR TITLE
INT-2134 Fixed CorrelationMessageHandler

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -36,19 +36,20 @@ import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.util.Assert;
 
 /**
- * Message handler that holds a buffer of correlated messages in a
+ * Abstract Message handler that holds a buffer of correlated messages in a
  * {@link MessageStore}. This class takes care of correlated groups of messages
- * that can be completed in batches. It is useful for aggregating, resequencing,
- * or custom implementations requiring correlation. Note that for resequencing it is better to use 
- * {@link ResequensingMessageHandler}
+ * that can be completed in batches. It is useful for custom implementation of MessageHandlers that require correlation 
+ * and is used as a base class for Aggregator - {@link AggregatingMessageHandler} and
+ * Resequencer - {@link ResequencingMessageHandler},
+ * or custom implementations requiring correlation. 
  * <p/>
  * To customize this handler inject {@link CorrelationStrategy},
  * {@link ReleaseStrategy}, and {@link MessageGroupProcessor} implementations as
  * you require.
  * <p/>
- * By default the CorrelationStrategy will be a
- * HeaderAttributeCorrelationStrategy and the ReleaseStrategy will be a
- * SequenceSizeReleaseStrategy.
+ * By default the {@link CorrelationStrategy} will be a
+ * {@link HeaderAttributeCorrelationStrategy} and the {@link ReleaseStrategy} will be a
+ * {@link SequenceSizeReleaseStrategy}.
  *
  * @author Iwein Fuld
  * @author Dave Syer

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -14,7 +14,6 @@
 package org.springframework.integration.aggregator;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -29,7 +28,6 @@ import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.handler.AbstractMessageHandler;
-import org.springframework.integration.store.AbstractMessageGroupStore;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupCallback;
 import org.springframework.integration.store.MessageGroupStore;
@@ -64,7 +62,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageH
 	public static final long DEFAULT_SEND_TIMEOUT = 1000L;
 
 
-	private MessageGroupStore messageStore;
+	protected volatile MessageGroupStore messageStore;
 
 	private final MessageGroupProcessor outputProcessor;
 
@@ -84,7 +82,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageH
 
 	private final ConcurrentMap<Object, Object> locks = new ConcurrentHashMap<Object, Object>();
 
-	private boolean expireGroupsUponCompletion = false;
+	protected volatile boolean expireGroupsUponCompletion = false;
 
 	public AbstractCorrelatingMessageHandler(MessageGroupProcessor processor, MessageGroupStore store,
 									 CorrelationStrategy correlationStrategy, ReleaseStrategy releaseStrategy) {
@@ -212,17 +210,6 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageH
 	
 	protected boolean shouldExpireGroupsUponCompletion(){
 		return this.expireGroupsUponCompletion;
-	}
-
-	public void setExpireGroupsUponCompletion(boolean expireGroupsUponCompletion) {
-		this.expireGroupsUponCompletion = expireGroupsUponCompletion;
-		Iterator<MessageGroup> messageGroups = ((AbstractMessageGroupStore)this.messageStore).iterator();
-		while (messageGroups.hasNext()) {
-			MessageGroup messageGroup = (MessageGroup) messageGroups.next();
-			if (messageGroup.isComplete()){
-				remove(messageGroup);
-			}
-		}
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -50,9 +50,9 @@ public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler
 	public void setExpireGroupsUponCompletion(boolean expireGroupsUponCompletion) {
 		this.expireGroupsUponCompletion = expireGroupsUponCompletion;
 		if (expireGroupsUponCompletion){
-			Iterator<MessageGroup> messageGroups = ((AbstractMessageGroupStore)this.messageStore).iterator();
+			Iterator<MessageGroup> messageGroups = this.messageStore.iterator();
 			while (messageGroups.hasNext()) {
-				MessageGroup messageGroup = (MessageGroup) messageGroups.next();
+				MessageGroup messageGroup = messageGroups.next();
 				if (messageGroup.isComplete()){
 					remove(messageGroup);
 				}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -19,44 +19,45 @@ import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 
 /**
- * Resequencer specific implementation of {@link AbstractCorrelatingMessageHandler}. It takes into account the fact that 
- * it must remember the last released message sequence in implementation of {@link #cleanUpForReleasedGroup(MessageGroup, Collection)} method 
+ * Aggregator specific implementation of {@link AbstractCorrelatingMessageHandler}. It takes into account the fact that 
+ * it must not remember the last released message but may remember processed MessageGroups
  *
  * @author Oleg Zhurakousky
  * @since 2.1
  */
-public class ResequensingMessageHandler extends AbstractCorrelatingMessageHandler {
+public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler {
 
 	
-	public ResequensingMessageHandler(MessageGroupProcessor processor,
+	public AggregatingMessageHandler(MessageGroupProcessor processor,
 			MessageGroupStore store, CorrelationStrategy correlationStrategy,
 			ReleaseStrategy releaseStrategy) {
 		super(processor, store, correlationStrategy, releaseStrategy);
 	}
 
 	
-	public ResequensingMessageHandler(MessageGroupProcessor processor,
+	public AggregatingMessageHandler(MessageGroupProcessor processor,
 			MessageGroupStore store) {
 		super(processor, store);
 	}
 
 	
-	public ResequensingMessageHandler(MessageGroupProcessor processor) {
+	public AggregatingMessageHandler(MessageGroupProcessor processor) {
 		super(processor);
 	}
 	
 	@SuppressWarnings("rawtypes")
 	protected void cleanUpForReleasedGroup(MessageGroup group, Collection<Message> completedMessages) {
-		if (group.isComplete() || group.getSequenceSize() == 0) {
+		if (this.shouldExpireGroupsUponCompletion()){
 			remove(group);
 		}
-		else {
-			if (completedMessages == null) {
-				mark(group);
-			} 
-			else {
-				mark(group, completedMessages);
+		else { // remove messages from the group and mark is as complete
+			for (Message message : group.getMarked()) {
+				this.getMessageStore().removeMessageFromGroup(group.getGroupId(), message);
 			}
+			for (Message message : group.getUnmarked()) {
+				this.getMessageStore().removeMessageFromGroup(group.getGroupId(), message);
+			}
+			group.complete();
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -13,8 +13,10 @@
 package org.springframework.integration.aggregator;
 
 import java.util.Collection;
+import java.util.Iterator;
 
 import org.springframework.integration.Message;
+import org.springframework.integration.store.AbstractMessageGroupStore;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 
@@ -43,6 +45,19 @@ public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler
 	
 	public AggregatingMessageHandler(MessageGroupProcessor processor) {
 		super(processor);
+	}
+	
+	public void setExpireGroupsUponCompletion(boolean expireGroupsUponCompletion) {
+		this.expireGroupsUponCompletion = expireGroupsUponCompletion;
+		if (expireGroupsUponCompletion){
+			Iterator<MessageGroup> messageGroups = ((AbstractMessageGroupStore)this.messageStore).iterator();
+			while (messageGroups.hasNext()) {
+				MessageGroup messageGroup = (MessageGroup) messageGroups.next();
+				if (messageGroup.isComplete()){
+					remove(messageGroup);
+				}
+			}
+		}
 	}
 	
 	@SuppressWarnings("rawtypes")

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageHandler.java
@@ -226,19 +226,8 @@ public class CorrelatingMessageHandler extends AbstractMessageHandler implements
 	}
 
 	@SuppressWarnings("rawtypes")
-	private void cleanUpForReleasedGroup(MessageGroup group, Collection<Message> completedMessages) {
-		if (this.keepClosedAggregates){
-			remove(group);
-		}
-		else {
-			// Mark these messages as processed, but do not
-			// remove the group from store
-			if (completedMessages == null) {
-				mark(group);
-			} else {
-				mark(group, completedMessages);
-			}
-		}
+	protected void cleanUpForReleasedGroup(MessageGroup group, Collection<Message> completedMessages) {
+		remove(group);
 	}
 
 	private final boolean forceComplete(MessageGroup group) {
@@ -271,12 +260,12 @@ public class CorrelatingMessageHandler extends AbstractMessageHandler implements
 		}
 	}
 
-	private void mark(MessageGroup group) {
+	void mark(MessageGroup group) {
 		messageStore.markMessageGroup(group);
 	}
 
 	@SuppressWarnings("rawtypes")
-	private void mark(MessageGroup group, Collection<Message> partialSequence) {
+	void mark(MessageGroup group, Collection<Message> partialSequence) {
 		Object id = group.getGroupId();
 		for (Message message : partialSequence) {
 			messageStore.markMessageFromGroup(id, message);

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageHandler.java
@@ -191,18 +191,7 @@ public class CorrelatingMessageHandler extends AbstractMessageHandler implements
 						// processing messages
 						cleanUpForReleasedGroup(group, completedMessages);
 					}
-				} else if (group.isComplete()) {
-					try {
-						// If not releasing any messages the group might still
-						// be complete
-						for (Message<?> discard : group.getUnmarked()) {
-							discardChannel.send(discard);
-						}
-					}
-					finally {
-						remove(group);
-					}
-				}
+				} 
 			} else {
 				discardChannel.send(message);
 			}
@@ -211,7 +200,7 @@ public class CorrelatingMessageHandler extends AbstractMessageHandler implements
 
 	@SuppressWarnings("rawtypes")
 	private void cleanUpForReleasedGroup(MessageGroup group, Collection<Message> completedMessages) {
-		if (group.isComplete() || group.getSequenceSize() == 0) {
+		if (this.releaseStrategy instanceof SequenceSizeReleaseStrategy && (group.isComplete() || group.getSequenceSize() == 0)) {
 			// The group is complete or else there is no
 			// sequence so there is no more state to track
 			remove(group);

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -25,23 +25,23 @@ import org.springframework.integration.store.MessageGroupStore;
  * @author Oleg Zhurakousky
  * @since 2.1
  */
-public class ResequensingMessageHandler extends AbstractCorrelatingMessageHandler {
+public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandler {
 
 	
-	public ResequensingMessageHandler(MessageGroupProcessor processor,
+	public ResequencingMessageHandler(MessageGroupProcessor processor,
 			MessageGroupStore store, CorrelationStrategy correlationStrategy,
 			ReleaseStrategy releaseStrategy) {
 		super(processor, store, correlationStrategy, releaseStrategy);
 	}
 
 	
-	public ResequensingMessageHandler(MessageGroupProcessor processor,
+	public ResequencingMessageHandler(MessageGroupProcessor processor,
 			MessageGroupStore store) {
 		super(processor, store);
 	}
 
 	
-	public ResequensingMessageHandler(MessageGroupProcessor processor) {
+	public ResequencingMessageHandler(MessageGroupProcessor processor) {
 		super(processor);
 	}
 	

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -47,7 +47,7 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 	
 	@SuppressWarnings("rawtypes")
 	protected void cleanUpForReleasedGroup(MessageGroup group, Collection<Message> completedMessages) {
-		if (group.isComplete() || group.getSequenceSize() == 0) {
+		if ((group.isComplete() || group.getSequenceSize() == 0) && !this.shouldExpireGroupsUponCompletion()) {
 			remove(group);
 		}
 		else {

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequensingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequensingMessageHandler.java
@@ -17,47 +17,47 @@ import java.util.Collection;
 import org.springframework.integration.Message;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.integration.store.SimpleMessageGroup;
 
 /**
+ * Resequencer specific implementation of {@link CorrelatingMessageHandler}. It takes into account the fact that 
+ * it must remember the last released message sequence so it overrides {@link #cleanUpForReleasedGroup(MessageGroup, Collection)} method 
+ *
  * @author Oleg Zhurakousky
  * @since 2.1
  */
 public class ResequensingMessageHandler extends CorrelatingMessageHandler {
 
-	/**
-	 * @param processor
-	 * @param store
-	 * @param correlationStrategy
-	 * @param releaseStrategy
-	 */
+	
 	public ResequensingMessageHandler(MessageGroupProcessor processor,
 			MessageGroupStore store, CorrelationStrategy correlationStrategy,
 			ReleaseStrategy releaseStrategy) {
 		super(processor, store, correlationStrategy, releaseStrategy);
 	}
 
-	/**
-	 * @param processor
-	 * @param store
-	 */
+	
 	public ResequensingMessageHandler(MessageGroupProcessor processor,
 			MessageGroupStore store) {
 		super(processor, store);
 	}
 
-	/**
-	 * @param processor
-	 */
+	
 	public ResequensingMessageHandler(MessageGroupProcessor processor) {
 		super(processor);
 	}
 	
 	@SuppressWarnings("rawtypes")
-	protected void cleanUpForReleasedGroup(MessageGroup group, Collection<Message> completedMessages) {
-		if (completedMessages == null) {
-			mark(group);
-		} else {
-			mark(group, completedMessages);
+	void cleanUpForReleasedGroup(SimpleMessageGroup group, Collection<Message> completedMessages) {
+		if (group.isComplete() || group.getSequenceSize() == 0) {
+			remove(group);
+		}
+		else {
+			if (completedMessages == null) {
+				mark(group);
+			} 
+			else {
+				mark(group, completedMessages);
+			}
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequensingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequensingMessageHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.integration.aggregator;
+
+import java.util.Collection;
+
+import org.springframework.integration.Message;
+import org.springframework.integration.store.MessageGroup;
+import org.springframework.integration.store.MessageGroupStore;
+
+/**
+ * @author Oleg Zhurakousky
+ * @since 2.1
+ */
+public class ResequensingMessageHandler extends CorrelatingMessageHandler {
+
+	/**
+	 * @param processor
+	 * @param store
+	 * @param correlationStrategy
+	 * @param releaseStrategy
+	 */
+	public ResequensingMessageHandler(MessageGroupProcessor processor,
+			MessageGroupStore store, CorrelationStrategy correlationStrategy,
+			ReleaseStrategy releaseStrategy) {
+		super(processor, store, correlationStrategy, releaseStrategy);
+	}
+
+	/**
+	 * @param processor
+	 * @param store
+	 */
+	public ResequensingMessageHandler(MessageGroupProcessor processor,
+			MessageGroupStore store) {
+		super(processor, store);
+	}
+
+	/**
+	 * @param processor
+	 */
+	public ResequensingMessageHandler(MessageGroupProcessor processor) {
+		super(processor);
+	}
+	
+	@SuppressWarnings("rawtypes")
+	protected void cleanUpForReleasedGroup(MessageGroup group, Collection<Message> completedMessages) {
+		if (completedMessages == null) {
+			mark(group);
+		} else {
+			mark(group, completedMessages);
+		}
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/SequenceSizeReleaseStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/SequenceSizeReleaseStrategy.java
@@ -16,18 +16,16 @@
 
 package org.springframework.integration.aggregator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.springframework.integration.Message;
-import org.springframework.integration.store.MessageGroup;
-import org.springframework.integration.store.SimpleMessageGroup;
-import org.springframework.util.Assert;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.integration.Message;
+import org.springframework.integration.store.MessageGroup;
 
 /**
  * An implementation of {@link ReleaseStrategy} that simply compares the current size of the message list to the
@@ -65,9 +63,7 @@ public class SequenceSizeReleaseStrategy implements ReleaseStrategy {
 		this.releasePartialSequences = releasePartialSequences;
 	}
 
-	public boolean canRelease(MessageGroup messages) {
-		Assert.isInstanceOf(SimpleMessageGroup.class, messages, "MessageGroup must be an instance of SimpleMessageGroup");
-		SimpleMessageGroup messageGroup = (SimpleMessageGroup) messages;
+	public boolean canRelease(MessageGroup messageGroup) {
 		if (releasePartialSequences) {
 			Collection<Message<?>> unmarked = messageGroup.getUnmarked();
 			if (!unmarked.isEmpty()) {
@@ -88,15 +84,17 @@ public class SequenceSizeReleaseStrategy implements ReleaseStrategy {
 		int size = messageGroup.getUnmarked().size() + messageGroup.getMarked().size();
 		
 		if (size == 0){
-			messageGroup.setComplete(true);
+			messageGroup.complete();
 		}
 		else {
 			int sequenceSize = messageGroup.getOne().getHeaders().getSequenceSize();
 			// If there is no sequence then it must be incomplete....
-			messageGroup.setComplete(sequenceSize > 0 && sequenceSize == size);
+			if (sequenceSize > 0 && sequenceSize == size){
+				messageGroup.complete();
+			}
 		}
 		
-		return messages.isComplete();
+		return messageGroup.isComplete();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Aggregator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Aggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.integration.aggregator.CorrelatingMessageHandler;
+import org.springframework.integration.aggregator.AbstractCorrelatingMessageHandler;
 
 /**
  * Indicates that a method is capable of aggregating messages. 
@@ -32,6 +32,7 @@ import org.springframework.integration.aggregator.CorrelatingMessageHandler;
  * Message or a single Object to be used as a Message payload.
  * 
  * @author Marius Bogoevici
+ * @author Oleg Zhurakousky
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -56,7 +57,7 @@ public @interface Aggregator {
 	/**
 	 * timeout for sending results to the reply target (in milliseconds)
 	 */
-	long sendTimeout() default CorrelatingMessageHandler.DEFAULT_SEND_TIMEOUT;
+	long sendTimeout() default AbstractCorrelatingMessageHandler.DEFAULT_SEND_TIMEOUT;
 
 	/**
 	 * indicates whether to send an incomplete aggregate on expiry of the message group

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AggregatorAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AggregatorAnnotationPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.integration.MessageChannel;
-import org.springframework.integration.aggregator.CorrelatingMessageHandler;
+import org.springframework.integration.aggregator.AggregatingMessageHandler;
 import org.springframework.integration.aggregator.MethodInvokingCorrelationStrategy;
 import org.springframework.integration.aggregator.MethodInvokingMessageGroupProcessor;
 import org.springframework.integration.aggregator.MethodInvokingReleaseStrategy;
@@ -40,6 +40,7 @@ import org.springframework.util.StringUtils;
  * Post-processor for the {@link Aggregator @Aggregator} annotation.
  * 
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  */
 public class AggregatorAnnotationPostProcessor extends AbstractMethodAnnotationPostProcessor<Aggregator> {
 
@@ -53,7 +54,7 @@ public class AggregatorAnnotationPostProcessor extends AbstractMethodAnnotationP
 		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(bean, method);
 		MethodInvokingReleaseStrategy releaseStrategy = getReleaseStrategy(bean);
 		MethodInvokingCorrelationStrategy correlationStrategy = getCorrelationStrategy(bean);
-		CorrelatingMessageHandler handler = new CorrelatingMessageHandler(processor, new SimpleMessageStore(), correlationStrategy, releaseStrategy);
+		AggregatingMessageHandler handler = new AggregatingMessageHandler(processor, new SimpleMessageStore(), correlationStrategy, releaseStrategy);
 		String discardChannelName = annotation.discardChannel();
 		if (StringUtils.hasText(discardChannelName)) {
 			MessageChannel discardChannel = this.channelResolver.resolveChannelName(discardChannelName);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AggregatorParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AggregatorParser.java
@@ -21,6 +21,8 @@ import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.aggregator.AggregatingMessageHandler;
+import org.springframework.integration.aggregator.MethodInvokingMessageGroupProcessor;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
@@ -68,14 +70,12 @@ public class AggregatorParser extends AbstractConsumerEndpointParser {
 		String ref = element.getAttribute(REF_ATTRIBUTE);
 		BeanDefinitionBuilder builder;
 
-		builder = BeanDefinitionBuilder.genericBeanDefinition(IntegrationNamespaceUtils.BASE_PACKAGE
-				+ ".aggregator.CorrelatingMessageHandler");
+		builder = BeanDefinitionBuilder.genericBeanDefinition(AggregatingMessageHandler.class);
 		BeanDefinitionBuilder processorBuilder = null;
 		BeanMetadataElement processor = null;
 
 		if (innerHandlerDefinition != null || StringUtils.hasText(ref)) {
-			processorBuilder = BeanDefinitionBuilder.genericBeanDefinition(IntegrationNamespaceUtils.BASE_PACKAGE
-					+ ".aggregator.MethodInvokingMessageGroupProcessor");
+			processorBuilder = BeanDefinitionBuilder.genericBeanDefinition(MethodInvokingMessageGroupProcessor.class);
 			builder.addConstructorArgValue(processorBuilder.getBeanDefinition());
 			if (innerHandlerDefinition != null) {
 				processor = innerHandlerDefinition;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ResequencerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ResequencerParser.java
@@ -19,7 +19,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.aggregator.ResequencingMessageGroupProcessor;
-import org.springframework.integration.aggregator.ResequensingMessageHandler;
+import org.springframework.integration.aggregator.ResequencingMessageHandler;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
@@ -60,7 +60,7 @@ public class ResequencerParser extends AbstractConsumerEndpointParser {
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
 
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(ResequensingMessageHandler.class);
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(ResequencingMessageHandler.class);
 		BeanDefinitionBuilder processorBuilder = BeanDefinitionBuilder.genericBeanDefinition(ResequencingMessageGroupProcessor.class);
 
 		// Comparator

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ResequencerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ResequencerParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -18,6 +18,8 @@ import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.aggregator.ResequencingMessageGroupProcessor;
+import org.springframework.integration.aggregator.ResequensingMessageHandler;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
@@ -27,6 +29,7 @@ import org.w3c.dom.Element;
  * @author Marius Bogoevici
  * @author Dave Syer
  * @author Iwein Fuld
+ * @author Oleg Zhurakousky
  */
 public class ResequencerParser extends AbstractConsumerEndpointParser {
 
@@ -57,11 +60,8 @@ public class ResequencerParser extends AbstractConsumerEndpointParser {
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
 
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder
-				.genericBeanDefinition(IntegrationNamespaceUtils.BASE_PACKAGE + ".aggregator.CorrelatingMessageHandler");
-		BeanDefinitionBuilder processorBuilder = BeanDefinitionBuilder
-				.genericBeanDefinition(IntegrationNamespaceUtils.BASE_PACKAGE
-						+ ".aggregator.ResequencingMessageGroupProcessor");
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(ResequensingMessageHandler.class);
+		BeanDefinitionBuilder processorBuilder = BeanDefinitionBuilder.genericBeanDefinition(ResequencingMessageGroupProcessor.class);
 
 		// Comparator
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(processorBuilder, element, COMPARATOR_REF_ATTRIBUTE);

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -14,7 +14,6 @@
 package org.springframework.integration.store;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 
 import org.apache.commons.logging.Log;
@@ -67,8 +66,6 @@ public abstract class AbstractMessageGroupStore implements MessageGroupStore, It
 		}
 		return count;
 	}
-	
-	public abstract Iterator<MessageGroup> iterator();
 
 	@ManagedAttribute
 	public int getMessageCountForAllMessageGroups() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroup.java
@@ -54,6 +54,11 @@ public interface MessageGroup {
 	 * @return true if the group is complete (i.e. no more messages are expected to be added)
 	 */
 	boolean isComplete();
+	
+	/**
+	 * @return true if the group is complete (i.e. no more messages are expected to be added)
+	 */
+	void complete();
 
 	/**
 	 * @return the size of the sequence expected 0 if unknown

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -12,6 +12,8 @@
  */
 package org.springframework.integration.store;
 
+import java.util.Iterator;
+
 import org.springframework.integration.Message;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 
@@ -121,4 +123,9 @@ public interface MessageGroupStore {
 	 * @see #registerMessageGroupExpiryCallback(MessageGroupCallback)
 	 */
 	int expireMessageGroups(long timeout);
+	
+	/**
+	 * Returns the iterator of currently accumulated Messages
+	 */
+	Iterator<MessageGroup> iterator();
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -125,7 +125,7 @@ public interface MessageGroupStore {
 	int expireMessageGroups(long timeout);
 	
 	/**
-	 * Returns the iterator of currently accumulated Messages
+	 * Returns the iterator of currently accumulated {@link MessageGroup}s
 	 */
 	Iterator<MessageGroup> iterator();
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
@@ -145,10 +145,10 @@ public class SimpleMessageGroup implements MessageGroup {
 		return this.complete;
 	}
 	
-	public void setComplete(boolean complete) {
-		this.complete = complete;
+	public void complete() {
+		this.complete = true;
 	}
-
+	
 	public int getSequenceSize() {
 		if (size() == 0) {
 			return 0;
@@ -238,6 +238,4 @@ public class SimpleMessageGroup implements MessageGroup {
 				", timestamp=" + timestamp +
 				'}';
 	}
-	
-	
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -43,6 +43,8 @@ public class SimpleMessageGroup implements MessageGroup {
 	public final BlockingQueue<Message<?>> unmarked = new LinkedBlockingQueue<Message<?>>();
 
 	private final long timestamp;
+	
+	private volatile boolean complete;
 
 	public SimpleMessageGroup(Object groupId) {
 		this(Collections.<Message<?>> emptyList(), Collections.<Message<?>> emptyList(), groupId, System
@@ -69,6 +71,7 @@ public class SimpleMessageGroup implements MessageGroup {
 
 	public SimpleMessageGroup(MessageGroup template) {
 		this.groupId = template.getGroupId();
+		this.complete = template.isComplete();
 		synchronized (lock) {
 			// Explicit iteration to work around bug in JDK (before 1.6.0_20
 			for (Message<?> message : template.getMarked()) {
@@ -139,12 +142,11 @@ public class SimpleMessageGroup implements MessageGroup {
 	}
 
 	public boolean isComplete() {
-		if (size() == 0) {
-			return true;
-		}
-		int sequenceSize = getSequenceSize();
-		// If there is no sequence then it must be incomplete....
-		return sequenceSize > 0 && sequenceSize == size();
+		return this.complete;
+	}
+	
+	public void setComplete(boolean complete) {
+		this.complete = complete;
 	}
 
 	public int getSequenceSize() {
@@ -182,6 +184,11 @@ public class SimpleMessageGroup implements MessageGroup {
 			one = marked.peek();
 		}
 		return one;
+	}
+	
+	public void cleanup(){
+		this.marked.clear();
+		this.unmarked.clear();
 	}
 
 	/**
@@ -231,4 +238,6 @@ public class SimpleMessageGroup implements MessageGroup {
 				", timestamp=" + timestamp +
 				'}';
 	}
+	
+	
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
@@ -148,7 +148,6 @@ public class SimpleMessageStore extends AbstractMessageGroupStore implements Mes
 		return group;
 	}
 
-	@Override
 	public Iterator<MessageGroup> iterator() {
 		return new HashSet<MessageGroup>(groupIdToMessageGroup.values()).iterator();
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatorTests.java
@@ -42,14 +42,14 @@ import org.springframework.integration.support.MessageBuilder;
  */
 public class AggregatorTests {
 
-	private CorrelatingMessageHandler aggregator;
+	private AggregatingMessageHandler aggregator;
 
 	private SimpleMessageStore store = new SimpleMessageStore(50);
 
 
 	@Before
 	public void configureAggregator() {
-		this.aggregator = new CorrelatingMessageHandler(new MultiplyingProcessor(), store);
+		this.aggregator = new AggregatingMessageHandler(new MultiplyingProcessor(), store);
 	}
 
 
@@ -211,7 +211,7 @@ public class AggregatorTests {
 
 	@Test
 	public void testNullReturningAggregator() throws InterruptedException {
-		this.aggregator = new CorrelatingMessageHandler(new NullReturningMessageProcessor(), new SimpleMessageStore(50));
+		this.aggregator = new AggregatingMessageHandler(new NullReturningMessageProcessor(), new SimpleMessageStore(50));
 		QueueChannel replyChannel = new QueueChannel();
 		Message<?> message1 = createMessage(3, "ABC", 3, 1, replyChannel, null);
 		Message<?> message2 = createMessage(5, "ABC", 3, 2, replyChannel, null);

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ConcurrentAggregatorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ConcurrentAggregatorTests.java
@@ -16,19 +16,12 @@
 
 package org.springframework.integration.aggregator;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.integration.Message;
@@ -42,6 +35,13 @@ import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.integration.support.MessageBuilder;
 
+import static org.hamcrest.CoreMatchers.is;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
 /**
  * @author Mark Fisher
  * @author Marius Bogoevici
@@ -51,7 +51,7 @@ public class ConcurrentAggregatorTests {
 
 	private TaskExecutor taskExecutor;
 
-	private CorrelatingMessageHandler aggregator;
+	private AggregatingMessageHandler aggregator;
 
 	private MessageGroupStore store = new SimpleMessageStore();
 
@@ -59,7 +59,7 @@ public class ConcurrentAggregatorTests {
 	@Before
 	public void configureAggregator() {
 		this.taskExecutor = new SimpleAsyncTaskExecutor();
-		this.aggregator = new CorrelatingMessageHandler(new MultiplyingProcessor(), store);
+		this.aggregator = new AggregatingMessageHandler(new MultiplyingProcessor(), store);
 	}
 
 
@@ -274,7 +274,7 @@ public class ConcurrentAggregatorTests {
 
 	@Test
 	public void testNullReturningAggregator() throws InterruptedException {
-		this.aggregator = new CorrelatingMessageHandler(new NullReturningMessageProcessor(), new SimpleMessageStore(
+		this.aggregator = new AggregatingMessageHandler(new NullReturningMessageProcessor(), new SimpleMessageStore(
 						50));
 		QueueChannel replyChannel = new QueueChannel();
 		Message<?> message1 = createMessage(3, "ABC", 3, 1, replyChannel, null);

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelatingMessageHandlerIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelatingMessageHandlerIntegrationTests.java
@@ -16,20 +16,19 @@
 
 package org.springframework.integration.aggregator;
 
-import static org.mockito.Mockito.isA;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.integration.support.MessageBuilder;
+
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class CorrelatingMessageHandlerIntegrationTests {
 
@@ -39,7 +38,7 @@ public class CorrelatingMessageHandlerIntegrationTests {
 
 	private MessageGroupProcessor processor = new PassThroughMessageGroupProcessor();
 
-	private CorrelatingMessageHandler defaultHandler = new CorrelatingMessageHandler(processor, store);
+	private AggregatingMessageHandler defaultHandler = new AggregatingMessageHandler(processor, store);
 
 	@Before
 	public void setupHandler() {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelatingMessageHandlerIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelatingMessageHandlerIntegrationTests.java
@@ -67,6 +67,7 @@ public class CorrelatingMessageHandlerIntegrationTests {
 		verify(outputChannel).send(message1);
 		defaultHandler.handleMessage(message2);
 		verify(outputChannel, never()).send(message2);
+		verify(discardChannel).send(message2);
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelatingMessageHandlerIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelatingMessageHandlerIntegrationTests.java
@@ -67,7 +67,6 @@ public class CorrelatingMessageHandlerIntegrationTests {
 		verify(outputChannel).send(message1);
 		defaultHandler.handleMessage(message2);
 		verify(outputChannel, never()).send(message2);
-		verify(discardChannel).send(message2);
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelatingMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelatingMessageHandlerTests.java
@@ -16,13 +16,6 @@
 
 package org.springframework.integration.aggregator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +28,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.internal.stubbing.answers.ThrowsException;
 import org.mockito.runners.MockitoJUnitRunner;
-
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessageHandlingException;
@@ -45,6 +37,14 @@ import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 /**
  * @author Iwein Fuld
  * @author Dave Syer
@@ -52,7 +52,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 @RunWith(MockitoJUnitRunner.class)
 public class CorrelatingMessageHandlerTests {
 
-	private CorrelatingMessageHandler handler;
+	private AggregatingMessageHandler handler;
 
 	@Mock
 	private CorrelationStrategy correlationStrategy;
@@ -70,7 +70,7 @@ public class CorrelatingMessageHandlerTests {
 
 	@Before
 	public void initializeSubject() {
-		handler = new CorrelatingMessageHandler(processor, store, correlationStrategy, ReleaseStrategy);
+		handler = new AggregatingMessageHandler(processor, store, correlationStrategy, ReleaseStrategy);
 		handler.setOutputChannel(outputChannel);
 	}
 
@@ -94,7 +94,7 @@ public class CorrelatingMessageHandlerTests {
 		verify(processor).processMessageGroup(isA(SimpleMessageGroup.class));
 	}
 
-	private void verifyLocks(CorrelatingMessageHandler handler, int lockCount) {
+	private void verifyLocks(AggregatingMessageHandler handler, int lockCount) {
 		assertEquals(lockCount, ((Map<?, ?>) ReflectionTestUtils.getField(handler, "locks")).size());
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessorTests.java
@@ -479,7 +479,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 		proxyFactory.setProxyTargetClass(false);
 		testBean = (GreetingService) proxyFactory.getProxy();
 		MethodInvokingMessageGroupProcessor aggregator = new MethodInvokingMessageGroupProcessor(testBean);
-		CorrelatingMessageHandler handler = new CorrelatingMessageHandler(aggregator);
+		AggregatingMessageHandler handler = new AggregatingMessageHandler(aggregator);
 		handler.setReleaseStrategy(new MessageCountReleaseStrategy());
 		handler.setOutputChannel(output);
 		EventDrivenConsumer endpoint = new EventDrivenConsumer(input, handler);
@@ -498,7 +498,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 		proxyFactory.setProxyTargetClass(true);
 		testBean = (GreetingService) proxyFactory.getProxy();
 		MethodInvokingMessageGroupProcessor aggregator = new MethodInvokingMessageGroupProcessor(testBean);
-		CorrelatingMessageHandler handler = new CorrelatingMessageHandler(aggregator);
+		AggregatingMessageHandler handler = new AggregatingMessageHandler(aggregator);
 		handler.setReleaseStrategy(new MessageCountReleaseStrategy());
 		handler.setOutputChannel(output);
 		EventDrivenConsumer endpoint = new EventDrivenConsumer(input, handler);

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertThat;
  */
 public class ResequencerTests {
 
-	private CorrelatingMessageHandler resequencer;
+	private ResequensingMessageHandler resequencer;
 
 	private ResequencingMessageGroupProcessor processor = new ResequencingMessageGroupProcessor();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertThat;
  */
 public class ResequencerTests {
 
-	private ResequensingMessageHandler resequencer;
+	private ResequencingMessageHandler resequencer;
 
 	private ResequencingMessageGroupProcessor processor = new ResequencingMessageGroupProcessor();
 
@@ -53,7 +53,7 @@ public class ResequencerTests {
 
 	@Before
 	public void configureResequencer() {
-		this.resequencer = new ResequensingMessageHandler(processor, store, null, null);
+		this.resequencer = new ResequencingMessageHandler(processor, store, null, null);
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
@@ -16,6 +16,11 @@
 
 package org.springframework.integration.aggregator;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.integration.Message;
@@ -25,13 +30,12 @@ import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.integration.support.MessageBuilder;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
+import static org.hamcrest.Matchers.is;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Marius Bogoevici
@@ -49,7 +53,7 @@ public class ResequencerTests {
 
 	@Before
 	public void configureResequencer() {
-		this.resequencer = new CorrelatingMessageHandler(processor, store, null, null);
+		this.resequencer = new ResequensingMessageHandler(processor, store, null, null);
 	}
 
 	@Test
@@ -122,7 +126,7 @@ public class ResequencerTests {
 	@Test
 	public void testResequencingWithIncompleteSequenceRelease() throws InterruptedException {
 		this.resequencer.setReleaseStrategy(new SequenceSizeReleaseStrategy(true));
-		this.resequencer.setKeepClosedAggregates(false);
+		//this.resequencer.setKeepClosedAggregates(false);
 		QueueChannel replyChannel = new QueueChannel();
 		Message<?> message1 = createMessage("123", "ABC", 4, 2, replyChannel);
 		Message<?> message2 = createMessage("456", "ABC", 4, 1, replyChannel);
@@ -153,7 +157,7 @@ public class ResequencerTests {
 	@Test
 	public void testResequencingWithPartialSequenceAndComparator() throws InterruptedException {
 		this.resequencer.setReleaseStrategy(new SequenceSizeReleaseStrategy(true));
-		this.resequencer.setKeepClosedAggregates(false);
+		//this.resequencer.setKeepClosedAggregates(false);
 		this.processor.setComparator(new Comparator<Message<?>>() {			
 			@SuppressWarnings({ "unchecked", "rawtypes" })
 			public int compare(Message<?> o1, Message<?> o2) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
@@ -122,6 +122,7 @@ public class ResequencerTests {
 	@Test
 	public void testResequencingWithIncompleteSequenceRelease() throws InterruptedException {
 		this.resequencer.setReleaseStrategy(new SequenceSizeReleaseStrategy(true));
+		this.resequencer.setKeepClosedAggregates(false);
 		QueueChannel replyChannel = new QueueChannel();
 		Message<?> message1 = createMessage("123", "ABC", 4, 2, replyChannel);
 		Message<?> message2 = createMessage("456", "ABC", 4, 1, replyChannel);
@@ -152,6 +153,7 @@ public class ResequencerTests {
 	@Test
 	public void testResequencingWithPartialSequenceAndComparator() throws InterruptedException {
 		this.resequencer.setReleaseStrategy(new SequenceSizeReleaseStrategy(true));
+		this.resequencer.setKeepClosedAggregates(false);
 		this.processor.setComparator(new Comparator<Message<?>>() {			
 			@SuppressWarnings({ "unchecked", "rawtypes" })
 			public int compare(Message<?> o1, Message<?> o2) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,7 +126,6 @@ public class ResequencerTests {
 	@Test
 	public void testResequencingWithIncompleteSequenceRelease() throws InterruptedException {
 		this.resequencer.setReleaseStrategy(new SequenceSizeReleaseStrategy(true));
-		//this.resequencer.setKeepClosedAggregates(false);
 		QueueChannel replyChannel = new QueueChannel();
 		Message<?> message1 = createMessage("123", "ABC", 4, 2, replyChannel);
 		Message<?> message2 = createMessage("456", "ABC", 4, 1, replyChannel);
@@ -157,7 +156,6 @@ public class ResequencerTests {
 	@Test
 	public void testResequencingWithPartialSequenceAndComparator() throws InterruptedException {
 		this.resequencer.setReleaseStrategy(new SequenceSizeReleaseStrategy(true));
-		//this.resequencer.setKeepClosedAggregates(false);
 		this.processor.setComparator(new Comparator<Message<?>>() {			
 			@SuppressWarnings({ "unchecked", "rawtypes" })
 			public int compare(Message<?> o1, Message<?> o2) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorSupportedUseCasesTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorSupportedUseCasesTests.java
@@ -16,7 +16,7 @@ package org.springframework.integration.aggregator.integration;
 import java.util.List;
 
 import org.junit.Test;
-import org.springframework.integration.aggregator.CorrelatingMessageHandler;
+import org.springframework.integration.aggregator.AggregatingMessageHandler;
 import org.springframework.integration.aggregator.DefaultAggregatingMessageGroupProcessor;
 import org.springframework.integration.aggregator.ReleaseStrategy;
 import org.springframework.integration.channel.QueueChannel;
@@ -39,7 +39,7 @@ public class AggregatorSupportedUseCasesTests {
 	
 	private DefaultAggregatingMessageGroupProcessor processor = new DefaultAggregatingMessageGroupProcessor();
 	
-	private CorrelatingMessageHandler defaultHandler = new CorrelatingMessageHandler(processor, store);
+	private AggregatingMessageHandler defaultHandler = new AggregatingMessageHandler(processor, store);
 
 	@Test
 	public void waitForAllDefaultReleaseStrategyWithLateArrivals(){

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorSupportedUseCasesTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorSupportedUseCasesTests.java
@@ -61,7 +61,7 @@ public class AggregatorSupportedUseCasesTests {
 		assertNotNull(discardChannel.receive(0));
 		
 		// set 'keepClosedOutAggregates' to 'false' and the messages should start accumulating again
-		defaultHandler.setKeepClosedAggregates(false);
+		defaultHandler.setExpireGroupsUponCompletion(true);
 		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setSequenceSize(5).setCorrelationId("A").setSequenceNumber(3).build());
 		assertNull(discardChannel.receive(0));
 		assertEquals(1, store.getMessageGroup("A").getUnmarked().size());
@@ -88,7 +88,7 @@ public class AggregatorSupportedUseCasesTests {
 		assertNotNull(discardChannel.receive(0));
 		
 		// set 'keepClosedOutAggregates' to 'false' and the messages should start accumulating again
-		defaultHandler.setKeepClosedAggregates(false);
+		defaultHandler.setExpireGroupsUponCompletion(true);
 		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setCorrelationId("A").build());
 		assertNull(discardChannel.receive(0));
 		assertEquals(1, store.getMessageGroup("A").getUnmarked().size());
@@ -119,7 +119,7 @@ public class AggregatorSupportedUseCasesTests {
 		defaultHandler.setOutputChannel(outputChannel);
 		defaultHandler.setDiscardChannel(discardChannel);
 		defaultHandler.setReleaseStrategy(new SampleSizeReleaseStrategy());
-		defaultHandler.setKeepClosedAggregates(false);
+		defaultHandler.setExpireGroupsUponCompletion(true);
 		
 		for (int i = 0; i < 10; i++) {
 			defaultHandler.handleMessage(MessageBuilder.withPayload(i).setCorrelationId("A").build());
@@ -136,7 +136,7 @@ public class AggregatorSupportedUseCasesTests {
 		defaultHandler.setOutputChannel(outputChannel);
 		defaultHandler.setDiscardChannel(discardChannel);
 		defaultHandler.setReleaseStrategy(new SampleSizeReleaseStrategy());
-		defaultHandler.setKeepClosedAggregates(false);
+		defaultHandler.setExpireGroupsUponCompletion(true);
 		
 		for (int i = 0; i < 12; i++) {
 			defaultHandler.handleMessage(MessageBuilder.withPayload(i).setCorrelationId("A").build());

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorSupportedUseCasesTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorSupportedUseCasesTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.integration.aggregator.integration;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.integration.aggregator.CorrelatingMessageHandler;
+import org.springframework.integration.aggregator.DefaultAggregatingMessageGroupProcessor;
+import org.springframework.integration.aggregator.ReleaseStrategy;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.store.MessageGroup;
+import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.integration.store.SimpleMessageStore;
+import org.springframework.integration.support.MessageBuilder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Oleg Zhurakousky
+ *
+ */
+public class AggregatorSupportedUseCasesTests {
+	
+	private MessageGroupStore store = new SimpleMessageStore(100);
+	
+	private DefaultAggregatingMessageGroupProcessor processor = new DefaultAggregatingMessageGroupProcessor();
+	
+	private CorrelatingMessageHandler defaultHandler = new CorrelatingMessageHandler(processor, store);
+
+	@Test
+	public void waitForAllDefaultReleaseStrategyWithLateArrivals(){
+		QueueChannel outputChannel = new QueueChannel();
+		QueueChannel discardChannel = new QueueChannel();
+		defaultHandler.setOutputChannel(outputChannel);
+		defaultHandler.setDiscardChannel(discardChannel);
+		
+		for (int i = 0; i < 5; i++) {
+			defaultHandler.handleMessage(MessageBuilder.withPayload(i).setSequenceSize(5).setCorrelationId("A").setSequenceNumber(i).build());
+		}
+		assertEquals(5, ((List<?>)outputChannel.receive(0).getPayload()).size());
+		assertNull(discardChannel.receive(0));
+		assertEquals(0, store.getMessageGroup("A").getUnmarked().size());
+		assertEquals(0, store.getMessageGroup("A").getMarked().size());
+		
+		// send another message with the same correlation id and see it in the discard channel
+		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setSequenceSize(5).setCorrelationId("A").setSequenceNumber(3).build());
+		assertNotNull(discardChannel.receive(0));
+		
+		// set 'keepClosedOutAggregates' to 'false' and the messages should start accumulating again
+		defaultHandler.setKeepClosedAggregates(false);
+		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setSequenceSize(5).setCorrelationId("A").setSequenceNumber(3).build());
+		assertNull(discardChannel.receive(0));
+		assertEquals(1, store.getMessageGroup("A").getUnmarked().size());
+	}
+	
+	@Test
+	public void waitForAllCustomReleaseStrategyWithLateArrivals(){
+		QueueChannel outputChannel = new QueueChannel();
+		QueueChannel discardChannel = new QueueChannel();
+		defaultHandler.setOutputChannel(outputChannel);
+		defaultHandler.setDiscardChannel(discardChannel);
+		defaultHandler.setReleaseStrategy(new SampleSizeReleaseStrategy());
+		
+		for (int i = 0; i < 5; i++) {
+			defaultHandler.handleMessage(MessageBuilder.withPayload(i).setCorrelationId("A").build());
+		}
+		assertEquals(5, ((List<?>)outputChannel.receive(0).getPayload()).size());
+		assertNull(discardChannel.receive(0));
+		assertEquals(0, store.getMessageGroup("A").getUnmarked().size());
+		assertEquals(0, store.getMessageGroup("A").getMarked().size());
+		
+		// send another message with the same correlation id and see it in the discard channel
+		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setCorrelationId("A").build());
+		assertNotNull(discardChannel.receive(0));
+		
+		// set 'keepClosedOutAggregates' to 'false' and the messages should start accumulating again
+		defaultHandler.setKeepClosedAggregates(false);
+		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setCorrelationId("A").build());
+		assertNull(discardChannel.receive(0));
+		assertEquals(1, store.getMessageGroup("A").getUnmarked().size());
+	}
+	
+	@Test
+	public void firstBest(){
+		QueueChannel outputChannel = new QueueChannel();
+		QueueChannel discardChannel = new QueueChannel();
+		defaultHandler.setOutputChannel(outputChannel);
+		defaultHandler.setDiscardChannel(discardChannel);
+		defaultHandler.setReleaseStrategy(new FirstBestReleaseStrategy());
+		
+		for (int i = 0; i < 5; i++) {
+			defaultHandler.handleMessage(MessageBuilder.withPayload(i).setCorrelationId("A").build());
+		}
+		assertEquals(1, ((List<?>)outputChannel.receive(0).getPayload()).size());
+		assertNotNull(discardChannel.receive(0));
+		assertNotNull(discardChannel.receive(0));
+		assertNotNull(discardChannel.receive(0));
+		assertNotNull(discardChannel.receive(0));
+	}
+	
+	private class SampleSizeReleaseStrategy implements ReleaseStrategy {
+
+		public boolean canRelease(MessageGroup group) {
+			return group.getUnmarked().size() == 5;
+		}
+		
+	}
+	
+	private class FirstBestReleaseStrategy implements ReleaseStrategy {
+
+		public boolean canRelease(MessageGroup group) {
+			return true;
+		}
+		
+	}
+	
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorSupportedUseCasesTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorSupportedUseCasesTests.java
@@ -60,7 +60,7 @@ public class AggregatorSupportedUseCasesTests {
 		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setSequenceSize(5).setCorrelationId("A").setSequenceNumber(3).build());
 		assertNotNull(discardChannel.receive(0));
 		
-		// set 'keepClosedOutAggregates' to 'false' and the messages should start accumulating again
+		// set 'expireGroupsUponCompletion' to 'true' and the messages should start accumulating again
 		defaultHandler.setExpireGroupsUponCompletion(true);
 		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setSequenceSize(5).setCorrelationId("A").setSequenceNumber(3).build());
 		assertNull(discardChannel.receive(0));
@@ -87,7 +87,7 @@ public class AggregatorSupportedUseCasesTests {
 		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setCorrelationId("A").build());
 		assertNotNull(discardChannel.receive(0));
 		
-		// set 'keepClosedOutAggregates' to 'false' and the messages should start accumulating again
+		// set 'expireGroupsUponCompletion' to 'true' and the messages should start accumulating again
 		defaultHandler.setExpireGroupsUponCompletion(true);
 		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setCorrelationId("A").build());
 		assertNull(discardChannel.receive(0));

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
@@ -16,11 +16,6 @@
 
 package org.springframework.integration.config;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +33,7 @@ import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessageDeliveryException;
 import org.springframework.integration.MessageHandlingException;
 import org.springframework.integration.MessageRejectedException;
-import org.springframework.integration.aggregator.CorrelatingMessageHandler;
+import org.springframework.integration.aggregator.AggregatingMessageHandler;
 import org.springframework.integration.aggregator.CorrelationStrategy;
 import org.springframework.integration.aggregator.MethodInvokingReleaseStrategy;
 import org.springframework.integration.aggregator.ReleaseStrategy;
@@ -48,6 +43,12 @@ import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Marius Bogoevici
@@ -111,7 +112,7 @@ public class AggregatorParserTests {
 		MessageChannel outputChannel = (MessageChannel) context.getBean("outputChannel");
 		MessageChannel discardChannel = (MessageChannel) context.getBean("discardChannel");
 		Object consumer = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		assertThat(consumer, is(CorrelatingMessageHandler.class));
+		assertThat(consumer, is(AggregatingMessageHandler.class));
 		DirectFieldAccessor accessor = new DirectFieldAccessor(consumer);
 		Map<?, ?> map = (Map<?, ?>) new DirectFieldAccessor(new DirectFieldAccessor(new DirectFieldAccessor(accessor
 				.getPropertyValue("outputProcessor")).getPropertyValue("processor")).getPropertyValue("delegate"))

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ResequencerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ResequencerParserTests.java
@@ -47,8 +47,8 @@ public class ResequencerParserTests {
 	@Test
 	public void testDefaultResequencerProperties() {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("defaultResequencer");
-		CorrelatingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
-				CorrelatingMessageHandler.class);
+		ResequensingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
+				ResequensingMessageHandler.class);
 		assertNull(getPropertyValue(resequencer, "outputChannel"));
 		assertTrue(getPropertyValue(resequencer, "discardChannel") instanceof NullChannel);
 		assertEquals("The ResequencerEndpoint is not set with the appropriate timeout value", 1000l, getPropertyValue(
@@ -65,8 +65,8 @@ public class ResequencerParserTests {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("completelyDefinedResequencer");
 		MessageChannel outputChannel = (MessageChannel) context.getBean("outputChannel");
 		MessageChannel discardChannel = (MessageChannel) context.getBean("discardChannel");
-		CorrelatingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
-				CorrelatingMessageHandler.class);
+		ResequensingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
+				ResequensingMessageHandler.class);
 		assertEquals("The ResequencerEndpoint is not injected with the appropriate output channel", outputChannel,
 				getPropertyValue(resequencer, "outputChannel"));
 		assertEquals("The ResequencerEndpoint is not injected with the appropriate discard channel", discardChannel,
@@ -84,8 +84,8 @@ public class ResequencerParserTests {
 	public void testCorrelationStrategyRefOnly() throws Exception {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context
 				.getBean("resequencerWithCorrelationStrategyRefOnly");
-		CorrelatingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
-				CorrelatingMessageHandler.class);
+		ResequensingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
+				ResequensingMessageHandler.class);
 		assertEquals("The ResequencerEndpoint is not configured with the appropriate CorrelationStrategy", context
 				.getBean("testCorrelationStrategy"), getPropertyValue(resequencer, "correlationStrategy"));
 	}
@@ -93,8 +93,8 @@ public class ResequencerParserTests {
 	@Test
 	public void shouldSetReleasePartialSequencesFlag(){
 				EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("completelyDefinedResequencer");
-		CorrelatingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
-				CorrelatingMessageHandler.class);
+				ResequensingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
+						ResequensingMessageHandler.class);
 		assertEquals("The ResequencerEndpoint is not configured with the appropriate 'release partial sequences' flag",
 				true, getPropertyValue(getPropertyValue(resequencer, "releaseStrategy"), "releasePartialSequences"));
 	}
@@ -103,8 +103,8 @@ public class ResequencerParserTests {
 	public void testCorrelationStrategyRefAndMethod() throws Exception {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context
 				.getBean("resequencerWithCorrelationStrategyRefAndMethod");
-		CorrelatingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
-				CorrelatingMessageHandler.class);
+		ResequensingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
+				ResequensingMessageHandler.class);
 		Object correlationStrategy = getPropertyValue(resequencer, "correlationStrategy");
 		assertEquals("The ResequencerEndpoint is not configured with a CorrelationStrategy adapter",
 				MethodInvokingCorrelationStrategy.class, correlationStrategy.getClass());
@@ -115,8 +115,8 @@ public class ResequencerParserTests {
 	@Test
 	public void testComparator() throws Exception {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("resequencerWithComparator");
-		CorrelatingMessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler",
-				CorrelatingMessageHandler.class);
+		ResequensingMessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler",
+				ResequensingMessageHandler.class);
 		ResequencingMessageGroupProcessor resequencer = TestUtils.getPropertyValue(handler, "outputProcessor",
 				ResequencingMessageGroupProcessor.class);
 		Object comparator = getPropertyValue(resequencer, "comparator");
@@ -127,8 +127,8 @@ public class ResequencerParserTests {
 	@Test
 	public void testReleaseStrategy() throws Exception {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("resequencerWithReleaseStrategy");
-		CorrelatingMessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler",
-				CorrelatingMessageHandler.class);
+		ResequensingMessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler",
+				ResequensingMessageHandler.class);
 		Object releaseStrategy = getPropertyValue(handler, "releaseStrategy");
 		assertEquals("The Resequencer is not configured with an adapter", MethodInvokingReleaseStrategy.class, releaseStrategy
 				.getClass());

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ResequencerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ResequencerParserTests.java
@@ -13,21 +13,28 @@
 
 package org.springframework.integration.config;
 
+import java.util.Comparator;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
-import org.springframework.integration.aggregator.*;
+import org.springframework.integration.aggregator.CorrelationStrategy;
+import org.springframework.integration.aggregator.MethodInvokingCorrelationStrategy;
+import org.springframework.integration.aggregator.MethodInvokingReleaseStrategy;
+import org.springframework.integration.aggregator.ResequencingMessageGroupProcessor;
+import org.springframework.integration.aggregator.ResequencingMessageHandler;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 
-import java.util.Comparator;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
-import static org.junit.Assert.*;
 import static org.springframework.integration.test.util.TestUtils.getPropertyValue;
 
 /**
@@ -47,8 +54,8 @@ public class ResequencerParserTests {
 	@Test
 	public void testDefaultResequencerProperties() {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("defaultResequencer");
-		ResequensingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
-				ResequensingMessageHandler.class);
+		ResequencingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
+				ResequencingMessageHandler.class);
 		assertNull(getPropertyValue(resequencer, "outputChannel"));
 		assertTrue(getPropertyValue(resequencer, "discardChannel") instanceof NullChannel);
 		assertEquals("The ResequencerEndpoint is not set with the appropriate timeout value", 1000l, getPropertyValue(
@@ -65,8 +72,8 @@ public class ResequencerParserTests {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("completelyDefinedResequencer");
 		MessageChannel outputChannel = (MessageChannel) context.getBean("outputChannel");
 		MessageChannel discardChannel = (MessageChannel) context.getBean("discardChannel");
-		ResequensingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
-				ResequensingMessageHandler.class);
+		ResequencingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
+				ResequencingMessageHandler.class);
 		assertEquals("The ResequencerEndpoint is not injected with the appropriate output channel", outputChannel,
 				getPropertyValue(resequencer, "outputChannel"));
 		assertEquals("The ResequencerEndpoint is not injected with the appropriate discard channel", discardChannel,
@@ -84,8 +91,8 @@ public class ResequencerParserTests {
 	public void testCorrelationStrategyRefOnly() throws Exception {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context
 				.getBean("resequencerWithCorrelationStrategyRefOnly");
-		ResequensingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
-				ResequensingMessageHandler.class);
+		ResequencingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
+				ResequencingMessageHandler.class);
 		assertEquals("The ResequencerEndpoint is not configured with the appropriate CorrelationStrategy", context
 				.getBean("testCorrelationStrategy"), getPropertyValue(resequencer, "correlationStrategy"));
 	}
@@ -93,8 +100,8 @@ public class ResequencerParserTests {
 	@Test
 	public void shouldSetReleasePartialSequencesFlag(){
 				EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("completelyDefinedResequencer");
-				ResequensingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
-						ResequensingMessageHandler.class);
+				ResequencingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
+						ResequencingMessageHandler.class);
 		assertEquals("The ResequencerEndpoint is not configured with the appropriate 'release partial sequences' flag",
 				true, getPropertyValue(getPropertyValue(resequencer, "releaseStrategy"), "releasePartialSequences"));
 	}
@@ -103,8 +110,8 @@ public class ResequencerParserTests {
 	public void testCorrelationStrategyRefAndMethod() throws Exception {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context
 				.getBean("resequencerWithCorrelationStrategyRefAndMethod");
-		ResequensingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
-				ResequensingMessageHandler.class);
+		ResequencingMessageHandler resequencer = TestUtils.getPropertyValue(endpoint, "handler",
+				ResequencingMessageHandler.class);
 		Object correlationStrategy = getPropertyValue(resequencer, "correlationStrategy");
 		assertEquals("The ResequencerEndpoint is not configured with a CorrelationStrategy adapter",
 				MethodInvokingCorrelationStrategy.class, correlationStrategy.getClass());
@@ -115,8 +122,8 @@ public class ResequencerParserTests {
 	@Test
 	public void testComparator() throws Exception {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("resequencerWithComparator");
-		ResequensingMessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler",
-				ResequensingMessageHandler.class);
+		ResequencingMessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler",
+				ResequencingMessageHandler.class);
 		ResequencingMessageGroupProcessor resequencer = TestUtils.getPropertyValue(handler, "outputProcessor",
 				ResequencingMessageGroupProcessor.class);
 		Object comparator = getPropertyValue(resequencer, "comparator");
@@ -127,8 +134,8 @@ public class ResequencerParserTests {
 	@Test
 	public void testReleaseStrategy() throws Exception {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("resequencerWithReleaseStrategy");
-		ResequensingMessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler",
-				ResequensingMessageHandler.class);
+		ResequencingMessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler",
+				ResequencingMessageHandler.class);
 		Object releaseStrategy = getPropertyValue(handler, "releaseStrategy");
 		assertEquals("The Resequencer is not configured with an adapter", MethodInvokingReleaseStrategy.class, releaseStrategy
 				.getClass());

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/AggregatorAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/AggregatorAnnotationTests.java
@@ -16,12 +16,6 @@
 
 package org.springframework.integration.config.annotation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.springframework.integration.test.util.TestUtils.getPropertyValue;
-
 import java.lang.reflect.Method;
 import java.util.Map;
 
@@ -30,9 +24,9 @@ import org.junit.Test;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.integration.aggregator.MethodInvokingReleaseStrategy;
-import org.springframework.integration.aggregator.CorrelatingMessageHandler;
+import org.springframework.integration.aggregator.AggregatingMessageHandler;
 import org.springframework.integration.aggregator.MethodInvokingCorrelationStrategy;
+import org.springframework.integration.aggregator.MethodInvokingReleaseStrategy;
 import org.springframework.integration.aggregator.SequenceSizeReleaseStrategy;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.core.MessageHandler;
@@ -40,6 +34,13 @@ import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.support.channel.ChannelResolver;
 import org.springframework.integration.test.util.TestUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import static org.springframework.integration.test.util.TestUtils.getPropertyValue;
 
 /**
  * @author Marius Bogoevici
@@ -56,7 +57,7 @@ public class AggregatorAnnotationTests {
 		assertTrue(getPropertyValue(aggregator, "releaseStrategy") instanceof SequenceSizeReleaseStrategy);
 		assertNull(getPropertyValue(aggregator, "outputChannel"));
 		assertTrue(getPropertyValue(aggregator, "discardChannel") instanceof NullChannel);
-		assertEquals(CorrelatingMessageHandler.DEFAULT_SEND_TIMEOUT, getPropertyValue(aggregator,
+		assertEquals(AggregatingMessageHandler.DEFAULT_SEND_TIMEOUT, getPropertyValue(aggregator,
 				"messagingTemplate.sendTimeout"));
 		assertEquals(false, getPropertyValue(aggregator, "sendPartialResultOnExpiry"));
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PNamespaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PNamespaceTests.java
@@ -16,20 +16,19 @@
 
 package org.springframework.integration.config.xml;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.integration.aggregator.CorrelatingMessageHandler;
+import org.springframework.integration.aggregator.AggregatingMessageHandler;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Validates the "p:namespace" is working for inner "bean" definition within SI components.
@@ -92,7 +91,7 @@ public class PNamespaceTests {
 	@Test
 	public void testPNamespaceChain() {		
 		List<?> handlers = (List<?>) TestUtils.getPropertyValue(sampleChain, "handler.handlers");
-		CorrelatingMessageHandler handler = (CorrelatingMessageHandler) handlers.get(0);
+		AggregatingMessageHandler handler = (AggregatingMessageHandler) handlers.get(0);
 		SampleAggregator aggregator = 
 			(SampleAggregator) TestUtils.getPropertyValue(handler, "outputProcessor.processor.delegate.targetObject");
 		assertEquals("Bill", aggregator.getName());

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
@@ -87,7 +87,6 @@ public class MessageStoreTests {
 
 		private boolean removed = false;
 
-		@Override
 		public Iterator<MessageGroup> iterator() {
 			return Arrays.asList(testMessages).iterator();
 		}

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/store/KeyValueMessageGroup.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/store/KeyValueMessageGroup.java
@@ -337,4 +337,9 @@ public class KeyValueMessageGroup implements MessageGroup, Serializable {
 
 		return false;
 	}
+
+	public void complete() {
+		// no op for now pending complete refactoring of this class to rely on SMG
+		
+	}
 }


### PR DESCRIPTION
Removed call to isComplete() since canRelease() returning 'true' already identifies a completed aggregate. Added validation to the cleanUpForReleasedGroup() method to make sure that the sequenceSize is only checked if the default SequenceSizeReleaseStrategy is used
