### PR TITLE
INT-2493 Add Edit For Filter on Get

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -163,9 +163,9 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 				"command must be one of "
 						+ StringUtils
 								.collectionToCommaDelimitedString(this.supportedCommands));
-		// NOTE: Filter also not used on GET, need to correct in 2.2.
-		if (COMMAND_RM.equals(this.command) || COMMAND_MGET.equals(this.command)) {
-			Assert.isNull(this.filter, "Filters are not supported with the rm and mget commands");
+		if (COMMAND_RM.equals(this.command) || COMMAND_MGET.equals(this.command) ||
+				COMMAND_GET.equals(this.command)) {
+			Assert.isNull(this.filter, "Filters are not supported with the rm, get, and mget commands");
 		}
 		if (COMMAND_GET.equals(this.command)
 				|| COMMAND_MGET.equals(this.command)) {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -18,6 +18,7 @@ package org.springframework.integration.file.remote.gateway;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,6 +38,7 @@ import org.springframework.integration.Message;
 import org.springframework.integration.MessagingException;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.filters.AbstractSimplePatternFileListFilter;
+import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.AbstractFileInfo;
 import org.springframework.integration.file.remote.session.ExtendedSession;
 import org.springframework.integration.file.remote.session.Session;
@@ -61,6 +63,51 @@ public class RemoteFileOutboundGatewayTests {
 		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway
 			(sessionFactory, "bad", "payload");
 		gw.afterPropertiesSet();
+	}
+
+	@Test
+	public void testBadFilterGet() throws Exception {
+		SessionFactory sessionFactory = mock(SessionFactory.class);
+		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway
+				(sessionFactory, "get", "payload");
+		gw.setFilter(new TestPatternFilter(""));
+		try {
+			gw.onInit();
+			fail("Exception expected");
+		}
+		catch (IllegalArgumentException e) {
+			assertTrue(e.getMessage().startsWith("Filters are not supported"));
+		}
+	}
+
+	@Test
+	public void testBadFilterMGet() throws Exception {
+		SessionFactory sessionFactory = mock(SessionFactory.class);
+		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway
+				(sessionFactory, "mget", "payload");
+		gw.setFilter(new TestPatternFilter(""));
+		try {
+			gw.onInit();
+			fail("Exception expected");
+		}
+		catch (IllegalArgumentException e) {
+			assertTrue(e.getMessage().startsWith("Filters are not supported"));
+		}
+	}
+
+	@Test
+	public void testBadFilterRm() throws Exception {
+		SessionFactory sessionFactory = mock(SessionFactory.class);
+		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway
+				(sessionFactory, "rm", "payload");
+		gw.setFilter(new TestPatternFilter(""));
+		try {
+			gw.onInit();
+			fail("Exception expected");
+		}
+		catch (IllegalArgumentException e) {
+			assertTrue(e.getMessage().startsWith("Filters are not supported"));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Previously, the Filter property was ignored for a Get
command; this adds a hard edit to ensure a filter is
not provided when this command is used.
