### PR TITLE
INT-2445

### DIFF
--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParser.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -70,7 +70,9 @@ public class WebServiceInboundGatewayParser extends AbstractInboundGatewayParser
 	}
 
 	protected void doParse(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
-		super.doParse(element, parserContext, builder);
 		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultSoapHeaderMapper.class, null);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "extract-payload");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout");
+		this.postProcess(builder, element);
 	}
 }

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests-context.xml
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests-context.xml
@@ -23,7 +23,9 @@
 	<ws:inbound-gateway id="extractsPayload" request-channel="requestsSimple" extract-payload="false"/>
 	
 	<ws:inbound-gateway id="marshalling" request-channel="requestsMarshalling" error-channel="customErrorChannel"
-		marshaller="marshaller" unmarshaller="marshaller" />
+		marshaller="marshaller" unmarshaller="marshaller" 
+		mapped-request-headers="testRequest"
+        mapped-reply-headers="testReply"/>
 
 	<si:channel id="requestsMarshalling">
 		<si:queue/>
@@ -39,7 +41,7 @@
 
 	<ws:inbound-gateway id="headerMappingGateway" request-channel="headerMappingRequests"
 			header-mapper="testHeaderMapper"/>
-
+			
 	<bean id="marshaller" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.oxm.support.AbstractMarshaller" />
 	</bean>

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2002-2011 the original author or authors.
+ *  Copyright 2002-2012 the original author or authors.
  * 
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.ws.config;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -124,6 +125,7 @@ public class WebServiceInboundGatewayParserTests {
 	@Autowired
 	AbstractMarshaller marshaller;
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void marshallersSet() throws Exception {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(marshallingGateway);
@@ -136,6 +138,12 @@ public class WebServiceInboundGatewayParserTests {
 		assertThat(
 				(MessageChannel) accessor.getPropertyValue("errorChannel"),
 				is(customErrorChannel));
+		List<String> requestHeaders = TestUtils.getPropertyValue(marshallingGateway, "headerMapper.requestHeaderNames", List.class);
+		List<String> replyHeaders = TestUtils.getPropertyValue(marshallingGateway, "headerMapper.replyHeaderNames", List.class);
+		assertEquals(1, requestHeaders.size());
+		assertEquals(1, replyHeaders.size());
+		assertTrue(requestHeaders.contains("testRequest"));
+		assertTrue(replyHeaders.contains("testReply"));
 	}
 
 	@Test

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.integration.ws.config;
+
+import java.util.List;
 
 import org.junit.Test;
 
@@ -38,14 +40,18 @@ import org.springframework.ws.client.core.WebServiceMessageCallback;
 import org.springframework.ws.client.support.interceptor.ClientInterceptor;
 import org.springframework.ws.transport.WebServiceMessageSender;
 
-import static org.junit.Assert.assertEquals;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
 import static org.junit.Assert.assertNull;
 
 /**
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  */
 public class WebServiceOutboundGatewayParserTests {
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void simpleGatewayWithReplyChannel() {
 		ApplicationContext context = new ClassPathXmlApplicationContext(
@@ -57,6 +63,13 @@ public class WebServiceOutboundGatewayParserTests {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
 		Object expected = context.getBean("outputChannel");
 		assertEquals(expected, accessor.getPropertyValue("outputChannel"));
+		
+		List<String> requestHeaders = TestUtils.getPropertyValue(endpoint, "handler.headerMapper.requestHeaderNames", List.class);
+		List<String> replyHeaders = TestUtils.getPropertyValue(endpoint, "handler.headerMapper.replyHeaderNames", List.class);
+		assertEquals(1, requestHeaders.size());
+		assertEquals(1, replyHeaders.size());
+		assertTrue(requestHeaders.contains("testRequest"));
+		assertTrue(replyHeaders.contains("testReply"));
 	}
 
 	@Test

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/simpleWebServiceOutboundGatewayParserTests.xml
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/simpleWebServiceOutboundGatewayParserTests.xml
@@ -26,7 +26,9 @@
 	<ws:outbound-gateway id="gatewayWithReplyChannel"
 	                     request-channel="inputChannel"
 	                     uri="http://example.org"
-	                     reply-channel="outputChannel"/>
+	                     reply-channel="outputChannel"
+	                     mapped-request-headers="testRequest"
+                         mapped-reply-headers="testReply"/>
 
 	<ws:outbound-gateway id="gatewayWithIgnoreEmptyResponsesFalse"
 	                     request-channel="inputChannel"


### PR DESCRIPTION
fixed WebServiceInboundGatewayParser to not fall back on super.doParse() which was iterating through all attributes in the element attempting to set a corresponding property on the BeanDefinition.
Added tests for both Inbound and Outbound gateways
