### PR TITLE
INT-2468 - Fix DocBook <ulink/> PDF Problems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.springframework.build.gradle:bundlor-plugin:0.1.2-SNAPSHOT'
-        classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.1.2-SNAPSHOT'
+        classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.1.3'
     }
 }
 

--- a/src/reference/docbook/claim-check.xml
+++ b/src/reference/docbook/claim-check.xml
@@ -15,7 +15,7 @@
     </para>
 
     <para>
-    The <link href="http://www.eaipatterns.com/StoreInLibrary.html">Claim Check</link> pattern describes a mechanism that allows you
+    The <ulink url="http://www.eaipatterns.com/StoreInLibrary.html">Claim Check</ulink> pattern describes a mechanism that allows you
     to store data in a well known place while only maintaining a pointer (Claim Check) to where that data is located. You can pass that
     pointer around as a payload of a new Message thereby allowing any component within the message flow to get the actual data as soon as
     it needs it. This approach is very similar to the Certified Mail process where you'll get a Claim Check in your mailbox and

--- a/src/reference/docbook/content-enrichment.xml
+++ b/src/reference/docbook/content-enrichment.xml
@@ -8,7 +8,7 @@
 	    <para>
 		    At times you may have a requirement to enhance a request with more
 		    information than was provided by the target system. The
-		    <link href="http://www.eaipatterns.com/DataEnricher.html">Content Enricher</link>
+		    <ulink url="http://www.eaipatterns.com/DataEnricher.html">Content Enricher</ulink>
 		    pattern describes various scenarios as well as the component
 		    (Enricher), which allows you to address such requirements.
 	    </para>
@@ -122,7 +122,7 @@
 	    </para>
 	    <para>
 	        In Spring Integration 2.0 we have introduced the convenience of the
-	        <link href="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/expressions.html">Spring Expression Language (SpEL)</link>
+	        <ulink url="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/expressions.html">Spring Expression Language (SpEL)</ulink>
 	        to help configure many different components. The <emphasis>Header
 	        Enricher</emphasis> is one of them.
 


### PR DESCRIPTION
- upgrade the Docbook Reference plugin dependency from version **0.1.2-SNAPSHOT** to **0.1.3**
- change any occurrences (only the external links):

from

```
<link href="http://www.eaipatterns.com/StoreInLibrary.html">Claim Check</link>
```

to

```
<ulink url="http://www.eaipatterns.com/StoreInLibrary.html">Claim Check</ulink>
```

For reference see: https://jira.springsource.org/browse/INT-2468
