### PR TITLE
INT-2471 Improve Run Time For JMS Tests

### DIFF
--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsInboundChannelAdapterParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsInboundChannelAdapterParserTests.java
@@ -53,6 +53,7 @@ public class JmsInboundChannelAdapterParserTests {
 		assertEquals("jms:inbound-channel-adapter", componentHistoryRecord.get("type"));
 		assertNotNull("message should not be null", message);
 		assertEquals("polling-test", message.getPayload());
+		context.stop();
 	}
 	
 	@Test
@@ -62,6 +63,7 @@ public class JmsInboundChannelAdapterParserTests {
 		JmsTemplate jmsTemplate = 
 			TestUtils.getPropertyValue(context.getBean("inboundAdapterWithoutJmsTemplate"), "source.jmsTemplate", JmsTemplate.class);
 		assertEquals(0, jmsTemplate.getSessionAcknowledgeMode());
+		context.stop();
 	}
 
 	@Test
@@ -127,6 +129,7 @@ public class JmsInboundChannelAdapterParserTests {
 		Message<?> message = output.receive(timeoutOnReceive);
 		assertNotNull("message should not be null", message);
 		assertEquals("polling-test", message.getPayload());
+		context.stop();
 	}
 
 	@Test
@@ -139,6 +142,7 @@ public class JmsInboundChannelAdapterParserTests {
 		assertEquals("polling-test", message.getPayload());
 		assertEquals("foo", message.getHeaders().get("testProperty"));
 		assertEquals(new Integer(123), message.getHeaders().get("testAttribute"));
+		context.stop();
 	}
 
 	@Test
@@ -149,6 +153,7 @@ public class JmsInboundChannelAdapterParserTests {
 		Message<?> message = output.receive(timeoutOnReceive);
 		assertNotNull("message should not be null", message);
 		assertEquals("test [with selector: TestProperty = 'foo']", message.getPayload());
+		context.stop();
 	}
 
 	@Test
@@ -168,6 +173,7 @@ public class JmsInboundChannelAdapterParserTests {
 		Message<?> message = output.receive(timeoutOnReceive);
 		assertNotNull("message should not be null", message);
 		assertEquals("converted-test", message.getPayload());
+		context.stop();
 	}
 
 	@Test
@@ -178,6 +184,7 @@ public class JmsInboundChannelAdapterParserTests {
 		Message<?> message = output.receive(timeoutOnReceive);
 		assertNotNull("message should not be null", message);
 		assertEquals("converted-test", message.getPayload());
+		context.stop();
 	}
 
 }

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
@@ -51,11 +51,12 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		assertNotNull(history);
 		Properties componentHistoryRecord = TestUtils.locateComponentInHistory(history, "messageDrivenAdapter", 0);
 		assertNotNull(componentHistoryRecord);
-		JmsMessageDrivenEndpoint o =  context.getBean("messageDrivenAdapter", JmsMessageDrivenEndpoint.class);
-		System.out.println(o.getComponentType());
+		JmsMessageDrivenEndpoint endpoint =  context.getBean("messageDrivenAdapter", JmsMessageDrivenEndpoint.class);
+		System.out.println(endpoint.getComponentType());
 		assertEquals("jms:message-driven-channel-adapter", componentHistoryRecord.get("type"));
 		assertNotNull("message should not be null", message);
 		assertEquals("test [with selector: TestProperty = 'foo']", message.getPayload());
+		endpoint.stop();
 	}
 
 	@Test
@@ -65,6 +66,7 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		JmsMessageDrivenEndpoint endpoint = context.getBean("messageDrivenAdapter", JmsMessageDrivenEndpoint.class);
 		JmsDestinationAccessor container = (JmsDestinationAccessor) new DirectFieldAccessor(endpoint).getPropertyValue("listenerContainer");
 		assertEquals(Boolean.TRUE, container.isPubSubDomain());
+		endpoint.stop();
 	}
 
 	@Test
@@ -77,6 +79,7 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		assertEquals(Boolean.TRUE, container.isSubscriptionDurable());
 		assertEquals("testDurableSubscriptionName", container.getDurableSubscriptionName());
 		assertEquals("testClientId", container.getClientId());
+		endpoint.stop();
 	}
 
 	@Test

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
@@ -52,7 +52,6 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		Properties componentHistoryRecord = TestUtils.locateComponentInHistory(history, "messageDrivenAdapter", 0);
 		assertNotNull(componentHistoryRecord);
 		JmsMessageDrivenEndpoint endpoint =  context.getBean("messageDrivenAdapter", JmsMessageDrivenEndpoint.class);
-		System.out.println(endpoint.getComponentType());
 		assertEquals("jms:message-driven-channel-adapter", componentHistoryRecord.get("type"));
 		assertNotNull("message should not be null", message);
 		assertEquals("test [with selector: TestProperty = 'foo']", message.getPayload());

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewayWithContainerSettings.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewayWithContainerSettings.xml
@@ -19,6 +19,7 @@
 		 			 	 request-channel="requestChannel"
 		 			 	 request-destination-name="testQueue"
 		 			 	 request-pub-sub-domain="false"
+						 auto-startup="false"
 		 			 	 concurrent-consumers="3"/>
 
 	<jms:inbound-gateway id="gatewayWithMaxConcurrentConsumers"
@@ -26,6 +27,7 @@
 		 			 	 request-channel="requestChannel"
 		 			 	 request-destination-name="testTopic"
 		 			 	 request-pub-sub-domain="true"
+						 auto-startup="false"
 		 				 max-concurrent-consumers="22"/>
 
 	<jms:inbound-gateway id="gatewayWithMaxMessagesPerTask"
@@ -33,6 +35,7 @@
 		 			 	 request-channel="requestChannel"
 		 			 	 request-destination-name="testQueue"
 		 			 	 request-pub-sub-domain="false"
+						 auto-startup="false"
 		 			 	 max-messages-per-task="99"/>
 
 	<jms:inbound-gateway id="gatewayWithReceiveTimeout"
@@ -40,6 +43,7 @@
 		 		   	 	 request-channel="requestChannel"
 		 			 	 request-destination-name="testTopic"
 		 			 	 request-pub-sub-domain="true"
+						 auto-startup="false"
 		 				 receive-timeout="1111"/>
 
 	<jms:inbound-gateway id="gatewayWithRecoveryInterval"
@@ -47,6 +51,7 @@
 		 		   	 	 request-channel="requestChannel"
 		 			 	 request-destination-name="testTopic"
 		 			 	 request-pub-sub-domain="true"
+						 auto-startup="false"
 		 				 recovery-interval="2222"/>
 
 	<jms:inbound-gateway id="gatewayWithIdleTaskExecutionLimit"
@@ -54,6 +59,7 @@
 		 		   	 	 request-channel="requestChannel"
 		 			 	 request-destination-name="testTopic"
 		 			 	 request-pub-sub-domain="true"
+						 auto-startup="false"
 		 				 idle-task-execution-limit="7"/>
 
 	<jms:inbound-gateway id="gatewayWithIdleConsumerLimit"
@@ -61,6 +67,7 @@
 		 		   	 	 request-channel="requestChannel"
 		 			 	 request-destination-name="testTopic"
 		 			 	 request-pub-sub-domain="true"
+						 auto-startup="false"
 		 				 idle-consumer-limit="33"/>
 
 	<bean id="testConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewayWithPubSubDomain.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewayWithPubSubDomain.xml
@@ -17,7 +17,8 @@
 	<jms:inbound-gateway id="gateway"
 			request-destination-name="testDestination"
 			request-pub-sub-domain="true"
-			request-channel="output"/>
+			request-channel="output"
+			auto-startup="false"/>
 
 	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewaysWithExtractPayloadAttributes.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewaysWithExtractPayloadAttributes.xml
@@ -16,28 +16,33 @@
 
 	<jms:inbound-gateway id="defaultGateway"
 	                     request-destination="testDestination"
-	                     request-channel="requestChannel"/>
+	                     request-channel="requestChannel"
+	                     auto-startup="false"/>
 
 	<jms:inbound-gateway id="extractReplyPayloadTrue"
 	                     request-destination="testDestination"
 	                     request-channel="requestChannel"
-	                     extract-reply-payload="true"/>
+	                     extract-reply-payload="true"
+	                     auto-startup="false"/>
 
 	<jms:inbound-gateway id="extractReplyPayloadFalse"
 	                     request-destination="testDestination"
 	                     request-channel="requestChannel"
-	                     extract-reply-payload="false"/>
+	                     extract-reply-payload="false"
+	                     auto-startup="false"/>
 
 
 	<jms:inbound-gateway id="extractRequestPayloadTrue"
 	                     request-destination="testDestination"
 	                     request-channel="requestChannel"
-	                     extract-request-payload="true"/>
+	                     extract-request-payload="true"
+	                     auto-startup="false"/>
 
 	<jms:inbound-gateway id="extractRequestPayloadFalse"
 	                     request-destination="testDestination"
 	                     request-channel="requestChannel"
-	                     extract-request-payload="false"/>
+	                     extract-request-payload="false"
+	                     auto-startup="false"/>
 
 	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>


### PR DESCRIPTION
Mostly due to auto-started adapters in parser tests.

Reduced gradle run time from several minutes down to < 1 min.
