### PR TITLE
INT-2557: chain with jpa:outbound-channel-adapter

### DIFF
--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundChannelAdapterTests-context.xml
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundChannelAdapterTests-context.xml
@@ -6,13 +6,19 @@
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation=
-	"http://www.springframework.org/schema/beans          http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/integration     http://www.springframework.org/schema/integration/spring-integration-2.0.xsd
-	http://www.springframework.org/schema/integration/jpa http://www.springframework.org/schema/integration/jpa/spring-integration-jpa-2.1.xsd
+	"http://www.springframework.org/schema/beans          http://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/integration     http://www.springframework.org/schema/integration/spring-integration.xsd
+	http://www.springframework.org/schema/integration/jpa http://www.springframework.org/schema/integration/jpa/spring-integration-jpa.xsd
 	http://www.springframework.org/schema/jdbc            http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
 	http://www.springframework.org/schema/data/jpa        http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
 	http://www.springframework.org/schema/task            http://www.springframework.org/schema/task/spring-task.xsd">
 
 	<import resource="BaseJpaPollingChannelAdapterTests-context.xml"/>
+
+	<int:chain input-channel="jpaOutboundChannelAdapterWithinChain">
+		<jpa:outbound-channel-adapter entity-manager="entityManager" persist-mode="PERSIST">
+			<jpa:transactional/>
+		</jpa:outbound-channel-adapter>
+	</int:chain>
 
 </beans>

--- a/spring-integration-jpa/src/test/resources/commonJpa-context.xml
+++ b/spring-integration-jpa/src/test/resources/commonJpa-context.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:c="http://www.springframework.org/schema/c"
 	xmlns:jpa="http://www.springframework.org/schema/integration/jpa"
 	xmlns:task="http://www.springframework.org/schema/task"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
@@ -8,12 +9,12 @@
 	xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.1.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
-		http://www.springframework.org/schema/integration/jpa http://www.springframework.org/schema/integration/jpa/spring-integration-jpa-2.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+		http://www.springframework.org/schema/integration/jpa http://www.springframework.org/schema/integration/jpa/spring-integration-jpa.xsd">
 
     <jdbc:embedded-database id="dataSource" type="H2"/>
     
@@ -22,7 +23,9 @@
         <jdbc:script location="classpath:H2-CreateTables.sql" />
         <jdbc:script location="classpath:H2-PopulateData.sql" />
     </jdbc:initialize-database>
-		
+
+	<bean id="jdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate" c:dataSource-ref="dataSource"/>
+
 	<tx:annotation-driven transaction-manager="transactionManager"/>
     <!-- <context:load-time-weaver />
  -->


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-2557

Integration test for `<jpa:outbound-channel-adapter>` inside `<chain>`.
Polishing JpaOutboundChannelAdapterTests for increase execution speed.
Removal version from XDS URLs from the affected contexts.

After removal @DirtiesContext JpaOutboundChannelAdapterTests (4 test methods) execution speed has increased at 1 second.
