### PR TITLE
INT-2404 Fix Auto-Created Channel; Event, TCP, UDP

### DIFF
--- a/spring-integration-event/src/main/java/org/springframework/integration/event/config/EventInboundChannelAdapterParser.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/config/EventInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.event.inbound.ApplicationEventListeningMessageProducer;
 
 /**
  * @author Oleg Zhurakousky
@@ -34,9 +35,9 @@ public class EventInboundChannelAdapterParser extends AbstractChannelAdapterPars
 
 	@Override
 	protected AbstractBeanDefinition doParse(Element element, ParserContext parserContext, String channelName) {
-		BeanDefinitionBuilder adapterBuilder = BeanDefinitionBuilder.rootBeanDefinition(
-				"org.springframework.integration.event.inbound.ApplicationEventListeningMessageProducer");
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(adapterBuilder, element, "channel", "outputChannel");
+		BeanDefinitionBuilder adapterBuilder = BeanDefinitionBuilder
+				.rootBeanDefinition(ApplicationEventListeningMessageProducer.class);
+		adapterBuilder.addPropertyReference("outputChannel", channelName);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(adapterBuilder, element, "error-channel", "errorChannel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(adapterBuilder, element, "event-types");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(adapterBuilder, element, "payload-expression");

--- a/spring-integration-event/src/main/resources/org/springframework/integration/event/config/spring-integration-event-2.0.xsd
+++ b/spring-integration-event/src/main/resources/org/springframework/integration/event/config/spring-integration-event-2.0.xsd
@@ -25,7 +25,7 @@
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:attribute name="id" type="xsd:ID" use="optional" />
-			<xsd:attribute name="channel" type="xsd:string" use="required">
+			<xsd:attribute name="channel" type="xsd:string">
 				<xsd:annotation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">

--- a/spring-integration-event/src/main/resources/org/springframework/integration/event/config/spring-integration-event-2.1.xsd
+++ b/spring-integration-event/src/main/resources/org/springframework/integration/event/config/spring-integration-event-2.1.xsd
@@ -25,7 +25,7 @@
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:attribute name="id" type="xsd:string" use="optional" />
-			<xsd:attribute name="channel" type="xsd:string" use="required">
+			<xsd:attribute name="channel" type="xsd:string">
 				<xsd:annotation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests-context.xml
@@ -38,6 +38,10 @@
 		<int:queue/>
 	</int:channel>
 
+	<int-event:inbound-channel-adapter id="autoChannel" payload-expression="source + '-test'"/>
+
+	<int:bridge input-channel="autoChannel" output-channel="nullChannel"/>
+
 	<context:property-placeholder location="classpath:org/springframework/integration/event/config/inbound-adapter.properties"/>
 
 </beans>

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.event.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
@@ -31,6 +32,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -59,6 +61,12 @@ public class EventInboundChannelAdapterParserTests {
 
 	@Autowired
 	MessageChannel errorChannel;
+
+	@Autowired
+	MessageChannel autoChannel;
+
+	@Autowired @Qualifier("autoChannel.adapter")
+	ApplicationEventListeningMessageProducer eventListener;
 
 	@Test
 	public void validateEventParser() {
@@ -126,6 +134,10 @@ public class EventInboundChannelAdapterParserTests {
 		Assert.assertEquals("source + '-test'", expression.getExpressionString());
 	}
 
+	@Test
+	public void testAutoCreateChannel() {
+		assertSame(autoChannel, TestUtils.getPropertyValue(eventListener, "outputChannel"));
+	}
 
 	@SuppressWarnings("serial")
 	public static class SampleEvent extends ApplicationEvent {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpInboundChannelAdapterParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.ip.tcp.TcpReceivingChannelAdapter;
 import org.w3c.dom.Element;
 
 /**
@@ -31,15 +32,11 @@ import org.w3c.dom.Element;
  */
 public class TcpInboundChannelAdapterParser extends AbstractChannelAdapterParser {
 	
-	private static final String BASE_PACKAGE = "org.springframework.integration.ip.tcp";
-
 	protected AbstractBeanDefinition doParse(Element element, ParserContext parserContext, String channelName) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(BASE_PACKAGE +
-				".TcpReceivingChannelAdapter");
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(TcpReceivingChannelAdapter.class);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, 
 				IpAdapterParserUtils.TCP_CONNECTION_FACTORY);
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder,
-				element, "channel", "outputChannel");
+		builder.addPropertyReference("outputChannel", channelName);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder,
 				element, "error-channel", "errorChannel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/UdpInboundChannelAdapterParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/UdpInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.ip.udp.MulticastReceivingChannelAdapter;
+import org.springframework.integration.ip.udp.UnicastReceivingChannelAdapter;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
@@ -32,8 +34,6 @@ import org.w3c.dom.Element;
  */
 public class UdpInboundChannelAdapterParser extends AbstractChannelAdapterParser {
 	
-	private static final String BASE_PACKAGE = "org.springframework.integration.ip.udp";
-
 	protected AbstractBeanDefinition doParse(Element element, ParserContext parserContext, String channelName) {
 		BeanDefinitionBuilder builder = parseUdp(element, parserContext);
 		IpAdapterParserUtils.addCommonSocketOptions(builder, element);
@@ -41,8 +41,7 @@ public class UdpInboundChannelAdapterParser extends AbstractChannelAdapterParser
 				IpAdapterParserUtils.RECEIVE_BUFFER_SIZE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.POOL_SIZE);
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder,
-				element, "channel", "outputChannel");
+		builder.addPropertyReference("outputChannel", channelName);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder,
 				element, "error-channel", "errorChannel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, 
@@ -72,12 +71,10 @@ public class UdpInboundChannelAdapterParser extends AbstractChannelAdapterParser
 		BeanDefinitionBuilder builder;
 		String multicast = IpAdapterParserUtils.getMulticast(element);
 		if (multicast.equals("false")) {
-			builder = BeanDefinitionBuilder.genericBeanDefinition(BASE_PACKAGE +
-					".UnicastReceivingChannelAdapter");
+			builder = BeanDefinitionBuilder.genericBeanDefinition(UnicastReceivingChannelAdapter.class);
 		}
 		else {
-			builder = BeanDefinitionBuilder.genericBeanDefinition(BASE_PACKAGE +
-					".MulticastReceivingChannelAdapter");
+			builder = BeanDefinitionBuilder.genericBeanDefinition(MulticastReceivingChannelAdapter.class);
 			String mcAddress = element
 					.getAttribute(IpAdapterParserUtils.MULTICAST_ADDRESS);
 			if (!StringUtils.hasText(mcAddress)) {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
@@ -331,4 +331,12 @@
 
 	<task:scheduler id="sched"/>
 
+	<ip:tcp-inbound-channel-adapter id="tcpAutoChannel" />
+
+	<int:bridge input-channel="tcpAutoChannel" output-channel="nullChannel" />
+
+	<ip:udp-inbound-channel-adapter id="udpAutoChannel" port="#{tcpIpUtils.findAvailableUdpSocket(5050)}" />
+
+	<int:bridge input-channel="udpAutoChannel" output-channel="nullChannel" />
+
 </beans>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -194,6 +194,18 @@ public class ParserUnitTests {
 	@Autowired
 	@Qualifier(value="org.springframework.integration.ip.tcp.TcpSendingMessageHandler#3")
 	TcpSendingMessageHandler tcpOutClientMode;
+
+	@Autowired
+	MessageChannel tcpAutoChannel;
+
+	@Autowired
+	MessageChannel udpAutoChannel;
+
+	@Autowired @Qualifier("tcpAutoChannel.adapter")
+	TcpReceivingChannelAdapter tcpAutoAdapter;
+
+	@Autowired @Qualifier("udpAutoChannel.adapter")
+	UnicastReceivingChannelAdapter udpAutoAdapter;
 
 	@Test
 	public void testInUdp() {
@@ -518,4 +530,13 @@ public class ParserUnitTests {
 		assertEquals(125000L, dfa.getPropertyValue("retryInterval"));
 	}
 
+	@Test
+	public void testAutoTcp() {
+		assertSame(tcpAutoChannel, TestUtils.getPropertyValue(tcpAutoAdapter, "outputChannel"));
+	}
+
+	@Test
+	public void testAutoUdp() {
+		assertSame(udpAutoChannel, TestUtils.getPropertyValue(udpAutoAdapter, "outputChannel"));
+	}
 }


### PR DESCRIPTION
The AbstractChannelAdapterParser creates an implicit DirectChannel
if the adapter has no 'channel' attribute.

The Event, TCP, and UDP channel adapter parsers did not bind
this channel to the adapter and AC initialization failed with
'outputChannel is required'.

Further, the event schema marked the channel as being 'required',
precluding this feature.
