### PR TITLE
Add a description and group to the 'reference' task.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -875,6 +875,8 @@ apply plugin: 'docbook-reference'
 
 reference {
     sourceDir = file('src/reference/docbook')
+    group = 'Documentation'
+    description = 'Generate HTML and PDF reference documentation'
 }
 
 task api(type: Javadoc) {


### PR DESCRIPTION
'./gradlew tasks' did not output a description of the reference task.
Add a description of the task to the documentation group.
