### PR TITLE
INT-2465 Fix Temporary File Suffix

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,12 @@ import org.springframework.integration.file.FileNameGenerator;
 import org.springframework.integration.file.FileWritingMessageHandler;
 
 /**
+ * Factory bean used to create {@link FileWritingMessageHandler}s.
+ *
  * @author Mark Fisher
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 1.0.3
  */
 public class FileWritingMessageHandlerFactoryBean extends AbstractSimpleMessageHandlerFactoryBean<FileWritingMessageHandler>{
@@ -99,7 +102,9 @@ public class FileWritingMessageHandlerFactoryBean extends AbstractSimpleMessageH
 		if (this.sendTimeout != null) {
 			handler.setSendTimeout(this.sendTimeout);
 		}
-		handler.setTemporaryFileSuffix(this.temporaryFileSuffix);
+		if (this.temporaryFileSuffix != null) {
+			handler.setTemporaryFileSuffix(this.temporaryFileSuffix);
+		}
 		return handler;
 	}
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Mark Fisher
  * @author Marius Bogoevici
  * @author Iwein Fuld
+ * @author Gary Russell
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -89,6 +90,7 @@ public class FileOutboundChannelAdapterParserTests {
         File actual = (File) handlerAccessor.getPropertyValue("destinationDirectory");
         assertEquals(expected, actual);
         assertTrue(handlerAccessor.getPropertyValue("fileNameGenerator") instanceof CustomFileNameGenerator);
+        assertEquals(".writing", handlerAccessor.getPropertyValue("temporaryFileSuffix"));
     }
 
     @Test


### PR DESCRIPTION
file:outbound-channel-adapter/ temporary suffix (.writing) was
overwritten to null by the factory bean if no suffix provided.
