### PR TITLE
INT-2298 Remove Versions From Schemas in Reference

### DIFF
--- a/docs/src/reference/docbook/configuration.xml
+++ b/docs/src/reference/docbook/configuration.xml
@@ -30,9 +30,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        ]]><emphasis>xmlns:int="http://www.springframework.org/schema/integration"</emphasis><![CDATA[
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans.xsd
            ]]><emphasis>http://www.springframework.org/schema/integration
-           http://www.springframework.org/schema/integration/spring-integration-2.0.xsd"</emphasis>&gt;</programlisting>
+           http://www.springframework.org/schema/integration/spring-integration.xsd"</emphasis>&gt;</programlisting>
     </para>
     <para>
       You can choose any name after "xmlns:"; <emphasis>int</emphasis> is used here for clarity, but you might
@@ -43,9 +43,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        ]]><emphasis>xmlns:beans="http://www.springframework.org/schema/beans"</emphasis><![CDATA[
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans.xsd
            http://www.springframework.org/schema/integration
-           http://www.springframework.org/schema/integration/spring-integration-2.0.xsd">]]></programlisting>
+           http://www.springframework.org/schema/integration/spring-integration.xsd">]]></programlisting>
     </para>
     <para>
       When using this alternative, no prefix is necessary for the Spring Integration elements. On the other hand, if
@@ -71,19 +71,19 @@
     xmlns:int-rmi="http://www.springframework.org/schema/integration/rmi"
     xmlns:int-ws="http://www.springframework.org/schema/integration/ws"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+            http://www.springframework.org/schema/beans/spring-beans.xsd
             http://www.springframework.org/schema/integration
-            http://www.springframework.org/schema/integration/spring-integration-2.0.xsd
+            http://www.springframework.org/schema/integration/spring-integration.xsd
             http://www.springframework.org/schema/integration/file
-            http://www.springframework.org/schema/integration/file/spring-integration-file-2.0.xsd
+            http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
             http://www.springframework.org/schema/integration/jms
-            http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.0.xsd
+            http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
             http://www.springframework.org/schema/integration/mail
-            http://www.springframework.org/schema/integration/mail/spring-integration-mail-2.0.xsd
+            http://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd
             http://www.springframework.org/schema/integration/rmi
-            http://www.springframework.org/schema/integration/rmi/spring-integration-rmi-2.0.xsd
+            http://www.springframework.org/schema/integration/rmi/spring-integration-rmi.xsd
             http://www.springframework.org/schema/integration/ws
-            http://www.springframework.org/schema/integration/ws/spring-integration-ws-2.0.xsd">
+            http://www.springframework.org/schema/integration/ws/spring-integration-ws.xsd">
  ...
 </beans>]]></programlisting>
       The reference manual provides specific examples of the various elements in their corresponding chapters. Here, the

--- a/docs/src/reference/docbook/feed.xml
+++ b/docs/src/reference/docbook/feed.xml
@@ -18,7 +18,7 @@
 	
 	<programlisting language="xml"><![CDATA[xmlns:int-feed="http://www.springframework.org/schema/integration/feed"
 xsi:schemaLocation="http://www.springframework.org/schema/integration/feed 
-	http://www.springframework.org/schema/integration/feed/spring-integration-feed-2.0.xsd"]]></programlisting>
+	http://www.springframework.org/schema/integration/feed/spring-integration-feed.xsd"]]></programlisting>
 
     </para>
   </section>

--- a/docs/src/reference/docbook/file.xml
+++ b/docs/src/reference/docbook/file.xml
@@ -75,11 +75,11 @@
   xmlns:int="http://www.springframework.org/schema/integration"
   xmlns:int-file="http://www.springframework.org/schema/integration/file"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    http://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
-    http://www.springframework.org/schema/integration/spring-integration-2.0.xsd
+    http://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/file
-    http://www.springframework.org/schema/integration/file/spring-integration-file-2.0.xsd">
+    http://www.springframework.org/schema/integration/file/spring-integration-file.xsd">
 </beans>]]></programlisting>
     </para>
         <para>

--- a/docs/src/reference/docbook/ftp.xml
+++ b/docs/src/reference/docbook/ftp.xml
@@ -27,7 +27,7 @@
     	To use the <emphasis>FTP</emphasis> namespace, add the following to the header of your XML file:
     	<programlisting language="xml"><![CDATA[xmlns:int-ftp="http://www.springframework.org/schema/integration/ftp"
 xsi:schemaLocation="http://www.springframework.org/schema/integration/ftp 
-	http://www.springframework.org/schema/integration/ftp/spring-integration-ftp-2.0.xsd" 
+	http://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd"
 ]]></programlisting>
     </para>
   </section>

--- a/docs/src/reference/docbook/gemfire.xml
+++ b/docs/src/reference/docbook/gemfire.xml
@@ -25,7 +25,7 @@
 	
 	<programlisting language="xml"><![CDATA[xmlns:int-gfe="http://www.springframework.org/schema/integration/gemfire"
 xsi:schemaLocation="http://www.springframework.org/schema/integration/gemfire 
-	http://www.springframework.org/schema/integration/gemfire/spring-integration-gemfire-2.1.xsd"]]></programlisting>
+	http://www.springframework.org/schema/integration/gemfire/spring-integration-gemfire.xsd"]]></programlisting>
     </para>
   </section>
   <section>

--- a/docs/src/reference/docbook/jms.xml
+++ b/docs/src/reference/docbook/jms.xml
@@ -79,7 +79,7 @@
         an instance of DefaultMessageListenerContainer will be created and configured based on these properties.
         For example, you can specify the "transaction-manager" reference, the "concurrent-consumers" value, and
         several other property references and values. Refer to the JavaDoc and Spring Integration's JMS Schema
-        (spring-integration-jms-2.0.xsd) for more detail.
+        (spring-integration-jms.xsd) for more detail.
       </note>
     </para>
     <para>

--- a/docs/src/reference/docbook/mail.xml
+++ b/docs/src/reference/docbook/mail.xml
@@ -72,9 +72,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:int-mail="http://www.springframework.org/schema/integration/mail"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-            http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+            http://www.springframework.org/schema/beans/spring-beans.xsd
             http://www.springframework.org/schema/integration/mail
-            http://www.springframework.org/schema/integration/mail/spring-integration-mail-2.0.xsd">]]></programlisting>
+            http://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd">]]></programlisting>
     </para>
     <para>
       To configure an outbound Channel Adapter, provide the channel to receive from, and the MailSender:

--- a/docs/src/reference/docbook/preface.xml
+++ b/docs/src/reference/docbook/preface.xml
@@ -32,7 +32,7 @@
    http://www.springframework.org/schema/beans 
    http://www.springframework.org/schema/beans/spring-beans.xsd
    http://www.springframework.org/schema/integration 
-   http://www.springframework.org/schema/integration/spring-integration-2.0.xsd
+   http://www.springframework.org/schema/integration/spring-integration.xsd
    http://www.springframework.org/schema/integration/twitter 
    http://www.springframework.org/schema/integration/twitter/spring-integration-twitter.xsd  
    http://www.springframework.org/schema/integration/stream 

--- a/docs/src/reference/docbook/samples.xml
+++ b/docs/src/reference/docbook/samples.xml
@@ -486,11 +486,11 @@ That includes Samples; so, if you can't find what you are looking for, let us kn
       xmlns:beans="http://www.springframework.org/schema/beans"
       xmlns:int-stream="http://www.springframework.org/schema/integration/stream"
       xsi:schemaLocation="http://www.springframework.org/schema/beans
-              http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+              http://www.springframework.org/schema/beans/spring-beans.xsd
               http://www.springframework.org/schema/integration
-              http://www.springframework.org/schema/integration/spring-integration-2.0.xsd
+              http://www.springframework.org/schema/integration/spring-integration.xsd
               http://www.springframework.org/schema/integration/stream
-              http://www.springframework.org/schema/integration/stream/spring-integration-stream-2.0.xsd">
+              http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd">
 
       <int:gateway id="cafe" service-interface="org.springframework.integration.samples.cafe.Cafe"/>
 

--- a/docs/src/reference/docbook/security.xml
+++ b/docs/src/reference/docbook/security.xml
@@ -32,13 +32,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:security="http://www.springframework.org/schema/security"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-      http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+      http://www.springframework.org/schema/beans/spring-beans.xsd
       http://www.springframework.org/schema/security
-      http://www.springframework.org/schema/security/spring-security-2.0.xsd
+      http://www.springframework.org/schema/security/spring-security.xsd
       http://www.springframework.org/schema/integration
-      http://www.springframework.org/schema/integration/spring-integration-2.0.xsd
+      http://www.springframework.org/schema/integration/spring-integration.xsd
       http://www.springframework.org/schema/integration/security
-      http://www.springframework.org/schema/integration/security/spring-integration-security-2.0.xsd">
+      http://www.springframework.org/schema/integration/security/spring-integration-security.xsd">
 
 <int-security:secured-channels>
     <int-security:access-policy pattern="admin.*" send-access="ROLE_ADMIN"/>

--- a/docs/src/reference/docbook/sftp.xml
+++ b/docs/src/reference/docbook/sftp.xml
@@ -25,7 +25,7 @@
     
     <programlisting language="xml"><![CDATA[xmlns:int-sftp="http://www.springframework.org/schema/integration/sftp"
 xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp 
-	http://www.springframework.org/schema/integration/sftp/spring-integration-sftp-2.0.xsd" 
+	http://www.springframework.org/schema/integration/sftp/spring-integration-sftp.xsd"
 ]]></programlisting>
     </para>
   </section>

--- a/docs/src/reference/docbook/stream.xml
+++ b/docs/src/reference/docbook/stream.xml
@@ -66,9 +66,9 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:beans="http://www.springframework.org/schema/beans"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-      http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+      http://www.springframework.org/schema/beans/spring-beans.xsd
       http://www.springframework.org/schema/integration/stream
-      http://www.springframework.org/schema/integration/stream/spring-integration-stream-2.0.xsd">]]></programlisting>
+      http://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd">]]></programlisting>
   </para>
     <para>
     To configure the inbound channel adapter the following code snippet shows the different configuration options that are supported.

--- a/docs/src/reference/docbook/twitter.xml
+++ b/docs/src/reference/docbook/twitter.xml
@@ -29,7 +29,7 @@
 the following within your XML header.
     <programlisting language="xml"><![CDATA[xmlns:int-twitter="http://www.springframework.org/schema/integration/twitter"
 xsi:schemaLocation="http://www.springframework.org/schema/integration/twitter 
-	http://www.springframework.org/schema/integration/twitter/spring-integration-twitter-2.1.xsd"]]></programlisting>
+	http://www.springframework.org/schema/integration/twitter/spring-integration-twitter.xsd"]]></programlisting>
     </para>
   </section>
   

--- a/docs/src/reference/docbook/whats-new.xml
+++ b/docs/src/reference/docbook/whats-new.xml
@@ -276,7 +276,7 @@
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xmlns:int="http://www.springframework.org/schema/integration"
    xsi:schemaLocation="http://www.springframework.org/schema/integration
-           http://www.springframework.org/schema/integration/spring-integration-2.1.xsd
+           http://www.springframework.org/schema/integration/spring-integration.xsd
            http://www.springframework.org/schema/beans
            http://www.springframework.org/schema/beans/spring-beans.xsd">
 ...

--- a/docs/src/reference/docbook/xml.xml
+++ b/docs/src/reference/docbook/xml.xml
@@ -66,7 +66,7 @@
   xmlns:int="http://www.springframework.org/schema/integration"
   xmlns:int-xml="http://www.springframework.org/schema/integration/xml"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    http://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/integration
     http://www.springframework.org/schema/integration/spring-integration.xsd
     http://www.springframework.org/schema/integration/xml

--- a/docs/src/reference/docbook/xmpp.xml
+++ b/docs/src/reference/docbook/xmpp.xml
@@ -34,7 +34,7 @@
     
     <programlisting language="xml"><![CDATA[xmlns:int-xmpp="http://www.springframework.org/schema/integration/xmpp"
 xsi:schemaLocation="http://www.springframework.org/schema/integration/xmpp 
-	http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp-2.0.xsd"]]></programlisting>
+	http://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd"]]></programlisting>
 	
     </para>
   </section>


### PR DESCRIPTION
It is generally advised to use version-less schemas; it is even
mentioned in the what's new section. Some examples
in the reference still had 2.0 schema versions.
