### PR TITLE
INT-2396

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
@@ -65,15 +65,15 @@ public abstract class AbstractCorrelatingMessageHandlerParser extends AbstractCo
 		if (StringUtils.hasText(beanRef)) {
 			adapter = this.createAdapter(new RuntimeBeanReference(beanRef), beanMethod, adapterClass, parserContext);
 		}
-		else if (processor != null) {
-			adapter = this.createAdapter(processor, beanMethod, adapterClass, parserContext);
-		}
 		else if (StringUtils.hasText(expression)) {
 			BeanDefinitionBuilder adapterBuilder = BeanDefinitionBuilder
 					.genericBeanDefinition(IntegrationNamespaceUtils.BASE_PACKAGE + ".aggregator.ExpressionEvaluating"
 							+ adapterClass);
 			adapterBuilder.addConstructorArgValue(expression);
 			adapter = adapterBuilder.getBeanDefinition();
+		}
+		else if (processor != null) {
+			adapter = this.createAdapter(processor, beanMethod, adapterClass, parserContext);
 		}
 		else {
 			adapter = this.createAdapter(null, beanMethod, adapterClass, parserContext);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
@@ -58,14 +58,25 @@ public abstract class AbstractCorrelatingMessageHandlerParser extends AbstractCo
 	protected void injectPropertyWithAdapter(String beanRefAttribute, String methodRefAttribute,
 			String expressionAttribute, String beanProperty, String adapterClass, Element element,
 			BeanDefinitionBuilder builder, BeanMetadataElement processor, ParserContext parserContext) {
+		
 		final String beanRef = element.getAttribute(beanRefAttribute);
 		final String beanMethod = element.getAttribute(methodRefAttribute);
 		final String expression = element.getAttribute(expressionAttribute);
+		
+		final boolean hasBeanRef = StringUtils.hasText(beanRef);
+		final boolean hasExpression = StringUtils.hasText(expression);
+		
+		if (hasBeanRef && hasExpression) {
+			parserContext.getReaderContext().error(
+					"Exactly one of the '" + beanRefAttribute + "' or '" + expressionAttribute +
+					"' attribute is allowed.", element);
+		}
+		
 		BeanMetadataElement adapter = null;
-		if (StringUtils.hasText(beanRef)) {
+		if (hasBeanRef) {
 			adapter = this.createAdapter(new RuntimeBeanReference(beanRef), beanMethod, adapterClass, parserContext);
 		}
-		else if (StringUtils.hasText(expression)) {
+		else if (hasExpression) {
 			BeanDefinitionBuilder adapterBuilder = BeanDefinitionBuilder
 					.genericBeanDefinition(IntegrationNamespaceUtils.BASE_PACKAGE + ".aggregator.ExpressionEvaluating"
 							+ adapterClass);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
@@ -18,6 +18,9 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.aggregator.AbstractCorrelatingMessageHandler;
 import org.springframework.util.StringUtils;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Element;
 
 /**
@@ -28,6 +31,8 @@ import org.w3c.dom.Element;
  *
  */
 public abstract class AbstractCorrelatingMessageHandlerParser extends AbstractConsumerEndpointParser {
+	
+	private final Log logger = LogFactory.getLog(this.getClass());
 
 	private static final String CORRELATION_STRATEGY_REF_ATTRIBUTE = "correlation-strategy";
 
@@ -67,9 +72,9 @@ public abstract class AbstractCorrelatingMessageHandlerParser extends AbstractCo
 		final boolean hasExpression = StringUtils.hasText(expression);
 		
 		if (hasBeanRef && hasExpression) {
-			parserContext.getReaderContext().error(
-					"Exactly one of the '" + beanRefAttribute + "' or '" + expressionAttribute +
-					"' attribute is allowed.", element);
+			this.logger.warn("Exactly one of the '" + beanRefAttribute + "' or '" + expressionAttribute +
+					"' attribute is allowed. NOTE: This is a warining message only to avoid breaking change in the point release and should " +
+					"be treated as error. In the future release this condition will result in the actual exception");
 		}
 		
 		BeanMetadataElement adapter = null;

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanCreationException;
-import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
@@ -237,10 +236,11 @@ public class AggregatorParserTests {
 		assertTrue(ExpressionEvaluatingCorrelationStrategy.class.equals(correlationStrategy.getClass()));
 	}
 	
-	@Test(expected=BeanDefinitionParsingException.class)
-	public void testAggregatorFailureIfMutuallyExclusivityPresent() {
-		this.context = new ClassPathXmlApplicationContext("aggregatorParserFailTests.xml", this.getClass());
-	}
+	// should be re-enabled for INT-2497
+//	@Test(expected=BeanDefinitionParsingException.class) 
+//	public void testAggregatorFailureIfMutuallyExclusivityPresent() {
+//		this.context = new ClassPathXmlApplicationContext("aggregatorParserFailTests.xml", this.getClass());
+//	}
 	
 	private static <T> Message<T> createMessage(T payload, Object correlationId, int sequenceSize, int sequenceNumber,
 			MessageChannel outputChannel) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
@@ -235,11 +236,15 @@ public class AggregatorParserTests {
 		assertTrue(ExpressionEvaluatingReleaseStrategy.class.equals(releaseStrategy.getClass()));
 		assertTrue(ExpressionEvaluatingCorrelationStrategy.class.equals(correlationStrategy.getClass()));
 	}
-
+	
+	@Test(expected=BeanDefinitionParsingException.class)
+	public void testAggregatorFailureIfMutuallyExclusivityPresent() {
+		this.context = new ClassPathXmlApplicationContext("aggregatorParserFailTests.xml", this.getClass());
+	}
+	
 	private static <T> Message<T> createMessage(T payload, Object correlationId, int sequenceSize, int sequenceNumber,
 			MessageChannel outputChannel) {
 		return MessageBuilder.withPayload(payload).setCorrelationId(correlationId).setSequenceSize(sequenceSize)
 				.setSequenceNumber(sequenceNumber).setReplyChannel(outputChannel).build();
 	}
-
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.ApplicationContext;
@@ -35,6 +36,9 @@ import org.springframework.integration.MessageHandlingException;
 import org.springframework.integration.MessageRejectedException;
 import org.springframework.integration.aggregator.AggregatingMessageHandler;
 import org.springframework.integration.aggregator.CorrelationStrategy;
+import org.springframework.integration.aggregator.ExpressionEvaluatingCorrelationStrategy;
+import org.springframework.integration.aggregator.ExpressionEvaluatingReleaseStrategy;
+import org.springframework.integration.aggregator.MethodInvokingMessageGroupProcessor;
 import org.springframework.integration.aggregator.MethodInvokingReleaseStrategy;
 import org.springframework.integration.aggregator.ReleaseStrategy;
 import org.springframework.integration.core.MessageHandler;
@@ -47,6 +51,7 @@ import org.springframework.integration.test.util.TestUtils;
 import static org.hamcrest.CoreMatchers.is;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -215,6 +220,20 @@ public class AggregatorParserTests {
 	@Test(expected = BeanCreationException.class)
 	public void testAggregatorWithInvalidReleaseStrategyMethod() {
 		context = new ClassPathXmlApplicationContext("invalidReleaseStrategyMethod.xml", this.getClass());
+	}
+	
+	@Test
+	public void testAggregationWithExpressionsAndPojoAggregator() {
+		EventDrivenConsumer aggregatorConsumer = (EventDrivenConsumer) context.getBean("aggregatorWithExpressionsAndPojoAggregator");
+		AggregatingMessageHandler aggregatingMessageHandler = (AggregatingMessageHandler) TestUtils.getPropertyValue(aggregatorConsumer, "handler");
+		MethodInvokingMessageGroupProcessor messageGroupProcessor = (MethodInvokingMessageGroupProcessor) TestUtils.getPropertyValue(aggregatingMessageHandler, "outputProcessor");
+		Object messageGroupProcessorTargetObject = TestUtils.getPropertyValue(messageGroupProcessor, "processor.delegate.targetObject");
+		assertSame(context.getBean("aggregatorBean"), messageGroupProcessorTargetObject);
+		ReleaseStrategy releaseStrategy = (ReleaseStrategy) TestUtils.getPropertyValue(aggregatingMessageHandler, "releaseStrategy");
+		CorrelationStrategy correlationStrategy = (CorrelationStrategy) TestUtils.getPropertyValue(aggregatingMessageHandler, "correlationStrategy");
+
+		assertTrue(ExpressionEvaluatingReleaseStrategy.class.equals(releaseStrategy.getClass()));
+		assertTrue(ExpressionEvaluatingCorrelationStrategy.class.equals(correlationStrategy.getClass()));
 	}
 
 	private static <T> Message<T> createMessage(T payload, Object correlationId, int sequenceSize, int sequenceNumber,

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/aggregatorParserFailTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/aggregatorParserFailTests.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+			http://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/integration
+			http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<channel id="aggregatorWithExpressionsAndPojoAggregatorInput"/>
+	<aggregator id="aggregatorWithExpressionsAndPojoAggregator"
+		input-channel="aggregatorWithExpressionsAndPojoAggregatorInput"
+		ref="aggregatorBean"
+		release-strategy="releaseStrategy"
+		release-strategy-expression="size() == 2"
+        correlation-strategy-expression="headers['foo']"/>
+
+	<beans:bean id="aggregatorBean"
+		class="org.springframework.integration.config.TestAggregatorBean" />
+
+	<beans:bean id="releaseStrategy"
+		class="org.springframework.integration.config.TestReleaseStrategy" />
+
+</beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/aggregatorParserTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/aggregatorParserTests.xml
@@ -62,11 +62,20 @@
 		method="add"
 		release-strategy="pojoReleaseStrategy"
 		release-strategy-method="checkCompletenessAsCollection"/>
+		
+	<channel id="aggregatorWithExpressionsAndPojoAggregatorInput"/>
+	<channel id="aggregatorWithExpressionsAndPojoAggregatorOutput"/>
+	<aggregator id="aggregatorWithExpressionsAndPojoAggregator"
+		input-channel="aggregatorWithExpressionsAndPojoAggregatorInput"
+		output-channel="aggregatorWithExpressionsAndPojoAggregatorOutput"
+		ref="aggregatorBean"
+		release-strategy-expression="size() == 2"
+        correlation-strategy-expression="headers['foo']"/>
 
 	<beans:bean id="aggregatorBean"
 		class="org.springframework.integration.config.TestAggregatorBean" />
 
-	<beans:bean id="adderBean"
+	 <beans:bean id="adderBean"
 		class="org.springframework.integration.config.Adder" />
 
 	<beans:bean id="releaseStrategy"
@@ -77,6 +86,6 @@
 	<beans:bean id="pojoReleaseStrategy"
 		class="org.springframework.integration.config.MaxValueReleaseStrategy">
 		<beans:constructor-arg value="10" />
-	</beans:bean>
+	</beans:bean> 
 
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/aggregatorParserTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/aggregatorParserTests.xml
@@ -64,10 +64,8 @@
 		release-strategy-method="checkCompletenessAsCollection"/>
 		
 	<channel id="aggregatorWithExpressionsAndPojoAggregatorInput"/>
-	<channel id="aggregatorWithExpressionsAndPojoAggregatorOutput"/>
 	<aggregator id="aggregatorWithExpressionsAndPojoAggregator"
 		input-channel="aggregatorWithExpressionsAndPojoAggregatorInput"
-		output-channel="aggregatorWithExpressionsAndPojoAggregatorOutput"
 		ref="aggregatorBean"
 		release-strategy-expression="size() == 2"
         correlation-strategy-expression="headers['foo']"/>
@@ -87,5 +85,4 @@
 		class="org.springframework.integration.config.MaxValueReleaseStrategy">
 		<beans:constructor-arg value="10" />
 	</beans:bean> 
-
 </beans:beans>


### PR DESCRIPTION
ensured that 'expression*' attributes are parsed by the AggregatorParser when 'ref' is used to define the actual aggregator
