### PR TITLE
Int 2542 2.1.x backport: add 'order' attribute for <logging-channel-adapter>

### DIFF
--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
@@ -866,6 +866,16 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="order">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specifies the order for invocation when this endpoint is connected as a
+	subscriber to a channel. This is particularly relevant when that channel
+	is using a "failover" dispatching strategy. It has no effect when this
+	endpoint itself is a Polling Consumer for a channel with a queue.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/LoggingChannelAdapterParserTests-fail-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/LoggingChannelAdapterParserTests-fail-context.xml
@@ -8,11 +8,7 @@
 			http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<logging-channel-adapter id="logger"
-							 logger-name="org.springframework.integration.test.logger"
-							 order="1"
-							 level="WARN"
-							 log-full-message="true"/>
-
-	<logging-channel-adapter id="loggerWithExpression" expression="payload.foo"/>
+							 expression="payload.foo"
+							 log-full-message="false"/>
 
 </beans:beans>


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-2542.
Additional tests for LoggingChannelAdapterParser
