### PR TITLE
INT-2287 Timing Hole With Send-and-Forget TCP

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -306,6 +306,9 @@ public class TcpNioConnection extends AbstractTcpConnection {
 		try {
 			doRead();
 		} catch (ClosedChannelException cce) {
+			if (logger.isDebugEnabled()) {
+				logger.debug(this.getConnectionId() + " Channel is closed");
+			}
 			this.closeConnection();
 		} catch (Exception e) {
 			logger.error("Exception on Read " + 


### PR DESCRIPTION
If a tcp client connection factory was configured for single-use
connections (one socket per message), and it was used by an outbound
channel adapter (send and forget), the socket is closed immediately
after sending the message.

This could cause issues with the connection handling because certain
failures could occur. For example, the close could occur before we
ever registered the channel for read selection, resulting in a
ClosedChannelException. Secondly, there was a small timing hole
where a selection key could be invalidated between the isValid()
call and isReadable().

These problems have been corrected.
