### PR TITLE
INT-2545 - Upgrade bundlor-plugin + docbook-reference-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
 		maven { url 'https://repo.springsource.org/plugins-snapshot' }
 	}
 	dependencies {
-		classpath 'org.springframework.build.gradle:bundlor-plugin:0.1.2-SNAPSHOT'
-		classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.1.3'
+		classpath 'org.springframework.build.gradle:bundlor-plugin:0.1.2'
+		classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.1.5'
 	}
 }
 


### PR DESCRIPTION
- Upgrade bundlor-plugin version to 0.1.2
- Upgrade docbook-reference-plugin to 0.1.5

For reference see: https://jira.springsource.org/browse/INT-2545
