### PR TITLE
INT-2408 Add Spring Project Nature with Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,12 @@ subprojects { subproject ->
     springSocialTwitterVersion = '1.0.1.RELEASE'
     springWsVersion = '2.0.3.RELEASE'
 
+    eclipse {
+        project {
+            natures += 'org.springframework.ide.eclipse.core.springnature'
+        }
+    }
+
     sourceSets {
         test {
             resources {


### PR DESCRIPTION
STS needs Spring Project Nature to get classpath XSD/Namespace resolution.
When switching back and forth between 2.0 and 2.1, ./gradlew eclipse
removes Spring Project Nature.

It is now added by ./gradlew eclipse when generating eclipse metadata
files.
