### PR TITLE
INT-2409 Fix STS 'Missing Bean' Warnings

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractOutboundChannelAdapterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.config.xml;
 
 import org.w3c.dom.Element;
 
+import org.springframework.beans.factory.parsing.BeanComponentDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
@@ -29,6 +30,7 @@ import org.springframework.util.xml.DomUtils;
  * Base class for outbound Channel Adapter parsers.
  * 
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public abstract class AbstractOutboundChannelAdapterParser extends AbstractChannelAdapterParser {
 
@@ -65,8 +67,10 @@ public abstract class AbstractOutboundChannelAdapterParser extends AbstractChann
 		if (StringUtils.hasText(order)) {
 			definition.getPropertyValues().addPropertyValue("order", order);
 		}
-		return BeanDefinitionReaderUtils.registerWithGeneratedName(
+		String beanName = BeanDefinitionReaderUtils.generateBeanName(
 				definition, parserContext.getRegistry());
+		parserContext.registerBeanComponent(new BeanComponentDefinition(definition, beanName));
+		return beanName;
 	}
 
 	/**


### PR DESCRIPTION
Some generated bean names (e.g. LoggingHandler) cause
warnings in STS:

(Warning "Referenced bean
'org.springframework.integration.handler.LoggingHandler#0' not found")

Fix is to register these beans as components so an event is fired.
