### PR TITLE
Fixing a simple Adapter Parser error

### DIFF
--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/config/xml/GemfireCqInboundChannelAdapterParser.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/config/xml/GemfireCqInboundChannelAdapterParser.java
@@ -59,11 +59,11 @@ public class GemfireCqInboundChannelAdapterParser extends AbstractChannelAdapter
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(continuousQueryMesageProducer, element, EXPRESSION_ATTRIBUTE,PAYLOAD_EXPRESSION_PROPERTY);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(continuousQueryMesageProducer, element, QUERY_EVENTS_ATTRIBUTE, SUPPORTED_EVENT_TYPES_PROPERTY);
 	 	
-		if (!StringUtils.hasText(QUERY_LISTENER_CONTAINER_ATTRIBUTE)){
+		if (!element.hasAttribute(QUERY_LISTENER_CONTAINER_ATTRIBUTE)){
 			parserContext.getReaderContext().error("'query-listener-container' attribute is required.",element);
 		}
 		
-		if (!StringUtils.hasText(QUERY_ATTRIBUTE)){
+		if (!element.hasAttribute(QUERY_ATTRIBUTE)){
 			parserContext.getReaderContext().error("'query' attribute is required.",element);
 		}
 		 

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/config/xml/GemfireInboundChannelAdapterParser.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/config/xml/GemfireInboundChannelAdapterParser.java
@@ -53,7 +53,7 @@ public class GemfireInboundChannelAdapterParser extends AbstractChannelAdapterPa
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(listeningMessageProducer, element, EXPRESSION_ATTRIBUTE,PAYLOAD_EXPRESSION_PROPERTY);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(listeningMessageProducer, element, CACHE_EVENTS_ATTRIBUTE, SUPPORTED_EVENT_TYPES_PROPERTY);
 	 	
-		if (!StringUtils.hasText(REGION_ATTRIBUTE)){
+		if (!element.hasAttribute(REGION_ATTRIBUTE)){
 			parserContext.getReaderContext().error("'region' attribute is required.",element);
 		}
 		 

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/config/xml/GemfireOutboundChannelAdapterParser.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/config/xml/GemfireOutboundChannelAdapterParser.java
@@ -44,7 +44,7 @@ public class GemfireOutboundChannelAdapterParser extends AbstractOutboundChannel
 	protected AbstractBeanDefinition parseConsumer(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder cacheWritingMessageHandler = BeanDefinitionBuilder.genericBeanDefinition(
 				GEMFIRE_OUTBOUND_CACHE_WRITING_MESSAGE_HANDLER);
-		if (!StringUtils.hasText(REGION_ATTRIBUTE)){
+		if (!element.hasAttribute(REGION_ATTRIBUTE)){
 			parserContext.getReaderContext().error("'region' attribute is required.",element);
 		}
 		 

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireCqInboundChannelAdapterParserTest.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireCqInboundChannelAdapterParserTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.integration.gemfire.config.xml;
+
+import org.junit.Test;
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
+import org.w3c.dom.Element;
+
+import static org.springframework.integration.gemfire.config.xml.ParserTestUtil.createFakeParserContext;
+import static org.springframework.integration.gemfire.config.xml.ParserTestUtil.loadXMLFrom;
+
+/**
+ * @author Dan Oxlade
+ */
+public class GemfireCqInboundChannelAdapterParserTest {
+
+    private GemfireCqInboundChannelAdapterParser underTest = new GemfireCqInboundChannelAdapterParser();
+
+    @Test(expected = BeanDefinitionParsingException.class)
+    public void cqListenerContainerIsARequiredAttribute() throws Exception {
+        String xml = "<cq-inbound-channel-adapter query=\"some-query\"/>";
+        Element element = loadXMLFrom(xml).getDocumentElement();
+        underTest.doParse(element, createFakeParserContext(), null);
+    }
+
+    @Test(expected = BeanDefinitionParsingException.class)
+    public void queryIsARequiredAttribute() throws Exception {
+        String xml = "<cq-inbound-channel-adapter cq-listener-container=\"some-reference\" />";
+        Element element = loadXMLFrom(xml).getDocumentElement();
+        underTest.doParse(element, createFakeParserContext(), null);
+    }
+}

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireInboundChannelAdapterParserTest.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireInboundChannelAdapterParserTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.integration.gemfire.config.xml;
+
+import org.junit.Test;
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
+import org.w3c.dom.Element;
+
+import static org.springframework.integration.gemfire.config.xml.ParserTestUtil.createFakeParserContext;
+import static org.springframework.integration.gemfire.config.xml.ParserTestUtil.loadXMLFrom;
+
+/**
+ * @author Dan Oxlade
+ */
+public class GemfireInboundChannelAdapterParserTest {
+    private GemfireInboundChannelAdapterParser underTest = new GemfireInboundChannelAdapterParser();
+
+    @Test(expected = BeanDefinitionParsingException.class)
+    public void regionIsARequiredAttribute() throws Exception {
+        String xml = "<inbound-channel-adapter />";
+        Element element = loadXMLFrom(xml).getDocumentElement();
+        underTest.doParse(element, createFakeParserContext(), null);
+    }
+}

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireOutboundChannelAdapterParserTest.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireOutboundChannelAdapterParserTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.integration.gemfire.config.xml;
+
+import org.junit.Test;
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
+import org.w3c.dom.Element;
+
+import static org.springframework.integration.gemfire.config.xml.ParserTestUtil.createFakeParserContext;
+import static org.springframework.integration.gemfire.config.xml.ParserTestUtil.loadXMLFrom;
+
+/**
+ * @author Dan Oxlade
+ */
+public class GemfireOutboundChannelAdapterParserTest {
+    private GemfireOutboundChannelAdapterParser underTest = new GemfireOutboundChannelAdapterParser();
+
+    @Test(expected = BeanDefinitionParsingException.class)
+    public void regionIsARequiredAttribute() throws Exception {
+        String xml = "<outbound-channel-adapter />";
+        Element element = loadXMLFrom(xml).getDocumentElement();
+        underTest.parseConsumer(element, createFakeParserContext());
+    }
+}

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/ParserTestUtil.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/ParserTestUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.integration.gemfire.config.xml;
+
+import org.springframework.beans.factory.parsing.FailFastProblemReporter;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.beans.factory.xml.XmlReaderContext;
+import org.springframework.core.io.InputStreamResource;
+
+/**
+ * @author Dan Oxlade
+ */
+class ParserTestUtil {
+    static ParserContext createFakeParserContext() {
+        return new ParserContext(new XmlReaderContext(thisClassAsResource(), new FailFastProblemReporter(), null, null, null, null), null);
+    }
+
+    static InputStreamResource thisClassAsResource() {
+        return new InputStreamResource(ParserTestUtil.class.getResourceAsStream(ParserTestUtil.class.getSimpleName() + ".class"));
+    }
+
+
+    static org.w3c.dom.Document loadXMLFrom(String xml)
+            throws org.xml.sax.SAXException, java.io.IOException {
+        return loadXMLFrom(new java.io.ByteArrayInputStream(xml.getBytes()));
+    }
+
+    static org.w3c.dom.Document loadXMLFrom(java.io.InputStream is)
+            throws org.xml.sax.SAXException, java.io.IOException {
+        javax.xml.parsers.DocumentBuilderFactory factory =
+                javax.xml.parsers.DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        javax.xml.parsers.DocumentBuilder builder = null;
+        try {
+            builder = factory.newDocumentBuilder();
+        } catch (javax.xml.parsers.ParserConfigurationException ex) {
+        }
+        org.w3c.dom.Document doc = builder.parse(is);
+        is.close();
+        return doc;
+    }
+}


### PR DESCRIPTION
Validate that the attributes are present.

The current checks will always resolve to true and never apply the correct validation rules.
