### PR TITLE
INT-1132: DelayHandler: rescheduling support

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/DelayHandlerFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/DelayHandlerFactoryBean.java
@@ -82,8 +82,6 @@ public class DelayHandlerFactoryBean extends AbstractSimpleMessageHandlerFactory
 			handler.setTaskScheduler(taskScheduler);
 		}
 
-		handler.afterPropertiesSet();
-
 		this.delayHandler = handler;
 
 		return this.delayHandler;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/DelayHandlerFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/DelayHandlerFactoryBean.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.config;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.integration.channel.MessagePublishingErrorHandler;
+import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.handler.DelayHandler;
+import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.integration.store.SimpleMessageStore;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ExecutorConfigurationSupport;
+import org.springframework.util.Assert;
+import org.springframework.util.ErrorHandler;
+
+/**
+ * FactoryBean for creating {@link DelayHandler}.
+ *
+ * @author Artem Bilan
+ * @since 2.2
+ */
+public class DelayHandlerFactoryBean extends AbstractSimpleMessageHandlerFactoryBean<DelayHandler> implements SmartLifecycle, DisposableBean {
+
+	private static final Set<String> usedDelayersTaskSchedulers = new HashSet<String>();
+
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	private String messageGroupId;
+
+	private long defaultDelay;
+
+	private String delayHeaderName;
+
+	private boolean waitForTasksToCompleteOnShutdown;
+
+	private MessageGroupStore messageStore;
+
+	private String taskSchedulerBeanName;
+
+	private long sendTimeout;
+
+	private volatile boolean autoStartup = true;
+
+	private volatile int phase = Integer.MAX_VALUE;
+
+	private volatile DelayHandler delayHandler;
+
+	@Override
+	protected DelayHandler createHandler() {
+		Assert.isTrue(this.taskSchedulerBeanName == null || usedDelayersTaskSchedulers.add(this.taskSchedulerBeanName),
+				"DelayHandlers can't share taskSchedulers. Provide unique TaskScheduler bean for this DelayHandler or " +
+						"don't use it at all preferring global shared ThreadPoolTaskScheduler.");
+		DelayHandler handler = new DelayHandler(this.messageGroupId);
+		handler.setDefaultDelay(this.defaultDelay);
+		handler.setDelayHeaderName(this.delayHeaderName);
+		handler.setSendTimeout(this.sendTimeout);
+		handler.setAutoStartup(this.autoStartup);
+		handler.setPhase(this.phase);
+		handler.setMessageStore(this.messageStore != null ? this.messageStore : new SimpleMessageStore());
+		if (this.taskSchedulerBeanName != null) {
+			TaskScheduler taskScheduler = this.resolveAndConfigureTaskScheduler();
+			handler.setTaskScheduler(taskScheduler);
+		}
+
+		handler.afterPropertiesSet();
+
+		this.delayHandler = handler;
+
+		return this.delayHandler;
+	}
+
+	private TaskScheduler resolveAndConfigureTaskScheduler() {
+		TaskScheduler taskScheduler = this.getBeanFactory().getBean(this.taskSchedulerBeanName, TaskScheduler.class);
+		if (taskScheduler instanceof ExecutorConfigurationSupport) {
+			((ExecutorConfigurationSupport) taskScheduler).setWaitForTasksToCompleteOnShutdown(this.waitForTasksToCompleteOnShutdown);
+		}
+		else if (this.logger.isWarnEnabled()) {
+			this.logger.warn("The 'waitForJobsToCompleteOnShutdown' property is not supported for TaskScheduler of type [" +
+					taskScheduler.getClass() + "]");
+		}
+		DirectFieldAccessor taskSchedulerFieldAccessor = new DirectFieldAccessor(taskScheduler);
+		if (taskSchedulerFieldAccessor.isReadableProperty("errorHandler") && taskSchedulerFieldAccessor.getPropertyValue("errorHandler") == null) {
+			ErrorHandler errorHandler = this.createTaskSchedulerErrorHandler();
+			taskSchedulerFieldAccessor.setPropertyValue("errorHandler", errorHandler);
+		}
+
+		return taskScheduler;
+	}
+
+	private ErrorHandler createTaskSchedulerErrorHandler() {
+		MessagePublishingErrorHandler errorHandler = new MessagePublishingErrorHandler();
+		errorHandler.setBeanFactory(this.getBeanFactory());
+		errorHandler.setDefaultErrorChannel(IntegrationContextUtils.getErrorChannel(this.getBeanFactory()));
+		return errorHandler;
+	}
+
+	public void setMessageGroupId(String messageGroupId) {
+		this.messageGroupId = messageGroupId;
+	}
+
+	public void setDefaultDelay(long defaultDelay) {
+		this.defaultDelay = defaultDelay;
+	}
+
+	public void setDelayHeaderName(String delayHeaderName) {
+		this.delayHeaderName = delayHeaderName;
+	}
+
+	/**
+	 * Set whether to wait for scheduled tasks to complete on shutdown.
+	 * <p>Default is "false". Switch this to "true" if you prefer
+	 * fully completed tasks at the expense of a longer shutdown phase.
+	 * <p/>
+	 * This property will only have an effect for TaskScheduler implementations
+	 * that extend from {@link ExecutorConfigurationSupport}.
+	 *
+	 * @see ExecutorConfigurationSupport#setWaitForTasksToCompleteOnShutdown(boolean)
+	 */
+	public void setWaitForTasksToCompleteOnShutdown(boolean waitForTasksToCompleteOnShutdown) {
+		this.waitForTasksToCompleteOnShutdown = waitForTasksToCompleteOnShutdown;
+	}
+
+	public void setMessageStore(MessageGroupStore messageStore) {
+		this.messageStore = messageStore;
+	}
+
+	public void setTaskSchedulerBeanName(String taskSchedulerBeanName) {
+		this.taskSchedulerBeanName = taskSchedulerBeanName;
+	}
+
+	public void setSendTimeout(long sendTimeout) {
+		this.sendTimeout = sendTimeout;
+	}
+
+	public void setAutoStartup(boolean autoStartup) {
+		this.autoStartup = autoStartup;
+	}
+
+	public void setPhase(int phase) {
+		this.phase = phase;
+	}
+
+	@Override
+	public int getPhase() {
+		return this.delayHandler.getPhase();
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return this.delayHandler.isAutoStartup();
+	}
+
+	@Override
+	public void stop(Runnable callback) {
+		this.delayHandler.stop(callback);
+	}
+
+	@Override
+	public void start() {
+		this.delayHandler.start();
+	}
+
+	@Override
+	public void stop() {
+		this.delayHandler.stop();
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.delayHandler.isRunning();
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		usedDelayersTaskSchedulers.clear();
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
@@ -16,11 +16,11 @@
 
 package org.springframework.integration.config.xml;
 
+import org.springframework.integration.config.DelayHandlerFactoryBean;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.springframework.integration.handler.DelayHandler;
 import org.springframework.util.StringUtils;
 
 /**
@@ -34,27 +34,34 @@ public class DelayerParser extends AbstractConsumerEndpointParser {
 
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(DelayHandler.class);
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(DelayHandlerFactoryBean.class);
 
 		String id = element.getAttribute(ID_ATTRIBUTE);
 		if (!StringUtils.hasText(id)) {
 			parserContext.getReaderContext().error("The 'id' attribute is required.", element);
 		}
-		builder.addConstructorArgValue(id + ".messageGroupId");
-		String scheduler = element.getAttribute("scheduler");
-		if (StringUtils.hasText(scheduler)) {
-			builder.addConstructorArgReference(scheduler);
-		}
+		builder.addPropertyValue("messageGroupId", id + ".messageGroupId");
+
 
 		String defaultDelay = element.getAttribute("default-delay");
 		String delayHeaderName = element.getAttribute("delay-header-name");
+		String scheduler = element.getAttribute("scheduler");
+		String waitForTasks = element.getAttribute("wait-for-tasks-to-complete-on-shutdown");
 
 		boolean hasDefaultDelay = StringUtils.hasText(defaultDelay);
 		boolean hasDelayHeaderName = StringUtils.hasText(delayHeaderName);
+		boolean hasScheduler = StringUtils.hasText(scheduler);
+		boolean hasWaitForTasks = waitForTasks.equals("true");
 
 		if (!(hasDefaultDelay | hasDelayHeaderName)) {
 			parserContext.getReaderContext()
 					.error("The 'default-delay' or 'delay-header-name' attributes should be provided.", element);
+		}
+
+		if (hasWaitForTasks && !hasScheduler) {
+			parserContext.getReaderContext()
+					.error("The unique 'scheduler' bean is required when 'wait-for-tasks-to-complete-on-shutdown=true'." +
+							" You cannot modify global shared TaskScheduler.", element);
 		}
 
 		if (hasDefaultDelay) {
@@ -63,10 +70,17 @@ public class DelayerParser extends AbstractConsumerEndpointParser {
 		if (hasDelayHeaderName) {
 			builder.addPropertyValue("delayHeaderName", delayHeaderName);
 		}
+		if (hasScheduler) {
+			builder.addPropertyValue("taskSchedulerBeanName", scheduler);
+		}
+		if (hasWaitForTasks) {
+			builder.addPropertyValue("waitForTasksToCompleteOnShutdown", waitForTasks);
+		}
 
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-store");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "send-timeout");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "wait-for-tasks-to-complete-on-shutdown");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-startup");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "phase");
 		return builder;
 	}
 

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -1272,6 +1272,15 @@
 						<xsd:element name="poller" type="basePollerType" />
 					</xsd:sequence>
 					<xsd:attributeGroup ref="inputOutputChannelGroup"/>
+					<xsd:attribute name="phase" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+							The lifecycle phase within which this endpoint should start and stop.
+							The lower the value the earlier this endpoint will start and the later it will stop. The
+							default is Integer.MAX_VALUE. Values can be negative. See SmartLifecycle.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -716,7 +716,7 @@
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="resource-inbound-channel-adapter">
 		<xsd:annotation>
 			<xsd:documentation>
@@ -770,11 +770,11 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
-			
+
 			<xsd:attribute name="pattern-resolver" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>
-						Reference to a org.springframework.core.io.support.ResourcePatternResolver. 
+						Reference to a org.springframework.core.io.support.ResourcePatternResolver.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -986,7 +986,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="expressionOrInnerEndpointDefinitionAware">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 					<xsd:attribute name="requires-reply" type="xsd:string" use="optional">
 						<xsd:annotation>
 							<xsd:documentation>
@@ -1085,7 +1085,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="enricher-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -1138,7 +1138,7 @@
         <xsd:attribute name="request-timeout" type="xsd:string">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[
-                    Set the timeout value for sending request messages in milliseconds. 
+                    Set the timeout value for sending request messages in milliseconds.
                     If not explicitly configured, the default is one second.
                     ]]>
                 </xsd:documentation>
@@ -1147,7 +1147,7 @@
         <xsd:attribute name="reply-timeout" type="xsd:string">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[
-                    Set the timeout value for receiving reply messages in milliseconds. 
+                    Set the timeout value for receiving reply messages in milliseconds.
                     If not explicitly configured, the default is one second.
                     ]]>
                 </xsd:documentation>
@@ -1156,25 +1156,25 @@
         <xsd:attribute name="requires-reply" use="optional" default="true">
         <xsd:annotation>
             <xsd:documentation><![CDATA[
-                If you specify a 'request-channel' you can optionally set the 
-                'requires-reply' attribute as well. If you set this attribute to 
-                'true', a reply must return a non-null value. 
-                
+                If you specify a 'request-channel' you can optionally set the
+                'requires-reply' attribute as well. If you set this attribute to
+                'true', a reply must return a non-null value.
+
                 For example, you dispatch a message to the request-channel
                 (backed by a 'QueueChannel'). If the reply does not return within
-                the specified 'replyTimeout', then the reply message will end up 
+                the specified 'replyTimeout', then the reply message will end up
                 being Null.
-                
+
                 By setting 'requires-reply' to 'true', a 'ReplyRequiredException'
-                will be raised for null reply messages. If 'requires-reply' is set 
-                to false, those messages are silently dropped. 
-                
+                will be raised for null reply messages. If 'requires-reply' is set
+                to false, those messages are silently dropped.
+
                 This attribute defaults to 'true', if not specified.]]>
                 </xsd:documentation>
             </xsd:annotation>
             <xsd:simpleType>
                 <xsd:union memberTypes="xsd:boolean xsd:string" />
-            </xsd:simpleType>            
+            </xsd:simpleType>
         </xsd:attribute>
 		<xsd:attribute name="should-clone-payload">
 			<xsd:annotation>
@@ -1268,17 +1268,28 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="delayer-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:sequence minOccurs="0" maxOccurs="1">
+						<xsd:element name="poller" type="basePollerType" />
+					</xsd:sequence>
+					<xsd:attributeGroup ref="inputOutputChannelGroup"/>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:complexType name="delayer-type">
-		<xsd:sequence>
-			<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1" />
-		</xsd:sequence>
-		<xsd:attribute name="default-delay" type="xsd:string" use="required">
+		<xsd:attribute name="id" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+					'id' value is used:
+					- as 'AbstractEndpoint' bean 'id' if this tag is defined as root element.
+					- as DelayHandler bean alias together with suffix '.handler'
+					- as 'messageGroupId' property of DelayHandler together with suffix '.messageGroupId'
+					  in the operations of MessageGroupStore for scheduling delayed messages.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="default-delay" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation>
 					Specify the default delay in milliseconds. This value can be set to 0
@@ -1310,9 +1321,7 @@
 					this endpoint should
 					delegate when scheduling the sending of delayed Messages. If not
 					provided, the default
-					will use a thread pool of
-					size
-					1.
+					will use registered in the ApplicationContext {ThreadPoolTaskScheduler}.
 					</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
@@ -1358,7 +1367,7 @@
 				<xsd:any processContents="strict" namespace="##other" minOccurs="0" maxOccurs="unbounded" />
 				<xsd:element ref="poller" />
 			</xsd:choice>
-			<xsd:attributeGroup ref="inputOutputChannelGroup" />
+			<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 		</xsd:complexType>
 	</xsd:element>
 
@@ -1372,7 +1381,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="chain-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -1621,7 +1630,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="header-enricher-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -1881,7 +1890,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="header-filter-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -1920,7 +1929,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="expressionOrInnerEndpointDefinitionAware">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -1937,7 +1946,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="specialized-transformer-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -1951,7 +1960,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="specialized-transformer-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -1965,7 +1974,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="map-to-object-transformer-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -2007,7 +2016,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="object-to-json-transformer-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -2051,7 +2060,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="json-to-object-transformer-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -2093,7 +2102,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="payload-serializing-transformer-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -2128,7 +2137,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="payload-deserializing-transformer-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -2171,7 +2180,7 @@
                 <xsd:sequence minOccurs="0" maxOccurs="1">
                     <xsd:element ref="poller" />
                 </xsd:sequence>
-                <xsd:attributeGroup ref="inputOutputChannelGroup" />
+                <xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
@@ -2199,7 +2208,7 @@
                 <xsd:sequence minOccurs="0" maxOccurs="1">
                     <xsd:element ref="poller" />
                 </xsd:sequence>
-                <xsd:attributeGroup ref="inputOutputChannelGroup" />
+                <xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 	        </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
@@ -2265,7 +2274,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="filter-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -2973,7 +2982,7 @@ is provided, the return value is expected to match a channel name exactly.
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="splitter-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -3023,7 +3032,7 @@ is provided, the return value is expected to match a channel name exactly.
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="aggregator-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -3156,7 +3165,7 @@ is provided, the return value is expected to match a channel name exactly.
 						Specifies whether messages that expired should be aggregated and sent to the 'output-channel' or 'replyChannel'.
 						Messages are expired when their containing MessageGroup expires. One of the ways of expiring MessageGroups is by
 						configuring a MessageGroupStoreReaper. However MessageGroups can alternatively be expired by simply calling
-						MessageGroupStore.expireMessageGroup(groupId). That could be accomplished via a ControlBus operation
+						MessageGroupStore.expireMessageGroup(messageGroupId). That could be accomplished via a ControlBus operation
 						or by simply invoking that method if you have a reference to the MessageGroupStore instance.
 						</xsd:documentation>
 					</xsd:annotation>
@@ -3174,7 +3183,7 @@ is provided, the return value is expected to match a channel name exactly.
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="resequencer-type">
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -3590,7 +3599,7 @@ The list of component name patterns you want to track (e.g.,  tracked-components
 					<xsd:all minOccurs="0" maxOccurs="1">
 						<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1" />
 					</xsd:all>
-					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -3611,7 +3620,6 @@ The list of component name patterns you want to track (e.g.,  tracked-components
 	</xsd:complexType>
 
 	<xsd:attributeGroup name="inputOutputChannelGroup">
-		<xsd:attribute name="id" type="xsd:string" />
 		<xsd:attribute name="output-channel" type="xsd:string">
 			<xsd:annotation>
 				<xsd:appinfo>
@@ -3667,4 +3675,18 @@ endpoint itself is a Polling Consumer for a channel with a queue.
             </xsd:simpleType>
         </xsd:attribute>
 	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="inputOutputChannelGroupWithId">
+		<xsd:attribute name="id" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					'id' value:
+					- Identifies the underlying Spring bean definition (AbstractEndpoint)
+					- as MessageHandler bean alias together with suffix '.handler'
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="inputOutputChannelGroup"/>
+	</xsd:attributeGroup>
+
 </xsd:schema>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests-context.xml
@@ -16,15 +16,6 @@
 		<queue />
 	</channel>
 
-	<delayer id="delayerWithDefaultScheduler"
-			 input-channel="input"
-			 output-channel="output"
-			 default-delay="1234"
-			 delay-header-name="foo"
-			 order="99"
-			 send-timeout="987"
-			 wait-for-tasks-to-complete-on-shutdown="true"/>
-
 	<delayer id="delayerWithCustomScheduler"
 			 input-channel="input"
 			 output-channel="output"
@@ -36,6 +27,15 @@
 			 output-channel="output"
 			 default-delay="0"
 			 message-store="testMessageStore"/>
+
+	<delayer id="delayerWithDefaultScheduler"
+			 input-channel="input"
+			 output-channel="output"
+			 default-delay="1234"
+			 delay-header-name="foo"
+			 order="99"
+			 send-timeout="987"
+			 wait-for-tasks-to-complete-on-shutdown="true"/>
 
 	<task:scheduler id="testScheduler" pool-size="7"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests-context.xml
@@ -20,6 +20,8 @@
 			 input-channel="input"
 			 output-channel="output"
 			 default-delay="0"
+			 auto-startup="false"
+			 phase="123"
 			 scheduler="testScheduler"
 			 wait-for-tasks-to-complete-on-shutdown="true"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests-context.xml
@@ -20,7 +20,8 @@
 			 input-channel="input"
 			 output-channel="output"
 			 default-delay="0"
-			 scheduler="testScheduler"/>
+			 scheduler="testScheduler"
+			 wait-for-tasks-to-complete-on-shutdown="true"/>
 
 	<delayer id="delayerWithCustomMessageStore"
 			 input-channel="input"
@@ -35,7 +36,7 @@
 			 delay-header-name="foo"
 			 order="99"
 			 send-timeout="987"
-			 wait-for-tasks-to-complete-on-shutdown="true"/>
+			 wait-for-tasks-to-complete-on-shutdown="false"/>
 
 	<task:scheduler id="testScheduler" pool-size="7"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.integration.config.xml;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +35,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  * @since 1.0.3
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -57,8 +60,7 @@ public class DelayerParserTests {
 		assertEquals("foo", accessor.getPropertyValue("delayHeaderName"));
 		assertEquals(new Long(987), new DirectFieldAccessor(
 				accessor.getPropertyValue("messagingTemplate")).getPropertyValue("sendTimeout"));
-		assertEquals(Boolean.TRUE, new DirectFieldAccessor(
-				accessor.getPropertyValue("taskScheduler")).getPropertyValue("waitForTasksToCompleteOnShutdown"));
+		assertNull(accessor.getPropertyValue("taskScheduler"));
 	}
 
 	@Test
@@ -73,6 +75,9 @@ public class DelayerParserTests {
 		assertEquals(context.getBean("output"), accessor.getPropertyValue("outputChannel"));
 		assertEquals(new Long(0), accessor.getPropertyValue("defaultDelay"));
 		assertEquals(context.getBean("testScheduler"), accessor.getPropertyValue("taskScheduler"));
+		assertNotNull(accessor.getPropertyValue("taskScheduler"));
+		assertEquals(Boolean.TRUE, new DirectFieldAccessor(
+				accessor.getPropertyValue("taskScheduler")).getPropertyValue("waitForTasksToCompleteOnShutdown"));
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
@@ -58,6 +58,8 @@ public class DelayerParserTests {
 		assertEquals(context.getBean("output"), accessor.getPropertyValue("outputChannel"));
 		assertEquals(new Long(1234), accessor.getPropertyValue("defaultDelay"));
 		assertEquals("foo", accessor.getPropertyValue("delayHeaderName"));
+		assertEquals(Boolean.TRUE, accessor.getPropertyValue("autoStartup"));
+		assertEquals(Integer.MAX_VALUE, accessor.getPropertyValue("phase"));
 		assertEquals(new Long(987), new DirectFieldAccessor(
 				accessor.getPropertyValue("messagingTemplate")).getPropertyValue("sendTimeout"));
 		assertNull(accessor.getPropertyValue("taskScheduler"));
@@ -74,6 +76,8 @@ public class DelayerParserTests {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(delayHandler);
 		assertEquals(context.getBean("output"), accessor.getPropertyValue("outputChannel"));
 		assertEquals(new Long(0), accessor.getPropertyValue("defaultDelay"));
+		assertEquals(Boolean.FALSE, accessor.getPropertyValue("autoStartup"));
+		assertEquals(123, accessor.getPropertyValue("phase"));
 		assertEquals(context.getBean("testScheduler"), accessor.getPropertyValue("taskScheduler"));
 		assertNotNull(accessor.getPropertyValue("taskScheduler"));
 		assertEquals(Boolean.TRUE, new DirectFieldAccessor(

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests-context.xml
@@ -30,18 +30,24 @@
 	<channel id="outputB1">
 		<queue />
 	</channel>
- 
+
 	<delayer id="delayerWithCustomScheduler"
 			 input-channel="inputB"
 			 output-channel="outputB"
 			 default-delay="1000"
 			 send-timeout="20000"
-			 scheduler="multiThreadScheduler"/> 
+			 scheduler="multiThreadScheduler"/>
+
+	<chain input-channel="delayerInsideChain" output-channel="outputA">
+		<transformer expression="payload.toUpperCase()"/>
+		<delayer id="delayerInsideChain" default-delay="1000"/>
+		<transformer expression="payload.toLowerCase()"/>
+	</chain>
 
 	<task:scheduler id="multiThreadScheduler" pool-size="5"/>
-	
+
 	<service-activator input-channel="outputB" output-channel="outputB1" method="processMessage" ref="sampleHandler"/>
-	
+
 	<beans:bean id="sampleHandler" class="org.springframework.integration.config.xml.DelayerUsageTests$SampleService"/>
- 
+
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests-context.xml
@@ -22,8 +22,7 @@
 			 default-delay="1000"
 			 delay-header-name="foo"
 			 order="99"
-			 send-timeout="1000"
-			 wait-for-tasks-to-complete-on-shutdown="true"/>
+			 send-timeout="1000"/>
 
 	<channel id="inputB"/>
 	<channel id="outputB"/>
@@ -36,7 +35,8 @@
 			 output-channel="outputB"
 			 default-delay="1000"
 			 send-timeout="20000"
-			 scheduler="multiThreadScheduler"/>
+			 scheduler="multiThreadScheduler"
+			 wait-for-tasks-to-complete-on-shutdown="true"/>
 
 	<chain input-channel="delayerInsideChain" output-channel="outputA">
 		<transformer expression="payload.toUpperCase()"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.config.xml;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -23,6 +24,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.message.GenericMessage;
@@ -32,22 +34,28 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  * @since 1.0.3
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 public class DelayerUsageTests {
-	
+
 	@Autowired @Qualifier("inputA")
 	private MessageChannel inputA;
+
+	@Autowired
+	private MessageChannel delayerInsideChain;
+
 	@Autowired @Qualifier("outputA")
 	private PollableChannel outputA;
-	
+
 	@Autowired @Qualifier("inputB")
 	private MessageChannel inputB;
+
 	@Autowired @Qualifier("outputB1")
 	private PollableChannel outputB1;
-	
+
 	@Test
 	public void testDelayWithDefaultScheduler(){
 		long start = System.currentTimeMillis();
@@ -55,20 +63,22 @@ public class DelayerUsageTests {
 		outputA.receive();
 		assertTrue((System.currentTimeMillis() - start) >= 1000);
 	}
+
 	@Test
 	public void testDelayWithDefaultSchedulerCustomDelayHeader(){
 		MessageBuilder<String> builder = MessageBuilder.withPayload("Hello");
 		// set custom delay header
 		builder.setHeader("foo", 2000);
 		long start = System.currentTimeMillis();
-		inputA.send(builder.build());		
+		inputA.send(builder.build());
 		outputA.receive();
 		assertTrue((System.currentTimeMillis() - start) >= 2000);
 	}
+
 	@Test
-	public void testDelayWithCustomScheduler(){	
+	public void testDelayWithCustomScheduler(){
 		long start = System.currentTimeMillis();
-		inputB.send(new GenericMessage<String>("1")); 
+		inputB.send(new GenericMessage<String>("1"));
 		inputB.send(new GenericMessage<String>("2"));
 		inputB.send(new GenericMessage<String>("3"));
 		inputB.send(new GenericMessage<String>("4"));
@@ -82,14 +92,22 @@ public class DelayerUsageTests {
 		outputB1.receive();
 		outputB1.receive();
 		outputB1.receive();
-	
+
 		// must execute under 3 seconds, since threadPool is set too 5.
 		// first batch is 5 concurrent invocations on SA, then 2 more
 		// elapsed time for the whole execution should be a bit over 2 seconds depending on the hardware
 		assertTrue(((System.currentTimeMillis() - start) >= 1000) && ((System.currentTimeMillis() - start) < 3000));
 	}
-	
-	
+
+	@Test //INT-1132
+	public void testDelayerInsideChain(){
+		long start = System.currentTimeMillis();
+		delayerInsideChain.send(new GenericMessage<String>("Hello"));
+		Message<?> message = outputA.receive();
+		assertTrue((System.currentTimeMillis() - start) >= 1000);
+		assertEquals("hello", message.getPayload());
+	}
+
 	public static class SampleService{
 		public String processMessage(String message) throws Exception {
 			Thread.sleep(500);

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
@@ -81,6 +81,7 @@ public class DelayHandlerTests {
 	@Test
 	public void noDelayHeaderAndDefaultDelayIsZero() throws Exception {
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		Message<?> message = MessageBuilder.withPayload("test").build();
 		input.send(message);
 		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
@@ -91,6 +92,7 @@ public class DelayHandlerTests {
 	public void noDelayHeaderAndDefaultDelayIsPositive() throws Exception {
 		delayHandler.setDefaultDelay(10);
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		Message<?> message = MessageBuilder.withPayload("test").build();
 		input.send(message);
 		this.waitForLatch(1000);
@@ -103,6 +105,7 @@ public class DelayHandlerTests {
 		delayHandler.setDefaultDelay(5000);
 		delayHandler.setDelayHeaderName("delay");
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", 100).build();
 		input.send(message);
@@ -116,6 +119,7 @@ public class DelayHandlerTests {
 		delayHandler.setDefaultDelay(5000);
 		delayHandler.setDelayHeaderName("delay");
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", -7000).build();
 		input.send(message);
@@ -129,6 +133,7 @@ public class DelayHandlerTests {
 		delayHandler.setDefaultDelay(5);
 		delayHandler.setDelayHeaderName("delay");
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", "not a number").build();
 		input.send(message);
@@ -142,6 +147,7 @@ public class DelayHandlerTests {
 		delayHandler.setDefaultDelay(5000);
 		delayHandler.setDelayHeaderName("delay");
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", new Date(new Date().getTime() + 150)).build();
 		input.send(message);
@@ -155,6 +161,7 @@ public class DelayHandlerTests {
 		delayHandler.setDefaultDelay(5000);
 		delayHandler.setDelayHeaderName("delay");
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", new Date(new Date().getTime() - 60 * 1000)).build();
 		input.send(message);
@@ -167,6 +174,7 @@ public class DelayHandlerTests {
 	public void delayHeaderIsNullDateAndDefaultDelayIsZero() throws Exception {
 		delayHandler.setDelayHeaderName("delay");
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		Date nullDate = null;
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", nullDate).build();
@@ -180,6 +188,7 @@ public class DelayHandlerTests {
 	public void delayHeaderIsFutureDateAndTimesOut() throws Exception {
 		delayHandler.setDelayHeaderName("delay");
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		Date future = new Date(new Date().getTime() + 60 * 1000);
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", future).build();
@@ -194,6 +203,7 @@ public class DelayHandlerTests {
 		delayHandler.setDefaultDelay(5000);
 		delayHandler.setDelayHeaderName("delay");
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", "20").build();
 		input.send(message);
@@ -206,6 +216,7 @@ public class DelayHandlerTests {
 	public void verifyShutdownWithoutWaitingByDefault() throws Exception {
 		delayHandler.setDefaultDelay(5000);
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		delayHandler.handleMessage(new GenericMessage<String>("foo"));
 		delayHandler.destroy();
 
@@ -230,6 +241,7 @@ public class DelayHandlerTests {
 		delayHandler.setDefaultDelay(5000);
 		taskScheduler.setWaitForTasksToCompleteOnShutdown(true);
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		delayHandler.handleMessage(new GenericMessage<String>("foo"));
 		delayHandler.destroy();
 
@@ -252,6 +264,7 @@ public class DelayHandlerTests {
 	@Test(expected = MessageDeliveryException.class)
 	public void handlerThrowsExceptionWithNoDelay() throws Exception {
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		output.unsubscribe(resultHandler);
 		output.subscribe(new MessageHandler() {
 			public void handleMessage(Message<?> message) {
@@ -270,6 +283,7 @@ public class DelayHandlerTests {
 		taskScheduler.setErrorHandler(errorHandler);
 		delayHandler.setDelayHeaderName("delay");
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		output.unsubscribe(resultHandler);
 		errorChannel.subscribe(resultHandler);
 		output.subscribe(new MessageHandler() {
@@ -303,6 +317,7 @@ public class DelayHandlerTests {
 		taskScheduler.setErrorHandler(errorHandler);
 		delayHandler.setDelayHeaderName("delay");
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		output.unsubscribe(resultHandler);
 		customErrorChannel.subscribe(resultHandler);
 		output.subscribe(new MessageHandler() {
@@ -334,6 +349,7 @@ public class DelayHandlerTests {
 		taskScheduler.setErrorHandler(errorHandler);
 		delayHandler.setDelayHeaderName("delay");
 		delayHandler.afterPropertiesSet();
+		delayHandler.start();
 		output.unsubscribe(resultHandler);
 		defaultErrorChannel.subscribe(resultHandler);
 		output.subscribe(new MessageHandler() {
@@ -360,13 +376,14 @@ public class DelayHandlerTests {
 		this.delayHandler.setDefaultDelay(200);
 		this.delayHandler.setMessageStore(messageGroupStore);
 		this.delayHandler.afterPropertiesSet();
+		this.delayHandler.start();
 		Message<?> message = MessageBuilder.withPayload("test").build();
 		input.send(message);
 
+		Thread.sleep(110);
+
 		// emulate restart
 		this.delayHandler.destroy();
-
-		Thread.sleep(100);
 
 		assertEquals(1, messageGroupStore.getMessageGroupCount());
 		assertEquals(DELAYER_MESSAGE_GROUP_ID, messageGroupStore.iterator().next().getGroupId());

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,23 +27,28 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageDeliveryException;
-import org.springframework.integration.MessageHandlingException;
 import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.store.MessageGroup;
+import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  * @since 1.0.3
  */
 public class DelayHandlerTests {
+
+	private static final String DELAYER_MESSAGE_GROUP_ID = "testDelayer.messageGroupId";
 
 	private final DirectChannel input = new DirectChannel();
 
@@ -51,189 +56,155 @@ public class DelayHandlerTests {
 
 	private final CountDownLatch latch = new CountDownLatch(1);
 
+	private ThreadPoolTaskScheduler taskScheduler;
+
+	private DelayHandler delayHandler;
+
+	private ResultHandler resultHandler = new ResultHandler();
 
 	@Before
-	public void setChannelNames() {
+	public void setup() {
 		input.setBeanName("input");
 		output.setBeanName("output");
+		taskScheduler = new ThreadPoolTaskScheduler();
+		taskScheduler.afterPropertiesSet();
+		delayHandler = new DelayHandler(DELAYER_MESSAGE_GROUP_ID, taskScheduler);
+		delayHandler.setOutputChannel(output);
+		input.subscribe(delayHandler);
+		output.subscribe(resultHandler);
 	}
-
 
 	@Test
 	public void noDelayHeaderAndDefaultDelayIsZero() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(0);
-		ResultHandler resultHandler = new ResultHandler();
-		delayHandler.setOutputChannel(output);
 		delayHandler.afterPropertiesSet();
-		input.subscribe(delayHandler);
-		output.subscribe(resultHandler);
 		Message<?> message = MessageBuilder.withPayload("test").build();
 		input.send(message);
-		assertSame(message, resultHandler.lastMessage);
+		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
 		assertSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
 	@Test
 	public void noDelayHeaderAndDefaultDelayIsPositive() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(10);
-		ResultHandler resultHandler = new ResultHandler();
-		delayHandler.setOutputChannel(output);
+		delayHandler.setDefaultDelay(10);
 		delayHandler.afterPropertiesSet();
-		input.subscribe(delayHandler);
-		output.subscribe(resultHandler);
 		Message<?> message = MessageBuilder.withPayload("test").build();
 		input.send(message);
 		this.waitForLatch(1000);
-		assertSame(message, resultHandler.lastMessage);
+		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
 		assertNotSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
 	@Test
 	public void delayHeaderAndDefaultDelayWouldTimeout() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(5000);
+		delayHandler.setDefaultDelay(5000);
 		delayHandler.setDelayHeaderName("delay");
-		ResultHandler resultHandler = new ResultHandler();
-		delayHandler.setOutputChannel(output);
 		delayHandler.afterPropertiesSet();
-		input.subscribe(delayHandler);
-		output.subscribe(resultHandler);
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", 100).build();
 		input.send(message);
 		this.waitForLatch(1000);
-		assertSame(message, resultHandler.lastMessage);
+		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
 		assertNotSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
 	@Test
 	public void delayHeaderIsNegativeAndDefaultDelayWouldTimeout() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(5000);
+		delayHandler.setDefaultDelay(5000);
 		delayHandler.setDelayHeaderName("delay");
-		ResultHandler resultHandler = new ResultHandler();
-		delayHandler.setOutputChannel(output);
 		delayHandler.afterPropertiesSet();
-		input.subscribe(delayHandler);
-		output.subscribe(resultHandler);
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", -7000).build();
 		input.send(message);
 		this.waitForLatch(1000);
-		assertSame(message, resultHandler.lastMessage);
+		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
 		assertSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
 	@Test
 	public void delayHeaderIsInvalidFallsBackToDefaultDelay() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(5);
+		delayHandler.setDefaultDelay(5);
 		delayHandler.setDelayHeaderName("delay");
-		ResultHandler resultHandler = new ResultHandler();
-		delayHandler.setOutputChannel(output);
 		delayHandler.afterPropertiesSet();
-		input.subscribe(delayHandler);
-		output.subscribe(resultHandler);
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", "not a number").build();
 		input.send(message);
 		this.waitForLatch(1000);
-		assertSame(message, resultHandler.lastMessage);
+		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
 		assertNotSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
 	@Test
 	public void delayHeaderIsDateInTheFutureAndDefaultDelayWouldTimeout() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(5000);
+		delayHandler.setDefaultDelay(5000);
 		delayHandler.setDelayHeaderName("delay");
-		ResultHandler resultHandler = new ResultHandler();
-		delayHandler.setOutputChannel(output);
 		delayHandler.afterPropertiesSet();
-		input.subscribe(delayHandler);
-		output.subscribe(resultHandler);
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", new Date(new Date().getTime() + 150)).build();
 		input.send(message);
 		this.waitForLatch(3000);
-		assertSame(message, resultHandler.lastMessage);
+		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
 		assertNotSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
 	@Test
 	public void delayHeaderIsDateInThePastAndDefaultDelayWouldTimeout() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(5000);
+		delayHandler.setDefaultDelay(5000);
 		delayHandler.setDelayHeaderName("delay");
-		ResultHandler resultHandler = new ResultHandler();
-		delayHandler.setOutputChannel(output);
 		delayHandler.afterPropertiesSet();
-		input.subscribe(delayHandler);
-		output.subscribe(resultHandler);
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", new Date(new Date().getTime() - 60 * 1000)).build();
 		input.send(message);
 		this.waitForLatch(3000);
-		assertSame(message, resultHandler.lastMessage);
+		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
 		assertSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
 	@Test
 	public void delayHeaderIsNullDateAndDefaultDelayIsZero() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(0);
 		delayHandler.setDelayHeaderName("delay");
-		ResultHandler resultHandler = new ResultHandler();
-		delayHandler.setOutputChannel(output);
 		delayHandler.afterPropertiesSet();
-		input.subscribe(delayHandler);
-		output.subscribe(resultHandler);
 		Date nullDate = null;
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", nullDate).build();
 		input.send(message);
 		this.waitForLatch(3000);
-		assertSame(message, resultHandler.lastMessage);
+		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
 		assertSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
 	@Test(expected = TestTimedOutException.class)
 	public void delayHeaderIsFutureDateAndTimesOut() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(0);
 		delayHandler.setDelayHeaderName("delay");
-		ResultHandler resultHandler = new ResultHandler();
-		delayHandler.setOutputChannel(output);
 		delayHandler.afterPropertiesSet();
-		input.subscribe(delayHandler);
-		output.subscribe(resultHandler);
 		Date future = new Date(new Date().getTime() + 60 * 1000);
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", future).build();
 		input.send(message);
 		this.waitForLatch(50);
-		assertSame(message, resultHandler.lastMessage);
+		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
 		assertSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
 	@Test
 	public void delayHeaderIsValidStringAndDefaultDelayWouldTimeout() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(5000);
+		delayHandler.setDefaultDelay(5000);
 		delayHandler.setDelayHeaderName("delay");
-		ResultHandler resultHandler = new ResultHandler();
-		delayHandler.setOutputChannel(output);
 		delayHandler.afterPropertiesSet();
-		input.subscribe(delayHandler);
-		output.subscribe(resultHandler);
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", "20").build();
 		input.send(message);
 		this.waitForLatch(1000);
-		assertSame(message, resultHandler.lastMessage);
+		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
 		assertNotSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
 	@Test
 	public void verifyShutdownWithoutWaitingByDefault() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(5000);
+		delayHandler.setDefaultDelay(5000);
 		delayHandler.afterPropertiesSet();
 		delayHandler.handleMessage(new GenericMessage<String>("foo"));
 		delayHandler.destroy();
-		final ThreadPoolTaskScheduler taskScheduler = (ThreadPoolTaskScheduler)
-				new DirectFieldAccessor(delayHandler).getPropertyValue("taskScheduler");
+
 		final CountDownLatch latch = new CountDownLatch(1);
 		new Thread(new Runnable() {
 			public void run() {
@@ -252,13 +223,12 @@ public class DelayHandlerTests {
 
 	@Test
 	public void verifyShutdownWithWait() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(5000);
+		delayHandler.setDefaultDelay(5000);
 		delayHandler.setWaitForTasksToCompleteOnShutdown(true);
 		delayHandler.afterPropertiesSet();
 		delayHandler.handleMessage(new GenericMessage<String>("foo"));
 		delayHandler.destroy();
-		final ThreadPoolTaskScheduler taskScheduler = (ThreadPoolTaskScheduler)
-				new DirectFieldAccessor(delayHandler).getPropertyValue("taskScheduler");
+
 		final CountDownLatch latch = new CountDownLatch(1);
 		new Thread(new Runnable() {
 			public void run() {
@@ -277,10 +247,8 @@ public class DelayHandlerTests {
 
 	@Test(expected = MessageDeliveryException.class)
 	public void handlerThrowsExceptionWithNoDelay() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(0);
-		delayHandler.setOutputChannel(output);
 		delayHandler.afterPropertiesSet();
-		input.subscribe(delayHandler);
+		output.unsubscribe(resultHandler);
 		output.subscribe(new MessageHandler() {
 			public void handleMessage(Message<?> message) {
 				throw new UnsupportedOperationException("intentional test failure");
@@ -292,14 +260,14 @@ public class DelayHandlerTests {
 
 	@Test
 	public void errorChannelHeaderAndHandlerThrowsExceptionWithDelay() throws Exception {
-		DelayHandler delayHandler = new DelayHandler(0);
-		delayHandler.setDelayHeaderName("delay");
-		delayHandler.setOutputChannel(output);
-		delayHandler.afterPropertiesSet();
 		DirectChannel errorChannel = new DirectChannel();
-		ResultHandler resultHandler = new ResultHandler();
+		MessagePublishingErrorHandler errorHandler = new MessagePublishingErrorHandler();
+		errorHandler.setDefaultErrorChannel(errorChannel);
+		taskScheduler.setErrorHandler(errorHandler);
+		delayHandler.setDelayHeaderName("delay");
+		delayHandler.afterPropertiesSet();
+		output.unsubscribe(resultHandler);
 		errorChannel.subscribe(resultHandler);
-		input.subscribe(delayHandler);
 		output.subscribe(new MessageHandler() {
 			public void handleMessage(Message<?> message) {
 				throw new UnsupportedOperationException("intentional test failure");
@@ -311,13 +279,10 @@ public class DelayHandlerTests {
 		input.send(message);
 		this.waitForLatch(1000);
 		Message<?> errorMessage = resultHandler.lastMessage;
-		assertEquals(MessageHandlingException.class, errorMessage.getPayload().getClass());
-		MessageHandlingException exceptionPayload = (MessageHandlingException) errorMessage.getPayload();
-		assertSame(message, exceptionPayload.getFailedMessage());
-		assertEquals(MessageDeliveryException.class, exceptionPayload.getCause().getClass());
-		MessageDeliveryException nestedException = (MessageDeliveryException) exceptionPayload.getCause();
-		assertEquals(UnsupportedOperationException.class, nestedException.getCause().getClass());
-		assertSame(message, nestedException.getFailedMessage());
+		assertEquals(MessageDeliveryException.class, errorMessage.getPayload().getClass());
+		MessageDeliveryException exceptionPayload = (MessageDeliveryException) errorMessage.getPayload();
+		assertSame(message.getPayload(), exceptionPayload.getFailedMessage().getPayload());
+		assertEquals(UnsupportedOperationException.class, exceptionPayload.getCause().getClass());
 		assertNotSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
@@ -326,16 +291,16 @@ public class DelayHandlerTests {
 		String errorChannelName = "customErrorChannel";
 		StaticApplicationContext context = new StaticApplicationContext();
 		context.registerSingleton(errorChannelName, DirectChannel.class);
+		context.registerSingleton(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME, DirectChannel.class);
 		context.refresh();
 		DirectChannel customErrorChannel = (DirectChannel) context.getBean(errorChannelName);
-		DelayHandler delayHandler = new DelayHandler(0);
-		delayHandler.setBeanFactory(context);
+		MessagePublishingErrorHandler errorHandler = new MessagePublishingErrorHandler();
+		errorHandler.setBeanFactory(context);
+		taskScheduler.setErrorHandler(errorHandler);
 		delayHandler.setDelayHeaderName("delay");
-		delayHandler.setOutputChannel(output);
 		delayHandler.afterPropertiesSet();
-		ResultHandler resultHandler = new ResultHandler();
+		output.unsubscribe(resultHandler);
 		customErrorChannel.subscribe(resultHandler);
-		input.subscribe(delayHandler);
 		output.subscribe(new MessageHandler() {
 			public void handleMessage(Message<?> message) {
 				throw new UnsupportedOperationException("intentional test failure");
@@ -347,32 +312,26 @@ public class DelayHandlerTests {
 		input.send(message);
 		this.waitForLatch(1000);
 		Message<?> errorMessage = resultHandler.lastMessage;
-		assertEquals(MessageHandlingException.class, errorMessage.getPayload().getClass());
-		MessageHandlingException exceptionPayload = (MessageHandlingException) errorMessage.getPayload();
-		assertSame(message, exceptionPayload.getFailedMessage());
-		assertEquals(MessageDeliveryException.class, exceptionPayload.getCause().getClass());
-		MessageDeliveryException nestedException = (MessageDeliveryException) exceptionPayload.getCause();
-		assertEquals(UnsupportedOperationException.class, nestedException.getCause().getClass());
-		assertSame(message, nestedException.getFailedMessage());
+		assertEquals(MessageDeliveryException.class, errorMessage.getPayload().getClass());
+		MessageDeliveryException exceptionPayload = (MessageDeliveryException) errorMessage.getPayload();
+		assertSame(message.getPayload(), exceptionPayload.getFailedMessage().getPayload());
+		assertEquals(UnsupportedOperationException.class, exceptionPayload.getCause().getClass());
 		assertNotSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
 	@Test
 	public void defaultErrorChannelAndHandlerThrowsExceptionWithDelay() throws Exception {
 		StaticApplicationContext context = new StaticApplicationContext();
-		context.registerSingleton(
-				IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME, DirectChannel.class);
+		context.registerSingleton(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME, DirectChannel.class);
 		context.refresh();
-		DirectChannel defaultErrorChannel = (DirectChannel) context.getBean(
-				IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME);
-		DelayHandler delayHandler = new DelayHandler(0);
-		delayHandler.setBeanFactory(context);
+		DirectChannel defaultErrorChannel = (DirectChannel) context.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME);
+		MessagePublishingErrorHandler errorHandler = new MessagePublishingErrorHandler();
+		errorHandler.setBeanFactory(context);
+		taskScheduler.setErrorHandler(errorHandler);
 		delayHandler.setDelayHeaderName("delay");
-		delayHandler.setOutputChannel(output);
 		delayHandler.afterPropertiesSet();
-		ResultHandler resultHandler = new ResultHandler();
+		output.unsubscribe(resultHandler);
 		defaultErrorChannel.subscribe(resultHandler);
-		input.subscribe(delayHandler);
 		output.subscribe(new MessageHandler() {
 			public void handleMessage(Message<?> message) {
 				throw new UnsupportedOperationException("intentional test failure");
@@ -383,16 +342,46 @@ public class DelayHandlerTests {
 		input.send(message);
 		this.waitForLatch(1000);
 		Message<?> errorMessage = resultHandler.lastMessage;
-		assertEquals(MessageHandlingException.class, errorMessage.getPayload().getClass());
-		MessageHandlingException exceptionPayload = (MessageHandlingException) errorMessage.getPayload();
-		assertSame(message, exceptionPayload.getFailedMessage());
-		assertEquals(MessageDeliveryException.class, exceptionPayload.getCause().getClass());
-		MessageDeliveryException nestedException = (MessageDeliveryException) exceptionPayload.getCause();
-		assertEquals(UnsupportedOperationException.class, nestedException.getCause().getClass());
-		assertSame(message, nestedException.getFailedMessage());
+		assertEquals(MessageDeliveryException.class, errorMessage.getPayload().getClass());
+		MessageDeliveryException exceptionPayload = (MessageDeliveryException) errorMessage.getPayload();
+		assertSame(message.getPayload(), exceptionPayload.getFailedMessage().getPayload());
+		assertEquals(UnsupportedOperationException.class, exceptionPayload.getCause().getClass());
 		assertNotSame(Thread.currentThread(), resultHandler.lastThread);
 	}
 
+
+	@Test //INT-1132
+	public void testReschedulePersistedMessagesOnStartup() throws Exception {
+		MessageGroupStore messageGroupStore = new SimpleMessageStore();
+		this.delayHandler.setDefaultDelay(1000);
+		this.delayHandler.setMessageStore(messageGroupStore);
+		this.delayHandler.afterPropertiesSet();
+		Message<?> message = MessageBuilder.withPayload("test").build();
+		input.send(message);
+
+		// emulate restart
+		this.delayHandler.destroy();
+		assertEquals(1, messageGroupStore.getMessageGroupCount());
+		assertEquals(DELAYER_MESSAGE_GROUP_ID, messageGroupStore.iterator().next().getGroupId());
+		assertEquals(1, messageGroupStore.messageGroupSize(DELAYER_MESSAGE_GROUP_ID));
+		assertEquals(1, messageGroupStore.getMessageCountForAllMessageGroups());
+		MessageGroup messageGroup = messageGroupStore.getMessageGroup(DELAYER_MESSAGE_GROUP_ID);
+		assertEquals(message.getPayload(), messageGroup.getMessages().iterator().next().getPayload());
+		taskScheduler.afterPropertiesSet();
+
+		DelayHandler delayHandler = new DelayHandler(DELAYER_MESSAGE_GROUP_ID, taskScheduler);
+		delayHandler.setOutputChannel(output);
+		delayHandler.setDefaultDelay(100);
+		delayHandler.setMessageStore(messageGroupStore);
+		delayHandler.afterPropertiesSet();
+
+		this.waitForLatch(1000);
+		messageGroupStore.expireMessageGroups(-1000);
+		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
+		assertNotSame(Thread.currentThread(), resultHandler.lastThread);
+		assertEquals(1, messageGroupStore.getMessageGroupCount());
+		assertEquals(0, messageGroupStore.messageGroupSize(DELAYER_MESSAGE_GROUP_ID));
+	}
 
 	private void waitForLatch(long timeout) {
 		try {

--- a/spring-integration-groovy/src/main/resources/org/springframework/integration/groovy/config/spring-integration-groovy-2.2.xsd
+++ b/spring-integration-groovy/src/main/resources/org/springframework/integration/groovy/config/spring-integration-groovy-2.2.xsd
@@ -7,7 +7,7 @@
 	elementFormDefault="qualified" attributeFormDefault="unqualified">
 
 	<xsd:include
-		schemaLocation="http://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core-2.2.xsd" 
+		schemaLocation="http://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core-2.2.xsd"
 		/>
 
 	<xsd:import namespace="http://www.springframework.org/schema/integration" schemaLocation="http://www.springframework.org/schema/integration/spring-integration-2.2.xsd" />
@@ -53,7 +53,7 @@
 				<xsd:element ref="integration:poller" minOccurs="0"
 					maxOccurs="1" />
 			</xsd:all>
-			<xsd:attributeGroup ref="integration:inputOutputChannelGroup" />
+			<xsd:attributeGroup ref="integration:inputOutputChannelGroupWithId" />
 			<xsd:attribute name="customizer" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns:beans="http://www.springframework.org/schema/beans"
+			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			 xmlns="http://www.springframework.org/schema/integration"
+			 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<beans:bean id="messageStore"
+				class="org.springframework.integration.jdbc.DelayerHandlerRescheduleIntegrationTests$TestJdbcMessageStore"/>
+
+	<channel id="output">
+		<queue/>
+	</channel>
+
+	<delayer id="#{T (org.springframework.integration.jdbc.DelayerHandlerRescheduleIntegrationTests).DELAYER_ID}"
+			 input-channel="input"
+			 output-channel="output"
+			 default-delay="1000"
+			 message-store="messageStore"/>
+
+</beans:beans>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
@@ -15,7 +15,7 @@
 	<delayer id="#{T (org.springframework.integration.jdbc.DelayerHandlerRescheduleIntegrationTests).DELAYER_ID}"
 			 input-channel="input"
 			 output-channel="output"
-			 default-delay="1000"
+			 default-delay="200"
 			 message-store="messageStore"/>
 
 </beans:beans>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.Message;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.core.PollableChannel;
+import org.springframework.integration.store.MessageGroup;
+import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.util.UUIDConverter;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+
+
+
+/**
+ * @author Arte Bilan
+ */
+//INT-1132
+public class DelayerHandlerRescheduleIntegrationTests {
+
+	public static final String DELAYER_ID = "delayerWithJdbcMS";
+
+
+	private static EmbeddedDatabase dataSource;
+
+	@BeforeClass
+	public static void init() {
+		dataSource = new EmbeddedDatabaseBuilder()
+				.setType(EmbeddedDatabaseType.DERBY)
+				.addScript("classpath:/org/springframework/integration/jdbc/schema-derby.sql")
+				.build();
+	}
+
+	@AfterClass
+	public static void destroy() {
+		dataSource.shutdown();
+	}
+
+	@Test
+	public void testDelayerHandlerRescheduleWithJdbcMessageStore() {
+		AbstractApplicationContext context = new ClassPathXmlApplicationContext("DelayerHandlerRescheduleIntegrationTests-context.xml", this.getClass());
+		MessageChannel input = context.getBean("input", MessageChannel.class);
+		MessageGroupStore messageStore = context.getBean("messageStore", MessageGroupStore.class);
+
+		assertEquals(0, messageStore.getMessageGroupCount());
+		String testPayload = "test";
+		input.send(MessageBuilder.withPayload(testPayload).build());
+
+		// Emulate restart and check DB state before next start
+		context.destroy();
+
+		try {
+			context.getBean("input", MessageChannel.class);
+			fail("IllegalStateException expected");
+		}
+		catch (Exception e) {
+			assertTrue(e instanceof IllegalStateException);
+			assertTrue(e.getMessage().contains("BeanFactory not initialized or already closed - call 'refresh'"));
+		}
+
+		String delayerMessageGroupId = UUIDConverter.getUUID(DELAYER_ID + ".messageGroupId").toString();
+
+		assertEquals(1, messageStore.getMessageGroupCount());
+		assertEquals(delayerMessageGroupId, messageStore.iterator().next().getGroupId());
+		assertEquals(1, messageStore.messageGroupSize(delayerMessageGroupId));
+		assertEquals(1, messageStore.getMessageCountForAllMessageGroups());
+		MessageGroup messageGroup = messageStore.getMessageGroup(delayerMessageGroupId);
+		assertEquals(testPayload, messageGroup.getMessages().iterator().next().getPayload());
+
+		context.refresh();
+		PollableChannel output = context.getBean("output", PollableChannel.class);
+		Message<?> message = output.receive();
+		assertEquals(testPayload, message.getPayload());
+		assertEquals(1, messageStore.getMessageGroupCount());
+		assertEquals(0, messageStore.messageGroupSize(delayerMessageGroupId));
+
+	}
+
+	private static class TestJdbcMessageStore extends JdbcMessageStore {
+
+		private TestJdbcMessageStore() {
+			super();
+			this.setDataSource(dataSource);
+		}
+
+	}
+
+}

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
@@ -35,6 +35,7 @@ import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.util.UUIDConverter;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
@@ -96,7 +97,10 @@ public class DelayerHandlerRescheduleIntegrationTests {
 		assertEquals(1, messageStore.messageGroupSize(delayerMessageGroupId));
 		assertEquals(1, messageStore.getMessageCountForAllMessageGroups());
 		MessageGroup messageGroup = messageStore.getMessageGroup(delayerMessageGroupId);
-		assertEquals(testPayload, messageGroup.getMessages().iterator().next().getPayload());
+		Message<?> messageInStore = messageGroup.getMessages().iterator().next();
+		Object payload = messageInStore.getPayload();
+		assertEquals("DelayedMessageWrapper", payload.getClass().getSimpleName());
+		assertEquals(testPayload, TestUtils.getPropertyValue(payload, "original.payload"));
 
 		context.refresh();
 


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-1132
- Add support for DelayHandler reschedule persisted Messages on startup
- Change DelayHandler dependency to MessageGroupStore
- Add required DelayHandler.messageGroupId property
- Make registered by SI-namespace TaskScheduler as default for DelayHandler
- Remove 'required' from delayer's xml-attribute 'default-delay' as redundant
- Additional refactoring & polishing around <delayer>
- Polishing delayer's Tests
- Test about 'rescheduling'
- Integration test about 'rescheduling' with JdbcMS

I've made a lot of changes around <delayer> ( sorry Mark ;-) ) and radically changed its internal behavior.
So, be careful on reviewing it, please.
And in the end if it will be OK I'll open new Task about changing Reference Manual.
