### PR TITLE
INT-2180: fix Delayer's scheduler docs

### DIFF
--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
@@ -1286,7 +1286,7 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 		<xsd:attribute name="scheduler" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation>
-					Provide a reference to the ScheduledExecutorService instance to which
+					Provide a reference to the TaskScheduler instance to which
 					this endpoint should
 					delegate when scheduling the sending of delayed Messages. If not
 					provided, the default
@@ -1296,7 +1296,7 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 					</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="java.util.concurrent.ScheduledExecutorService" />
+						<tool:expected-type type="org.springframework.scheduling.TaskScheduler" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>

--- a/src/reference/docbook/delayer.xml
+++ b/src/reference/docbook/delayer.xml
@@ -8,7 +8,7 @@
     <para>
       A Delayer is a simple endpoint that allows a Message flow to be delayed by a certain interval. When
       a Message is delayed, the original sender will not block. Instead, the delayed Messages will be
-      scheduled with an instance of <interfacename>java.util.concurrent.ScheduledExecutorService</interfacename>
+      scheduled with an instance of <interfacename>org.springframework.scheduling.TaskScheduler</interfacename>
       to be sent to the output channel after the delay has passed. This approach is scalable even for
       rather long delays, since it does not result in a large number of blocked sender Threads. On the
       contrary, in the typical case a thread pool will be used for the actual execution of releasing the


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-2180.
spring-integration-2.1.xsd: Delayer's scheduler 'documentation' & tool's expected-type.
Reference Manual: Delayer's introduction: fix scheduler's `<interfacename>`.
