### PR TITLE
INT-2434 fixed how input-channels are auto-created

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractConsumerEndpointParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractConsumerEndpointParser.java
@@ -16,18 +16,30 @@
 
 package org.springframework.integration.config.xml;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.w3c.dom.Element;
 
-import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.config.BeanExpressionContext;
+import org.springframework.beans.factory.config.BeanExpressionResolver;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.core.Ordered;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.xml.DomUtils;
@@ -45,8 +57,9 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 	protected static final String METHOD_ATTRIBUTE = "method";
 
 	protected static final String EXPRESSION_ATTRIBUTE = "expression";
-
-
+	
+	protected static final String CHANNEL_CREATOR_BEAN_NAME = "$_inputChannelCreator";
+	
 	@Override
 	protected boolean shouldGenerateId() {
 		return false;
@@ -66,6 +79,7 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 		return "input-channel";
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	protected final AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder handlerBuilder = this.parseHandler(element, parserContext);
@@ -83,28 +97,28 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 			return handlerBeanDefinition;
 		}
 
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-				IntegrationNamespaceUtils.BASE_PACKAGE + ".config.ConsumerEndpointFactoryBean");
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(ConsumerEndpointFactoryBean.class);
 
 		String handlerBeanName = BeanDefinitionReaderUtils.generateBeanName(handlerBeanDefinition, parserContext.getRegistry());
 		parserContext.registerBeanComponent(new BeanComponentDefinition(handlerBeanDefinition, handlerBeanName));
 		
 		builder.addPropertyReference("handler", handlerBeanName);
 		String inputChannelName = element.getAttribute(inputChannelAttributeName);
-		boolean channelExists = false;
-		if (parserContext.getRegistry() instanceof BeanFactory) {
-			// BeanFactory also checks ancestor contexts in a hierarchy
-			channelExists = ((BeanFactory) parserContext.getRegistry()).containsBean(inputChannelName);
+		
+		if (parserContext.getRegistry().containsBeanDefinition(CHANNEL_CREATOR_BEAN_NAME)){
+			BeanDefinition definition = parserContext.getRegistry().getBeanDefinition(CHANNEL_CREATOR_BEAN_NAME);
+			Set<String> channelNames = (Set<String>) definition.getConstructorArgumentValues().getArgumentValue(0, Set.class).getValue();
+			channelNames.add(inputChannelName);
 		}
 		else {
-			channelExists = parserContext.getRegistry().containsBeanDefinition(inputChannelName);
+			BeanDefinitionBuilder channelDef = BeanDefinitionBuilder.genericBeanDefinition(ChannelCreatingPostProcessor.class);
+			Set<String> channelNames = new HashSet<String>();
+			channelNames.add(inputChannelName);
+			channelDef.addConstructorArgValue(channelNames);
+			BeanDefinitionHolder channelCreatorHolder = new BeanDefinitionHolder(channelDef.getBeanDefinition(), CHANNEL_CREATOR_BEAN_NAME);
+			BeanDefinitionReaderUtils.registerBeanDefinition(channelCreatorHolder, parserContext.getRegistry());
 		}
-		if (!channelExists && this.shouldAutoCreateChannel(inputChannelName)) {
-			BeanDefinitionBuilder channelDef = BeanDefinitionBuilder.genericBeanDefinition(
-					IntegrationNamespaceUtils.BASE_PACKAGE + ".channel.DirectChannel");
-			BeanDefinitionHolder holder = new BeanDefinitionHolder(channelDef.getBeanDefinition(), inputChannelName);
-			BeanDefinitionReaderUtils.registerBeanDefinition(holder, parserContext.getRegistry());
-		}
+			
 		builder.addPropertyValue("inputChannelName", inputChannelName);
 		List<Element> pollerElementList = DomUtils.getChildElementsByTagName(element, "poller");
 		if (!CollectionUtils.isEmpty(pollerElementList)) {
@@ -121,9 +135,47 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 		return null;
 	}
 
-	private boolean shouldAutoCreateChannel(String channelName) {
-		return !IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME.equals(channelName)
-				&& !IntegrationContextUtils.NULL_CHANNEL_BEAN_NAME.equals(channelName);
-	}
+	private static class ChannelCreatingPostProcessor implements BeanFactoryPostProcessor, Ordered {
+		
+		private final Set<String> channels;
+		
+		@SuppressWarnings("unused")
+		public ChannelCreatingPostProcessor(Set<String> channels){
+			this.channels = channels;
+		}
+	
+		public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
 
+			BeanExpressionResolver beanExpressionResolver = beanFactory.getBeanExpressionResolver();
+			
+			for (String channelName : this.channels) {
+				if (beanExpressionResolver != null) {
+					channelName = (String) beanExpressionResolver.evaluate(channelName, new BeanExpressionContext(beanFactory, null));
+				}
+				if (!beanFactory.containsBean(channelName) && this.shouldAutoCreateChannel(channelName)){		
+					BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
+					RootBeanDefinition messageChannel = new RootBeanDefinition();
+					messageChannel.setBeanClass(DirectChannel.class);
+					BeanDefinitionHolder messageChannelHolder = new BeanDefinitionHolder(messageChannel, channelName);
+					BeanDefinitionReaderUtils.registerBeanDefinition(messageChannelHolder, registry);
+				}
+			}		
+		}
+		
+		private boolean shouldAutoCreateChannel(String channelName) {
+			return !IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME.equals(channelName)
+					&& !IntegrationContextUtils.NULL_CHANNEL_BEAN_NAME.equals(channelName);
+		}
+		/**
+		 * Within the context of Spring Integration this Factory Post Processor must be invoked *first*. 
+		 * It must also be invoked *after* PropertyPlaceholderConfigurer etc., becouse channel names in the 
+		 * 'channels' Set might contain property placeholders. Given the fact that the order of BeanFactoryPostProcessor 
+		 * invocation in AbstractApplicationContext.invokeBeanFactoryPostProcessors(..) is PriorityOrdered -> Ordered -> Regular FPP and 
+		 * that PropertyPlaceholderConfigurer implements PriorityOrdered this post processor 
+		 * implements Ordered with HIGHEST_PRECEDENCE.
+		 */
+		public int getOrder() {
+			return Ordered.HIGHEST_PRECEDENCE;
+		}
+	}
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractConsumerEndpointParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractConsumerEndpointParser.java
@@ -16,18 +16,17 @@
 
 package org.springframework.integration.config.xml;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
-import org.springframework.beans.factory.config.BeanExpressionContext;
-import org.springframework.beans.factory.config.BeanExpressionResolver;
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -37,11 +36,12 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.springframework.core.Ordered;
+import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 
 /**
@@ -51,15 +51,13 @@ import org.springframework.util.xml.DomUtils;
  * @author Oleg Zhurakousky
  */
 public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinitionParser {
-
+	
 	protected static final String REF_ATTRIBUTE = "ref";
 
 	protected static final String METHOD_ATTRIBUTE = "method";
 
 	protected static final String EXPRESSION_ATTRIBUTE = "expression";
-	
-	protected static final String CHANNEL_CREATOR_BEAN_NAME = "$_inputChannelCreator";
-	
+
 	@Override
 	protected boolean shouldGenerateId() {
 		return false;
@@ -79,11 +77,17 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 		return "input-channel";
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
 	protected final AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder handlerBuilder = this.parseHandler(element, parserContext);
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(handlerBuilder, element, "output-channel");
+		
+		String outChannelValue = element.getAttribute("output-channel");
+		if (StringUtils.hasText(outChannelValue)){
+			BeanDefinitionBuilder outDef = BeanDefinitionBuilder.genericBeanDefinition(OutputChannelFactoryBean.class);
+			outDef.addConstructorArgValue(outChannelValue);
+			handlerBuilder.addPropertyValue("outputChannel", outDef.getBeanDefinition());
+		}
+					
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(handlerBuilder, element, "order");
 		AbstractBeanDefinition handlerBeanDefinition = handlerBuilder.getBeanDefinition();
 		String inputChannelAttributeName = this.getInputChannelAttributeName();
@@ -105,21 +109,11 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 		builder.addPropertyReference("handler", handlerBeanName);
 		String inputChannelName = element.getAttribute(inputChannelAttributeName);
 		
-		if (parserContext.getRegistry().containsBeanDefinition(CHANNEL_CREATOR_BEAN_NAME)){
-			BeanDefinition definition = parserContext.getRegistry().getBeanDefinition(CHANNEL_CREATOR_BEAN_NAME);
-			Set<String> channelNames = (Set<String>) definition.getConstructorArgumentValues().getArgumentValue(0, Set.class).getValue();
-			channelNames.add(inputChannelName);
-		}
-		else {
-			BeanDefinitionBuilder channelDef = BeanDefinitionBuilder.genericBeanDefinition(ChannelCreatingPostProcessor.class);
-			Set<String> channelNames = new HashSet<String>();
-			channelNames.add(inputChannelName);
-			channelDef.addConstructorArgValue(channelNames);
-			BeanDefinitionHolder channelCreatorHolder = new BeanDefinitionHolder(channelDef.getBeanDefinition(), CHANNEL_CREATOR_BEAN_NAME);
-			BeanDefinitionReaderUtils.registerBeanDefinition(channelCreatorHolder, parserContext.getRegistry());
-		}
+		BeanDefinitionBuilder strDef = BeanDefinitionBuilder.genericBeanDefinition(InputChannelNameFactoryBean.class);
+		strDef.addConstructorArgValue(inputChannelName);
+		BeanDefinitionReaderUtils.registerWithGeneratedName(strDef.getBeanDefinition(), parserContext.getRegistry());
+		builder.addPropertyValue("inputChannelName", strDef.getBeanDefinition());
 			
-		builder.addPropertyValue("inputChannelName", inputChannelName);
 		List<Element> pollerElementList = DomUtils.getChildElementsByTagName(element, "poller");
 		if (!CollectionUtils.isEmpty(pollerElementList)) {
 			if (pollerElementList.size() != 1) {
@@ -134,48 +128,75 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 		parserContext.registerBeanComponent(new BeanComponentDefinition(beanDefinition, beanName));
 		return null;
 	}
-
-	private static class ChannelCreatingPostProcessor implements BeanFactoryPostProcessor, Ordered {
+	
+	private static class InputChannelNameFactoryBean implements FactoryBean<String>, BeanFactoryAware{
 		
-		private final Set<String> channels;
+		private final Log logger = LogFactory.getLog(this.getClass());
+		
+		private final String channelName;
+
+		private volatile BeanFactory beanFactory;
 		
 		@SuppressWarnings("unused")
-		public ChannelCreatingPostProcessor(Set<String> channels){
-			this.channels = channels;
+		public InputChannelNameFactoryBean(String channelName){
+			this.channelName = channelName;
 		}
-	
-		public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
 
-			BeanExpressionResolver beanExpressionResolver = beanFactory.getBeanExpressionResolver();
-			
-			for (String channelName : this.channels) {
-				if (beanExpressionResolver != null) {
-					channelName = (String) beanExpressionResolver.evaluate(channelName, new BeanExpressionContext(beanFactory, null));
-				}
-				if (!beanFactory.containsBean(channelName) && this.shouldAutoCreateChannel(channelName)){		
-					BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
-					RootBeanDefinition messageChannel = new RootBeanDefinition();
-					messageChannel.setBeanClass(DirectChannel.class);
-					BeanDefinitionHolder messageChannelHolder = new BeanDefinitionHolder(messageChannel, channelName);
-					BeanDefinitionReaderUtils.registerBeanDefinition(messageChannelHolder, registry);
-				}
-			}		
+		public String getObject() throws Exception {
+			if (!this.beanFactory.containsBean(this.channelName) && this.shouldAutoCreateChannel(channelName)){
+				logger.info("Channel '" + this.channelName + "' is not explicitly defined. Will auto-create as DirectChannel");
+				RootBeanDefinition messageChannel = new RootBeanDefinition();
+				messageChannel.setBeanClass(DirectChannel.class);
+				BeanDefinitionHolder messageChannelHolder = new BeanDefinitionHolder(messageChannel, channelName);
+				BeanDefinitionReaderUtils.registerBeanDefinition(messageChannelHolder, (BeanDefinitionRegistry)beanFactory);
+			}
+			return this.channelName;
+		}
+		
+		public Class<?> getObjectType() {
+			return String.class;
+		}
+
+		public boolean isSingleton() {
+			return true;
+		}
+
+		public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+			this.beanFactory = beanFactory;
 		}
 		
 		private boolean shouldAutoCreateChannel(String channelName) {
 			return !IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME.equals(channelName)
 					&& !IntegrationContextUtils.NULL_CHANNEL_BEAN_NAME.equals(channelName);
 		}
-		/**
-		 * Within the context of Spring Integration this Factory Post Processor must be invoked *first*. 
-		 * It must also be invoked *after* PropertyPlaceholderConfigurer etc., becouse channel names in the 
-		 * 'channels' Set might contain property placeholders. Given the fact that the order of BeanFactoryPostProcessor 
-		 * invocation in AbstractApplicationContext.invokeBeanFactoryPostProcessors(..) is PriorityOrdered -> Ordered -> Regular FPP and 
-		 * that PropertyPlaceholderConfigurer implements PriorityOrdered this post processor 
-		 * implements Ordered with HIGHEST_PRECEDENCE.
-		 */
-		public int getOrder() {
-			return Ordered.HIGHEST_PRECEDENCE;
+	}
+	
+	private static class OutputChannelFactoryBean implements FactoryBean<MessageChannel>, BeanFactoryAware{
+		private final String channelName;
+		private volatile ConfigurableListableBeanFactory beanFactory;
+		
+		@SuppressWarnings("unused")
+		public OutputChannelFactoryBean(String channelName){
+			this.channelName = channelName;
+		}
+
+		public MessageChannel getObject() throws Exception {
+			// the following line will force creation of all InputChannelFactoryBean, thus creating channels
+			this.beanFactory.getBeansOfType(InputChannelNameFactoryBean.class);
+			
+			return this.beanFactory.getBean(this.channelName, MessageChannel.class);
+		}
+
+		public Class<?> getObjectType() {
+			return MessageChannel.class;
+		}
+
+		public boolean isSingleton() {
+			return true;
+		}
+
+		public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+			this.beanFactory = (ConfigurableListableBeanFactory) beanFactory;		
 		}
 	}
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/DirectChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/DirectChannelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,26 @@
 
 package org.springframework.integration.channel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
+import java.lang.reflect.Method;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.dispatcher.RoundRobinLoadBalancingStrategy;
 import org.springframework.integration.dispatcher.UnicastingDispatcher;
+import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.util.ReflectionUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Mark Fisher
@@ -66,6 +72,38 @@ public class DirectChannelTests {
 		}, "test-thread").start();
 		latch.await(1000, TimeUnit.MILLISECONDS);
 		assertEquals("test-thread", target.threadName);
+	}
+	
+	@Test //  See INT-2434
+	public void testChannelCreationWithBeanDefinitionOverrideTrue() throws Exception {
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext();
+		context.setAllowBeanDefinitionOverriding(false);
+		context.setConfigLocations(new String[]{"classpath:org/springframework/integration/channel/channel-override-config.xml"});
+		Method method = ReflectionUtils.findMethod(ClassPathXmlApplicationContext.class, "obtainFreshBeanFactory"); 
+		method.setAccessible(true);
+		method.invoke(context);
+		assertFalse(context.containsBean("channelA"));
+		assertFalse(context.containsBean("channelB"));
+		assertTrue(context.containsBean("channelC"));
+		assertTrue(context.containsBean("channelD"));
+		
+		context.refresh();
+		
+		assertTrue(context.containsBean("channelA"));
+		assertTrue(context.containsBean("channelB"));
+		assertTrue(context.containsBean("channelC"));
+		assertTrue(context.containsBean("channelD"));
+		EventDrivenConsumer consumerA = context.getBean("serviceA", EventDrivenConsumer.class);
+		assertEquals(context.getBean("channelA"), TestUtils.getPropertyValue(consumerA, "inputChannel"));
+		assertEquals(context.getBean("channelB"), TestUtils.getPropertyValue(consumerA, "handler.outputChannel"));
+		
+		EventDrivenConsumer consumerB = context.getBean("serviceB", EventDrivenConsumer.class);
+		assertEquals(context.getBean("channelB"), TestUtils.getPropertyValue(consumerB, "inputChannel"));
+		assertEquals(context.getBean("channelC"), TestUtils.getPropertyValue(consumerB, "handler.outputChannel"));
+		
+		EventDrivenConsumer consumerC = context.getBean("serviceC", EventDrivenConsumer.class);
+		assertEquals(context.getBean("channelC"), TestUtils.getPropertyValue(consumerC, "inputChannel"));
+		assertEquals(context.getBean("channelD"), TestUtils.getPropertyValue(consumerC, "handler.outputChannel"));
 	}
 
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/channel-override-config.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/channel-override-config.xml
@@ -20,7 +20,7 @@
 	
 	<int:service-activator id="serviceB" input-channel="#{'channelB'}" output-channel="${channelC}" expression="''"/>
 	
-	<int:service-activator id="serviceC" input-channel="${channelC}" output-channel="#{@channelD.getComponentName()}" expression="''"/>
+	<int:service-activator id="serviceC" input-channel="#{@channelC.getComponentName()}" output-channel="#{@channelD.getComponentName()}" expression="''"/>
 	
 	<int:channel id="channelC"/>
 	

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/channel-override-config.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/channel-override-config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+		
+	<context:property-placeholder properties-ref="props"/>
+	
+	<util:properties id="props">
+			<prop key="channelC" >channelC</prop>
+			<prop key="channelB" >channelB</prop>
+	</util:properties>
+
+	<int:service-activator id="serviceA" input-channel="channelA" output-channel="#{'channelB'}" expression="''"/>
+	
+	<int:service-activator id="serviceB" input-channel="#{'channelB'}" output-channel="${channelC}" expression="''"/>
+	
+	<int:service-activator id="serviceC" input-channel="${channelC}" output-channel="#{@channelD.getComponentName()}" expression="''"/>
+	
+	<int:channel id="channelC"/>
+	
+	<int:channel id="channelD"/>
+
+</beans>

--- a/spring-integration-core/src/test/resources/log4j.properties
+++ b/spring-integration-core/src/test/resources/log4j.properties
@@ -4,4 +4,4 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%c{1}: %m%n
 
-log4j.category.org.springframework.integration=WARN
+log4j.category.org.springframework.integration=INFO

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/MBeanExporterHelper.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/MBeanExporterHelper.java
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.core.PriorityOrdered;
+import org.springframework.core.Ordered;
 import org.springframework.integration.monitor.IntegrationMBeanExporter;
 import org.springframework.jmx.export.MBeanExporter;
 import org.springframework.util.StringUtils;
@@ -36,7 +36,7 @@ import org.springframework.util.StringUtils;
  * @since 2.1
  *
  */
-class MBeanExporterHelper implements BeanFactoryPostProcessor, BeanPostProcessor, PriorityOrdered {
+class MBeanExporterHelper implements BeanFactoryPostProcessor, BeanPostProcessor, Ordered {
 
 	private final static String EXCLUDED_BEANS_PROPERTY_NAME = "excludedBeans";
 	
@@ -79,6 +79,6 @@ class MBeanExporterHelper implements BeanFactoryPostProcessor, BeanPostProcessor
 	}
 
 	public int getOrder() {
-		return Integer.MIN_VALUE;
+		return Ordered.HIGHEST_PRECEDENCE + 100;
 	}
 }

--- a/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/Int2307Tests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/Int2307Tests.java
@@ -34,9 +34,10 @@ import org.springframework.jmx.export.MBeanExporter;
  */
 public class Int2307Tests {
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt2307_DefaultMBeanExporter() throws Exception{
-		new ClassPathXmlApplicationContext("single-config.xml", this.getClass());
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("single-config.xml", this.getClass());
 		List<MBeanServer> servers = MBeanServerFactory.findMBeanServer(null);
 		assertEquals(1, servers.size());
 		MBeanServer server = servers.get(0);
@@ -60,6 +61,10 @@ public class Int2307Tests {
 		}
 		assertEquals(0xf, bits);
 		assertEquals(4, count);
+		
+		Class<?> clazz = Class.forName("org.springframework.integration.jmx.config.MBeanExporterHelper");
+		Object mBeanExporterHelper = context.getBean(clazz);
+		assertTrue(((Set<String>)TestUtils.getPropertyValue(mBeanExporterHelper, "siBeanNames")).contains("z"));
 
 		// make sure there are no duplicate MBean ObjectNames if 2 contexts loaded from same config
 		new ClassPathXmlApplicationContext("single-config.xml", this.getClass());
@@ -76,6 +81,9 @@ public class Int2307Tests {
 		assertTrue(excludedBeanNames.contains("x"));
 		assertTrue(excludedBeanNames.contains("y"));
 		assertTrue(excludedBeanNames.contains("foo")); // non SI bean
+		Class<?> clazz = Class.forName("org.springframework.integration.jmx.config.MBeanExporterHelper");
+		Object mBeanExporterHelper = context.getBean(clazz);
+		assertTrue(((Set<String>)TestUtils.getPropertyValue(mBeanExporterHelper, "siBeanNames")).contains("z"));
 	}
 	
 	public static class Foo{}

--- a/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/single-config-custom-exporter.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/single-config-custom-exporter.xml
@@ -38,4 +38,6 @@
 	<int:channel id="x" />
 	<int:channel id="y" />
 	
+	<int:service-activator input-channel="z" expression="''"/>
+	
 </beans>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/single-config.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/single-config.xml
@@ -34,4 +34,6 @@
 	<int:channel id="x" />
 	<int:channel id="y" />
 	
+	<int:service-activator input-channel="z" expression="''"/>
+	
 </beans>


### PR DESCRIPTION
Moved channel auto-creation logic from the parser to a BeanFactoryPostProcessor, to eliminate a
dependency on the order in which channels are defined, in relation to endpoints where they
are used. Previously, this resulted in the generation of the implicit input-channel even though the channel
had an explicit definition later on in XML.

Moving the creation to a BeanFactoryPostProcessor ensures that all explicitly defined components are present
before the input-channel is auto-created

INT-2434 polishing,
refactored code to ensure only one instance of MessageChannelCreator is created

INT-2434 polishing,
qualified  CHANNEL_NAMES attribute name,
added null check to getAttribute(..) call

INT-2434 polishing,
changed List to Set for collection of channel names to avoid duplicates

INT-2434 added support for resolving placeholders and expressions for channel names

INT-2434 added test properties file

INT-2434 polished test

INT-2434 polishing

@garyrussell
