### PR TITLE
INT-2415 MBean Name Collisions in Tests

### DIFF
--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/UpdateMappingsTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/UpdateMappingsTests-context.xml
@@ -11,7 +11,7 @@
 
 	<context:mbean-server />
 
-	<int-jmx:mbean-export/>
+	<int-jmx:mbean-export default-domain="update.mapping.domain"/>
 
 	<int:channel id="in" />
 


### PR DESCRIPTION
JMX Tests failed due to InstanceAlreadyExistsException; name
collisions between MBeans registered in multiple tests.

Adds a domain to the new tests added to fix INT-2413 to
force unique MBean names.
