### PR TITLE
INT-2035 Simple Cookie Handling

### DIFF
--- a/docs/src/reference/docbook/http.xml
+++ b/docs/src/reference/docbook/http.xml
@@ -100,6 +100,17 @@ By default the HTTP request will be generated using an instance of <classname>Si
 In the case of the Outbound Gateway, the reply message produced by the gateway will contain all Message Headers present in the request message.
     	</note>
     </para>
+    <para><emphasis>Cookies</emphasis></para>
+    <para>
+      Basic cookie support is provided by the <emphasis>transfer-cookies</emphasis> attribute on the outbound gateway. When
+      set to true (default is false), a <emphasis>Set-Cookie</emphasis> header received from the server in a response, will be inserted into
+      the reply message in header <emphasis>http_transferredCookie</emphasis>. This header will be transferred to the
+      <emphasis>Cookie</emphasis> header on subsequent sends to gateways that also have <emphasis>transfer-cookies</emphasis>
+      set to true. This enables simple stateful interactions, such as...
+    </para>
+    <para>
+      <emphasis>...-&gt;logonGateway-&gt;...-&gt;doWorkGateway-&gt;...-&gt;logoffGateway-&gt;...</emphasis>
+    </para>
   </section>
 
   <section id="http-namespace">

--- a/docs/src/reference/docbook/http.xml
+++ b/docs/src/reference/docbook/http.xml
@@ -103,13 +103,16 @@ In the case of the Outbound Gateway, the reply message produced by the gateway w
     <para><emphasis>Cookies</emphasis></para>
     <para>
       Basic cookie support is provided by the <emphasis>transfer-cookies</emphasis> attribute on the outbound gateway. When
-      set to true (default is false), a <emphasis>Set-Cookie</emphasis> header received from the server in a response, will be inserted into
-      the reply message in header <emphasis>http_transferredCookie</emphasis>. This header will be transferred to the
-      <emphasis>Cookie</emphasis> header on subsequent sends to gateways that also have <emphasis>transfer-cookies</emphasis>
-      set to true. This enables simple stateful interactions, such as...
+      set to true (default is false), a <emphasis>Set-Cookie</emphasis> header received from the server in a response will be
+      converted to <emphasis>Cookie</emphasis> in the reply message. This header will then be used 
+      on subsequent sends. This enables simple stateful interactions, such as...
     </para>
     <para>
       <emphasis>...-&gt;logonGateway-&gt;...-&gt;doWorkGateway-&gt;...-&gt;logoffGateway-&gt;...</emphasis>
+    </para>
+    <para>
+      If <emphasis>transfer-cookies</emphasis> is false, any <emphasis>Set-Cookie</emphasis> header received will
+      remain as <emphasis>Set-Cookie</emphasis> in the reply message, and will be dropped on subsequent sends.
     </para>
   </section>
 

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundGatewayParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundGatewayParser.java
@@ -80,6 +80,7 @@ public class HttpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "request-timeout", "sendTimeout");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel", "outputChannel");
 		HttpAdapterParsingUtils.configureUriVariableExpressions(builder, element);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "transfer-cookies");
 		return builder;
 	}
 

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -91,7 +91,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 
 	private volatile String charset = "UTF-8";
 
-	private volatile boolean transferSetCookieHeaders = true; //TODO: default false;
+	private volatile boolean transferCookies = false;
 
 	private volatile HeaderMapper<HttpHeaders> headerMapper = DefaultHttpHeaderMapper.outboundMapper();
 
@@ -222,10 +222,13 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 	}
 
 	/**
-	 * @param transferSetCookieHeaders the transferSetCookieHeaders to set
+	 * Set to true if you wish 'Set-Cookie' headers in responses to be
+	 * transferred as 'Cookie' headers in subsequent interactions for
+	 * a message.
+	 * @param transferCookies the transferCookies to set.
 	 */
-	public void setTransferSetCookieHeaders(boolean transferSetCookieHeaders) {
-		this.transferSetCookieHeaders = transferSetCookieHeaders;
+	public void setTransferCookies(boolean transferCookies) {
+		this.transferCookies = transferCookies;
 	}
 
 	@Override
@@ -259,7 +262,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 			ResponseEntity<?> httpResponse = this.restTemplate.exchange(this.uri, this.httpMethod, httpRequest, this.expectedResponseType, uriVariables);
 			if (this.expectReply) {
 				HttpHeaders httpHeaders = httpResponse.getHeaders();
-				if (this.transferSetCookieHeaders) {
+				if (this.transferCookies) {
 					httpHeaders = this.doConvertSetCookie(httpHeaders);
 				}
 				Map<String, ?> headers = this.headerMapper.toHeaders(httpHeaders);
@@ -348,7 +351,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 	protected HttpHeaders mapHeaders(Message<?> message) {
 		HttpHeaders httpHeaders = new HttpHeaders();
 		this.headerMapper.fromHeaders(message.getHeaders(), httpHeaders);
-		if (this.transferSetCookieHeaders) {
+		if (this.transferCookies) {
 			doTransferCookies(httpHeaders);
 		}
 		return httpHeaders;

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -100,7 +100,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 
 	private static final String CONTENT_TYPE = "Content-Type";
 
-	private static final String COOKIE = "Cookie";
+	public  static final String COOKIE = "Cookie";
 
 	private static final String DATE = "Date";
 
@@ -146,15 +146,13 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 
 	private static final String SERVER = "Server";
 
-	private static final String SET_COOKIE = "Set-Cookie";
+	public  static final String SET_COOKIE = "Set-Cookie";
 
 	private static final String TE = "TE";
 
 	private static final String TRAILER = "Trailer";
 
 	private static final String TRANSFER_ENCODING = "Transfer-Encoding";
-
-	public  static final String TRANSFERRED_COOKIE = "http_transferredCookie";
 
 	private static final String UPGRADE = "Upgrade";
 
@@ -195,7 +193,6 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			RANGE,
 			REFERER,
 			TE,
-			TRANSFERRED_COOKIE,
 			UPGRADE,
 			USER_AGENT,
 			VIA,
@@ -227,7 +224,6 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			SET_COOKIE,
 			TRAILER,
 			TRANSFER_ENCODING,
-			TRANSFERRED_COOKIE,
 			VARY,
 			VIA,
 			WARNING,

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -154,6 +154,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 
 	private static final String TRANSFER_ENCODING = "Transfer-Encoding";
 
+	public  static final String TRANSFERRED_COOKIE = "http_transferredCookie";
+
 	private static final String UPGRADE = "Upgrade";
 
 	private static final String USER_AGENT = "User-Agent";
@@ -193,6 +195,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			RANGE,
 			REFERER,
 			TE,
+			TRANSFERRED_COOKIE,
 			UPGRADE,
 			USER_AGENT,
 			VIA,
@@ -224,6 +227,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			SET_COOKIE,
 			TRAILER,
 			TRANSFER_ENCODING,
+			TRANSFERRED_COOKIE,
 			VARY,
 			VIA,
 			WARNING,

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.1.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.1.xsd
@@ -508,9 +508,7 @@ The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Re
 					<xsd:attribute name="transfer-cookies" type="xsd:string" default="false">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
-	When set to "true", if a response contains a 'Set-Cookie' header, it will be placed in the message
-	under header 'http_transferredCookie'; also, when the gateway receives a message containing a
-	'http_transferredCookie' header, it will be mapped to a 'Cookie' header. This enables simple
+	When set to "true", if a response contains a 'Set-Cookie' header, it will mapped to a 'Cookie' header. This enables simple
 	cookie handling where subsequent HTTP interactions in the same message flow can use a cookie
 	supplied by the server. Default "false".
 							]]></xsd:documentation>

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.1.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.1.xsd
@@ -505,6 +505,17 @@ The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Re
 						</xsd:annotation>
 					</xsd:attribute>
 					<xsd:attribute name="auto-startup" type="xsd:string" />
+					<xsd:attribute name="transfer-cookies" type="xsd:string" default="false">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	When set to "true", if a response contains a 'Set-Cookie' header, it will be placed in the message
+	under header 'http_transferredCookie'; also, when the gateway receives a message containing a
+	'http_transferredCookie' header, it will be mapped to a 'Cookie' header. This enables simple
+	cookie handling where subsequent HTTP interactions in the same message flow can use a cookie
+	supplied by the server. Default "false".
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests-context.xml
@@ -35,7 +35,8 @@
 			reply-channel="replies"
 			charset="UTF-8"
 			order="77"
-			auto-startup="false">
+			auto-startup="false"
+			transfer-cookies="true">
 		<uri-variable name="foo" expression="headers.bar"/>
 	</outbound-gateway>
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
@@ -79,6 +79,7 @@ public class HttpOutboundGatewayParserTests {
 		assertEquals(HttpMethod.POST, handlerAccessor.getPropertyValue("httpMethod"));
 		assertEquals("UTF-8", handlerAccessor.getPropertyValue("charset"));
 		assertEquals(true, handlerAccessor.getPropertyValue("extractPayload"));
+		assertEquals(false, handlerAccessor.getPropertyValue("transferCookies"));
 	}
 
 	@Test
@@ -125,6 +126,7 @@ public class HttpOutboundGatewayParserTests {
 		assertTrue(ObjectUtils.containsElement(mappedRequestHeaders, "requestHeader1"));
 		assertTrue(ObjectUtils.containsElement(mappedRequestHeaders, "requestHeader2"));
 		assertEquals("responseHeader", mappedResponseHeaders[0]);
+		assertEquals(true, handlerAccessor.getPropertyValue("transferCookies"));
 	}
 
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests-context.xml
@@ -10,6 +10,7 @@
 	<int:channel id="ch1" />
 
 	<int-http:outbound-gateway url="http://localhost:18080/it/" request-channel="ch1" reply-channel="ch2"
+		transfer-cookies="true"
 		request-factory="requestFactory"
 	/>
 
@@ -18,12 +19,14 @@
 	<int:transformer input-channel="ch2" output-channel="ch3" expression="'Hello, again!'" />
 
 	<int-http:outbound-gateway url="http://localhost:18080/it/" request-channel="ch3" reply-channel="ch4"
+		transfer-cookies="true"
 		request-factory="requestFactory"
 	/>
 
 	<int:transformer input-channel="ch4" output-channel="ch5" expression="'Hello, once more!'" />
 
 	<int-http:outbound-gateway url="http://localhost:18080/it/" request-channel="ch5" reply-channel="ch6"
+		transfer-cookies="true"
 		request-factory="requestFactory"
 	/>
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests-context.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-http="http://www.springframework.org/schema/integration/http"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.1.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<int:channel id="ch1" />
+
+	<int-http:outbound-gateway url="http://localhost:18080/it/" request-channel="ch1" reply-channel="ch2"
+		request-factory="requestFactory"
+	/>
+
+	<bean id="requestFactory" class="org.springframework.integration.http.outbound.CookieTests$RequestFactory" />
+
+	<int:transformer input-channel="ch2" output-channel="ch3" expression="'Hello, again!'" />
+
+	<int-http:outbound-gateway url="http://localhost:18080/it/" request-channel="ch3" reply-channel="ch4"
+		request-factory="requestFactory"
+	/>
+
+	<int:transformer input-channel="ch4" output-channel="ch5" expression="'Hello, once more!'" />
+
+	<int-http:outbound-gateway url="http://localhost:18080/it/" request-channel="ch5" reply-channel="ch6"
+		request-factory="requestFactory"
+	/>
+
+	<int:channel id="ch6">
+		<int:queue/>
+	</int:channel>
+
+</beans>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.http.outbound;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class CookieTests {
+
+	@Autowired
+	private MessageChannel ch1;
+
+	@Autowired
+	private QueueChannel ch6;
+
+	private static ByteArrayOutputStream bos = new ByteArrayOutputStream();
+
+	private static List<HttpHeaders> allHeaders = new ArrayList<HttpHeaders>();
+
+	@Test
+	public void testCookie() throws Exception {
+		ch1.send(new GenericMessage<String>("Hello, world!"));
+		Assert.assertNotNull(ch6.receive());
+
+
+		bos.close();
+		BufferedReader br = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(bos.toByteArray())));
+		String line = br.readLine();
+		assertEquals("Hello, world!Hello, again!Hello, once more!", line);
+		assertNull(br.readLine());
+		br.close();
+		assertEquals(3, allHeaders.size());
+		assertFalse(allHeaders.get(0).containsKey("Cookie"));
+		assertTrue(allHeaders.get(1).containsKey("Cookie"));
+		assertEquals("JSESSIONID=X123", allHeaders.get(1).get("Cookie").get(0));
+		assertTrue(allHeaders.get(2).containsKey("Cookie"));
+		assertEquals("JSESSIONID=X124", allHeaders.get(2).get("Cookie").get(0));
+	}
+
+	public static class RequestFactory implements ClientHttpRequestFactory {
+
+		private int count = 123;
+
+		public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod)
+				throws IOException {
+			return new ClientHttpRequest() {
+
+				private HttpHeaders headers = new HttpHeaders();
+
+				public HttpHeaders getHeaders() {
+					return headers;
+				}
+
+				public OutputStream getBody() throws IOException {
+					return bos;
+				}
+
+				public URI getURI() {
+					return null;
+				}
+
+				public HttpMethod getMethod() {
+					return null;
+				}
+
+				public ClientHttpResponse execute() throws IOException {
+					allHeaders.add(headers);
+					return new ClientHttpResponse() {
+
+						public HttpHeaders getHeaders() {
+							HttpHeaders headers = new HttpHeaders();
+							headers.set("Set-cookie", "JSESSIONID=X" + count++); // test case insensitivity
+							headers.set("Content-Length", "2");
+							headers.set("Content-Type", "text/plain");
+							return headers;
+						}
+
+						public InputStream getBody() throws IOException {
+							return new ByteArrayInputStream("OK".getBytes());
+						}
+
+						public String getStatusText() throws IOException {
+							return "OK";
+						}
+
+						public HttpStatus getStatusCode() throws IOException {
+							return HttpStatus.OK;
+						}
+
+						public void close() {
+						}
+					};
+				}
+			};
+		}
+
+	}
+}


### PR DESCRIPTION
Saves off Set-Cookie header in http_transferredCookie MessageHeader.
Transferred cookies are converted to Cookie: headers on subsequent
outbound messages.
