### PR TITLE
INT-2399 fix MessageProcessor for service-activator

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,11 @@ import org.springframework.integration.annotation.ServiceActivator;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandler {
 
-	private final AbstractMessageProcessor<Object> processor;
+	private final MessageProcessor<?> processor;
 
 
 	public ServiceActivatingHandler(final Object object) {
@@ -42,7 +43,7 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 		this(new MethodInvokingMessageProcessor<Object>(object, methodName));
 	}
 
-	public ServiceActivatingHandler(AbstractMessageProcessor<Object> processor) {
+	public <T> ServiceActivatingHandler(MessageProcessor<T> processor) {
 		this.processor = processor;
 	}
 
@@ -55,7 +56,9 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 	@Override
 	public final void onInit() {
 		super.onInit();
-		this.processor.setConversionService(this.getConversionService());
+		if (processor instanceof AbstractMessageProcessor) {
+			((AbstractMessageProcessor<?>) this.processor).setConversionService(this.getConversionService());
+		}
 	}
 
 	@Override

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/ServiceActivatorDefaultFrameworkMethodTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/ServiceActivatorDefaultFrameworkMethodTests-context.xml
@@ -13,6 +13,8 @@
 
 	<service-activator id="handlerTestService" input-channel="handlerTestInputChannel" ref="testMessageHandler"/>
 
+	<service-activator id="processorTestService" input-channel="processorTestInputChannel" ref="testMessageProcessor"/>
+
 	<gateway id="gateway" default-request-channel="requestChannel" default-reply-channel="replyChannel"/>
 
 	<channel id="requestChannel"/>
@@ -24,5 +26,9 @@
 	</channel>
 
 	<beans:bean id="testMessageHandler" class="org.springframework.integration.handler.ServiceActivatorDefaultFrameworkMethodTests$TestMessageHandler"/>
+
+	<beans:bean id="testMessageProcessor" class="org.springframework.integration.handler.ServiceActivatorDefaultFrameworkMethodTests$TestMessageProcessor">
+		<beans:property name="prefix" value="foo"/>
+	</beans:bean>
 
 </beans:beans>

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyServiceActivatorTests-context.xml
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyServiceActivatorTests-context.xml
@@ -41,5 +41,17 @@
 	<beans:bean id="date" class="java.util.Date" scope="prototype">
 		<aop:scoped-proxy/>
 	</beans:bean>
-	
+
+	<service-activator input-channel="invalidInlineScript">
+        <groovy:script>
+            <![CDATA[
+                  //import org.springframework.integration.handler.ReplyRequiredException
+
+                  if (payload in ReplyRequiredException) return 'OK'
+                  throw payload
+                ]]>
+        </groovy:script>
+    </service-activator>
+
+
 </beans:beans>


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-2399.
1. ServiceActivatingHandler: refactor for using MessageProcessor interface.
2. ServiceActivatorDefaultFrameworkMethodTests#testMessageProcessor
3. Integration test for <service-activator> with invalid Groovy inline script.
