### PR TITLE
INT-2334 Fix for MongoDbMessageStore storing MessageHistory

### DIFF
--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -16,11 +16,14 @@
 
 package org.springframework.integration.mongodb.store;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.beans.DirectFieldAccessor;
@@ -39,6 +42,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageHeaders;
+import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.store.AbstractMessageGroupStore;
 import org.springframework.integration.store.MessageGroup;
@@ -49,11 +53,17 @@ import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 import com.mongodb.DBObject;
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.integration.history.MessageHistory.NAME_PROPERTY;
+import static org.springframework.integration.history.MessageHistory.TIMESTAMP_PROPERTY;
+import static org.springframework.integration.history.MessageHistory.TYPE_PROPERTY;
 
 /**
  * An implementation of both the {@link MessageStore} and {@link MessageGroupStore}
@@ -61,6 +71,7 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
  * 
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Sean Brandt
  * @since 2.1
  */
 public class MongoDbMessageStore extends AbstractMessageGroupStore implements MessageStore, BeanClassLoaderAware {
@@ -298,6 +309,8 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore implements Me
 			List<Converter<?, ?>> customConverters = new ArrayList<Converter<?,?>>();
 			customConverters.add(new UuidToStringConverter());
 			customConverters.add(new StringToUuidConverter());
+            customConverters.add(new MessageHistoryToDBObjectConverter());
+            customConverters.add(new DBObjectToMessageHistoryConverter());
 			this.setCustomConversions(new CustomConversions(customConverters));
 			super.afterPropertiesSet();
 		}
@@ -356,7 +369,8 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore implements Me
 						throw new IllegalStateException("failed to load class: " + payloadType, e);
 					}
 				}
-				GenericMessage message = new GenericMessage(payload, headers);
+                this.readMessageHistoryHeader(headers);
+                GenericMessage message = new GenericMessage(payload, headers);
 				Map innerMap = (Map) new DirectFieldAccessor(message.getHeaders()).getPropertyValue("headers");
 				// using reflection to set ID and TIMESTAMP since they are immutable through MessageHeaders
 				innerMap.put(MessageHeaders.ID, UUID.fromString((String) headers.get(MessageHeaders.ID)));
@@ -389,7 +403,17 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore implements Me
 			}
 			return null;
 		}
-	}
+
+        private void readMessageHistoryHeader(Map<String, Object> headers) {
+            if ( headers.containsKey(MessageHistory.HEADER_NAME) ) {
+                final Object messageHistoryObject = headers.get(MessageHistory.HEADER_NAME);
+                if (messageHistoryObject != null){
+                	final MessageHistory messageHistory = conversionService.convert(messageHistoryObject, MessageHistory.class);
+                    headers.put(MessageHistory.HEADER_NAME, messageHistory);
+                }  
+            }
+        }
+    }
 
 
 	private static class UuidToStringConverter implements Converter<UUID, String> {
@@ -405,6 +429,49 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore implements Me
 		}
 	}
 
+    private static class MessageHistoryToDBObjectConverter implements Converter<MessageHistory,DBObject> {
+
+        public DBObject convert(MessageHistory source) {
+            BasicDBObject obj = new BasicDBObject();
+            obj.put("_class", MessageHistory.class.getName());
+            BasicDBList dbList = new BasicDBList();
+            obj.put("components", dbList);
+            for (Properties properties : source) {
+                BasicDBObject dbo = new BasicDBObject();
+                dbo.put(NAME_PROPERTY, properties.getProperty(NAME_PROPERTY));
+                dbo.put(TYPE_PROPERTY, properties.getProperty(TYPE_PROPERTY));
+                dbo.put(TIMESTAMP_PROPERTY, properties.getProperty(TIMESTAMP_PROPERTY));
+                dbList.add(dbo);
+            }
+            return obj;
+        }
+    }
+
+    private static class DBObjectToMessageHistoryConverter implements Converter<DBObject,MessageHistory> {
+
+        public MessageHistory convert(DBObject source) {
+            final BasicDBList components = (BasicDBList) source.get("components");
+            List<Properties> history = new ArrayList<Properties>();
+            for (Object o : components) {
+                DBObject dbo = (DBObject) o;
+                Properties p = new Properties();
+                final Set<String> keys = dbo.keySet();
+                for (String key : keys) {
+                    p.setProperty(key, (String) dbo.get(key));
+                }
+                history.add(p);
+            }
+            try {
+                final Constructor<MessageHistory> messageHistoryConstructor = MessageHistory.class.getDeclaredConstructor(List.class);
+                ReflectionUtils.makeAccessible(messageHistoryConstructor);
+                return messageHistoryConstructor.newInstance(history);
+            } 
+            catch (Exception e) {
+                ReflectionUtils.handleReflectionException(e);
+            }
+            return null;
+        }
+    }
 
 	/**
 	 * Wrapper class used for storing Messages in MongoDB along with their "group" metadata.

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -16,14 +16,12 @@
 
 package org.springframework.integration.mongodb.store;
 
-import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.beans.DirectFieldAccessor;
@@ -53,7 +51,6 @@ import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 import com.mongodb.BasicDBList;
@@ -310,7 +307,6 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore implements Me
 			customConverters.add(new UuidToStringConverter());
 			customConverters.add(new StringToUuidConverter());
             customConverters.add(new MessageHistoryToDBObjectConverter());
-            customConverters.add(new DBObjectToMessageHistoryConverter());
 			this.setCustomConversions(new CustomConversions(customConverters));
 			super.afterPropertiesSet();
 		}
@@ -458,32 +454,6 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore implements Me
                 dbList.add(dbo);
             }
             return obj;
-        }
-    }
-
-    private static class DBObjectToMessageHistoryConverter implements Converter<DBObject,MessageHistory> {
-
-        public MessageHistory convert(DBObject source) {
-            final BasicDBList components = (BasicDBList) source.get("components");
-            List<Properties> history = new ArrayList<Properties>();
-            for (Object o : components) {
-                DBObject dbo = (DBObject) o;
-                Properties p = new Properties();
-                final Set<String> keys = dbo.keySet();
-                for (String key : keys) {
-                    p.setProperty(key, (String) dbo.get(key));
-                }
-                history.add(p);
-            }
-            try {
-                final Constructor<MessageHistory> messageHistoryConstructor = MessageHistory.class.getDeclaredConstructor(List.class);
-                ReflectionUtils.makeAccessible(messageHistoryConstructor);
-                return messageHistoryConstructor.newInstance(history);
-            } 
-            catch (Exception e) {
-                ReflectionUtils.handleReflectionException(e);
-            }
-            return null;
         }
     }
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageStoreTests.java
@@ -25,7 +25,6 @@ import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
 import org.springframework.integration.Message;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.history.MessageHistory;
-import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
 import org.springframework.integration.mongodb.rules.MongoDbAvailableTests;
 import org.springframework.integration.support.MessageBuilder;
@@ -35,6 +34,7 @@ import com.mongodb.Mongo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Mark Fisher
@@ -92,7 +92,15 @@ public class MongoDbMessageStoreTests extends MongoDbAvailableTests{
 		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoDbMessageStore store = new MongoDbMessageStore(mongoDbFactory);
 		
-		Message<?> message = new GenericMessage<String>("Hello");
+		Foo foo = new Foo();
+		foo.setName("foo");
+		Message<?> message = MessageBuilder.withPayload(foo).
+				setHeader("foo", foo).
+				setHeader("bar", new Bar("bar")).
+				setHeader("baz", new Baz()).
+				setHeader("abc", new Abc()).
+				setHeader("xyz", new Xyz()).
+				build();
 		DirectChannel fooChannel = new DirectChannel();
 		fooChannel.setBeanName("fooChannel");
 		DirectChannel barChannel = new DirectChannel();
@@ -102,12 +110,66 @@ public class MongoDbMessageStoreTests extends MongoDbAvailableTests{
 		message = MessageHistory.write(message, barChannel);
 		store.addMessage(message);
 		message = store.getMessage(message.getHeaders().getId());
+		assertTrue(message.getHeaders().get("foo") instanceof Foo);
+		assertTrue(message.getHeaders().get("bar") instanceof Bar);
+		assertTrue(message.getHeaders().get("baz") instanceof Baz);
+		assertTrue(message.getHeaders().get("abc") instanceof Abc);
+		assertTrue(message.getHeaders().get("xyz") instanceof Xyz);
 		MessageHistory messageHistory = MessageHistory.read(message);
 		assertNotNull(messageHistory);
 		assertEquals(2, messageHistory.size());
 		Properties fooChannelHistory = messageHistory.get(0);
 		assertEquals("fooChannel", fooChannelHistory.get("name"));
 		assertEquals("channel", fooChannelHistory.get("type"));
+	}
+	
+	public static class Foo{
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+	
+	public static class Bar{
+		private String name;
+		
+		public Bar(String name){
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+	}
+	
+	public static class Baz{
+		private String name = "baz";
+		
+		public String getName() {
+			return name;
+		}
+	}
+	
+	public static class Abc{
+		private String name = "abx";
+		
+		private Abc(){}
+		
+		public String getName() {
+			return name;
+		}
+	}
+	
+	public static class Xyz{
+		@SuppressWarnings("unused")
+		private String name = "xyz";
+		
+		private Xyz(){}
 	}
 
 


### PR DESCRIPTION
This fix ensures that MongoDbMessageStore properly stores
MessageHistory that is stored in the 'history' header
of MessageHeaders.

INT-2334
polished contribution from Sean Brandt, added tests
