### PR TITLE
INT-2517 - Upgrade to Spring 3.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ subprojects { subproject ->
 		junitVersion = '4.8.2'
 		log4jVersion = '1.2.12'
 		mockitoVersion = '1.9.0'
-		springVersion = '3.0.7.RELEASE'
+		springVersion = '3.1.1.RELEASE'
 		springAmqpVersion = '1.0.0.RELEASE'
 		springDataMongoVersion = '1.0.0.RELEASE'
 		springDataRedisVersion = '1.0.0.RELEASE'

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Gunnar Hillert
+ *
  * @since 2.1
  *
  */
@@ -138,6 +140,10 @@ public class CookieTests {
 						}
 
 						public void close() {
+						}
+
+						public int getRawStatusCode() throws IOException {
+							return 200;
 						}
 					};
 				}


### PR DESCRIPTION
- Update **build.gradle** and change the _springVersion_ property to **3.1.1.RELEASE**
- Due to change in Spring 3.1, add missing method **getRawStatusCode()** in _org.springframework.integration.http.outbound.CookieTests_
