### PR TITLE
INT-2519 Fix Failing Test

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -155,6 +155,8 @@ public class TcpNioConnectionTests {
 			assertEquals(1, connections.size());
 			connection.close();
 			assertTrue(!connection.isOpen());
+			// force a wakeup of the selector
+			factory.close();
 			int n = 0;
 			while (connections.size() > 0) {
 				Thread.sleep(100);


### PR DESCRIPTION
Depending on timing, it was possible the event the test
case was waiting for would never happen. With no timeout
the selector will block until the next IO event occurs,
and there is none in this test.

Adding a call to factory.close() forces a wakeup of
the selector, which will force the harvest to occur.

This is a test-only problem.
