### PR TITLE
INT-2550,INT-2552:added properties regionName and region to GemfireMessageStore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ subprojects { subproject ->
 		springAmqpVersion = '1.0.0.RELEASE'
 		springDataMongoVersion = '1.1.0.M1'
 		springDataRedisVersion = '1.0.0.RELEASE'
-		springGemfireVersion = '1.1.0.RELEASE'
+		springGemfireVersion = '1.1.1.RELEASE'
 		springSecurityVersion = '3.1.0.RELEASE'
 		springSocialTwitterVersion = '1.0.1.RELEASE'
 		springWsVersion = '2.0.3.RELEASE'

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/store/GemfireMessageStore.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/store/GemfireMessageStore.java
@@ -74,11 +74,6 @@ public class GemfireMessageStore extends AbstractKeyValueMessageStore implements
 	public void setIgnoreJta(boolean ignoreJta) {
 		this.ignoreJta = ignoreJta;
 	}
-
-
-	public void setRegion(Region<Object, Object> messageStoreRegion) {
-		this.messageStoreRegion = messageStoreRegion;
-	}
 	
 	@SuppressWarnings("unchecked")
 	public void afterPropertiesSet() {

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/inbound/CqInboundChannelAdapterTests-context.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/inbound/CqInboundChannelAdapterTests-context.xml
@@ -11,7 +11,7 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
-	<gfe:cache use-bean-factory-locator="false" id="client-cache"/>
+	<gfe:client-cache use-bean-factory-locator="false" id="client-cache" pool-name="client-pool"/>
 	
 	<gfe:pool id="client-pool" subscription-enabled="true" >
 		<gfe:server host="localhost" port="40404"/>

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
@@ -16,12 +16,15 @@
 
 package org.springframework.integration.gemfire.store;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
 import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.data.gemfire.CacheFactoryBean;
 import org.springframework.data.gemfire.RegionFactoryBean;
 import org.springframework.integration.Message;
@@ -33,12 +36,6 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.util.Assert;
 
 import com.gemstone.gemfire.cache.Cache;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 
 /**
  * @author Mark Fisher
@@ -61,44 +58,15 @@ public class GemfireMessageStoreTests {
 	}
 	
 	@Test
-	public void testSetRegionName() {
-		assertNull(this.cache.getRegion("someRegion"));
-		GemfireMessageStore store = new GemfireMessageStore(this.cache);
-		store.setRegionName("someRegion");
-		store.afterPropertiesSet();
-		assertNotNull(this.cache.getRegion("someRegion"));
-		assertNull(this.cache.getRegion("messageStoreRegion"));
-	}
-	
-	@Test
-	public void testSetRegion() throws Exception {
+	public void testRegionConstructor() throws Exception {
 		RegionFactoryBean<Object, Object> region = new RegionFactoryBean<Object, Object>();
 		region.setName("someRegion");
 		region.setCache(this.cache);
 		region.afterPropertiesSet();
-		GemfireMessageStore store = new GemfireMessageStore();
-		store.setRegion(region.getObject());
+
+		GemfireMessageStore store = new GemfireMessageStore(region.getObject());
 		store.afterPropertiesSet();
 		assertSame(region.getObject(),TestUtils.getPropertyValue(store, "messageStoreRegion"));
-	}
-	
-	@Test 
-	public void testRegionAndRegionNameAreMutuallyExclusive() {
-		try {
-			RegionFactoryBean<Object, Object> region = new RegionFactoryBean<Object, Object>();
-			region.setName("someRegion");
-			region.setCache(this.cache);
-			region.afterPropertiesSet();
-			GemfireMessageStore store = new GemfireMessageStore();
-			store.setRegion(region.getObject());
-			store.setRegionName("someRegion");
-			store.afterPropertiesSet();
-			fail("should throw exception");
-		} catch (IllegalArgumentException e) {
-			 
-		} catch (Exception e) {
-			fail("wrong exception type");
-		}
 	}
 	
 	@Test

--- a/src/reference/docbook/gemfire.xml
+++ b/src/reference/docbook/gemfire.xml
@@ -11,8 +11,8 @@
     <para>
       VMWare vFabric GemFire (GemFire) is a distributed data management platform providing a key-value data grid along with advanced distributed system features such as event processing, continuous querying, and 
       remote function execution. This guide assumes
-      some familiarity with <ulink url="http://www.gemstone.com/docs/6.6.RC/product/docs/html/user_guide/UserGuide_GemFire.html#Getting%20Started%20with%20Gemfire">GemFire</ulink>
-       and its <ulink url="http://www.gemstone.com/docs/6.6.RC/product/docs/japi/index.html">API</ulink>. 
+      some familiarity with <ulink url="http://www.vmware.com/support/pubs/vfabric-gemfire.html">GemFire</ulink>
+       and its <ulink url="http://www.vmware.com/support/developer/vfabric-gemfire/662-api/index.html">API</ulink>.
     </para>
     <para>
     Spring integration provides support for GemFire by providing inbound adapters for entry and continuous query events, 
@@ -65,8 +65,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/gemfire
   	</note> 
   
   	
-  	<programlisting language="xml">
-  	<![CDATA[<gfe:cache id="client-cache"/>
+  <programlisting language="xml"><![CDATA[<gfe:client-cache id="client-cache" pool-name="client-pool"/>
 	
 	<gfe:pool id="client-pool" subscription-enabled="true" >
 		<!--configure server or locator here required to address the cache server -->
@@ -84,7 +83,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/gemfire
 	</programlisting>
 
 	In the above configuration, we are creating a GemFire client cache 
-	(recall a cache server is required for this implementation and its address is configured as a sub-element of the pool), a client region and a <classname>ContinuousQueryListenerContainer</classname> 
+	(recall a remote cache server is required for this implementation and its address is configured as a sub-element of the pool), a client region and a <classname>ContinuousQueryListenerContainer</classname>
 	using Spring GemFire. 	The continuous query inbound channel adapter requires a <code>cq-listener-container</code> attribute which contains a reference to the <classname>ContinuousQueryListenerContainer</classname>. Optionally,
   	it accepts an <code>expression</code> attribute which uses SpEL to transform the <code>CqEvent</code> or extract an individual property as needed. The cq-inbound-channel-adapter provides a
   	<code>query-events</code> attribute, containing a comma separated list of event types for which a message will be produced on the input channel. Available event types are CREATED, UPDATED, DESTROYED,
@@ -160,9 +159,31 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/gemfire
     </para>
 
     <para>
-    Above is a sample <classname>GemfireMessageStore</classname> configuration that shows its usage by a <emphasis>QueueChannel</emphasis>
-    and an <emphasis>Aggregator</emphasis>. As you can see it is a simple bean configuration, and it expects a
-    <classname>GemFireCache</classname> (created by <classname>CacheFactoryBean</classname>) as a constructor argument.
-    </para>
-  </section>
+    Above is a sample <classname>GemfireMessageStore</classname> configuration that shows its usage by a <emphasis>QueueChannel</emphasis> and an <emphasis>Aggregator</emphasis>. As you can see it is a normal Spring bean configuration. The simplest configuration requires a reference to a <classname>GemFireCache</classname> (created by <classname>CacheFactoryBean</classname>) as a constructor argument. If the cache is standalone, i.e., embedded in the same JVM, the MessageStore will create a message store region named "messageStoreRegion" by default. An alternate name be set via the <emphasis>regionName</emphasis> property. In many cases, it is desirable for the message store to be maintained in one or more remote cache servers in a client-server configuration (See the
+<ulink url="http://www.vmware.com/support/pubs/vfabric-gemfire.html">GemFire product documentation</ulink> for more details). In this case, a client cache and client region may be configured using the spring-gemfire namespace and the region is injected into the MessageStore by setting the <emphasis>region</emphasis> property. Here is an example:
+</para>
+
+<para>
+<programlisting lang="xml"><![CDATA[
+  <bean id="gemfireMessageStore"
+        class="org.springframework.integration.gemfire.store.GemfireMessageStore">
+        <property name="region" ref="myRegion"/>
+    </bean>
+
+    <gfe:client-cache/>
+
+    <gfe:client-region id="myRegion" shortcut="PROXY" pool-name="messageStorePool"/>
+
+    <gfe:pool id="messageStorePool">
+        <gfe:server host="localhost" port="40404" />
+    </gfe:pool>
+]]></programlisting>
+</para>
+<para>
+The above example shows a typical client cache configuration. Note the <emphasis>pool</emphasis> element is configured with the address of a cache server (a locator may be substituted here). The region is configured as a 'PROXY' so that no data will be stored locally. The region's id corresponds to a named region configured in the cache server.
+<note>
+The <classname>GemfireMessageStore</classname> <emphasis>region</emphasis> and <emphasis>regionName</emphasis> properties are mutually exclusive. The former is used to provide a configured region, the latter is intended as the name of the local region which the message store will create internally. Specifying both values will result in an error.
+</note>
+</para>
+</section>
 </chapter>

--- a/src/reference/docbook/gemfire.xml
+++ b/src/reference/docbook/gemfire.xml
@@ -100,23 +100,22 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/gemfire
   	The <emphasis>outbound-channel-adapter</emphasis> writes cache entries mapped from the message payload. In its simplest form, it expects a 
   	payload of type <classname>java.util.Map</classname> and puts the map entries into its configured region. 
   
-  	<programlisting language="xml">
-  	<![CDATA[<int-gfe:outbound-channel-adapter id="cacheChannel" region="region"/>]]>
-
-	</programlisting>
+<programlisting language="xml"><![CDATA[
+<int-gfe:outbound-channel-adapter id="cacheChannel" region="region"/>]]>
+</programlisting>
 	
 	Given the above configuration, an exception will be thrown if the payload is not a Map. Additionally, the outbound channel adapter can be configured to create a 
 	map of cache entries using SpEL of course. 
 	
-		<programlisting language="xml">
-<![CDATA[<int-gfe:outbound-channel-adapter id="cacheChannel" region="region">
-	<int-gfe:cache-entries>
-		<entry key="payload.toUpperCase()" value="payload.toLowerCase()"/> 
-		<entry key="'foo'" value="'bar'"/> 
-	</int-gfe:cache-entries>		 
+		<programlisting language="xml"><![CDATA[
+<int-gfe:outbound-channel-adapter id="cacheChannel" region="region">
+<int-gfe:cache-entries>
+        <entry key="payload.toUpperCase()" value="payload.toLowerCase()"/>
+        <entry key="'foo'" value="'bar'"/>
+</int-gfe:cache-entries>
 </int-gfe:outbound-channel-adapter>
-	]]>
-	</programlisting>
+]]>
+</programlisting>
 	In the above configuration, the inner element <code>cache-entries</code> is semantically equivalent to Spring 'map' element. The adapter interprets the <code>key</code> and 
 	<code>value</code> attributes as SpEL expressions with the message as the evaluation context. Note that this contain  
 	arbitrary cache entries (not only those derived from the message) and that literal values must be enclosed in single quotes. In the above example, if the message sent to 
@@ -141,49 +140,57 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/gemfire
     the <classname>MessageStore</classname> strategy (mainly used by the <emphasis>QueueChannel</emphasis> and <emphasis>ClaimCheck</emphasis>
     patterns) and the <classname>MessageGroupStore</classname> strategy (mainly used by the <emphasis>Aggregator</emphasis> and
     <emphasis>Resequencer</emphasis> patterns).
-    </para>
-
-	<para>
-	<programlisting lang="xml"><![CDATA[<bean id="gemfireMessageStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
-		<constructor-arg ref="myCache"/>
-	</bean>
+<programlisting language="xml"><![CDATA[
+<bean id="gemfireMessageStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
+        <constructor-arg ref="myCache"/>
+</bean>
 	
-	<bean id="myCache" class="org.springframework.data.gemfire.CacheFactoryBean"/>
+<bean id="myCache" class="org.springframework.data.gemfire.CacheFactoryBean"/>
 
 <int:channel id="somePersistentQueueChannel">
     <int:queue message-store="gemfireMessageStore"/>
 <int:channel>
 
 <int:aggregator input-channel="inputChannel" output-channel="outputChannel"
-         message-store="gemfireMessageStore"/>]]></programlisting>
-    </para>
-
-    <para>
-    Above is a sample <classname>GemfireMessageStore</classname> configuration that shows its usage by a <emphasis>QueueChannel</emphasis> and an <emphasis>Aggregator</emphasis>. As you can see it is a normal Spring bean configuration. The simplest configuration requires a reference to a <classname>GemFireCache</classname> (created by <classname>CacheFactoryBean</classname>) as a constructor argument. If the cache is standalone, i.e., embedded in the same JVM, the MessageStore will create a message store region named "messageStoreRegion" by default. An alternate name be set via the <emphasis>regionName</emphasis> property. In many cases, it is desirable for the message store to be maintained in one or more remote cache servers in a client-server configuration (See the
-<ulink url="http://www.vmware.com/support/pubs/vfabric-gemfire.html">GemFire product documentation</ulink> for more details). In this case, a client cache and client region may be configured using the spring-gemfire namespace and the region is injected into the MessageStore by setting the <emphasis>region</emphasis> property. Here is an example:
+         message-store="gemfireMessageStore"/>
+]]></programlisting>
 </para>
 
 <para>
-<programlisting lang="xml"><![CDATA[
-  <bean id="gemfireMessageStore"
-        class="org.springframework.integration.gemfire.store.GemfireMessageStore">
-        <property name="region" ref="myRegion"/>
-    </bean>
+Above is a sample <classname>GemfireMessageStore</classname> configuration that shows its usage by a <emphasis>QueueChannel</emphasis> and an <emphasis>Aggregator</emphasis>. As you can see it is a normal Spring bean configuration. The simplest configuration requires a reference to a <classname>GemFireCache</classname> (created by <classname>CacheFactoryBean</classname>) as a constructor argument. If the cache is standalone, i.e., embedded in the same JVM, the MessageStore will create a message store region named "messageStoreRegion". If your application requires customization of the messageStore region, for example, multiple Gemfire message stores each with its own region, you can configure a region for each message store instance and use the <classname>Region</classname> as the constructor argument:
 
-    <gfe:client-cache/>
+<programlisting language="xml"><![CDATA[
+<bean id="gemfireMessageStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
+        <constructor-arg ref="myRegion"/>
+</bean>
 
-    <gfe:client-region id="myRegion" shortcut="PROXY" pool-name="messageStorePool"/>
+<gfe:cache/>
 
-    <gfe:pool id="messageStorePool">
+<gfe:replicated-region id="myRegion"/>
+]]></programlisting>
+</para>
+
+<para>
+In the above examle, the cache and region are configured using the spring-gemfire namespace (not to be confused with the spring-integration-gemfire namespace). Often it is desirable for the message store to be maintained in one or more remote cache servers in a client-server configuration (See the
+<ulink url="http://www.vmware.com/support/pubs/vfabric-gemfire.html">GemFire product documentation</ulink> for more details). In this case, you configure a client cache, client region, and client pool and inject the region into the MessageStore. Here is an example:
+
+<programlisting language="xml"><![CDATA[
+<bean id="gemfireMessageStore"
+      class="org.springframework.integration.gemfire.store.GemfireMessageStore">
+        <constructor-arg ref="myRegion"/>
+</bean>
+
+<gfe:client-cache/>
+
+<gfe:client-region id="myRegion" shortcut="PROXY" pool-name="messageStorePool"/>
+
+<gfe:pool id="messageStorePool">
         <gfe:server host="localhost" port="40404" />
-    </gfe:pool>
+</gfe:pool>
 ]]></programlisting>
 </para>
 <para>
-The above example shows a typical client cache configuration. Note the <emphasis>pool</emphasis> element is configured with the address of a cache server (a locator may be substituted here). The region is configured as a 'PROXY' so that no data will be stored locally. The region's id corresponds to a named region configured in the cache server.
-<note>
-The <classname>GemfireMessageStore</classname> <emphasis>region</emphasis> and <emphasis>regionName</emphasis> properties are mutually exclusive. The former is used to provide a configured region, the latter is intended as the name of the local region which the message store will create internally. Specifying both values will result in an error.
-</note>
+Note the <emphasis>pool</emphasis> element is configured with the address of a cache server (a locator may be substituted here). The region is configured as a 'PROXY' so that no data will be stored locally. The region's id corresponds to a region with the same name configured in the cache server.
 </para>
 </section>
 </chapter>


### PR DESCRIPTION
The regionName may be set (INT-2550)
A configured region may be injected. In this case, the GMS will use that instead of creating a message store region. This resolves INT-2552). 

Region name and region are mutually exclusive. This is checked during initialization and described in javadoc. 

Also added a default constructor as injecting a cache is not required if a region is injected. These are not considered mutually exclusive because it is not ambiguous (since the cache is a true singleton, there is no opportunity to pass a different instance in the region and the GMS). If the region and cache or both provided, the cache is simply ignored.
