### PR TITLE
INT-2274: Manual par. 7.6.2 Groovy Control Bus

### DIFF
--- a/docs/src/reference/docbook/groovy.xml
+++ b/docs/src/reference/docbook/groovy.xml
@@ -84,7 +84,7 @@
     (e.g. several of the <classname>TaskExecutor</classname> and <classname>TaskScheduler</classname> implementations).</para>
     <para>
        <important>
-        Be careful about using managed beans from custom scopes (e.g. 'request') in the Control Bus' command scripts, especially
+        Be careful about using managed beans with custom scopes (e.g. 'request') in the Control Bus' command scripts, especially
         inside <emphasis>async</emphasis> message flow. If <emphasis>The Control Bus' customizer</emphasis> can't expose a bean
         from the application context, it skips <classname>BeanCreationException</classname> and goes on to other beans.
        </important>

--- a/docs/src/reference/docbook/groovy.xml
+++ b/docs/src/reference/docbook/groovy.xml
@@ -80,9 +80,15 @@
     customizes it with a <classname>GroovyObjectCustomizer</classname>, and then executes it. The
     Control Bus' customizer exposes all the beans in the application context
     that are annotated with <code>@ManagedResource</code>, implement Spring's
-    <classname>Lifecycle</classname>interface or extend Spring's <classname>CustomizableThreadCreator</classname> base class
+    <classname>Lifecycle</classname> interface or extend Spring's <classname>CustomizableThreadCreator</classname> base class
     (e.g. several of the <classname>TaskExecutor</classname> and <classname>TaskScheduler</classname> implementations).</para>
-    
+    <para>
+       <important>
+        Be careful about using managed beans from custom scopes (e.g. 'request') in the Control Bus' command scripts, especially
+        inside <emphasis>async</emphasis> message flow. If <emphasis>The Control Bus' customizer</emphasis> can't expose a bean
+        from the application context, it skips <classname>BeanCreationException</classname> and goes on to other beans.
+       </important>
+    </para>
     <para>
      If you need to further customize the Groovy objects, you can also provide a reference to a bean
      that implements <classname>org.springframework.scripting.groovy.GroovyObjectCustomizer</classname> via


### PR DESCRIPTION
It is about: Manual. Limitation of usage scoped beans in the command scripts for Groovy Control Bus.
Jira: https://jira.springsource.org/browse/INT-2274.
