### PR TITLE
INT-2184 Lifecycle Problem With TCP OB Adapter

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandler.java
@@ -61,7 +61,7 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 
 	private Map<String, TcpConnection> connections = new ConcurrentHashMap<String, TcpConnection>();
 
-	private volatile boolean autoStartup;
+	private volatile boolean autoStartup = true;
 
 	private volatile int phase;
 
@@ -237,9 +237,7 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 	}
 
 	public boolean isRunning() {
-		boolean cfRunning = this.clientConnectionFactory != null ? this.clientConnectionFactory.isRunning() : false;
-		boolean sfRunning = this.serverConnectionFactory != null ? this.serverConnectionFactory.isRunning() : false;
-		return cfRunning | sfRunning;
+		return this.active;
 	}
 
 	public int getPhase() {


### PR DESCRIPTION
Autostartup defaulted to false and isRunnin() returned
the status of the associated connection factory instead
of its own status. Precluded it being started because
LifeCycle processor thought it was already started.
