### PR TITLE
INT-2325: fix RedisChannelParser 'serializer' ref

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
@@ -126,7 +126,7 @@ public class SubscribableRedisChannel extends AbstractMessageChannel implements 
 	}
 
 	public int getPhase() {
-		return 0;
+		return (this.container != null) ? this.container.getPhase() : 0;
 	}
 
 	public boolean isRunning() {

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisChannelParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisChannelParser.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.redis.config;
 
+import org.springframework.integration.redis.channel.SubscribableRedisChannel;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -29,14 +30,14 @@ import org.springframework.util.StringUtils;
  * Spring Integration Redis namespace.
  * 
  * @author Oleg Zhurakusky
+ * @author Artem Bilan
  * @since 2.1
  */
 public class RedisChannelParser extends AbstractChannelParser {
 
 	@Override
 	protected BeanDefinitionBuilder buildBeanDefinition(Element element, ParserContext parserContext) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-				"org.springframework.integration.redis.channel.SubscribableRedisChannel");
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(SubscribableRedisChannel.class);
 		String connectionFactory = element.getAttribute("connection-factory");
 		if (!StringUtils.hasText(connectionFactory)) {
 			connectionFactory = "redisConnectionFactory";
@@ -47,9 +48,9 @@ public class RedisChannelParser extends AbstractChannelParser {
 		
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "task-executor");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "phase");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "serializer");
+//		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "phase");
 //		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-startup");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "serializer");
 		return builder;
 	}
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisChannelParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisChannelParserTests-context.xml
@@ -9,9 +9,13 @@
 		http://www.springframework.org/schema/integration/redis http://www.springframework.org/schema/integration/redis/spring-integration-redis.xsd
 		http://www.springframework.org/schema/redis http://www.springframework.org/schema/redis/spring-redis.xsd">
 
-	<int-redis:publish-subscribe-channel id="redisChannel" topic-name="si.test.topic"/>
+	<int-redis:publish-subscribe-channel id="redisChannel" topic-name="si.test.topic"
+			serializer="redisSerializer"/>
 
 	<bean id="redisConnectionFactory" class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory">
 		<property name="port" value="7379"/>
 	</bean>
+
+	<bean id="redisSerializer" class="org.springframework.data.redis.serializer.StringRedisSerializer"/>
+
 </beans>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisChannelParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisChannelParserTests.java
@@ -20,6 +20,7 @@ import org.mockito.Mockito;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessagingException;
 import org.springframework.integration.core.MessageHandler;
@@ -44,7 +45,9 @@ public class RedisChannelParserTests extends RedisAvailableTests{
 		SubscribableChannel redisChannel = context.getBean("redisChannel", SubscribableChannel.class);
 		JedisConnectionFactory connectionFactory = 
 			TestUtils.getPropertyValue(redisChannel, "connectionFactory", JedisConnectionFactory.class);
+		RedisSerializer redisSerializer = TestUtils.getPropertyValue(redisChannel, "serializer", RedisSerializer.class);
 		assertEquals(connectionFactory, context.getBean("redisConnectionFactory"));
+		assertEquals(redisSerializer, context.getBean("redisSerializer"));
 		assertEquals("si.test.topic", TestUtils.getPropertyValue(redisChannel, "topicName"));
 	}
 


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-2325.
Some RedisChannelParser polishing.
Test for 'serializer' attribute.

Also I've removed comments about **'auto-startup'**, because we use in **SubscribableRedisChannel** final **RedisMessageListenerContainer** variable which always is auto-startup:

```
public boolean isAutoStartup() {
    return true;
  }
```
