### PR TITLE
INT-2511 Change Default Socket Timeout

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.ip.tcp.connection;
 
 import java.net.Socket;
-import java.net.SocketException;
 
 /**
  * Abstract class for client connection factories; client connection factories
@@ -72,20 +71,6 @@ public abstract class AbstractClientConnectionFactory extends AbstractConnection
 		TcpListener listener = this.getListener();
 		if (listener != null) {
 			connection.registerListener(listener);
-		}
-		if (listener != null || this.isSingleUse()) {
-			if (this.getSoTimeout() < 0) {
-				try {
-					/* Default so-timeout, when we have a collaborating inbound adapter,
-					 * may go to infinity in a future release; currently it's 10 seconds.
-					 * While it makes sense in a request/reply scenario, it doesn't
-					 * really for completely asynchronous communication between peers.
-					 */
-					socket.setSoTimeout(DEFAULT_REPLY_TIMEOUT);
-				} catch (SocketException e) {
-					logger.error("Error setting default reply timeout", e);
-				}
-			}
 		}
 		TcpSender sender = this.getSender();
 		if (sender != null) {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/DefaultTimeoutTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/DefaultTimeoutTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.ip.tcp.connection;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.Socket;
+
+import org.junit.Test;
+import org.springframework.integration.Message;
+import org.springframework.integration.ip.util.SocketTestUtils;
+import org.springframework.integration.test.util.TestUtils;
+
+/**
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+public class DefaultTimeoutTests {
+
+	@Test
+	public void test() throws Exception {
+		int port = SocketTestUtils.findAvailableServerSocket();
+		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(port);
+		server.registerListener(new TcpListener() {
+			public boolean onMessage(Message<?> message) {
+				return false;
+			}
+		});
+		TcpNetClientConnectionFactory client = new TcpNetClientConnectionFactory("localhost", port);
+		client.registerSender(new TcpSender() {
+			public void addNewConnection(TcpConnection connection) {
+			}
+			public void removeDeadConnection(TcpConnection connection) {
+			}
+		});
+		client.registerListener(new TcpListener() {
+			public boolean onMessage(Message<?> message) {
+				return false;
+			}
+		});
+		server.start();
+		client.start();
+		TcpConnection connection = client.getConnection();
+		Socket socket = TestUtils.getPropertyValue(connection, "socket", Socket.class);
+		// should default to 0 (infinite) timeout
+		assertEquals(0, socket.getSoTimeout());
+		connection.close();
+		server.stop();
+		client.stop();
+	}
+
+}

--- a/src/reference/docbook/ip.xml
+++ b/src/reference/docbook/ip.xml
@@ -709,23 +709,20 @@
     <para>
         <note>
             <para>
-                When a <emphasis>client</emphasis> connection factory is used by
+                Before the 2.2 release,
+                when a <emphasis>client</emphasis> connection factory was used by
                 collaborating channel
-                adapters, the <emphasis>so-timeout</emphasis> attribute defaults
-                to the default reply timeout (10 seconds). This means that if
-                no data are received by the inbound adapter for this period of
-                time, the socket will be closed.
+                adapters, the <emphasis>so-timeout</emphasis> attribute defaulted
+                to the default reply timeout (10 seconds). This meant that if
+                no data were received by the inbound adapter for this period of
+                time, the socket was closed.
             </para>
             <para>
-                This may not be appropriate in a truly asynch environment, or
-                if you expect the server to take more than 10 seconds to respond
-                in a request/reply environment.
-                The timeout can be increased by setting the
-                <emphasis>so-timeout</emphasis> attribute on the connection
-                factory.
-            </para>
-            <para>
-                Setting the attribute to 0 will enable an infinite timeout.
+                This default behavior was not appropriate in a truly asynchronous
+                environment, so it now defaults to an infinite timeout.
+                You can reinstate the previous default behavior by setting the
+                <emphasis>so-timeout</emphasis> attribute on the client connection
+                factory to 10000 milliseconds.
             </para>
         </note>
     </para>
@@ -887,13 +884,10 @@
               <entry>Y</entry>
               <entry>Y</entry>
               <entry></entry>
-              <entry>Defaults to 0 (infinity), except when the connection
-                     factory is used by collaborating adapters, and for
+              <entry>Defaults to 0 (infinity), except for
                      server connection factories with single-use="true". 
-                     In those cases, it
+                     In that case, it
                      defaults to the default reply timeout (10 seconds).
-                     See the section about collaborating adapters above
-                     and <classname>java.net.Socket. setSoTimeout()</classname>.
                      </entry>
             </row>
             <row>


### PR DESCRIPTION
Previously, when a client connection factory was used by
both an inbound and outbound adapter, the socket timeout
defaulted to 10 seconds.

This was inappropriate because, often, collaborating
channel adapters are used for aysnchronous messaaging and,
even when used for request/response, it is generatlly not
appropriate to timeout the socket due to a lack of recent
send activity.
