### PR TITLE
HeaderMapper refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -491,6 +491,7 @@ project('spring-integration-ws') {
         compile("javax.activation:activation:$javaxActivationVersion") { optional = true }
         testCompile project(":spring-integration-test")
         testCompile "stax:stax-api:1.0.1"
+        testCompile "xstream:xstream:1.2.2"
     }
 
     // suppress saaj path warnings

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AbstractAmqpInboundAdapterParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AbstractAmqpInboundAdapterParser.java
@@ -101,7 +101,7 @@ abstract class AbstractAmqpInboundAdapterParser extends AbstractSingleBeanDefini
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
 		
-		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultAmqpHeaderMapper.class, false, null);
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultAmqpHeaderMapper.class, null);
 		
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-startup");

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AbstractAmqpInboundAdapterParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AbstractAmqpInboundAdapterParser.java
@@ -20,20 +20,21 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.w3c.dom.Element;
-
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
 
 /**
  * Base class for inbound adapter parsers for the AMQP namespace.
  * 
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  * @since 2.1
  */
 abstract class AbstractAmqpInboundAdapterParser extends AbstractSingleBeanDefinitionParser {
@@ -99,7 +100,9 @@ abstract class AbstractAmqpInboundAdapterParser extends AbstractSingleBeanDefini
 			builder.addConstructorArgValue(listenerContainerBeanDef);
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "header-mapper");
+		
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultAmqpHeaderMapper.class, false, null);
+		
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-startup");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "phase");

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParser.java
@@ -48,7 +48,7 @@ public class AmqpOutboundChannelAdapterParser extends AbstractOutboundChannelAda
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "routing-key");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "routing-key-expression");
 	
-		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultAmqpHeaderMapper.class, true, null);
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultAmqpHeaderMapper.class, null);
 		
 		return builder.getBeanDefinition();
 	}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParser.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint;
+import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
 import org.springframework.integration.config.xml.AbstractOutboundChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.util.StringUtils;
@@ -29,6 +30,7 @@ import org.w3c.dom.Element;
  * Parser for the AMQP 'outbound-channel-adapter' element.
  * 
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  * @since 2.1
  */
 public class AmqpOutboundChannelAdapterParser extends AbstractOutboundChannelAdapterParser {
@@ -45,6 +47,9 @@ public class AmqpOutboundChannelAdapterParser extends AbstractOutboundChannelAda
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "exchange-name-expression");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "routing-key");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "routing-key-expression");
+	
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultAmqpHeaderMapper.class, true, null);
+		
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParser.java
@@ -52,7 +52,7 @@ public class AmqpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "routing-key-expression");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel", "outputChannel");
 		
-		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultAmqpHeaderMapper.class, true, null);
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultAmqpHeaderMapper.class, null);
 		
 		return builder;
 	}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParser.java
@@ -18,6 +18,7 @@ import org.w3c.dom.Element;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint;
+import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
 import org.springframework.integration.config.xml.AbstractConsumerEndpointParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.util.StringUtils;
@@ -26,6 +27,7 @@ import org.springframework.util.StringUtils;
  * Parser for the AMQP 'outbound-channel-adapter' element.
  * 
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  * @since 2.1
  */
 public class AmqpOutboundGatewayParser extends AbstractConsumerEndpointParser {
@@ -49,6 +51,9 @@ public class AmqpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "routing-key");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "routing-key-expression");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel", "outputChannel");
+		
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultAmqpHeaderMapper.class, true, null);
+		
 		return builder;
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -42,7 +42,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport {
 
 	private volatile MessageConverter messageConverter = new SimpleMessageConverter();
 
-	private volatile AmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
+	private volatile AmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(false);
 
 
 	public AmqpInboundChannelAdapter(AbstractMessageListenerContainer listenerContainer) {

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -42,7 +42,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport {
 
 	private volatile MessageConverter messageConverter = new SimpleMessageConverter();
 
-	private volatile AmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(false);
+	private volatile AmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
 
 
 	public AmqpInboundChannelAdapter(AbstractMessageListenerContainer listenerContainer) {
@@ -69,7 +69,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport {
 		this.messageListenerContainer.setMessageListener(new MessageListener() {
 			public void onMessage(Message message) {
 				Object payload = messageConverter.fromMessage(message);
-				Map<String, ?> headers = headerMapper.toHeaders(message.getMessageProperties());
+				Map<String, ?> headers = headerMapper.toHeadersFromRequest(message.getMessageProperties());
 				sendMessage(MessageBuilder.withPayload(payload).copyHeaders(headers).build());
 			}
 		});

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
@@ -50,7 +50,7 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 
 	private volatile MessageConverter amqpMessageConverter = new SimpleMessageConverter();
 
-	private volatile AmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
+	private volatile AmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(false);
 
 	private final RabbitTemplate amqpTemplate;
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
@@ -50,7 +50,7 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 
 	private volatile MessageConverter amqpMessageConverter = new SimpleMessageConverter();
 
-	private volatile AmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(false);
+	private volatile AmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
 
 	private final RabbitTemplate amqpTemplate;
 
@@ -81,7 +81,7 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 		this.messageListenerContainer.setMessageListener(new MessageListener() {
 			public void onMessage(Message message) {
 				Object payload = amqpMessageConverter.fromMessage(message);
-				Map<String, ?> headers = headerMapper.toHeaders(message.getMessageProperties());
+				Map<String, ?> headers = headerMapper.toHeadersFromRequest(message.getMessageProperties());
 				org.springframework.integration.Message<?> request =
 						MessageBuilder.withPayload(payload).copyHeaders(headers).build();
 				final org.springframework.integration.Message<?> reply = sendAndReceiveMessage(request);
@@ -97,7 +97,7 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 									String contentEncoding = messageProperties.getContentEncoding();
 									long contentLength = messageProperties.getContentLength();
 									String contentType = messageProperties.getContentType();
-									headerMapper.fromHeaders(reply.getHeaders(), messageProperties);
+									headerMapper.fromHeadersToReply(reply.getHeaders(), messageProperties);
 									// clear the replyTo from the original message since we are using it now
 									messageProperties.setReplyTo(null);
 									// reset the content-* properties as determined by the MessageConverter

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
@@ -60,8 +60,7 @@ public class AmqpOutboundEndpoint extends AbstractReplyProducingMessageHandler {
 
 	private volatile ExpressionEvaluatingMessageProcessor<String> exchangeNameGenerator;
 
-	private volatile AmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
-
+	private volatile AmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(true);
 
 	@Override
 	protected void onInit() {
@@ -83,6 +82,10 @@ public class AmqpOutboundEndpoint extends AbstractReplyProducingMessageHandler {
 	public AmqpOutboundEndpoint(AmqpTemplate amqpTemplate) {
 		Assert.notNull(amqpTemplate, "AmqpTemplate must not be null");
 		this.amqpTemplate = amqpTemplate;
+	}
+	
+	public void setHeaderMapper(AmqpHeaderMapper headerMapper) {
+		this.headerMapper = headerMapper;
 	}
 
 	public void setExchangeName(String exchangeName) {

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/AmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/AmqpHeaderMapper.java
@@ -18,12 +18,15 @@ package org.springframework.integration.amqp.support;
 
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.integration.mapping.HeaderMapper;
+import org.springframework.integration.mapping.RequestReplyHeaderMapper;
 
 /**
  * A convenience interface that extends {@link HeaderMapper}
  * but parameterized with {@link MessageProperties}.
  *  
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
+ * @since 2.1
  */
-public interface AmqpHeaderMapper extends HeaderMapper<MessageProperties> {
+public interface AmqpHeaderMapper extends RequestReplyHeaderMapper<MessageProperties> {
 }

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -45,6 +45,8 @@ import org.springframework.util.StringUtils;
  * @since 2.1
  */
 public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessageProperties> implements AmqpHeaderMapper {
+	
+	private static final String PREFIX = "";
 
 	private static final List<String> STANDARD_HEADER_NAMES = new ArrayList<String>();
 
@@ -68,12 +70,6 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 		STANDARD_HEADER_NAMES.add(AmqpHeaders.TYPE);
 		STANDARD_HEADER_NAMES.add(AmqpHeaders.USER_ID);
 	}
-
-
-	public DefaultAmqpHeaderMapper() {
-		super(AmqpHeaders.class);
-	}
-
 
 	/**
 	 * Extract "standard" headers from an AMQP MessageProperties instance.
@@ -270,8 +266,20 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 
 
 	@Override
-	protected List<String> getStandardOutboundHeaderNames() {
+	protected List<String> getStandardRequestHeaderNames() {
 		return STANDARD_HEADER_NAMES;
+	}
+
+
+	@Override
+	protected List<String> getStandardReplyHeaderNames() {
+		return STANDARD_HEADER_NAMES;
+	}
+
+
+	@Override
+	protected String getStandardHeaderPrefix() {
+		return PREFIX;
 	}
 
 }

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -70,8 +70,8 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 	}
 
 
-	public DefaultAmqpHeaderMapper(boolean outbound) {
-		super(AmqpHeaders.class, outbound);
+	public DefaultAmqpHeaderMapper() {
+		super(AmqpHeaders.class);
 	}
 
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -46,8 +46,6 @@ import org.springframework.util.StringUtils;
  */
 public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessageProperties> implements AmqpHeaderMapper {
 	
-	private static final String PREFIX = "";
-
 	private static final List<String> STANDARD_HEADER_NAMES = new ArrayList<String>();
 
 	static {
@@ -279,7 +277,7 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 
 	@Override
 	protected String getStandardHeaderPrefix() {
-		return PREFIX;
+		return AmqpHeaders.PREFIX;
 	}
 
 }

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -16,20 +16,17 @@
 
 package org.springframework.integration.amqp.support;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.amqp.AmqpHeaders;
-import org.springframework.util.CollectionUtils;
-import org.springframework.util.ObjectUtils;
+import org.springframework.integration.mapping.AbstractHeaderMapper;
 import org.springframework.util.StringUtils;
 
 /**
@@ -47,166 +44,42 @@ import org.springframework.util.StringUtils;
  * @author Oleg Zhurakousky
  * @since 2.1
  */
-public class DefaultAmqpHeaderMapper implements AmqpHeaderMapper {
+public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessageProperties> implements AmqpHeaderMapper {
 
-	private static final String[] TRANSIENT_HEADER_NAMES = new String[] {
-		MessageHeaders.ID,
-		MessageHeaders.ERROR_CHANNEL,
-		MessageHeaders.REPLY_CHANNEL,
-		MessageHeaders.TIMESTAMP
-	};
+	private static final List<String> STANDARD_HEADER_NAMES = new ArrayList<String>();
 
-
-	private final Log logger = LogFactory.getLog(this.getClass());
-
-	private volatile String inboundPrefix = "";
-
-	private volatile String outboundPrefix = "";
-
-
-	/**
-	 * Specify a prefix to be appended to the integration message header name for
-	 * any user-defined AMQP header that is being mapped into the MessageHeaders.
-	 * The Default is an empty string (no prefix).
-	 * <p/>
-	 * This does not affect the standard AMQP properties, such as contentType, etc.
-	 * The header names used for mapping such properties are all defined in the
-	 * {@link AmqpHeaders} class as constants.   
-	 */
-	public void setInboundPrefix(String inboundPrefix) {
-		this.inboundPrefix = (inboundPrefix != null) ? inboundPrefix : "";
+	static {
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.APP_ID);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.CLUSTER_ID);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.CONTENT_ENCODING);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.CONTENT_LENGTH);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.CONTENT_TYPE);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.CORRELATION_ID);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.DELIVERY_MODE);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.DELIVERY_TAG);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.EXPIRATION);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.MESSAGE_COUNT);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.MESSAGE_ID);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.RECEIVED_EXCHANGE);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.RECEIVED_ROUTING_KEY);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.REDELIVERED);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.REPLY_TO);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.TIMESTAMP);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.TYPE);
+		STANDARD_HEADER_NAMES.add(AmqpHeaders.USER_ID);
 	}
 
-	/**
-	 * Specify a prefix to be appended to the AMQP header name for any
-	 * integration message header that is being mapped into the AMQP Message.
-	 * The Default is an empty string (no prefix).
-	 * <p/>
-	 * This does not affect the standard AMQP properties, such as contentType, etc.
-	 * The header names used for mapping such properties are all defined in
-	 * the {@link AmqpHeaders} class as constants.   
-	 */
-	public void setOutboundPrefix(String outboundPrefix) {
-		this.outboundPrefix = (outboundPrefix != null) ? outboundPrefix : "";
+
+	public DefaultAmqpHeaderMapper(boolean outbound) {
+		super(AmqpHeaders.class, outbound);
 	}
 
-	/**
-	 * Maps headers from a Spring Integration MessageHeaders instance to the MessageProperties
-	 * of an AMQP Message.
-	 */
-	public void fromHeaders(MessageHeaders headers, MessageProperties amqpMessageProperties) {
-		try {
-			String appId = getHeaderIfAvailable(headers, AmqpHeaders.APP_ID, String.class);
-			if (StringUtils.hasText(appId)) {
-				amqpMessageProperties.setAppId(appId);
-			}				
-			String clusterId = getHeaderIfAvailable(headers, AmqpHeaders.CLUSTER_ID, String.class);
-			if (StringUtils.hasText(clusterId)) {
-				amqpMessageProperties.setClusterId(clusterId);
-			}
-			String contentEncoding = getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_ENCODING, String.class);
-			if (StringUtils.hasText(contentEncoding)) {
-				amqpMessageProperties.setContentEncoding(contentEncoding);
-			}
-			Long contentLength = getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_LENGTH, Long.class);
-			if (contentLength != null) {
-				amqpMessageProperties.setContentLength(contentLength);
-			}			
-			String contentType = getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_TYPE, String.class);
-			if (StringUtils.hasText(contentType)) {
-				amqpMessageProperties.setContentType(contentType);
-			}
-			Object correlationId = headers.get(AmqpHeaders.CORRELATION_ID);
-			if (correlationId instanceof byte[]) {
-				amqpMessageProperties.setCorrelationId((byte[]) correlationId);
-			}
-			MessageDeliveryMode deliveryMode = getHeaderIfAvailable(headers, AmqpHeaders.DELIVERY_MODE, MessageDeliveryMode.class);
-			if (deliveryMode != null) {
-				amqpMessageProperties.setDeliveryMode(deliveryMode);
-			}
-			Long deliveryTag = getHeaderIfAvailable(headers, AmqpHeaders.DELIVERY_TAG, Long.class);
-			if (deliveryTag != null) {
-				amqpMessageProperties.setDeliveryTag(deliveryTag);
-			}
-			String expiration = getHeaderIfAvailable(headers, AmqpHeaders.EXPIRATION, String.class);
-			if (StringUtils.hasText(expiration)) {
-				amqpMessageProperties.setExpiration(expiration);
-			}
-			Integer messageCount = getHeaderIfAvailable(headers, AmqpHeaders.MESSAGE_COUNT, Integer.class);
-			if (messageCount != null) {
-				amqpMessageProperties.setMessageCount(messageCount);
-			}
-			String messageId = getHeaderIfAvailable(headers, AmqpHeaders.MESSAGE_ID, String.class);
-			if (StringUtils.hasText(messageId)) {
-				amqpMessageProperties.setMessageId(messageId);
-			}
-			Integer priority = headers.getPriority();
-			if (priority != null) {
-				amqpMessageProperties.setPriority(priority);
-			}
-			String receivedExchange = getHeaderIfAvailable(headers, AmqpHeaders.RECEIVED_EXCHANGE, String.class);
-			if (StringUtils.hasText(receivedExchange)) {
-				amqpMessageProperties.setReceivedExchange(receivedExchange);
-			}
-			String receivedRoutingKey = getHeaderIfAvailable(headers, AmqpHeaders.RECEIVED_ROUTING_KEY, String.class);
-			if (StringUtils.hasText(receivedRoutingKey)) {
-				amqpMessageProperties.setReceivedRoutingKey(receivedRoutingKey);
-			}
-			Boolean redelivered = getHeaderIfAvailable(headers, AmqpHeaders.REDELIVERED, Boolean.class);
-			if (redelivered != null) {
-				amqpMessageProperties.setRedelivered(redelivered);
-			}
-			String replyTo = getHeaderIfAvailable(headers, AmqpHeaders.REPLY_TO, String.class);
-			if (replyTo != null) {
-				amqpMessageProperties.setReplyTo(replyTo);
-			}
-			Date timestamp = getHeaderIfAvailable(headers, AmqpHeaders.TIMESTAMP, Date.class);
-			if (timestamp != null) {
-				amqpMessageProperties.setTimestamp(timestamp);
-			}
-			String type = getHeaderIfAvailable(headers, AmqpHeaders.TYPE, String.class);
-			if (type != null) {
-				amqpMessageProperties.setType(type);
-			}
-			String userId = getHeaderIfAvailable(headers, AmqpHeaders.USER_ID, String.class);
-			if (StringUtils.hasText(userId)) {
-				amqpMessageProperties.setUserId(userId);
-			}
-			// now map to the user-defined headers, if any, within the AMQP MessageProperties
-			Set<String> headerNames = headers.keySet();
-			for (String headerName : headerNames) {
-				if (this.shouldMapOutboundHeader(headerName)) {
-					Object value = headers.get(headerName);
-					if (value != null) {
-						try {
-							String key = this.fromHeaderName(headerName);
-							// do not overwrite an existing header with the same key
-							// TODO: do we need to expose a boolean 'overwrite' flag?
-							if (!amqpMessageProperties.getHeaders().containsKey(key)) {
-								amqpMessageProperties.setHeader(key, value);
-							}
-						}
-						catch (Exception e) {
-							if (logger.isWarnEnabled()) {
-								logger.warn("failed to map Message header '" + headerName + "' to AMQP header", e);
-							}
-						}
-					}
-				}
-			}
-		}
-		catch (Exception e) {
-			if (logger.isWarnEnabled()) {
-				logger.warn("error occurred while mapping from MessageHeaders to AMQP properties", e);
-			}
-		}
-	}
 
 	/**
-	 * Maps headers from an AMQP MessageProperties instance to the MessageHeaders of a
-	 * Spring Integration Message.
+	 * Extract "standard" headers from an AMQP MessageProperties instance.
 	 */
-	public Map<String, Object> toHeaders(MessageProperties amqpMessageProperties) {
+	@Override
+	protected Map<String, Object> extractStandardHeaders(MessageProperties amqpMessageProperties) {
 		Map<String, Object> headers = new HashMap<String, Object>();
 		try {
 			String appId = amqpMessageProperties.getAppId();
@@ -285,23 +158,6 @@ public class DefaultAmqpHeaderMapper implements AmqpHeaderMapper {
 			if (StringUtils.hasText(userId)) {
 				headers.put(AmqpHeaders.USER_ID, userId);
 			}
-			Map<String, Object> amqpHeaders = amqpMessageProperties.getHeaders();
-			if (!CollectionUtils.isEmpty(amqpHeaders)) {
-				for (Map.Entry<String, Object> entry : amqpHeaders.entrySet()) {
-					try {
-						String headerName = this.toHeaderName(entry.getKey());
-						if (!ObjectUtils.containsElement(TRANSIENT_HEADER_NAMES, headerName)) {
-							headers.put(headerName, entry.getValue());
-						}
-					}
-					catch (Exception e) {
-						if (logger.isWarnEnabled()) {
-							logger.warn("error occurred while mapping AMQP header '"
-									+ entry.getKey() + "' to Message header", e);
-						}
-					}
-				}
-			}
 		}
 		catch (Exception e) {
 			if (logger.isWarnEnabled()) {
@@ -311,44 +167,111 @@ public class DefaultAmqpHeaderMapper implements AmqpHeaderMapper {
 		return headers;
 	}
 
-	private boolean shouldMapOutboundHeader(String headerName) {
-		return StringUtils.hasText(headerName)
-				&& !headerName.startsWith(AmqpHeaders.PREFIX)
-				&& !ObjectUtils.containsElement(TRANSIENT_HEADER_NAMES, headerName);
-	}
-
-	private <T> T getHeaderIfAvailable(MessageHeaders headers, String name, Class<T> type) {
-		try {
-			return headers.get(name, type);
-		}
-		catch (IllegalArgumentException e) {
-			if (logger.isWarnEnabled()) {
-				logger.warn("skipping header '" + name + "' since it is not of expected type [" + type + "]", e);
-			}
-			return null;
-		}
+	/**
+	 * Extract user-defined headers from an AMQP MessageProperties instance.
+	 */
+	@Override
+	protected Map<String, Object> extractUserDefinedHeaders(MessageProperties amqpMessageProperties) {
+		return amqpMessageProperties.getHeaders();
 	}
 
 	/**
-	 * Adds the outbound prefix if necessary.
+	 * Maps headers from a Spring Integration MessageHeaders instance to the MessageProperties
+	 * of an AMQP Message.
 	 */
-	private String fromHeaderName(String headerName) {
-		String propertyName = headerName;
-		if (StringUtils.hasText(this.outboundPrefix) && !propertyName.startsWith(this.outboundPrefix)) {
-			propertyName = this.outboundPrefix + headerName;
+	@Override
+	protected void populateStandardHeaders(Map<String, Object> headers, MessageProperties amqpMessageProperties) {
+		String appId = getHeaderIfAvailable(headers, AmqpHeaders.APP_ID, String.class);
+		if (StringUtils.hasText(appId)) {
+			amqpMessageProperties.setAppId(appId);
 		}
-		return propertyName;
+		String clusterId = getHeaderIfAvailable(headers, AmqpHeaders.CLUSTER_ID, String.class);
+		if (StringUtils.hasText(clusterId)) {
+			amqpMessageProperties.setClusterId(clusterId);
+		}
+		String contentEncoding = getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_ENCODING, String.class);
+		if (StringUtils.hasText(contentEncoding)) {
+			amqpMessageProperties.setContentEncoding(contentEncoding);
+		}
+		Long contentLength = getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_LENGTH, Long.class);
+		if (contentLength != null) {
+			amqpMessageProperties.setContentLength(contentLength);
+		}
+		String contentType = getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_TYPE, String.class);
+		if (StringUtils.hasText(contentType)) {
+			amqpMessageProperties.setContentType(contentType);
+		}
+		Object correlationId = headers.get(AmqpHeaders.CORRELATION_ID);
+		if (correlationId instanceof byte[]) {
+			amqpMessageProperties.setCorrelationId((byte[]) correlationId);
+		}
+		MessageDeliveryMode deliveryMode = getHeaderIfAvailable(headers, AmqpHeaders.DELIVERY_MODE, MessageDeliveryMode.class);
+		if (deliveryMode != null) {
+			amqpMessageProperties.setDeliveryMode(deliveryMode);
+		}
+		Long deliveryTag = getHeaderIfAvailable(headers, AmqpHeaders.DELIVERY_TAG, Long.class);
+		if (deliveryTag != null) {
+			amqpMessageProperties.setDeliveryTag(deliveryTag);
+		}
+		String expiration = getHeaderIfAvailable(headers, AmqpHeaders.EXPIRATION, String.class);
+		if (StringUtils.hasText(expiration)) {
+			amqpMessageProperties.setExpiration(expiration);
+		}
+		Integer messageCount = getHeaderIfAvailable(headers, AmqpHeaders.MESSAGE_COUNT, Integer.class);
+		if (messageCount != null) {
+			amqpMessageProperties.setMessageCount(messageCount);
+		}
+		String messageId = getHeaderIfAvailable(headers, AmqpHeaders.MESSAGE_ID, String.class);
+		if (StringUtils.hasText(messageId)) {
+			amqpMessageProperties.setMessageId(messageId);
+		}
+		Integer priority = getHeaderIfAvailable(headers, MessageHeaders.PRIORITY, Integer.class);
+		if (priority != null) {
+			amqpMessageProperties.setPriority(priority);
+		}
+		String receivedExchange = getHeaderIfAvailable(headers, AmqpHeaders.RECEIVED_EXCHANGE, String.class);
+		if (StringUtils.hasText(receivedExchange)) {
+			amqpMessageProperties.setReceivedExchange(receivedExchange);
+		}
+		String receivedRoutingKey = getHeaderIfAvailable(headers, AmqpHeaders.RECEIVED_ROUTING_KEY, String.class);
+		if (StringUtils.hasText(receivedRoutingKey)) {
+			amqpMessageProperties.setReceivedRoutingKey(receivedRoutingKey);
+		}
+		Boolean redelivered = getHeaderIfAvailable(headers, AmqpHeaders.REDELIVERED, Boolean.class);
+		if (redelivered != null) {
+			amqpMessageProperties.setRedelivered(redelivered);
+		}
+		String replyTo = getHeaderIfAvailable(headers, AmqpHeaders.REPLY_TO, String.class);
+		if (replyTo != null) {
+			amqpMessageProperties.setReplyTo(replyTo);
+		}
+		Date timestamp = getHeaderIfAvailable(headers, AmqpHeaders.TIMESTAMP, Date.class);
+		if (timestamp != null) {
+			amqpMessageProperties.setTimestamp(timestamp);
+		}
+		String type = getHeaderIfAvailable(headers, AmqpHeaders.TYPE, String.class);
+		if (type != null) {
+			amqpMessageProperties.setType(type);
+		}
+		String userId = getHeaderIfAvailable(headers, AmqpHeaders.USER_ID, String.class);
+		if (StringUtils.hasText(userId)) {
+			amqpMessageProperties.setUserId(userId);
+		}
 	}
 
-	/**
-	 * Adds the inbound prefix if necessary.
-	 */
-	private String toHeaderName(String propertyName) {
-		String headerName = propertyName;
-		if (StringUtils.hasText(this.inboundPrefix) && !headerName.startsWith(this.inboundPrefix)) {
-			headerName = this.inboundPrefix + propertyName;
+	@Override
+	protected void populateUserDefinedHeader(String headerName, Object headerValue, MessageProperties amqpMessageProperties) {
+		// do not overwrite an existing header with the same key
+		// TODO: do we need to expose a boolean 'overwrite' flag?
+		if (!amqpMessageProperties.getHeaders().containsKey(headerName)) {
+			amqpMessageProperties.setHeader(headerName, headerValue);
 		}
-		return headerName;
+	}
+
+
+	@Override
+	protected List<String> getStandardOutboundHeaderNames() {
+		return STANDARD_HEADER_NAMES;
 	}
 
 }

--- a/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-2.1.xsd
+++ b/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-2.1.xsd
@@ -85,6 +85,24 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="header-mapper" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="mapped-request-headers" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Comma-separated list of names of AMQP Headers to be mapped from the AMQP request into the MessageHeaders.
+This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+						]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 
@@ -201,6 +219,35 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="header-mapper" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-request-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Comma-separated list of names of AMQP Headers to be mapped from the AMQP request into the MessageHeaders.
+This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+						]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-reply-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[							
+    Comma-separated list of names of MessageHeaders to be mapped into the AMQP Message Properties of the AMQP reply message.
+	All standard Headers (e.g., contentType) will be mapped to AMQP Message Properties while user-defined headers will be mapped to 'headers' property 
+	which itself is a Map.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+						]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 
@@ -236,6 +283,17 @@
 									<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
 								</tool:annotation>
 							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="mapped-reply-headers" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[							
+	Comma-separated list of names of MessageHeaders to be mapped into the AMQP Message Properties of the AMQP reply message.
+	All standard Headers (e.g., contentType) will be mapped to AMQP Message Properties while user-defined headers will be mapped to 'headers' property 
+	which itself is a Map.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
 				</xsd:extension>
@@ -380,6 +438,24 @@
 				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="header-mapper" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="mapped-request-headers" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Comma-separated list of names of AMQP Headers to be mapped from the AMQP request into the MessageHeaders.
+This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+						]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="message-converter" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation>
@@ -388,18 +464,6 @@
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
 						<tool:expected-type type="org.springframework.amqp.support.converter.MessageConverter"/>
-					</tool:annotation>
-				</xsd:appinfo>
-			</xsd:annotation>
-		</xsd:attribute>
-		<xsd:attribute name="header-mapper" type="xsd:string">
-			<xsd:annotation>
-				<xsd:documentation>
-	HeaderMapper to use when receiving AMQP Messages.
-				</xsd:documentation>
-				<xsd:appinfo>
-					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.integration.amqp.support.AmqpHeaderMapper"/>
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests-context.xml
@@ -13,6 +13,25 @@
 
 	<amqp:inbound-channel-adapter id="autoStartFalse" queue-names="inboundchanneladapter.test.2"
 		auto-startup="false" phase="123"/>
+		
+	<amqp:inbound-channel-adapter id="withHeaderMapperStandardAndCustomHeaders" channel="requestChannel" queue-names="inboundchanneladapter.test.2"
+		auto-startup="false" phase="123"
+		mapped-request-headers="foo*, STANDARD_REQUEST_HEADERS"/>
+		
+	<amqp:inbound-channel-adapter id="withHeaderMapperOnlyCustomHeaders" channel="requestChannel" queue-names="inboundchanneladapter.test.2"
+		auto-startup="false" phase="123"
+		mapped-request-headers="foo*"/>
+		
+	<amqp:inbound-channel-adapter id="withHeaderMapperNothingToMap" channel="requestChannel" queue-names="inboundchanneladapter.test.2"
+		auto-startup="false" phase="123"
+		mapped-request-headers=""/>
+		
+	<amqp:inbound-channel-adapter id="withHeaderMapperDefaultMapping" channel="requestChannel" queue-names="inboundchanneladapter.test.2"
+		auto-startup="false" phase="123"/>
+		
+	<int:channel id="requestChannel">
+		<int:queue/>
+	</int:channel>
 
 	<bean id="rabbitConnectionFactory" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.amqp.rabbit.connection.ConnectionFactory"/>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests.java
@@ -16,18 +16,25 @@
 
 package org.springframework.integration.amqp.config;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.integration.amqp.AmqpHeaders;
 import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter;
 import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Mark Fisher
@@ -55,5 +62,114 @@ public class AmqpInboundChannelAdapterParserTests {
 		Object adapter = context.getBean("autoStartFalse.adapter");
 		assertEquals(Boolean.FALSE, TestUtils.getPropertyValue(adapter, "autoStartup"));
 		assertEquals(123, TestUtils.getPropertyValue(adapter, "phase"));
+	}
+	
+	@Test
+	public void withHeaderMapperStandardAndCustomHeaders() {
+		AmqpInboundChannelAdapter adapter = context.getBean("withHeaderMapperStandardAndCustomHeaders", AmqpInboundChannelAdapter.class);
+		
+		AbstractMessageListenerContainer mlc = 
+				TestUtils.getPropertyValue(adapter, "messageListenerContainer", AbstractMessageListenerContainer.class);
+		MessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener", MessageListener.class);
+		MessageProperties amqpProperties = new MessageProperties();
+		amqpProperties.setAppId("test.appId");
+		amqpProperties.setClusterId("test.clusterId");
+		amqpProperties.setContentEncoding("test.contentEncoding");
+		amqpProperties.setContentLength(99L);
+		amqpProperties.setContentType("test.contentType");
+		amqpProperties.setHeader("foo", "foo");
+		amqpProperties.setHeader("bar", "bar");
+		Message amqpMessage = new Message("hello".getBytes(), amqpProperties);
+		listener.onMessage(amqpMessage);
+		QueueChannel requestChannel = context.getBean("requestChannel", QueueChannel.class);
+		org.springframework.integration.Message<?> siMessage = requestChannel.receive(0);
+		assertEquals("foo", siMessage.getHeaders().get("foo"));
+		assertNull(siMessage.getHeaders().get("bar"));
+		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_ENCODING));
+		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CLUSTER_ID));
+		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.APP_ID));
+		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE));
+	}
+	
+	@Test
+	public void withHeaderMapperOnlyCustomHeaders() {
+		AmqpInboundChannelAdapter adapter = context.getBean("withHeaderMapperOnlyCustomHeaders", AmqpInboundChannelAdapter.class);
+		
+		AbstractMessageListenerContainer mlc = 
+				TestUtils.getPropertyValue(adapter, "messageListenerContainer", AbstractMessageListenerContainer.class);
+		MessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener", MessageListener.class);
+		MessageProperties amqpProperties = new MessageProperties();
+		amqpProperties.setAppId("test.appId");
+		amqpProperties.setClusterId("test.clusterId");
+		amqpProperties.setContentEncoding("test.contentEncoding");
+		amqpProperties.setContentLength(99L);
+		amqpProperties.setContentType("test.contentType");
+		amqpProperties.setHeader("foo", "foo");
+		amqpProperties.setHeader("bar", "bar");
+		Message amqpMessage = new Message("hello".getBytes(), amqpProperties);
+		listener.onMessage(amqpMessage);
+		QueueChannel requestChannel = context.getBean("requestChannel", QueueChannel.class);
+		org.springframework.integration.Message<?> siMessage = requestChannel.receive(0);
+		assertEquals("foo", siMessage.getHeaders().get("foo"));
+		assertNull(siMessage.getHeaders().get("bar"));
+		assertNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_ENCODING));
+		assertNull(siMessage.getHeaders().get(AmqpHeaders.CLUSTER_ID));
+		assertNull(siMessage.getHeaders().get(AmqpHeaders.APP_ID));
+		assertNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE));
+	}
+	
+	@Test
+	public void withHeaderMapperNothingToMap() {
+		AmqpInboundChannelAdapter adapter = context.getBean("withHeaderMapperNothingToMap", AmqpInboundChannelAdapter.class);
+		
+		AbstractMessageListenerContainer mlc = 
+				TestUtils.getPropertyValue(adapter, "messageListenerContainer", AbstractMessageListenerContainer.class);
+		MessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener", MessageListener.class);
+		MessageProperties amqpProperties = new MessageProperties();
+		amqpProperties.setAppId("test.appId");
+		amqpProperties.setClusterId("test.clusterId");
+		amqpProperties.setContentEncoding("test.contentEncoding");
+		amqpProperties.setContentLength(99L);
+		amqpProperties.setContentType("test.contentType");
+		amqpProperties.setHeader("foo", "foo");
+		amqpProperties.setHeader("bar", "bar");
+		Message amqpMessage = new Message("hello".getBytes(), amqpProperties);
+		listener.onMessage(amqpMessage);
+		
+		QueueChannel requestChannel = context.getBean("requestChannel", QueueChannel.class);
+		org.springframework.integration.Message<?> siMessage = requestChannel.receive(0);
+		assertNull(siMessage.getHeaders().get("foo"));
+		assertNull(siMessage.getHeaders().get("bar"));
+		assertNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_ENCODING));
+		assertNull(siMessage.getHeaders().get(AmqpHeaders.CLUSTER_ID));
+		assertNull(siMessage.getHeaders().get(AmqpHeaders.APP_ID));
+		assertNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE));
+	}
+	
+	@Test
+	public void withHeaderMapperDefaultMapping() {
+		AmqpInboundChannelAdapter adapter = context.getBean("withHeaderMapperDefaultMapping", AmqpInboundChannelAdapter.class);
+		
+		AbstractMessageListenerContainer mlc = 
+				TestUtils.getPropertyValue(adapter, "messageListenerContainer", AbstractMessageListenerContainer.class);
+		MessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener", MessageListener.class);
+		MessageProperties amqpProperties = new MessageProperties();
+		amqpProperties.setAppId("test.appId");
+		amqpProperties.setClusterId("test.clusterId");
+		amqpProperties.setContentEncoding("test.contentEncoding");
+		amqpProperties.setContentLength(99L);
+		amqpProperties.setContentType("test.contentType");
+		amqpProperties.setHeader("foo", "foo");
+		amqpProperties.setHeader("bar", "bar");
+		Message amqpMessage = new Message("hello".getBytes(), amqpProperties);
+		listener.onMessage(amqpMessage);
+		QueueChannel requestChannel = context.getBean("requestChannel", QueueChannel.class);
+		org.springframework.integration.Message<?> siMessage = requestChannel.receive(0);
+		assertNull(siMessage.getHeaders().get("bar"));
+		assertNull(siMessage.getHeaders().get("foo"));
+		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_ENCODING));
+		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CLUSTER_ID));
+		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.APP_ID));
+		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE));
 	}
 }

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests-context.xml
@@ -23,5 +23,12 @@
 	<si-amqp:inbound-gateway id="autoStartFalseGateway" request-channel="requests" queue-names="test"
 			connection-factory="rabbitConnectionFactory" message-converter="testConverter"
 			auto-startup="false" phase="123"/>
-
+			
+	<si-amqp:inbound-gateway id="withHeaderMapper" request-channel="requestChannel" queue-names="inboundchanneladapter.test.2"
+		auto-startup="false" phase="123"
+		mapped-request-headers="foo*, STANDARD_REQUEST_HEADERS"
+		mapped-reply-headers="bar*"/>
+		
+	<int:channel id="requestChannel"/>
+		
 </beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests-context.xml
@@ -16,5 +16,11 @@
 	<bean id="connectionFactory" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.amqp.rabbit.connection.ConnectionFactory"/>
 	</bean>
+	
+	<amqp:outbound-channel-adapter id="withHeaderMapperCustomHeaders" channel="requestChannel" 
+								   exchange-name="outboundchanneladapter.test.1"
+								   mapped-request-headers="foo*"/>
+								   
+    <int:channel id="requestChannel"/>
 		
 </beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests-context.xml
@@ -23,6 +23,35 @@
 	</bean>
 		
 	<int:channel id="toRabbit"/>
-	<int:channel id="fromRabbit"/>
+	<int:channel id="fromRabbit">
+		<int:queue/>
+	</int:channel>
+	
+	<amqp:outbound-gateway id="withHeaderMapperCustomRequestResponse" request-channel="toRabbit"
+		reply-channel="fromRabbit"
+		exchange-name="si.test.exchange"
+		routing-key="si.test.binding"
+		amqp-template="amqpTemplate" 
+		order="5"
+		mapped-request-headers="foo*"
+		mapped-reply-headers="bar*"/>
+		
+	<amqp:outbound-gateway id="withHeaderMapperCustomAndStandardResponse" request-channel="toRabbit"
+		reply-channel="fromRabbit"
+		exchange-name="si.test.exchange"
+		routing-key="si.test.binding"
+		amqp-template="amqpTemplate" 
+		order="5"
+		mapped-request-headers="foo*"
+		mapped-reply-headers="bar*, STANDARD_REPLY_HEADERS"/>
+		
+	<amqp:outbound-gateway id="withHeaderMapperNothingToMap" request-channel="toRabbit"
+		reply-channel="fromRabbit"
+		exchange-name="si.test.exchange"
+		routing-key="si.test.binding"
+		amqp-template="amqpTemplate" 
+		order="5"
+		mapped-request-headers=""
+		mapped-reply-headers=""/>
 
 </beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
@@ -95,7 +95,6 @@ public class AmqpOutboundGatewayParserTests {
 		// verify reply
 		QueueChannel queueChannel = context.getBean("fromRabbit", QueueChannel.class);
 		Message<?> replyMessage = queueChannel.receive(0);
-		System.out.println(replyMessage);
 		assertEquals("bar", replyMessage.getHeaders().get("bar"));
 		assertEquals("foo", replyMessage.getHeaders().get("foo")); // copied from request Message
 		assertNull(replyMessage.getHeaders().get("foobar"));

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
@@ -15,15 +15,30 @@
  */
 package org.springframework.integration.amqp.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import java.lang.reflect.Field;
 
 import org.junit.Test;
-
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.Message;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.amqp.AmqpHeaders;
 import org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.util.ReflectionUtils;
+
+import static junit.framework.Assert.assertEquals;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Oleg Zhurakousky
@@ -34,9 +49,152 @@ public class AmqpOutboundGatewayParserTests {
 	@Test
 	public void testGatewayConfig(){
 		ApplicationContext context = new ClassPathXmlApplicationContext("AmqpOutboundGatewayParserTests-context.xml", this.getClass());
-		AmqpOutboundEndpoint gateway = context.getBean(AmqpOutboundEndpoint.class);
+		Object edc = context.getBean("rabbitGateway");
+		AmqpOutboundEndpoint gateway = TestUtils.getPropertyValue(edc, "handler", AmqpOutboundEndpoint.class);
 		assertEquals(5, gateway.getOrder());
 		assertTrue(context.containsBean("rabbitGateway"));
 		assertEquals(context.getBean("fromRabbit"), TestUtils.getPropertyValue(gateway, "outputChannel"));
+	}
+	
+	@SuppressWarnings("rawtypes")
+	@Test
+	public void withHeaderMapperCustomRequestResponse() {
+		ApplicationContext context = new ClassPathXmlApplicationContext("AmqpOutboundGatewayParserTests-context.xml", this.getClass());
+		Object eventDrivernConsumer = context.getBean("withHeaderMapperCustomRequestResponse");
+		
+		AmqpOutboundEndpoint endpoint = TestUtils.getPropertyValue(eventDrivernConsumer, "handler", AmqpOutboundEndpoint.class);
+		
+		Field amqpTemplateField = ReflectionUtils.findField(AmqpOutboundEndpoint.class, "amqpTemplate");
+		amqpTemplateField.setAccessible(true);
+		RabbitTemplate amqpTemplate = TestUtils.getPropertyValue(endpoint, "amqpTemplate", RabbitTemplate.class);
+		amqpTemplate = Mockito.spy(amqpTemplate);
+		
+		Mockito.doAnswer(new Answer() {
+		      public Object answer(InvocationOnMock invocation) {
+		          Object[] args = invocation.getArguments();
+		          org.springframework.amqp.core.Message amqpRequestMessage = (org.springframework.amqp.core.Message) args[2];
+		          MessageProperties properties = amqpRequestMessage.getMessageProperties();
+		          assertEquals("foo", properties.getHeaders().get("foo"));
+		          // mock reply AMQP message
+		          MessageProperties amqpProperties = new MessageProperties();
+		  		  amqpProperties.setAppId("test.appId");
+		  		  amqpProperties.setHeader("foobar", "foobar");
+		  		  amqpProperties.setHeader("bar", "bar");
+		          org.springframework.amqp.core.Message amqpReplyMessage = new org.springframework.amqp.core.Message("hello".getBytes(), amqpProperties);
+		          return amqpReplyMessage;
+		      }})
+		 .when(amqpTemplate).sendAndReceive(Mockito.any(String.class), Mockito.any(String.class), Mockito.any(org.springframework.amqp.core.Message.class));
+		ReflectionUtils.setField(amqpTemplateField, endpoint, amqpTemplate);
+
+		MessageChannel requestChannel = context.getBean("toRabbit", MessageChannel.class);
+		Message<?> message = MessageBuilder.withPayload("hello").setHeader("foo", "foo").build();
+		requestChannel.send(message);
+		
+		Mockito.verify(amqpTemplate, Mockito.times(1)).sendAndReceive(Mockito.any(String.class), Mockito.any(String.class), Mockito.any(org.springframework.amqp.core.Message.class));
+		
+		// verify reply
+		QueueChannel queueChannel = context.getBean("fromRabbit", QueueChannel.class);
+		Message<?> replyMessage = queueChannel.receive(0);
+		System.out.println(replyMessage);
+		assertEquals("bar", replyMessage.getHeaders().get("bar"));
+		assertEquals("foo", replyMessage.getHeaders().get("foo")); // copied from request Message
+		assertNull(replyMessage.getHeaders().get("foobar"));
+		assertNull(replyMessage.getHeaders().get(AmqpHeaders.DELIVERY_MODE));
+		assertNull(replyMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE));
+		assertNull(replyMessage.getHeaders().get(AmqpHeaders.APP_ID));
+	}
+	
+	@SuppressWarnings("rawtypes")
+	@Test
+	public void withHeaderMapperCustomAndStandardResponse() {
+		ApplicationContext context = new ClassPathXmlApplicationContext("AmqpOutboundGatewayParserTests-context.xml", this.getClass());
+		Object eventDrivernConsumer = context.getBean("withHeaderMapperCustomAndStandardResponse");
+		
+		AmqpOutboundEndpoint endpoint = TestUtils.getPropertyValue(eventDrivernConsumer, "handler", AmqpOutboundEndpoint.class);
+		
+		Field amqpTemplateField = ReflectionUtils.findField(AmqpOutboundEndpoint.class, "amqpTemplate");
+		amqpTemplateField.setAccessible(true);
+		RabbitTemplate amqpTemplate = TestUtils.getPropertyValue(endpoint, "amqpTemplate", RabbitTemplate.class);
+		amqpTemplate = Mockito.spy(amqpTemplate);
+		
+		Mockito.doAnswer(new Answer() {
+		      public Object answer(InvocationOnMock invocation) {
+		          Object[] args = invocation.getArguments();
+		          org.springframework.amqp.core.Message amqpRequestMessage = (org.springframework.amqp.core.Message) args[2];
+		          MessageProperties properties = amqpRequestMessage.getMessageProperties();
+		          assertEquals("foo", properties.getHeaders().get("foo"));
+		          // mock reply AMQP message
+		          MessageProperties amqpProperties = new MessageProperties();
+		  		  amqpProperties.setAppId("test.appId");
+		  		  amqpProperties.setHeader("foobar", "foobar");
+		  		  amqpProperties.setHeader("bar", "bar");
+		          org.springframework.amqp.core.Message amqpReplyMessage = new org.springframework.amqp.core.Message("hello".getBytes(), amqpProperties);
+		          return amqpReplyMessage;
+		      }})
+		 .when(amqpTemplate).sendAndReceive(Mockito.any(String.class), Mockito.any(String.class), Mockito.any(org.springframework.amqp.core.Message.class));
+		ReflectionUtils.setField(amqpTemplateField, endpoint, amqpTemplate);
+
+		MessageChannel requestChannel = context.getBean("toRabbit", MessageChannel.class);
+		Message<?> message = MessageBuilder.withPayload("hello").setHeader("foo", "foo").build();
+		requestChannel.send(message);
+		
+		Mockito.verify(amqpTemplate, Mockito.times(1)).sendAndReceive(Mockito.any(String.class), Mockito.any(String.class), Mockito.any(org.springframework.amqp.core.Message.class));
+		
+		// verify reply
+		QueueChannel queueChannel = context.getBean("fromRabbit", QueueChannel.class);
+		Message<?> replyMessage = queueChannel.receive(0);
+		assertEquals("bar", replyMessage.getHeaders().get("bar"));
+		assertEquals("foo", replyMessage.getHeaders().get("foo")); // copied from request Message
+		assertNull(replyMessage.getHeaders().get("foobar"));
+		assertNotNull(replyMessage.getHeaders().get(AmqpHeaders.DELIVERY_MODE));
+		assertNotNull(replyMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE));
+		assertNotNull(replyMessage.getHeaders().get(AmqpHeaders.APP_ID));
+	}
+	
+	@SuppressWarnings("rawtypes")
+	@Test
+	public void withHeaderMapperNothingToMap() {
+		ApplicationContext context = new ClassPathXmlApplicationContext("AmqpOutboundGatewayParserTests-context.xml", this.getClass());
+		Object eventDrivernConsumer = context.getBean("withHeaderMapperNothingToMap");
+		
+		AmqpOutboundEndpoint endpoint = TestUtils.getPropertyValue(eventDrivernConsumer, "handler", AmqpOutboundEndpoint.class);
+		
+		Field amqpTemplateField = ReflectionUtils.findField(AmqpOutboundEndpoint.class, "amqpTemplate");
+		amqpTemplateField.setAccessible(true);
+		RabbitTemplate amqpTemplate = TestUtils.getPropertyValue(endpoint, "amqpTemplate", RabbitTemplate.class);
+		amqpTemplate = Mockito.spy(amqpTemplate);
+		
+		Mockito.doAnswer(new Answer() {
+		      public Object answer(InvocationOnMock invocation) {
+		          Object[] args = invocation.getArguments();
+		          org.springframework.amqp.core.Message amqpRequestMessage = (org.springframework.amqp.core.Message) args[2];
+		          MessageProperties properties = amqpRequestMessage.getMessageProperties();
+		          assertNull(properties.getHeaders().get("foo"));
+		          // mock reply AMQP message
+		          MessageProperties amqpProperties = new MessageProperties();
+		  		  amqpProperties.setAppId("test.appId");
+		  		  amqpProperties.setHeader("foobar", "foobar");
+		  		  amqpProperties.setHeader("bar", "bar");
+		          org.springframework.amqp.core.Message amqpReplyMessage = new org.springframework.amqp.core.Message("hello".getBytes(), amqpProperties);
+		          return amqpReplyMessage;
+		      }})
+		 .when(amqpTemplate).sendAndReceive(Mockito.any(String.class), Mockito.any(String.class), Mockito.any(org.springframework.amqp.core.Message.class));
+		ReflectionUtils.setField(amqpTemplateField, endpoint, amqpTemplate);
+
+		MessageChannel requestChannel = context.getBean("toRabbit", MessageChannel.class);
+		Message<?> message = MessageBuilder.withPayload("hello").setHeader("foo", "foo").build();
+		requestChannel.send(message);
+		
+		Mockito.verify(amqpTemplate, Mockito.times(1)).sendAndReceive(Mockito.any(String.class), Mockito.any(String.class), Mockito.any(org.springframework.amqp.core.Message.class));
+		
+		// verify reply
+		QueueChannel queueChannel = context.getBean("fromRabbit", QueueChannel.class);
+		Message<?> replyMessage = queueChannel.receive(0);
+		assertNull(replyMessage.getHeaders().get("bar"));
+		assertEquals("foo", replyMessage.getHeaders().get("foo")); // copied from request Message
+		assertNull(replyMessage.getHeaders().get("foobar"));
+		assertNull(replyMessage.getHeaders().get(AmqpHeaders.DELIVERY_MODE));
+		assertNull(replyMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE));
+		assertNull(replyMessage.getHeaders().get(AmqpHeaders.APP_ID));
 	}
 }

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
@@ -18,15 +18,17 @@ package org.springframework.integration.amqp.support;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
-
 import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.support.converter.JsonMessageConverter;
 import org.springframework.integration.MessageHeaders;
+import org.springframework.integration.amqp.AmqpHeaders;
 
 /**
  * @author Mark Fisher
@@ -35,8 +37,98 @@ import org.springframework.integration.MessageHeaders;
 public class DefaultAmqpHeaderMapperTests {
 
 	@Test
+	public void fromHeaders() {
+		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(true);
+		Map<String, Object> headerMap = new HashMap<String, Object>();
+		headerMap.put(AmqpHeaders.APP_ID, "test.appId");
+		headerMap.put(AmqpHeaders.CLUSTER_ID, "test.clusterId");
+		headerMap.put(AmqpHeaders.CONTENT_ENCODING, "test.contentEncoding");
+		headerMap.put(AmqpHeaders.CONTENT_LENGTH, 99L);
+		headerMap.put(AmqpHeaders.CONTENT_TYPE, "test.contentType");
+		byte[] testCorrelationId = new byte[] {1,2,3};
+		headerMap.put(AmqpHeaders.CORRELATION_ID, testCorrelationId);
+		headerMap.put(AmqpHeaders.DELIVERY_MODE, MessageDeliveryMode.NON_PERSISTENT);
+		headerMap.put(AmqpHeaders.DELIVERY_TAG, 1234L);
+		headerMap.put(AmqpHeaders.EXPIRATION, "test.expiration");
+		headerMap.put(AmqpHeaders.MESSAGE_COUNT, 42);
+		headerMap.put(AmqpHeaders.MESSAGE_ID, "test.messageId");
+		headerMap.put(AmqpHeaders.RECEIVED_EXCHANGE, "test.receivedExchange");
+		headerMap.put(AmqpHeaders.RECEIVED_ROUTING_KEY, "test.receivedRoutingKey");
+		headerMap.put(AmqpHeaders.REPLY_TO, "test.replyTo");
+		Date testTimestamp = new Date();
+		headerMap.put(AmqpHeaders.TIMESTAMP, testTimestamp);
+		headerMap.put(AmqpHeaders.TYPE, "test.type");
+		headerMap.put(AmqpHeaders.USER_ID, "test.userId");
+		MessageHeaders integrationHeaders = new MessageHeaders(headerMap);
+		MessageProperties amqpProperties = new MessageProperties();
+		headerMapper.fromHeaders(integrationHeaders, amqpProperties);
+		assertEquals("test.appId", amqpProperties.getAppId());
+		assertEquals("test.clusterId", amqpProperties.getClusterId());
+		assertEquals("test.contentEncoding", amqpProperties.getContentEncoding());
+		assertEquals(99L, amqpProperties.getContentLength());
+		assertEquals("test.contentType", amqpProperties.getContentType());
+		assertEquals(testCorrelationId, amqpProperties.getCorrelationId());
+		assertEquals(MessageDeliveryMode.NON_PERSISTENT, amqpProperties.getDeliveryMode());
+		assertEquals(1234L, amqpProperties.getDeliveryTag());
+		assertEquals("test.expiration", amqpProperties.getExpiration());
+		assertEquals(new Integer(42), amqpProperties.getMessageCount());
+		assertEquals("test.messageId", amqpProperties.getMessageId());
+		assertEquals("test.receivedExchange", amqpProperties.getReceivedExchange());
+		assertEquals("test.receivedRoutingKey", amqpProperties.getReceivedRoutingKey());
+		assertEquals("test.replyTo", amqpProperties.getReplyTo());
+		assertEquals(testTimestamp, amqpProperties.getTimestamp());
+		assertEquals("test.type", amqpProperties.getType());
+		assertEquals("test.userId", amqpProperties.getUserId());
+	}
+
+	@Test
+	public void toHeaders() {
+		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(true);
+		MessageProperties amqpProperties = new MessageProperties();
+		amqpProperties.setAppId("test.appId");
+		amqpProperties.setClusterId("test.clusterId");
+		amqpProperties.setContentEncoding("test.contentEncoding");
+		amqpProperties.setContentLength(99L);
+		amqpProperties.setContentType("test.contentType");
+		byte[] testCorrelationId = new byte[] {1,2,3};
+		amqpProperties.setCorrelationId(testCorrelationId);
+		amqpProperties.setDeliveryMode(MessageDeliveryMode.NON_PERSISTENT);
+		amqpProperties.setDeliveryTag(1234L);
+		amqpProperties.setExpiration("test.expiration");
+		amqpProperties.setMessageCount(42);
+		amqpProperties.setMessageId("test.messageId");
+		amqpProperties.setPriority(22);
+		amqpProperties.setReceivedExchange("test.receivedExchange");
+		amqpProperties.setReceivedRoutingKey("test.receivedRoutingKey");
+		amqpProperties.setRedelivered(true);
+		amqpProperties.setReplyTo("test.replyTo");
+		Date testTimestamp = new Date();
+		amqpProperties.setTimestamp(testTimestamp);
+		amqpProperties.setType("test.type");
+		amqpProperties.setUserId("test.userId");
+		Map<String, Object> headerMap = headerMapper.toHeaders(amqpProperties);
+		assertEquals("test.appId", headerMap.get(AmqpHeaders.APP_ID));
+		assertEquals("test.clusterId", headerMap.get(AmqpHeaders.CLUSTER_ID));
+		assertEquals("test.contentEncoding", headerMap.get(AmqpHeaders.CONTENT_ENCODING));
+		assertEquals(99L, headerMap.get(AmqpHeaders.CONTENT_LENGTH));
+		assertEquals("test.contentType", headerMap.get(AmqpHeaders.CONTENT_TYPE));
+		assertEquals(testCorrelationId, headerMap.get(AmqpHeaders.CORRELATION_ID));
+		assertEquals(MessageDeliveryMode.NON_PERSISTENT, headerMap.get(AmqpHeaders.DELIVERY_MODE));
+		assertEquals(1234L, headerMap.get(AmqpHeaders.DELIVERY_TAG));
+		assertEquals("test.expiration", headerMap.get(AmqpHeaders.EXPIRATION));
+		assertEquals(new Integer(42), headerMap.get(AmqpHeaders.MESSAGE_COUNT));
+		assertEquals("test.messageId", headerMap.get(AmqpHeaders.MESSAGE_ID));
+		assertEquals("test.receivedExchange", headerMap.get(AmqpHeaders.RECEIVED_EXCHANGE));
+		assertEquals("test.receivedRoutingKey", headerMap.get(AmqpHeaders.RECEIVED_ROUTING_KEY));
+		assertEquals("test.replyTo", headerMap.get(AmqpHeaders.REPLY_TO));
+		assertEquals(testTimestamp, headerMap.get(AmqpHeaders.TIMESTAMP));
+		assertEquals("test.type", headerMap.get(AmqpHeaders.TYPE));
+		assertEquals("test.userId", headerMap.get(AmqpHeaders.USER_ID));
+	}
+
+	@Test
 	public void replyChannelNotMappedToAmqpProperties() {
-		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
+		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(true);
 		Map<String, Object> headerMap = new HashMap<String, Object>();
 		headerMap.put(MessageHeaders.REPLY_CHANNEL, "foo");
 		MessageHeaders integrationHeaders = new MessageHeaders(headerMap);
@@ -47,7 +139,7 @@ public class DefaultAmqpHeaderMapperTests {
 
 	@Test
 	public void errorChannelNotMappedToAmqpProperties() {
-		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
+		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(true);
 		Map<String, Object> headerMap = new HashMap<String, Object>();
 		headerMap.put(MessageHeaders.ERROR_CHANNEL, "foo");
 		MessageHeaders integrationHeaders = new MessageHeaders(headerMap);
@@ -58,7 +150,7 @@ public class DefaultAmqpHeaderMapperTests {
 
 	@Test // INT-2090
 	public void jsonTypeIdNotOverwritten() {
-		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
+		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(true);
 		JsonMessageConverter converter = new JsonMessageConverter();
 		MessageProperties amqpProperties = new MessageProperties();
 		converter.toMessage("123", amqpProperties);

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
@@ -38,7 +38,7 @@ public class DefaultAmqpHeaderMapperTests {
 
 	@Test
 	public void fromHeaders() {
-		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(true);
+		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
 		Map<String, Object> headerMap = new HashMap<String, Object>();
 		headerMap.put(AmqpHeaders.APP_ID, "test.appId");
 		headerMap.put(AmqpHeaders.CLUSTER_ID, "test.clusterId");
@@ -61,7 +61,7 @@ public class DefaultAmqpHeaderMapperTests {
 		headerMap.put(AmqpHeaders.USER_ID, "test.userId");
 		MessageHeaders integrationHeaders = new MessageHeaders(headerMap);
 		MessageProperties amqpProperties = new MessageProperties();
-		headerMapper.fromHeaders(integrationHeaders, amqpProperties);
+		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
 		assertEquals("test.appId", amqpProperties.getAppId());
 		assertEquals("test.clusterId", amqpProperties.getClusterId());
 		assertEquals("test.contentEncoding", amqpProperties.getContentEncoding());
@@ -83,7 +83,7 @@ public class DefaultAmqpHeaderMapperTests {
 
 	@Test
 	public void toHeaders() {
-		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(true);
+		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
 		MessageProperties amqpProperties = new MessageProperties();
 		amqpProperties.setAppId("test.appId");
 		amqpProperties.setClusterId("test.clusterId");
@@ -106,7 +106,7 @@ public class DefaultAmqpHeaderMapperTests {
 		amqpProperties.setTimestamp(testTimestamp);
 		amqpProperties.setType("test.type");
 		amqpProperties.setUserId("test.userId");
-		Map<String, Object> headerMap = headerMapper.toHeaders(amqpProperties);
+		Map<String, Object> headerMap = headerMapper.toHeadersFromReply(amqpProperties);
 		assertEquals("test.appId", headerMap.get(AmqpHeaders.APP_ID));
 		assertEquals("test.clusterId", headerMap.get(AmqpHeaders.CLUSTER_ID));
 		assertEquals("test.contentEncoding", headerMap.get(AmqpHeaders.CONTENT_ENCODING));
@@ -128,36 +128,36 @@ public class DefaultAmqpHeaderMapperTests {
 
 	@Test
 	public void replyChannelNotMappedToAmqpProperties() {
-		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(true);
+		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
 		Map<String, Object> headerMap = new HashMap<String, Object>();
 		headerMap.put(MessageHeaders.REPLY_CHANNEL, "foo");
 		MessageHeaders integrationHeaders = new MessageHeaders(headerMap);
 		MessageProperties amqpProperties = new MessageProperties();
-		headerMapper.fromHeaders(integrationHeaders, amqpProperties);
+		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
 		assertEquals(null, amqpProperties.getHeaders().get(MessageHeaders.REPLY_CHANNEL));
 	}
 
 	@Test
 	public void errorChannelNotMappedToAmqpProperties() {
-		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(true);
+		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
 		Map<String, Object> headerMap = new HashMap<String, Object>();
 		headerMap.put(MessageHeaders.ERROR_CHANNEL, "foo");
 		MessageHeaders integrationHeaders = new MessageHeaders(headerMap);
 		MessageProperties amqpProperties = new MessageProperties();
-		headerMapper.fromHeaders(integrationHeaders, amqpProperties);
+		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
 		assertEquals(null, amqpProperties.getHeaders().get(MessageHeaders.ERROR_CHANNEL));
 	}
 
 	@Test // INT-2090
 	public void jsonTypeIdNotOverwritten() {
-		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper(true);
+		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
 		JsonMessageConverter converter = new JsonMessageConverter();
 		MessageProperties amqpProperties = new MessageProperties();
 		converter.toMessage("123", amqpProperties);
 		Map<String, Object> headerMap = new HashMap<String, Object>();
 		headerMap.put("__TypeId__", "java.lang.Integer");
 		MessageHeaders integrationHeaders = new MessageHeaders(headerMap);
-		headerMapper.fromHeaders(integrationHeaders, amqpProperties);
+		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
 		assertEquals("java.lang.String", amqpProperties.getHeaders().get("__TypeId__"));
 		Object result = converter.fromMessage(new Message("123".getBytes(), amqpProperties));
 		assertEquals(String.class, result.getClass());

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
@@ -230,23 +230,23 @@ public abstract class IntegrationNamespaceUtils {
 		}
 		boolean hasHeaderMapper = element.hasAttribute("header-mapper");
 		boolean hasMappedRequestHeaders = element.hasAttribute("mapped-request-headers");
-		boolean hasMappedResponseHeaders = element.hasAttribute(replyHeaderValue);
+		boolean hasMappedReplyHeaders = element.hasAttribute(replyHeaderValue);
 		
-		if (hasHeaderMapper && (hasMappedRequestHeaders || hasMappedResponseHeaders)){
+		if (hasHeaderMapper && (hasMappedRequestHeaders || hasMappedReplyHeaders)){
 			parserContext.getReaderContext().error("The 'header-mapper' attribute is mutually exclusive with" +
-					" 'mapped-request-headers' or 'mapped-response-headers'. " +
+					" 'mapped-request-headers' or 'mapped-reply-headers'. " +
 					"You can only use one or the others", element);
 		}
 		
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(rootBuilder, element, "header-mapper");
 		
-		if (hasMappedRequestHeaders || hasMappedResponseHeaders){
+		if (hasMappedRequestHeaders || hasMappedReplyHeaders){
 			BeanDefinitionBuilder headerMapperBuilder = BeanDefinitionBuilder.genericBeanDefinition(headerMapperClass);
 			
 			if (hasMappedRequestHeaders) {
 				headerMapperBuilder.addPropertyValue("requestHeaderNames", element.getAttribute("mapped-request-headers"));
 			}
-			if (hasMappedResponseHeaders) {
+			if (hasMappedReplyHeaders) {
 				headerMapperBuilder.addPropertyValue("replyHeaderNames", element.getAttribute(replyHeaderValue));
 			}
 			

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
@@ -222,8 +222,7 @@ public abstract class IntegrationNamespaceUtils {
 	/**
 	 * Utility method to configure HeaderMapper for Inbound and Outbound channel adapters/gateway
 	 */
-	public static void configureHeaderMapper(Element element, BeanDefinitionBuilder rootBuilder, ParserContext parserContext, Class<?> headerMapperClass, 
-										     boolean outbound, String replyHeaderValue){
+	public static void configureHeaderMapper(Element element, BeanDefinitionBuilder rootBuilder, ParserContext parserContext, Class<?> headerMapperClass, String replyHeaderValue){
 		String defaultMappedReplyHeadersAttributeName = "mapped-reply-headers";
 		if (!StringUtils.hasText(replyHeaderValue)){
 			replyHeaderValue = defaultMappedReplyHeadersAttributeName;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
@@ -242,13 +242,12 @@ public abstract class IntegrationNamespaceUtils {
 		
 		if (hasMappedRequestHeaders || hasMappedResponseHeaders){
 			BeanDefinitionBuilder headerMapperBuilder = BeanDefinitionBuilder.genericBeanDefinition(headerMapperClass);
-			headerMapperBuilder.addConstructorArgValue(outbound);
 			
 			if (hasMappedRequestHeaders) {
 				headerMapperBuilder.addPropertyValue("requestHeaderNames", element.getAttribute("mapped-request-headers"));
 			}
 			if (hasMappedResponseHeaders) {
-				headerMapperBuilder.addPropertyValue("responseHeaderNames", element.getAttribute(replyHeaderValue));
+				headerMapperBuilder.addPropertyValue("replyHeaderNames", element.getAttribute(replyHeaderValue));
 			}
 			
 			rootBuilder.addPropertyValue("headerMapper", headerMapperBuilder.getBeanDefinition());

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -19,6 +19,7 @@ package org.springframework.integration.mapping;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -277,12 +278,16 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	/**
 	 * Returns the list of standard REQUEST headers. Implementation provided by a subclass
 	 */
-	protected abstract List<String> getStandardReplyHeaderNames();
+	protected List<String> getStandardReplyHeaderNames(){
+		return Collections.emptyList();
+	}
 
 	/**
 	 * Returns the PREFIX used by standard headers (if any)
 	 */
-	protected abstract List<String> getStandardRequestHeaderNames();
+	protected List<String> getStandardRequestHeaderNames(){
+		return Collections.emptyList();
+	}
 	
 	/**
 	 * Returns the list of standard REPLY headers. Implementation provided by a subclass

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mapping;
+
+import java.lang.reflect.Field;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.integration.MessageHeaders;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.PatternMatchUtils;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.ReflectionUtils.FieldCallback;
+import org.springframework.util.StringUtils;
+
+/**
+ * Abstract base class for HeaderMapper implementations.
+ *
+ * @author Mark Fisher
+ * @author Oleg Zhurakousky
+ * @since 2.1
+ */
+public abstract class AbstractHeaderMapper<T> implements HeaderMapper<T> {
+
+	public static final String STANDARD_REQUEST_HEADER_NAME_PATTERN = "STANDARD_REQUEST_HEADERS";
+
+	public static final String STANDARD_REPLY_HEADER_NAME_PATTERN = "STANDARD_REPLY_HEADERS";
+
+	private static final String[] TRANSIENT_HEADER_NAMES = new String[] {
+		MessageHeaders.ID,
+		MessageHeaders.ERROR_CHANNEL,
+		MessageHeaders.REPLY_CHANNEL,
+		MessageHeaders.TIMESTAMP
+	};
+
+	protected final Log logger = LogFactory.getLog(this.getClass());
+
+	private final boolean outbound; 
+	
+	private final String standardHeaderPrefix;
+
+	private volatile String userDefinedHeaderPrefix = "";
+
+	private final List<String> standardRequestHeaderNames = new ArrayList<String>();
+
+	private final List<String> standardReplyHeaderNames = new ArrayList<String>();
+
+	private volatile String[] requestHeaderNames = new String[0];
+
+	private volatile String[] responseHeaderNames = new String[0];
+
+
+	protected AbstractHeaderMapper(Class<?> headersClass, boolean outbound) {
+		Assert.notNull(headersClass, "headersClass must not be null");
+		this.outbound = outbound;
+		final StringBuilder prefixBuilder = new StringBuilder();
+		final List<String> headerNames = new ArrayList<String>();
+		this.introspectHeaderFields(headersClass, prefixBuilder, headerNames);
+		this.standardHeaderPrefix = prefixBuilder.toString();
+		this.standardRequestHeaderNames.addAll(headerNames);
+		this.standardReplyHeaderNames.addAll(headerNames);
+		if (outbound) {
+			this.responseHeaderNames = this.standardRequestHeaderNames.toArray(new String[0]);
+			this.requestHeaderNames = this.standardReplyHeaderNames.toArray(new String[0]);
+		}
+		else {
+			this.requestHeaderNames = this.standardRequestHeaderNames.toArray(new String[0]);
+			this.responseHeaderNames = this.standardReplyHeaderNames.toArray(new String[0]);			
+		}
+	}
+
+
+	private void introspectHeaderFields(Class<?> headersClass, final StringBuilder prefixBuilder, final List<String> headerNames) {
+		ReflectionUtils.doWithFields(headersClass, new FieldCallback() {
+			public void doWith(Field f) throws IllegalArgumentException, IllegalAccessException {
+				try {
+					String fieldName = f.getName();
+					Object fieldValue = f.get(null);
+					if (fieldValue instanceof String) {
+						if ("PREFIX".equals(fieldName)) {
+							prefixBuilder.append((String) fieldValue);
+						}
+						else {
+							headerNames.add((String) fieldValue);
+						}
+					}
+				}
+				catch (Exception e) {
+					// ignore
+				}
+			}
+		});
+	}
+
+	/**
+	 * Provide the header names that should be mapped from a request (for inbound/outbound adapters)
+	 * TO a Spring Integration Message's headers.
+	 * The values can also contain simple wildcard patterns (e.g. "foo*" or "*foo") to be matched.
+	 * <p>
+	 * This will match the header name directly or, for non-standard headers, it will match
+	 * the header name prefixed with the value specified by {@link #setInboundPrefix(String)}.
+	 */
+	public void setRequestHeaderNames(String[] requestHeaderNames) {
+		this.requestHeaderNames = (requestHeaderNames != null) ? requestHeaderNames : new String[0];
+	}
+
+	/**
+	 * Provide the header names that should be mapped to a response (for inbound/outbound adapters)
+	 * FROM a Spring Integration Message's headers.
+	 * The values can also contain simple wildcard patterns (e.g. "foo*" or "*foo") to be matched.
+	 * <p>
+	 * Any non-standard headers will be prefixed with the value specified by {@link #setOutboundPrefix(String)}.
+	 */
+	public void setResponseHeaderNames(String[] responseHeaderNames) {
+		this.responseHeaderNames = (responseHeaderNames != null) ? responseHeaderNames : new String[0];
+	}
+
+	/**
+	 * Specify a prefix to be prepended to the header name for any integration
+	 * message header that is being mapped to or from a user-defined value.
+	 * <p/>
+	 * This does not affect the standard properties for the particular protocol, such as
+	 * contentType for AMQP, etc. The header names used for mapping such properties are
+	 * defined in a corresponding Headers class as constants (e.g. AmqpHeaders).
+	 */
+	public void setUserDefinedHeaderPrefix(String userDefinedHeaderPrefix) {
+		this.userDefinedHeaderPrefix = (userDefinedHeaderPrefix != null) ? userDefinedHeaderPrefix : "";
+	}
+
+	/**
+	 * Maps headers from a Spring Integration MessageHeaders instance to the target instance.
+	 */
+	public void fromHeaders(MessageHeaders headers, T target) {
+		try {
+			Map<String, Object> subset = new HashMap<String, Object>();
+			for (String headerName : headers.keySet()) {
+				boolean shouldMap = this.outbound				
+						? this.shouldMapRequestHeader(headerName)
+				        : this.shouldMapResponseHeader(headerName);
+				if (shouldMap) {
+					subset.put(headerName, headers.get(headerName));
+				}
+			}
+			this.populateStandardHeaders(subset, target);
+			this.populateUserDefinedHeaders(subset, target);
+		}
+		catch (Exception e) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("error occurred while mapping from MessageHeaders", e);
+			}
+		}
+	}
+
+	private void populateUserDefinedHeaders(Map<String, Object> headers, T target) {
+		for (String headerName : headers.keySet()) {
+			Object value = headers.get(headerName);
+			if (value != null) {
+				try {
+					String key = this.addPrefixIfNecessary(this.userDefinedHeaderPrefix, headerName);
+					this.populateUserDefinedHeader(key, value, target);
+				}
+				catch (Exception e) {
+					if (logger.isWarnEnabled()) {
+						logger.warn("failed to map from Message header '" + headerName + "' to target", e);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Maps headers from a source instance to the MessageHeaders of a
+	 * Spring Integration Message.
+	 */
+	public <V> Map<String, V> toHeaders(T source) {
+		Map<String, V> headers = new HashMap<String, V>();
+		Map<String, Object> standardHeaders = this.extractStandardHeaders(source);
+		this.copyHeaders(this.standardHeaderPrefix, standardHeaders, headers);
+		Map<String, Object> userDefinedHeaders = this.extractUserDefinedHeaders(source);
+		this.copyHeaders(this.userDefinedHeaderPrefix, userDefinedHeaders, headers);
+		return headers;
+	}
+
+	@SuppressWarnings("unchecked")
+	private <V> void copyHeaders(String prefix, Map<String, Object> source, Map<String, V> target) {
+		if (!CollectionUtils.isEmpty(source)) {
+			for (Map.Entry<String, Object> entry : source.entrySet()) {
+				try {
+					String headerName = this.addPrefixIfNecessary(prefix, entry.getKey());
+					boolean shouldMap = this.outbound
+							? this.shouldMapResponseHeader(headerName)
+							: this.shouldMapRequestHeader(headerName);
+					if (shouldMap) {
+						target.put(headerName, (V) entry.getValue());
+					}
+				}
+				catch (Exception e) {
+					if (logger.isWarnEnabled()) {
+						logger.warn("error occurred while mapping header '"
+								+ entry.getKey() + "' to Message header", e);
+					}
+				}
+			}
+		}
+	}
+
+	private boolean shouldMapRequestHeader(String headerName) {
+		return this.shouldMapHeader(headerName, this.requestHeaderNames);
+	}
+
+	private boolean shouldMapResponseHeader(String headerName) {
+		return this.shouldMapHeader(headerName, this.responseHeaderNames);
+	}
+
+	private boolean shouldMapHeader(String headerName, String[] patterns) {
+		if (!StringUtils.hasText(headerName)
+				|| ObjectUtils.containsElement(TRANSIENT_HEADER_NAMES, headerName)) {
+			return false;
+		}
+		if (patterns != null && patterns.length > 0) {
+			for (String pattern : patterns) {
+				if (PatternMatchUtils.simpleMatch(pattern.toLowerCase(), headerName.toLowerCase())) {
+					if (logger.isDebugEnabled()) {
+						logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}", headerName, pattern));
+					}
+					return true;
+				}
+				else if (STANDARD_REQUEST_HEADER_NAME_PATTERN.equals(pattern)
+						&& this.containsElementIgnoreCase(this.standardRequestHeaderNames, headerName)) {
+					if (logger.isDebugEnabled()) {
+						logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}", headerName, pattern));
+					}
+					return true;
+				}
+				else if (STANDARD_REPLY_HEADER_NAME_PATTERN.equals(pattern)
+						&& this.containsElementIgnoreCase(this.standardReplyHeaderNames, headerName)) {
+					if (logger.isDebugEnabled()) {
+						logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}", headerName, pattern));
+					}
+					return true;
+				}
+			}
+		}
+		if (logger.isDebugEnabled()) {
+			logger.debug(MessageFormat.format("headerName=[{0}] WILL NOT be mapped", headerName));
+		}
+		return false;
+	}
+
+	private boolean containsElementIgnoreCase(List<String> headerNames, String name) {
+		for (String headerName : headerNames) {
+			if (headerName.equalsIgnoreCase(name)){
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@SuppressWarnings("unchecked")
+	protected <V> V getHeaderIfAvailable(Map<String, Object> headers, String name, Class<V> type) {
+		Object value = headers.get(name);
+		if (value == null) {
+			return null;
+		}
+		if (!type.isAssignableFrom(value.getClass())) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("skipping header '" + name + "' since it is not of expected type [" + type + "]");
+			}
+		}
+		return (V) value;
+	}
+
+	/**
+	 * Adds the outbound or inbound prefix if necessary.
+	 */
+	private String addPrefixIfNecessary(String prefix, String propertyName) {
+		String headerName = propertyName;
+		if (StringUtils.hasText(prefix) && !headerName.startsWith(prefix)) {
+			headerName = prefix + propertyName;
+		}
+		return headerName;
+	}
+
+	/**
+	 * By default this returns all header names discovered on the underlying Headers class.
+	 * Subclasses may override. For example, a subset of headers may be used for inbound.
+	 */
+	protected List<String> getStandardInboundHeaderNames() {
+		return Collections.unmodifiableList(this.standardRequestHeaderNames);
+	}
+
+	/**
+	 * By default this returns all header names discovered on the underlying Headers class.
+	 * Subclasses may override. For example, a subset of headers may be used for outbound.
+	 */
+	protected List<String> getStandardOutboundHeaderNames() {
+		return Collections.unmodifiableList(this.standardReplyHeaderNames);
+	}
+
+	protected abstract Map<String, Object> extractStandardHeaders(T source);
+
+	protected abstract Map<String, Object> extractUserDefinedHeaders(T source);
+
+	protected abstract void populateStandardHeaders(Map<String, Object> headers, T target);
+
+	protected abstract void populateUserDefinedHeader(String headerName, Object headerValue, T target);
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -210,9 +210,6 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 		}
 		if (patterns != null && patterns.size() > 0) {
 			for (String pattern : patterns) {
-				if (pattern.startsWith("bar")){
-					System.out.println();
-				}
 				if (PatternMatchUtils.simpleMatch(pattern.toLowerCase(), headerName.toLowerCase())) {
 					if (logger.isDebugEnabled()) {
 						logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}", headerName, pattern));

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/RequestReplyHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/RequestReplyHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,8 @@ public interface RequestReplyHeaderMapper<T> {
 	
 	void fromHeadersToReply(MessageHeaders headers, T target);
 	
-	<V> Map<String, V> toHeadersFromRequest(T source);
+	Map<String, Object> toHeadersFromRequest(T source);
 
-	<V> Map<String, V> toHeadersFromReply(T source);
+	Map<String, Object> toHeadersFromReply(T source);
 	
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/RequestReplyHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/RequestReplyHeaderMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.mapping;
+
+import java.util.Map;
+
+import org.springframework.integration.MessageHeaders;
+
+/**
+ * Request/Reply strategy interface for mapping {@link MessageHeaders} to and from other
+ * types of objects. This would typically be used by adapters where the "other type"
+ * has a concept of headers or properties (HTTP, JMS, AMQP, etc).
+ * 
+ * @author Oleg Zhurakousky
+ * @since 2.1
+ *
+ */
+public interface RequestReplyHeaderMapper<T> {
+	
+	void fromHeadersToRequest(MessageHeaders headers, T target);
+	
+	void fromHeadersToReply(MessageHeaders headers, T target);
+	
+	<V> Map<String, V> toHeadersFromRequest(T source);
+
+	<V> Map<String, V> toHeadersFromReply(T source);
+	
+}

--- a/spring-integration-ws/pom.xml
+++ b/spring-integration-ws/pom.xml
@@ -89,12 +89,6 @@
   </repositories>
   <dependencies>
     <dependency>
-      <groupId>org.springframework.integration</groupId>
-      <artifactId>spring-integration-core</artifactId>
-      <version>2.1.0.BUILD-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>com.sun.xml.messaging.saaj</groupId>
       <artifactId>saaj-impl</artifactId>
       <version>1.3</version>
@@ -150,6 +144,12 @@
           <groupId>org.springframework</groupId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <version>1.2.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -212,6 +212,12 @@
       <artifactId>mockito-all</artifactId>
       <version>1.8.4</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.integration</groupId>
+      <artifactId>spring-integration-core</artifactId>
+      <version>2.1.0.BUILD-SNAPSHOT</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceInboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceInboundGateway.java
@@ -37,10 +37,10 @@ import org.springframework.ws.soap.SoapMessage;
  */
 abstract public class AbstractWebServiceInboundGateway extends MessagingGatewaySupport implements MessageEndpoint {
 	
-	protected volatile HeaderMapper<SoapHeader> headerMapper = new DefaultSoapHeaderMapper();
+	protected volatile HeaderMapper<SoapHeader> headerMapper = new DefaultSoapHeaderMapper(false);
 	
 	public String getComponentType() {
-		return "ws:outbound-gateway";
+		return "ws:inbound-gateway";
 	}
 	
 	public void setHeaderMapper(HeaderMapper<SoapHeader> headerMapper) {

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceInboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceInboundGateway.java
@@ -21,14 +21,12 @@ import org.springframework.expression.ExpressionException;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessagingException;
 import org.springframework.integration.gateway.MessagingGatewaySupport;
-import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.ws.WebServiceMessage;
 import org.springframework.ws.context.MessageContext;
 import org.springframework.ws.server.endpoint.MessageEndpoint;
-import org.springframework.ws.soap.SoapHeader;
 import org.springframework.ws.soap.SoapMessage;
 
 /**
@@ -37,13 +35,13 @@ import org.springframework.ws.soap.SoapMessage;
  */
 abstract public class AbstractWebServiceInboundGateway extends MessagingGatewaySupport implements MessageEndpoint {
 	
-	protected volatile HeaderMapper<SoapHeader> headerMapper = new DefaultSoapHeaderMapper(false);
+	protected volatile SoapHeaderMapper headerMapper = new DefaultSoapHeaderMapper();
 	
 	public String getComponentType() {
 		return "ws:inbound-gateway";
 	}
 	
-	public void setHeaderMapper(HeaderMapper<SoapHeader> headerMapper) {
+	public void setHeaderMapper(SoapHeaderMapper headerMapper) {
 		Assert.notNull(headerMapper, "headerMapper must not be null");
 		this.headerMapper = headerMapper;
 	}
@@ -73,7 +71,7 @@ abstract public class AbstractWebServiceInboundGateway extends MessagingGatewayS
 		}
 		if (request instanceof SoapMessage) {
 			SoapMessage soapMessage = (SoapMessage) request;
-			Map<String, ?> headers = this.headerMapper.toHeaders(soapMessage.getSoapHeader());
+			Map<String, ?> headers = this.headerMapper.toHeadersFromRequest(soapMessage.getSoapHeader());
 			if (!CollectionUtils.isEmpty(headers)) {
 				builder.copyHeaders(headers);
 			}
@@ -82,7 +80,7 @@ abstract public class AbstractWebServiceInboundGateway extends MessagingGatewayS
 	
 	protected void toSoapHeaders(WebServiceMessage response, Message<?> replyMessage){
 		if (response instanceof SoapMessage) {
-			this.headerMapper.fromHeaders(
+			this.headerMapper.fromHeadersToReply(
 					replyMessage.getHeaders(), ((SoapMessage) response).getSoapHeader());
 		}
 	}

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceInboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceInboundGateway.java
@@ -71,7 +71,7 @@ abstract public class AbstractWebServiceInboundGateway extends MessagingGatewayS
 		}
 		if (request instanceof SoapMessage) {
 			SoapMessage soapMessage = (SoapMessage) request;
-			Map<String, ?> headers = this.headerMapper.toHeadersFromRequest(soapMessage.getSoapHeader());
+			Map<String, ?> headers = this.headerMapper.toHeadersFromRequest(soapMessage);
 			if (!CollectionUtils.isEmpty(headers)) {
 				builder.copyHeaders(headers);
 			}
@@ -81,7 +81,7 @@ abstract public class AbstractWebServiceInboundGateway extends MessagingGatewayS
 	protected void toSoapHeaders(WebServiceMessage response, Message<?> replyMessage){
 		if (response instanceof SoapMessage) {
 			this.headerMapper.fromHeadersToReply(
-					replyMessage.getHeaders(), ((SoapMessage) response).getSoapHeader());
+					replyMessage.getHeaders(), (SoapMessage) response);
 		}
 	}
 	

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
@@ -35,7 +35,6 @@ import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessageDeliveryException;
 import org.springframework.integration.MessagingException;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
-import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriTemplate;
@@ -74,7 +73,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 
 	private volatile boolean ignoreEmptyResponses = true;
 	
-	protected volatile HeaderMapper<SoapHeader> headerMapper = new DefaultSoapHeaderMapper(true);
+	protected volatile SoapHeaderMapper headerMapper = new DefaultSoapHeaderMapper();
 
 	public AbstractWebServiceOutboundGateway(String uri, WebServiceMessageFactory messageFactory) {
 		Assert.hasText(uri, "URI must not be empty");
@@ -95,7 +94,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 		this.uriTemplate = null;
 	}
 
-	public void setHeaderMapper(HeaderMapper<SoapHeader> headerMapper) {
+	public void setHeaderMapper(SoapHeaderMapper headerMapper) {
 		this.headerMapper = headerMapper;
 	}
 
@@ -221,7 +220,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 			
 			if (message instanceof SoapMessage) {
 				SoapHeader target = ((SoapMessage)message).getSoapHeader();
-				headerMapper.fromHeaders(requestMessage.getHeaders(), target);
+				headerMapper.fromHeadersToRequest(requestMessage.getHeaders(), target);
 				super.doWithMessage(message);
 			}
 			if (this.callbackDelegate != null) {

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.ws;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import javax.xml.namespace.QName;
@@ -43,10 +44,8 @@ import org.springframework.xml.namespace.QNameUtils;
  * @since 2.0
  */
 public class DefaultSoapHeaderMapper extends AbstractHeaderMapper<SoapHeader> implements SoapHeaderMapper {
-
-	public DefaultSoapHeaderMapper() {
-		super(WebServiceHeaders.class);
-	}
+	
+	private static final String PREFIX = "";
 
 	@Override
 	protected Map<String, Object> extractStandardHeaders(SoapHeader source) {
@@ -95,4 +94,17 @@ public class DefaultSoapHeaderMapper extends AbstractHeaderMapper<SoapHeader> im
 		}
 	}
 
+	@Override
+	protected List<String> getStandardReplyHeaderNames() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	protected List<String> getStandardRequestHeaderNames() {
+		return Collections.emptyList();
+	}
+	@Override
+	protected String getStandardHeaderPrefix() {
+		return PREFIX;
+	}
 }

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
@@ -19,7 +19,6 @@ package org.springframework.integration.ws;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
 import javax.xml.namespace.QName;
@@ -45,8 +44,6 @@ import org.springframework.xml.namespace.QNameUtils;
  */
 public class DefaultSoapHeaderMapper extends AbstractHeaderMapper<SoapHeader> implements SoapHeaderMapper {
 	
-	private static final String PREFIX = "";
-
 	@Override
 	protected Map<String, Object> extractStandardHeaders(SoapHeader source) {
 		return Collections.emptyMap();
@@ -95,16 +92,7 @@ public class DefaultSoapHeaderMapper extends AbstractHeaderMapper<SoapHeader> im
 	}
 
 	@Override
-	protected List<String> getStandardReplyHeaderNames() {
-		return Collections.emptyList();
-	}
-
-	@Override
-	protected List<String> getStandardRequestHeaderNames() {
-		return Collections.emptyList();
-	}
-	@Override
 	protected String getStandardHeaderPrefix() {
-		return PREFIX;
+		return WebServiceHeaders.PREFIX;
 	}
 }

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
@@ -92,9 +92,10 @@ public class DefaultSoapHeaderMapper extends AbstractHeaderMapper<SoapMessage> i
 	@Override
 	protected void populateStandardHeaders(Map<String, Object> headers, SoapMessage target) {
 		String soapAction = getHeaderIfAvailable(headers, WebServiceHeaders.SOAP_ACTION, String.class);
-		if (StringUtils.hasText(soapAction)) {
-			target.setSoapAction(soapAction);
-		}
+		if (!StringUtils.hasText(soapAction)) {
+            soapAction = "\"\"";
+        }
+		target.setSoapAction(soapAction);
 	}
 
 	@Override

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
@@ -42,10 +42,10 @@ import org.springframework.xml.namespace.QNameUtils;
  * @author Oleg Zhurakousky
  * @since 2.0
  */
-public class DefaultSoapHeaderMapper extends AbstractHeaderMapper<SoapHeader> {
+public class DefaultSoapHeaderMapper extends AbstractHeaderMapper<SoapHeader> implements SoapHeaderMapper {
 
-	public DefaultSoapHeaderMapper(boolean outbound) {
-		super(WebServiceHeaders.class, outbound);
+	public DefaultSoapHeaderMapper() {
+		super(WebServiceHeaders.class);
 	}
 
 	@Override

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
@@ -34,7 +34,6 @@ import org.springframework.ws.client.support.destination.DestinationProvider;
 import org.springframework.ws.soap.SoapHeader;
 import org.springframework.ws.soap.SoapMessage;
 import org.springframework.ws.support.MarshallingUtils;
-import org.springframework.xml.transform.TransformerObjectSupport;
 
 /**
  * An outbound Messaging Gateway for invoking Web Services that also supports
@@ -107,13 +106,13 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 	@Override
 	protected Object doHandle(String uri, Object requestPayload, WebServiceMessageCallback requestCallback) {
 		Object reply = this.getWebServiceTemplate().sendAndReceive(uri, 
-				new RequestMessageCallback(requestCallback, requestPayload), new ResponseMessageextractor());
+				new RequestMessageCallback(requestCallback, requestPayload), new ResponseMessageExtractor());
 		return reply;
 	}
 	
 	
 	
-	private class RequestMessageCallback extends TransformerObjectSupport implements WebServiceMessageCallback {
+	private class RequestMessageCallback implements WebServiceMessageCallback {
 		
 		private final WebServiceMessageCallback requestCallback;
 		private final Object source;
@@ -132,7 +131,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 		
 	}
 	
-	private class ResponseMessageextractor extends TransformerObjectSupport implements WebServiceMessageExtractor<Object> {
+	private class ResponseMessageExtractor implements WebServiceMessageExtractor<Object> {
 		
 		public Object extractData(WebServiceMessage message)
 				throws IOException, TransformerException {

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
@@ -141,7 +141,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
             
             if (message instanceof SoapMessage){			
 				SoapHeader soapHeader = ((SoapMessage)message).getSoapHeader();
-				Map<String, Object> mappedMessageHeaders = headerMapper.toHeaders(soapHeader);
+				Map<String, Object> mappedMessageHeaders = headerMapper.toHeadersFromReply(soapHeader);
 				Message<?> siMessage = MessageBuilder.withPayload(unmarshalledObject).copyHeaders(mappedMessageHeaders).build();
 				return siMessage;
 			}

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
@@ -79,15 +79,15 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 		Object reply = null;
 		if (requestPayload instanceof Source) {
 			reply = this.getWebServiceTemplate().sendAndReceive(uri, 
-					new RequestMessageCallback(requestCallback, (Source) requestPayload), new ResponseMessageextractor(null));
+					new RequestMessageCallback(requestCallback, (Source) requestPayload), new ResponseMessageExtractor(null));
 		}
 		else if (requestPayload instanceof String) {
 			reply = this.getWebServiceTemplate().sendAndReceive(uri, 
-						new RequestMessageCallback(requestCallback, new StringSource((String) requestPayload)), new ResponseMessageextractor(new StringResult()));
+						new RequestMessageCallback(requestCallback, new StringSource((String) requestPayload)), new ResponseMessageExtractor(new StringResult()));
 		}
 		else if (requestPayload instanceof Document) {
 			reply = this.getWebServiceTemplate().sendAndReceive(uri, 
-					new RequestMessageCallback(requestCallback, new DOMSource((Document) requestPayload)), new ResponseMessageextractor(new DOMResult()));
+					new RequestMessageCallback(requestCallback, new DOMSource((Document) requestPayload)), new ResponseMessageExtractor(new DOMResult()));
 		}
 		else {
 			throw new MessagingException("Unsupported payload type '" + requestPayload.getClass() +
@@ -117,11 +117,11 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 		
 	}
 	
-	private class ResponseMessageextractor extends TransformerObjectSupport implements WebServiceMessageExtractor<Object> {
+	private class ResponseMessageExtractor extends TransformerObjectSupport implements WebServiceMessageExtractor<Object> {
 		
 		private final Result result;
 		
-		public ResponseMessageextractor(Result result){
+		public ResponseMessageExtractor(Result result){
 			this.result = result;
 		}
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
@@ -28,6 +28,7 @@ import org.w3c.dom.Document;
 
 import org.springframework.integration.Message;
 import org.springframework.integration.MessagingException;
+import org.springframework.util.Assert;
 import org.springframework.ws.WebServiceMessage;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.SourceExtractor;
@@ -106,7 +107,9 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 
 			if (requestPayload instanceof Source) {
 				source = (Source) requestPayload;
-				source = (Source) sourceExtractor.extractData(source);
+				Object o = sourceExtractor.extractData(source);
+				Assert.isInstanceOf(Source.class, o);
+				source = (Source) o;
 			}
 			else if (requestPayload instanceof String) {
 				source = new StringSource((String) requestPayload);

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
@@ -106,6 +106,7 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 
 			if (requestPayload instanceof Source) {
 				source = (Source) requestPayload;
+				source = (Source) sourceExtractor.extractData(source);
 			}
 			else if (requestPayload instanceof String) {
 				source = new StringSource((String) requestPayload);
@@ -120,7 +121,7 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 						+ MarshallingWebServiceOutboundGateway.class.getName() + "' or a Message Transformer.");
 			}
 			
-			return (Source) sourceExtractor.extractData(source);
+			return source;
 		}		
 	}
 	

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
@@ -148,7 +148,7 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 					
 			if (message instanceof SoapMessage){			
 				SoapHeader soapHeader = ((SoapMessage)message).getSoapHeader();
-				Map<String, Object> mappedMessageHeaders = headerMapper.toHeaders(soapHeader);
+				Map<String, Object> mappedMessageHeaders = headerMapper.toHeadersFromReply(soapHeader);
 				Message<?> siMessage = MessageBuilder.withPayload(payload).copyHeaders(mappedMessageHeaders).build();
 				return siMessage;
 			}

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/SoapHeaderMapper.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/SoapHeaderMapper.java
@@ -6,6 +6,7 @@ package org.springframework.integration.ws;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.mapping.RequestReplyHeaderMapper;
 import org.springframework.ws.soap.SoapHeader;
+import org.springframework.ws.soap.SoapMessage;
 
 /**
  * A convenience interface that extends {@link HeaderMapper}
@@ -14,6 +15,6 @@ import org.springframework.ws.soap.SoapHeader;
  * @author Oleg Zhurakousky
  * @since 2.1
  */
-public interface SoapHeaderMapper extends RequestReplyHeaderMapper<SoapHeader>{
+public interface SoapHeaderMapper extends RequestReplyHeaderMapper<SoapMessage>{
 
 }

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/SoapHeaderMapper.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/SoapHeaderMapper.java
@@ -1,0 +1,19 @@
+/**
+ * 
+ */
+package org.springframework.integration.ws;
+
+import org.springframework.integration.mapping.HeaderMapper;
+import org.springframework.integration.mapping.RequestReplyHeaderMapper;
+import org.springframework.ws.soap.SoapHeader;
+
+/**
+ * A convenience interface that extends {@link HeaderMapper}
+ * but parameterized with {@link SoapHeader}.
+ *
+ * @author Oleg Zhurakousky
+ * @since 2.1
+ */
+public interface SoapHeaderMapper extends RequestReplyHeaderMapper<SoapHeader>{
+
+}

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParser.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParser.java
@@ -16,14 +16,15 @@
 
 package org.springframework.integration.ws.config;
 
-import org.w3c.dom.Element;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractInboundGatewayParser;
-import org.springframework.util.Assert;
+import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.ws.DefaultSoapHeaderMapper;
 import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
 
 /**
  * @author Iwein Fuld
@@ -66,12 +67,16 @@ public class WebServiceInboundGatewayParser extends AbstractInboundGatewayParser
 				logger.warn("Setting 'extract-payload' attribute has no effect when used with a marshalling Web Service Inbound Gateway.");
 			}
 		}
-		String headerMapperRef = element.getAttribute("header-mapper");
-		if (StringUtils.hasText(headerMapperRef)) {
-			Assert.isTrue(!StringUtils.hasText(marshallerRef),
-					"The 'header-mapper' attribute cannot be used when a 'marshaller' is provided.");
-			builder.addPropertyReference("headerMapper", headerMapperRef);
-		}
+//		String headerMapperRef = element.getAttribute("header-mapper");
+//		if (StringUtils.hasText(headerMapperRef)) {
+//			Assert.isTrue(!StringUtils.hasText(marshallerRef),
+//					"The 'header-mapper' attribute cannot be used when a 'marshaller' is provided.");
+//			builder.addPropertyReference("headerMapper", headerMapperRef);
+//		}
 	}
 
+	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		super.doParse(element, parserContext, builder);
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultSoapHeaderMapper.class, false, null);
+	}
 }

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParser.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParser.java
@@ -67,16 +67,10 @@ public class WebServiceInboundGatewayParser extends AbstractInboundGatewayParser
 				logger.warn("Setting 'extract-payload' attribute has no effect when used with a marshalling Web Service Inbound Gateway.");
 			}
 		}
-//		String headerMapperRef = element.getAttribute("header-mapper");
-//		if (StringUtils.hasText(headerMapperRef)) {
-//			Assert.isTrue(!StringUtils.hasText(marshallerRef),
-//					"The 'header-mapper' attribute cannot be used when a 'marshaller' is provided.");
-//			builder.addPropertyReference("headerMapper", headerMapperRef);
-//		}
 	}
 
 	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
 		super.doParse(element, parserContext, builder);
-		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultSoapHeaderMapper.class, false, null);
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultSoapHeaderMapper.class, null);
 	}
 }

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.ExpressionFactoryBean;
 import org.springframework.integration.config.xml.AbstractOutboundGatewayParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.ws.DefaultSoapHeaderMapper;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
@@ -84,6 +85,9 @@ public class WebServiceOutboundGatewayParser extends AbstractOutboundGatewayPars
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "ignore-empty-responses");
 		this.postProcessGateway(builder, element, parserContext);
+		
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultSoapHeaderMapper.class, true, null);
+		
 		return builder;
 	}
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
@@ -86,7 +86,7 @@ public class WebServiceOutboundGatewayParser extends AbstractOutboundGatewayPars
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "ignore-empty-responses");
 		this.postProcessGateway(builder, element, parserContext);
 		
-		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultSoapHeaderMapper.class, true, null);
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultSoapHeaderMapper.class, null);
 		
 		return builder;
 	}

--- a/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws-2.1.xsd
+++ b/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws-2.1.xsd
@@ -167,7 +167,7 @@
 			<xsd:attribute name="message-sender" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>
-						Reference to the bean definition of a WebServiceMessageSender.
+						Reference to the bean definition of a webservicemessagesender.
 					</xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
@@ -204,6 +204,39 @@
 			</xsd:attribute>
 			<xsd:attribute name="order" type="xsd:string"/>
 			<xsd:attribute name="auto-startup" type="xsd:string" default="true"/>
+			<xsd:attribute name="header-mapper">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to a HeaderMapper&lt;SoapHeader&gt; implementation
+						that this gateway will use to map between Spring Integration
+						MessageHeaders and the SoapHeader. This strategy can only be
+						applied when a 'marshaller' is not being configured.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-request-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Comma-separated list of names of SOAP Headers to be mapped from the SOAP request into the MessageHeaders.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-reply-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[							
+Comma-separated list of names of MessageHeaders to be mapped into the SOAP Headers of the SOAP reply.
+This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+						]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 
@@ -303,6 +336,24 @@
 							<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper"/>
 						</tool:annotation>
 					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-request-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Comma-separated list of names of SOAP Headers to be mapped from the SOAP request into the MessageHeaders.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-reply-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[							
+Comma-separated list of names of MessageHeaders to be mapped into the SOAP Headers of the SOAP reply.
+This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+						]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 		</xsd:complexType>

--- a/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws-2.1.xsd
+++ b/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws-2.1.xsd
@@ -167,7 +167,7 @@
 			<xsd:attribute name="message-sender" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>
-						Reference to the bean definition of a webservicemessagesender.
+						Reference to the bean definition of a WebServiceMessageSender.
 					</xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
@@ -209,8 +209,7 @@
 					<xsd:documentation>
 						Reference to a HeaderMapper&lt;SoapHeader&gt; implementation
 						that this gateway will use to map between Spring Integration
-						MessageHeaders and the SoapHeader. This strategy can only be
-						applied when a 'marshaller' is not being configured.
+						MessageHeaders and the SoapHeader. 
 					</xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
@@ -328,8 +327,7 @@ this list can also be simple patterns to be matched against the header names (e.
 					<xsd:documentation>
 						Reference to a HeaderMapper&lt;SoapHeader&gt; implementation
 						that this gateway will use to map between Spring Integration
-						MessageHeaders and the SoapHeader. This strategy can only be
-						applied when a 'marshaller' is not being configured.
+						MessageHeaders and the SoapHeader. 
 					</xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
@@ -149,7 +149,7 @@ public class WebServiceInboundGatewayParserTests {
 		assertNotNull(history);
 		Properties componentHistoryRecord = TestUtils.locateComponentInHistory(history, "marshalling", 0);
 		assertNotNull(componentHistoryRecord);
-		assertEquals("ws:outbound-gateway", componentHistoryRecord.get("type"));
+		assertEquals("ws:inbound-gateway", componentHistoryRecord.get("type"));
 	}
 
 	@Test
@@ -162,7 +162,7 @@ public class WebServiceInboundGatewayParserTests {
 		Properties componentHistoryRecord = TestUtils.locateComponentInHistory(history, "extractsPayload", 0);
 		System.out.println(componentHistoryRecord);
 		assertNotNull(componentHistoryRecord);
-		assertEquals("ws:outbound-gateway", componentHistoryRecord.get("type"));
+		assertEquals("ws:inbound-gateway", componentHistoryRecord.get("type"));
 	}
 
 	@Autowired
@@ -185,6 +185,7 @@ public class WebServiceInboundGatewayParserTests {
 		public void fromHeaders(MessageHeaders headers, SoapHeader target) {
 		}
 
+		@SuppressWarnings("unchecked")
 		public Map<String, ?> toHeaders(SoapHeader source) {
 			return Collections.emptyMap();
 		}

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
@@ -37,6 +37,7 @@ import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.ws.MarshallingWebServiceInboundGateway;
 import org.springframework.integration.ws.SimpleWebServiceInboundGateway;
+import org.springframework.integration.ws.SoapHeaderMapper;
 import org.springframework.oxm.Unmarshaller;
 import org.springframework.oxm.support.AbstractMarshaller;
 import org.springframework.test.context.ContextConfiguration;
@@ -169,7 +170,7 @@ public class WebServiceInboundGatewayParserTests {
 	private SimpleWebServiceInboundGateway headerMappingGateway;
 
 	@Autowired
-	private HeaderMapper<SoapHeader> testHeaderMapper;
+	private SoapHeaderMapper testHeaderMapper;
 
 	@Test
 	public void testHeaderMapperReference() throws Exception {
@@ -180,13 +181,20 @@ public class WebServiceInboundGatewayParserTests {
 
 
 	@SuppressWarnings("unused")
-	private static class TestHeaderMapper implements HeaderMapper<SoapHeader> {
-
-		public void fromHeaders(MessageHeaders headers, SoapHeader target) {
+	private static class TestHeaderMapper implements SoapHeaderMapper {
+		
+		public void fromHeadersToRequest(MessageHeaders headers,
+				SoapHeader target) {
 		}
 
-		@SuppressWarnings("unchecked")
-		public Map<String, ?> toHeaders(SoapHeader source) {
+		public void fromHeadersToReply(MessageHeaders headers, SoapHeader target) {
+		}
+
+		public <V> Map<String, V> toHeadersFromRequest(SoapHeader source) {
+			return Collections.emptyMap();
+		}
+
+		public <V> Map<String, V> toHeadersFromReply(SoapHeader source) {
 			return Collections.emptyMap();
 		}
 	}

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
@@ -25,6 +25,7 @@ import javax.xml.transform.Source;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -33,7 +34,6 @@ import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.history.MessageHistory;
-import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.ws.MarshallingWebServiceInboundGateway;
 import org.springframework.integration.ws.SimpleWebServiceInboundGateway;
@@ -190,11 +190,11 @@ public class WebServiceInboundGatewayParserTests {
 		public void fromHeadersToReply(MessageHeaders headers, SoapHeader target) {
 		}
 
-		public <V> Map<String, V> toHeadersFromRequest(SoapHeader source) {
+		public Map<String, Object> toHeadersFromRequest(SoapHeader source) {
 			return Collections.emptyMap();
 		}
 
-		public <V> Map<String, V> toHeadersFromReply(SoapHeader source) {
+		public Map<String, Object> toHeadersFromReply(SoapHeader source) {
 			return Collections.emptyMap();
 		}
 	}

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2002-2010 the original author or authors.
+ *  Copyright 2002-2011 the original author or authors.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.ws.context.DefaultMessageContext;
 import org.springframework.ws.context.MessageContext;
-import org.springframework.ws.soap.SoapHeader;
+import org.springframework.ws.soap.SoapMessage;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
@@ -184,17 +184,17 @@ public class WebServiceInboundGatewayParserTests {
 	private static class TestHeaderMapper implements SoapHeaderMapper {
 		
 		public void fromHeadersToRequest(MessageHeaders headers,
-				SoapHeader target) {
+				SoapMessage target) {
 		}
 
-		public void fromHeadersToReply(MessageHeaders headers, SoapHeader target) {
+		public void fromHeadersToReply(MessageHeaders headers, SoapMessage target) {
 		}
 
-		public Map<String, Object> toHeadersFromRequest(SoapHeader source) {
+		public Map<String, Object> toHeadersFromRequest(SoapMessage source) {
 			return Collections.emptyMap();
 		}
 
-		public Map<String, Object> toHeadersFromReply(SoapHeader source) {
+		public Map<String, Object> toHeadersFromReply(SoapMessage source) {
 			return Collections.emptyMap();
 		}
 	}

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.ws.config;
 
 import org.junit.Test;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
@@ -32,6 +33,7 @@ import org.springframework.oxm.Unmarshaller;
 import org.springframework.scheduling.support.PeriodicTrigger;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.FaultMessageResolver;
+import org.springframework.ws.client.core.SourceExtractor;
 import org.springframework.ws.client.core.WebServiceMessageCallback;
 import org.springframework.ws.client.support.interceptor.ClientInterceptor;
 import org.springframework.ws.transport.WebServiceMessageSender;
@@ -81,30 +83,30 @@ public class WebServiceOutboundGatewayParserTests {
 		assertEquals(Boolean.FALSE, accessor.getPropertyValue("ignoreEmptyResponses"));
 	}
 
-//	@Test SourceExtractor was removed
-//	public void simpleGatewayWithDefaultSourceExtractor() {
-//		ApplicationContext context = new ClassPathXmlApplicationContext(
-//				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
-//		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithDefaultSourceExtractor");
-//		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-//		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-//		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
-//		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
-//		assertEquals("DefaultSourceExtractor", accessor.getPropertyValue("sourceExtractor").getClass().getSimpleName());
-//	}
-//
-//	@Test
-//	public void simpleGatewayWithCustomSourceExtractor() {
-//		ApplicationContext context = new ClassPathXmlApplicationContext(
-//				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
-//		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithCustomSourceExtractor");
-//		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-//		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-//		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
-//		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
-//		SourceExtractor<?> sourceExtractor = (SourceExtractor<?>) context.getBean("sourceExtractor");
-//		assertEquals(sourceExtractor, accessor.getPropertyValue("sourceExtractor"));
-//	}
+	@Test
+	public void simpleGatewayWithDefaultSourceExtractor() {
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
+		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithDefaultSourceExtractor");
+		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
+		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
+		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
+		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
+		assertEquals("DefaultSourceExtractor", accessor.getPropertyValue("sourceExtractor").getClass().getSimpleName());
+	}
+
+	@Test
+	public void simpleGatewayWithCustomSourceExtractor() {
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
+		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithCustomSourceExtractor");
+		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
+		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
+		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
+		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
+		SourceExtractor<?> sourceExtractor = (SourceExtractor<?>) context.getBean("sourceExtractor");
+		assertEquals(sourceExtractor, accessor.getPropertyValue("sourceExtractor"));
+	}
 
 	@Test
 	public void simpleGatewayWithCustomRequestCallback() {
@@ -133,21 +135,21 @@ public class WebServiceOutboundGatewayParserTests {
 		assertEquals(factory, accessor.getPropertyValue("messageFactory"));
 	}
 
-//	@Test
-//	public void simpleGatewayWithCustomSourceExtractorAndMessageFactory() {
-//		ApplicationContext context = new ClassPathXmlApplicationContext(
-//				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
-//		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithCustomSourceExtractorAndMessageFactory");
-//		SourceExtractor<?> sourceExtractor = (SourceExtractor<?>) context.getBean("sourceExtractor");
-//		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-//		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-//		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
-//		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
-//		assertEquals(sourceExtractor, accessor.getPropertyValue("sourceExtractor"));
-//		accessor = new DirectFieldAccessor(accessor.getPropertyValue("webServiceTemplate"));
-//		WebServiceMessageFactory factory = (WebServiceMessageFactory) context.getBean("messageFactory");
-//		assertEquals(factory, accessor.getPropertyValue("messageFactory"));
-//	}
+	@Test
+	public void simpleGatewayWithCustomSourceExtractorAndMessageFactory() {
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
+		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithCustomSourceExtractorAndMessageFactory");
+		SourceExtractor<?> sourceExtractor = (SourceExtractor<?>) context.getBean("sourceExtractor");
+		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
+		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
+		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
+		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
+		assertEquals(sourceExtractor, accessor.getPropertyValue("sourceExtractor"));
+		accessor = new DirectFieldAccessor(accessor.getPropertyValue("webServiceTemplate"));
+		WebServiceMessageFactory factory = (WebServiceMessageFactory) context.getBean("messageFactory");
+		assertEquals(factory, accessor.getPropertyValue("messageFactory"));
+	}
 
 	@Test
 	public void simpleGatewayWithCustomFaultMessageResolver() {

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -16,11 +16,7 @@
 
 package org.springframework.integration.ws.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
 import org.junit.Test;
-
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
@@ -28,6 +24,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.endpoint.PollingConsumer;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.ws.MarshallingWebServiceOutboundGateway;
 import org.springframework.integration.ws.SimpleWebServiceOutboundGateway;
 import org.springframework.oxm.Marshaller;
@@ -35,10 +32,12 @@ import org.springframework.oxm.Unmarshaller;
 import org.springframework.scheduling.support.PeriodicTrigger;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.FaultMessageResolver;
-import org.springframework.ws.client.core.SourceExtractor;
 import org.springframework.ws.client.core.WebServiceMessageCallback;
 import org.springframework.ws.client.support.interceptor.ClientInterceptor;
 import org.springframework.ws.transport.WebServiceMessageSender;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Mark Fisher
@@ -82,30 +81,30 @@ public class WebServiceOutboundGatewayParserTests {
 		assertEquals(Boolean.FALSE, accessor.getPropertyValue("ignoreEmptyResponses"));
 	}
 
-	@Test
-	public void simpleGatewayWithDefaultSourceExtractor() {
-		ApplicationContext context = new ClassPathXmlApplicationContext(
-				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
-		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithDefaultSourceExtractor");
-		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
-		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
-		assertEquals("DefaultSourceExtractor", accessor.getPropertyValue("sourceExtractor").getClass().getSimpleName());
-	}
-
-	@Test
-	public void simpleGatewayWithCustomSourceExtractor() {
-		ApplicationContext context = new ClassPathXmlApplicationContext(
-				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
-		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithCustomSourceExtractor");
-		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
-		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
-		SourceExtractor<?> sourceExtractor = (SourceExtractor<?>) context.getBean("sourceExtractor");
-		assertEquals(sourceExtractor, accessor.getPropertyValue("sourceExtractor"));
-	}
+//	@Test SourceExtractor was removed
+//	public void simpleGatewayWithDefaultSourceExtractor() {
+//		ApplicationContext context = new ClassPathXmlApplicationContext(
+//				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
+//		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithDefaultSourceExtractor");
+//		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
+//		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
+//		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
+//		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
+//		assertEquals("DefaultSourceExtractor", accessor.getPropertyValue("sourceExtractor").getClass().getSimpleName());
+//	}
+//
+//	@Test
+//	public void simpleGatewayWithCustomSourceExtractor() {
+//		ApplicationContext context = new ClassPathXmlApplicationContext(
+//				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
+//		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithCustomSourceExtractor");
+//		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
+//		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
+//		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
+//		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
+//		SourceExtractor<?> sourceExtractor = (SourceExtractor<?>) context.getBean("sourceExtractor");
+//		assertEquals(sourceExtractor, accessor.getPropertyValue("sourceExtractor"));
+//	}
 
 	@Test
 	public void simpleGatewayWithCustomRequestCallback() {
@@ -134,21 +133,21 @@ public class WebServiceOutboundGatewayParserTests {
 		assertEquals(factory, accessor.getPropertyValue("messageFactory"));
 	}
 
-	@Test
-	public void simpleGatewayWithCustomSourceExtractorAndMessageFactory() {
-		ApplicationContext context = new ClassPathXmlApplicationContext(
-				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
-		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithCustomSourceExtractorAndMessageFactory");
-		SourceExtractor<?> sourceExtractor = (SourceExtractor<?>) context.getBean("sourceExtractor");
-		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
-		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
-		assertEquals(sourceExtractor, accessor.getPropertyValue("sourceExtractor"));
-		accessor = new DirectFieldAccessor(accessor.getPropertyValue("webServiceTemplate"));
-		WebServiceMessageFactory factory = (WebServiceMessageFactory) context.getBean("messageFactory");
-		assertEquals(factory, accessor.getPropertyValue("messageFactory"));
-	}
+//	@Test
+//	public void simpleGatewayWithCustomSourceExtractorAndMessageFactory() {
+//		ApplicationContext context = new ClassPathXmlApplicationContext(
+//				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
+//		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithCustomSourceExtractorAndMessageFactory");
+//		SourceExtractor<?> sourceExtractor = (SourceExtractor<?>) context.getBean("sourceExtractor");
+//		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
+//		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
+//		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
+//		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
+//		assertEquals(sourceExtractor, accessor.getPropertyValue("sourceExtractor"));
+//		accessor = new DirectFieldAccessor(accessor.getPropertyValue("webServiceTemplate"));
+//		WebServiceMessageFactory factory = (WebServiceMessageFactory) context.getBean("messageFactory");
+//		assertEquals(factory, accessor.getPropertyValue("messageFactory"));
+//	}
 
 	@Test
 	public void simpleGatewayWithCustomFaultMessageResolver() {
@@ -261,14 +260,10 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithAllInOneMarshaller");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		assertEquals(MarshallingWebServiceOutboundGateway.class, gateway.getClass());
-		DirectFieldAccessor gatewayAccessor = new DirectFieldAccessor(gateway);
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(
-				gatewayAccessor.getPropertyValue("webServiceTemplate"));
+		MarshallingWebServiceOutboundGateway gateway = (MarshallingWebServiceOutboundGateway) new DirectFieldAccessor(endpoint).getPropertyValue("handler");
 		Marshaller marshaller = (Marshaller) context.getBean("marshallerAndUnmarshaller");
-		assertEquals(marshaller, templateAccessor.getPropertyValue("marshaller"));
-		assertEquals(marshaller, templateAccessor.getPropertyValue("unmarshaller"));
+		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "marshaller", Marshaller.class));
+		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "unmarshaller", Unmarshaller.class));
 	}
 
 	@Test
@@ -277,15 +272,11 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithSeparateMarshallerAndUnmarshaller");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		assertEquals(MarshallingWebServiceOutboundGateway.class, gateway.getClass());
-		DirectFieldAccessor gatewayAccessor = new DirectFieldAccessor(gateway);
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(
-				gatewayAccessor.getPropertyValue("webServiceTemplate"));
+		MarshallingWebServiceOutboundGateway gateway = (MarshallingWebServiceOutboundGateway) new DirectFieldAccessor(endpoint).getPropertyValue("handler");
 		Marshaller marshaller = (Marshaller) context.getBean("marshaller");
 		Unmarshaller unmarshaller = (Unmarshaller) context.getBean("unmarshaller");
-		assertEquals(marshaller, templateAccessor.getPropertyValue("marshaller"));
-		assertEquals(unmarshaller, templateAccessor.getPropertyValue("unmarshaller"));
+		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "marshaller", Marshaller.class));
+		assertEquals(unmarshaller, TestUtils.getPropertyValue(gateway, "unmarshaller", Unmarshaller.class));
 	}
 
 	@Test
@@ -307,16 +298,13 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithAllInOneMarshallerAndMessageFactory");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		assertEquals(MarshallingWebServiceOutboundGateway.class, gateway.getClass());
-		DirectFieldAccessor gatewayAccessor = new DirectFieldAccessor(gateway);
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(
-				gatewayAccessor.getPropertyValue("webServiceTemplate"));
+		MarshallingWebServiceOutboundGateway gateway = (MarshallingWebServiceOutboundGateway) new DirectFieldAccessor(endpoint).getPropertyValue("handler");
 		Marshaller marshaller = (Marshaller) context.getBean("marshallerAndUnmarshaller");
-		assertEquals(marshaller, templateAccessor.getPropertyValue("marshaller"));
-		assertEquals(marshaller, templateAccessor.getPropertyValue("unmarshaller"));
+		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "marshaller", Marshaller.class));
+		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "unmarshaller", Unmarshaller.class));
+		
 		WebServiceMessageFactory messageFactory = (WebServiceMessageFactory) context.getBean("messageFactory");
-		assertEquals(messageFactory, templateAccessor.getPropertyValue("messageFactory"));
+		assertEquals(messageFactory, TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageFactory"));
 	}
 
 	@Test
@@ -325,17 +313,14 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithSeparateMarshallerAndUnmarshallerAndMessageFactory");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		assertEquals(MarshallingWebServiceOutboundGateway.class, gateway.getClass());
-		DirectFieldAccessor gatewayAccessor = new DirectFieldAccessor(gateway);
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(
-				gatewayAccessor.getPropertyValue("webServiceTemplate"));
+		MarshallingWebServiceOutboundGateway gateway = (MarshallingWebServiceOutboundGateway) new DirectFieldAccessor(endpoint).getPropertyValue("handler");
+		
 		Marshaller marshaller = (Marshaller) context.getBean("marshaller");
 		Unmarshaller unmarshaller = (Unmarshaller) context.getBean("unmarshaller");
-		assertEquals(marshaller, templateAccessor.getPropertyValue("marshaller"));
-		assertEquals(unmarshaller, templateAccessor.getPropertyValue("unmarshaller"));
+		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "marshaller", Marshaller.class));
+		assertEquals(unmarshaller, TestUtils.getPropertyValue(gateway, "unmarshaller", Unmarshaller.class));
 		WebServiceMessageFactory messageFactory = (WebServiceMessageFactory) context.getBean("messageFactory");
-		assertEquals(messageFactory, templateAccessor.getPropertyValue("messageFactory"));
+		assertEquals(messageFactory, TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageFactory"));
 	}
 
 	@Test

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayWithHeaderMapperTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayWithHeaderMapperTests.java
@@ -85,7 +85,7 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		assertEquals("foo*", requestHeaderNames[0]);
 		assertEquals("*baz*", requestHeaderNames[1]);
 		
-		String[] responseHeaderNames = TestUtils.getPropertyValue(headerMapper, "responseHeaderNames", String[].class);
+		String[] responseHeaderNames = TestUtils.getPropertyValue(headerMapper, "replyHeaderNames", String[].class);
 		assertEquals(1, responseHeaderNames.length);
 		assertEquals("bar*", responseHeaderNames[0]);
 	}

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayWithHeaderMapperTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayWithHeaderMapperTests.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.ws.config;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Source;
+import javax.xml.transform.dom.DOMSource;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.Message;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.integration.ws.AbstractWebServiceOutboundGateway;
+import org.springframework.integration.ws.DefaultSoapHeaderMapper;
+import org.springframework.integration.ws.SimpleWebServiceOutboundGateway;
+import org.springframework.integration.ws.WebServiceHeaders;
+import org.springframework.oxm.Unmarshaller;
+import org.springframework.oxm.XmlMappingException;
+import org.springframework.util.xml.DomUtils;
+import org.springframework.ws.WebServiceMessage;
+import org.springframework.ws.WebServiceMessageFactory;
+import org.springframework.ws.soap.SoapHeader;
+import org.springframework.ws.soap.SoapMessage;
+import org.springframework.ws.soap.SoapMessageFactory;
+import org.springframework.ws.transport.WebServiceConnection;
+import org.springframework.ws.transport.WebServiceMessageSender;
+import org.springframework.xml.namespace.QNameUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import static junit.framework.Assert.assertEquals;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Oleg Zhurakousky
+ *
+ */
+public class WebServiceOutboundGatewayWithHeaderMapperTests {
+	
+	String responseMessage = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?> " + 
+			  "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"> " + 
+			  "<SOAP-ENV:Header/>" +
+			  "<SOAP-ENV:Body> " + 
+			  "<root><name>jane</name></root>" + 
+			  "</SOAP-ENV:Body> " + 
+			  "</SOAP-ENV:Envelope>";
+		
+	@Test
+	public void headerMapperParserTest() throws Exception{
+		ApplicationContext context = new ClassPathXmlApplicationContext("ws-outbound-gateway-with-headermappers.xml", this.getClass());
+		SimpleWebServiceOutboundGateway gateway = TestUtils.getPropertyValue(context.getBean("withHeaderMapper"), "handler", SimpleWebServiceOutboundGateway.class);
+		DefaultSoapHeaderMapper headerMapper = TestUtils.getPropertyValue(gateway, "headerMapper", DefaultSoapHeaderMapper.class);
+		assertNotNull(headerMapper);
+		
+		String[] requestHeaderNames = TestUtils.getPropertyValue(headerMapper, "requestHeaderNames", String[].class);
+		assertEquals(2, requestHeaderNames.length);
+		assertEquals("foo*", requestHeaderNames[0]);
+		assertEquals("*baz*", requestHeaderNames[1]);
+		
+		String[] responseHeaderNames = TestUtils.getPropertyValue(headerMapper, "responseHeaderNames", String[].class);
+		assertEquals(1, responseHeaderNames.length);
+		assertEquals("bar*", responseHeaderNames[0]);
+	}
+	
+	@Test
+	public void withHeaderMapperString() throws Exception{
+		String payload = "<root><name>bill</name></root>";
+		this.process(payload, "withHeaderMapper", "inputChannel");
+	}
+	
+	@Test
+	public void withHeaderMapperSource() throws Exception{
+		DocumentBuilderFactory dbfac = DocumentBuilderFactory.newInstance();
+		DocumentBuilder docBuilder = dbfac.newDocumentBuilder();
+		Document document = docBuilder.parse(new ByteArrayInputStream("<root><name>bill</name></root>".getBytes()));
+		DOMSource payload = new DOMSource(document);
+		this.process(payload, "withHeaderMapper", "inputChannel");
+	}
+	
+	@Test
+	public void withHeaderMapperDocument() throws Exception{
+		DocumentBuilderFactory dbfac = DocumentBuilderFactory.newInstance();
+		DocumentBuilder docBuilder = dbfac.newDocumentBuilder();
+		Document payload = docBuilder.parse(new ByteArrayInputStream("<root><name>bill</name></root>".getBytes()));
+		this.process(payload, "withHeaderMapper", "inputChannel");
+	}
+	
+	@Test
+	public void withHeaderMapperAndMarshaller() throws Exception{
+		Person person = new Person();
+		person.setName("Bill Clinton");
+		this.process(person, "marshallingWithHeaderMapper", "inputMarshallingChannel");
+	}
+	
+	@SuppressWarnings("rawtypes")
+	public void process(Object payload, String gatewayName, String channelName) throws Exception{
+		ApplicationContext context = new ClassPathXmlApplicationContext("ws-outbound-gateway-with-headermappers.xml", this.getClass());
+		AbstractWebServiceOutboundGateway gateway = TestUtils.getPropertyValue(context.getBean(gatewayName), "handler", AbstractWebServiceOutboundGateway.class);
+		
+		WebServiceMessageSender messageSender = Mockito.mock(WebServiceMessageSender.class);
+		WebServiceConnection wsConnection = Mockito.mock(WebServiceConnection.class);
+		Mockito.when(messageSender.createConnection(Mockito.any(URI.class))).thenReturn(wsConnection);
+		Mockito.when(messageSender.supports(Mockito.any(URI.class))).thenReturn(true);
+		
+		Mockito.doAnswer(new Answer() {
+		      public Object answer(InvocationOnMock invocation) {
+		          Object[] args = invocation.getArguments();
+		          SoapMessage soapMessage = (SoapMessage) args[0];
+//		          try { // uncomment if you want to see a pretty-print of SOAP message
+//		        	  Transformer transformer = TransformerFactory.newInstance().newTransformer();
+//			  	      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+//			  	      transformer.transform(new DOMSource(soapMessage.getDocument()), new StreamResult(System.out));    
+//		          } catch (Exception e) {
+//					// ignore
+//		          }
+		          SoapHeader soapHeader = soapMessage.getSoapHeader();
+		          assertNotNull(soapHeader.getAttributeValue(QNameUtils.parseQNameString("foo")));
+		          assertNotNull(soapHeader.getAttributeValue(QNameUtils.parseQNameString("foobar")));
+		          assertNotNull(soapHeader.getAttributeValue(QNameUtils.parseQNameString("abaz")));
+		          assertNull(soapHeader.getAttributeValue(QNameUtils.parseQNameString("bar")));
+		          return null;
+		      }})
+		 .when(wsConnection).send(Mockito.any(WebServiceMessage.class));
+		
+		Mockito.doAnswer(new Answer() {
+		      public Object answer(InvocationOnMock invocation) throws Exception{
+		          Object[] args = invocation.getArguments();
+		          SoapMessageFactory factory = (SoapMessageFactory) args[0];
+		          SoapMessage soapMessage = factory.createWebServiceMessage(new ByteArrayInputStream(responseMessage.getBytes()));
+		          soapMessage.getSoapHeader().addAttribute(QNameUtils.parseQNameString("bar"), "bar");
+		          soapMessage.getSoapHeader().addAttribute(QNameUtils.parseQNameString("baz"), "baz");
+//		          try { // uncomment if you want to see a pretty-print of SOAP message
+//		        	  Transformer transformer = TransformerFactory.newInstance().newTransformer();
+//			  	      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+//			  	      transformer.transform(new DOMSource(soapMessage.getDocument()), new StreamResult(System.out));    
+//		          } catch (Exception e) {
+//					// ignore
+//		          }
+		          return soapMessage;
+		      }})
+		 .when(wsConnection).receive(Mockito.any(WebServiceMessageFactory.class));
+		
+		gateway.setMessageSender(messageSender);
+		
+		MessageChannel inputChannel = context.getBean(channelName, MessageChannel.class);
+		Message<?> message = 
+				MessageBuilder.withPayload(payload).
+				setHeader("foo", "foo").setHeader("foobar", "foobar").setHeader("abaz", "abaz").setHeader("bar", "bar").
+				setHeader(WebServiceHeaders.SOAP_ACTION, "someAction").build();
+		inputChannel.send(message);
+		QueueChannel outputChannel = context.getBean("outputChannel", QueueChannel.class);
+		Message<?> replyMessage = outputChannel.receive(0);
+		assertEquals("bar", replyMessage.getHeaders().get("bar"));
+		assertNull(replyMessage.getHeaders().get("baz"));
+	}
+	
+	public static class Person{
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+	
+	public static class SampleUnmarshaller implements Unmarshaller {
+
+		public boolean supports(Class<?> clazz) {
+			return true;
+		}
+
+		public Object unmarshal(Source source) throws IOException, XmlMappingException {
+			Element documentElement = (Element) ((DOMSource) source).getNode();
+			
+			String name = DomUtils.getChildElementValueByTagName(documentElement, "name");
+			Person person = new Person();
+			person.setName(name);
+			return person;
+		}
+	}
+}

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayWithHeaderMapperTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayWithHeaderMapperTests.java
@@ -19,6 +19,7 @@ package org.springframework.integration.ws.config;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -29,6 +30,9 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
@@ -51,8 +55,6 @@ import org.springframework.ws.soap.SoapMessageFactory;
 import org.springframework.ws.transport.WebServiceConnection;
 import org.springframework.ws.transport.WebServiceMessageSender;
 import org.springframework.xml.namespace.QNameUtils;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 
 import static junit.framework.Assert.assertEquals;
 
@@ -73,6 +75,7 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 			  "</SOAP-ENV:Body> " + 
 			  "</SOAP-ENV:Envelope>";
 		
+	@SuppressWarnings("unchecked")
 	@Test
 	public void headerMapperParserTest() throws Exception{
 		ApplicationContext context = new ClassPathXmlApplicationContext("ws-outbound-gateway-with-headermappers.xml", this.getClass());
@@ -80,14 +83,14 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		DefaultSoapHeaderMapper headerMapper = TestUtils.getPropertyValue(gateway, "headerMapper", DefaultSoapHeaderMapper.class);
 		assertNotNull(headerMapper);
 		
-		String[] requestHeaderNames = TestUtils.getPropertyValue(headerMapper, "requestHeaderNames", String[].class);
-		assertEquals(2, requestHeaderNames.length);
-		assertEquals("foo*", requestHeaderNames[0]);
-		assertEquals("*baz*", requestHeaderNames[1]);
+		List<String> requestHeaderNames = TestUtils.getPropertyValue(headerMapper, "requestHeaderNames", List.class);
+		assertEquals(2, requestHeaderNames.size());
+		assertEquals("foo*", requestHeaderNames.get(0));
+		assertEquals("*baz*", requestHeaderNames.get(1));
 		
-		String[] responseHeaderNames = TestUtils.getPropertyValue(headerMapper, "replyHeaderNames", String[].class);
-		assertEquals(1, responseHeaderNames.length);
-		assertEquals("bar*", responseHeaderNames[0]);
+		List<String> responseHeaderNames = TestUtils.getPropertyValue(headerMapper, "replyHeaderNames", List.class);
+		assertEquals(1, responseHeaderNames.size());
+		assertEquals("bar*", responseHeaderNames.get(0));
 	}
 	
 	@Test

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/ws-outbound-gateway-with-headermappers.xml
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/ws-outbound-gateway-with-headermappers.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int-ws="http://www.springframework.org/schema/integration/ws"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/ws http://www.springframework.org/schema/integration/ws/spring-integration-ws-2.1.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+
+	<int:channel id="inputChannel"/>
+	<int:channel id="inputMarshallingChannel"/>
+
+	<int-ws:outbound-gateway id="withHeaderMapper"
+	                     request-channel="inputChannel"
+	                     reply-channel="outputChannel"
+	                     uri="http://example.org"
+	                     mapped-request-headers="foo*, *baz*"
+	                     mapped-reply-headers="bar*"/>
+	                     
+	<int-ws:outbound-gateway id="marshallingWithHeaderMapper"
+	                     request-channel="inputMarshallingChannel"
+	                     reply-channel="outputChannel"
+	                     uri="http://example.org"
+	                     marshaller="marshaller"
+	                     unmarshaller="ubmarshaller"
+	                     mapped-request-headers="foo*, *baz*"
+	                     mapped-reply-headers="bar*"/>
+	                     
+	<bean id="marshaller" class="org.springframework.oxm.xstream.XStreamMarshaller"/>
+	
+	<bean id="ubmarshaller" class="org.springframework.integration.ws.config.WebServiceOutboundGatewayWithHeaderMapperTests.SampleUnmarshaller"/>
+	                     
+	<int:channel id="outputChannel">
+		<int:queue/>
+	</int:channel> 
+	
+</beans>

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/XmppHeaders.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/XmppHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,13 +27,29 @@ package org.springframework.integration.xmpp;
  */
 public class XmppHeaders {
 
-	private static final String PREFIX = "xmpp_";
+	public static final String PREFIX = "xmpp_";
 
-	public static final String CHAT = PREFIX + "chatKey";
+	public static final String CHAT = PREFIX + "chat";
 
-	public static final String CHAT_TO = PREFIX + "chatTo";
+	public static final String TO = PREFIX + "to";
 
-	public static final String CHAT_THREAD_ID = PREFIX + "chatThreadId";
+	/**
+	 * {@link Deprecated} use {@link #TO} instead
+	 */
+	@Deprecated
+	public static final String CHAT_TO = TO;
+
+	public static final String FROM = PREFIX + "from";
+
+	public static final String THREAD = PREFIX + "thread";
+
+	/**
+	 * {@link Deprecated} use {@link #THREAD} instead
+	 */
+	@Deprecated
+	public static final String CHAT_THREAD_ID = THREAD;
+
+	public static final String SUBJECT = PREFIX + "subject";
 
 	public static final String TYPE = PREFIX + "type";
 

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/AbstractXmppInboundChannelAdapterParser.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/AbstractXmppInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.xmpp.support.DefaultXmppHeaderMapper;
 import org.springframework.util.StringUtils;
 
 /**
@@ -45,6 +46,9 @@ public abstract class AbstractXmppInboundChannelAdapterParser extends AbstractSi
 
 	@Override
 	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+		
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultXmppHeaderMapper.class, false, null);
+		
 		String connectionName = element.getAttribute("xmpp-connection");
 		
 		if (StringUtils.hasText(connectionName)){

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/AbstractXmppInboundChannelAdapterParser.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/AbstractXmppInboundChannelAdapterParser.java
@@ -47,7 +47,7 @@ public abstract class AbstractXmppInboundChannelAdapterParser extends AbstractSi
 	@Override
 	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
 		
-		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultXmppHeaderMapper.class, false, null);
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultXmppHeaderMapper.class, null);
 		
 		String connectionName = element.getAttribute("xmpp-connection");
 		

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/AbstractXmppOutboundChannelAdapterParser.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/AbstractXmppOutboundChannelAdapterParser.java
@@ -39,7 +39,7 @@ public abstract class AbstractXmppOutboundChannelAdapterParser extends AbstractO
 	protected AbstractBeanDefinition parseConsumer(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(this.getHandlerClassName());
 		
-		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultXmppHeaderMapper.class, true, null);
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultXmppHeaderMapper.class, null);
 		
 		String connectionName = element.getAttribute("xmpp-connection");
 		if (StringUtils.hasText(connectionName)){

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/AbstractXmppOutboundChannelAdapterParser.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/AbstractXmppOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractOutboundChannelAdapterParser;
+import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.xmpp.support.DefaultXmppHeaderMapper;
 import org.springframework.util.StringUtils;
 
 import org.w3c.dom.Element;
@@ -36,6 +38,9 @@ public abstract class AbstractXmppOutboundChannelAdapterParser extends AbstractO
 	@Override
 	protected AbstractBeanDefinition parseConsumer(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(this.getHandlerClassName());
+		
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultXmppHeaderMapper.class, true, null);
+		
 		String connectionName = element.getAttribute("xmpp-connection");
 		if (StringUtils.hasText(connectionName)){
 			builder.addConstructorArgReference(connectionName);

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpoint.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpoint.java
@@ -93,8 +93,7 @@ public class ChatMessageListeningEndpoint extends AbstractXmppConnectionAwareEnd
 			if (packet instanceof org.jivesoftware.smack.packet.Message) {
 				org.jivesoftware.smack.packet.Message xmppMessage = (org.jivesoftware.smack.packet.Message) packet;
 				Map<String, ?> mappedHeaders = headerMapper.toHeadersFromRequest(xmppMessage);
-				//Chat chat = xmppConnection.getChatManager().getThreadChat(xmppMessage.getThread());
-	
+				
 				String messageBody = xmppMessage.getBody();
 				/*
 				 * Since there are several types of chat messages with different ChatState (e.g., composing, paused etc) 

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpoint.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpoint.java
@@ -18,13 +18,11 @@ package org.springframework.integration.xmpp.inbound;
 
 import java.util.Map;
 
-import org.jivesoftware.smack.Chat;
 import org.jivesoftware.smack.PacketListener;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.Packet;
 
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.xmpp.XmppHeaders;
 import org.springframework.integration.xmpp.core.AbstractXmppConnectionAwareEndpoint;
 import org.springframework.integration.xmpp.support.DefaultXmppHeaderMapper;
 import org.springframework.integration.xmpp.support.XmppHeaderMapper;
@@ -46,7 +44,7 @@ public class ChatMessageListeningEndpoint extends AbstractXmppConnectionAwareEnd
 
 	private final PacketListener packetListener = new ChatMessagePublishingPacketListener();
 	
-	private volatile XmppHeaderMapper headerMapper = new DefaultXmppHeaderMapper(false);
+	private volatile XmppHeaderMapper headerMapper = new DefaultXmppHeaderMapper();
 
 	public ChatMessageListeningEndpoint() {
 		super();
@@ -94,7 +92,7 @@ public class ChatMessageListeningEndpoint extends AbstractXmppConnectionAwareEnd
 		public void processPacket(final Packet packet) {
 			if (packet instanceof org.jivesoftware.smack.packet.Message) {
 				org.jivesoftware.smack.packet.Message xmppMessage = (org.jivesoftware.smack.packet.Message) packet;
-				Map<String, ?> mappedHeaders = headerMapper.toHeaders(xmppMessage);
+				Map<String, ?> mappedHeaders = headerMapper.toHeadersFromRequest(xmppMessage);
 				//Chat chat = xmppConnection.getChatManager().getThreadChat(xmppMessage.getThread());
 	
 				String messageBody = xmppMessage.getBody();

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/outbound/ChatMessageSendingMessageHandler.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/outbound/ChatMessageSendingMessageHandler.java
@@ -20,7 +20,6 @@ import org.jivesoftware.smack.XMPPConnection;
 
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageHandlingException;
-import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.xmpp.XmppHeaders;
 import org.springframework.integration.xmpp.core.AbstractXmppConnectionAwareMessageHandler;
 import org.springframework.integration.xmpp.support.DefaultXmppHeaderMapper;
@@ -39,7 +38,7 @@ import org.springframework.util.StringUtils;
  */
 public class ChatMessageSendingMessageHandler extends AbstractXmppConnectionAwareMessageHandler {
 
-	private volatile HeaderMapper<org.jivesoftware.smack.packet.Message> headerMapper = new DefaultXmppHeaderMapper(true);
+	private volatile XmppHeaderMapper headerMapper = new DefaultXmppHeaderMapper();
 
 
 	public ChatMessageSendingMessageHandler() {
@@ -68,7 +67,7 @@ public class ChatMessageSendingMessageHandler extends AbstractXmppConnectionAwar
 			Assert.state(StringUtils.hasText(to), "The '" + XmppHeaders.TO + "' header must not be null");
 			xmppMessage = new org.jivesoftware.smack.packet.Message(to);
 			if (this.headerMapper != null) {
-				this.headerMapper.fromHeaders(message.getHeaders(), xmppMessage);
+				this.headerMapper.fromHeadersToRequest(message.getHeaders(), xmppMessage);
 			}
 			xmppMessage.setBody((String) messageBody);
 		}

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapper.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapper.java
@@ -29,12 +29,13 @@ import org.springframework.util.StringUtils;
  * Default implementation of {@link XmppHeaderMapper}.
  *
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  * @since 2.1
  */
 public class DefaultXmppHeaderMapper extends AbstractHeaderMapper<Message> implements XmppHeaderMapper {
 
-	public DefaultXmppHeaderMapper(boolean outbound) {
-		super(XmppHeaders.class, outbound);
+	public DefaultXmppHeaderMapper() {
+		super(XmppHeaders.class);
 	}
 
 	@Override

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapper.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapper.java
@@ -36,8 +36,6 @@ import org.springframework.util.StringUtils;
  */
 public class DefaultXmppHeaderMapper extends AbstractHeaderMapper<Message> implements XmppHeaderMapper {
 	
-	private static final String PREFIX = "";
-	
 	private static final List<String> STANDARD_HEADER_NAMES = new ArrayList<String>();
 
 	static {
@@ -145,6 +143,6 @@ public class DefaultXmppHeaderMapper extends AbstractHeaderMapper<Message> imple
 	}
 	@Override
 	protected String getStandardHeaderPrefix() {
-		return PREFIX;
+		return XmppHeaders.PREFIX;
 	}
 }

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapper.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapper.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.xmpp.support;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jivesoftware.smack.packet.Message;
+
+import org.springframework.integration.mapping.AbstractHeaderMapper;
+import org.springframework.integration.xmpp.XmppHeaders;
+import org.springframework.util.StringUtils;
+
+/**
+ * Default implementation of {@link XmppHeaderMapper}.
+ *
+ * @author Mark Fisher
+ * @since 2.1
+ */
+public class DefaultXmppHeaderMapper extends AbstractHeaderMapper<Message> implements XmppHeaderMapper {
+
+	public DefaultXmppHeaderMapper(boolean outbound) {
+		super(XmppHeaders.class, outbound);
+	}
+
+	@Override
+	protected Map<String, Object> extractStandardHeaders(Message source) {
+		Map<String, Object> headers = new HashMap<String, Object>();
+		/*Collection<PacketExtension> extensions = source.getExtensions();
+		if (!CollectionUtils.isEmpty(extensions)) {
+			for (PacketExtension extension : extensions) {
+				String name = extension.getElementName();
+				String namespace = extension.getNamespace();
+				if (StringUtils.hasText(namespace)) {
+					name = namespace + ":" + name;
+				}
+				headers.put(name, extension.toXML());
+			}
+		}*/
+		String from = source.getFrom();
+		if (StringUtils.hasText(from)) {
+			headers.put(XmppHeaders.FROM, from);
+		}
+		String subject = source.getSubject();
+		if (StringUtils.hasText(subject)) {
+			headers.put(XmppHeaders.SUBJECT, subject);
+		}
+		String thread = source.getThread();
+		if (StringUtils.hasText(thread)) {
+			headers.put(XmppHeaders.THREAD, thread);
+		}
+		String to = source.getTo();
+		if (StringUtils.hasText(to)) {
+			headers.put(XmppHeaders.TO, to);
+		}
+		Message.Type type = source.getType();
+		if (type != null) {
+			headers.put(XmppHeaders.TYPE, type);
+		}
+		return headers;
+	}
+
+	@Override
+	protected Map<String, Object> extractUserDefinedHeaders(Message source) {
+		Map<String, Object> headers = new HashMap<String, Object>();
+		for (String propertyName : source.getPropertyNames()) {
+			headers.put(propertyName, source.getProperty(propertyName));
+		}
+		return headers;
+	}
+
+	@Override
+	protected void populateStandardHeaders(Map<String, Object> headers, Message target) {
+		String threadId = getHeaderIfAvailable(headers, XmppHeaders.THREAD, String.class);
+		if (StringUtils.hasText(threadId)) {
+			target.setThread(threadId);
+		}
+		String to = getHeaderIfAvailable(headers, XmppHeaders.TO, String.class);
+		if (StringUtils.hasText(to)) {
+			target.setTo(to);
+		}
+		String from = getHeaderIfAvailable(headers, XmppHeaders.FROM, String.class);
+		if (StringUtils.hasText(from)) {
+			target.setFrom(from);
+		}
+		String subject = getHeaderIfAvailable(headers, XmppHeaders.SUBJECT, String.class);
+		if (StringUtils.hasText(subject)) {
+			target.setSubject(subject);
+		}
+		Object typeHeader = getHeaderIfAvailable(headers, XmppHeaders.TYPE, Object.class);
+		if (typeHeader instanceof String) {
+			try {
+				typeHeader = Message.Type.valueOf((String) typeHeader);
+			}
+			catch (Exception e) {
+				if (logger.isWarnEnabled()) {
+					logger.warn("XMPP Type must be either a valid [Message.Type] " +
+							"enum value or a String representation of such.");
+				}
+			}
+		}
+		if (typeHeader instanceof Message.Type) {
+			target.setType((Message.Type) typeHeader);
+		}
+	}
+
+	@Override
+	protected void populateUserDefinedHeader(String headerName, Object headerValue, Message target) {
+		target.setProperty(headerName, headerValue);
+	}
+
+}

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapper.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapper.java
@@ -16,7 +16,9 @@
 
 package org.springframework.integration.xmpp.support;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.jivesoftware.smack.packet.Message;
@@ -33,9 +35,17 @@ import org.springframework.util.StringUtils;
  * @since 2.1
  */
 public class DefaultXmppHeaderMapper extends AbstractHeaderMapper<Message> implements XmppHeaderMapper {
+	
+	private static final String PREFIX = "";
+	
+	private static final List<String> STANDARD_HEADER_NAMES = new ArrayList<String>();
 
-	public DefaultXmppHeaderMapper() {
-		super(XmppHeaders.class);
+	static {
+		STANDARD_HEADER_NAMES.add(XmppHeaders.FROM);
+		STANDARD_HEADER_NAMES.add(XmppHeaders.SUBJECT);
+		STANDARD_HEADER_NAMES.add(XmppHeaders.THREAD);
+		STANDARD_HEADER_NAMES.add(XmppHeaders.TO);
+		STANDARD_HEADER_NAMES.add(XmppHeaders.TYPE);
 	}
 
 	@Override
@@ -124,4 +134,17 @@ public class DefaultXmppHeaderMapper extends AbstractHeaderMapper<Message> imple
 		target.setProperty(headerName, headerValue);
 	}
 
+	@Override
+	protected List<String> getStandardReplyHeaderNames() {
+		return STANDARD_HEADER_NAMES;
+	}
+
+	@Override
+	protected List<String> getStandardRequestHeaderNames() {
+		return STANDARD_HEADER_NAMES;
+	}
+	@Override
+	protected String getStandardHeaderPrefix() {
+		return PREFIX;
+	}
 }

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/XmppHeaderMapper.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/XmppHeaderMapper.java
@@ -14,22 +14,17 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.xmpp.config;
+package org.springframework.integration.xmpp.support;
 
-import org.springframework.integration.config.xml.HeaderEnricherParserSupport;
-import org.springframework.integration.xmpp.XmppHeaders;
+import org.jivesoftware.smack.packet.Message;
+import org.springframework.integration.mapping.HeaderMapper;
 
 /**
- * Parser for 'xmpp:header-enricher' element
- * @author Josh Long
- * @author Oleg Zhurakousky
- * @since 2.0
+ * A convenience interface that extends {@link HeaderMapper}
+ * but parameterized with {@link MessageProperties}.
+ *
+ * @author Mark Fisher
+ * @since 2.1
  */
-public class XmppHeaderEnricherParser extends HeaderEnricherParserSupport {
-
-	public XmppHeaderEnricherParser() {
-		this.addElementToHeaderMapping("chat-to", XmppHeaders.TO);
-		this.addElementToHeaderMapping("chat-thread-id", XmppHeaders.THREAD);
-	}
-
+public interface XmppHeaderMapper extends HeaderMapper<Message> {
 }

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/XmppHeaderMapper.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/XmppHeaderMapper.java
@@ -17,7 +17,9 @@
 package org.springframework.integration.xmpp.support;
 
 import org.jivesoftware.smack.packet.Message;
+
 import org.springframework.integration.mapping.HeaderMapper;
+import org.springframework.integration.mapping.RequestReplyHeaderMapper;
 
 /**
  * A convenience interface that extends {@link HeaderMapper}
@@ -26,5 +28,5 @@ import org.springframework.integration.mapping.HeaderMapper;
  * @author Mark Fisher
  * @since 2.1
  */
-public interface XmppHeaderMapper extends HeaderMapper<Message> {
+public interface XmppHeaderMapper extends RequestReplyHeaderMapper<Message> {
 }

--- a/spring-integration-xmpp/src/main/resources/org/springframework/integration/xmpp/config/spring-integration-xmpp-2.1.xsd
+++ b/spring-integration-xmpp/src/main/resources/org/springframework/integration/xmpp/config/spring-integration-xmpp-2.1.xsd
@@ -195,6 +195,22 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="header-mapper">
+				<xsd:annotation>
+					<xsd:documentation>
+						Allows you to reference custom implementation of HeaderMapper.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-request-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Comma-separated list of names of MessageHeaders to be mapped into the XMPP Headers of the request.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 	</xsd:complexType>
 	
 	<xsd:complexType name="xmppOutboundAdapterType">
@@ -234,6 +250,22 @@
 						Specifies the order for invocation when this endpoint is connected as a
 						subscriber to a SubscribableChannel.
 					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="header-mapper">
+				<xsd:annotation>
+					<xsd:documentation>
+						Allows you to reference custom implementation of HeaderMapper.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-request-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Comma-separated list of names of MessageHeaders to be mapped into the XMPP Headers of the request.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 		</xsd:complexType>

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageInboundChannelAdapterParserTests-context.xml
@@ -22,9 +22,13 @@
 		<beans:constructor-arg value="org.jivesoftware.smack.XMPPConnection"/>
 	</beans:bean>
 	
-	<channel id="xmppInbound"/>
+	<channel id="xmppInbound">
+		<queue/>
+	</channel>
 
 	<xmpp:inbound-channel-adapter id="xmppInboundAdapter" channel="xmppInbound" 
-			xmpp-connection="testConnection" extract-payload="false" auto-startup="false" error-channel="errorChannel"/>
+			xmpp-connection="testConnection" extract-payload="false" 
+			auto-startup="false" error-channel="errorChannel"
+			mapped-request-headers="foo*, xmpp*"/>
 
 </beans:beans>

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests-context.xml
@@ -36,13 +36,11 @@
 	</int-xmpp:outbound-channel-adapter>
 	
 	<bean id="headerMapper" class="org.springframework.integration.xmpp.support.DefaultXmppHeaderMapper">
-		<constructor-arg value="true"/>
 		<property name="requestHeaderNames" value="foo*"/>
 	</bean>
 	
 	<int-xmpp:outbound-channel-adapter id="outboundNoChannelAdapter" 
 						xmpp-connection="testConnection">
-<!--		<int:poller fixed-rate="1000" max-messages-per-poll="1"/>-->
 	</int-xmpp:outbound-channel-adapter>
 
 </beans>

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests-context.xml
@@ -15,17 +15,30 @@
 	
 	<int-xmpp:outbound-channel-adapter id="outboundEventAdapter" 
 					channel="outboundEventChannel" 
-					xmpp-connection="testConnection"/>
+					xmpp-connection="testConnection"
+					mapped-request-headers="foo*, bar*"/>
 						
 	<int:channel id="outboundPollingChannel">
 		<int:queue/>
 	</int:channel>
 	
-	<int-xmpp:outbound-channel-adapter id="outboundPollingAdapter" 
+	<int-xmpp:outbound-channel-adapter id="pollingConsumer" 
 					channel="outboundPollingChannel" 
 					xmpp-connection="testConnection">
-		<int:poller fixed-rate="1000" max-messages-per-poll="1"/>
+		<int:poller fixed-rate="5000" max-messages-per-poll="1"/>
 	</int-xmpp:outbound-channel-adapter>
+	
+	<int-xmpp:outbound-channel-adapter id="withHeaderMapper" 
+					channel="outboundPollingChannel" 
+					xmpp-connection="testConnection"
+					header-mapper="headerMapper">
+		<int:poller fixed-rate="5000" max-messages-per-poll="1"/>
+	</int-xmpp:outbound-channel-adapter>
+	
+	<bean id="headerMapper" class="org.springframework.integration.xmpp.support.DefaultXmppHeaderMapper">
+		<constructor-arg value="true"/>
+		<property name="requestHeaderNames" value="foo*"/>
+	</bean>
 	
 	<int-xmpp:outbound-channel-adapter id="outboundNoChannelAdapter" 
 						xmpp-connection="testConnection">

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2011 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.integration.Message;
@@ -30,11 +31,11 @@ import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.endpoint.PollingConsumer;
-import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.xmpp.XmppHeaders;
 import org.springframework.integration.xmpp.support.DefaultXmppHeaderMapper;
+import org.springframework.integration.xmpp.support.XmppHeaderMapper;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -55,7 +56,7 @@ public class ChatMessageOutboundChannelAdapterParserTests {
 	private ApplicationContext context;
 	
 	@Autowired
-	private HeaderMapper<org.jivesoftware.smack.packet.Message> headerMapper;
+	private XmppHeaderMapper headerMapper;
 
 	@Test
 	public void testPollingConsumer() {

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.xmpp.config;
 
+import java.util.List;
+
 import org.jivesoftware.smack.XMPPConnection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,15 +74,16 @@ public class ChatMessageOutboundChannelAdapterParserTests {
 		assertTrue(eventConsumer instanceof SubscribableChannel);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testEventConsumer() {
 		Object eventConsumer = context.getBean("outboundEventAdapter");
 		DefaultXmppHeaderMapper headerMapper = 
 				TestUtils.getPropertyValue(eventConsumer, "handler.headerMapper", DefaultXmppHeaderMapper.class);
-		String[] requestHeaderNames = TestUtils.getPropertyValue(headerMapper, "requestHeaderNames", String[].class);
-		assertEquals(2, requestHeaderNames.length);
-		assertEquals("foo*", requestHeaderNames[0]);
-		assertEquals("bar*", requestHeaderNames[1]);
+		List<String> requestHeaderNames = TestUtils.getPropertyValue(headerMapper, "requestHeaderNames", List.class);
+		assertEquals(2, requestHeaderNames.size());
+		assertEquals("foo*", requestHeaderNames.get(0));
+		assertEquals("bar*", requestHeaderNames.get(1));
 		assertTrue(eventConsumer instanceof EventDrivenConsumer);
 	}
 

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapperTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapperTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2002-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.xmpp.support;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jivesoftware.smack.packet.Message;
+
+import org.junit.Test;
+
+import org.springframework.integration.MessageHeaders;
+import org.springframework.integration.xmpp.XmppHeaders;
+
+/**
+ * @author Mark Fisher
+ * @since 2.1
+ */
+public class DefaultXmppHeaderMapperTests {
+
+	@Test
+	public void fromHeadersStandardOutbound() {
+		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper(true);
+		Map<String, Object> headerMap = new HashMap<String, Object>();
+		headerMap.put("userDefined1", "foo");
+		headerMap.put("userDefined2", "bar");
+		headerMap.put(XmppHeaders.THREAD, "test.thread");
+		headerMap.put(XmppHeaders.TO, "test.to");
+		headerMap.put(XmppHeaders.FROM, "test.from");
+		headerMap.put(XmppHeaders.SUBJECT, "test.subject");
+		headerMap.put(XmppHeaders.TYPE, "headline");
+		MessageHeaders headers = new MessageHeaders(headerMap);
+		Message target = new Message();
+		mapper.fromHeaders(headers, target);
+
+		// "standard" XMPP headers
+		assertEquals("test.thread", target.getThread());
+		assertEquals("test.to", target.getTo());
+		assertEquals("test.from", target.getFrom());
+		assertEquals("test.subject", target.getSubject());
+		assertEquals(Message.Type.headline, target.getType());
+
+		// user-defined headers not included by default
+		assertNull(target.getProperty("userDefined1"));
+		assertNull(target.getProperty("userDefined2"));
+
+		// transient headers should not be copied
+		assertNull(target.getProperty("id"));
+		assertNull(target.getProperty("timestamp"));
+	}
+
+	@Test
+	public void fromHeadersUserDefinedOnly() {
+		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper(true);
+		mapper.setRequestHeaderNames(new String[] { "userDefined1", "userDefined2" });
+		Map<String, Object> headerMap = new HashMap<String, Object>();
+		headerMap.put("userDefined1", "foo");
+		headerMap.put("userDefined2", "bar");
+		headerMap.put("userDefined3", "baz");
+		headerMap.put(XmppHeaders.THREAD, "test.thread");
+		headerMap.put(XmppHeaders.TO, "test.to");
+		headerMap.put(XmppHeaders.FROM, "test.from");
+		headerMap.put(XmppHeaders.SUBJECT, "test.subject");
+		headerMap.put(XmppHeaders.TYPE, "headline");
+		MessageHeaders headers = new MessageHeaders(headerMap);
+		Message target = new Message();
+		mapper.fromHeaders(headers, target);
+
+		// "standard" XMPP headers not included
+		assertNull(target.getThread());
+		assertNull(target.getTo());
+		assertNull(target.getFrom());
+		assertNull(target.getSubject());
+		assertEquals(Message.Type.normal, target.getType());
+
+		// user-defined headers are included if in the list
+		assertEquals("foo", target.getProperty("userDefined1"));
+		assertEquals("bar", target.getProperty("userDefined2"));
+
+		// user-defined headers are not included if not in the list
+		assertNull(target.getProperty("userDefined3"));
+
+		// transient headers should not be copied
+		assertNull(target.getProperty("id"));
+		assertNull(target.getProperty("timestamp"));
+	}
+
+	@Test
+	public void toHeadersStandardOnly() {
+		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper(true);
+		Message source = new Message("test.to", Message.Type.headline);
+		source.setFrom("test.from");
+		source.setSubject("test.subject");
+		source.setThread("test.thread");
+		source.setProperty("userDefined1", "foo");
+		source.setProperty("userDefined2", "bar");
+		Map<String, Object> headers = mapper.toHeaders(source);
+		assertEquals("test.to", headers.get(XmppHeaders.TO));
+		assertEquals("test.from", headers.get(XmppHeaders.FROM));
+		assertEquals("test.subject", headers.get(XmppHeaders.SUBJECT));
+		assertEquals("test.thread", headers.get(XmppHeaders.THREAD));
+		assertEquals(Message.Type.headline, headers.get(XmppHeaders.TYPE));
+		assertNull(headers.get("userDefined1"));
+		assertNull(headers.get("userDefined2"));
+	}
+
+	@Test
+	public void toHeadersUserDefinedOnly() {
+		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper(true);
+		mapper.setResponseHeaderNames(new String[] { "userDefined*" });
+		Message source = new Message("test.to", Message.Type.headline);
+		source.setFrom("test.from");
+		source.setSubject("test.subject");
+		source.setThread("test.thread");
+		source.setProperty("userDefined1", "foo");
+		source.setProperty("userDefined2", "bar");
+		Map<String, Object> headers = mapper.toHeaders(source);
+		assertNull(headers.get(XmppHeaders.TO));
+		assertNull(headers.get(XmppHeaders.FROM));
+		assertNull(headers.get(XmppHeaders.SUBJECT));
+		assertNull(headers.get(XmppHeaders.THREAD));
+		assertNull(headers.get(XmppHeaders.TYPE));
+		assertEquals("foo", headers.get("userDefined1"));
+		assertEquals("bar", headers.get("userDefined2"));
+	}
+
+}

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapperTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapperTests.java
@@ -37,7 +37,7 @@ public class DefaultXmppHeaderMapperTests {
 
 	@Test
 	public void fromHeadersStandardOutbound() {
-		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper(true);
+		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper();
 		Map<String, Object> headerMap = new HashMap<String, Object>();
 		headerMap.put("userDefined1", "foo");
 		headerMap.put("userDefined2", "bar");
@@ -48,7 +48,7 @@ public class DefaultXmppHeaderMapperTests {
 		headerMap.put(XmppHeaders.TYPE, "headline");
 		MessageHeaders headers = new MessageHeaders(headerMap);
 		Message target = new Message();
-		mapper.fromHeaders(headers, target);
+		mapper.fromHeadersToRequest(headers, target);
 
 		// "standard" XMPP headers
 		assertEquals("test.thread", target.getThread());
@@ -68,7 +68,7 @@ public class DefaultXmppHeaderMapperTests {
 
 	@Test
 	public void fromHeadersUserDefinedOnly() {
-		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper(true);
+		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper();
 		mapper.setRequestHeaderNames(new String[] { "userDefined1", "userDefined2" });
 		Map<String, Object> headerMap = new HashMap<String, Object>();
 		headerMap.put("userDefined1", "foo");
@@ -81,7 +81,7 @@ public class DefaultXmppHeaderMapperTests {
 		headerMap.put(XmppHeaders.TYPE, "headline");
 		MessageHeaders headers = new MessageHeaders(headerMap);
 		Message target = new Message();
-		mapper.fromHeaders(headers, target);
+		mapper.fromHeadersToRequest(headers, target);
 
 		// "standard" XMPP headers not included
 		assertNull(target.getThread());
@@ -104,14 +104,14 @@ public class DefaultXmppHeaderMapperTests {
 
 	@Test
 	public void toHeadersStandardOnly() {
-		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper(true);
+		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper();
 		Message source = new Message("test.to", Message.Type.headline);
 		source.setFrom("test.from");
 		source.setSubject("test.subject");
 		source.setThread("test.thread");
 		source.setProperty("userDefined1", "foo");
 		source.setProperty("userDefined2", "bar");
-		Map<String, Object> headers = mapper.toHeaders(source);
+		Map<String, Object> headers = mapper.toHeadersFromRequest(source);
 		assertEquals("test.to", headers.get(XmppHeaders.TO));
 		assertEquals("test.from", headers.get(XmppHeaders.FROM));
 		assertEquals("test.subject", headers.get(XmppHeaders.SUBJECT));
@@ -123,15 +123,15 @@ public class DefaultXmppHeaderMapperTests {
 
 	@Test
 	public void toHeadersUserDefinedOnly() {
-		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper(true);
-		mapper.setResponseHeaderNames(new String[] { "userDefined*" });
+		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper();
+		mapper.setReplyHeaderNames(new String[] { "userDefined*" });
 		Message source = new Message("test.to", Message.Type.headline);
 		source.setFrom("test.from");
 		source.setSubject("test.subject");
 		source.setThread("test.thread");
 		source.setProperty("userDefined1", "foo");
 		source.setProperty("userDefined2", "bar");
-		Map<String, Object> headers = mapper.toHeaders(source);
+		Map<String, Object> headers = mapper.toHeadersFromReply(source);
 		assertNull(headers.get(XmppHeaders.TO));
 		assertNull(headers.get(XmppHeaders.FROM));
 		assertNull(headers.get(XmppHeaders.SUBJECT));


### PR DESCRIPTION
INT-2083
added outbound namespace support for XMPP header mapper

INT-2083
added inbound namespace support for XMPP header mapper

INT-2083
polished XMPP inbound/outbound header mappings, added namespace support for AMQP inbound adapter/gateway header mappings

INT-2083
added support and tests for AMQP outbound gateways and adapters

INT-2083
polishing and adding more tests for AMQP support for header mappings

INT-2083
polishing AMQP and XMPP header mappings, generalized headerMapper configuration in IntegrationNamespaceUtils.configureHeaderMapper(..) method

INT-2803
added headermapping support to WS outbound gateways

INT-2803 polishing

INT-2083
refactored SimpleWebServiceOutboundGateway, added full request/reply test
