### PR TITLE
INT-2406 Add JMSTimestamp Property To Headers

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
@@ -196,6 +196,11 @@ public class DefaultJmsHeaderMapper implements JmsHeaderMapper {
 			catch (Exception e) {
 				logger.info("failed to read JMSType property, skipping", e);
 			}
+			try {
+				headers.put(JmsHeaders.TIMESTAMP, jmsMessage.getJMSTimestamp());
+			} catch (Exception e) {
+				logger.info("failed to read JMSTimestamp property, skipping", e);
+			}
 			Enumeration<?> jmsPropertyNames = jmsMessage.getPropertyNames();
 			if (jmsPropertyNames != null) {
 				while (jmsPropertyNames.hasMoreElements()) {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsHeaders.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsHeaders.java
@@ -41,4 +41,6 @@ public abstract class JmsHeaders {
 
 	public static final String TYPE = PREFIX + "type";
 
+	public static final String TIMESTAMP = PREFIX + "timestamp";
+
 }

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/DefaultJmsHeaderMapperTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/DefaultJmsHeaderMapperTests.java
@@ -206,6 +206,18 @@ public class DefaultJmsHeaderMapperTests {
 	}
 
 	@Test
+	public void testJmsTimestampMappedToHeader() throws JMSException {
+		long timestamp = 123L;
+		javax.jms.Message jmsMessage = new StubTextMessage();
+		jmsMessage.setJMSTimestamp(timestamp);
+		DefaultJmsHeaderMapper mapper = new DefaultJmsHeaderMapper();
+		Map<String, Object> headers = mapper.toHeaders(jmsMessage);
+		Object attrib = headers.get(JmsHeaders.TIMESTAMP);
+		assertNotNull(attrib);
+		assertEquals(timestamp, attrib);
+	}
+
+	@Test
 	public void testUserDefinedPropertyMappedToHeader() throws JMSException {
 		javax.jms.Message jmsMessage = new StubTextMessage();
 		jmsMessage.setIntProperty("foo", 123);


### PR DESCRIPTION
Inbound JMSTimestamp property is now mapped to header
jms_timestamp.

Backport to 2.0.x - simple cherry-pick.
