### PR TITLE
INT-2405 HeaderEnricher scripts' 'processMessage'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -333,6 +333,7 @@ project('spring-integration-groovy') {
         compile project(":spring-integration-scripting")
         compile "org.codehaus.groovy:groovy-all:$groovyVersion"
         compile "org.springframework:spring-context-support:$springVersion"
+        testCompile project(":spring-integration-test")
     }
     bundlor {
         bundleSymbolicName = 'org.springframework.integration.groovy'

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/HeaderEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/HeaderEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.springframework.integration.support.MessageBuilder;
  * 
  * @author Mark Fisher
  * @author David Turanski
+ * @author Artem Bilan
  */
 public class HeaderEnricher implements Transformer, BeanNameAware, InitializingBean {
 
@@ -249,11 +250,19 @@ public class HeaderEnricher implements Transformer, BeanNameAware, InitializingB
 		}
 	}
 
-	static class MethodInvokingHeaderValueMessageProcessor extends AbstractHeaderValueMessageProcessor<Object> {
+	static class MessageProcessingHeaderValueMessageProcessor extends AbstractHeaderValueMessageProcessor<Object> {
 
-		private final MethodInvokingMessageProcessor<Object> targetProcessor;
+		private final MessageProcessor<?> targetProcessor;
 
-		public MethodInvokingHeaderValueMessageProcessor(Object targetObject, String method) {
+		public <T> MessageProcessingHeaderValueMessageProcessor(MessageProcessor<T> targetProcessor) {
+			this.targetProcessor = targetProcessor;
+		}
+
+		public MessageProcessingHeaderValueMessageProcessor(Object targetObject) {
+			this(targetObject, null);
+		}
+
+		public MessageProcessingHeaderValueMessageProcessor(Object targetObject, String method) {
 			this.targetProcessor = new MethodInvokingMessageProcessor<Object>(targetObject, method);
 		}
 

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyHeaderEnricherTests-context.xml
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyHeaderEnricherTests-context.xml
@@ -22,7 +22,7 @@
 	
 	<int:channel id="inputB"/>
 	
-	<int:header-enricher  input-channel="inputB" output-channel="outputB">
+	<int:header-enricher id="headerEnricherWithInlineGroovyScript" input-channel="inputB" output-channel="outputB">
 		<int:header name="TEST_HEADER">
             <int-groovy:script>
             	<![CDATA[


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-2405.

Force HeaderEnricherParserSupport to use 'processMessage' method-name for scripts MessageProcessor.
GroovyHeaderEnricherTests: polishing to check HeaderValueMessageProcessor for Groovy scripts.
build.gradle: add dependency to 'spring-integration-test' for 'spring-integration-groovy'.
