### PR TITLE
INT-1884 polished test that intermittently break CI

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/InnerDefinitionHandlerAwareEndpointParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/InnerDefinitionHandlerAwareEndpointParserTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.config.xml;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collection;
@@ -256,7 +257,9 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 			inChannel.send(message);
 		}
 		PollableChannel output = (PollableChannel) ac.getBean("outChannel");
-		assertEquals(0 + 1 + 2 + 3 + 4, output.receive(100).getPayload());
+		Message<?> receivedMessage = output.receive(2000);
+		assertNotNull(receivedMessage);
+		assertEquals(0 + 1 + 2 + 3 + 4, receivedMessage.getPayload());
 	}
 
 	private void testFilterDefinitionSuccess(String configProperty){

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreChannelIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreChannelIntegrationTests.java
@@ -115,7 +115,7 @@ public class JdbcMessageStoreChannelIntegrationTests {
 					boolean result = input.send(new GenericMessage<String>("foo"), 500L);
 					// This will time out because the transaction has not committed yet
 					try {
-						Service.await(1000);
+						Service.await(3000);
 						fail("Expected timeout");
 					} catch (Exception e) {
 						// expected


### PR DESCRIPTION
Increased the 'await' time in JdbcMessageStoreChannelIntegrationTests.testTransactionalSendAndReceive(), polished InnerDefinitionHandlerAwareEndpointParserTests.testAggregatorDefinitionSuccess to avoid NPE and increased its receive timeout as well
