### PR TITLE
INT-2453

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/AmqpHeaders.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/AmqpHeaders.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.amqp;
 
+import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
 
 /**
@@ -44,7 +45,7 @@ public abstract class AmqpHeaders {
 
 	public static final String CONTENT_LENGTH = PREFIX + "contentLength";
 
-	public static final String CONTENT_TYPE = PREFIX + "contentType";
+	public static final String CONTENT_TYPE = MessageHeaders.CONTENT_TYPE;
 
 	public static final String CORRELATION_ID = PREFIX + "correlationId";
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/MessageHeaders.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/MessageHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,8 @@ public final class MessageHeaders implements Map<String, Object>, Serializable {
 	public static final String SEQUENCE_SIZE = "sequenceSize";
 
 	public static final String SEQUENCE_DETAILS = "sequenceDetails";
+	
+	public static final String CONTENT_TYPE = "content-type";
 
 
 	private final Map<String, Object> headers;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ObjectToJsonTransformerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ObjectToJsonTransformerParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,13 @@ package org.springframework.integration.config.xml;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.MessageHeaders;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
 /**
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  * @since 2.0
  */
 public class ObjectToJsonTransformerParser extends AbstractTransformerParser {
@@ -37,6 +39,9 @@ public class ObjectToJsonTransformerParser extends AbstractTransformerParser {
 		String objectMapper = element.getAttribute("object-mapper");
 		if (StringUtils.hasText(objectMapper)) {
 			builder.addConstructorArgReference(objectMapper);
+		}
+		if (element.hasAttribute(MessageHeaders.CONTENT_TYPE)){
+			builder.addPropertyValue("contentType", element.getAttribute(MessageHeaders.CONTENT_TYPE));
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ObjectToJsonTransformerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ObjectToJsonTransformerParser.java
@@ -41,8 +41,7 @@ public class ObjectToJsonTransformerParser extends AbstractTransformerParser {
 			builder.addConstructorArgReference(objectMapper);
 		}
 		if (element.hasAttribute(MessageHeaders.CONTENT_TYPE)){
-			builder.addPropertyValue("contentType", element.getAttribute(MessageHeaders.CONTENT_TYPE));
+			builder.addPropertyValue("contentType", element.getAttribute("content-type"));
 		}
 	}
-
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/ObjectToJsonTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/ObjectToJsonTransformer.java
@@ -25,7 +25,6 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.transformer.AbstractTransformer;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedCaseInsensitiveMap;
-import org.springframework.util.StringUtils;
 
 /**
  * Transformer implementation that converts a payload instance into a JSON string representation.
@@ -59,11 +58,9 @@ public class ObjectToJsonTransformer extends AbstractTransformer {
 	 * @param contentType
 	 */
 	public void setContentType(String contentType){
-		// no assertion is needed since we should allow to un-set content type
+		// only null assertion is needed since "" is a valid value
+		Assert.notNull(contentType, "'contentType' must not be null");
 		this.contentTypeExplicitlySet = true;
-		if (!StringUtils.hasText(contentType)){
-			contentType = null;
-		}
 		this.contentType = contentType;
 	}
 
@@ -76,7 +73,7 @@ public class ObjectToJsonTransformer extends AbstractTransformer {
 	@Override
 	protected Object doTransform(Message<?> message) throws Exception {
 		String payload = this.transformPayload(message.getPayload());
-		MessageBuilder<String> messageBuilder = MessageBuilder.withPayload(payload).copyHeaders(message.getHeaders());
+		MessageBuilder<String> messageBuilder = MessageBuilder.withPayload(payload);
 		
 		LinkedCaseInsensitiveMap<Object> headers = new LinkedCaseInsensitiveMap<Object>();
 		headers.putAll(message.getHeaders());
@@ -84,13 +81,13 @@ public class ObjectToJsonTransformer extends AbstractTransformer {
 		if (headers.containsKey(MessageHeaders.CONTENT_TYPE)) {
 			if (this.contentTypeExplicitlySet){
 				// override
-				messageBuilder.setHeader(MessageHeaders.CONTENT_TYPE, this.contentType);
+				headers.put(MessageHeaders.CONTENT_TYPE, this.contentType);		
 			}
 		}
 		else {
-			messageBuilder.setHeader(MessageHeaders.CONTENT_TYPE, this.contentType);
+			headers.put(MessageHeaders.CONTENT_TYPE, this.contentType);
 		}
-
+		messageBuilder.copyHeaders(headers);
 		return messageBuilder.build();
 	}
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -268,7 +268,7 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	 */
 	private String addPrefixIfNecessary(String prefix, String propertyName) {
 		String headerName = propertyName;
-		if (StringUtils.hasText(prefix) && !headerName.startsWith(prefix)) {
+		if (StringUtils.hasText(prefix) && !headerName.startsWith(prefix) && !headerName.equals(MessageHeaders.CONTENT_TYPE)) {
 			headerName = prefix + propertyName;
 		}
 		return headerName;

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -2017,6 +2017,15 @@
 		<xsd:choice minOccurs="0" maxOccurs="unbounded">
 			<xsd:element ref="poller" />
 		</xsd:choice>
+		<xsd:attribute name="content-type" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Allows you to set 'content-type' Message header. In the case that a content-type header is already present, 
+					we will only override that value IF this attribute is explicitely set with 
+					content-type value (e.g., content-type="text/xml")
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="object-mapper" use="optional">
 			<xsd:annotation>
 				<xsd:documentation>

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests-context.xml
@@ -7,9 +7,13 @@
 		http://www.springframework.org/schema/integration
 		http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<object-to-json-transformer input-channel="defaultObjectMapperInput"/>
+	<object-to-json-transformer id="defaultTransformer" input-channel="defaultObjectMapperInput"/>
 
-	<object-to-json-transformer input-channel="customObjectMapperInput" object-mapper="customObjectMapper"/>
+	<object-to-json-transformer id="customTransformer" input-channel="customObjectMapperInput" object-mapper="customObjectMapper"/>
+	
+	<object-to-json-transformer id="emptyContentTypeTransformer" input-channel="customObjectMapperInput" content-type=""/>
+	
+	<object-to-json-transformer id="overridenContentTypeTransformer" input-channel="customObjectMapperInput" content-type="text/xml"/>
 
 	<beans:bean id="customObjectMapper" class="org.springframework.integration.json.ObjectToJsonTransformerParserTests$CustomObjectMapper"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests.java
@@ -69,7 +69,7 @@ public class ObjectToJsonTransformerParserTests {
 		
 		transformer = 
 				TestUtils.getPropertyValue(context.getBean("emptyContentTypeTransformer"), "handler.transformer", ObjectToJsonTransformer.class);
-		assertNull(TestUtils.getPropertyValue(transformer, "contentType"));
+		assertEquals("", TestUtils.getPropertyValue(transformer, "contentType"));
 		
 		transformer = 
 				TestUtils.getPropertyValue(context.getBean("overridenContentTypeTransformer"), "handler.transformer", ObjectToJsonTransformer.class);

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests.java
@@ -16,10 +16,6 @@
 
 package org.springframework.integration.json;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -29,26 +25,56 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  * @since 2.0
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ObjectToJsonTransformerParserTests {
+	
+	@Autowired
+	private volatile ApplicationContext context;
 
 	@Autowired
 	private volatile MessageChannel defaultObjectMapperInput;
 
 	@Autowired
 	private volatile MessageChannel customObjectMapperInput;
+	
+	@Test
+	public void testContextType(){
+		ObjectToJsonTransformer transformer = 
+				TestUtils.getPropertyValue(context.getBean("defaultTransformer"), "handler.transformer", ObjectToJsonTransformer.class);
+		assertEquals("application/json", TestUtils.getPropertyValue(transformer, "contentType"));
+		
+		transformer = 
+				TestUtils.getPropertyValue(context.getBean("customTransformer"), "handler.transformer", ObjectToJsonTransformer.class);
+		assertEquals("application/json", TestUtils.getPropertyValue(transformer, "contentType"));
+		
+		transformer = 
+				TestUtils.getPropertyValue(context.getBean("emptyContentTypeTransformer"), "handler.transformer", ObjectToJsonTransformer.class);
+		assertNull(TestUtils.getPropertyValue(transformer, "contentType"));
+		
+		transformer = 
+				TestUtils.getPropertyValue(context.getBean("overridenContentTypeTransformer"), "handler.transformer", ObjectToJsonTransformer.class);
+		assertEquals("text/xml", TestUtils.getPropertyValue(transformer, "contentType"));	
+	}
 
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
@@ -59,6 +59,30 @@ public class ObjectToJsonTransformerTests {
 		Message<?> result = transformer.transform(message);
 		assertEquals("text/xml", result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 	}
+	
+	@Test
+	public void withProvidedContentTypeWithOverride() throws Exception {
+		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		transformer.setContentType(ObjectToJsonTransformer.JSON_CONTENT_TYPE);
+		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "text/xml").build();
+		Message<?> result = transformer.transform(message);
+		assertEquals(ObjectToJsonTransformer.JSON_CONTENT_TYPE, result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
+	}
+	
+	@Test
+	public void withProvidedContentTypeAsEmptyString() throws Exception {
+		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		transformer.setContentType("");
+		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "text/xml").build();
+		Message<?> result = transformer.transform(message);
+		assertEquals("", result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void withProvidedContentTypeAsNull() throws Exception {
+		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		transformer.setContentType(null);
+	}
 
 	@Test
 	public void simpleIntegerPayload() throws Exception {

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,6 @@
 
 package org.springframework.integration.json;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -26,8 +23,17 @@ import org.codehaus.jackson.JsonGenerator.Feature;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
 
+import org.springframework.integration.Message;
+import org.springframework.integration.MessageHeaders;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.support.MessageBuilder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  * @since 2.0
  */
 public class ObjectToJsonTransformerTests {
@@ -35,14 +41,29 @@ public class ObjectToJsonTransformerTests {
 	@Test
 	public void simpleStringPayload() throws Exception {
 		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
-		String result = transformer.transformPayload("foo");
+		String result = (String) transformer.transform(new GenericMessage<String>("foo")).getPayload();
 		assertEquals("\"foo\"", result);
+	}
+	
+	@Test
+	public void withDefaultContentType() throws Exception {
+		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		Message<?> result = transformer.transform(new GenericMessage<String>("foo"));
+		assertEquals(ObjectToJsonTransformer.JSON_CONTENT_TYPE, result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
+	}
+	
+	@Test
+	public void withProvidedContentType() throws Exception {
+		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "text/xml").build();
+		Message<?> result = transformer.transform(message);
+		assertEquals("text/xml", result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test
 	public void simpleIntegerPayload() throws Exception {
 		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
-		String result = transformer.transformPayload(123);
+		String result = (String) transformer.transform(new GenericMessage<Integer>(123)).getPayload();
 		assertEquals("123", result);
 	}
 
@@ -52,7 +73,7 @@ public class ObjectToJsonTransformerTests {
 		TestAddress address = new TestAddress(123, "Main Street");
 		TestPerson person = new TestPerson("John", "Doe", 42);
 		person.setAddress(address);
-		String result = transformer.transformPayload(person);
+		String result = (String) transformer.transform(new GenericMessage<TestPerson>(person)).getPayload();
 		assertTrue(result.contains("\"firstName\":\"John\""));
 		assertTrue(result.contains("\"lastName\":\"Doe\""));
 		assertTrue(result.contains("\"age\":42"));
@@ -71,7 +92,7 @@ public class ObjectToJsonTransformerTests {
 		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer(customMapper);
 		TestPerson person = new TestPerson("John", "Doe", 42);
 		person.setAddress(new TestAddress(123, "Main Street"));
-		String result = transformer.transformPayload(person);
+		String result = (String) transformer.transform(new GenericMessage<TestPerson>(person)).getPayload();
 		assertTrue(result.contains("firstName:\"John\""));
 		assertTrue(result.contains("lastName:\"Doe\""));
 		assertTrue(result.contains("age:42"));


### PR DESCRIPTION
Added 'content-type' functionality to ObjectToJsonTransformer
Added 'content-type' attribute to object-to-json-transformer element
Added parser and usage tests to ensure propper overrides (see Mark's last comment here https://github.com/SpringSource/spring-integration/pull/409)
Applied required changes to Amqp module to work with standard 'content-type' header

_SEE Mark's last comment https://github.com/SpringSource/spring-integration/pull/409_
