### PR TITLE
INT-2508

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PriorityChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PriorityChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@
 package org.springframework.integration.channel;
 
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.util.UpperBound;
@@ -80,26 +80,20 @@ public class PriorityChannel extends QueueChannel {
 		this(0, null);
 	}
 
-
-	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	protected boolean doSend(Message<?> message, long timeout) {
 		if (!upperBound.tryAcquire(timeout)) {
 			return false;
 		}
-		Map innerMap = (Map) new DirectFieldAccessor(message.getHeaders()).getPropertyValue("headers");
-		innerMap.put(SEQUENCE_HEADER_NAME, sequenceCounter.incrementAndGet());
+		message = new MessageWrapper(message);
 		return super.doSend(message, 0);
 	}
 
-	@SuppressWarnings({ "rawtypes"})
 	@Override
 	protected Message<?> doReceive(long timeout) {
 		Message<?> message = super.doReceive(timeout);
-
 		if (message != null) {
-			Map innerMap = (Map) new DirectFieldAccessor(message.getHeaders()).getPropertyValue("headers");
-			innerMap.remove(SEQUENCE_HEADER_NAME);
+			message = ((MessageWrapper)message).getRootMessage();
 			upperBound.release();
 		}
 		return message;
@@ -135,5 +129,29 @@ public class PriorityChannel extends QueueChannel {
 			return compareResult;
 		}
 	}
+	
+	//we need this because of INT-2508
+	private class MessageWrapper implements Message<Object>{
+		private final Message<?> rootMessage;
+		private final MessageHeaders modifiedHeaders;
 
+		public MessageWrapper(Message<?> rootMessage){
+			this.rootMessage = rootMessage;
+			Map<String, Object> headersMap = new HashMap<String, Object>(rootMessage.getHeaders());
+			headersMap.put(SEQUENCE_HEADER_NAME, sequenceCounter.incrementAndGet());
+			modifiedHeaders = new MessageHeaders(headersMap);
+		}
+
+		public Message<?> getRootMessage(){
+			return this.rootMessage;
+		}
+
+		public MessageHeaders getHeaders() {			
+			return this.modifiedHeaders;
+		}
+
+		public Object getPayload() {
+			return rootMessage.getPayload();
+		}	
+	}
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/PriorityChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/PriorityChannelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,6 @@
 
 package org.springframework.integration.channel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Comparator;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -34,6 +28,12 @@ import org.junit.Test;
 import org.springframework.integration.Message;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Mark Fisher
@@ -80,6 +80,27 @@ public class PriorityChannelTests {
 		assertEquals("test:0", channel.receive(0).getPayload());
 		assertEquals("test:-3", channel.receive(0).getPayload());
 		assertEquals("test:-99", channel.receive(0).getPayload());
+	}
+	
+	// although this test has no assertions it results in ConcurrentModificationException
+	// if executed before changes for INT-2508
+	@Test
+	public void testPriorityChannelWithConcurrentModification() throws Exception{
+		final PriorityChannel channel = new PriorityChannel();
+		final Message<String> message = new GenericMessage<String>("hello");
+		for (int i = 0; i < 1000; i++) {
+			channel.send(message);
+			new Thread(new Runnable() {	
+				public void run() {
+					channel.receive();
+				}
+			}).start();
+			new Thread(new Runnable() {	
+				public void run() {
+					message.getHeaders().toString();
+				}
+			}).start();
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Fixed the concurrency issue with PriorityChannel by
introducing private MessageWrapper as an implementation of Message to maintain the contract with the Comparator.The MessageWrapper will maintain the original Message in tact plus
the copy of MessageHeaders + sequence header which previously was injected in the original Message via DFA. The only downside of this approach is the invocation of
new MessageHeaders which generates the UUID, but its much better than the other approach i tried (Proxy)
