### PR TITLE
INT-2414 Error When container-class Supplied

### DIFF
--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests-context.xml
@@ -59,9 +59,19 @@
 	</bean>
 
 	<alias name="connectionFactory" alias="connFact"/>
-	
-	
+
 	<jms:channel id="withPlaceholders" queue="${queue}" 
 									   concurrency="${concurrency}"/>
+
+	<jms:channel id="withDefaultContainer" queue-name="default.container.queue" />
+
+	<jms:channel id="withExplicitDefaultContainer" queue-name="explicit.default.container.queue"
+		container-type="default" />
+
+	<jms:channel id="withSimpleContainer" queue-name="simple.container.queue"
+		container-type="simple"/>
+
+	<jms:channel id="withContainerClass" queue-name="custom.container.queue"
+		container-class="org.springframework.integration.jms.config.JmsChannelParserTests$CustomTestMessageListenerContainer" />
 
 </beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import javax.jms.Topic;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.support.AbstractApplicationContext;
@@ -42,12 +41,14 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
+import org.springframework.jms.listener.SimpleMessageListenerContainer;
 import org.springframework.jms.support.destination.DestinationResolver;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -94,6 +95,18 @@ public class JmsChannelParserTests {
 
 	@Autowired
 	private Topic topic;
+
+	@Autowired
+	private MessageChannel withDefaultContainer;
+
+	@Autowired
+	private MessageChannel withExplicitDefaultContainer;
+
+	@Autowired
+	private MessageChannel withSimpleContainer;
+
+	@Autowired
+	private MessageChannel withContainerClass;
 
 	@Autowired
 	private AbstractApplicationContext context;
@@ -231,6 +244,38 @@ public class JmsChannelParserTests {
 		System.out.println(container.getMaxConcurrentConsumers());
 	}
 
+	@Test
+	public void withDefaultContainer() {
+		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(
+				withDefaultContainer, "container",
+				DefaultMessageListenerContainer.class);
+		assertEquals("default.container.queue", container.getDestinationName());
+	}
+
+	@Test
+	public void withExplicitDefaultContainer() {
+		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(
+				withExplicitDefaultContainer, "container",
+				DefaultMessageListenerContainer.class);
+		assertEquals("explicit.default.container.queue", container.getDestinationName());
+	}
+
+	@Test
+	public void withSimpleContainer() {
+		SimpleMessageListenerContainer container = TestUtils.getPropertyValue(
+				withSimpleContainer, "container",
+				SimpleMessageListenerContainer.class);
+		assertEquals("simple.container.queue", container.getDestinationName());
+	}
+
+	@Test
+	public void withContainerClass() {
+		CustomTestMessageListenerContainer container = TestUtils.getPropertyValue(
+				withContainerClass, "container",
+				CustomTestMessageListenerContainer.class);
+		assertEquals("custom.container.queue", container.getDestinationName());
+	}
+
 
 	static class TestDestinationResolver implements DestinationResolver {
 
@@ -251,6 +296,10 @@ public class JmsChannelParserTests {
 
 
 	static class TestInterceptor extends ChannelInterceptorAdapter {
+	}
+
+	static class CustomTestMessageListenerContainer extends DefaultMessageListenerContainer {
+
 	}
 
 }


### PR DESCRIPTION
JMS backed channels can have container-type and
container-class. Parser rejected container-class because
the schema has a default for container-type.

Both attributes are allowed; user must set container-type
appropriately (based on the superclass of the custom class)
when container-class is provided.
