### PR TITLE
INT-1876 Add auto-startup and phase to TCP Endpoints

### DIFF
--- a/spring-integration-ip/.springBeans
+++ b/spring-integration-ip/.springBeans
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beansProjectDescription>
 	<version>1</version>
-	<pluginVersion><![CDATA[2.5.1.201011101000-RELEASE]]></pluginVersion>
+	<pluginVersion><![CDATA[2.7.2.201109122348-RELEASE]]></pluginVersion>
 	<configSuffixes>
 		<configSuffix><![CDATA[xml]]></configSuffix>
 	</configSuffixes>
 	<enableImports><![CDATA[false]]></enableImports>
 	<configs>
 		<config>src/test/java/org/springframework/integration/ip/tcp/connection/SOLingerTests-context.xml</config>
+		<config>src/test/java/org/springframework/integration/ip/tcp/AutoStartTests-context.xml</config>
 	</configs>
 	<configSets>
 	</configSets>

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/CommonSocketOptions.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/CommonSocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2001-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,19 +29,19 @@ public interface CommonSocketOptions {
 	 * @see Socket#setSoTimeout(int)
 	 * @see DatagramSocket#setSoTimeout(int)
 	 */
-	public void setSoTimeout(int soTimeout);
+	void setSoTimeout(int soTimeout);
 
 	/**
 	 * @see Socket#setReceiveBufferSize(int)
 	 * @see DatagramSocket#setReceiveBufferSize(int)
 	 */
-	public void setSoReceiveBufferSize(int soReceiveBufferSize);
+	void setSoReceiveBufferSize(int soReceiveBufferSize);
 
 	/**
 	 * @see Socket#setSendBufferSize(int)
 	 * @see DatagramSocket#setSendBufferSize(int)
 	 */
-	public void setSoSendBufferSize(int soSendBufferSize);
+	void setSoSendBufferSize(int soSendBufferSize);
 	
 	/**
 	 * On a multi-homed system, specifies the ip address of the network interface used to communicate.
@@ -53,6 +53,6 @@ public interface CommonSocketOptions {
 	 * 
  	 * @param localAddress
 	 */
-	public void setLocalAddress(String localAddress);
+	void setLocalAddress(String localAddress);
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/IpAdapterParserUtils.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/IpAdapterParserUtils.java
@@ -107,6 +107,9 @@ public abstract class IpAdapterParserUtils {
 
 	public static final String LOOKUP_HOST = "lookup-host";
 	
+	public static final String AUTO_STARTUP = "auto-startup";
+
+	public static final String PHASE = "phase";
 
 	/**
 	 * Adds a constructor-arg to the provided bean definition builder 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
@@ -17,6 +17,7 @@ package org.springframework.integration.ip.config;
 
 import java.util.concurrent.Executor;
 
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.core.serializer.Deserializer;
@@ -40,22 +41,22 @@ import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer
  *
  */
 public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<AbstractConnectionFactory> 
-		implements SmartLifecycle {
+		implements SmartLifecycle, BeanNameAware {
 
 	private volatile AbstractConnectionFactory connectionFactory;
-	
+
 	private volatile String type;
 
 	private volatile String host;
-	
+
 	private volatile int port;
-	
+
 	private volatile int soTimeout;
 
 	private volatile int soSendBufferSize;
 
 	private volatile int soReceiveBufferSize;
-	
+
 	private volatile boolean soTcpNoDelay;
 
 	private volatile int soLinger  = -1; // don't set by default
@@ -63,13 +64,13 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 	private volatile boolean soKeepAlive;
 
 	private volatile int soTrafficClass = -1; // don't set by default
-	
+
 	private volatile Executor taskExecutor;
-	
+
 	private volatile Deserializer<?> deserializer = new ByteArrayCrLfSerializer();
-	
+
 	private volatile Serializer<?> serializer = new ByteArrayCrLfSerializer();
-	
+
 	private volatile TcpMessageMapper mapper = new TcpMessageMapper();
 
 	private volatile boolean singleUse;
@@ -77,15 +78,17 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 	private volatile int poolSize = 5;
 
 	private volatile TcpConnectionInterceptorFactoryChain interceptorFactoryChain;
-	
+
 	private volatile boolean lookupHost = true;
-	
+
 	private volatile String localAddress;
 
 	private volatile boolean usingNio;
-	
+
 	private volatile boolean usingDirectBuffers;
-	
+
+	private volatile String beanName;
+
 	@Override
 	public Class<?> getObjectType() {
 		return this.connectionFactory != null ? this.connectionFactory.getClass() 
@@ -140,6 +143,7 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 		factory.setSoTimeout(this.soTimeout);
 		factory.setSoTrafficClass(this.soTrafficClass);
 		factory.setTaskExecutor(this.taskExecutor);
+		factory.setBeanName(this.beanName);
 	}
 
 	private void setServerAttributes(AbstractServerConnectionFactory factory) {
@@ -353,6 +357,10 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 
 	public boolean isRunning() {
 		return this.connectionFactory.isRunning();
+	}
+
+	public void setBeanName(String name) {
+		this.beanName = name;
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
@@ -24,13 +24,11 @@ import org.springframework.core.serializer.Serializer;
 import org.springframework.integration.ip.tcp.connection.AbstractConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.TcpConnectionInterceptorFactoryChain;
-import org.springframework.integration.ip.tcp.connection.TcpListener;
 import org.springframework.integration.ip.tcp.connection.TcpMessageMapper;
 import org.springframework.integration.ip.tcp.connection.TcpNetClientConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.TcpNetServerConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.TcpNioClientConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.TcpNioServerConnectionFactory;
-import org.springframework.integration.ip.tcp.connection.TcpSender;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer;
 
 /**
@@ -44,55 +42,49 @@ import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer
 public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<AbstractConnectionFactory> 
 		implements SmartLifecycle {
 
-	private AbstractConnectionFactory connectionFactory;
+	private volatile AbstractConnectionFactory connectionFactory;
 	
-	private String type;
+	private volatile String type;
 
-	protected String host;
+	private volatile String host;
 	
-	protected int port;
+	private volatile int port;
 	
-	protected TcpListener listener;
+	private volatile int soTimeout;
 
-	protected TcpSender sender;
+	private volatile int soSendBufferSize;
 
-	protected int soTimeout;
-
-	private int soSendBufferSize;
-
-	private int soReceiveBufferSize;
+	private volatile int soReceiveBufferSize;
 	
-	private boolean soTcpNoDelay;
+	private volatile boolean soTcpNoDelay;
 
-	private int soLinger  = -1; // don't set by default
+	private volatile int soLinger  = -1; // don't set by default
 
-	private boolean soKeepAlive;
+	private volatile boolean soKeepAlive;
 
-	private int soTrafficClass = -1; // don't set by default
+	private volatile int soTrafficClass = -1; // don't set by default
 	
-	private Executor taskExecutor;
+	private volatile Executor taskExecutor;
 	
-	protected Deserializer<?> deserializer = new ByteArrayCrLfSerializer();
+	private volatile Deserializer<?> deserializer = new ByteArrayCrLfSerializer();
 	
-	protected Serializer<?> serializer = new ByteArrayCrLfSerializer();
+	private volatile Serializer<?> serializer = new ByteArrayCrLfSerializer();
 	
-	protected TcpMessageMapper mapper = new TcpMessageMapper();
+	private volatile TcpMessageMapper mapper = new TcpMessageMapper();
 
-	protected boolean singleUse;
+	private volatile boolean singleUse;
 
-	protected int poolSize = 5;
+	private volatile int poolSize = 5;
 
-	protected volatile boolean active;
-
-	protected TcpConnectionInterceptorFactoryChain interceptorFactoryChain;
+	private volatile TcpConnectionInterceptorFactoryChain interceptorFactoryChain;
 	
-	private boolean lookupHost = true;
+	private volatile boolean lookupHost = true;
 	
-	private String localAddress;
+	private volatile String localAddress;
 
-	private boolean usingNio;
+	private volatile boolean usingNio;
 	
-	private boolean usingDirectBuffers;
+	private volatile boolean usingDirectBuffers;
 	
 	@Override
 	public Class<?> getObjectType() {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpInboundChannelAdapterParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpInboundChannelAdapterParser.java
@@ -42,6 +42,10 @@ public class TcpInboundChannelAdapterParser extends AbstractChannelAdapterParser
 				element, "channel", "outputChannel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder,
 				element, "error-channel", "errorChannel");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.AUTO_STARTUP);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.PHASE);
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpOutboundChannelAdapterParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpOutboundChannelAdapterParser.java
@@ -36,6 +36,10 @@ public class TcpOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 				".TcpSendingMessageHandler");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, 
 				IpAdapterParserUtils.TCP_CONNECTION_FACTORY);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.AUTO_STARTUP);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.PHASE);
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpOutboundGatewayParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpOutboundGatewayParser.java
@@ -49,6 +49,10 @@ public class TcpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 				IpAdapterParserUtils.REQUEST_TIMEOUT);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, 
 				IpAdapterParserUtils.REPLY_TIMEOUT);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.AUTO_STARTUP);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.PHASE);
 		return builder;
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2001-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,10 +134,6 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler imp
 			return false;
 		}
 		reply.setReply(message);
-		return false;
-	}
-
-	public boolean isListening() {
 		return false;
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.context.SmartLifecycle;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessageTimeoutException;
@@ -35,28 +36,34 @@ import org.springframework.integration.ip.tcp.connection.TcpListener;
 import org.springframework.integration.ip.tcp.connection.TcpSender;
 import org.springframework.util.Assert;
 
-/** 
+/**
  * TCP outbound gateway that uses a client connection factory. If the factory is configured
  * for single-use connections, each request is sent on a new connection; if the factory does not use
  * single use connections, each request is blocked until the previous response is received
- * (or times out). Asynchronous requests/responses over the same connection are not 
+ * (or times out). Asynchronous requests/responses over the same connection are not
  * supported - use a pair of outbound/inbound adapters for that use case.
- * 
+ * <p/>
+ * {@link SmartLifecycle} methods delegate to the underlying {@link AbstractConnectionFactory}
+ *
+ *
  * @author Gary Russell
  * @since 2.0
  */
-public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler implements TcpSender, TcpListener {
+public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler implements TcpSender, TcpListener, SmartLifecycle {
 
-	protected AbstractConnectionFactory connectionFactory;
-	
+	protected volatile AbstractConnectionFactory connectionFactory;
+
 	private Map<String, AsyncReply> pendingReplies = new ConcurrentHashMap<String, AsyncReply>();
-	
+
 	private Semaphore semaphore = new Semaphore(1, true);
 
-	private long replyTimeout = 10000;
-	
-	private long requestTimeout = 10000;
+	private volatile long replyTimeout = 10000;
 
+	private volatile long requestTimeout = 10000;
+
+	private volatile boolean autoStartup = true;
+
+	private volatile int phase;
 
 	/**
 	 * @param requestTimeout the requestTimeout to set
@@ -98,7 +105,7 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler imp
 			connection.send(requestMessage);
 			Message<?> replyMessage = reply.getReply();
 			if (replyMessage == null) {
-				throw new MessageTimeoutException(requestMessage, "Timed out waiting for response");				
+				throw new MessageTimeoutException(requestMessage, "Timed out waiting for response");
 			}
 			if (logger.isDebugEnabled()) {
 				logger.debug("Respose " + replyMessage);
@@ -138,7 +145,7 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler imp
 	}
 
 	public void setConnectionFactory(AbstractConnectionFactory connectionFactory) {
-		Assert.isTrue(connectionFactory instanceof AbstractClientConnectionFactory, 
+		Assert.isTrue(connectionFactory instanceof AbstractClientConnectionFactory,
 				this.getClass().getName() + " requires a client connection factory");
 		this.connectionFactory = connectionFactory;
 		connectionFactory.registerListener(this);
@@ -153,10 +160,52 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler imp
 		// do nothing - no asynchronous multiplexing supported
 	}
 
+	/**
+	 * Specify the Spring Integration reply channel. If this property is not
+	 * set the gateway will check for a 'replyChannel' header on the request.
+	 */
+	public void setReplyChannel(MessageChannel replyChannel) {
+		this.setOutputChannel(replyChannel);
+	}
+	public String getComponentType(){
+		return "ip:tcp-outbound-gateway";
+	}
+
+	public void start() {
+		this.connectionFactory.start();
+	}
+
+	public void stop() {
+		this.connectionFactory.stop();
+	}
+
+	public boolean isRunning() {
+		return this.connectionFactory.isRunning();
+	}
+
+	public int getPhase() {
+		return this.phase;
+	}
+
+	public boolean isAutoStartup() {
+		return this.autoStartup;
+	}
+
+	public void stop(Runnable callback) {
+		this.connectionFactory.stop(callback);
+	}
+
+	public void setAutoStartup(boolean autoStartup) {
+		this.autoStartup = autoStartup;
+	}
+
+	public void setPhase(int phase) {
+		this.phase = phase;
+	}
 
 	/**
 	 * Class used to coordinate the asynchronous reply to its request.
-	 * 
+	 *
 	 * @author Gary Russell
 	 * @since 2.0
 	 */
@@ -193,14 +242,4 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler imp
 		}
 	}
 
-	/**
-	 * Specify the Spring Integration reply channel. If this property is not
-	 * set the gateway will check for a 'replyChannel' header on the request.
-	 */
-	public void setReplyChannel(MessageChannel replyChannel) {
-		this.setOutputChannel(replyChannel);
-	}
-	public String getComponentType(){
-		return "ip:tcp-outbound-gateway";
-	}
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapter.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapter.java
@@ -51,12 +51,22 @@ public class TcpReceivingChannelAdapter
 	
 	@Override
 	protected void doStart() {
-		// Nothing to do; we're passive
+		if (this.serverConnectionFactory != null) {
+			this.serverConnectionFactory.start();
+		}
+		if (this.clientConnectionFactory != null) {
+			this.clientConnectionFactory.start();
+		}
 	}
 
 	@Override
 	protected void doStop() {
-		// Nothing to do; we're passive
+		if (this.clientConnectionFactory != null) {
+			this.clientConnectionFactory.stop();
+		}
+		if (this.serverConnectionFactory != null) {
+			this.serverConnectionFactory.stop();
+		}
 	}
 
 	/**

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandler.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageDeliveryException;
 import org.springframework.integration.MessageHandlingException;
@@ -35,7 +36,7 @@ import org.springframework.integration.ip.tcp.connection.TcpSender;
 import org.springframework.integration.mapping.MessageMappingException;
 
 /**
- * Tcp outbound channel adapter using a TcpConnection to 
+ * Tcp outbound channel adapter using a TcpConnection to
  * send data - if the connection factory is a server
  * factory, the TcpListener owns the connections. If it is
  * a client factory, this object owns the connection.
@@ -43,39 +44,33 @@ import org.springframework.integration.mapping.MessageMappingException;
  * @since 2.0
  *
  */
-public class TcpSendingMessageHandler extends AbstractMessageHandler implements TcpSender {
-	
-	protected Log logger = LogFactory.getLog(this.getClass());	
-	
-	protected TcpConnection connection;
-	
-	protected ConnectionFactory clientConnectionFactory;
-	
-	protected ConnectionFactory serverConnectionFactory;
-	
+public class TcpSendingMessageHandler extends AbstractMessageHandler implements TcpSender, SmartLifecycle {
+
+	protected final Log logger = LogFactory.getLog(this.getClass());
+
+	protected volatile ConnectionFactory clientConnectionFactory;
+
+	protected volatile ConnectionFactory serverConnectionFactory;
+
 	protected Map<String, TcpConnection> connections = new ConcurrentHashMap<String, TcpConnection>();
-	
+
+	private volatile boolean autoStartup;
+
+	private volatile int phase;
+
 	protected synchronized TcpConnection getConnection() {
+		TcpConnection connection = null;
 		try {
-			this.connection = clientConnectionFactory.getConnection();
+			connection = clientConnectionFactory.getConnection();
 		} catch (Exception e) {
 			logger.error("Error creating SocketWriter", e);
 		}
-		return this.connection;
-	}
-
-	/**
-	 * Close the underlying socket and prepare to establish a new socket on
-	 * the next write.
-	 */
-	protected void close() {
-		this.connection.close();
-		this.connection = null;
+		return connection;
 	}
 
 	/**
 	 * Writes the message payload to the underlying socket, using the specified
-	 * message format. 
+	 * message format.
 	 * @see org.springframework.integration.core.MessageHandler#handleMessage(org.springframework.integration.Message)
 	 */
 	public void handleMessageInternal(final Message<?> message) throws MessageRejectedException,
@@ -96,7 +91,7 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements 
 			}
 			return;
 		}
-		
+
 		// we own the connection
 		try {
 			doWrite(message);
@@ -116,8 +111,9 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements 
 	 * @param message The message to write.
 	 */
 	protected void doWrite(Message<?> message) {
+		TcpConnection connection = null;
 		try {
-			TcpConnection connection = getConnection();
+			connection = getConnection();
 			if (connection == null) {
 				throw new MessageMappingException(message, "Failed to create connection");
 			}
@@ -126,11 +122,10 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements 
 			}
 			connection.send(message);
 		} catch (Exception e) {
-			String connectionId = null; 
-			if (this.connection != null) {
-				connectionId = this.connection.getConnectionId();
+			String connectionId = null;
+			if (connection != null) {
+				connectionId = connection.getConnectionId();
 			}
-			this.connection = null;
 			if (e instanceof MessageMappingException) {
 				throw (MessageMappingException) e;
 			}
@@ -142,7 +137,7 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements 
 	 * Sets the client or server connection factory; for this (an outbound adapter), if
 	 * the factory is a server connection factory, the sockets are owned by a receiving
 	 * channel adapter and this adapter is used to send replies.
-	 * 
+	 *
 	 * @param connectionFactory the connectionFactory to set
 	 */
 	public void setConnectionFactory(AbstractConnectionFactory connectionFactory) {
@@ -157,11 +152,61 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements 
 	public void addNewConnection(TcpConnection connection) {
 		connections.put(connection.getConnectionId(), connection);
 	}
-	
+
 	public void removeDeadConnection(TcpConnection connection) {
 		connections.remove(connection.getConnectionId());
 	}
 	public String getComponentType(){
 		return "ip:tcp-outbound-channel-adapter";
 	}
+
+	public void start() {
+		if (this.clientConnectionFactory != null) {
+			this.clientConnectionFactory.start();
+		}
+		if (this.serverConnectionFactory != null) {
+			this.serverConnectionFactory.start();
+		}
+	}
+
+	public void stop() {
+		if (this.clientConnectionFactory != null) {
+			this.clientConnectionFactory.stop();
+		}
+		if (this.serverConnectionFactory != null) {
+			this.serverConnectionFactory.stop();
+		}
+	}
+
+	public boolean isRunning() {
+		boolean cfRunning = this.clientConnectionFactory != null ? this.clientConnectionFactory.isRunning() : false;
+		boolean sfRunning = this.serverConnectionFactory != null ? this.serverConnectionFactory.isRunning() : false;
+		return cfRunning | sfRunning;
+	}
+
+	public int getPhase() {
+		return this.phase;
+	}
+
+	public boolean isAutoStartup() {
+		return this.autoStartup;
+	}
+
+	public void stop(Runnable callback) {
+		if (this.clientConnectionFactory != null) {
+			this.clientConnectionFactory.stop(callback);
+		}
+		if (this.serverConnectionFactory != null) {
+			this.serverConnectionFactory.stop(callback);
+		}
+	}
+
+	public void setAutoStartup(boolean autoStartup) {
+		this.autoStartup = autoStartup;
+	}
+
+	public void setPhase(int phase) {
+		this.phase = phase;
+	}
+
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
@@ -19,8 +19,6 @@ package org.springframework.integration.ip.tcp.connection;
 import java.net.Socket;
 import java.net.SocketException;
 
-import org.springframework.util.Assert;
-
 /**
  * Abstract class for client connection factories; client connection factories
  * establish outgoing connections.
@@ -38,9 +36,7 @@ public abstract class AbstractClientConnectionFactory extends AbstractConnection
 	 * @param port The port.
 	 */
 	public AbstractClientConnectionFactory(String host, int port) {
-		Assert.notNull(host, "host must not be null");
-		this.host = host;
-		this.port = port;
+		super(host, port);
 	}
 	
 	/**
@@ -53,11 +49,12 @@ public abstract class AbstractClientConnectionFactory extends AbstractConnection
 	 * @param socket The new socket. 
 	 */
 	protected void initializeConnection(TcpConnection connection, Socket socket) {
-		if (this.listener != null) {
-			connection.registerListener(this.listener);
+		TcpListener listener = this.getListener();
+		if (listener != null) {
+			connection.registerListener(listener);
 		}
-		if (this.listener != null || this.singleUse) {
-			if (this.soTimeout <= 0) {
+		if (listener != null || this.isSingleUse()) {
+			if (this.getSoTimeout() <= 0) {
 				try {
 					socket.setSoTimeout(DEFAULT_REPLY_TIMEOUT);
 				} catch (SocketException e) {
@@ -65,10 +62,10 @@ public abstract class AbstractClientConnectionFactory extends AbstractConnection
 				}
 			}
 		}
-		connection.setMapper(this.mapper);
-		connection.setDeserializer(this.deserializer);
-		connection.setSerializer(this.serializer);
-		connection.setSingleUse(this.singleUse);
+		connection.setMapper(this.getMapper());
+		connection.setDeserializer(this.getDeserializer());
+		connection.setSerializer(this.getSerializer());
+		connection.setSingleUse(this.isSingleUse());
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -45,64 +45,74 @@ import org.springframework.util.Assert;
 
 /**
  * Base class for all connection factories.
- * 
+ *
  * @author Gary Russell
  * @since 2.0
  *
  */
-public abstract class AbstractConnectionFactory 
+public abstract class AbstractConnectionFactory
 		implements ConnectionFactory, Runnable, SmartLifecycle  {
 
-	protected Log logger = LogFactory.getLog(this.getClass());
-	
-	protected final static int DEFAULT_REPLY_TIMEOUT = 10000;
-	
-	protected String host;
-	
-	protected int port;
-	
-	protected TcpListener listener;
+	protected final Log logger = LogFactory.getLog(this.getClass());
 
-	protected TcpSender sender;
+	protected static final int DEFAULT_REPLY_TIMEOUT = 10000;
 
-	protected int soTimeout;
+	private volatile String host;
 
-	private int soSendBufferSize;
+	private volatile int port;
 
-	private int soReceiveBufferSize;
-	
-	private boolean soTcpNoDelay;
+	private volatile TcpListener listener;
 
-	private int soLinger  = -1; // don't set by default
+	private volatile TcpSender sender;
 
-	private boolean soKeepAlive;
+	private volatile int soTimeout;
 
-	private int soTrafficClass = -1; // don't set by default
-	
-	private Executor taskExecutor;
-	
-	private boolean privateExecutor;
+	private volatile int soSendBufferSize;
 
-	protected Deserializer<?> deserializer = new ByteArrayCrLfSerializer();
-	
-	protected Serializer<?> serializer = new ByteArrayCrLfSerializer();
-	
-	protected TcpMessageMapper mapper = new TcpMessageMapper();
+	private volatile int soReceiveBufferSize;
 
-	protected boolean singleUse;
+	private volatile boolean soTcpNoDelay;
 
-	protected int poolSize = 5;
+	private volatile int soLinger  = -1; // don't set by default
 
-	protected volatile boolean active;
+	private volatile boolean soKeepAlive;
 
-	protected TcpConnectionInterceptorFactoryChain interceptorFactoryChain;
-	
-	private boolean lookupHost = true;
-	
-	private List<TcpConnection> connections = new LinkedList<TcpConnection>();
+	private volatile int soTrafficClass = -1; // don't set by default
+
+	private volatile Executor taskExecutor;
+
+	private volatile boolean privateExecutor;
+
+	private volatile Deserializer<?> deserializer = new ByteArrayCrLfSerializer();
+
+	private volatile Serializer<?> serializer = new ByteArrayCrLfSerializer();
+
+	private volatile TcpMessageMapper mapper = new TcpMessageMapper();
+
+	private volatile boolean singleUse;
+
+	private volatile int poolSize = 5;
+
+	private volatile boolean active;
+
+	private volatile TcpConnectionInterceptorFactoryChain interceptorFactoryChain;
+
+	private volatile boolean lookupHost = true;
+
+	private volatile List<TcpConnection> connections = new LinkedList<TcpConnection>();
 
 	protected final Object lifecycleMonitor = new Object();
-	
+
+	public AbstractConnectionFactory(int port) {
+		this.port = port;
+	}
+
+	public AbstractConnectionFactory(String host, int port) {
+		Assert.notNull(host, "host must not be null");
+		this.host = host;
+		this.port = port;
+	}
+
 	/**
 	 * Sets socket attributes on the socket.
 	 * @param socket The socket.
@@ -241,6 +251,48 @@ public abstract class AbstractConnectionFactory
 	}
 
 	/**
+	 * @return the listener
+	 */
+	public TcpListener getListener() {
+		return listener;
+	}
+
+	/**
+	 * @return the sender
+	 */
+	public TcpSender getSender() {
+		return sender;
+	}
+
+	/**
+	 * @return the serializer
+	 */
+	public Serializer<?> getSerializer() {
+		return serializer;
+	}
+
+	/**
+	 * @return the deserializer
+	 */
+	public Deserializer<?> getDeserializer() {
+		return deserializer;
+	}
+
+	/**
+	 * @return the mapper
+	 */
+	public TcpMessageMapper getMapper() {
+		return mapper;
+	}
+
+	/**
+	 * @return the poolSize
+	 */
+	public int getPoolSize() {
+		return poolSize;
+	}
+
+	/**
 	 * Registers a TcpListener to receive messages after
 	 * the payload has been converted from the input data.
 	 * @param listener the TcpListener.
@@ -252,7 +304,7 @@ public abstract class AbstractConnectionFactory
 	}
 
 	/**
-	 * Registers a TcpSender; for server sockets, used to 
+	 * Registers a TcpSender; for server sockets, used to
 	 * provide connection information so a sender can be used
 	 * to reply to incoming messages.
 	 * @param sender The sender
@@ -271,7 +323,7 @@ public abstract class AbstractConnectionFactory
 	}
 
 	/**
-	 * 
+	 *
 	 * @param deserializer the deserializer to set
 	 */
 	public void setDeserializer(Deserializer<?> deserializer) {
@@ -279,7 +331,7 @@ public abstract class AbstractConnectionFactory
 	}
 
 	/**
-	 * 
+	 *
 	 * @param serializer the serializer to set
 	 */
 	public void setSerializer(Serializer<?> serializer) {
@@ -287,7 +339,7 @@ public abstract class AbstractConnectionFactory
 	}
 
 	/**
-	 * 
+	 *
 	 * @param mapper the mapper to set; defaults to a {@link TcpMessageMapper}
 	 */
 	public void setMapper(TcpMessageMapper mapper) {
@@ -309,7 +361,7 @@ public abstract class AbstractConnectionFactory
 		this.singleUse = singleUse;
 	}
 
-	
+
 	public void setPoolSize(int poolSize) {
 		this.poolSize = poolSize;
 	}
@@ -352,7 +404,7 @@ public abstract class AbstractConnectionFactory
 	}
 
 	/**
-	 * Creates a taskExecutor (if one was not provided). 
+	 * Creates a taskExecutor (if one was not provided).
 	 */
 	protected Executor getTaskExecutor() {
 		synchronized (this.lifecycleMonitor) {
@@ -388,7 +440,7 @@ public abstract class AbstractConnectionFactory
 				try {
 					if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
 						logger.debug("Forcing executor shutdown");
-						executorService.shutdownNow();					
+						executorService.shutdownNow();
 						if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
 							logger.debug("Executor failed to shutdown");
 						}
@@ -409,7 +461,7 @@ public abstract class AbstractConnectionFactory
 			if (this.interceptorFactoryChain == null) {
 				return connection;
 			}
-			TcpConnectionInterceptorFactory[] interceptorFactories = 
+			TcpConnectionInterceptorFactory[] interceptorFactories =
 				this.interceptorFactoryChain.getInterceptorFactories();
 			if (interceptorFactories == null) {
 				return connection;
@@ -433,9 +485,9 @@ public abstract class AbstractConnectionFactory
 	}
 
 	/**
-	 * 
+	 *
 	 * Times out any expired connections then, if selectionCount > 0, processes the selected keys.
-	 *  
+	 *
 	 * @param selectionCount
 	 * @param selector
 	 * @param connections
@@ -483,7 +535,7 @@ public abstract class AbstractConnectionFactory
 				else if (key.isReadable()) {
 					try {
 						key.interestOps(key.interestOps() - key.readyOps());
-						final TcpNioConnection connection; 
+						final TcpNioConnection connection;
 						connection = (TcpNioConnection) key.attachment();
 						connection.setLastRead(System.currentTimeMillis());
 						this.taskExecutor.execute(new Runnable() {
@@ -535,7 +587,7 @@ public abstract class AbstractConnectionFactory
 	protected void doAccept(final Selector selector, ServerSocketChannel server, long now) throws IOException {
 		throw new UnsupportedOperationException("Nio server factory must override this method");
 	}
-	
+
 	public int getPhase() {
 		return 0;
 	}
@@ -558,7 +610,7 @@ public abstract class AbstractConnectionFactory
 			this.connections.add(connection);
 		}
 	}
-	
+
 	protected void harvestClosedConnections() {
 		synchronized (this.connections) {
 			Iterator<TcpConnection> iterator = this.connections.iterator();
@@ -569,5 +621,23 @@ public abstract class AbstractConnectionFactory
 				}
 			}
 		}
+	}
+
+	public boolean isRunning() {
+		return this.active;
+	}
+
+	/**
+	 * @return the active
+	 */
+	protected boolean isActive() {
+		return active;
+	}
+
+	/**
+	 * @param active the active to set
+	 */
+	protected void setActive(boolean active) {
+		this.active = active;
 	}
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -36,10 +36,12 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.core.serializer.Deserializer;
 import org.springframework.core.serializer.Serializer;
 import org.springframework.integration.MessagingException;
+import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer;
 import org.springframework.util.Assert;
 
@@ -50,8 +52,8 @@ import org.springframework.util.Assert;
  * @since 2.0
  *
  */
-public abstract class AbstractConnectionFactory
-		implements ConnectionFactory, Runnable, SmartLifecycle  {
+public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
+		implements ConnectionFactory, Runnable, SmartLifecycle, BeanNameAware  {
 
 	protected final Log logger = LogFactory.getLog(this.getClass());
 
@@ -401,6 +403,9 @@ public abstract class AbstractConnectionFactory
 				this.getTaskExecutor().execute(this);
 			}
 		}
+		if (logger.isInfoEnabled()) {
+			logger.info("started " + this);
+		}
 	}
 
 	/**
@@ -453,6 +458,9 @@ public abstract class AbstractConnectionFactory
 					this.privateExecutor = false;
 				}
 			}
+		}
+		if (logger.isInfoEnabled()) {
+			logger.info("stopped " + this);
 		}
 	}
 
@@ -592,8 +600,12 @@ public abstract class AbstractConnectionFactory
 		return 0;
 	}
 
+	/**
+	 * We are controlled by the startup options of
+	 * the bound endpoint.
+	 */
 	public boolean isAutoStartup() {
-		return true;
+		return false;
 	}
 
 	public void stop(Runnable callback) {
@@ -640,4 +652,11 @@ public abstract class AbstractConnectionFactory
 	protected void setActive(boolean active) {
 		this.active = active;
 	}
+
+	protected void checkActive() throws IOException {
+		if (!this.isActive()) {
+			throw new IOException(this + " connection factory has not been started");
+		}
+	}
+
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractServerConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2001-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public abstract class AbstractServerConnectionFactory extends AbstractConnection
 	 * @param port
 	 */
 	public AbstractServerConnectionFactory(int port) {
-		this.port = port;
+		super(port);
 	}
 
 
@@ -66,20 +66,21 @@ public abstract class AbstractServerConnectionFactory extends AbstractConnection
 	 * @param socket The new socket. 
 	 */
 	protected void initializeConnection(TcpConnection connection, Socket socket) {
-		if (this.listener != null) {
-			connection.registerListener(this.listener);
+		TcpListener listener = this.getListener();
+		if (listener != null) {
+			connection.registerListener(listener);
 		}
-		connection.registerSender(this.sender);
-		connection.setMapper(this.mapper);
-		connection.setDeserializer(this.deserializer);
-		connection.setSerializer(this.serializer);
-		connection.setSingleUse(this.singleUse);
+		connection.registerSender(this.getSender());
+		connection.setMapper(this.getMapper());
+		connection.setDeserializer(this.getDeserializer());
+		connection.setSerializer(this.getSerializer());
+		connection.setSingleUse(this.isSingleUse());
 		/*
 		 * If we have a collaborating outbound channel adapter and we are configured
 		 * for single use; need to enforce a timeout on the socket so we will close
 		 * it some period after the response was sent (timeout on the next read).
 		 */
-		if (this.singleUse && this.soTimeout <= 0 && this.listener != null) {
+		if (this.isSingleUse() && this.getSoTimeout() <= 0 && listener != null) {
 			try {
 				socket.setSoTimeout(DEFAULT_REPLY_TIMEOUT);
 			} catch (SocketException e) {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractTcpConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractTcpConnection.java
@@ -33,7 +33,7 @@ import org.springframework.util.Assert;
  * Base class for TcpConnections. TcpConnections are established by
  * client connection factories (outgoing) or server connection factories
  * (incoming).
- * 
+ *
  * @author Gary Russell
  * @since 2.0
  *
@@ -41,17 +41,17 @@ import org.springframework.util.Assert;
 public abstract class AbstractTcpConnection implements TcpConnection {
 
 	protected final Log logger = LogFactory.getLog(this.getClass());
-	
+
 	@SuppressWarnings("rawtypes")
 	private volatile Deserializer deserializer;
-	
+
 	@SuppressWarnings("rawtypes")
 	private volatile Serializer serializer;
-	
+
 	private volatile TcpMessageMapper mapper;
-	
+
 	private volatile TcpListener listener;
-	
+
 	private volatile TcpListener actualListener;
 
 	private volatile TcpSender sender;
@@ -61,20 +61,21 @@ public abstract class AbstractTcpConnection implements TcpConnection {
 	private final boolean server;
 
 	private volatile String connectionId;
-	
+
 	private final AtomicLong sequence = new AtomicLong();
-	
+
 	private volatile int soLinger = -1;
 
 	private volatile String hostName = "unknown";
 
 	private volatile String hostAddress = "unknown";
-	
+
 	private volatile int port;
-	
+
+	private static AtomicLong connectionNumber = new AtomicLong();
+
 	public AbstractTcpConnection(Socket socket, boolean server, boolean lookupHost) {
 		this.server = server;
-		int hashCode = socket.hashCode();
 		InetAddress inetAddress = socket.getInetAddress();
 		if (inetAddress != null) {
 			this.hostAddress = inetAddress.getHostAddress();
@@ -84,12 +85,12 @@ public abstract class AbstractTcpConnection implements TcpConnection {
 				this.hostName = this.hostAddress;
 			}
 		}
-		this.connectionId = this.hostName + ":" + this.port + ":" + hashCode;
+		this.connectionId = this.hostName + ":" + this.port + ":" + connectionNumber.incrementAndGet();
 		try {
 			this.soLinger = socket.getSoLinger();
 		} catch (SocketException e) { }
 	}
-	
+
 	public void afterSend(Message<?> message) throws Exception {
 		if (logger.isDebugEnabled())
 			logger.debug("Message sent " + message);
@@ -114,7 +115,7 @@ public abstract class AbstractTcpConnection implements TcpConnection {
 	}
 
 	/**
-	 * If we have been intercepted, propagate the close from the outermost interceptor; 
+	 * If we have been intercepted, propagate the close from the outermost interceptor;
 	 * otherwise, just call close().
 	 */
 	protected void closeConnection() {
@@ -142,14 +143,14 @@ public abstract class AbstractTcpConnection implements TcpConnection {
 	public void setMapper(TcpMessageMapper mapper) {
 		Assert.notNull(mapper, this.getClass().getName() + " Mapper may not be null");
 		this.mapper = mapper;
-		if (this.serializer != null && 
+		if (this.serializer != null &&
 			 !(this.serializer instanceof AbstractByteArraySerializer)) {
 			mapper.setStringToBytes(false);
 		}
 	}
 
 	/**
-	 * 
+	 *
 	 * @return the deserializer
 	 */
 	public Deserializer<?> getDeserializer() {
@@ -164,7 +165,7 @@ public abstract class AbstractTcpConnection implements TcpConnection {
 	}
 
 	/**
-	 * 
+	 *
 	 * @return the serializer
 	 */
 	public Serializer<?> getSerializer() {
@@ -172,7 +173,7 @@ public abstract class AbstractTcpConnection implements TcpConnection {
 	}
 
 	/**
-	 * @param serializer the serializer to set 
+	 * @param serializer the serializer to set
 	 */
 	public void setSerializer(Serializer<?> serializer) {
 		this.serializer = serializer;
@@ -197,7 +198,7 @@ public abstract class AbstractTcpConnection implements TcpConnection {
 			this.actualListener = outerInterceptor.getListener();
 		}
 	}
-	
+
 	/**
 	 * @param sender the sender to set
 	 */
@@ -214,7 +215,7 @@ public abstract class AbstractTcpConnection implements TcpConnection {
 	public TcpListener getListener() {
 		return this.listener;
 	}
-	
+
 	/**
 	 * @return the sender
 	 */
@@ -223,7 +224,7 @@ public abstract class AbstractTcpConnection implements TcpConnection {
 	}
 
 	/**
-	 * @param singleUse true if this socket is to used once and 
+	 * @param singleUse true if this socket is to used once and
 	 * discarded.
 	 */
 	public void setSingleUse(boolean singleUse) {
@@ -231,7 +232,7 @@ public abstract class AbstractTcpConnection implements TcpConnection {
 	}
 
 	/**
-	 * 
+	 *
 	 * @return True if connection is used once.
 	 */
 	public boolean isSingleUse() {
@@ -257,5 +258,5 @@ public abstract class AbstractTcpConnection implements TcpConnection {
 	public String getConnectionId() {
 		return this.connectionId;
 	}
-	
+
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractTcpConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractTcpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2001-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,56 +40,51 @@ import org.springframework.util.Assert;
  */
 public abstract class AbstractTcpConnection implements TcpConnection {
 
-	protected Log logger = LogFactory.getLog(this.getClass());
+	protected final Log logger = LogFactory.getLog(this.getClass());
 	
 	@SuppressWarnings("rawtypes")
-	protected Deserializer deserializer;
+	private volatile Deserializer deserializer;
 	
 	@SuppressWarnings("rawtypes")
-	protected Serializer serializer;
+	private volatile Serializer serializer;
 	
-	protected TcpMessageMapper mapper;
+	private volatile TcpMessageMapper mapper;
 	
-	protected TcpListener listener;
+	private volatile TcpListener listener;
 	
-	private TcpListener actualListener;
+	private volatile TcpListener actualListener;
 
-	protected TcpSender sender;
+	private volatile TcpSender sender;
 
-	protected boolean singleUse;
+	private volatile boolean singleUse;
 
-	protected final boolean server;
+	private final boolean server;
 
-	protected String connectionId;
+	private volatile String connectionId;
 	
-	private AtomicLong sequence = new AtomicLong();
+	private final AtomicLong sequence = new AtomicLong();
 	
-	private int soLinger = -1;
+	private volatile int soLinger = -1;
 
-	private String hostName = "unknown";
+	private volatile String hostName = "unknown";
 
-	private String hostAddress = "unknown";
+	private volatile String hostAddress = "unknown";
 	
-	private int port;
-	
-	private final boolean lookupHost;
-
-	private int hashCode;
+	private volatile int port;
 	
 	public AbstractTcpConnection(Socket socket, boolean server, boolean lookupHost) {
 		this.server = server;
-		this.lookupHost = lookupHost;
-		this.hashCode = socket.hashCode();
+		int hashCode = socket.hashCode();
 		InetAddress inetAddress = socket.getInetAddress();
 		if (inetAddress != null) {
 			this.hostAddress = inetAddress.getHostAddress();
-			if (this.lookupHost) {
+			if (lookupHost) {
 				this.hostName = inetAddress.getHostName();
 			} else {
 				this.hostName = this.hostAddress;
 			}
 		}
-		this.connectionId = this.hostName + ":" + this.port + ":" + this.hashCode;
+		this.connectionId = this.hostName + ":" + this.port + ":" + hashCode;
 		try {
 			this.soLinger = socket.getSoLinger();
 		} catch (SocketException e) { }
@@ -220,6 +215,13 @@ public abstract class AbstractTcpConnection implements TcpConnection {
 		return this.listener;
 	}
 	
+	/**
+	 * @return the sender
+	 */
+	public TcpSender getSender() {
+		return sender;
+	}
+
 	/**
 	 * @param singleUse true if this socket is to used once and 
 	 * discarded.

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/ConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/ConnectionFactory.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.ip.tcp.connection;
 
+import org.springframework.context.SmartLifecycle;
+
 
 
 /**
@@ -25,7 +27,7 @@ package org.springframework.integration.ip.tcp.connection;
  * @since 2.0
  *
  */
-public interface ConnectionFactory {
+public interface ConnectionFactory extends SmartLifecycle {
 
 	TcpConnection getConnection() throws Exception;
 	

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/ConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/ConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2001-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,6 @@ package org.springframework.integration.ip.tcp.connection;
  */
 public interface ConnectionFactory {
 
-	public TcpConnection getConnection() throws Exception;
+	TcpConnection getConnection() throws Exception;
 	
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2001-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,9 @@ import org.springframework.integration.Message;
 /**
  * An abstraction over {@link Socket} and {@link SocketChannel} that
  * sends {@link Message} objects by serializing the payload
- * and streaming it to the destination. Requires a {@link TcpListener} 
+ * and streaming it to the destination. Requires a {@link TcpListener}
  * to receive incoming messages.
- *   
+ *
  * @author Gary Russell
  * @since 2.0
  *
@@ -38,115 +38,115 @@ public interface TcpConnection extends Runnable {
 	/**
 	 * Closes the connection.
 	 */
-	public void close();
+	void close();
 
 	/**
 	 * @return true if the connection is open.
 	 */
-	public boolean isOpen();
+	boolean isOpen();
 
 	/**
 	 * Converts and sends the message.
 	 * @param message The message
-	 * @throws Exception 
+	 * @throws Exception
 	 */
-	public void send(Message<?> message) throws Exception;
+	void send(Message<?> message) throws Exception;
 
 	/**
 	 * Uses the deserializer to obtain the message payload
 	 * from the connection's input stream.
 	 * @return The payload
-	 * @throws Exception 
+	 * @throws Exception
 	 */
-	public Object getPayload() throws Exception;
+	Object getPayload() throws Exception;
 
 	/**
 	 * @return the host name
 	 */
-	public String getHostName();
+	String getHostName();
 
 	/**
 	 * @return the host address
 	 */
-	public String getHostAddress();
+	String getHostAddress();
 
 	/**
 	 * @return the port
 	 */
-	public int getPort();
+	int getPort();
 
 	/**
-	 * Sets the listener that will receive incoming Messages. 
+	 * Sets the listener that will receive incoming Messages.
 	 * @param listener The listener
 	 */
-	public void registerListener(TcpListener listener);
+	void registerListener(TcpListener listener);
 
 	/**
 	 * Registers a sender. Used on server side sockets so a
 	 * sender can determine which connection to send a reply
 	 * to.
-	 * @param sender the sender 
+	 * @param sender the sender
 	 */
-	public void registerSender(TcpSender sender);
+	void registerSender(TcpSender sender);
 	
 	/**
 	 * @return a string uniquely representing a connection.
 	 */
-	public String getConnectionId();
+	String getConnectionId();
 	
 	/**
 	 * When true, the socket is used once and discarded.
 	 * @param singleUse the singleUse
 	 */
-	public void setSingleUse(boolean singleUse);
+	void setSingleUse(boolean singleUse);
 
 	/**
-	 * 
+	 *
 	 * @return True if connection is used once.
 	 */
-	public boolean isSingleUse(); 
+	boolean isSingleUse();
 	
 	/**
-	 * 
+	 *
 	 * @return True if connection is used once.
 	 */
-	public boolean isServer(); 
+	boolean isServer();
 	
 	/**
 	 * @param mapper the mapper
 	 */
-	public void setMapper(TcpMessageMapper mapper);
+	void setMapper(TcpMessageMapper mapper);
 
 	/**
-	 * 
+	 *
 	 * @return the deserializer
 	 */
-	public Deserializer<?> getDeserializer();
+	Deserializer<?> getDeserializer();
 
 	/**
 	 * @param deserializer the deserializer to set
 	 */
-	public void setDeserializer(Deserializer<?> deserializer);
+	void setDeserializer(Deserializer<?> deserializer);
 
 	/**
-	 * 
+	 *
 	 * @return the serializer
 	 */
-	public Serializer<?> getSerializer();
+	Serializer<?> getSerializer();
 	
 	/**
 	 * @param serializer the serializer to set
 	 */
-	public void setSerializer(Serializer<?> serializer);
+	void setSerializer(Serializer<?> serializer);
 	
 	/**
 	 * @return this connection's listener
 	 */
-	public TcpListener getListener();
+	TcpListener getListener();
 
 	/**
 	 * @return the next sequence number for a message received on this socket
 	 */
-	public long getConnectionSeq();
+	long getConnectionSeq();
 	
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptor.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2001-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,6 @@ package org.springframework.integration.ip.tcp.connection;
  */
 public interface TcpConnectionInterceptor extends TcpConnection, TcpListener, TcpSender {
 	
-	public void setTheConnection(TcpConnection connection);
+	void setTheConnection(TcpConnection connection);
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2001-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,6 @@ public interface TcpConnectionInterceptorFactory {
 	 *  
 	 * @return the TcpInterceptor 
 	 */
-	public abstract TcpConnectionInterceptor getInterceptor();
+	abstract TcpConnectionInterceptor getInterceptor();
 }
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpListener.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2001-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,6 @@ public interface TcpListener {
 	 * @param message The message.
 	 * @return true if the message was intercepted
 	 */
-	public abstract boolean onMessage(Message<?> message);
+	abstract boolean onMessage(Message<?> message);
 	
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetClientConnectionFactory.java
@@ -44,6 +44,7 @@ public class TcpNetClientConnectionFactory extends
 	 * reused for all requests while the connection remains open.
 	 */
 	public TcpConnection getConnection() throws Exception {
+		this.checkActive();
 		if (this.theConnection != null && this.theConnection.isOpen()) {
 			return this.theConnection;
 		}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetClientConnectionFactory.java
@@ -47,14 +47,16 @@ public class TcpNetClientConnectionFactory extends
 		if (this.theConnection != null && this.theConnection.isOpen()) {
 			return this.theConnection;
 		}
-		logger.debug("Opening new socket connection to " + this.host + ":" + this.port);
-		Socket socket = SocketFactory.getDefault().createSocket(this.host, this.port);
+		if (logger.isDebugEnabled()) {
+			logger.debug("Opening new socket connection to " + this.getHost() + ":" + this.getPort());
+		}
+		Socket socket = SocketFactory.getDefault().createSocket(this.getHost(), this.getPort());
 		setSocketAttributes(socket);
 		TcpConnection connection = new TcpNetConnection(socket, false, this.isLookupHost());
 		connection = wrapConnection(connection);
 		initializeConnection(connection, socket);
 		this.getTaskExecutor().execute(connection);
-		if (!this.singleUse) {
+		if (!this.isSingleUse()) {
 			this.theConnection = connection;
 		}
 		this.harvestClosedConnections();
@@ -65,10 +67,6 @@ public class TcpNetClientConnectionFactory extends
 	}
 
 	public void run() {
-	}
-
-	public boolean isRunning() {
-		return this.active;
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetServerConnectionFactory.java
@@ -52,22 +52,22 @@ public class TcpNetServerConnectionFactory extends AbstractServerConnectionFacto
 	 */
 	public void run() {
 		ServerSocket theServerSocket = null;
-		if (this.listener == null) {
+		if (this.getListener() == null) {
 			logger.info("No listener bound to server connection factory; will not read; exiting...");
 			return;
 		}
 		try {
 			if (this.localAddress == null) {
 				this.serverSocket = ServerSocketFactory.getDefault()
-						.createServerSocket(this.port, Math.abs(this.poolSize));
+						.createServerSocket(this.getPort(), Math.abs(this.getPoolSize()));
 			} else {
 				InetAddress whichNic = InetAddress.getByName(this.localAddress);
 				this.serverSocket = ServerSocketFactory.getDefault()
-						.createServerSocket(port, Math.abs(poolSize), whichNic);
+						.createServerSocket(this.getPort(), Math.abs(this.getPoolSize()), whichNic);
 			}
 			theServerSocket = this.serverSocket;
 			this.listening = true;
-			logger.info("Listening on port " + this.port);
+			logger.info("Listening on port " + this.getPort());
 			while (true) {
 				final Socket socket = serverSocket.accept();
 				logger.debug("Accepted connection from " + socket.getInetAddress().getHostAddress());
@@ -83,15 +83,11 @@ public class TcpNetServerConnectionFactory extends AbstractServerConnectionFacto
 			// don't log an error if we had a good socket once and now it's closed
 			if (e instanceof SocketException && theServerSocket != null) {
 				logger.warn("Server Socket closed");
-			} else if (this.active) {
+			} else if (this.isActive()) {
 				logger.error("Error on ServerSocket", e);
 			}
-			this.active = false;
+			this.setActive(false);
 		}
-	}
-
-	public boolean isRunning() {
-		return this.active;
 	}
 
 	public void close() {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
@@ -60,6 +60,7 @@ public class TcpNioClientConnectionFactory extends
 	 * reused for all requests while the connection remains open.
 	 */
 	public TcpConnection getConnection() throws Exception {
+		this.checkActive();
 		int n = 0;
 		while (this.selector == null) {
 			try {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/MulticastSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/MulticastSendingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2001-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,18 +101,18 @@ public class MulticastSendingMessageHandler extends UnicastSendingMessageHandler
 	protected synchronized DatagramSocket getSocket() throws IOException {
 		if (this.socket == null) {
 			MulticastSocket socket;
-			if (acknowledge) {
+			if (this.isAcknowledge()) {
 				if (logger.isDebugEnabled()) {
-					logger.debug("Listening for acks on port: " + ackPort);
+					logger.debug("Listening for acks on port: " + this.getAckPort());
 				}
 				if (localAddress == null) {
-					socket = new MulticastSocket(this.ackPort);
+					socket = new MulticastSocket(this.getAckPort());
 				} else {
 					InetAddress whichNic = InetAddress.getByName(this.localAddress);
-					socket = new MulticastSocket(new InetSocketAddress(whichNic, this.ackPort));
+					socket = new MulticastSocket(new InetSocketAddress(whichNic, this.getAckPort()));
 				}
-				if (this.soReceiveBufferSize > 0) {
-					socket.setReceiveBufferSize(this.soReceiveBufferSize);
+				if (this.getSoReceiveBufferSize() > 0) {
+					socket.setReceiveBufferSize(this.getSoReceiveBufferSize());
 				}
 			} else {
 				socket = new MulticastSocket();
@@ -137,7 +137,7 @@ public class MulticastSendingMessageHandler extends UnicastSendingMessageHandler
 	 * @param minAcksForSuccess
 	 */
 	public void setMinAcksForSuccess(int minAcksForSuccess) {
-		this.ackCounter = minAcksForSuccess;
+		this.setAckCounter(minAcksForSuccess);
 	}
 
 	/**

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastSendingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2001-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
-import java.net.Socket;
 import java.net.SocketException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,12 +36,11 @@ import org.springframework.integration.MessageDeliveryException;
 import org.springframework.integration.MessageHandlingException;
 import org.springframework.integration.MessageRejectedException;
 import org.springframework.integration.MessagingException;
-import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.ip.AbstractInternetProtocolSendingMessageHandler;
 import org.springframework.util.Assert;
 
 /**
- * A {@link MessageHandler} implementation that maps a Message into
+ * A {@link org.springframework.integration.core.MessageHandler} implementation that maps a Message into
  * a UDP datagram packet and sends that to the specified host and port.
  *
  * Messages can be basic, with no support for reliability, can be prefixed
@@ -55,7 +53,7 @@ import org.springframework.util.Assert;
 public class UnicastSendingMessageHandler extends
 		AbstractInternetProtocolSendingMessageHandler implements Runnable{
 
-	protected final DatagramPacketMessageMapper mapper = new DatagramPacketMessageMapper();
+	private final DatagramPacketMessageMapper mapper = new DatagramPacketMessageMapper();
 
 	protected volatile DatagramSocket socket;
 
@@ -63,30 +61,30 @@ public class UnicastSendingMessageHandler extends
 	/**
 	 * If true adds headers to instruct receiving adapter to return an ack.
 	 */
-	protected volatile boolean waitForAck = false;
+	private volatile boolean waitForAck = false;
 	
-	protected volatile boolean acknowledge = false;
+	private volatile boolean acknowledge = false;
 
-	protected volatile int ackPort;
+	private volatile int ackPort;
 
-	protected volatile int ackTimeout = 5000;
+	private volatile int ackTimeout = 5000;
 
-	protected volatile int ackCounter = 1;
+	private volatile int ackCounter = 1;
 
-	protected volatile Map<String, CountDownLatch> ackControl = Collections
+	private volatile Map<String, CountDownLatch> ackControl = Collections
 			.synchronizedMap(new HashMap<String, CountDownLatch>());
 
-	protected volatile Exception fatalException;
+	private volatile Exception fatalException;
 
-	protected int soReceiveBufferSize = -1;
+	private volatile int soReceiveBufferSize = -1;
 
-	protected String localAddress;
+	private volatile String localAddress;
 	
-	private CountDownLatch ackLatch;
+	private volatile CountDownLatch ackLatch;
 
-	private boolean ackThreadRunning;
+	private volatile boolean ackThreadRunning;
 
-	protected volatile Executor taskExecutor;
+	private volatile Executor taskExecutor;
 	
 	/**
 	 * Basic constructor; no reliability; no acknowledgment.
@@ -153,7 +151,7 @@ public class UnicastSendingMessageHandler extends
 				ackTimeout);
 	}
 
-	protected void setReliabilityAttributes(boolean lengthCheck,
+	protected final void setReliabilityAttributes(boolean lengthCheck,
 			boolean acknowledge, String ackHost, int ackPort, int ackTimeout) {
 		this.mapper.setLengthCheck(lengthCheck);
 		this.waitForAck = acknowledge;
@@ -334,7 +332,7 @@ public class UnicastSendingMessageHandler extends
 	}
 
 	/**
-	 * @see Socket#setReceiveBufferSize(int)
+	 * @see java.net.Socket#setReceiveBufferSize(int)
 	 * @see DatagramSocket#setReceiveBufferSize(int)
 	 */
 	public void setSoReceiveBufferSize(int size) {
@@ -349,7 +347,35 @@ public class UnicastSendingMessageHandler extends
 		this.taskExecutor = taskExecutor;
 	}
 	
+	/**
+	 * @param ackCounter the ackCounter to set
+	 */
+	public void setAckCounter(int ackCounter) {
+		this.ackCounter = ackCounter;
+	}
+
 	public String getComponentType(){
 		return "ip:udp-outbound-channel-adapter";
+	}
+
+	/**
+	 * @return the acknowledge
+	 */
+	public boolean isAcknowledge() {
+		return acknowledge;
+	}
+
+	/**
+	 * @return the ackPort
+	 */
+	public int getAckPort() {
+		return ackPort;
+	}
+
+	/**
+	 * @return the soReceiveBufferSize
+	 */
+	public int getSoReceiveBufferSize() {
+		return soReceiveBufferSize;
 	}
 }

--- a/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-2.1.xsd
+++ b/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-2.1.xsd
@@ -500,16 +500,16 @@ apply to TCP outbound adapters and gateways.
 		<xsd:attribute name="auto-startup" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-Boolean value indicating whether this connection factory should start automatically.
+Boolean value indicating whether this endpoint should start automatically.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="phase" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-The lifecycle phase within which this connection factory should start and stop.
-The lower the value the earlier this factory will start and the later it will stop. The
-default is 0. See SmartLifeCycle.
+The lifecycle phase within which this endpoint should start and stop.
+The lower the value the earlier this endpoint will start and the later it will stop. The
+default is 0. Values can be negative. See SmartLifeCycle.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-2.1.xsd
+++ b/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-2.1.xsd
@@ -65,7 +65,7 @@ its configuration specifies the number of threads.
 					<xsd:attribute name="lookup-host" type="xsd:string" >
 						<xsd:annotation>
 							<xsd:documentation>
-Whether or not to do a DNS reverse-lookup on the remote ip address to insert the host name into the 
+Whether or not to do a DNS reverse-lookup on the remote ip address to insert the host name into the
 message headers (ip_hostName). Default "true".
 							</xsd:documentation>
 						</xsd:annotation>
@@ -115,183 +115,199 @@ task executors such as a WorkManagerTaskExecutor.
 
 	<xsd:element name="tcp-inbound-channel-adapter">
 		<xsd:complexType>
-			<xsd:attribute name="id" type="xsd:string"/>		
-			<xsd:attribute name="connection-factory" type="xsd:string">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.ip.tcp.connection.ConnectionFactory"/>
-						</tool:annotation>
-					</xsd:appinfo>
-					<xsd:documentation>
-A connection factory is needed by an inbound adapter. If the connection factory has a type 'server',
-the factory is 'owned' by this adapter. If it has a type 'client', it is owned by an outbound channel
-adapter and this adapter will receive any incoming messages on the connection created by the outbound
-adapter. 						 
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="channel" type="xsd:string">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
-						</tool:annotation>
-					</xsd:appinfo>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="error-channel" type="xsd:string">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
-						</tool:annotation>
-					</xsd:appinfo>
-					<xsd:documentation>
-						If a (synchronous) downstream exception is thrown and an "error-channel" is specified,
-						the MessagingException will be sent to this channel. Otherwise, any such exception
-						will simply be logged by the channel adapter.
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
+			<xsd:complexContent>
+				<xsd:extension base="smartLifeCycleType">
+					<xsd:attribute name="id" type="xsd:string"/>
+					<xsd:attribute name="connection-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.ip.tcp.connection.ConnectionFactory"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+		A connection factory is needed by an inbound adapter. If the connection factory has a type 'server',
+		the factory is 'owned' by this adapter. If it has a type 'client', it is owned by an outbound channel
+		adapter and this adapter will receive any incoming messages on the connection created by the outbound
+		adapter.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="error-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								If a (synchronous) downstream exception is thrown and an "error-channel" is specified,
+								the MessagingException will be sent to this channel. Otherwise, any such exception
+								will simply be logged by the channel adapter.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="tcp-outbound-channel-adapter">
 		<xsd:complexType>
-			<xsd:attribute name="id" type="xsd:string"/>		
-			<xsd:attribute name="connection-factory" type="xsd:string">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.ip.tcp.connection.ConnectionFactory"/>
-						</tool:annotation>
-					</xsd:appinfo>
-					<xsd:documentation>
-A connection factory is needed by an outbound adapter. If the connection factory has a type 'client',
-the factory is 'owned' by this adapter. If it has a type 'server', it is owned by an inbound channel
-adapter and this adapter will attempt to correlate messages to the connection on which an original
-inbound message was received. 						 
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="channel" type="xsd:string">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
-						</tool:annotation>
-					</xsd:appinfo>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="order">
-				<xsd:annotation>
-					<xsd:documentation>
-						Specifies the order for invocation when this endpoint is connected as a
-						subscriber to a SubscribableChannel.
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
+			<xsd:complexContent>
+				<xsd:extension base="smartLifeCycleType">
+					<xsd:attribute name="id" type="xsd:string"/>
+					<xsd:attribute name="connection-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.ip.tcp.connection.ConnectionFactory"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+		A connection factory is needed by an outbound adapter. If the connection factory has a type 'client',
+		the factory is 'owned' by this adapter. If it has a type 'server', it is owned by an inbound channel
+		adapter and this adapter will attempt to correlate messages to the connection on which an original
+		inbound message was received.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the order for invocation when this endpoint is connected as a
+								subscriber to a SubscribableChannel.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="tcp-inbound-gateway">
 		<xsd:complexType>
-			<xsd:attribute name="id" type="xsd:string"/>		
-			<xsd:attribute name="connection-factory" type="xsd:string">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory"/>
-						</tool:annotation>
-					</xsd:appinfo>
-					<xsd:documentation>
-A connection factory is needed by an inbound adapter. The connection factory must be of type 'server'.
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="request-channel" type="xsd:string" use="required">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
-						</tool:annotation>
-					</xsd:appinfo>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="reply-channel" type="xsd:string">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
-						</tool:annotation>
-					</xsd:appinfo>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="reply-timeout" type="xsd:string"/>
-			<xsd:attribute name="error-channel" type="xsd:string">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
-						</tool:annotation>
-					</xsd:appinfo>
-					<xsd:documentation>
-						If a (synchronous) downstream exception is thrown and an "error-channel" is specified,
-						the MessagingException will be sent to this channel and the ultimate response
-						of the error flow will be returned as a response by the gateway. If no  
-						"error-channel" is specified, any such exception
-						will simply be logged by the gateway. In such a situation, no response is sent
-						to the client. 
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
+			<xsd:complexContent>
+				<xsd:extension base="smartLifeCycleType">
+					<xsd:attribute name="id" type="xsd:string"/>
+					<xsd:attribute name="connection-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+		A connection factory is needed by an inbound adapter. The connection factory must be of type 'server'.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-channel" type="xsd:string" use="required">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string"/>
+					<xsd:attribute name="error-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								If a (synchronous) downstream exception is thrown and an "error-channel" is specified,
+								the MessagingException will be sent to this channel and the ultimate response
+								of the error flow will be returned as a response by the gateway. If no
+								"error-channel" is specified, any such exception
+								will simply be logged by the gateway. In such a situation, no response is sent
+								to the client.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="tcp-outbound-gateway">
 		<xsd:complexType>
-			<xsd:attribute name="id" type="xsd:string"/>		
-			<xsd:attribute name="connection-factory" type="xsd:string">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.ip.tcp.connection.ConnectionFactory"/>
-						</tool:annotation>
-					</xsd:appinfo>
-					<xsd:documentation>
-A connection factory is needed by an outbound adapter. The connection factory must be of 'client'.
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="request-channel" type="xsd:string" use="required">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
-						</tool:annotation>
-					</xsd:appinfo>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="reply-channel" type="xsd:string">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
-						</tool:annotation>
-					</xsd:appinfo>
-				</xsd:annotation>
-			</xsd:attribute>
-			<xsd:attribute name="request-timeout" type="xsd:string"/>
-			<xsd:attribute name="reply-timeout" type="xsd:string"/>
-			<xsd:attribute name="order">
-				<xsd:annotation>
-					<xsd:documentation>
-						Specifies the order for invocation when this endpoint is connected as a
-						subscriber to a SubscribableChannel.
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
+			<xsd:complexContent>
+				<xsd:extension base="smartLifeCycleType">
+					<xsd:attribute name="id" type="xsd:string"/>
+					<xsd:attribute name="connection-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.ip.tcp.connection.ConnectionFactory"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+		A connection factory is needed by an outbound adapter. The connection factory must be of 'client'.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-channel" type="xsd:string" use="required">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-timeout" type="xsd:string"/>
+					<xsd:attribute name="reply-timeout" type="xsd:string"/>
+					<xsd:attribute name="order">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the order for invocation when this endpoint is connected as a
+								subscriber to a SubscribableChannel.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
 
@@ -317,7 +333,7 @@ connection request.
 			<xsd:attribute name="host" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>
-The host to which a client connection factory will connect.					
+The host to which a client connection factory will connect.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -326,14 +342,14 @@ The host to which a client connection factory will connect.
 					<xsd:documentation>
 For client factories, the port to which a client connection factory will connect.
 For server factories, the port on which the factory will listen for incoming
-connections. 					
+connections.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="using-nio" type="xsd:string" default="false">
 				<xsd:annotation>
 					<xsd:documentation>
-If true, the factory will use java.nio.channel.SocketChannel for communication; 
+If true, the factory will use java.nio.channel.SocketChannel for communication;
 for a large number of connections on the server side, this can provide better
 performance and may use fewer threads.
 					</xsd:documentation>
@@ -350,10 +366,10 @@ performance and may use fewer threads.
 				<xsd:annotation>
 					<xsd:documentation>
 If true, instructs the factory to use direct buffers if possible; only applies if
-using-nio is true. Refer to ByteBuffer javadocs for more information.		
+using-nio is true. Refer to ByteBuffer javadocs for more information.
 					</xsd:documentation>
 				</xsd:annotation>
-			</xsd:attribute>			
+			</xsd:attribute>
 			<xsd:attribute name="single-use" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>
@@ -363,7 +379,7 @@ be closed after a message is received. For outbound adapters where there is
 no inbound adapter sharing the factory, or for inbound adapters where an
 outbound adapter shares the factory, the connection will be closed after
 so-timeout milliseconds. For outbound adapters where an inbound adapter shares
-the factory, the connection will be closed after a response is received. 					
+the factory, the connection will be closed after a response is received.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -377,7 +393,7 @@ the factory, the connection will be closed after a response is received.
 					<xsd:documentation>
 A Serializer that converts message payloads to/from output streams/input streams
 associated with the connection. Default is ByteArrayCrLfSerializer. Serializer and Deserializer
-would normally be the same but this is not required.									
+would normally be the same but this is not required.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -391,7 +407,7 @@ would normally be the same but this is not required.
 					<xsd:documentation>
 A Deserializer that converts message payloads to/from output streams/input streams
 associated with the connection. Default is ByteArrayCrLfSerializer. Serializer and Deserializer
-would normally be the same but this is not required.					
+would normally be the same but this is not required.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -420,7 +436,7 @@ its configuration specifies the number of threads.
 			<xsd:attribute name="lookup-host" type="xsd:string" >
 				<xsd:annotation>
 					<xsd:documentation>
-Whether or not to do a DNS reverse-lookup on the remote ip address to insert the host name into the 
+Whether or not to do a DNS reverse-lookup on the remote ip address to insert the host name into the
 message headers (ip_connectionId, ip_hostName). Default "true".
 					</xsd:documentation>
 				</xsd:annotation>
@@ -476,6 +492,25 @@ specifies the interface to which multicast packets will be sent. For UDP unicast
 adapters, specifies which interface to which the acknowledgment socket will be bound. Does not
 apply to TCP outbound adapters and gateways.
 				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="smartLifeCycleType">
+		<xsd:attribute name="auto-startup" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Boolean value indicating whether this connection factory should start automatically.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="phase" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The lifecycle phase within which this connection factory should start and stop.
+The lower the value the earlier this factory will start and the later it will stop. The
+default is 0. See SmartLifeCycle.
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
@@ -12,15 +12,16 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
-
 	<bean id="tcpIpUtils" class="org.springframework.integration.ip.util.SocketTestUtils" />
 
 	<int:channel id="udpChannel" />
+
 	<int:channel id="tcpChannel" />
+
 	<int:channel id="replyChannel" />
-	
+
 	<task:executor id="externalTE" pool-size="10"/>
-	
+
 	<ip:udp-inbound-channel-adapter id="testInUdp"
 		channel="udpChannel"
 		check-length="true"
@@ -48,7 +49,7 @@
 		so-receive-buffer-size="30"
 		so-send-buffer-size="31"
 		so-timeout="32"
-		local-address="127.0.0.1"		
+		local-address="127.0.0.1"
 	/>
 
 	<ip:tcp-connection-factory id="cfS1"
@@ -56,14 +57,16 @@
 		port="#{tcpIpUtils.findAvailableServerSocket(5200)}"
 		lookup-host="false"
 		/>
-		
+
 	<ip:tcp-inbound-channel-adapter id="testInTcp"
 		channel="tcpChannel"
 		error-channel="errorChannel"
 		connection-factory="cfS1"
+		auto-startup="false"
+		phase="124"
 	/>
 
-	<ip:udp-outbound-channel-adapter id="testOutUdp" 
+	<ip:udp-outbound-channel-adapter id="testOutUdp"
 		ack-host="somehost"
 		ack-port="#{tcpIpUtils.findAvailableUdpSocket(5300)}"
 		ack-timeout="51"
@@ -76,12 +79,12 @@
 		so-receive-buffer-size="52"
 		so-send-buffer-size="53"
 		so-timeout="54"
-		local-address="127.0.0.1"	
+		local-address="127.0.0.1"
 		task-executor="externalTE"
-		order="23"	
+		order="23"
 	/>
-	
-	<ip:udp-outbound-channel-adapter id="testOutUdpiMulticast" 
+
+	<ip:udp-outbound-channel-adapter id="testOutUdpiMulticast"
 		ack-host="somehost"
 		ack-port="#{tcpIpUtils.findAvailableUdpSocket(5500)}"
 		ack-timeout="51"
@@ -105,44 +108,48 @@
 		host="localhost"
 		lookup-host="false"
 		/>
-		
-	<ip:tcp-outbound-channel-adapter id="testOutTcpNio" 
+
+	<ip:tcp-outbound-channel-adapter id="testOutTcpNio"
 		channel="tcpChannel"
 		connection-factory="cfC1"
 		order="35"
+		auto-startup="false"
+		phase="125"
 	/>
 
 	<ip:tcp-connection-factory id="cfS2"
 		type="server"
 		port="#{tcpIpUtils.findAvailableServerSocket(5800)}"
 		/>
-		
+
 	<ip:tcp-inbound-gateway id="inGateway1"
 		request-channel="tcpChannel"
 		reply-channel="replyChannel"
 		error-channel="errorChannel"
 		connection-factory="cfS2"
 		reply-timeout="456"
-		/>	
+		auto-startup="false"
+		phase="126"
+		/>
 
 	<ip:tcp-connection-factory id="cfS3"
 		type="server"
 		port="#{tcpIpUtils.findAvailableServerSocket(5850)}"
 		/>
-		
+
 	<ip:tcp-inbound-gateway id="inGateway2"
 		request-channel="tcpChannel"
 		reply-channel="replyChannel"
 		connection-factory="cfS3"
 		reply-timeout="456"
-		/>	
+		/>
 
 	<ip:tcp-connection-factory id="cfC2"
 		type="client"
 		port="#{tcpIpUtils.findAvailableServerSocket(5900)}"
 		host="localhost"
 		/>
-		
+
 	<ip:tcp-outbound-gateway id="outGateway"
 		request-channel="tcpChannel"
 		reply-channel="replyChannel"
@@ -150,7 +157,9 @@
 		request-timeout="234"
 		reply-timeout="567"
 		order="24"
-		/>		
+		auto-startup="false"
+		phase="127"
+		/>
 
 	<ip:tcp-connection-factory
 		id="client1"
@@ -169,15 +178,15 @@
 		using-nio="#{props['use.nio']}"
 		single-use="true"
 		task-executor="externalTE"
-		pool-size="321"		
+		pool-size="321"
 		using-direct-buffers="true"
 		interceptor-factory-chain="interceptors"
 	/>
-	
+
 	<util:properties id="props">
 		<prop key="use.nio">true</prop>
 	</util:properties>
-	
+
 	<ip:tcp-connection-factory
 		id="server1"
 		type="server"
@@ -199,7 +208,7 @@
 		using-direct-buffers="true"
 		interceptor-factory-chain="interceptors"
 	/>
-	
+
 	<ip:tcp-connection-factory
 		id="client2"
 		type="client"
@@ -217,10 +226,10 @@
 		using-nio="false"
 		single-use="true"
 		task-executor="externalTE"
-		pool-size="321"		
+		pool-size="321"
 		interceptor-factory-chain="interceptors"
 	/>
-	
+
 	<ip:tcp-connection-factory
 		id="server2"
 		type="server"
@@ -241,32 +250,29 @@
 		pool-size="123"
 		interceptor-factory-chain="interceptors"
 	/>
-	
+
 	<bean id="interceptors" class="org.springframework.integration.ip.tcp.connection.TcpConnectionInterceptorFactoryChain" />
-	
+
 	<bean id="defaultSerializer" class="org.springframework.core.serializer.DefaultSerializer" />
-	
+
 	<bean id="defaultDeserializer" class="org.springframework.core.serializer.DefaultDeserializer" />
 
 	<ip:tcp-outbound-channel-adapter id="tcpNewOut1"
 		channel="tcpChannel"
-		connection-factory="client1" 
+		connection-factory="client1"
 		order="25"/>
-		
+
 	<ip:tcp-outbound-channel-adapter id="tcpNewOut2"
 		channel="tcpChannel"
-		connection-factory="server1" 
+		connection-factory="server1"
 		order="15"/>
-		
+
 	<ip:tcp-inbound-channel-adapter id="tcpNewIn1"
 		channel="tcpChannel"
 		connection-factory="client1" />
-		
+
 	<ip:tcp-inbound-channel-adapter id="tcpNewIn2"
 		channel="tcpChannel"
 		connection-factory="server1" />
-
-
-		
 
 </beans>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/AutoStartTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/AutoStartTests-context.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ip="http://www.springframework.org/schema/integration/ip"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/ip http://www.springframework.org/schema/integration/ip/spring-integration-ip-2.1.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	<bean id="tcpIpUtils" class="org.springframework.integration.ip.util.SocketTestUtils" />
+
+	<ip:tcp-connection-factory id="cfS1"
+		type="server"
+		port="#{tcpIpUtils.findAvailableServerSocket(15200)}"
+		lookup-host="false"
+		/>
+
+	<ip:tcp-inbound-channel-adapter id="tcpNetIn"
+		channel="tcpChannel1"
+		error-channel="errorChannel"
+		connection-factory="cfS1"
+		auto-startup="false"
+	/>
+
+	<int:channel id="tcpChannel1">
+		<int:queue/>
+	</int:channel>
+
+</beans>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/AutoStartTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/AutoStartTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.ip.tcp;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class AutoStartTests {
+
+	@Autowired
+	AbstractServerConnectionFactory cfS1;
+
+	@Autowired
+	TcpReceivingChannelAdapter tcpNetIn;
+
+	@Test
+	public void testNetIn() throws Exception {
+		assertFalse(cfS1.isAutoStartup());
+		DirectFieldAccessor dfa = new DirectFieldAccessor(cfS1);
+		assertNull(dfa.getPropertyValue("serverSocket"));
+		startAndStop();
+		assertNull(dfa.getPropertyValue("serverSocket"));
+		startAndStop();
+		assertNull(dfa.getPropertyValue("serverSocket"));
+	}
+
+	/**
+	 * @throws InterruptedException
+	 */
+	private void startAndStop() throws InterruptedException {
+		tcpNetIn.start();
+		int n = 0;
+		while (!cfS1.isListening()) {
+			Thread.sleep(100);
+			if (n++ > 100) {
+				fail("Failed to start listening");
+			}
+		}
+		tcpNetIn.stop();
+		while (cfS1.isListening()) {
+			Thread.sleep(100);
+			if (n++ > 100) {
+				fail("Failed to stop listening");
+			}
+		}
+	}
+}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ConnectionToConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ConnectionToConnectionTests.java
@@ -86,6 +86,7 @@ public class ConnectionToConnectionTests {
 				throw new Exception("Failed to listen");
 			}
 		}
+		client.start();
 		for (int i = 0; i < 100; i++) {
 			TcpConnection connection = client.getConnection();
 			connection.send(MessageBuilder.withPayload("Test").build());
@@ -105,6 +106,7 @@ public class ConnectionToConnectionTests {
 		ByteArrayRawSerializer serializer = new ByteArrayRawSerializer();
 		client.setSerializer(serializer);
 		server.setDeserializer(serializer);
+		client.start();
 		TcpConnection connection = client.getConnection();
 		connection.send(MessageBuilder.withPayload("Test").build());
 		Message<?> message = serverSideChannel.receive(10000);
@@ -119,6 +121,7 @@ public class ConnectionToConnectionTests {
 	
 	@Test
 	public void testLookup() throws Exception {
+		client.start();
 		TcpConnection connection = client.getConnection();
 		assertFalse(connection.getConnectionId().contains("localhost"));
 		connection.close();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpConfigOutboundGatewayTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpConfigOutboundGatewayTests.java
@@ -133,6 +133,7 @@ public class TcpConfigOutboundGatewayTests {
 	@Test
 	public void testOutboundStxEtx() throws Exception {
 		TcpOutboundGateway gateway = new TcpOutboundGateway();
+		stxEtxClient.start();
 		gateway.setConnectionFactory(stxEtxClient);
 		waitListening(inboundGatewayStxEtx);
 		Message<String> message = MessageBuilder.withPayload("test").build();
@@ -144,6 +145,7 @@ public class TcpConfigOutboundGatewayTests {
 	@Test
 	public void testOutboundSerialized() throws Exception {
 		TcpOutboundGateway gateway = new TcpOutboundGateway();
+		javaSerialClient.start();
 		gateway.setConnectionFactory(javaSerialClient);
 		waitListening(inboundGatewaySerialized);
 		Message<String> message = MessageBuilder.withPayload("test").build();
@@ -155,6 +157,7 @@ public class TcpConfigOutboundGatewayTests {
 	@Test
 	public void testOutboundLength() throws Exception {
 		TcpOutboundGateway gateway = new TcpOutboundGateway();
+		lengthHeaderClient.start();
 		gateway.setConnectionFactory(lengthHeaderClient);
 		waitListening(inboundGatewayLength);
 		Message<String> message = MessageBuilder.withPayload("test").build();


### PR DESCRIPTION
There was no way for an application to control the startup
of TCP endpoints. This is particularly an issue for controlling
availability of inbound endpoints.

The TCP Endpoints are mostly static, with dynamic behavior
being contained in connection factories. The factories
implement SmartLifecycle but there is no way to 
configure auto-startup.

Adds auto-startup and phase attributes to all TCP endpoints

Starting/stopping an endpoint will start/stop the underlying
connection factory. When a connection factory is stopped,
all open connections are closed, and (for a server factory)
no new connections will be accepted.

While the factories implement SmartLifecycle, they return
false to auto-startup. We rely on the fact that 
the endpoints are dependent on factories and 
the factories will be started because of this dependency.

Finally, with collaborating endpoints (where an inbound and
outbound adapter are bound to the same factory), starting/
stopping one endpoint will affect the collaborating 
endpoint too.
