### PR TITLE
INT-1770 Support Client Mode For TCP Endpoints

### DIFF
--- a/docs/src/reference/docbook/ip.xml
+++ b/docs/src/reference/docbook/ip.xml
@@ -331,7 +331,7 @@
     </para>
   </section>
   <section id="ip-interceptors">
-    <title>Tcp Connection Interceptors</title>
+    <title>TCP Connection Interceptors</title>
     <para>
         Connection factories can be configured with a reference to a
         <classname>TcpConnectionInterceptorFactoryChain</classname>. Interceptors can be used
@@ -403,7 +403,7 @@
     <title>TCP Adapters</title>
     <para>
       TCP inbound and outbound channel adapters that utilize the above connection
-      factories are provided. These adapters have just 2 attributes
+      factories are provided. These adapters have attributes
       <classname>connection-factory</classname> and <classname>channel</classname>.
       The channel attribute specifies the channel on which messages arrive at an
       outbound adapter and on which messages are placed by an inbound adapter.
@@ -471,6 +471,48 @@
       'inboundClient' and deposited in channel 'replies'. Java
       serialization is used on the wire.
     </para>
+    <para>
+      Normally, inbound adapters use a type="server" connection
+      factory, which listens for incoming connection requests.
+      In some cases, it is desireable to establish the connection
+      in reverse, whereby the inbound adapter connects to an
+      external server and then waits for inbound messages on that
+      connection.
+    </para>
+    <para>
+      This topology is supported by using <emphasis>client-mode="true"</emphasis>
+      on the inbound adapter. In this case, the connection factory must
+      be of type 'client' and must have <emphasis>single-use</emphasis>
+      set to false.
+    </para>
+    <para>
+      Two additional attributes are used to support this mechanism:
+      <emphasis>retry-interval</emphasis> specifies (in milliseconds)
+      how often the framework will attempt to reconnect after a 
+      connection failure. <emphasis>scheduler</emphasis> is used to
+      supply a <classname>TaskScheduler</classname> used to
+      schedule the connection attempts, and to test that the connection is
+      still active.
+    </para>
+    <para>
+      For an outbound adapter, the connection is normally established
+      when the first message is sent. <emphasis>client-mode="true"</emphasis>
+      on an outbound adapter will cause the connection to be established
+      when the adapter is started. Adapters are automatically started
+      by default.  Again, the connection factory must be of type client
+      and have <emphasis>single-use</emphasis> set to false and
+      <emphasis>retry-interval</emphasis> and 
+      <emphasis>scheduler</emphasis> are also supported. If a connection
+      fails, it will be re-established either by the scheduler or
+      when the next message is sent.
+    </para>
+    <para>
+      For both inbound and outbound,
+      if the adapter is started, you may force the adapter to establish
+      a connection by sending a &lt;control-bus /&gt; command:
+      <classname>@adapter_id.retryConnection()</classname> and examine the
+      current state with <classname>@adapter_id.isConnected()</classname>.
+    </para>
   </section>
   <section id="tcp-gateways">
     <title>TCP Gateways</title>
@@ -496,6 +538,36 @@
        header value can be captured from the incoming message.
       </para>
      </note>
+    </para>
+    <para>
+      As with inbound adapters, inbound gateways normally use a 
+      type="server" connection
+      factory, which listens for incoming connection requests.
+      In some cases, it is desireable to establish the connection
+      in reverse, whereby the inbound gateway connects to an
+      external server and then waits for, and replies to, inbound 
+      messages on that connection.
+    </para>
+    <para>
+      This topology is supported by using <emphasis>client-mode="true"</emphasis>
+      on the inbound gateway. In this case, the connection factory must
+      be of type 'client' and must have <emphasis>single-use</emphasis>
+      set to false.
+    </para>
+    <para>
+      Two additional attributes are used to support this mechanism:
+      <emphasis>retry-interval</emphasis> specifies (in milliseconds)
+      how often the framework will attempt to reconnect after a 
+      connection failure. <emphasis>scheduler</emphasis> is used to
+      supply a <classname>TaskScheduler</classname> used to
+      schedule the connection attempts, and to test that the connection is
+      still active.
+    </para>
+    <para>
+      If the gateway is started, you may force the gateway to establish
+      a connection by sending a &lt;control-bus /&gt; command:
+      <classname>@adapter_id.retryConnection()</classname> and examine the
+      current state with <classname>@adapter_id.isConnected()</classname>.
     </para>
     <para>
       The outbound gateway, after sending a message over the connection, waits for a response and
@@ -1164,6 +1236,35 @@
                      component, the MessagingException message containing the exception 
                      and failed message is sent to this channel.</entry>
             </row>
+            <row>
+              <entry>client-mode</entry>
+              <entry>true, false</entry>
+              <entry>
+                When true, the inbound adapter will act as a client, with respect to establishing
+                the connection and then receive incoming messages on that connection. Default = false.
+                Also see <emphasis>retry-interval</emphasis> and <emphasis>scheduler</emphasis>.
+                The connection factory must be of type 'client' and have <emphasis>single-use</emphasis>
+                set to false.
+              </entry>
+            </row>
+            <row>
+              <entry>retry-interval</entry>
+              <entry></entry>
+              <entry>
+                 When in <emphasis>client-mode</emphasis>, specifies the number of milliseconds
+                 to wait between connection attempts, or after a connection failure. Default 60,000
+                 (60 seconds).
+              </entry>
+            </row>
+            <row>
+              <entry>scheduler</entry>
+              <entry>true, false</entry>
+              <entry>
+                Specifies a <classname>TaskScheduler</classname> to use for managing the 
+                <emphasis>client-mode</emphasis> connection. Defaults to a
+                <classname>ThreadPoolTaskScheduler</classname> with a pool size of `.
+              </entry>
+            </row>
           </tbody>
         </tgroup>
       </table>
@@ -1195,6 +1296,36 @@
                      by an inbound channel adapter and this adapter will attempt 
                      to correlate messages to the connection on which an 
                      original inbound message was received.  </entry>
+            </row>
+            <row>
+              <entry>client-mode</entry>
+              <entry>true, false</entry>
+              <entry>
+                When true, the outbound adapter will attempt to establish the connection as
+                soon as it is started. When false, the connection is established when
+                the first message is sent. Default = false.
+                Also see <emphasis>retry-interval</emphasis> and <emphasis>scheduler</emphasis>.
+                The connection factory must be of type 'client' and have <emphasis>single-use</emphasis>
+                set to false.
+              </entry>
+            </row>
+            <row>
+              <entry>retry-interval</entry>
+              <entry></entry>
+              <entry>
+                 When in <emphasis>client-mode</emphasis>, specifies the number of milliseconds
+                 to wait between connection attempts, or after a connection failure. Default 60,000
+                 (60 seconds).
+              </entry>
+            </row>
+            <row>
+              <entry>scheduler</entry>
+              <entry>true, false</entry>
+              <entry>
+                Specifies a <classname>TaskScheduler</classname> to use for managing the 
+                <emphasis>client-mode</emphasis> connection. Defaults to a
+                <classname>ThreadPoolTaskScheduler</classname> with a pool size of `.
+              </entry>
             </row>
           </tbody>
         </tgroup>
@@ -1245,6 +1376,36 @@
                      and failed message is sent to this channel;
                      any reply from that flow will then be returned as a response by
                      the gateway.</entry>
+            </row>
+            <row>
+              <entry>client-mode</entry>
+              <entry>true, false</entry>
+              <entry>
+                When true, the inbound gateway will act as a client, with respect to establishing
+                the connection and then receive (and reply to) incoming messages on that connection. 
+                Default = false.
+                Also see <emphasis>retry-interval</emphasis> and <emphasis>scheduler</emphasis>.
+                The connection factory must be of type 'client' and have <emphasis>single-use</emphasis>
+                set to false.
+              </entry>
+            </row>
+            <row>
+              <entry>retry-interval</entry>
+              <entry></entry>
+              <entry>
+                 When in <emphasis>client-mode</emphasis>, specifies the number of milliseconds
+                 to wait between connection attempts, or after a connection failure. Default 60,000
+                 (60 seconds).
+              </entry>
+            </row>
+            <row>
+              <entry>scheduler</entry>
+              <entry>true, false</entry>
+              <entry>
+                Specifies a <classname>TaskScheduler</classname> to use for managing the 
+                <emphasis>client-mode</emphasis> connection. Defaults to a
+                <classname>ThreadPoolTaskScheduler</classname> with a pool size of `.
+              </entry>
             </row>
           </tbody>
         </tgroup>

--- a/spring-integration-ip/.springBeans
+++ b/spring-integration-ip/.springBeans
@@ -9,6 +9,7 @@
 	<configs>
 		<config>src/test/java/org/springframework/integration/ip/tcp/connection/SOLingerTests-context.xml</config>
 		<config>src/test/java/org/springframework/integration/ip/tcp/AutoStartTests-context.xml</config>
+		<config>src/test/java/org/springframework/integration/ip/tcp/ClientModeControlBusTests-context.xml</config>
 	</configs>
 	<configSets>
 	</configSets>

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/IpAdapterParserUtils.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/IpAdapterParserUtils.java
@@ -98,20 +98,26 @@ public abstract class IpAdapterParserUtils {
 	static final String TCP_CONNECTION_FACTORY = "connection-factory";
 
 	public static final String INTERCEPTOR_FACTORY_CHAIN = "interceptor-factory-chain";
-	
+
 	public static final String REQUEST_TIMEOUT = "request-timeout";
-	
+
 	public static final String REPLY_TIMEOUT = "reply-timeout";
-	
+
 	public static final String REPLY_CHANNEL = "reply-channel";
 
 	public static final String LOOKUP_HOST = "lookup-host";
-	
+
 	public static final String AUTO_STARTUP = "auto-startup";
 
 	public static final String PHASE = "phase";
 
 	public static final String APPLY_SEQUENCE = "apply-sequence";
+
+	public static final String CLIENT_MODE = "client-mode";
+
+	public static final String RETRY_INTERVAL = "retry-interval";
+
+	public static final String SCHEDULER = "scheduler";
 
 	/**
 	 * Adds a constructor-arg to the provided bean definition builder 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpInboundChannelAdapterParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpInboundChannelAdapterParser.java
@@ -46,6 +46,12 @@ public class TcpInboundChannelAdapterParser extends AbstractChannelAdapterParser
 				IpAdapterParserUtils.AUTO_STARTUP);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.PHASE);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.CLIENT_MODE);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.RETRY_INTERVAL);
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.SCHEDULER);
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpInboundGatewayParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpInboundGatewayParser.java
@@ -37,12 +37,16 @@ public class TcpInboundGatewayParser extends AbstractInboundGatewayParser {
 	@Override
 	protected boolean isEligibleAttribute(String attributeName) {
 		return !attributeName.equals(IpAdapterParserUtils.TCP_CONNECTION_FACTORY)
+				&& !attributeName.equals(IpAdapterParserUtils.SCHEDULER)
 				&& super.isEligibleAttribute(attributeName);
 	}
 
 	@Override
 	protected void doPostProcess(BeanDefinitionBuilder builder, Element element) {
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, 
-				IpAdapterParserUtils.TCP_CONNECTION_FACTORY);	}
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.TCP_CONNECTION_FACTORY);
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.SCHEDULER);
+	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpOutboundChannelAdapterParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpOutboundChannelAdapterParser.java
@@ -40,6 +40,12 @@ public class TcpOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 				IpAdapterParserUtils.AUTO_STARTUP);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.PHASE);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.CLIENT_MODE);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.RETRY_INTERVAL);
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.SCHEDULER);
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandler.java
@@ -18,6 +18,7 @@ package org.springframework.integration.ip.tcp;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -30,10 +31,15 @@ import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.ip.tcp.connection.AbstractClientConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.AbstractConnectionFactory;
+import org.springframework.integration.ip.tcp.connection.ClientModeCapable;
+import org.springframework.integration.ip.tcp.connection.ClientModeConnectionManager;
 import org.springframework.integration.ip.tcp.connection.ConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.TcpConnection;
 import org.springframework.integration.ip.tcp.connection.TcpSender;
 import org.springframework.integration.mapping.MessageMappingException;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.util.Assert;
 
 /**
  * Tcp outbound channel adapter using a TcpConnection to
@@ -44,19 +50,34 @@ import org.springframework.integration.mapping.MessageMappingException;
  * @since 2.0
  *
  */
-public class TcpSendingMessageHandler extends AbstractMessageHandler implements TcpSender, SmartLifecycle {
+public class TcpSendingMessageHandler extends AbstractMessageHandler implements
+		TcpSender, SmartLifecycle, ClientModeCapable {
 
 	protected final Log logger = LogFactory.getLog(this.getClass());
 
-	private volatile ConnectionFactory clientConnectionFactory;
+	private volatile AbstractConnectionFactory clientConnectionFactory;
 
-	private volatile ConnectionFactory serverConnectionFactory;
+	private volatile AbstractConnectionFactory serverConnectionFactory;
 
 	private Map<String, TcpConnection> connections = new ConcurrentHashMap<String, TcpConnection>();
 
 	private volatile boolean autoStartup;
 
 	private volatile int phase;
+
+	private volatile boolean isClientMode;
+
+	private volatile TaskScheduler scheduler;
+
+	private volatile long retryInterval = 60000;
+
+	private volatile ScheduledFuture<?> scheduledFuture;
+
+	private volatile ClientModeConnectionManager clientModeConnectionManager;
+
+	protected final Object lifecycleMonitor = new Object();
+
+	private volatile boolean active;
 
 	protected TcpConnection getConnection() {
 		TcpConnection connection = null;
@@ -167,21 +188,51 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements 
 		return "ip:tcp-outbound-channel-adapter";
 	}
 
-	public void start() {
-		if (this.clientConnectionFactory != null) {
-			this.clientConnectionFactory.start();
+	@Override
+	protected void onInit() throws Exception {
+		super.onInit();
+		if (this.isClientMode) {
+			Assert.notNull(this.clientConnectionFactory,
+					"For client-mode, connection factory must be type='client'");
+			Assert.isTrue(!this.clientConnectionFactory.isSingleUse(),
+					"For client-mode, connection factory must have single-use='false'");
 		}
-		if (this.serverConnectionFactory != null) {
-			this.serverConnectionFactory.start();
+	}
+
+	public void start() {
+		synchronized (this.lifecycleMonitor) {
+			if (!this.active) {
+				this.active = true;
+				if (this.clientConnectionFactory != null) {
+					this.clientConnectionFactory.start();
+				}
+				if (this.serverConnectionFactory != null) {
+					this.serverConnectionFactory.start();
+				}
+				if (this.isClientMode) {
+					ClientModeConnectionManager manager = new ClientModeConnectionManager(
+							this.clientConnectionFactory);
+					this.clientModeConnectionManager = manager;
+					this.scheduledFuture = this.getScheduler().scheduleAtFixedRate(manager, this.retryInterval);
+				}
+			}
 		}
 	}
 
 	public void stop() {
-		if (this.clientConnectionFactory != null) {
-			this.clientConnectionFactory.stop();
-		}
-		if (this.serverConnectionFactory != null) {
-			this.serverConnectionFactory.stop();
+		synchronized (this.lifecycleMonitor) {
+			if (this.active) {
+				this.active = false;
+				if (this.scheduledFuture != null) {
+					this.scheduledFuture.cancel(true);
+				}
+				if (this.clientConnectionFactory != null) {
+					this.clientConnectionFactory.stop();
+				}
+				if (this.serverConnectionFactory != null) {
+					this.serverConnectionFactory.stop();
+				}
+			}
 		}
 	}
 
@@ -200,11 +251,20 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements 
 	}
 
 	public void stop(Runnable callback) {
-		if (this.clientConnectionFactory != null) {
-			this.clientConnectionFactory.stop(callback);
-		}
-		if (this.serverConnectionFactory != null) {
-			this.serverConnectionFactory.stop(callback);
+		synchronized (this.lifecycleMonitor) {
+			if (this.active) {
+				this.active = false;
+				if (this.scheduledFuture != null) {
+					this.scheduledFuture.cancel(true);
+				}
+				this.clientModeConnectionManager = null;
+				if (this.clientConnectionFactory != null) {
+					this.clientConnectionFactory.stop(callback);
+				}
+				if (this.serverConnectionFactory != null) {
+					this.serverConnectionFactory.stop(callback);
+				}
+			}
 		}
 	}
 
@@ -235,6 +295,70 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements 
 	 */
 	protected Map<String, TcpConnection> getConnections() {
 		return connections;
+	}
+
+	/**
+	 * @return the isClientMode
+	 */
+	public boolean isClientMode() {
+		return this.isClientMode;
+	}
+
+	/**
+	 * @param isClientMode
+	 *            the isClientMode to set
+	 */
+	public void setClientMode(boolean isClientMode) {
+		this.isClientMode = isClientMode;
+	}
+
+	/**
+	 * @return the scheduler
+	 */
+	protected TaskScheduler getScheduler() {
+		if (this.scheduler == null) {
+			ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+			scheduler.initialize();
+			this.scheduler = scheduler;
+		}
+		return this.scheduler;
+	}
+
+	/**
+	 * @param scheduler
+	 *            the scheduler to set
+	 */
+	public void setScheduler(TaskScheduler scheduler) {
+		this.scheduler = scheduler;
+	}
+
+	/**
+	 * @return the retryInterval
+	 */
+	public long getRetryInterval() {
+		return this.retryInterval;
+	}
+
+	/**
+	 * @param retryInterval
+	 *            the retryInterval to set
+	 */
+	public void setRetryInterval(long retryInterval) {
+		this.retryInterval = retryInterval;
+	}
+
+	public boolean isClientModeConnected() {
+		if (this.isClientMode && this.clientModeConnectionManager != null) {
+			return this.clientModeConnectionManager.isConnected();
+		} else {
+			return false;
+		}
+	}
+
+	public void retryConnection() {
+		if (this.active && this.isClientMode && this.clientModeConnectionManager != null) {
+			this.clientModeConnectionManager.run();
+		}
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/ClientModeCapable.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/ClientModeCapable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.ip.tcp.connection;
+
+import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+
+/**
+ * Edpoints implementing this interface are capable
+ * of running in client-mode. For inbound endpoints,
+ * this means that the endpoint establishes the connection
+ * and then receives incoming data.
+ * <p/>
+ * For an outbound adapter, it means that the adapter
+ * will establish the connection rather than waiting
+ * for a message to cause the connection to be
+ * established.
+ *
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+public interface ClientModeCapable {
+
+	/**
+	 * @return true if the endpoint is running in
+	 * client mode.
+	 */
+	@ManagedAttribute
+	boolean isClientMode();
+
+	/**
+	 * @return true if the endpoint is running in
+	 * client mode.
+	 */
+	@ManagedAttribute
+	boolean isClientModeConnected();
+
+	/**
+	 * Immediately attempt to establish the connection.
+	 */
+	@ManagedOperation
+	void retryConnection();
+
+}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/ClientModeConnectionManager.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/ClientModeConnectionManager.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.ip.tcp.connection;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.util.Assert;
+
+/**
+ * Intended to be run on a schedule, simply gets the connection
+ * from a client connection factory each time it is run.
+ * If no connection exists (or it has been closed), the
+ * connection factory will create a new one (if possible).
+ *
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+public class ClientModeConnectionManager implements Runnable {
+
+	private final Log logger = LogFactory.getLog(this.getClass());
+
+	private final AbstractConnectionFactory clientConnectionFactory;
+
+	private volatile TcpConnection lastConnection;
+
+	/**
+	 * @param clientConnectionFactory
+	 */
+	public ClientModeConnectionManager(
+			AbstractConnectionFactory clientConnectionFactory) {
+		Assert.notNull(clientConnectionFactory, "Connection factory cannot be null");
+		this.clientConnectionFactory = clientConnectionFactory;
+	}
+
+	public void run() {
+		synchronized (this.clientConnectionFactory) {
+			try {
+				TcpConnection connection = this.clientConnectionFactory.getConnection();
+				if (connection != lastConnection) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Connection " + connection.getConnectionId() + " established");
+					}
+					lastConnection = connection;
+				} else {
+					if (logger.isTraceEnabled()) {
+						logger.trace("Connection " + connection.getConnectionId() + " still OK");
+					}
+				}
+			} catch (Exception e) {
+				logger.error("Could not establish connection using " + this.clientConnectionFactory, e);
+			}
+		}
+	}
+
+	public boolean isConnected() {
+		return this.lastConnection == null ? false : this.lastConnection.isOpen();
+	}
+
+}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetClientConnectionFactory.java
@@ -18,6 +18,7 @@ package org.springframework.integration.ip.tcp.connection;
 
 import java.io.IOException;
 import java.net.Socket;
+import java.net.SocketException;
 
 import javax.net.SocketFactory;
 
@@ -40,12 +41,12 @@ public class TcpNetClientConnectionFactory extends
 	}
 
 	/**
-	 * Obtains a connection - if {@link #setSingleUse(boolean)} was called with
-	 * true, a new connection is returned; otherwise a single connection is
-	 * reused for all requests while the connection remains open.
+	 * @return
+	 * @throws IOException
+	 * @throws SocketException
+	 * @throws Exception
 	 */
-	public TcpConnection getConnection() throws Exception {
-		this.checkActive();
+	protected TcpConnection getOrMakeConnection() throws Exception {
 		TcpConnection theConnection = this.getTheConnection();
 		if (theConnection != null && theConnection.isOpen()) {
 			return theConnection;
@@ -59,9 +60,6 @@ public class TcpNetClientConnectionFactory extends
 		connection = wrapConnection(connection);
 		initializeConnection(connection, socket);
 		this.getTaskExecutor().execute(connection);
-		if (!this.isSingleUse()) {
-			this.setTheConnection(connection);
-		}
 		this.harvestClosedConnections();
 		return connection;
 	}

--- a/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-2.1.xsd
+++ b/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-2.1.xsd
@@ -156,6 +156,17 @@ task executors such as a WorkManagerTaskExecutor.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="client-mode" type="xsd:string" use="optional" default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+							 If set to true, causes the adapter to act as a client with respect to
+							 establishing the connection, rather than listening for incoming connections.
+							 Requires a type="client" connection factory, with single-use set to false.
+							 Defaults to true.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="clientModeAttributeGroup" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -198,6 +209,17 @@ task executors such as a WorkManagerTaskExecutor.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="client-mode" type="xsd:string" use="optional" default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+							 If set to true, causes the adapter to establish a connection when started,
+							 rather than when the first message is sent.
+							 Requires a type="client" connection factory, with single-use set to false.
+							 Defaults to true.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="clientModeAttributeGroup" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -256,6 +278,17 @@ task executors such as a WorkManagerTaskExecutor.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="client-mode" type="xsd:string" use="optional" default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+							 If set to true, causes the gateway to act as a client with respect to
+							 establishing the connection, rather than listening for incoming connections.
+							 Requires a type="client" connection factory, with single-use set to false.
+							 Defaults to true.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="clientModeAttributeGroup" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -523,4 +556,29 @@ default is 0. Values can be negative. See SmartLifeCycle.
 		</xsd:attribute>
 	</xsd:complexType>
 
+	<xsd:attributeGroup name="clientModeAttributeGroup">
+		<xsd:attribute name="retry-interval" type="xsd:string" use="optional" default="60000">
+			<xsd:annotation>
+				<xsd:documentation>
+				 When in client mode, specifies the retry interval, in milliseconds, if a connection
+				 cannot be established. Defaults to 60000.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="scheduler" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				    When in client mode,
+					provide a reference to the TaskScheduler instance to
+					be used for establishing connections. If not provided, the default
+					will use a thread pool of size 1.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.scheduling.TaskScheduler" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
 </xsd:schema>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
@@ -278,4 +278,54 @@
 		channel="tcpChannel"
 		connection-factory="server1" />
 
+	<ip:tcp-connection-factory id="cfC3"
+		type="client"
+		port="#{tcpIpUtils.findAvailableServerSocket(6120)}"
+		host="localhost"
+		lookup-host="false"
+		apply-sequence="false"
+		/>
+
+	<ip:tcp-inbound-channel-adapter id="tcpInClientMode"
+		channel="tcpChannel"
+		connection-factory="cfC3"
+		client-mode="true"
+		retry-interval="123"
+		scheduler="sched" />
+
+	<ip:tcp-connection-factory id="cfC4"
+		type="client"
+		port="#{tcpIpUtils.findAvailableServerSocket(6140)}"
+		host="localhost"
+		lookup-host="false"
+		apply-sequence="false"
+		/>
+
+	<ip:tcp-outbound-channel-adapter id="tcpOutClientMode"
+		channel="tcpChannel"
+		connection-factory="cfC4"
+		client-mode="true"
+		retry-interval="124"
+		scheduler="sched" />
+
+	<ip:tcp-connection-factory id="cfC5"
+		type="client"
+		port="#{tcpIpUtils.findAvailableServerSocket(6160)}"
+		host="localhost"
+		lookup-host="false"
+		apply-sequence="false"
+		/>
+
+	<ip:tcp-inbound-gateway id="inGatewayClientMode"
+		request-channel="tcpChannel"
+		reply-channel="replyChannel"
+		connection-factory="cfC5"
+		reply-timeout="456"
+		client-mode="true"
+		retry-interval="125"
+		scheduler="sched"
+		/>
+
+	<task:scheduler id="sched"/>
+
 </beans>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ClientModeControlBusTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ClientModeControlBusTests-context.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int-ip="http://www.springframework.org/schema/integration/ip"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/ip http://www.springframework.org/schema/integration/ip/spring-integration-ip-2.1.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+
+	<bean id="tcpIpUtils" class="org.springframework.integration.ip.util.SocketTestUtils" />
+
+	<int:channel id="in"/>
+
+	<int:channel id="dummy">
+		<int:queue />
+	</int:channel>
+
+	<int-ip:tcp-connection-factory id="server"
+		type="server"
+		using-nio="true"
+		port="#{tcpIpUtils.findAvailableServerSocket(12000)}"
+		lookup-host="false"
+		so-timeout="20000"
+	/>
+
+	<int-ip:tcp-connection-factory id="client1"
+		type="client"
+		host="localhost"
+		port="#{server.port}"
+		lookup-host="false"
+		so-timeout="100000"
+	/>
+
+	<int-ip:tcp-inbound-gateway id="servergw"
+		request-channel="dummy"
+		connection-factory="server"/>
+
+	<int-ip:tcp-inbound-channel-adapter
+		id="tcpIn"
+		connection-factory="client1"
+		channel="in"
+		client-mode="true"/>
+
+	<int:channel id="cbChannel" />
+
+	<int:control-bus input-channel="cbChannel" />
+
+	<int:gateway default-request-channel="cbChannel" service-interface="org.springframework.integration.ip.tcp.ClientModeControlBusTests$ControlBus"/>
+
+</beans>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ClientModeControlBusTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ClientModeControlBusTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.ip.tcp;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ClientModeControlBusTests {
+
+	@Autowired
+	ControlBus controlBus;
+
+	@Autowired
+	TcpReceivingChannelAdapter tcpIn;
+
+	@Test
+	public void test() throws Exception {
+		assertTrue(controlBus.boolResult("@tcpIn.isClientMode()"));
+		int n = 0;
+		while (!controlBus.boolResult("@tcpIn.isClientModeConnected()")) {
+			Thread.sleep(100);
+			n += 100;
+			if (n > 10000) {
+				fail("Connection never established");
+			}
+		}
+		assertTrue(controlBus.boolResult("@tcpIn.isRunning()"));
+		controlBus.voidResult("@tcpIn.retryConnection()");
+	}
+
+	public static interface ControlBus {
+
+		boolean boolResult(String command);
+
+		void voidResult(String command);
+	}
+}


### PR DESCRIPTION
Add client mode for inbound endpoints, and for the
outbound adapter.

INT-1770 Allow Inbound Adapter to Open Connection

Normally, inbound adapters use server sockets and wait for incoming
connection. There are use cases where the adapter should establish
the connection and wait for inbound messages.

INT-1770 Open Connection on Start

Allow configuration of outbound adapter to permit
connection establishment when the adapter is started
rather than when the first message arrives.

INT-1770 Allow Inbound Gateway to Open Connection

Normally, inbound gateways listen for connections. There are
use cases where an inbound gateway might open the connection
and then wait for incoming requests.

INT-1770 Parsers

Update parsers and tests to support attributes for setting
endpoints in client-mode.

INT-1770 Docs

Update reference with client-mode information.

INT-1770 Add Control Bus for Client Mode

Enable control bus commands to check status and to attempt
connection establishment.
