### PR TITLE
INT-2249

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
@@ -49,7 +49,7 @@ public class MethodInvokingMessageProcessor<T> extends AbstractMessageProcessor<
 	}
 
 	public MethodInvokingMessageProcessor(Object targetObject, String methodName, boolean canProcessMessageList) {
-		delegate = new MessagingMethodInvokerHelper<T>(targetObject, methodName, Object.class, canProcessMessageList);
+		delegate = new MessagingMethodInvokerHelper<T>(targetObject, methodName, canProcessMessageList);
 	}
 
 	public MethodInvokingMessageProcessor(Object targetObject, Class<? extends Annotation> annotationType) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
@@ -48,8 +48,8 @@ public class MethodInvokingMessageProcessor<T> extends AbstractMessageProcessor<
 		delegate = new MessagingMethodInvokerHelper<T>(targetObject, methodName, false);
 	}
 
-	public MethodInvokingMessageProcessor(Object targetObject, String methodName, boolean requiresReply) {
-		delegate = new MessagingMethodInvokerHelper<T>(targetObject, methodName, Object.class, false);
+	public MethodInvokingMessageProcessor(Object targetObject, String methodName, boolean canProcessMessageList) {
+		delegate = new MessagingMethodInvokerHelper<T>(targetObject, methodName, Object.class, canProcessMessageList);
 	}
 
 	public MethodInvokingMessageProcessor(Object targetObject, Class<? extends Annotation> annotationType) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -16,11 +16,6 @@
 
 package org.springframework.integration.handler;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Properties;
@@ -39,6 +34,10 @@ import org.springframework.integration.annotation.Header;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Mark Fisher
@@ -219,31 +218,32 @@ public class MethodInvokingMessageProcessorTests {
 		assertEquals(12, processor.processMessage(MessageBuilder.withPayload(12).build()));
 	}
 
-	@Test
-	public void testVoidMethodsExcludedByFlag() {
-		@SuppressWarnings("unused")
-		class VoidMethodsBean {
-			public void testVoidReturningMethods(String s) {
-				// do nothing
-			}
-			public int testVoidReturningMethods(int i) {
-				return i;
-			}
-		}
-		Exception exception = null;
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new VoidMethodsBean(),
-				"testVoidReturningMethods", true);
-		assertEquals(12, processor.processMessage(MessageBuilder.withPayload(12).build()));
-		try {
-			processor.processMessage(MessageBuilder.withPayload("not_a_number").build());
-			fail();
-		}
-		catch (MessageHandlingException ex) {
-			// the only void method expects a number
-			exception = ex;
-		}
-		assertNotNull(exception);
-	}
+//	@Test
+//	public void testVoidMethodsExcludedByFlag() {
+//		@SuppressWarnings("unused")
+//		class VoidMethodsBean {
+//			public void testVoidReturningMethods(String s) {
+//				System.out.println("Hello");
+//				// do nothing
+//			}
+//			public int testVoidReturningMethods(int i) {
+//				return i;
+//			}
+//		}
+//		Exception exception = null;
+//		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new VoidMethodsBean(),
+//				"testVoidReturningMethods", true);
+//		assertEquals(12, processor.processMessage(MessageBuilder.withPayload(12).build()));
+//		try {
+//			processor.processMessage(MessageBuilder.withPayload("not_a_number").build());
+//			fail();
+//		}
+//		catch (MessageHandlingException ex) {
+//			// the only void method expects a number
+//			exception = ex;
+//		}
+//		assertNotNull(exception);
+//	}
 
 	@Test
 	public void messageOnlyWithAnnotatedMethod() throws Exception {
@@ -342,7 +342,7 @@ public class MethodInvokingMessageProcessorTests {
 	@Test
 	public void filterSelectsNonVoidReturningMethodsOnly() {
 		OverloadedMethodBean bean = new OverloadedMethodBean();
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, "foo", true);
+		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, ServiceActivator.class);
 		processor.processMessage(MessageBuilder.withPayload(true).build());
 		assertNotNull(bean.lastArg);
 		assertEquals(String.class, bean.lastArg.getClass());
@@ -352,7 +352,7 @@ public class MethodInvokingMessageProcessorTests {
 	@Test
 	public void testOverloadedNonVoidReturningMethodsWithExactMatchForType() {
 		AmbiguousMethodBean bean = new AmbiguousMethodBean();
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, "foo", true);
+		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, ServiceActivator.class);
 		processor.processMessage(MessageBuilder.withPayload("true").build());
 		assertNotNull(bean.lastArg);
 		assertEquals(String.class, bean.lastArg.getClass());

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -303,26 +303,6 @@ public class MethodInvokingMessageProcessorTests {
 	}
 
 	@Test
-	public void filterSelectsAnnotationMethodsOnly() {
-		OverloadedMethodBean bean = new OverloadedMethodBean();
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, ServiceActivator.class);
-		processor.processMessage(MessageBuilder.withPayload(123).build());
-		assertNotNull(bean.lastArg);
-		assertEquals(String.class, bean.lastArg.getClass());
-		assertEquals("123", bean.lastArg);
-	}
-
-	@Test
-	public void filterSelectsNonVoidReturningMethodsOnly() {
-		OverloadedMethodBean bean = new OverloadedMethodBean();
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, ServiceActivator.class);
-		processor.processMessage(MessageBuilder.withPayload(true).build());
-		assertNotNull(bean.lastArg);
-		assertEquals(String.class, bean.lastArg.getClass());
-		assertEquals("true", bean.lastArg);
-	}
-
-	@Test
 	public void testOverloadedNonVoidReturningMethodsWithExactMatchForType() {
 		AmbiguousMethodBean bean = new AmbiguousMethodBean();
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, ServiceActivator.class);
@@ -498,6 +478,5 @@ public class MethodInvokingMessageProcessorTests {
 			this.lastArg = s;
 			return s;
 		}
-
 	}
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -218,33 +218,6 @@ public class MethodInvokingMessageProcessorTests {
 		assertEquals(12, processor.processMessage(MessageBuilder.withPayload(12).build()));
 	}
 
-//	@Test
-//	public void testVoidMethodsExcludedByFlag() {
-//		@SuppressWarnings("unused")
-//		class VoidMethodsBean {
-//			public void testVoidReturningMethods(String s) {
-//				System.out.println("Hello");
-//				// do nothing
-//			}
-//			public int testVoidReturningMethods(int i) {
-//				return i;
-//			}
-//		}
-//		Exception exception = null;
-//		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new VoidMethodsBean(),
-//				"testVoidReturningMethods", true);
-//		assertEquals(12, processor.processMessage(MessageBuilder.withPayload(12).build()));
-//		try {
-//			processor.processMessage(MessageBuilder.withPayload("not_a_number").build());
-//			fail();
-//		}
-//		catch (MessageHandlingException ex) {
-//			// the only void method expects a number
-//			exception = ex;
-//		}
-//		assertNotNull(exception);
-//	}
-
 	@Test
 	public void messageOnlyWithAnnotatedMethod() throws Exception {
 		AnnotatedTestService service = new AnnotatedTestService();


### PR DESCRIPTION
polished MethodInvokingMessageProcessor constructor that takes boolean argument by renaming the argument from 'requiresReply' to 'canProcessMessageList' which is what it really maps to in MessagingMethodInvokerHelper.HandlerMethod.

See https://jira.springsource.org/browse/INT-2249 comments for more details
