### PR TITLE
INT-2581 Fix Failing Test (Timing)

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/SocketSupportTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/SocketSupportTests.java
@@ -144,9 +144,11 @@ public class SocketSupportTests {
 		});
 		final AtomicInteger ppSocketCountServer = new AtomicInteger();
 		final AtomicInteger ppServerSocketCountServer = new AtomicInteger();
+		final CountDownLatch latch = new CountDownLatch(1);
 		TcpSocketSupport serverSocketSupport = new TcpSocketSupport() {
 			public void postProcessSocket(Socket socket) {
 				ppSocketCountServer.incrementAndGet();
+				latch.countDown();
 			}
 			public void postProcessServerSocket(ServerSocket serverSocket) {
 				ppServerSocketCountServer.incrementAndGet();
@@ -156,6 +158,7 @@ public class SocketSupportTests {
 		serverConnectionFactory.start();
 		waitListening(serverConnectionFactory);
 		clientConnectionFactory.getConnection().send(new GenericMessage<String>("Hello, world!"));
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
 		assertEquals(0, ppServerSocketCountClient.get());
 		assertEquals(1, ppSocketCountClient.get());
 


### PR DESCRIPTION
When sending a message to the server, we checked that the
user hook for the socket creation was called. However,
it was possible (likely) that we tested the counter before
the socket actually opened.
