### PR TITLE
Int 2095

### DIFF
--- a/docs/src/reference/docbook/router.xml
+++ b/docs/src/reference/docbook/router.xml
@@ -97,10 +97,6 @@
                     <entry><imagedata fileref="images/tickmark.png"/></entry><entry><imagedata fileref="images/tickmark.png"/></entry><entry><imagedata fileref="images/tickmark.png"/></entry><entry><imagedata fileref="images/tickmark.png"/></entry><entry><imagedata fileref="images/tickmark.png"/></entry><entry><imagedata fileref="images/tickmark.png"/></entry>
                   </row>
                 <row>
-                    <entry>channel-resolver</entry>
-                    <entry><imagedata fileref="images/tickmark.png"/></entry><entry></entry><entry></entry><entry></entry><entry></entry><entry></entry>
-                  </row>
-                <row>
                     <entry>method</entry>
                     <entry><imagedata fileref="images/tickmark.png"/></entry><entry></entry><entry></entry><entry></entry><entry></entry><entry></entry>
                   </row>
@@ -187,10 +183,6 @@
                   <row>
                       <entry>order</entry>
                       <entry></entry><entry></entry><entry></entry><entry></entry><entry></entry><entry></entry>
-                  </row>
-                  <row>
-                      <entry>channel-resolver</entry>
-                      <entry><imagedata fileref="images/tickmark.png"/></entry><entry></entry><entry></entry><entry></entry><entry></entry><entry></entry>
                   </row>
                   <row>
                       <entry>method</entry>
@@ -793,8 +785,8 @@ public List<String> route(@Header("orderStatus") OrderStatus status)]]></program
             </listitem>
             <listitem>
               <para><emphasis>Step 3</emphasis> - Resolve <code>channel name</code> to the actual instance of the
-              <classname>MessageChannel</classname> where using <classname>ChannelResolver</classname>, the router will obtain a
-              reference to a bean (which is hopefully a <classname>MessageChannel</classname>) identified by the result of the
+              <classname>MessageChannel</classname> as a reference to a bean within the Application Context
+              (which is hopefully a <classname>MessageChannel</classname>) identified by the result of the
               previous step.</para>
             </listitem>
         </itemizedlist>
@@ -825,8 +817,8 @@ public List<String> route(@Header("orderStatus") OrderStatus status)]]></program
             </listitem>
             <listitem>
               <para><emphasis>Step 3</emphasis> - Resolve <code>channel name</code> to the actual instance of the
-              <classname>MessageChannel</classname> where using <classname>ChannelResolver</classname>, the router will obtain a
-              reference to a bean (which is hopefully a <classname>MessageChannel</classname>) identified by the result of the
+              <classname>MessageChannel</classname> as a reference to a bean within the Application Context
+              (which is hopefully a <classname>MessageChannel</classname>) identified by the result of the
               previous step.</para>
             </listitem>
         </itemizedlist>
@@ -860,9 +852,8 @@ public List<String> route(@Header("orderStatus") OrderStatus status)]]></program
         </para>
         <para>
             So all that is left is for Step 3 to resolve the <code>channel name</code> ('kermit') to an actual instance of the
-            <classname>MessageChannel</classname> identified by this name. That will be done via the default
-            <interface>ChannelResolver</interface> implementation which is a <classname>BeanFactoryChannelResolver</classname>. It
-            basically does a bean lookup for the name provided. So now all messages which contain the header/value pair as <code>testHeader=kermit</code>
+            <classname>MessageChannel</classname> identified by this name. That basically involves a bean lookup
+            for the name provided. So now all messages which contain the header/value pair as <code>testHeader=kermit</code>
             are going to be routed to a <classname>MessageChannel</classname> whose bean name (id) is 'kermit'.
         </para>
         <para>

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
@@ -34,7 +34,7 @@ import org.springframework.util.StringUtils;
  */
 public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean {
 
-	private volatile Map<String, String> channelIdentifierMap;
+	private volatile Map<String, String> channelMappings;
 
 	private volatile MessageChannel defaultOutputChannel;
 
@@ -67,8 +67,8 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 		this.ignoreSendFailures = ignoreSendFailures;
 	}
 	
-	public void setChannelIdentifierMap(Map<String, String> channelIdentifierMap) {
-		this.channelIdentifierMap = channelIdentifierMap;
+	public void setChannelMappings(Map<String, String> channelMappings) {
+		this.channelMappings = channelMappings;
 	}
 
 	@Override
@@ -103,8 +103,8 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 	}
 
 	private AbstractMessageRouter configureRouter(AbstractMessageRouter router) {
-		if (this.channelIdentifierMap != null) {
-			router.setChannelIdentifierMap(this.channelIdentifierMap);
+		if (this.channelMappings != null) {
+			router.setChannelMappings(this.channelMappings);
 		}
 		if (this.defaultOutputChannel != null) {
 			router.setDefaultOutputChannel(this.defaultOutputChannel);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -21,7 +21,6 @@ import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.router.AbstractMessageRouter;
 import org.springframework.integration.router.ExpressionEvaluatingRouter;
 import org.springframework.integration.router.MethodInvokingRouter;
-import org.springframework.integration.support.channel.ChannelResolver;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -35,8 +34,6 @@ import org.springframework.util.StringUtils;
  */
 public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean {
 
-	private volatile ChannelResolver channelResolver;
-	
 	private volatile Map<String, String> channelIdentifierMap;
 
 	private volatile MessageChannel defaultOutputChannel;
@@ -49,10 +46,6 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 
 	private volatile Boolean ignoreSendFailures;
 
-
-	public void setChannelResolver(ChannelResolver channelResolver) {
-		this.channelResolver = channelResolver;
-	}
 
 	public void setDefaultOutputChannel(MessageChannel defaultOutputChannel) {
 		this.defaultOutputChannel = defaultOutputChannel;
@@ -110,9 +103,6 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 	}
 
 	private AbstractMessageRouter configureRouter(AbstractMessageRouter router) {
-		if (this.channelResolver != null) {
-			router.setChannelResolver(this.channelResolver);
-		}
 		if (this.channelIdentifierMap != null) {
 			router.setChannelIdentifierMap(this.channelIdentifierMap);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import org.springframework.expression.Expression;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.core.MessageHandler;
-import org.springframework.integration.router.AbstractMessageRouter;
+import org.springframework.integration.router.AbstractMappingMessageRouter;
 import org.springframework.integration.router.ExpressionEvaluatingRouter;
 import org.springframework.integration.router.MethodInvokingRouter;
 import org.springframework.util.Assert;
@@ -74,7 +74,7 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 	@Override
 	MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName) {
 		Assert.notNull(targetObject, "target object must not be null");
-		AbstractMessageRouter router = this.extractTypeIfPossible(targetObject, AbstractMessageRouter.class);
+		AbstractMappingMessageRouter router = this.extractTypeIfPossible(targetObject, AbstractMappingMessageRouter.class);
 		if (router == null) {
 			router = this.createMethodInvokingRouter(targetObject, targetMethodName);
 			this.configureRouter(router);
@@ -95,14 +95,14 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 		return this.configureRouter(new ExpressionEvaluatingRouter(expression));
 	}
 
-	private AbstractMessageRouter createMethodInvokingRouter(Object targetObject, String targetMethodName) {
+	private AbstractMappingMessageRouter createMethodInvokingRouter(Object targetObject, String targetMethodName) {
 		MethodInvokingRouter router = (StringUtils.hasText(targetMethodName)) 
 				? new MethodInvokingRouter(targetObject, targetMethodName)
 				: new MethodInvokingRouter(targetObject);
 		return router;
 	}
 
-	private AbstractMessageRouter configureRouter(AbstractMessageRouter router) {
+	private AbstractMappingMessageRouter configureRouter(AbstractMappingMessageRouter router) {
 		if (this.channelMappings != null) {
 			router.setChannelMappings(this.channelMappings);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class RouterAnnotationPostProcessor extends AbstractMethodAnnotationPostP
 	@Override
 	protected MessageHandler createHandler(Object bean, Method method, Router annotation) {
 		MethodInvokingRouter router = new MethodInvokingRouter(bean, method);
-		router.setChannelResolver(this.channelResolver);
+		router.setBeanFactory(this.beanFactory);
 		String defaultOutputChannelName = annotation.defaultOutputChannel();
 		if (StringUtils.hasText(defaultOutputChannelName)) {
 			MessageChannel defaultOutputChannel = this.channelResolver.resolveChannelName(defaultOutputChannelName);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractRouterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractRouterParser.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.config.RouterFactoryBean;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.xml.DomUtils;
 
@@ -36,8 +37,7 @@ public abstract class AbstractRouterParser extends AbstractConsumerEndpointParse
 
 	@Override
 	protected final BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-				IntegrationNamespaceUtils.BASE_PACKAGE + ".config.RouterFactoryBean");
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(RouterFactoryBean.class);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "default-output-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "timeout");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "resolution-required");

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractRouterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractRouterParser.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.xml.DomUtils;
 
 /**
@@ -51,23 +52,27 @@ public abstract class AbstractRouterParser extends AbstractConsumerEndpointParse
 		BeanDefinition beanDefinition = this.doParseRouter(element, parserContext);
 		if (beanDefinition != null) {
 			// check if mapping is provided otherwise returned values will be treated as channel names
-			List<Element> childElements = DomUtils.getChildElementsByTagName(element, "mapping");
-			if (childElements != null && childElements.size() > 0) {
-				ManagedMap<String, String> channelMap = new ManagedMap<String, String>();
-				for (Element childElement : childElements) {
-					String key = childElement.getAttribute(this.getMappingKeyAttributeValue());
-					channelMap.put(key, childElement.getAttribute("channel"));
+			List<Element> mappingElements = DomUtils.getChildElementsByTagName(element, "mapping");
+			if (!CollectionUtils.isEmpty(mappingElements)) {
+				ManagedMap<String, String> channelMappings = new ManagedMap<String, String>();
+				for (Element mappingElement : mappingElements) {
+					String key = mappingElement.getAttribute(this.getMappingKeyAttributeName());
+					channelMappings.put(key, mappingElement.getAttribute("channel"));
 				}
-				beanDefinition.getPropertyValues().add("channelIdentifierMap", channelMap);
+				beanDefinition.getPropertyValues().add("channelMappings", channelMappings);
 			}
 		}
 		return beanDefinition;
 	}
 
-	protected abstract BeanDefinition doParseRouter(Element element, ParserContext parserContext);
-	
-	protected String getMappingKeyAttributeValue(){
+	/**
+	 * Returns the name of the attribute that provides a key for the
+	 * channel mappings. This can be overridden by subclasses.
+	 */
+	protected String getMappingKeyAttributeName() {
 		return "value";
 	}
+
+	protected abstract BeanDefinition doParseRouter(Element element, ParserContext parserContext);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractRouterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractRouterParser.java
@@ -21,11 +21,9 @@ import java.util.List;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 
 /**
@@ -52,10 +50,6 @@ public abstract class AbstractRouterParser extends AbstractConsumerEndpointParse
 	protected final BeanDefinition parseRouter(Element element, ParserContext parserContext) {
 		BeanDefinition beanDefinition = this.doParseRouter(element, parserContext);
 		if (beanDefinition != null) {
-			String channelResolver = element.getAttribute("channel-resolver");
-			if (StringUtils.hasText(channelResolver)){
-				beanDefinition.getPropertyValues().add("channelResolver", new RuntimeBeanReference(channelResolver));
-			}
 			// check if mapping is provided otherwise returned values will be treated as channel names
 			List<Element> childElements = DomUtils.getChildElementsByTagName(element, "mapping");
 			if (childElements != null && childElements.size() > 0) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DefaultRouterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DefaultRouterParser.java
@@ -48,11 +48,11 @@ public class DefaultRouterParser extends AbstractDelegatingConsumerEndpointParse
 	protected void postProcess(BeanDefinitionBuilder builder, Element element, ParserContext parserContext) {
 		List<Element> mappingElements = DomUtils.getChildElementsByTagName(element, "mapping");
 		if (!CollectionUtils.isEmpty(mappingElements)) {
-			ManagedMap<String, String> channelMap = new ManagedMap<String, String>();
+			ManagedMap<String, String> channelMappings = new ManagedMap<String, String>();
 			for (Element mappingElement : mappingElements) {
-				channelMap.put(mappingElement.getAttribute("value"), mappingElement.getAttribute("channel"));
+				channelMappings.put(mappingElement.getAttribute("value"), mappingElement.getAttribute("channel"));
 			}
-			builder.addPropertyValue("channelIdentifierMap", channelMap);
+			builder.addPropertyValue("channelMappings", channelMappings);
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "default-output-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "timeout");

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ErrorMessageExceptionTypeRouterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ErrorMessageExceptionTypeRouterParser.java
@@ -28,7 +28,12 @@ import org.w3c.dom.Element;
  * @since 2.0.4
  */
 public class ErrorMessageExceptionTypeRouterParser extends AbstractRouterParser {
-	
+
+	@Override
+	protected String getMappingKeyAttributeName() {
+		return "exception-type";
+	}
+
 	@Override
 	protected BeanDefinition doParseRouter(Element element,
 			ParserContext parserContext) {
@@ -36,9 +41,5 @@ public class ErrorMessageExceptionTypeRouterParser extends AbstractRouterParser 
 				IntegrationNamespaceUtils.BASE_PACKAGE + ".router.ErrorMessageExceptionTypeRouter");
 		return payloadTypeRouterBuilder.getBeanDefinition();
 	}
-	
-	@Override
-	protected String getMappingKeyAttributeValue(){
-		return "exception-type";
-	}
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ErrorMessageExceptionTypeRouterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ErrorMessageExceptionTypeRouterParser.java
@@ -16,10 +16,12 @@
 
 package org.springframework.integration.config.xml;
 
-import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.support.BeanDefinitionBuilder;
-import org.springframework.beans.factory.xml.ParserContext;
 import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.router.ErrorMessageExceptionTypeRouter;
 
 /**
  * Parser for the &lt;exception-type-router/&gt; element.
@@ -35,11 +37,8 @@ public class ErrorMessageExceptionTypeRouterParser extends AbstractRouterParser 
 	}
 
 	@Override
-	protected BeanDefinition doParseRouter(Element element,
-			ParserContext parserContext) {
-		BeanDefinitionBuilder payloadTypeRouterBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-				IntegrationNamespaceUtils.BASE_PACKAGE + ".router.ErrorMessageExceptionTypeRouter");
-		return payloadTypeRouterBuilder.getBeanDefinition();
+	protected BeanDefinition doParseRouter(Element element, ParserContext parserContext) {
+		return new RootBeanDefinition(ErrorMessageExceptionTypeRouter.class);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/HeaderValueRouterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/HeaderValueRouterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.w3c.dom.Element;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.router.HeaderValueRouter;
 
 /**
  * Parser for the &lt;header-value-router/&gt; element.
@@ -33,8 +34,7 @@ public class HeaderValueRouterParser extends AbstractRouterParser {
 
 	@Override
 	protected BeanDefinition doParseRouter(Element element, ParserContext parserContext) {
-		BeanDefinitionBuilder headerValueRouterBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-				IntegrationNamespaceUtils.BASE_PACKAGE + ".router.HeaderValueRouter");
+		BeanDefinitionBuilder headerValueRouterBuilder = BeanDefinitionBuilder.genericBeanDefinition(HeaderValueRouter.class);
 		headerValueRouterBuilder.addConstructorArgValue(element.getAttribute("header-name"));
 		return headerValueRouterBuilder.getBeanDefinition();
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PayloadTypeRouterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PayloadTypeRouterParser.java
@@ -17,8 +17,9 @@
 package org.springframework.integration.config.xml;
 
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.router.PayloadTypeRouter;
 import org.w3c.dom.Element;
 
 /**
@@ -36,11 +37,8 @@ public class PayloadTypeRouterParser extends AbstractRouterParser {
 	}
 
 	@Override
-	protected BeanDefinition doParseRouter(Element element,
-			ParserContext parserContext) {
-		BeanDefinitionBuilder payloadTypeRouterBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-				IntegrationNamespaceUtils.BASE_PACKAGE + ".router.PayloadTypeRouter");
-		return payloadTypeRouterBuilder.getBeanDefinition();
+	protected BeanDefinition doParseRouter(Element element, ParserContext parserContext) {
+		return new RootBeanDefinition(PayloadTypeRouter.class);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PayloadTypeRouterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PayloadTypeRouterParser.java
@@ -29,7 +29,12 @@ import org.w3c.dom.Element;
  * @since 1.0.3
  */
 public class PayloadTypeRouterParser extends AbstractRouterParser {
-	
+
+	@Override
+	protected String getMappingKeyAttributeName() {
+		return "type";
+	}
+
 	@Override
 	protected BeanDefinition doParseRouter(Element element,
 			ParserContext parserContext) {
@@ -37,9 +42,5 @@ public class PayloadTypeRouterParser extends AbstractRouterParser {
 				IntegrationNamespaceUtils.BASE_PACKAGE + ".router.PayloadTypeRouter");
 		return payloadTypeRouterBuilder.getBeanDefinition();
 	}
-	
-	@Override
-	protected String getMappingKeyAttributeValue(){
-		return "type";
-	}
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.router;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.integration.Message;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.MessagingException;
+import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
+import org.springframework.integration.support.channel.ChannelResolutionException;
+import org.springframework.integration.support.channel.ChannelResolver;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Base class for all Message Routers.
+ * 
+ * @author Mark Fisher
+ * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
+ */
+@ManagedResource
+public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter {
+
+	private final Map<String, String> channelMappings = new ConcurrentHashMap<String, String>();
+
+	private volatile ChannelResolver channelResolver;
+
+	private volatile String prefix;
+
+	private volatile String suffix;
+
+	private volatile boolean resolutionRequired = true;
+
+
+	/**
+	 * Provide mappings from channel keys to channel names.
+	 * Channel names will be resolved by the {@link ChannelResolver}.
+	 */
+	public void setChannelMappings(Map<String, String> channelMappings) {
+		this.channelMappings.clear();
+		this.channelMappings.putAll(channelMappings);
+	}
+
+	/**
+	 * Specify the {@link ChannelResolver} strategy to use.
+	 * The default is a BeanFactoryChannelResolver.
+	 */
+	public void setChannelResolver(ChannelResolver channelResolver) {
+		Assert.notNull(channelResolver, "'channelResolver' must not be null");
+		this.channelResolver = channelResolver;
+	}
+
+	/**
+	 * Specify a prefix to be added to each channel name prior to resolution.
+	 */
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	/**
+	 * Specify a suffix to be added to each channel name prior to resolution.
+	 */
+	public void setSuffix(String suffix) {
+		this.suffix = suffix;
+	}
+
+	/**
+	 * Specify whether this router should ignore any failure to resolve a channel name to
+	 * an actual MessageChannel instance when delegating to the ChannelResolver strategy.
+	 */
+	public void setResolutionRequired(boolean resolutionRequired) {
+		this.resolutionRequired = resolutionRequired;
+	}
+
+	/**
+	 * Returns an unmodifiable version of the channel mappings.
+	 * This is intended for use by subclasses only.
+	 */
+	protected Map<String, String> getChannelMappings() {
+		return Collections.unmodifiableMap(this.channelMappings);
+	}
+
+	/**
+	 * Add a channel mapping from the provided key to channel name.
+	 */
+	@ManagedOperation
+	public void setChannelMapping(String key, String channelName) {
+		this.channelMappings.put(key, channelName);
+	}
+
+	/**
+	 * Remove a channel mapping for the given key if present.
+	 */
+	@ManagedOperation
+	public void removeChannelMapping(String key) {
+		this.channelMappings.remove(key);
+	}
+
+	@Override
+	public void onInit() {
+		BeanFactory beanFactory = this.getBeanFactory();
+		if (this.channelResolver == null && beanFactory != null) {
+			this.channelResolver = new BeanFactoryChannelResolver(beanFactory);
+		}
+	}
+
+	/**
+	 * Subclasses must implement this method to return the channel keys.
+	 * A "key" might be present in this router's "channelMappings", or it
+	 * could be the channel's name or even the Message Channel instance itself.
+	 */
+	protected abstract List<Object> getChannelKeys(Message<?> message);
+
+
+	@Override
+	protected Collection<MessageChannel> determineTargetChannels(Message<?> message) {
+		Collection<MessageChannel> channels = new ArrayList<MessageChannel>();
+		Collection<Object> channelKeys = this.getChannelKeys(message);
+		addToCollection(channels, channelKeys, message);
+		return channels;
+	}
+
+	private MessageChannel resolveChannelForName(String channelName, Message<?> message) {
+		if (this.channelResolver == null) {
+			this.onInit();
+		}
+		Assert.state(this.channelResolver != null, "unable to resolve channel names, no ChannelResolver available");
+		MessageChannel channel = null;
+		try {
+			channel = this.channelResolver.resolveChannelName(channelName);
+		}
+		catch (ChannelResolutionException e) {
+			if (this.resolutionRequired) {
+				throw new MessagingException(message, "failed to resolve channel name '" + channelName + "'", e);
+			}
+		}
+		if (channel == null && this.resolutionRequired) {
+			throw new MessagingException(message, "failed to resolve channel name '" + channelName + "'");
+		}
+		return channel;
+	}
+
+	private void addChannelFromString(Collection<MessageChannel> channels, String channelKey, Message<?> message) {
+		if (channelKey.indexOf(',') != -1) {
+			for (String name : StringUtils.tokenizeToStringArray(channelKey, ",")) {
+				addChannelFromString(channels, name, message);
+			}
+			return;
+		}
+
+		// if the channelMappings contains a mapping, we'll use the mapped value
+		// otherwise, the String-based channelKey itself will be used as the channel name
+		String channelName = channelKey;
+		if (this.channelMappings.containsKey(channelKey)) {
+			channelName = this.channelMappings.get(channelKey);
+		}
+		if (this.prefix != null) {
+			channelName = this.prefix + channelName;
+		}
+		if (this.suffix != null) {
+			channelName = channelName + this.suffix;
+		}
+		MessageChannel channel = resolveChannelForName(channelName, message);
+		if (channel != null) {
+			channels.add(channel);
+		}
+	}
+
+	private void addToCollection(Collection<MessageChannel> channels, Collection<?> channelKeys, Message<?> message) {
+		if (channelKeys == null) {
+			return;
+		}
+		for (Object channelKey : channelKeys) {
+			if (channelKey == null) {
+				continue;
+			}
+			else if (channelKey instanceof MessageChannel) {
+				channels.add((MessageChannel) channelKey);
+			}
+			else if (channelKey instanceof MessageChannel[]) {
+				channels.addAll(Arrays.asList((MessageChannel[]) channelKey));
+			}
+			else if (channelKey instanceof String) {
+				addChannelFromString(channels, (String) channelKey, message);
+			}
+			else if (channelKey instanceof String[]) {
+				for (String indicatorName : (String[]) channelKey) {
+					addChannelFromString(channels, indicatorName, message);
+				}
+			}
+			else if (channelKey instanceof Collection) {
+				addToCollection(channels, (Collection<?>) channelKey, message);
+			}
+			else if (this.getRequiredConversionService().canConvert(channelKey.getClass(), String.class)) {
+				addChannelFromString(channels, this.getConversionService().convert(channelKey, String.class), message);
+			}
+			else {
+				throw new MessagingException("unsupported return type for router [" + channelKey.getClass() + "]");
+			}
+		}
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
@@ -32,7 +32,7 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @since 2.0
  */
-class AbstractMessageProcessingRouter extends AbstractMessageRouter {
+class AbstractMessageProcessingRouter extends AbstractMappingMessageRouter {
 
 	private final MessageProcessor<Object> messageProcessor;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
@@ -55,7 +55,7 @@ class AbstractMessageProcessingRouter extends AbstractMessageRouter {
 	}
 
 	@Override
-	protected List<Object> getChannelIdentifiers(Message<?> message) {
+	protected List<Object> getChannelKeys(Message<?> message) {
 		Object result = this.messageProcessor.processMessage(message);
 		return Collections.singletonList(result);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageRouter.java
@@ -285,7 +285,7 @@ public abstract class AbstractMessageRouter extends AbstractMessageHandler {
 
 	private void addChannelFromString(Collection<MessageChannel> channels, String channelKey, Message<?> message) {
 		if (channelKey.indexOf(',') != -1) {
-			for (String name : StringUtils.commaDelimitedListToStringArray(channelKey)) {
+			for (String name : StringUtils.tokenizeToStringArray(channelKey, ",")) {
 				addChannelFromString(channels, name, message);
 			}
 			return;

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
@@ -33,20 +33,20 @@ import org.springframework.integration.MessageChannel;
 public class ErrorMessageExceptionTypeRouter extends AbstractMessageRouter {
 
 	@Override
-	protected List<Object> getChannelIdentifiers(Message<?> message) {
-		String channel = null;
+	protected List<Object> getChannelKeys(Message<?> message) {
+		String mostSpecificCause = null;
 		Object payload = message.getPayload();
 		if (payload instanceof Throwable) {
-			Throwable mostSpecificCause = (Throwable) payload;
-			while (mostSpecificCause != null) {
-				String mappedChannel = this.getChannelMapping(mostSpecificCause.getClass().getName());
-				if (mappedChannel != null) {
-					channel = mappedChannel;
+			Throwable cause = (Throwable) payload;
+			while (cause != null) {
+				String causeName = cause.getClass().getName();
+				if (this.getChannelMappings().keySet().contains(causeName)) {
+					mostSpecificCause = causeName;
 				}
-				mostSpecificCause = mostSpecificCause.getCause();
+				cause = cause.getCause();
 			}
 		}
-		return Collections.singletonList((Object) channel);
+		return Collections.singletonList((Object) mostSpecificCause);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,19 +34,19 @@ public class ErrorMessageExceptionTypeRouter extends AbstractMessageRouter {
 
 	@Override
 	protected List<Object> getChannelIdentifiers(Message<?> message) {
-		String channelIdentifier = null;
+		String channel = null;
 		Object payload = message.getPayload();
-		if (payload != null && (payload instanceof Throwable) && this.channelIdentifierMap != null) {
+		if (payload instanceof Throwable) {
 			Throwable mostSpecificCause = (Throwable) payload;
 			while (mostSpecificCause != null) {
-				String mappedChannelIdentifier = this.channelIdentifierMap.get(mostSpecificCause.getClass().getName());
-				if (mappedChannelIdentifier != null) {
-					channelIdentifier = mappedChannelIdentifier;
+				String mappedChannel = this.getChannelMapping(mostSpecificCause.getClass().getName());
+				if (mappedChannel != null) {
+					channel = mappedChannel;
 				}
 				mostSpecificCause = mostSpecificCause.getCause();
 			}
 		}
-		return Collections.singletonList((Object) channelIdentifier);
+		return Collections.singletonList((Object) channel);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
@@ -30,7 +30,7 @@ import org.springframework.integration.MessageChannel;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  */  
-public class ErrorMessageExceptionTypeRouter extends AbstractMessageRouter {
+public class ErrorMessageExceptionTypeRouter extends AbstractMappingMessageRouter {
 
 	@Override
 	protected List<Object> getChannelKeys(Message<?> message) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/HeaderValueRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/HeaderValueRouter.java
@@ -43,7 +43,7 @@ public class HeaderValueRouter extends AbstractMessageRouter {
 	}
 
 	@Override
-	protected List<Object> getChannelIdentifiers(Message<?> message) {
+	protected List<Object> getChannelKeys(Message<?> message) {
 		Object value = message.getHeaders().get(this.headerName);
 		if (value instanceof String && ((String) value).indexOf(',') != -1) {
 			value = StringUtils.tokenizeToStringArray((String) value, ",", true, true);

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/HeaderValueRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/HeaderValueRouter.java
@@ -30,7 +30,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @since 1.0.3
  */
-public class HeaderValueRouter extends AbstractMessageRouter {
+public class HeaderValueRouter extends AbstractMappingMessageRouter {
 
 	private final String headerName;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
@@ -45,7 +45,7 @@ public class PayloadTypeRouter extends AbstractMessageRouter {
 	 *    preferring direct interface over indirect subclass
 	 */
 	@Override
-	protected List<Object> getChannelIdentifiers(Message<?> message) {
+	protected List<Object> getChannelKeys(Message<?> message) {
 		String channelName = this.getChannelName(message);
 		return (channelName != null) ? Collections.<Object>singletonList(channelName) : null;
 	}
@@ -96,7 +96,7 @@ public class PayloadTypeRouter extends AbstractMessageRouter {
 			return null;
 		}
 		// we have a winner
-		return this.getChannelMapping(matches.get(0));		
+		return matches.get(0);//this.getMappedChannelName(matches.get(0));		
 	}
 
 	private int determineTypeDifferenceWeight(String candidate, Class<?> type, int level) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
@@ -51,7 +51,7 @@ public class PayloadTypeRouter extends AbstractMessageRouter {
 	}
 
 	private String getChannelName(Message<?> message) {
-		if (CollectionUtils.isEmpty(this.channelIdentifierMap)) {
+		if (CollectionUtils.isEmpty(this.getChannelMappings())) {
 			return null;
 		}
 		Class<?> type = message.getPayload().getClass();
@@ -65,7 +65,7 @@ public class PayloadTypeRouter extends AbstractMessageRouter {
 	private String findClosestMatch(Class<?> type, boolean isArray) {
 		int minTypeDiffWeight = Integer.MAX_VALUE;
 		List<String> matches = new ArrayList<String>();
-		for (String candidate : this.channelIdentifierMap.keySet()) {
+		for (String candidate : this.getChannelMappings().keySet()) {
 			if (isArray) {
 				if (!candidate.endsWith(ARRAY_SUFFIX)) {
 					continue;
@@ -96,7 +96,7 @@ public class PayloadTypeRouter extends AbstractMessageRouter {
 			return null;
 		}
 		// we have a winner
-		return this.channelIdentifierMap.get(matches.get(0));		
+		return this.getChannelMapping(matches.get(0));		
 	}
 
 	private int determineTypeDifferenceWeight(String candidate, Class<?> type, int level) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
@@ -31,7 +31,7 @@ import org.springframework.util.CollectionUtils;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  */
-public class PayloadTypeRouter extends AbstractMessageRouter {
+public class PayloadTypeRouter extends AbstractMappingMessageRouter {
 
 	private static final String ARRAY_SUFFIX = "[]";
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
@@ -46,11 +46,6 @@ public class PayloadTypeRouter extends AbstractMessageRouter {
 	 */
 	@Override
 	protected List<Object> getChannelKeys(Message<?> message) {
-		String channelName = this.getChannelName(message);
-		return (channelName != null) ? Collections.<Object>singletonList(channelName) : null;
-	}
-
-	private String getChannelName(Message<?> message) {
 		if (CollectionUtils.isEmpty(this.getChannelMappings())) {
 			return null;
 		}
@@ -59,8 +54,10 @@ public class PayloadTypeRouter extends AbstractMessageRouter {
 		if (isArray) {
 			type = type.getComponentType();
 		}
-		return this.findClosestMatch(type, isArray);
+		String closestMatch =  this.findClosestMatch(type, isArray);
+		return (closestMatch != null) ? Collections.<Object>singletonList(closestMatch) : null;
 	}
+
 
 	private String findClosestMatch(Class<?> type, boolean isArray) {
 		int minTypeDiffWeight = Integer.MAX_VALUE;

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.router;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.beans.factory.InitializingBean;
@@ -39,7 +40,7 @@ import org.springframework.util.Assert;
  * the values can be provided via the {@link #setRecipients(List)} method.
  * <p/>
  * For more advanced, programmatic control of dynamic recipient lists, consider
- * using the @Router annotation or extending {@link AbstractMessageRouter} instead.
+ * using the @Router annotation or extending {@link AbstractMappingMessageRouter} instead.
  * <p/>
  * Contrary to a standard &lt;router .../&gt; this handler will try to send to
  * all channels that are configured as recipients. It is to channels what a
@@ -90,8 +91,8 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 	}
 
 	@Override
-	protected List<Object> getChannelKeys(Message<?> message) {
-		List<Object> channels = new ArrayList<Object>();
+	protected Collection<MessageChannel> determineTargetChannels(Message<?> message) {
+		List<MessageChannel> channels = new ArrayList<MessageChannel>();
 		List<Recipient> recipientList = this.recipients;
 		for (Recipient recipient : recipientList) {
 			if (recipient.accept(message)) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
@@ -90,7 +90,7 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 	}
 
 	@Override
-	protected List<Object> getChannelIdentifiers(Message<?> message) {
+	protected List<Object> getChannelKeys(Message<?> message) {
 		List<Object> channels = new ArrayList<Object>();
 		List<Recipient> recipientList = this.recipients;
 		for (Recipient recipient : recipientList) {

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
@@ -2103,22 +2103,6 @@ endpoint itself is a Polling Consumer for a channel with a queue.
                         </xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
-                <xsd:attribute name="channel-resolver" type="xsd:string">
-                    <xsd:annotation>
-                        <xsd:documentation><![CDATA[
-                            Provides a reference to a ChannelResolver that resolves
-                            the return value to the name of a MessageChannel
-                            within the application context. If none is provided,
-                            the return value is expected to match a channel name
-                            exactly.
-                        ]]></xsd:documentation>
-                        <xsd:appinfo>
-                            <tool:annotation kind="ref">
-                                <tool:expected-type type="org.springframework.integration.core.ChannelResolver" />
-                            </tool:annotation>
-                        </xsd:appinfo>
-                    </xsd:annotation>
-                </xsd:attribute>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/RouterFactoryBeanDelegationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/RouterFactoryBeanDelegationTests-context.xml
@@ -19,7 +19,7 @@
 
 	<bean id="payloadTypeRouter" class="org.springframework.integration.router.PayloadTypeRouter">
 		<property name="resolutionRequired" value="true"/>
-		<property name="channelIdentifierMap">
+		<property name="channelMappings">
 			<map>
 				<entry key="java.lang.String" value="strings"/>
 			</map>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/RouterFactoryBeanDelegationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/RouterFactoryBeanDelegationTests.java
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.message.GenericMessage;
-import org.springframework.integration.router.AbstractMessageRouter;
+import org.springframework.integration.router.AbstractMappingMessageRouter;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -50,7 +50,7 @@ public class RouterFactoryBeanDelegationTests {
 	private PollableChannel discard;
 
 	@Autowired @Qualifier("org.springframework.integration.config.RouterFactoryBean#0")
-	private AbstractMessageRouter router;
+	private AbstractMappingMessageRouter router;
 
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class ErrorMessageExceptionTypeRouterTests {
 		exceptionTypeChannelMap.put(IllegalArgumentException.class.getName(), "illegalArgumentChannel");
 		exceptionTypeChannelMap.put(RuntimeException.class.getName(), "runtimeExceptionChannel");
 		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
-		router.setChannelIdentifierMap(exceptionTypeChannelMap);
+		router.setChannelMappings(exceptionTypeChannelMap);
 		
 		router.setBeanFactory(beanFactory);
 
@@ -95,7 +95,7 @@ public class ErrorMessageExceptionTypeRouterTests {
 		Map<String, String> exceptionTypeChannelMap = new HashMap<String, String>();
 		exceptionTypeChannelMap.put(RuntimeException.class.getName(), "runtimeExceptionChannel");
 		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "runtimeExceptionChannel");
-		router.setChannelIdentifierMap(exceptionTypeChannelMap);
+		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 
 		router.setDefaultOutputChannel(defaultChannel);
@@ -116,7 +116,7 @@ public class ErrorMessageExceptionTypeRouterTests {
 		ErrorMessageExceptionTypeRouter router = new ErrorMessageExceptionTypeRouter();
 		Map<String, String> exceptionTypeChannelMap = new HashMap<String, String>();
 		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
-		router.setChannelIdentifierMap(exceptionTypeChannelMap);
+		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		router.setDefaultOutputChannel(defaultChannel);
 		router.handleMessage(message);
@@ -152,7 +152,7 @@ public class ErrorMessageExceptionTypeRouterTests {
 		ErrorMessageExceptionTypeRouter router = new ErrorMessageExceptionTypeRouter();
 		Map<String, String> exceptionTypeChannelMap = new HashMap<String, String>();
 		exceptionTypeChannelMap.put(MessageDeliveryException.class.getName(), "messageDeliveryExceptionChannel");
-		router.setChannelIdentifierMap(exceptionTypeChannelMap);
+		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		router.setResolutionRequired(true);
 		router.handleMessage(message);
@@ -170,7 +170,7 @@ public class ErrorMessageExceptionTypeRouterTests {
 		exceptionTypeChannelMap.put(IllegalArgumentException.class.getName(), "illegalArgumentChannel");
 		exceptionTypeChannelMap.put(RuntimeException.class.getName(), "runtimeExceptionChannel");
 		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
-		router.setChannelIdentifierMap(exceptionTypeChannelMap);
+		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		router.setDefaultOutputChannel(defaultChannel);
 		router.handleMessage(message);
@@ -191,7 +191,7 @@ public class ErrorMessageExceptionTypeRouterTests {
 		Map<String, String> exceptionTypeChannelMap = new HashMap<String, String>();
 		exceptionTypeChannelMap.put(IllegalArgumentException.class.getName(), "illegalArgumentChannel");
 		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
-		router.setChannelIdentifierMap(exceptionTypeChannelMap);
+		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		router.setDefaultOutputChannel(defaultChannel);
 		router.handleMessage(message);

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/HeaderValueRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/HeaderValueRouterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,12 +90,12 @@ public class HeaderValueRouterTests {
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void resolveChannelNameFromMap() {
 		StaticApplicationContext context = new StaticApplicationContext();
-		ManagedMap channelMap = new ManagedMap();
-		channelMap.put("testKey", "testChannel");
+		ManagedMap channelMappings = new ManagedMap();
+		channelMappings.put("testKey", "testChannel");
 		RootBeanDefinition routerBeanDefinition = new RootBeanDefinition(HeaderValueRouter.class);
 		routerBeanDefinition.getConstructorArgumentValues().addGenericArgumentValue("testHeaderName");
 		routerBeanDefinition.getPropertyValues().addPropertyValue("resolutionRequired", "true");
-		routerBeanDefinition.getPropertyValues().addPropertyValue("channelIdentifierMap", channelMap);
+		routerBeanDefinition.getPropertyValues().addPropertyValue("channelMappings", channelMappings);
 		routerBeanDefinition.getPropertyValues().addPropertyValue("beanFactory", context);
 		context.registerBeanDefinition("router", routerBeanDefinition);
 		context.registerBeanDefinition("testChannel", new RootBeanDefinition(QueueChannel.class));
@@ -112,12 +112,12 @@ public class HeaderValueRouterTests {
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void resolveChannelNameFromMapAndCustomeResolver() {
 		final StaticApplicationContext context = new StaticApplicationContext();
-		ManagedMap channelMap = new ManagedMap();
-		channelMap.put("testKey", "testChannel");
+		ManagedMap channelMappings = new ManagedMap();
+		channelMappings.put("testKey", "testChannel");
 		RootBeanDefinition routerBeanDefinition = new RootBeanDefinition(HeaderValueRouter.class);
 		routerBeanDefinition.getConstructorArgumentValues().addGenericArgumentValue("testHeaderName");
 		routerBeanDefinition.getPropertyValues().addPropertyValue("resolutionRequired", "true");
-		routerBeanDefinition.getPropertyValues().addPropertyValue("channelIdentifierMap", channelMap);
+		routerBeanDefinition.getPropertyValues().addPropertyValue("channelMappings", channelMappings);
 		routerBeanDefinition.getPropertyValues().addPropertyValue("beanFactory", context);
 		routerBeanDefinition.getPropertyValues().addPropertyValue("channelResolver", new ChannelResolver() {
 			public MessageChannel resolveChannelName(String channelName) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/MultiChannelRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/MultiChannelRouterTests.java
@@ -39,7 +39,7 @@ public class MultiChannelRouterTests {
 
 	@Test
 	public void routeWithChannelMapping() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			public List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] {"channel1", "channel2"});
@@ -63,7 +63,7 @@ public class MultiChannelRouterTests {
 
 	@Test(expected = MessagingException.class)
 	public void channelNameLookupFailure() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			public List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] {"noSuchChannel"} );
@@ -77,7 +77,7 @@ public class MultiChannelRouterTests {
 
 	@Test(expected = MessagingException.class)
 	public void channelMappingNotAvailable() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			public List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] {"noSuchChannel"});

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/MultiChannelRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/MultiChannelRouterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import java.util.List;
 
 import org.junit.Test;
+
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessagingException;
@@ -40,7 +41,7 @@ public class MultiChannelRouterTests {
 	public void routeWithChannelMapping() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			public List<Object> getChannelIdentifiers(Message<?> message) {
+			public List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] {"channel1", "channel2"});
 			}
 		};
@@ -64,7 +65,7 @@ public class MultiChannelRouterTests {
 	public void channelNameLookupFailure() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			public List<Object> getChannelIdentifiers(Message<?> message) {
+			public List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] {"noSuchChannel"} );
 			}
 		};
@@ -78,7 +79,7 @@ public class MultiChannelRouterTests {
 	public void channelMappingNotAvailable() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			public List<Object> getChannelIdentifiers(Message<?> message) {
+			public List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] {"noSuchChannel"});
 			}
 		};

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/PayloadTypeRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/PayloadTypeRouterTests.java
@@ -51,7 +51,7 @@ public class PayloadTypeRouterTests {
 		payloadTypeChannelMap.put(String.class.getName(), "stringChannel");
 		payloadTypeChannelMap.put(Integer.class.getName(), "integerChannel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		
 		Message<String> message1 = new GenericMessage<String>("test");
@@ -98,7 +98,7 @@ public class PayloadTypeRouterTests {
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(Number.class.getName(), "numberChannel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<Integer> message = new GenericMessage<Integer>(99);
@@ -138,7 +138,7 @@ public class PayloadTypeRouterTests {
 		
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 	
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<Integer> message = new GenericMessage<Integer>(99);
@@ -166,7 +166,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 			
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<Integer> message = new GenericMessage<Integer>(99);
@@ -193,7 +193,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 			
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
@@ -224,7 +224,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 			
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
@@ -255,7 +255,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 			
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
@@ -286,7 +286,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 			
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
@@ -315,7 +315,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<Integer> message = new GenericMessage<Integer>(99);
@@ -356,7 +356,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<String> message = new GenericMessage<String>("test");
@@ -383,7 +383,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<Integer> message = new GenericMessage<Integer>(99);
@@ -412,7 +412,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		Message<String> message1 = new GenericMessage<String>("test");
 		Message<Integer> message2 = new GenericMessage<Integer>(123);
@@ -440,7 +440,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<String> message1 = new GenericMessage<String>("test");
@@ -481,7 +481,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
@@ -515,7 +515,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
@@ -548,7 +548,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
-		router.setChannelIdentifierMap(payloadTypeChannelMap);
+		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/PayloadTypeRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/PayloadTypeRouterTests.java
@@ -56,17 +56,27 @@ public class PayloadTypeRouterTests {
 		
 		Message<String> message1 = new GenericMessage<String>("test");
 		Message<Integer> message2 = new GenericMessage<Integer>(123);
-		assertEquals(1, router.getChannelIdentifiers(message1).size());
-		assertEquals("stringChannel", router.getChannelIdentifiers(message1).iterator().next());
-		assertEquals(1, router.getChannelIdentifiers(message2).size());
-		assertEquals("integerChannel", router.getChannelIdentifiers(message2).iterator().next());
+		assertEquals(1, router.getChannelKeys(message1).size());
 		
+		assertNull(stringChannel.receive(0));
+		router.handleMessage(message1);
+		assertEquals(message1, stringChannel.receive(0));
+		
+		assertEquals(1, router.getChannelKeys(message2).size());
+		
+		assertNull(integerChannel.receive(0));
+		router.handleMessage(message2);
+		assertEquals(message2, integerChannel.receive(0));
+
 		// validate dynamics
 		QueueChannel newChannel = new QueueChannel();
 		beanFactory.registerSingleton("newChannel", newChannel);
 		router.setChannelMapping(String.class.getName(), "newChannel");
-		assertEquals(1, router.getChannelIdentifiers(message1).size());
-		assertEquals("newChannel", router.getChannelIdentifiers(message1).iterator().next());
+		assertEquals(1, router.getChannelKeys(message1).size());
+
+		assertNull(newChannel.receive(0));
+		router.handleMessage(message1);
+		assertEquals(message1, newChannel.receive(0));
 
 		// validate exception is thrown if mappings were removed and 
 		// channelResolutionRequires = true (which is the default)
@@ -112,7 +122,7 @@ public class PayloadTypeRouterTests {
 		QueueChannel newChannel = new QueueChannel();
 		beanFactory.registerSingleton("newChannel", newChannel);
 		router.setChannelMapping(Integer.class.getName(), "newChannel");
-		assertEquals(1, router.getChannelIdentifiers(message).size());
+		assertEquals(1, router.getChannelKeys(message).size());
 		router.handleMessage(message);
 		result = newChannel.receive(10);
 		assertNotNull(result);
@@ -330,7 +340,7 @@ public class PayloadTypeRouterTests {
 		QueueChannel newChannel = new QueueChannel();
 		beanFactory.registerSingleton("newChannel", newChannel);
 		router.setChannelMapping(Integer.class.getName(), "newChannel");
-		assertEquals(1, router.getChannelIdentifiers(message).size());
+		assertEquals(1, router.getChannelKeys(message).size());
 		router.handleMessage(message);
 		result = newChannel.receive(10);
 		assertNotNull(result);

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/RouterTests.java
@@ -46,7 +46,7 @@ public class RouterTests {
 	public void nullChannelRaisesMessageDeliveryExceptionByDefault() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@Override
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return null;
 			}		
 		};
@@ -58,7 +58,7 @@ public class RouterTests {
 	public void nullChannelIdentifierUsingChannelResolverRaisesMessageDeliveryExceptionByDefault() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@Override
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return null;
 			}
 		};
@@ -72,7 +72,7 @@ public class RouterTests {
 	public void nullChannelIdentifierInListRaisesMessageDeliveryExceptionByDefault() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@Override
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return Collections.singletonList(null);
 			}
 		};
@@ -85,7 +85,7 @@ public class RouterTests {
 	@Test(expected = MessageDeliveryException.class)
 	public void emptyChannelNameArrayRaisesMessageDeliveryExceptionByDefault() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return new ArrayList<Object>();
 			}
 		};
@@ -99,7 +99,7 @@ public class RouterTests {
 	public void channelMappingIsRequiredWhenResolvingChannelNames() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			protected List<Object> getChannelIdentifiers(Message<?> message){
+			protected List<Object> getChannelKeys(Message<?> message){
 				return CollectionUtils.arrayToList(new String[] { "notImportant" });
 			}
 		};
@@ -111,7 +111,7 @@ public class RouterTests {
 	public void beanFactoryWithRouter() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "testChannel" });
 			}
 		};
@@ -128,7 +128,7 @@ public class RouterTests {
 	public void beanFactoryWithRouterAndMultipleCommaSeparatedChannelNames() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "testChannel1,testChannel2" });
 			}
 		};
@@ -156,7 +156,7 @@ public class RouterTests {
 		
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "testChannelDoesNotExist", "testChannel" });
 			}
 		};
@@ -174,7 +174,7 @@ public class RouterTests {
 		
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "testChannelDoesNotExist", "testChannel" });
 			}
 		};
@@ -195,7 +195,7 @@ public class RouterTests {
 	public void beanFactoryWithRouterAndChannelPrefix() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "MyChannel" });
 			}
 		};
@@ -216,7 +216,7 @@ public class RouterTests {
 	public void beanFactoryWithRouterAndChannelPrefixFailing() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "testing_MyChannel" });
 			}
 		};
@@ -235,7 +235,7 @@ public class RouterTests {
 	public void beanFactoryWithRouterAndChannelSuffix() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "MyChannel" });
 			}
 		};
@@ -255,7 +255,7 @@ public class RouterTests {
 	public void beanFactoryWithRouterAndChannelSuffixFailing() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "MyChannel_withSuffix" });
 			}
 		};
@@ -274,7 +274,7 @@ public class RouterTests {
 	public void beanFactoryWithRouterAndChannelIdentifiersInListWithinAList() {
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				
 				List<String> channelNames1 = CollectionUtils.arrayToList(new String[] { "channel1" });
 				List<String> channelNames2 = CollectionUtils.arrayToList(new String[] { "channel2" });
@@ -314,7 +314,7 @@ public class RouterTests {
 		
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				
 				MessageChannel[] channelNames1 = new MessageChannel[] { testChannel1 };
 				MessageChannel[] channelNames2 = new MessageChannel[] { testChannel2 };
@@ -351,7 +351,7 @@ public class RouterTests {
 		
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new Integer[] { 100, 200 });
 			}
 		};
@@ -389,7 +389,7 @@ public class RouterTests {
 
 		AbstractMessageRouter router = new AbstractMessageRouter() {
 			@SuppressWarnings("unchecked")
-			protected List<Object> getChannelIdentifiers(Message<?> message) {
+			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new CustomObjectWithChannelName[] { new CustomObjectWithChannelName() });
 			}
 		};

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/RouterTests.java
@@ -44,7 +44,7 @@ public class RouterTests {
 
 	@Test(expected = MessageDeliveryException.class)
 	public void nullChannelRaisesMessageDeliveryExceptionByDefault() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@Override
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return null;
@@ -56,7 +56,7 @@ public class RouterTests {
 
 	@Test(expected = MessageDeliveryException.class)
 	public void nullChannelIdentifierUsingChannelResolverRaisesMessageDeliveryExceptionByDefault() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@Override
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return null;
@@ -70,7 +70,7 @@ public class RouterTests {
 
 	@Test(expected = MessageDeliveryException.class)
 	public void nullChannelIdentifierInListRaisesMessageDeliveryExceptionByDefault() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@Override
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return Collections.singletonList(null);
@@ -84,7 +84,7 @@ public class RouterTests {
 
 	@Test(expected = MessageDeliveryException.class)
 	public void emptyChannelNameArrayRaisesMessageDeliveryExceptionByDefault() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return new ArrayList<Object>();
 			}
@@ -97,7 +97,7 @@ public class RouterTests {
 
 	@Test(expected = MessagingException.class)
 	public void channelMappingIsRequiredWhenResolvingChannelNames() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			protected List<Object> getChannelKeys(Message<?> message){
 				return CollectionUtils.arrayToList(new String[] { "notImportant" });
@@ -109,7 +109,7 @@ public class RouterTests {
 
 	@Test
 	public void beanFactoryWithRouter() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "testChannel" });
@@ -126,7 +126,7 @@ public class RouterTests {
 
 	@Test
 	public void beanFactoryWithRouterAndMultipleCommaSeparatedChannelNames() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "testChannel1,testChannel2" });
@@ -154,7 +154,7 @@ public class RouterTests {
 	@Test(expected = MessagingException.class)
 	public void channelResolutionIsRequiredByDefault() {
 		
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "testChannelDoesNotExist", "testChannel" });
@@ -172,7 +172,7 @@ public class RouterTests {
 	@Test
 	public void unresolvableChannelIdentifierInListAreIgnoredWhenResolutionRequiredIsFalse() {
 		
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "testChannelDoesNotExist", "testChannel" });
@@ -193,7 +193,7 @@ public class RouterTests {
 	
 	@Test
 	public void beanFactoryWithRouterAndChannelPrefix() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "MyChannel" });
@@ -214,7 +214,7 @@ public class RouterTests {
 
 	@Test(expected = MessagingException.class)
 	public void beanFactoryWithRouterAndChannelPrefixFailing() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "testing_MyChannel" });
@@ -233,7 +233,7 @@ public class RouterTests {
 	
 	@Test
 	public void beanFactoryWithRouterAndChannelSuffix() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "MyChannel" });
@@ -253,7 +253,7 @@ public class RouterTests {
 
 	@Test(expected = MessagingException.class)
 	public void beanFactoryWithRouterAndChannelSuffixFailing() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new String[] { "MyChannel_withSuffix" });
@@ -272,7 +272,7 @@ public class RouterTests {
 	
 	@Test
 	public void beanFactoryWithRouterAndChannelIdentifiersInListWithinAList() {
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			protected List<Object> getChannelKeys(Message<?> message) {
 				
@@ -312,7 +312,7 @@ public class RouterTests {
 		final QueueChannel testChannel1 = new QueueChannel();
 		final QueueChannel testChannel2 = new QueueChannel();
 		
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 
 			protected List<Object> getChannelKeys(Message<?> message) {
 				
@@ -349,7 +349,7 @@ public class RouterTests {
 		final QueueChannel testChannel1 = new QueueChannel();
 		final QueueChannel testChannel2 = new QueueChannel();
 		
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new Integer[] { 100, 200 });
@@ -387,7 +387,7 @@ public class RouterTests {
 				
 		final QueueChannel testChannel1 = new QueueChannel();
 
-		AbstractMessageRouter router = new AbstractMessageRouter() {
+		AbstractMappingMessageRouter router = new AbstractMappingMessageRouter() {
 			@SuppressWarnings("unchecked")
 			protected List<Object> getChannelKeys(Message<?> message) {
 				return CollectionUtils.arrayToList(new CustomObjectWithChannelName[] { new CustomObjectWithChannelName() });

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/RouterTests.java
@@ -375,6 +375,7 @@ public class RouterTests {
 		
 		String channel = "channel1";
 
+		@SuppressWarnings("unused")
 		public String getChannel() {
 			return this.channel;
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterParserTests.java
@@ -19,7 +19,6 @@ package org.springframework.integration.router.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -29,6 +28,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
@@ -194,7 +194,7 @@ public class RouterParserTests {
 
 
 		@Override
-		protected List<Object> getChannelIdentifiers(Message<?> message) {
+		protected List<Object> getChannelKeys(Message<?> message) {
 			return Collections.singletonList((Object)this.channel);
 		}
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterParserTests.java
@@ -41,7 +41,7 @@ import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.message.GenericMessage;
-import org.springframework.integration.router.AbstractMessageRouter;
+import org.springframework.integration.router.AbstractMappingMessageRouter;
 import org.springframework.integration.router.MethodInvokingRouter;
 import org.springframework.integration.support.channel.ChannelResolver;
 import org.springframework.integration.test.util.TestUtils;
@@ -184,7 +184,7 @@ public class RouterParserTests {
 		}
 	}
 
-	public static class TestRouterImplementation extends AbstractMessageRouter {
+	public static class TestRouterImplementation extends AbstractMappingMessageRouter {
 
 		private final MessageChannel channel;
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterParserTests.java
@@ -143,18 +143,6 @@ public class RouterParserTests {
 	}
 
 	@Test
-	public void channelResolverConfigured() {
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-				"routerParserTests.xml", this.getClass());
-		Object channelResolverBean = context.getBean("testChannelResolver");
-		Object endpoint = context.getBean("routerWithChannelResolver");
-		MethodInvokingRouter router = TestUtils.getPropertyValue(endpoint, "handler", MethodInvokingRouter.class);
-		ChannelResolver channelResolver = (ChannelResolver)
-				new DirectFieldAccessor(router).getPropertyValue("channelResolver");
-		assertSame(channelResolverBean, channelResolver);
-	}
-
-	@Test
 	public void sequence() {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"routerParserTests.xml", this.getClass());

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterWithMappingTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterWithMappingTests.java
@@ -28,7 +28,7 @@ import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.core.PollableChannel;
-import org.springframework.integration.router.AbstractMessageRouter;
+import org.springframework.integration.router.AbstractMappingMessageRouter;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
@@ -87,7 +87,7 @@ public class RouterWithMappingTests {
 		assertNull(fooChannelForExpression.receive(0));
 		assertNull(barChannelForExpression.receive(0));
 		// validate dynamics
-		AbstractMessageRouter router = (AbstractMessageRouter) TestUtils.getPropertyValue(spelRouter, "handler");
+		AbstractMappingMessageRouter router = (AbstractMappingMessageRouter) TestUtils.getPropertyValue(spelRouter, "handler");
 		router.setChannelMapping("baz", "fooChannelForExpression");
 		expressionRouter.send(message3);
 		assertNull(defaultChannelForExpression.receive(10));

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/routerParserTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/routerParserTests.xml
@@ -80,10 +80,6 @@
 	<channel id="timeoutRouterChannel"/>
 	<router id="routerWithTimeout" ref="payloadAsChannelNameRouter" timeout="1234" input-channel="timeoutRouterChannel"/>
 
-	<channel id="channelResolverRouterChannel"/>
-	<router id="routerWithChannelResolver" input-channel="channelResolverRouterChannel"
-		ref="payloadAsChannelNameRouter" channel-resolver="testChannelResolver"/>
-	
 	<beans:bean id="testChannelResolver"
 		class="org.springframework.integration.router.config.RouterParserTests$TestChannelResover"/>
 

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/config/XPathRouterParser.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/config/XPathRouterParser.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractRouterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.xml.router.XPathRouter;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -36,15 +37,13 @@ import org.springframework.util.StringUtils;
  */
 public class XPathRouterParser extends AbstractRouterParser {
 
-	private XPathExpressionParser xpathParser = new XPathExpressionParser();
+	private final XPathExpressionParser xpathParser = new XPathExpressionParser();
 
 
 	@Override
 	protected BeanDefinition doParseRouter(Element element, ParserContext parserContext) {
-		BeanDefinitionBuilder xpathRouterBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-				"org.springframework.integration.xml.router.XPathRouter");
-		NodeList xPathExpressionNodes = element.getElementsByTagNameNS(
-				element.getNamespaceURI(), "xpath-expression");
+		BeanDefinitionBuilder xpathRouterBuilder = BeanDefinitionBuilder.genericBeanDefinition(XPathRouter.class);
+		NodeList xPathExpressionNodes = element.getElementsByTagNameNS(element.getNamespaceURI(), "xpath-expression");
 		Assert.isTrue(xPathExpressionNodes.getLength() <= 1, "At most one xpath-expression child may be specified.");
 		String xPathExpressionRef = element.getAttribute("xpath-expression-ref");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(xpathRouterBuilder, element, "evaluate-as-string");
@@ -53,8 +52,7 @@ public class XPathRouterParser extends AbstractRouterParser {
 		Assert.isTrue(xPathExpressionChildPresent ^ xPathReferencePresent,
 				"Exactly one of 'xpath-expression' or 'xpath-expression-ref' is required.");
 		if (xPathExpressionChildPresent) {
-			BeanDefinition beanDefinition = this.xpathParser.parse(
-					(Element) xPathExpressionNodes.item(0), parserContext);
+			BeanDefinition beanDefinition = this.xpathParser.parse((Element) xPathExpressionNodes.item(0), parserContext);
 			xpathRouterBuilder.addConstructorArgValue(beanDefinition);
 		}
 		else { 

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/router/XPathRouter.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/router/XPathRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,10 +113,10 @@ public class XPathRouter extends AbstractMessageRouter {
 	}
 
 	@Override
-	protected List<Object> getChannelIdentifiers(Message<?> message) {
+	protected List<Object> getChannelKeys(Message<?> message) {
 		Node node = this.converter.convertToNode(message.getPayload());
-		if (this.evaluateAsString){		
-			return Collections.singletonList((Object)this.xPathExpression.evaluateAsString(node));
+		if (this.evaluateAsString) {
+			return Collections.singletonList((Object) this.xPathExpression.evaluateAsString(node));
 		}
 		else {
 			return this.xPathExpression.evaluate(node, this.nodeMapper);

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/router/XPathRouter.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/router/XPathRouter.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.integration.Message;
-import org.springframework.integration.router.AbstractMessageRouter;
+import org.springframework.integration.router.AbstractMappingMessageRouter;
 import org.springframework.integration.xml.DefaultXmlPayloadConverter;
 import org.springframework.integration.xml.XmlPayloadConverter;
 import org.springframework.util.Assert;
@@ -38,7 +38,7 @@ import org.w3c.dom.Node;
  * @author Jonas Partner
  * @author Oleg Zhurakousky
  */
-public class XPathRouter extends AbstractMessageRouter {
+public class XPathRouter extends AbstractMappingMessageRouter {
 
 	private volatile NodeMapper<Object> nodeMapper = new TextContentNodeMapper();
 

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathRouterParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathRouterParserTests.java
@@ -37,7 +37,7 @@ import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.message.GenericMessage;
-import org.springframework.integration.router.AbstractMessageRouter;
+import org.springframework.integration.router.AbstractMappingMessageRouter;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.xml.DefaultXmlPayloadConverter;
@@ -181,7 +181,7 @@ public class XPathRouterParserTests {
 		assertNull(channelB.receive(10));
 		
 		EventDrivenConsumer routerEndpoint = ac.getBean("xpathRouterEmpty", EventDrivenConsumer.class);
-		AbstractMessageRouter xpathRouter = (AbstractMessageRouter) TestUtils.getPropertyValue(routerEndpoint, "handler");
+		AbstractMappingMessageRouter xpathRouter = (AbstractMappingMessageRouter) TestUtils.getPropertyValue(routerEndpoint, "handler");
 		xpathRouter.setChannelMapping("channelA", "channelB");
 		inputChannel.send(docMessage);
 		assertNotNull(channelB.receive(10));
@@ -201,7 +201,7 @@ public class XPathRouterParserTests {
 		assertNotNull(channelB.receive(10));
 		
 		EventDrivenConsumer routerEndpoint = ac.getBean("xpathRouterWithMapping", EventDrivenConsumer.class);
-		AbstractMessageRouter xpathRouter = (AbstractMessageRouter) TestUtils.getPropertyValue(routerEndpoint, "handler");
+		AbstractMappingMessageRouter xpathRouter = (AbstractMappingMessageRouter) TestUtils.getPropertyValue(routerEndpoint, "handler");
 		xpathRouter.removeChannelMapping("channelA");
 		inputChannel.send(docMessage);
 		assertNotNull(channelA.receive(10));
@@ -223,7 +223,7 @@ public class XPathRouterParserTests {
 		assertNull(channelB.receive(10));
 		
 		EventDrivenConsumer routerEndpoint = ac.getBean("xpathRouterWithMappingMultiChannel", EventDrivenConsumer.class);
-		AbstractMessageRouter xpathRouter = (AbstractMessageRouter) TestUtils.getPropertyValue(routerEndpoint, "handler");
+		AbstractMappingMessageRouter xpathRouter = (AbstractMappingMessageRouter) TestUtils.getPropertyValue(routerEndpoint, "handler");
 		xpathRouter.removeChannelMapping("channelA");
 		xpathRouter.removeChannelMapping("channelB");
 		inputChannel.send(docMessage);

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/router/XPathRouterTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/router/XPathRouterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class XPathRouterTests {
 		Document doc = XmlTestUtil.getDocumentForString("<doc type=\"one\" />");
 		XPathExpression expression = XPathExpressionFactory.createXPathExpression("/doc/@type");
 		XPathRouter router = new XPathRouter(expression);
-		Object[] channelNames = router.getChannelIdentifiers(new GenericMessage(doc)).toArray();
+		Object[] channelNames = router.getChannelKeys(new GenericMessage(doc)).toArray();
 		assertEquals("Wrong number of channels returned", 1, channelNames.length);
 		assertEquals("Wrong channel name", "one", channelNames[0]);
 	}
@@ -53,7 +53,7 @@ public class XPathRouterTests {
 		XPathExpression expression = XPathExpressionFactory.createXPathExpression("/doc/@type");
 		XPathRouter router = new XPathRouter(expression);
 		router.setEvaluateAsString(true);
-		Object[] channelNames = router.getChannelIdentifiers(new GenericMessage(doc)).toArray();
+		Object[] channelNames = router.getChannelKeys(new GenericMessage(doc)).toArray();
 		assertEquals("Wrong number of channels returned", 1, channelNames.length);
 		assertEquals("Wrong channel name", "one", channelNames[0]);
 	}
@@ -65,7 +65,7 @@ public class XPathRouterTests {
 		XPathExpression expression = XPathExpressionFactory.createXPathExpression("name(./node())");
 		XPathRouter router = new XPathRouter(expression);
 		router.setEvaluateAsString(true);
-		Object[] channelNames = router.getChannelIdentifiers(new GenericMessage(doc)).toArray();
+		Object[] channelNames = router.getChannelKeys(new GenericMessage(doc)).toArray();
 		assertEquals("Wrong number of channels returned", 1, channelNames.length);
 		assertEquals("Wrong channel name", "doc", channelNames[0]);
 	}
@@ -76,7 +76,7 @@ public class XPathRouterTests {
 		Document doc = XmlTestUtil.getDocumentForString("<doc type=\"one\"><book>bOne</book><book>bTwo</book></doc>");
 		XPathExpression expression = XPathExpressionFactory.createXPathExpression("/doc/book");
 		XPathRouter router = new XPathRouter(expression);
-		Object[] channelNames = router.getChannelIdentifiers(new GenericMessage(doc)).toArray();
+		Object[] channelNames = router.getChannelKeys(new GenericMessage(doc)).toArray();
 		assertEquals("Wrong number of channels returned", 2, channelNames.length);
 		assertEquals("Wrong channel name", "bOne", channelNames[0]);
 		assertEquals("Wrong channel name", "bTwo", channelNames[1]);
@@ -96,7 +96,7 @@ public class XPathRouterTests {
 		XPathExpression expression = XPathExpressionFactory.createXPathExpression("/doc/book");
 		XPathRouter router = new XPathRouter(expression);
 		router.setEvaluateAsString(true);
-		Object[] channelNames = router.getChannelIdentifiers(new GenericMessage("<doc type=\"one\"><book>bOne</book><book>bTwo</book></doc>")).toArray();
+		Object[] channelNames = router.getChannelKeys(new GenericMessage("<doc type=\"one\"><book>bOne</book><book>bTwo</book></doc>")).toArray();
 		assertEquals("Wrong number of channels returned", 1, channelNames.length);
 		assertEquals("Wrong channel name", "bOne", channelNames[0]);
 	}
@@ -105,14 +105,14 @@ public class XPathRouterTests {
 	public void nonNodePayload() throws Exception {
 		XPathExpression expression = XPathExpressionFactory.createXPathExpression("/doc/@type");
 		XPathRouter router = new XPathRouter(expression);
-		router.getChannelIdentifiers(new GenericMessage<String>("test"));
+		router.getChannelKeys(new GenericMessage<String>("test"));
 	}
 
 	@Test
 	public void nodePayload() throws Exception {
 		XPathRouter router = new XPathRouter("./three/text()");
 		Document testDocument = XmlTestUtil.getDocumentForString("<one><two><three>bob</three><three>dave</three></two></one>");
-		Object[] channelNames =  router.getChannelIdentifiers(new GenericMessage<Node>(testDocument.getElementsByTagName("two").item(0))).toArray();
+		Object[] channelNames =  router.getChannelKeys(new GenericMessage<Node>(testDocument.getElementsByTagName("two").item(0))).toArray();
 		assertEquals("bob",channelNames[0]);
 		assertEquals("dave",channelNames[1]);
 	}
@@ -122,7 +122,7 @@ public class XPathRouterTests {
 		Document doc = XmlTestUtil.getDocumentForString("<doc type='one' />");
 		XPathExpression expression = XPathExpressionFactory.createXPathExpression("/doc/@type");
 		XPathRouter router = new XPathRouter(expression);
-		Object channelName = router.getChannelIdentifiers(new GenericMessage<Document>(doc)).toArray()[0];
+		Object channelName = router.getChannelKeys(new GenericMessage<Document>(doc)).toArray()[0];
 		assertEquals("Wrong channel name", "one", channelName);
 	}
 
@@ -130,7 +130,7 @@ public class XPathRouterTests {
 	public void testSimpleStringDoc() throws Exception {
 		XPathExpression expression = XPathExpressionFactory.createXPathExpression("/doc/@type");
 		XPathRouter router = new XPathRouter(expression);
-		Object channelName = router.getChannelIdentifiers(new GenericMessage<String>("<doc type='one' />")).toArray()[0];
+		Object channelName = router.getChannelKeys(new GenericMessage<String>("<doc type='one' />")).toArray()[0];
 		assertEquals("Wrong channel name", "one", channelName);
 	}
 
@@ -138,14 +138,14 @@ public class XPathRouterTests {
 	public void testNonNodePayload() throws Exception {
 		XPathExpression expression = XPathExpressionFactory.createXPathExpression("/doc/@type");
 		XPathRouter router = new XPathRouter(expression);
-		router.getChannelIdentifiers(new GenericMessage<String>("test"));
+		router.getChannelKeys(new GenericMessage<String>("test"));
 	}
 
 	@Test
 	public void testNodePayload() throws Exception {
 		XPathRouter router = new XPathRouter("./three/text()");
 		Document testDocument = XmlTestUtil.getDocumentForString("<one><two><three>bob</three></two></one>");
-		Object[] channelNames = router.getChannelIdentifiers(new GenericMessage<Node>(testDocument
+		Object[] channelNames = router.getChannelKeys(new GenericMessage<Node>(testDocument
 				.getElementsByTagName("two").item(0))).toArray();
 		assertEquals("bob", channelNames[0]);
 	}
@@ -155,7 +155,7 @@ public class XPathRouterTests {
 		Document doc = XmlTestUtil.getDocumentForString("<doc type='one' />");
 		XPathExpression expression = XPathExpressionFactory.createXPathExpression("/somethingelse/@type");
 		XPathRouter router = new XPathRouter(expression);
-		List<Object> channelNames = router.getChannelIdentifiers(new GenericMessage<Document>(doc));
+		List<Object> channelNames = router.getChannelKeys(new GenericMessage<Document>(doc));
 		assertEquals(0, channelNames.size());
 	}
 


### PR DESCRIPTION
The ChannelResolver strategy still exists on AbstractMessageRouter, but it is no longer being exposed as a public configuration option (no longer available as an attribute in the namespace or on the RouterFactoryBean). It is still useful for testing, and possibly for some 'internal' support via BeanPostProcessor modifications, etc.

A few other changes were made, such as renaming 'channelIdentifierMap' to 'channelMappings' for consistency with the add/remove methods that are exposed as @ManagedOperations

JIRA reference: https://jira.springsource.org/browse/INT-2095
