### PR TITLE
INT-1977 added a WARN message to HttpRequestExecutingMessageHandler

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -228,9 +228,8 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 		}
 		if (!this.shouldIncludeRequestBody() && this.extractPayloadExplicitlySet){
 			if (logger.isWarnEnabled()){
-				logger.warn("'extractPayload' attribute has no meaning in the context of this handler " +
-						"since provided HTTP Method is '" + this.httpMethod + "'. This attribute only has meaning " +
-						"for http methods methods other than GET");
+				logger.warn("The 'extractPayload' attribute has no meaning in the context of this handler since the provided HTTP Method is '" + 
+			           this.httpMethod + "', and no request body will be sent for that method.");		
 			}
 		}
 	}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -223,6 +223,13 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 		if (conversionService != null) {
 			this.evaluationContext.setTypeConverter(new StandardTypeConverter(conversionService));
 		}
+		if (!(this.httpMethod == HttpMethod.POST || this.httpMethod == HttpMethod.PUT) && this.extractPayload){
+			if (logger.isWarnEnabled()){
+				logger.warn("'extractPayload' attribute has no meaning in the context of this handler " +
+						"since provided HTTP Method is '" + this.httpMethod + "'. This attribute only has meaning " +
+						"if HTTP Method is POST or PUT.");
+			}
+		}
 	}
 
 	@Override

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -223,7 +223,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 		if (conversionService != null) {
 			this.evaluationContext.setTypeConverter(new StandardTypeConverter(conversionService));
 		}
-		if (this.httpMethod == HttpMethod.GET && this.extractPayload){
+		if (!this.shouldIncludeRequestBody() && this.extractPayload){
 			if (logger.isWarnEnabled()){
 				logger.warn("'extractPayload' attribute has no meaning in the context of this handler " +
 						"since provided HTTP Method is '" + this.httpMethod + "'. This attribute only has meaning " +

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -223,11 +223,11 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 		if (conversionService != null) {
 			this.evaluationContext.setTypeConverter(new StandardTypeConverter(conversionService));
 		}
-		if (!(this.httpMethod == HttpMethod.POST || this.httpMethod == HttpMethod.PUT) && this.extractPayload){
+		if (this.httpMethod == HttpMethod.GET && this.extractPayload){
 			if (logger.isWarnEnabled()){
 				logger.warn("'extractPayload' attribute has no meaning in the context of this handler " +
 						"since provided HTTP Method is '" + this.httpMethod + "'. This attribute only has meaning " +
-						"if HTTP Method is POST or PUT.");
+						"for http methods methods other than GET");
 			}
 		}
 	}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -83,6 +83,8 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 	private volatile Class<?> expectedResponseType;
 
 	private volatile boolean extractPayload = true;
+	
+	private volatile boolean extractPayloadExplicitlySetToTrue = false;
 
 	private volatile String charset = "UTF-8";
 
@@ -93,6 +95,8 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 	private final RestTemplate restTemplate;
 
 	private final StandardEvaluationContext evaluationContext;
+	
+	
 
 
 	/**
@@ -139,6 +143,9 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 	 */
 	public void setExtractPayload(boolean extractPayload) {
 		this.extractPayload = extractPayload;
+		if (extractPayload){
+			this.extractPayloadExplicitlySetToTrue = true;
+		}
 	}
 
 	/**
@@ -223,7 +230,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 		if (conversionService != null) {
 			this.evaluationContext.setTypeConverter(new StandardTypeConverter(conversionService));
 		}
-		if (!this.shouldIncludeRequestBody() && this.extractPayload){
+		if (!this.shouldIncludeRequestBody() && this.extractPayloadExplicitlySetToTrue){
 			if (logger.isWarnEnabled()){
 				logger.warn("'extractPayload' attribute has no meaning in the context of this handler " +
 						"since provided HTTP Method is '" + this.httpMethod + "'. This attribute only has meaning " +

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -84,7 +84,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 
 	private volatile boolean extractPayload = true;
 	
-	private volatile boolean extractPayloadExplicitlySetToTrue = false;
+	private volatile boolean extractPayloadExplicitlySet = false;
 
 	private volatile String charset = "UTF-8";
 
@@ -96,8 +96,6 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 
 	private final StandardEvaluationContext evaluationContext;
 	
-	
-
 
 	/**
 	 * Create a handler that will send requests to the provided URI.
@@ -143,9 +141,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 	 */
 	public void setExtractPayload(boolean extractPayload) {
 		this.extractPayload = extractPayload;
-		if (extractPayload){
-			this.extractPayloadExplicitlySetToTrue = true;
-		}
+		this.extractPayloadExplicitlySet = true;
 	}
 
 	/**
@@ -230,7 +226,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 		if (conversionService != null) {
 			this.evaluationContext.setTypeConverter(new StandardTypeConverter(conversionService));
 		}
-		if (!this.shouldIncludeRequestBody() && this.extractPayloadExplicitlySetToTrue){
+		if (!this.shouldIncludeRequestBody() && this.extractPayloadExplicitlySet){
 			if (logger.isWarnEnabled()){
 				logger.warn("'extractPayload' attribute has no meaning in the context of this handler " +
 						"since provided HTTP Method is '" + this.httpMethod + "'. This attribute only has meaning " +

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -532,10 +532,29 @@ public class HttpRequestExecutingMessageHandlerTests {
 	
 	@Test // no asertions just a warn message in a log
 	public void testWarnMessageForNonPostPutAndExtractPayload() throws Exception {
+		// should see a warn message
+		
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
 		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
 		handler.setHttpMethod(HttpMethod.GET);
+		handler.setExtractPayload(true);
+		handler.afterPropertiesSet();
+		
+		// should not see  a warn message since 'setExtractPayload' is not set explicitly
+		
+		handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
+		template = new MockRestTemplate();
+		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		handler.setHttpMethod(HttpMethod.GET);
+		handler.afterPropertiesSet();
+		
+		// should not see  a warn message since HTTP method is not GET
+		
+		handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
+		template = new MockRestTemplate();
+		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		handler.setHttpMethod(HttpMethod.POST);
 		handler.setExtractPayload(true);
 		handler.afterPropertiesSet();
 	}

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -530,6 +530,16 @@ public class HttpRequestExecutingMessageHandlerTests {
 		assertEquals(MediaType.TEXT_XML, request.getHeaders().getContentType());
 	}
 	
+	@Test // no asertions just a warn message in a log
+	public void testWarnMessageForNonPostPutAndExtractPayload() throws Exception {
+		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
+		MockRestTemplate template = new MockRestTemplate();
+		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		handler.setHttpMethod(HttpMethod.GET);
+		handler.setExtractPayload(true);
+		handler.afterPropertiesSet();
+	}
+	
 	@Test
 	public void contentTypeIsNotSetForGetRequest() throws Exception {
 		//GET


### PR DESCRIPTION
The warn message will let the user know that 'extractPayload' attribute is meaningless if the 'httpMethod' is not PUT/POST
