### PR TITLE
INT-2431 Improve 'Dispatcher Has No Subscribers'

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/AbstractSubscribableAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/AbstractSubscribableAmqpChannel.java
@@ -53,21 +53,20 @@ abstract class AbstractSubscribableAmqpChannel extends AbstractAmqpChannel imple
 
 	private volatile MessageDispatcher dispatcher;
 
-	private volatile boolean isPubSub;
+	private final boolean isPubSub;
 
 	public AbstractSubscribableAmqpChannel(String channelName, SimpleMessageListenerContainer container, AmqpTemplate amqpTemplate) {
+		this(channelName, container, amqpTemplate, false);
+	}
+
+	public AbstractSubscribableAmqpChannel(String channelName,
+			SimpleMessageListenerContainer container,
+			AmqpTemplate amqpTemplate, boolean isPubSub) {
 		super(amqpTemplate);
 		Assert.notNull(container, "container must not be null");
 		Assert.hasText(channelName, "channel name must not be empty");
 		this.channelName = channelName;
 		this.container = container;
-	}
-
-	public boolean isPubSub() {
-		return isPubSub;
-	}
-
-	public void setPubSub(boolean isPubSub) {
 		this.isPubSub = isPubSub;
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/AbstractSubscribableAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/AbstractSubscribableAmqpChannel.java
@@ -39,6 +39,7 @@ import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.dispatcher.MessageDispatcher;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Mark Fisher
@@ -138,8 +139,9 @@ abstract class AbstractSubscribableAmqpChannel extends AbstractAmqpChannel imple
 				}
 			}
 			catch (MessageDispatchingException e) {
+				String channelName = StringUtils.hasText(this.channelName) ? this.channelName : "unknown";
 				String exceptionMessage = e.getMessage() + " for amqp-channel "
-						+ this.channelName + ".";
+						+ channelName + ".";
 				if (this.isPubSub) {
 					// log only for backwards compatibility with pub/sub
 					if (logger.isWarnEnabled()) {

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
@@ -37,7 +37,7 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 
 
 	public PublishSubscribeAmqpChannel(String channelName, SimpleMessageListenerContainer container, AmqpTemplate amqpTemplate) {
-		super(channelName, container, amqpTemplate);
+		super(channelName, container, amqpTemplate, true);
 	}
 
 
@@ -49,7 +49,6 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 	 */
 	public void setExchange(FanoutExchange exchange) {
 		this.exchange = exchange;
-		this.setPubSub(true);
 	}
 
 	@Override

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.integration.dispatcher.MessageDispatcher;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.1
  */
 public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel {
@@ -48,6 +49,7 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 	 */
 	public void setExchange(FanoutExchange exchange) {
 		this.exchange = exchange;
+		this.setPubSub(true);
 	}
 
 	@Override
@@ -65,7 +67,7 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 
 	@Override
 	protected MessageDispatcher createDispatcher() {
-		return new BroadcastingDispatcher();
+		return new BroadcastingDispatcher(true);
 	}
 
 	@Override

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.amqp.channel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.integration.MessageDeliveryException;
+import org.springframework.integration.test.util.TestUtils;
+
+import com.rabbitmq.client.Channel;
+
+
+/**
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+public class DispatcherHasNoSubscribersTests {
+
+	@Test
+	public void testPtP() {
+		final Channel channel = mock(Channel.class);
+		Connection connection = mock(Connection.class);
+		doAnswer(new Answer<Channel>() {
+			public Channel answer(InvocationOnMock invocation) throws Throwable {
+				return channel;
+			}}).when(connection).createChannel(anyBoolean());
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
+
+		PointToPointSubscribableAmqpChannel amqpChannel = new PointToPointSubscribableAmqpChannel("noSubscribersChannel",
+				container, amqpTemplate);
+		amqpChannel.afterPropertiesSet();
+
+		MessageListener listener = (MessageListener) container.getMessageListener();
+		try {
+			listener.onMessage(new Message("Hello world!".getBytes(), null));
+			fail("Exception expected");
+		}
+		catch (MessageDeliveryException e) {
+			assertEquals("Dispatcher has no subscribers for amqp-channel noSubscribersChannel.", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testPubSub() {
+		final Channel channel = mock(Channel.class);
+		Connection connection = mock(Connection.class);
+		doAnswer(new Answer<Channel>() {
+			public Channel answer(InvocationOnMock invocation) throws Throwable {
+				return channel;
+			}}).when(connection).createChannel(anyBoolean());
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
+		final Queue queue = new Queue("noSubscribersQueue");
+		PublishSubscribeAmqpChannel amqpChannel = new PublishSubscribeAmqpChannel("noSubscribersChannel",
+				container, amqpTemplate) { 
+					@Override
+					protected Queue initializeQueue(AmqpAdmin admin,
+							String channelName) {
+						return queue;
+					}};
+		amqpChannel.setPubSub(true);
+		amqpChannel.afterPropertiesSet();
+
+		List<String> logList = insertMockLoggerInListener(amqpChannel);
+		MessageListener listener = (MessageListener) container.getMessageListener();
+		listener.onMessage(new Message("Hello world!".getBytes(), null));
+		verifyLogReceived(logList);
+	}
+
+	private List<String> insertMockLoggerInListener(
+			PublishSubscribeAmqpChannel channel) {
+		SimpleMessageListenerContainer container = TestUtils.getPropertyValue(
+				channel, "container", SimpleMessageListenerContainer.class);
+		Log logger = mock(Log.class);
+		final ArrayList<String> logList = new ArrayList<String>();
+		doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation)
+					throws Throwable {
+				String message = (String) invocation.getArguments()[0];
+				if (message.startsWith("Dispatcher has no subscribers")) {
+					logList.add(message);
+				}
+				return null;
+			}}).when(logger).warn(anyString(), any(Exception.class));
+		when(logger.isWarnEnabled()).thenReturn(true);
+		Object listener = container.getMessageListener();
+		DirectFieldAccessor dfa = new DirectFieldAccessor(listener);
+		dfa.setPropertyValue("logger", logger);
+		return logList;
+	}
+
+	private void verifyLogReceived(final List<String> logList) {
+		assertTrue("Failed to get expected exception", logList.size() > 0);
+		boolean expectedExceptionFound = false;
+		while (logList.size() > 0) {
+			String message = logList.remove(0);
+			assertNotNull("Failed to get expected exception", message);
+			if (message.startsWith("Dispatcher has no subscribers")) {
+				expectedExceptionFound = true;
+				assertEquals("Dispatcher has no subscribers for amqp-channel noSubscribersChannel.", message);
+				break;
+			}
+		}
+		assertTrue("Failed to get expected exception", expectedExceptionFound);
+	}
+
+}

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
@@ -104,7 +104,6 @@ public class DispatcherHasNoSubscribersTests {
 							String channelName) {
 						return queue;
 					}};
-		amqpChannel.setPubSub(true);
 		amqpChannel.afterPropertiesSet();
 
 		List<String> logList = insertMockLoggerInListener(amqpChannel);

--- a/spring-integration-core/src/main/java/org/springframework/integration/MessageDispatchingException.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/MessageDispatchingException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration;
+
+import org.springframework.integration.dispatcher.MessageDispatcher;
+
+/**
+ * Exception that indicates an internal error occurred within
+ * a {@link MessageDispatcher} preventing message delivery.
+ *
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+@SuppressWarnings("serial")
+public class MessageDispatchingException extends MessageDeliveryException {
+
+	public MessageDispatchingException(String description) {
+		super(description);
+	}
+
+	public MessageDispatchingException(Message<?> undeliveredMessage,
+			String description, Throwable cause) {
+		super(undeliveredMessage, description, cause);
+	}
+
+	public MessageDispatchingException(Message<?> undeliveredMessage,
+			String description) {
+		super(undeliveredMessage, description);
+	}
+
+	public MessageDispatchingException(Message<?> undeliveredMessage) {
+		super(undeliveredMessage);
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractSubscribableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractSubscribableChannel.java
@@ -27,6 +27,7 @@ import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.dispatcher.MessageDispatcher;
 import org.springframework.integration.dispatcher.UnicastingDispatcher;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Base implementation of {@link MessageChannel} that invokes the subscribed
@@ -65,8 +66,10 @@ public abstract class AbstractSubscribableChannel extends AbstractMessageChannel
 			return this.getRequiredDispatcher().dispatch(message);
 		}
 		catch (MessageDispatchingException e) {
+			String componentName = this.getComponentName();
+			componentName = StringUtils.hasText(componentName) ? componentName : "unknown";
 			throw new MessageDeliveryException(message, e.getMessage()
-					+ " for channel " + this.getComponentName() + ".", e);
+					+ " for channel " + componentName + ".", e);
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractSubscribableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractSubscribableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
+import org.springframework.integration.MessageDeliveryException;
+import org.springframework.integration.MessageDispatchingException;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.dispatcher.MessageDispatcher;
@@ -32,6 +34,7 @@ import org.springframework.util.Assert;
  * 
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
 public abstract class AbstractSubscribableChannel extends AbstractMessageChannel implements SubscribableChannel {
 	
@@ -58,7 +61,13 @@ public abstract class AbstractSubscribableChannel extends AbstractMessageChannel
 
 	@Override
 	protected boolean doSend(Message<?> message, long timeout) {
-		return this.getRequiredDispatcher().dispatch(message);
+		try {
+			return this.getRequiredDispatcher().dispatch(message);
+		}
+		catch (MessageDispatchingException e) {
+			throw new MessageDeliveryException(message, e.getMessage()
+					+ " for channel " + this.getComponentName() + ".", e);
+		}
 	}
 
 	private MessageDispatcher getRequiredDispatcher() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
@@ -1,4 +1,4 @@
-/* Copyright 2002-2010 the original author or authors.
+/* Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageDeliveryException;
+import org.springframework.integration.MessageDispatchingException;
 import org.springframework.integration.MessagingException;
 import org.springframework.integration.core.MessageHandler;
 
@@ -105,7 +106,7 @@ public class UnicastingDispatcher extends AbstractDispatcher {
 		boolean success = false;
 		Iterator<MessageHandler> handlerIterator = this.getHandlerIterator(message);
 		if (!handlerIterator.hasNext()) {
-			throw new MessageDeliveryException(message, "Dispatcher has no subscribers.");
+			throw new MessageDispatchingException(message, "Dispatcher has no subscribers");
 		}
 		List<RuntimeException> exceptions = new ArrayList<RuntimeException>();
 		while (success == false && handlerIterator.hasNext()) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/DispatcherHasNoSubscribersTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/DispatcherHasNoSubscribersTests-context.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://www.springframework.org/schema/integration"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.1.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<channel id="subscribedChannel" />
+
+	<bridge input-channel="subscribedChannel" output-channel="noSubscribersChannel" />
+
+	<channel id="noSubscribersChannel" />
+
+</beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/DispatcherHasNoSubscribersTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.channel;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.MessagingException;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class DispatcherHasNoSubscribersTests {
+
+	@Autowired
+	MessageChannel noSubscribersChannel;
+
+	@Autowired
+	MessageChannel subscribedChannel;
+
+	@Test
+	public void oneChannel() {
+		try {
+			noSubscribersChannel.send(new GenericMessage<String>("Hello, world!"));
+			fail("Exception expected");
+		} catch (MessagingException e) {
+			assertEquals("Dispatcher has no subscribers for channel noSubscribersChannel.", e.getMessage());
+			assertEquals("Dispatcher has no subscribers for channel noSubscribersChannel.", e.getLocalizedMessage());
+		}
+	}
+
+	@Test
+	public void stackedChannels() {
+		try {
+			subscribedChannel.send(new GenericMessage<String>("Hello, world!"));
+			fail("Exception expected");
+		} catch (MessagingException e) {
+			assertEquals("Dispatcher has no subscribers for channel noSubscribersChannel.", e.getMessage());
+			assertEquals("Dispatcher has no subscribers for channel noSubscribersChannel.", e.getLocalizedMessage());
+		}
+	}
+
+}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.integration.Message;
+import org.springframework.integration.MessageDeliveryException;
+import org.springframework.integration.MessageDispatchingException;
 import org.springframework.integration.MessagingException;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.SubscribableChannel;
@@ -38,6 +40,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.0
  */
 public class SubscribableJmsChannel extends AbstractJmsChannel implements SubscribableChannel, SmartLifecycle, DisposableBean {
@@ -71,8 +74,11 @@ public class SubscribableJmsChannel extends AbstractJmsChannel implements Subscr
 			return;
 		}
 		super.onInit();
-		this.configureDispatcher(this.container.isPubSubDomain());
-		MessageListener listener = new DispatchingMessageListener(this.getJmsTemplate(), this.dispatcher);
+		boolean isPubSub = this.container.isPubSubDomain();
+		this.configureDispatcher(isPubSub);
+		MessageListener listener = new DispatchingMessageListener(
+				this.getJmsTemplate(), this.dispatcher,
+				this.getComponentName(), isPubSub);
 		this.container.setMessageListener(listener);
 		if (!this.container.isActive()) {
 			this.container.afterPropertiesSet();
@@ -82,7 +88,7 @@ public class SubscribableJmsChannel extends AbstractJmsChannel implements Subscr
 
 	private void configureDispatcher(boolean isPubSub) {
 		if (isPubSub) {
-			this.dispatcher = new BroadcastingDispatcher();
+			this.dispatcher = new BroadcastingDispatcher(true);
 		}
 		else {
 			UnicastingDispatcher unicastingDispatcher = new UnicastingDispatcher();
@@ -100,23 +106,45 @@ public class SubscribableJmsChannel extends AbstractJmsChannel implements Subscr
 
 		private final MessageDispatcher dispatcher;
 
+		private final String channelName;
 
-		private DispatchingMessageListener(JmsTemplate jmsTemplate, MessageDispatcher dispatcher) {
+		private final boolean isPubSub;
+
+
+		private DispatchingMessageListener(JmsTemplate jmsTemplate,
+				MessageDispatcher dispatcher, String channelName, boolean isPubSub) {
 			this.jmsTemplate = jmsTemplate;
 			this.dispatcher = dispatcher;
+			this.channelName = channelName;
+			this.isPubSub = isPubSub;
 		}
 
 
 		public void onMessage(javax.jms.Message message) {
+			Message<?> messageToSend = null;
 			try {
 				Object converted = this.jmsTemplate.getMessageConverter().fromMessage(message);
 				if (converted != null) {
-					Message<?> messageToSend = (converted instanceof Message<?>) ? (Message<?>) converted
+					messageToSend = (converted instanceof Message<?>) ? (Message<?>) converted
 							: MessageBuilder.withPayload(converted).build();
 					this.dispatcher.dispatch(messageToSend);
 				}
 				else if (this.logger.isWarnEnabled()) {
 					logger.warn("MessageConverter returned null, no Message to dispatch");
+				}
+			}
+			catch (MessageDispatchingException e) {
+				String exceptionMessage = e.getMessage() + " for jms-channel "
+						+ this.channelName + ".";
+				if (this.isPubSub) {
+					// log only for backwards compatibility with pub/sub
+					if (logger.isWarnEnabled()) {
+						logger.warn(exceptionMessage, e);
+					}
+				}
+				else {
+					throw new MessageDeliveryException(
+							messageToSend, exceptionMessage, e);
 				}
 			}
 			catch (Exception e) {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
@@ -37,6 +37,7 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Mark Fisher
@@ -134,8 +135,9 @@ public class SubscribableJmsChannel extends AbstractJmsChannel implements Subscr
 				}
 			}
 			catch (MessageDispatchingException e) {
+				String channelName = StringUtils.hasText(this.channelName) ? this.channelName : "unknown";
 				String exceptionMessage = e.getMessage() + " for jms-channel "
-						+ this.channelName + ".";
+						+ channelName + ".";
 				if (this.isPubSub) {
 					// log only for backwards compatibility with pub/sub
 					if (logger.isWarnEnabled()) {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import org.springframework.util.StringUtils;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.0
  */
 public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChannel> implements SmartLifecycle, DisposableBean, BeanNameAware {
@@ -337,8 +338,8 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 		if (!CollectionUtils.isEmpty(this.interceptors)) {
 			this.channel.setInterceptors(this.interceptors);
 		}
-		this.channel.afterPropertiesSet();
 		this.channel.setBeanName(this.beanName);
+		this.channel.afterPropertiesSet();
 		return this.channel;
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
@@ -44,6 +44,7 @@ import org.springframework.integration.support.converter.SimpleMessageConverter;
 import org.springframework.integration.util.ErrorHandlingTaskExecutor;
 import org.springframework.util.Assert;
 import org.springframework.util.ErrorHandler;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Oleg Zhurakousky
@@ -178,9 +179,11 @@ public class SubscribableRedisChannel extends AbstractMessageChannel implements 
 				dispatcher.dispatch(siMessage);
 			}
 			catch (MessageDispatchingException e) {
+				String topicName = SubscribableRedisChannel.this.topicName;
+				topicName = StringUtils.hasText(topicName) ? topicName : "unknown";
 				throw new MessageDeliveryException(siMessage, e.getMessage()
 						+ " for redis-channel "
-						+ SubscribableRedisChannel.this.topicName + ".", e);
+						+ topicName + ".", e);
 			}
 		}
 	}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.integration.Message;
+import org.springframework.integration.MessageDeliveryException;
+import org.springframework.integration.MessageDispatchingException;
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.core.MessageHandler;
@@ -45,6 +47,7 @@ import org.springframework.util.ErrorHandler;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.0
  */
 @SuppressWarnings("rawtypes")
@@ -55,7 +58,7 @@ public class SubscribableRedisChannel extends AbstractMessageChannel implements 
 	private final RedisTemplate redisTemplate;
 	private final String topicName;
 	
-	private final MessageDispatcher dispatcher = new BroadcastingDispatcher();
+	private final MessageDispatcher dispatcher = new BroadcastingDispatcher(true);
 	
 	private volatile boolean initialized;
 	
@@ -171,7 +174,14 @@ public class SubscribableRedisChannel extends AbstractMessageChannel implements 
 		@SuppressWarnings("unused")
 		public void handleMessage(String s) {
 			Message<?> siMessage = messageConverter.toMessage(s);
-			dispatcher.dispatch(siMessage);
+			try {
+				dispatcher.dispatch(siMessage);
+			}
+			catch (MessageDispatchingException e) {
+				throw new MessageDeliveryException(siMessage, e.getMessage()
+						+ " for redis-channel "
+						+ SubscribableRedisChannel.this.topicName + ".", e);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Add channel name to MessageDeliveryException

'Dispatcher has no subscribers'.

In a large integration flow, it can be difficult to track
down which subscribable channel has no subscribers.

This commit adds to the message text in the form

```
[channel:someChannelName]
```

to the exception message. For example:

```
"Dispatcher has no subscribers. [channel:myChannel]"
```

Also

```
[amqp-channel:someAmqpChannelName]
[jms-channel:someJMSChannelName]
```

This does not apply to redis-backed channels because
they use a BroadcastingDispatcher, which does not throw
'Dispatcher has no subscribers' exceptions.

@olegz @dturanski
