### PR TITLE
INT-2332 Remove Benign Exceptions From Maven Build

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
@@ -290,7 +290,8 @@
 		channel="tcpChannel"
 		connection-factory="cfC3"
 		client-mode="true"
-		retry-interval="123"
+		retry-interval="123000"
+		auto-startup="false"
 		scheduler="sched" />
 
 	<ip:tcp-connection-factory id="cfC4"
@@ -305,8 +306,9 @@
 		channel="tcpChannel"
 		connection-factory="cfC4"
 		client-mode="true"
-		retry-interval="124"
-		scheduler="sched" />
+		retry-interval="124000"
+		scheduler="sched"
+		auto-startup="false" />
 
 	<ip:tcp-connection-factory id="cfC5"
 		type="client"
@@ -322,8 +324,9 @@
 		connection-factory="cfC5"
 		reply-timeout="456"
 		client-mode="true"
-		retry-interval="125"
+		retry-interval="125000"
 		scheduler="sched"
+		auto-startup="false"
 		/>
 
 	<task:scheduler id="sched"/>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -495,7 +495,7 @@ public class ParserUnitTests {
 		assertNull(dfa.getPropertyValue("serverConnectionFactory"));
 		assertEquals(Boolean.TRUE, dfa.getPropertyValue("isClientMode"));
 		assertSame(sched, dfa.getPropertyValue("scheduler"));
-		assertEquals(123L, dfa.getPropertyValue("retryInterval"));
+		assertEquals(123000L, dfa.getPropertyValue("retryInterval"));
 	}
 
 	@Test
@@ -505,7 +505,7 @@ public class ParserUnitTests {
 		assertNull(dfa.getPropertyValue("serverConnectionFactory"));
 		assertEquals(Boolean.TRUE, dfa.getPropertyValue("isClientMode"));
 		assertSame(sched, dfa.getPropertyValue("scheduler"));
-		assertEquals(124L, dfa.getPropertyValue("retryInterval"));
+		assertEquals(124000L, dfa.getPropertyValue("retryInterval"));
 	}
 
 	@Test
@@ -515,7 +515,7 @@ public class ParserUnitTests {
 		assertNull(dfa.getPropertyValue("serverConnectionFactory"));
 		assertEquals(Boolean.TRUE, dfa.getPropertyValue("isClientMode"));
 		assertSame(sched, dfa.getPropertyValue("scheduler"));
-		assertEquals(125L, dfa.getPropertyValue("retryInterval"));
+		assertEquals(125000L, dfa.getPropertyValue("retryInterval"));
 	}
 
 }


### PR DESCRIPTION
The IP module produced a significant number of benign exceptions
during a maven build. Due to auto-startup adapters with a
small retry-interval for client-mode adapters.

@ghillert
