### PR TITLE
INT-2202 Add auto-startup To Inbound Endpoints

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AbstractAmqpInboundAdapterParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AbstractAmqpInboundAdapterParser.java
@@ -101,6 +101,8 @@ abstract class AbstractAmqpInboundAdapterParser extends AbstractSingleBeanDefini
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "header-mapper");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-startup");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "phase");
 		this.configureChannels(element, parserContext, builder);
 	}
 

--- a/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-2.1.xsd
+++ b/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-2.1.xsd
@@ -369,6 +369,13 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Boolean value indicating whether this endpoint should start automatically.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:attributeGroup name="containerAttributes">

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests-context.xml
@@ -11,6 +11,9 @@
 
 	<amqp:inbound-channel-adapter id="rabbitInbound" queue-names="inboundchanneladapter.test.1"/>
 
+	<amqp:inbound-channel-adapter id="autoStartFalse" queue-names="inboundchanneladapter.test.2"
+		auto-startup="false" phase="123"/>
+
 	<bean id="rabbitConnectionFactory" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.amqp.rabbit.connection.ConnectionFactory"/>
 	</bean>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter;
 import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -45,6 +46,14 @@ public class AmqpInboundChannelAdapterParserTests {
 		Object adapter = context.getBean("rabbitInbound.adapter");
 		assertEquals(DirectChannel.class, channel.getClass());
 		assertEquals(AmqpInboundChannelAdapter.class, adapter.getClass());
+		assertEquals(Boolean.TRUE, TestUtils.getPropertyValue(adapter, "autoStartup"));
+		assertEquals(0, TestUtils.getPropertyValue(adapter, "phase"));
 	}
 
+	@Test
+	public void verifyLifeCycle() {
+		Object adapter = context.getBean("autoStartFalse.adapter");
+		assertEquals(Boolean.FALSE, TestUtils.getPropertyValue(adapter, "autoStartup"));
+		assertEquals(123, TestUtils.getPropertyValue(adapter, "phase"));
+	}
 }

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests-context.xml
@@ -20,4 +20,8 @@
 
 	<bean id="testConverter" class="org.springframework.integration.amqp.config.AmqpInboundGatewayParserTests$TestConverter"/>
 
+	<si-amqp:inbound-gateway id="autoStartFalseGateway" request-channel="requests" queue-names="test"
+			connection-factory="rabbitConnectionFactory" message-converter="testConverter"
+			auto-startup="false" phase="123"/>
+
 </beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.amqp.config;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
@@ -48,8 +49,16 @@ public class AmqpInboundGatewayParserTests {
 		TestConverter testConverter = context.getBean("testConverter", TestConverter.class);
 		assertSame(testConverter, gatewayConverter);
 		assertSame(testConverter, templateConverter);
+		assertEquals(Boolean.TRUE, TestUtils.getPropertyValue(gateway, "autoStartup"));
+		assertEquals(0, TestUtils.getPropertyValue(gateway, "phase"));
 	}
 
+	@Test
+	public void verifyLifeCycle() {
+		Object gateway = context.getBean("autoStartFalseGateway");
+		assertEquals(Boolean.FALSE, TestUtils.getPropertyValue(gateway, "autoStartup"));
+		assertEquals(123, TestUtils.getPropertyValue(gateway, "phase"));
+	}
 
 	private static class TestConverter extends SimpleMessageConverter {}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/GatewayEchoTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/GatewayEchoTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.amqp.config;
 
+import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
@@ -28,4 +29,9 @@ public class GatewayEchoTests {
 		new ClassPathXmlApplicationContext("GatewayEchoTests-context.xml", GatewayEchoTests.class);
 	}
 
+	@Test
+	/**
+	 * Dummy test to satisfy maven in some environments.
+	 */
+	public void test() {}
 }


### PR DESCRIPTION
Schema and parsers did not support auto-startup; inbound channel
adapter parser did not support phase.
