### PR TITLE
INT-2489:allow for empty temporaryFileSuffix

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/RemoteFileOutboundChannelAdapterParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/RemoteFileOutboundChannelAdapterParser.java
@@ -36,6 +36,7 @@ import org.springframework.util.StringUtils;
 /**
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author David Turanski
  * @since 2.0
  */
 public class RemoteFileOutboundChannelAdapterParser extends AbstractOutboundChannelAdapterParser {
@@ -49,9 +50,18 @@ public class RemoteFileOutboundChannelAdapterParser extends AbstractOutboundChan
 		sessionFactoryBuilder.addConstructorArgValue(element.getAttribute("cache-sessions"));
 		
 		handlerBuilder.addConstructorArgValue(sessionFactoryBuilder.getBeanDefinition());
-
 		// configure MessageHandler properties
+		String temporaryFileSuffix = element.getAttribute("temporary-file-suffix");
+		String useTemporaryFileNameAttr = element.getAttribute("use-temporary-file-name"); 
+		boolean useTemporaryFileName = (useTemporaryFileNameAttr == null || useTemporaryFileNameAttr.equals("true")); 
+		
+		if (StringUtils.hasText(temporaryFileSuffix) && !useTemporaryFileName){
+			throw new BeanDefinitionStoreException("cannot provide a 'temporary-file-suffix' if 'use-temporary-file-name is 'false'");
+		}
+		
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(handlerBuilder, element, "temporary-file-suffix");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(handlerBuilder, element, "use-temporary-file-name");
+		
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(handlerBuilder, element, "auto-create-directory");
 
 		this.configureRemoteDirectories(element, handlerBuilder);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/handler/FileTransferringMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/handler/FileTransferringMessageHandler.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -45,6 +44,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Josh Long
  * @author Oleg Zhurakousky
+ * @author David Turanski
  * @since 2.0
  */
 public class FileTransferringMessageHandler<F> extends AbstractMessageHandler {
@@ -119,6 +119,7 @@ public class FileTransferringMessageHandler<F> extends AbstractMessageHandler {
 		if (this.autoCreateDirectory){
 			Assert.hasText(this.remoteFileSeparator, "'remoteFileSeparator' must not be empty when 'autoCreateDirectory' is set to 'true'");
 		}
+		this.temporaryFileSuffix = this.temporaryFileSuffix == null ? "" : this.temporaryFileSuffix.trim();
 	}
 	
 	@Override
@@ -220,8 +221,10 @@ public class FileTransferringMessageHandler<F> extends AbstractMessageHandler {
 		FileInputStream fileInputStream = new FileInputStream(file);
 		try {
 			session.write(fileInputStream, tempFilePath);
-			// then rename it to its final name
-			session.rename(tempFilePath, remoteFilePath);
+			// then rename it to its final name if necessary
+			if (!this.temporaryFileSuffix.isEmpty()){
+			   session.rename(tempFilePath, remoteFilePath);
+			}
 		} 
 		catch (Exception e) {
 			throw new MessagingException("Failed to write to '" + tempFilePath + "' while uploading the file", e);

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-2.1.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-2.1.xsd
@@ -80,6 +80,14 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="use-temporary-file-name" type="xsd:boolean" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to supress using a temporary file name while writing the file. Invalid if
+								temporary-file-suffix is provided. 
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>					
 					<xsd:attribute name="order" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
@@ -439,6 +447,7 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+
 		<xsd:attribute name="remote-file-separator" type="xsd:string"
 			default="/">
 			<xsd:annotation>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests-context.xml
@@ -45,12 +45,23 @@
 				remote-filename-generator="fileNameGenerator"
 				order="12"/>
 				
+	<int-ftp:outbound-channel-adapter id="ftpOutbound3"
+				channel="anotherFtpChannel" 
+				session-factory="cachingSessionFactory"
+				remote-directory="foo/bar"
+				charset="UTF-8"
+				remote-file-separator="."
+				use-temporary-file-name="false"
+				remote-filename-generator="fileNameGenerator"/>		
+				
 
 	<int-ftp:outbound-channel-adapter id="simpleAdapter"
 				channel="ftpChannel" 
 				session-factory="cachingSessionFactory"
 				remote-directory="foo/bar"/>
 				
+	<int:channel id="anotherFtpChannel"/>
+	
 	<int:publish-subscribe-channel id="ftpChannel"/>
 	
 	<bean id="fileNameGenerator" class="org.mockito.Mockito" factory-method="mock">

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests.java
@@ -19,6 +19,7 @@ package org.springframework.integration.ftp.config;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 
 import java.util.Iterator;
@@ -94,6 +95,16 @@ public class FtpOutboundChannelAdapterParserTests {
 		assertEquals(CachingSessionFactory.class, sfProperty.getClass());
 		Object innerSfProperty = TestUtils.getPropertyValue(sfProperty, "sessionFactory");
 		assertEquals(DefaultFtpSessionFactory.class, innerSfProperty.getClass());
+	}
+	
+	
+	@Test
+	public void testTemporaryFileSuffix() {
+		ApplicationContext ac = 
+				new ClassPathXmlApplicationContext("FtpOutboundChannelAdapterParserTests-context.xml", this.getClass());
+			FileTransferringMessageHandler<?> handler = 
+					(FileTransferringMessageHandler<?>)TestUtils.getPropertyValue(ac.getBean("ftpOutbound3"), "handler");
+			assertFalse((Boolean)TestUtils.getPropertyValue(handler,"useTemporaryFileName"));
 	}
 
 }

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-2.1.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-2.1.xsd
@@ -83,6 +83,14 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="use-temporary-file-name" type="xsd:boolean" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to supress using a temporary file name while writing the file. Invalid if
+								temporary-file-suffix is provided. 
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>					
 					<xsd:attribute name="order" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests-context.xml
@@ -43,6 +43,13 @@
 				channel="inputChannel"
 				charset="UTF-8"
 				remote-directory="foo/bar"/>
+	
+	<int-sftp:outbound-channel-adapter id="sftpOutboundAdapterWithNoTemporaryFileName" 
+				session-factory="sftpSessionFactory" 
+				channel="inputChannel"
+				charset="UTF-8"
+				use-temporary-file-name="false"
+				remote-directory="foo/bar"/>			
 				
 	<bean id="fileNameGenerator" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.integration.file.FileNameGenerator"/>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
@@ -20,6 +20,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
@@ -46,6 +47,7 @@ import org.springframework.integration.test.util.TestUtils;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author David Turanski
  */
 public class OutboundChannelAdapterParserTests {
 
@@ -105,6 +107,15 @@ public class OutboundChannelAdapterParserTests {
 		assertNotNull(TestUtils.getPropertyValue(handler, "temporaryDirectory"));
 		assertNull(TestUtils.getPropertyValue(handler, "temporaryDirectoryExpressionProcessor"));
 		
+	}
+	
+	@Test
+	public void testOutboundChannelAdapterWithNoTemporaryFileName(){
+		ApplicationContext context = 
+				new ClassPathXmlApplicationContext("OutboundChannelAdapterParserTests-context.xml", this.getClass());
+		Object consumer = context.getBean("sftpOutboundAdapterWithNoTemporaryFileName");
+		FileTransferringMessageHandler<?> handler = TestUtils.getPropertyValue(consumer, "handler", FileTransferringMessageHandler.class);
+		assertFalse((Boolean)TestUtils.getPropertyValue(handler,"useTemporaryFileName"));
 	}
 	
 	@Test(expected=BeanDefinitionStoreException.class)


### PR DESCRIPTION
in FileTransferringMessageHandler. Will work the same for null, blank, and empty String, always converting to empty String in the initializer.  Added appropriate unit tests.
