### PR TITLE
Int 2439 maint

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PollerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PollerParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import org.springframework.util.xml.DomUtils;
  * @author Mark Fisher
  * @author Marius Bogoevici
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  */
 public class PollerParser extends AbstractBeanDefinitionParser {
 
@@ -273,6 +274,7 @@ public class PollerParser extends AbstractBeanDefinitionParser {
 							parserContext.getReaderContext().error(
 									"failed to parse custom element '" + localName + "'", childElement);
 						}
+						adviceChain.add(customBeanDefinition);
 					}
 				}
 			}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/pollerWithAdviceChain.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/pollerWithAdviceChain.xml
@@ -2,10 +2,14 @@
 <beans:beans xmlns="http://www.springframework.org/schema/integration"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tx="http://www.springframework.org/schema/tx"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
 			http://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd">
+			http://www.springframework.org/schema/integration/spring-integration.xsd
+			http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+
+	<beans:bean id="transactionManager" class="org.springframework.integration.util.TestTransactionManager"/>
 
 	<poller id="poller">
 		<interval-trigger interval="5000"/>
@@ -15,6 +19,11 @@
 				<beans:constructor-arg value="2"/>
 			</beans:bean>
 			<ref bean="adviceBean3"/>
+			<tx:advice>
+				<tx:attributes>
+					<tx:method name="*" read-only="true" propagation="REQUIRES_NEW"/>
+				</tx:attributes>
+			</tx:advice>
 		</advice-chain>
 	</poller>
 


### PR DESCRIPTION
https://jira.springsource.org/browse/INT-2439.

Fix PollerParser#configureAdviceChain for adding 'customBeanDefinition' into 'adviceChain' List.
PollerParserTests: adding tx:advice as customElement into poller's <advice-chain>.
