### PR TITLE
INT-2448 Add view-expression to Http Inbound

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,13 +91,14 @@ import org.springframework.web.util.UrlPathHelper;
  * In a request-reply scenario, the reply Message's payload will be extracted prior to generating a response by default.
  * To have the entire serialized Message available for the response, switch the {@link #extractReplyPayload} value to
  * <code>false</code>.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.0
  */
 abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySupport {
-	
+
 	private static final boolean jaxb2Present = ClassUtils.isPresent("javax.xml.bind.Binder",
 			HttpRequestHandlingEndpointSupport.class.getClassLoader());
 
@@ -105,7 +106,7 @@ abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySuppor
 			HttpRequestHandlingEndpointSupport.class.getClassLoader())
 			&& ClassUtils.isPresent("org.codehaus.jackson.JsonGenerator", HttpRequestHandlingEndpointSupport.class
 					.getClassLoader());
-	
+
 	private static boolean romePresent = ClassUtils.isPresent("com.sun.syndication.feed.WireFeed",
 			HttpRequestHandlingEndpointSupport.class.getClassLoader());
 
@@ -128,7 +129,7 @@ abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySuppor
 	private volatile boolean extractReplyPayload = true;
 
 	private volatile MultipartResolver multipartResolver;
-	
+
 	private volatile Expression payloadExpression;
 
 	private volatile Map<String, Expression> headerExpressions;
@@ -154,10 +155,10 @@ abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySuppor
 		}
 		if (romePresent) {
 			this.messageConverters.add(new AtomFeedHttpMessageConverter());
-			this.messageConverters.add(new RssChannelHttpMessageConverter()); 	
+			this.messageConverters.add(new RssChannelHttpMessageConverter());
 		}
 	}
-	
+
 	/**
 	 * @return whether to expect reply
 	 */
@@ -167,12 +168,12 @@ abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySuppor
 
 	/**
 	 * Set the path template for which this endpoint expects requests.
-	 * May include path variable {keys} to match against. 
+	 * May include path variable {keys} to match against.
 	 */
 	public void setPath(String path) {
 		this.path = path;
 	}
-	
+
 	String getPath() {
 		return path;
 	}
@@ -300,9 +301,10 @@ abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySuppor
 	/**
 	 * Handles the HTTP request by generating a Message and sending it to the request channel. If this gateway's
 	 * 'expectReply' property is true, it will also generate a response from the reply Message once received.
+	 * @return a the response Message
 	 */
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-	protected final Object doHandleRequest(HttpServletRequest servletRequest, HttpServletResponse servletResponse) throws IOException {
+	protected final Message<?> doHandleRequest(HttpServletRequest servletRequest, HttpServletResponse servletResponse) throws IOException {
 		try {
 			ServletServerHttpRequest request = this.prepareRequest(servletRequest);
 			if (!this.supportedMethods.contains(request.getMethod())) {
@@ -351,13 +353,13 @@ abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySuppor
 
 			if (payload == null) {
 				if (requestBody != null) {
-					payload = requestBody;		
+					payload = requestBody;
 				}
 				else {
 					payload = requestParams;
 				}
 			}
-			
+
 			MessageBuilder<?> messageBuilder = null;
 
 			if (payload instanceof Message<?>){
@@ -366,28 +368,16 @@ abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySuppor
 			else {
 				messageBuilder = MessageBuilder.withPayload(payload).copyHeaders(headers);
 			}
-			
+
 			Message<?> message = messageBuilder
 					.setHeader(org.springframework.integration.http.HttpHeaders.REQUEST_URL, request.getURI().toString())
 					.setHeader(org.springframework.integration.http.HttpHeaders.REQUEST_METHOD, request.getMethod().toString())
 					.setHeader(org.springframework.integration.http.HttpHeaders.USER_PRINCIPAL, servletRequest.getUserPrincipal())
 					.build();
-			
-			Object reply = null;
+
+			Message<?> reply = null;
 			if (this.expectReply) {
 				reply = this.sendAndReceiveMessage(message);
-				if (reply != null) {
-					ServletServerHttpResponse response = new ServletServerHttpResponse(servletResponse);
-					this.headerMapper.fromHeaders(((Message<?>) reply).getHeaders(), response.getHeaders());
-					HttpStatus httpStatus = this.resolveHttpStatusFromHeaders(((Message<?>) reply).getHeaders());
-					if (httpStatus != null) {
-						response.setStatusCode(httpStatus);
-					}	
-					response.close();
-					if (this.extractReplyPayload) {
-						reply = ((Message<?>) reply).getPayload();
-					}
-				}
 			}
 			else {
 				this.send(message);
@@ -397,6 +387,28 @@ abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySuppor
 		finally {
 			this.postProcessRequest(servletRequest);
 		}
+	}
+
+	/**
+	 * Converts the reply message to the appropriate HTTP reply object as well as
+	 * setting up the servlet response.
+	 * @param servletResponse The servlet response.
+	 * @param reply The reply message.
+	 * @return The message payload (if {@link #extractReplyPayload}) otherwise the
+	 * message.
+	 */
+	protected final Object setupResponseAndConvertReply(HttpServletResponse servletResponse, Object reply) {
+		ServletServerHttpResponse response = new ServletServerHttpResponse(servletResponse);
+		this.headerMapper.fromHeaders(((Message<?>) reply).getHeaders(), response.getHeaders());
+		HttpStatus httpStatus = this.resolveHttpStatusFromHeaders(((Message<?>) reply).getHeaders());
+		if (httpStatus != null) {
+			response.setStatusCode(httpStatus);
+		}
+		response.close();
+		if (this.extractReplyPayload) {
+			reply = ((Message<?>) reply).getPayload();
+		}
+		return reply;
 	}
 
 	/**
@@ -485,8 +497,8 @@ abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySuppor
 		}
 		return httpStatus;
 	}
-	
-	private StandardEvaluationContext createEvaluationContext(){
+
+	protected StandardEvaluationContext createEvaluationContext(){
 		StandardEvaluationContext evaluationContext = new StandardEvaluationContext();
 		evaluationContext.addPropertyAccessor(new MapAccessor());
 		BeanFactory beanFactory = this.getBeanFactory();

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGateway.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGateway.java
@@ -53,7 +53,7 @@ import org.springframework.web.HttpRequestHandler;
  * <p/>
  * By default a number of {@link HttpMessageConverter}s are already configured. The list can be overridden by calling
  * the {@link #setMessageConverters(List)} method.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @since 2.0
@@ -76,7 +76,7 @@ public class HttpRequestHandlingMessagingGateway extends HttpRequestHandlingEndp
 	 * Flag to determine if conversion and writing out of message handling exceptions should be attempted (default
 	 * false, in which case they will simply be re-thrown). If the flag is true and no message converter can convert the
 	 * exception a new exception will be thrown.
-	 * 
+	 *
 	 * @param convertExceptions the flag to set
 	 */
 	public void setConvertExceptions(boolean convertExceptions) {
@@ -93,6 +93,9 @@ public class HttpRequestHandlingMessagingGateway extends HttpRequestHandlingEndp
 		Object responseContent = null;
 		try {
 			responseContent = super.doHandleRequest(servletRequest, servletResponse);
+			if (responseContent != null) {
+				responseContent = setupResponseAndConvertReply(servletResponse, responseContent);
+			}
 		}
 		catch (Exception e) {
 			responseContent = handleExceptionInternal(e);

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.2.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.2.xsd
@@ -188,6 +188,16 @@ The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Re
 						<xsd:annotation>
 							<xsd:documentation>
 								View name to be resolved when rendering a response.
+								Deprecated in 2.2 - use a literal string in view-expression instead.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="view-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								SpEL expression that resolves to a view to be resolved when rendering a response.
+								The expression can resolve to a view name or View object.
+								The root object of the evaluation context is the reply message.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.2.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.2.xsd
@@ -188,7 +188,6 @@ The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Re
 						<xsd:annotation>
 							<xsd:documentation>
 								View name to be resolved when rendering a response.
-								Deprecated in 2.2 - use a literal string in view-expression instead.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests-context.xml
@@ -28,6 +28,12 @@
 
 	<inbound-gateway id="inboundController" request-channel="requests" reply-channel="responses" view-name="foo" error-code="oops"/>
 	
+	<inbound-gateway id="inboundControllerViewExp"
+		request-channel="requests"
+		reply-channel="responses"
+		view-expression="'bar'"
+		error-code="oops"/>
+
 	<inbound-gateway id="withMappedHeaders" request-channel="requests"
 								mapped-response-headers="abc, xyz"
 								mapped-request-headers="foo,bar"/>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests.java
@@ -37,6 +37,7 @@ import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.http.HttpHeaders;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageHeaders;
@@ -61,21 +62,24 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 public class HttpInboundGatewayParserTests {
-	
+
 	@Autowired
 	@Qualifier("inboundGateway")
 	private HttpRequestHandlingMessagingGateway gateway;
-	
+
 	@Autowired
 	@Qualifier("withMappedHeaders")
 	private HttpRequestHandlingMessagingGateway withMappedHeaders;
-	
+
 	@Autowired
 	@Qualifier("withMappedHeadersAndConverter")
 	private HttpRequestHandlingMessagingGateway withMappedHeadersAndConverter;
 
 	@Autowired
 	private HttpRequestHandlingController inboundController;
+
+	@Autowired
+	private HttpRequestHandlingController inboundControllerViewExp;
 
 	@Autowired
 	private SubscribableChannel requests;
@@ -96,7 +100,7 @@ public class HttpInboundGatewayParserTests {
 		assertEquals(Long.valueOf(1234), TestUtils.getPropertyValue(messagingTemplate, "sendTimeout"));
 		assertEquals(Long.valueOf(4567), TestUtils.getPropertyValue(messagingTemplate, "receiveTimeout"));
 	}
-	
+
 	@Test(timeout=1000)
 	public void checkFlow() throws Exception {
 		requests.subscribe(handlerExpecting(any(Message.class)));
@@ -115,13 +119,25 @@ public class HttpInboundGatewayParserTests {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(inboundController);
 		String errorCode =  (String) accessor.getPropertyValue("errorCode");
 		assertEquals("oops", errorCode);
+		String viewName = (String) accessor.getPropertyValue("viewName");
+		assertEquals("foo", viewName);
 	}
-	
+
+	@Test
+	public void testControllerViewExp() throws Exception {
+		DirectFieldAccessor accessor = new DirectFieldAccessor(inboundControllerViewExp);
+		String errorCode =  (String) accessor.getPropertyValue("errorCode");
+		assertEquals("oops", errorCode);
+		SpelExpression viewExpression = (SpelExpression) accessor.getPropertyValue("viewExpression");
+		assertNotNull(viewExpression);
+		assertEquals("'bar'", viewExpression.getExpressionString());
+	}
+
 	@Test
 	public void requestWithHeaders() throws Exception {
-		DefaultHttpHeaderMapper headerMapper = 
+		DefaultHttpHeaderMapper headerMapper =
 			(DefaultHttpHeaderMapper) TestUtils.getPropertyValue(withMappedHeaders, "headerMapper");
-		
+
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("foo", "foo");
 		headers.set("bar", "bar");
@@ -130,7 +146,7 @@ public class HttpInboundGatewayParserTests {
 		assertTrue(map.size() == 2);
 		assertEquals("foo", map.get("foo"));
 		assertEquals("bar", map.get("bar"));
-		
+
 		Map<String, Object> mapOfHeaders = new HashMap<String, Object>();
 		mapOfHeaders.put("abc", "abc");
 		MessageHeaders mh = new MessageHeaders(mapOfHeaders);
@@ -140,12 +156,12 @@ public class HttpInboundGatewayParserTests {
 		List<String> abc = headers.get("X-abc");
 		assertEquals("abc", abc.get(0));
 	}
-	
+
 	@Test
 	public void requestWithHeadersWithConversionService() throws Exception {
-		DefaultHttpHeaderMapper headerMapper = 
+		DefaultHttpHeaderMapper headerMapper =
 			(DefaultHttpHeaderMapper) TestUtils.getPropertyValue(withMappedHeadersAndConverter, "headerMapper");
-		
+
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("foo", "foo");
 		headers.set("bar", "bar");
@@ -154,7 +170,7 @@ public class HttpInboundGatewayParserTests {
 		assertTrue(map.size() == 2);
 		assertEquals("foo", map.get("foo"));
 		assertEquals("bar", map.get("bar"));
-		
+
 		Map<String, Object> mapOfHeaders = new HashMap<String, Object>();
 		mapOfHeaders.put("abc", "abc");
 		Person person = new Person();
@@ -169,7 +185,7 @@ public class HttpInboundGatewayParserTests {
 		List<String> personHeaders = headers.get("X-person");
 		assertEquals("Oleg", personHeaders.get(0));
 	}
-	
+
 	public static class Person{
 		private String name;
 
@@ -181,13 +197,13 @@ public class HttpInboundGatewayParserTests {
 			this.name = name;
 		}
 	}
-	
+
 	public static class PersonConverter implements Converter<Person, String>{
 
 		public String convert(Person source) {
 			return source.getName();
 		}
-		
+
 	}
 
 }

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGatewayTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGatewayTests.java
@@ -44,6 +44,7 @@ import org.springframework.util.SerializationUtils;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.0
  */
 public class HttpRequestHandlingMessagingGatewayTests {
@@ -89,6 +90,7 @@ public class HttpRequestHandlingMessagingGatewayTests {
 	public void stringExpectedWithReply() throws Exception {
 		DirectChannel requestChannel = new DirectChannel();
 		requestChannel.subscribe(new AbstractReplyProducingMessageHandler() {
+			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				return requestMessage.getPayload().toString().toUpperCase();
 			}
@@ -110,6 +112,7 @@ public class HttpRequestHandlingMessagingGatewayTests {
 	public void noAcceptHeaderOnRequest() throws Exception {
 		DirectChannel requestChannel = new DirectChannel();
 		requestChannel.subscribe(new AbstractReplyProducingMessageHandler() {
+			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				return requestMessage.getPayload().toString().toUpperCase();
 			}
@@ -149,7 +152,7 @@ public class HttpRequestHandlingMessagingGatewayTests {
 
 	@Test
 	public void multiValueParameterMap() throws Exception {
-		QueueChannel channel = new QueueChannel(); 
+		QueueChannel channel = new QueueChannel();
 		HttpRequestHandlingMessagingGateway gateway = new HttpRequestHandlingMessagingGateway(false);
 		gateway.setRequestChannel(channel);
 		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
@@ -175,7 +178,7 @@ public class HttpRequestHandlingMessagingGatewayTests {
 
 	@Test
 	public void serializableRequestBody() throws Exception {
-		QueueChannel channel = new QueueChannel(); 
+		QueueChannel channel = new QueueChannel();
 		HttpRequestHandlingMessagingGateway gateway = new HttpRequestHandlingMessagingGateway(false);
 		gateway.setRequestPayloadType(TestBean.class);
 		gateway.setRequestChannel(channel);
@@ -200,7 +203,7 @@ public class HttpRequestHandlingMessagingGatewayTests {
 
 
 	private static class TestHttpMessageConverter extends AbstractHttpMessageConverter<Exception> {
-		
+
 		public TestHttpMessageConverter() {
 			setSupportedMediaTypes(Arrays.asList(MediaType.ALL));
 		}


### PR DESCRIPTION
https://jira.springsource.org/browse/INT-2488

Previously the view name could be specified; with this
change, either the view name or a view-epression can be
provided, with the reply message being the root object
of the evaluation context.
