### PR TITLE
INT-2413 <int-jmx:mbean-export/> And <control-bus>

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @since 2.1
  */
-public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter {
+public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter implements MappingMessageRouterManagement {
 
 	private volatile Map<String, String> channelMappings = new ConcurrentHashMap<String, String>();
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/MappingMessageRouterManagement.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/MappingMessageRouterManagement.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.router;
+
+import org.springframework.jmx.export.annotation.ManagedOperation;
+
+/**
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+public interface MappingMessageRouterManagement {
+
+	/**
+	 * Add a channel mapping from the provided key to channel name.
+	 */
+	@ManagedOperation
+	public abstract void setChannelMapping(String key, String channelName);
+
+	/**
+	 * Remove a channel mapping for the given key if present.
+	 */
+	@ManagedOperation
+	public abstract void removeChannelMapping(String key);
+
+}

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/UpdateMappingsTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/UpdateMappingsTests-context.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jmx="http://www.springframework.org/schema/integration/jmx"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.1.xsd
+		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx-2.1.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+	<context:mbean-server />
+
+	<int-jmx:mbean-export/>
+
+	<int:channel id="in" />
+
+	<int:router id="router" input-channel="in" ref="myRouter" resolution-required="false"/>
+
+	<bean id="myRouter" class="org.springframework.integration.router.HeaderValueRouter">
+		<constructor-arg value="routing.header" />
+	</bean>
+
+	<int:channel id="control" />
+
+	<int:control-bus input-channel="control" />
+
+	<int:channel id="qux">
+		<int:queue />
+	</int:channel>
+
+</beans>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/UpdateMappingsTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/UpdateMappingsTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jmx;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.Message;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.core.PollableChannel;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class UpdateMappingsTests {
+
+	@Autowired
+	private MessageChannel control;
+
+	@Autowired
+	private MessageChannel in;
+
+	@Autowired
+	private PollableChannel qux;
+
+	@Test
+	public void test() {
+		control.send(new GenericMessage<String>("@myRouter.setChannelMapping('baz', 'qux')"));
+		Message<?> message = MessageBuilder.withPayload("Hello, world!")
+				.setHeader("routing.header", "baz").build();
+		in.send(message);
+		assertNotNull(qux.receive());
+	}
+
+}


### PR DESCRIPTION
When an AbstractMappingMessageRouter is included in an
ApplicationContext that also has an &lt;int-jmx:mbean-exporter/&gt;,
the @ManagedOperations (set and remove mapping) are no longer
visible to the &lt;control-bus/&gt;.

Adds these methods to a new interface MappingMessageRouterManagement,
thus making them available on the proxy that the MBean exporter
creates.
