### PR TITLE
INT-2427 Fix Types of AMQP Outbound Endpoints

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
  * 
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.1
  */
 public class AmqpOutboundEndpoint extends AbstractReplyProducingMessageHandler {
@@ -111,7 +112,7 @@ public class AmqpOutboundEndpoint extends AbstractReplyProducingMessageHandler {
 
 	@Override
 	public String getComponentType() {
-		return expectReply ? "amqp:outbound-channel-adapter" : "amqp:outbound-gateway";
+		return expectReply ? "amqp:outbound-gateway" : "amqp:outbound-channel-adapter";
 	}
 
 	@Override

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
@@ -46,6 +46,7 @@ import static junit.framework.Assert.assertEquals;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.1
  */
 @ContextConfiguration
@@ -63,6 +64,7 @@ public class AmqpOutboundChannelAdapterParserTests {
 		assertEquals(EventDrivenConsumer.class, adapter.getClass());
 		MessageHandler handler = TestUtils.getPropertyValue(adapter, "handler", MessageHandler.class);
 		assertEquals(AmqpOutboundEndpoint.class, handler.getClass());
+		assertEquals("amqp:outbound-channel-adapter", ((AmqpOutboundEndpoint) handler).getComponentType());
 	}
 	
 	@SuppressWarnings("rawtypes")

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
@@ -42,6 +42,8 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gary Russell
+ * @since 2.1
  *
  */
 public class AmqpOutboundGatewayParserTests {
@@ -54,6 +56,7 @@ public class AmqpOutboundGatewayParserTests {
 		assertEquals(5, gateway.getOrder());
 		assertTrue(context.containsBean("rabbitGateway"));
 		assertEquals(context.getBean("fromRabbit"), TestUtils.getPropertyValue(gateway, "outputChannel"));
+		assertEquals("amqp:outbound-gateway", gateway.getComponentType());
 	}
 	
 	@SuppressWarnings("rawtypes")


### PR DESCRIPTION
Logic for returning gateway Vs. channel-adapter was
reversed.

@olegz
