### PR TITLE
INT-2417 Alias Endpoints with Generated Names

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractConsumerEndpointParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractConsumerEndpointParser.java
@@ -40,6 +40,7 @@ import org.springframework.util.xml.DomUtils;
  * 
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
 public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinitionParser {
 
@@ -88,7 +89,8 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(ConsumerEndpointFactoryBean.class);
 
 		String handlerBeanName = BeanDefinitionReaderUtils.generateBeanName(handlerBeanDefinition, parserContext.getRegistry());
-		parserContext.registerBeanComponent(new BeanComponentDefinition(handlerBeanDefinition, handlerBeanName));
+		String[] handlerAlias = IntegrationNamespaceUtils.generateAlias(element);
+		parserContext.registerBeanComponent(new BeanComponentDefinition(handlerBeanDefinition, handlerBeanName, handlerAlias));
 
 		builder.addPropertyReference("handler", handlerBeanName);
 		String inputChannelName = element.getAttribute(inputChannelAttributeName);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractOutboundChannelAdapterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractOutboundChannelAdapterParser.java
@@ -76,7 +76,8 @@ public abstract class AbstractOutboundChannelAdapterParser extends AbstractChann
 			definition.getPropertyValues().addPropertyValue(IntegrationNamespaceUtils.ORDER, order);
 		}
 		String beanName = BeanDefinitionReaderUtils.generateBeanName(definition, parserContext.getRegistry());
-		parserContext.registerBeanComponent(new BeanComponentDefinition(definition, beanName));
+		String[] handlerAlias = IntegrationNamespaceUtils.generateAlias(element);
+		parserContext.registerBeanComponent(new BeanComponentDefinition(definition, beanName, handlerAlias));
 		return beanName;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
@@ -13,6 +13,8 @@
 
 package org.springframework.integration.config.xml;
 
+import static org.springframework.beans.factory.xml.AbstractBeanDefinitionParser.ID_ATTRIBUTE;
+
 import java.util.List;
 
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -45,6 +47,8 @@ public abstract class IntegrationNamespaceUtils {
 	static final String METHOD_ATTRIBUTE = "method";
 	static final String ORDER = "order";
 	static final String EXPRESSION_ATTRIBUTE = "expression";
+	public static final String HANDLER_ALIAS_SUFFIX = ".handler";
+
 
 	/**
 	 * Configures the provided bean definition builder with a property value corresponding to the attribute whose name
@@ -253,5 +257,14 @@ public abstract class IntegrationNamespaceUtils {
 			
 			rootBuilder.addPropertyValue("headerMapper", headerMapperBuilder.getBeanDefinition());
 		}
+	}
+
+	public static String[] generateAlias(Element element) {
+		String[] handlerAlias = null;
+		String id = element.getAttribute(ID_ATTRIBUTE);
+		if (StringUtils.hasText(id)) {
+			handlerAlias = new String[] {id + HANDLER_ALIAS_SUFFIX};
+		}
+		return handlerAlias;
 	}
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DefaultOutboundChannelAdapterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DefaultOutboundChannelAdapterParserTests.java
@@ -19,11 +19,9 @@ package org.springframework.integration.config.xml;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-
 import org.junit.runner.RunWith;
-
-import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.integration.config.TestConsumer;
 import org.springframework.integration.handler.MethodInvokingMessageHandler;
@@ -34,6 +32,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Gary Russell
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -42,6 +41,15 @@ public class DefaultOutboundChannelAdapterParserTests {
 	@Autowired
 	private ApplicationContext context;
 
+	@SuppressWarnings("unused") // testing auto wiring only
+	@Autowired
+	@Qualifier("org.springframework.integration.handler.MethodInvokingMessageHandler#0")
+	private MethodInvokingMessageHandler adapterByGeneratedName;
+
+	@SuppressWarnings("unused") // testing auto wiring only
+	@Autowired
+	@Qualifier("adapter.handler")
+	private MethodInvokingMessageHandler adapterByAlias;
 
 	@Test
 	public void checkConfig() {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ServiceActivatorParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ServiceActivatorParserTests-context.xml
@@ -7,7 +7,7 @@
 			http://www.springframework.org/schema/integration
 			http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<service-activator input-channel="literalExpressionInput" expression="'foo'"/>
+	<service-activator id="testAlias" input-channel="literalExpressionInput" expression="'foo'"/>
 
 	<service-activator input-channel="beanAsTargetInput" expression="@testBean.caps(payload)"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ServiceActivatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ServiceActivatorParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.core.MessagingTemplate;
+import org.springframework.integration.handler.ServiceActivatingHandler;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.0
  */
 @ContextConfiguration
@@ -53,6 +56,15 @@ public class ServiceActivatorParserTests {
 	@Autowired
 	private MessageChannel multipleArgsFromPayloadInput;
 
+	@SuppressWarnings("unused") // testing auto wiring only
+	@Autowired
+	@Qualifier("org.springframework.integration.config.ServiceActivatorFactoryBean#0")
+	private ServiceActivatingHandler testAliasByGeneratedName;
+
+	@SuppressWarnings("unused") // testing auto wiring only
+	@Autowired
+	@Qualifier("testAlias.handler")
+	private ServiceActivatingHandler testAlias;
 
 	@Test
 	public void literalExpression() {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -84,15 +84,15 @@ public class ParserUnitTests {
 	TcpReceivingChannelAdapter tcpIn;
 
 	@Autowired
-	@Qualifier(value="org.springframework.integration.ip.udp.UnicastSendingMessageHandler#0")
+	@Qualifier(value="testOutUdp.handler")
 	UnicastSendingMessageHandler udpOut;
 
 	@Autowired
-	@Qualifier(value="org.springframework.integration.ip.udp.MulticastSendingMessageHandler#0")
+	@Qualifier(value="testOutUdpiMulticast.handler")
 	MulticastSendingMessageHandler udpOutMulticast;
 
 	@Autowired
-	@Qualifier(value="org.springframework.integration.ip.tcp.TcpSendingMessageHandler#0")
+	@Qualifier(value="testOutTcpNio.handler")
 	TcpSendingMessageHandler tcpOut;
 
 	@Autowired
@@ -107,8 +107,13 @@ public class ParserUnitTests {
 	TcpInboundGateway tcpInboundGateway2;
 
 	@Autowired
-	@Qualifier(value="org.springframework.integration.ip.tcp.TcpOutboundGateway#0")
+	@Qualifier(value="outGateway.handler")
 	TcpOutboundGateway tcpOutboundGateway;
+
+	// verify we can still inject by generated name
+	@Autowired
+	@Qualifier(value="org.springframework.integration.ip.tcp.TcpOutboundGateway#0")
+	TcpOutboundGateway tcpOutboundGatewayByGeneratedName;
 
 	@Autowired
 	EventDrivenConsumer outGateway;
@@ -160,11 +165,11 @@ public class ParserUnitTests {
 	AbstractConnectionFactory cfS3;
 
 	@Autowired
-	@Qualifier(value="org.springframework.integration.ip.tcp.TcpSendingMessageHandler#1")
+	@Qualifier(value="tcpNewOut1.handler")
 	TcpSendingMessageHandler tcpNewOut1;
 
 	@Autowired
-	@Qualifier(value="org.springframework.integration.ip.tcp.TcpSendingMessageHandler#2")
+	@Qualifier(value="tcpNewOut2.handler")
 	TcpSendingMessageHandler tcpNewOut2;
 
 	@Autowired
@@ -192,7 +197,7 @@ public class ParserUnitTests {
 	TaskScheduler sched;
 
 	@Autowired
-	@Qualifier(value="org.springframework.integration.ip.tcp.TcpSendingMessageHandler#3")
+	@Qualifier(value="tcpOutClientMode.handler")
 	TcpSendingMessageHandler tcpOutClientMode;
 
 	@Autowired


### PR DESCRIPTION
Handlers for consumer endpoints get a generated name
derived from the endpoint class name.

It is useful (for example for autowiring in tests)
to give the handlers a well-known name.

If the endpoint has an ID attribute, the handler
now gets a bean name of "<ID>.handler".
