### PR TITLE
INT-2411 default-output-channel Ignored on RLR

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/RecipientListRouterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/RecipientListRouterParser.java
@@ -65,6 +65,7 @@ public class RecipientListRouterParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(recipientListRouterBuilder, element, "timeout");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(recipientListRouterBuilder, element, "ignore-send-failures");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(recipientListRouterBuilder, element, "apply-sequence");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(recipientListRouterBuilder, element, "default-output-channel");
 		return recipientListRouterBuilder;
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/RecipientListRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/RecipientListRouterTests.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
-
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
@@ -382,6 +381,25 @@ public class RecipientListRouterTests {
 		assertNull(reply5);
 	}
 
+	@Test
+	public void routeToDefaultChannelNoSelectorHits() {
+		QueueChannel channel = new QueueChannel();
+		channel.setBeanName("channel");
+		QueueChannel defaultChannel = new QueueChannel();
+		channel.setBeanName("default");
+		List<Recipient> recipients = new ArrayList<Recipient>();
+		recipients.add(new Recipient(channel, new AlwaysFalseSelector()));
+		RecipientListRouter router = new RecipientListRouter();
+		router.setRecipients(recipients);
+		router.setDefaultOutputChannel(defaultChannel);
+		Message<String> message = new GenericMessage<String>("test");
+		router.handleMessage(message);
+		Message<?> result1 = defaultChannel.receive(25);
+		assertNotNull(result1);
+		assertEquals("test", result1.getPayload());
+		Message<?> result2 = channel.receive(5);
+		assertNull(result2);
+	}
 
 	private static class AlwaysTrueSelector implements MessageSelector {
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RecipientListRouterParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RecipientListRouterParserTests-context.xml
@@ -44,6 +44,10 @@
 		<recipient selector-expression="@testBean.accept(payload)" channel="channel3"/>
 	</recipient-list-router>
 
+	<recipient-list-router id="noSelectorMatchRouter" input-channel="noSelectorMatchInput" default-output-channel="channel1">
+		<recipient selector-expression="false" channel="channel2"/>
+	</recipient-list-router>
+
 	<beans:bean id="testBean" class="org.springframework.integration.router.config.RecipientListRouterParserTests.TestBean"/>
 
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RecipientListRouterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RecipientListRouterParserTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.router.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -54,6 +55,9 @@ public class RecipientListRouterParserTests {
 
 	@Autowired
 	private MessageChannel simpleDynamicInput;
+
+	@Autowired
+	private MessageChannel noSelectorMatchInput;
 
 	@Test
 	public void checkMessageRouting() {
@@ -103,6 +107,18 @@ public class RecipientListRouterParserTests {
 		assertNull(chanel2.receive(0));
 	}
 
+	@Test
+	public void noSelectorMatchRouter() {
+		context.start();
+		Message<?> message = new GenericMessage<Integer>(1);
+		noSelectorMatchInput.send(message);
+		PollableChannel chanel1 = (PollableChannel) context.getBean("channel1");
+		PollableChannel chanel2 = (PollableChannel) context.getBean("channel2");
+		Message<?> output = chanel1.receive(0);
+		assertNotNull(output);
+		assertTrue(output.getPayload().equals(1));
+		assertNull(chanel2.receive(0));
+	}
 
 	public static class TestBean {
 


### PR DESCRIPTION
https://jira.springsource.org/browse/INT-2411

Namespace problem only; the default-output-channel was
not bound to the RecipientListRouter.

Workaround is to declare the router using &lt;bean/&gt; syntax.
