### PR TITLE
INT-2572 Use the reply-timeout attribute in outbound gateway parser

### DIFF
--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/JpaOutboundGatewayParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/JpaOutboundGatewayParser.java
@@ -41,14 +41,8 @@ import org.w3c.dom.Element;
  */
 public class JpaOutboundGatewayParser extends AbstractConsumerEndpointParser  {
 
-	protected boolean shouldGenerateId() {
-		return false;
-	}
 
-	protected boolean shouldGenerateIdAsFallback() {
-		return true;
-	}
-
+	@Override
 	protected BeanDefinitionBuilder parseHandler(Element gatewayElement, ParserContext parserContext) {
 
 		final BeanDefinitionBuilder jpaExecutorBuilder = JpaParserUtils.getJpaExecutorBuilder(gatewayElement, parserContext);
@@ -72,6 +66,7 @@ public class JpaOutboundGatewayParser extends AbstractConsumerEndpointParser  {
 		jpaOutboundGatewayBuilder.addConstructorArgReference(jpaExecutorBeanName);
 
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaOutboundGatewayBuilder, gatewayElement, "gateway-type");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaOutboundGatewayBuilder, gatewayElement, "reply-timeout");
 
 		final String replyChannel = gatewayElement.getAttribute("reply-channel");
 
@@ -81,7 +76,7 @@ public class JpaOutboundGatewayParser extends AbstractConsumerEndpointParser  {
 
 		final Element transactionalElement = DomUtils.getChildElementByTagName(gatewayElement, "transactional");
 
-		if(transactionalElement != null) {
+		if (transactionalElement != null) {
 			BeanDefinition txAdviceDefinition = JpaParserUtils.configureTransactionAttributes(transactionalElement);
 			ManagedList<BeanDefinition> adviceChain = new ManagedList<BeanDefinition>();
 			adviceChain.add(txAdviceDefinition);
@@ -92,6 +87,7 @@ public class JpaOutboundGatewayParser extends AbstractConsumerEndpointParser  {
 
 	}
 
+	@Override
 	protected String getInputChannelAttributeName() {
 		return "request-channel";
 	}

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
@@ -52,6 +52,7 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 	private boolean producesReply = true;
 	private MessageChannel outputChannel;
 	private int order;
+	private long replyTimeout;
 
 	/**
 	 * Constructor taking an {@link JpaExecutor} that wraps all JPA Operations.
@@ -81,6 +82,7 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 		jpaOutboundGateway.setProducesReply(this.producesReply);
 		jpaOutboundGateway.setOutputChannel(this.outputChannel);
 		jpaOutboundGateway.setOrder(this.order);
+		jpaOutboundGateway.setSendTimeout(replyTimeout);
 
 		if (!CollectionUtils.isEmpty(this.adviceChain)) {
 
@@ -112,5 +114,18 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 	public void setOrder(int order) {
 		this.order = order;
 	}
+
+	/**
+	 * Specifies the time the gateway will wait to send the result to the reply channel.
+	 * Only applies when the reply channel itself might block the send (for example a bounded QueueChannel that is currently full).
+	 * By default the Gateway will wait indefinitely.
+	 *
+	 * @param replyTimeout The timeout in milliseconds
+	 */
+	public void setReplyTimeout(long replyTimeout) {
+		this.replyTimeout = replyTimeout;
+	}
+
+
 
 }

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaOutboundGatewayParserTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaOutboundGatewayParserTests.java
@@ -31,6 +31,7 @@ import org.springframework.integration.test.util.TestUtils;
 
 /**
  * @author Gunnar Hillert
+ * @author Amol Nayak
  * @since 2.2
  *
  */
@@ -55,6 +56,11 @@ public class JpaOutboundGatewayParserTests {
 
 		assertEquals(OutboundGatewayType.RETRIEVING, gatewayType);
 
+		long sendTimeout = TestUtils.getPropertyValue(jpaOutboundGateway, "messagingTemplate.sendTimeout", Long.class);
+
+		assertEquals(100, sendTimeout);
+
+
 		final JpaExecutor jpaExecutor = TestUtils.getPropertyValue(this.consumer, "handler.jpaExecutor", JpaExecutor.class);
 
 		assertNotNull(jpaExecutor);
@@ -76,13 +82,13 @@ public class JpaOutboundGatewayParserTests {
 	}
 
 	@After
-	public void tearDown(){
-		if(context != null){
+	public void tearDown() {
+		if (context != null) {
 			context.close();
 		}
 	}
 
-	public void setUp(String name, Class<?> cls){
+	public void setUp(String name, Class<?> cls) {
 		context    = new ClassPathXmlApplicationContext(name, cls);
 		consumer   = this.context.getBean("jpaOutboundGateway", EventDrivenConsumer.class);
 	}

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaOutboundGatewayParserTests.xml
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaOutboundGatewayParserTests.xml
@@ -23,6 +23,7 @@
 		gateway-type="RETRIEVING"
 		order="1"
 		request-channel="in"
-		reply-channel="out"/>
+		reply-channel="out"
+		reply-timeout="100"/>
 
 </beans>


### PR DESCRIPTION
The reply-timeout attribute of the outbound gateway xml tag was ignored in the parser and hence was not getting set in the JPAOutboundGateway.
