### PR TITLE
INT-2570 Support url-expression on Outbound Http

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,20 @@
 
 package org.springframework.integration.http.config;
 
-import org.w3c.dom.Element;
-
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractOutboundChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
 
 /**
  * Parser for the 'outbound-channel-adapter' element of the http namespace.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.0
  */
 public class HttpOutboundChannelAdapterParser extends AbstractOutboundChannelAdapterParser {
@@ -39,9 +39,9 @@ public class HttpOutboundChannelAdapterParser extends AbstractOutboundChannelAda
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
 				"org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandler");
 		builder.addPropertyValue("expectReply", false);
-		builder.addConstructorArgValue(element.getAttribute("url"));
+		HttpAdapterParsingUtils.configureUrlConstructorArg(element, parserContext, builder);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "http-method");
-		
+
 		String restTemplate = element.getAttribute("rest-template");
 		if (StringUtils.hasText(restTemplate)) {
 			HttpAdapterParsingUtils.verifyNoRestTemplateAttributes(element, parserContext);
@@ -52,7 +52,7 @@ public class HttpOutboundChannelAdapterParser extends AbstractOutboundChannelAda
 				IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, referenceAttributeName);
 			}
 		}
-		
+
 		String headerMapper = element.getAttribute("header-mapper");
 		String mappedRequestHeaders = element.getAttribute("mapped-request-headers");
 		if (StringUtils.hasText(headerMapper)) {
@@ -66,7 +66,7 @@ public class HttpOutboundChannelAdapterParser extends AbstractOutboundChannelAda
 		else if (StringUtils.hasText(mappedRequestHeaders)) {
 			BeanDefinitionBuilder headerMapperBuilder = BeanDefinitionBuilder.genericBeanDefinition(
 					"org.springframework.integration.http.support.DefaultHttpHeaderMapper");
-			IntegrationNamespaceUtils.setValueIfAttributeDefined(headerMapperBuilder, element, "mapped-request-headers", "outboundHeaderNames");	
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(headerMapperBuilder, element, "mapped-request-headers", "outboundHeaderNames");
 			builder.addPropertyValue("headerMapper", headerMapperBuilder.getBeanDefinition());
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "charset");

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundGatewayParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,19 @@
 
 package org.springframework.integration.http.config;
 
-import org.w3c.dom.Element;
-
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractConsumerEndpointParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
 
 /**
  * Parser for the 'outbound-gateway' element of the http namespace.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
 public class HttpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 
@@ -41,9 +41,9 @@ public class HttpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
 				"org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandler");
-		builder.addConstructorArgValue(element.getAttribute("url"));
+		HttpAdapterParsingUtils.configureUrlConstructorArg(element, parserContext, builder);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "http-method");
-		
+
 		String restTemplate = element.getAttribute("rest-template");
 		if (StringUtils.hasText(restTemplate)) {
 			HttpAdapterParsingUtils.verifyNoRestTemplateAttributes(element, parserContext);
@@ -54,7 +54,7 @@ public class HttpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 				IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, referenceAttributeName);
 			}
 		}
-		
+
 		String headerMapper = element.getAttribute("header-mapper");
 		String mappedRequestHeaders = element.getAttribute("mapped-request-headers");
 		String mappedResponseHeaders = element.getAttribute("mapped-response-headers");

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.2.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.2.xsd
@@ -333,11 +333,21 @@ The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Re
 				<xsd:element name="uri-variable" type="uriVariableType" minOccurs="0" maxOccurs="unbounded" />
 			</xsd:sequence>
 			<xsd:attribute name="id" type="xsd:string" />
-			<xsd:attribute name="url" type="xsd:string" use="required">
+			<xsd:attribute name="url" type="xsd:string" use="optional">
 				<xsd:annotation>
 					<xsd:documentation>
 						<![CDATA[
-	URL to which the requests should be sent. It may include {placeholders}.
+	URL to which the requests should be sent. It may include {placeholders} for
+	evaluation against uri-variables.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="url-expression" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+	SpEL Expression resolving to a URL to which the requests should be sent. The resolved
+	value may include {placeholders} for further evaluation against uri-variables.
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -463,11 +473,21 @@ The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Re
 					<xsd:sequence>
 						<xsd:element name="uri-variable" type="uriVariableType" minOccurs="0" maxOccurs="unbounded" />
 					</xsd:sequence>
-					<xsd:attribute name="url" type="xsd:string" use="required">
+					<xsd:attribute name="url" type="xsd:string" use="optional">
 						<xsd:annotation>
 							<xsd:documentation>
-								URL to be used as a fallback for any request Message does not contain the request URL Message header.
+			URL to which the requests should be sent. It may include {placeholders} for
+			evaluation against uri-variables.
 							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="url-expression" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>
+								<![CDATA[
+			SpEL Expression resolving to a URL to which the requests should be sent. The resolved
+			value may include {placeholders} for further evaluation against uri-variables.
+							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
 					<xsd:attribute name="http-method" default="POST">

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests-context.xml
@@ -34,6 +34,16 @@
 		<uri-variable name="foo" expression="headers.bar"/>
 	</outbound-channel-adapter>
 
+	<outbound-channel-adapter id="withUrlAndTemplate"
+		url="http://localhost/test1" channel="requests"
+		rest-template="customRestTemplate"/>
+
+	<outbound-channel-adapter id="withUrlExpression" url-expression="'http://localhost/test1'" channel="requests"/>
+
+	<outbound-channel-adapter id="withUrlExpressionAndTemplate"
+		url-expression="'http://localhost/test1'" channel="requests"
+		rest-template="customRestTemplate"/>
+
 	<beans:bean id="testRequestFactory" class="org.springframework.http.client.SimpleClientHttpRequestFactory"/>
 
 	<beans:bean id="testErrorHandler" class="org.springframework.integration.http.config.HttpOutboundChannelAdapterParserTests$StubErrorHandler"/>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests-url-fail-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests-url-fail-context.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans
+	xmlns="http://www.springframework.org/schema/integration/http"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:si="http://www.springframework.org/schema/integration"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+	<si:channel id="requests"/>
+
+	<!-- Can't have both url and url-expression -->
+	<outbound-channel-adapter id="minimalConfig" url="http://localhost/test1" url-expression="'foo'"
+				error-handler="testErrorHandler" rest-template="restTemplate" channel="requests"/>
+
+	<beans:bean id="restTemplate" class="org.springframework.web.client.RestTemplate"/>
+
+	<beans:bean id="testErrorHandler" 
+		class="org.springframework.integration.http.config.HttpOutboundChannelAdapterParserTests$StubErrorHandler"/>
+
+</beans:beans>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests-context.xml
@@ -40,6 +40,8 @@
 		<uri-variable name="foo" expression="headers.bar"/>
 	</outbound-gateway>
 
+	<outbound-gateway id="withUrlExpression" url-expression="'http://localhost/test1'" request-channel="requests"/>
+
 	<beans:bean id="testRequestFactory" class="org.springframework.http.client.SimpleClientHttpRequestFactory"/>
 
 	<beans:bean id="testErrorHandler" class="org.springframework.integration.http.config.HttpOutboundGatewayParserTests$StubErrorHandler"/>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -51,9 +52,12 @@ import org.springframework.web.client.RestTemplate;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Gary Russell
  */
 public class HttpRequestExecutingMessageHandlerTests {
-	
+
+	private String resolvedUri;
+
 	@Test
 	public void simpleStringKeyStringValueFormData() throws Exception {
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
@@ -85,7 +89,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		assertEquals("3", map.get("c").iterator().next());
 		assertEquals(MediaType.APPLICATION_FORM_URLENCODED, request.getHeaders().getContentType());
 	}
-	
+
 	@Test
 	public void simpleStringKeyObjectValueFormData() throws Exception {
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
@@ -116,7 +120,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		assertEquals("Mohnton", map.get("c").get(0).toString());
 		assertEquals(MediaType.MULTIPART_FORM_DATA, request.getHeaders().getContentType());
 	}
-	
+
 	@Test
 	public void simpleObjectKeyObjectValueFormData() throws Exception {
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
@@ -173,13 +177,13 @@ public class HttpRequestExecutingMessageHandlerTests {
 		Object body = request.getBody();
 		assertTrue(body instanceof MultiValueMap<?, ?>);
 		MultiValueMap<?, ?> map = (MultiValueMap <?, ?>) body;
-		
+
 		List<?> aValue = map.get("a");
 		assertEquals(3, aValue.size());
 		assertEquals("1", aValue.get(0));
 		assertEquals("2", aValue.get(1));
 		assertEquals("3", aValue.get(2));
-		
+
 		List<?> bValue = map.get("b");
 		assertEquals(1, bValue.size());
 		assertEquals("4", bValue.get(0));
@@ -187,13 +191,13 @@ public class HttpRequestExecutingMessageHandlerTests {
 		List<?> cValue = map.get("c");
 		assertEquals(1, cValue.size());
 		assertEquals("5", cValue.get(0));
-		
+
 		List<?> dValue = map.get("d");
 		assertEquals(1, dValue.size());
 		assertEquals("6", dValue.get(0));
 		assertEquals(MediaType.APPLICATION_FORM_URLENCODED, request.getHeaders().getContentType());
 	}
-	
+
 	@Test
 	public void stringKeyPrimitiveArrayValueMixedFormData() throws Exception {
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
@@ -218,7 +222,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		Object body = request.getBody();
 		assertTrue(body instanceof MultiValueMap<?, ?>);
 		MultiValueMap<?, ?> map = (MultiValueMap <?, ?>) body;
-		
+
 		List<?> aValue = map.get("a");
 		assertEquals(1, aValue.size());
 		Object value = aValue.get(0);
@@ -227,7 +231,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		assertEquals(1, y[0]);
 		assertEquals(2, y[1]);
 		assertEquals(3, y[2]);
-		
+
 		List<?> bValue = map.get("b");
 		assertEquals(1, bValue.size());
 		assertEquals("4", bValue.get(0));
@@ -235,7 +239,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		List<?> cValue = map.get("c");
 		assertEquals(1, cValue.size());
 		assertEquals("5", cValue.get(0));
-		
+
 		List<?> dValue = map.get("d");
 		assertEquals(1, dValue.size());
 		assertEquals("6", dValue.get(0));
@@ -263,13 +267,13 @@ public class HttpRequestExecutingMessageHandlerTests {
 		Object body = request.getBody();
 		assertTrue(body instanceof MultiValueMap<?, ?>);
 		MultiValueMap<?, ?> map = (MultiValueMap <?, ?>) body;
-		
+
 		List<?> aValue = map.get("a");
 		assertEquals(3, aValue.size());
 		assertNull(aValue.get(0));
 		assertEquals(4, aValue.get(1));
 		assertNull(aValue.get(2));
-		
+
 		List<?> bValue = map.get("b");
 		assertEquals(1, bValue.size());
 		assertEquals("4", bValue.get(0));
@@ -278,8 +282,8 @@ public class HttpRequestExecutingMessageHandlerTests {
 	}
 	/**
 	 * This test and the one below might look identical, but they are not.
-	 * This test injected "5" into the list as String resulting in 
-	 * the Content-TYpe being application/x-www-form-urlencoded 
+	 * This test injected "5" into the list as String resulting in
+	 * the Content-TYpe being application/x-www-form-urlencoded
 	 * @throws Exception
 	 */
 	@Test
@@ -308,13 +312,13 @@ public class HttpRequestExecutingMessageHandlerTests {
 		Object body = request.getBody();
 		assertTrue(body instanceof MultiValueMap<?, ?>);
 		MultiValueMap<?, ?> map = (MultiValueMap <?, ?>) body;
-		
+
 		List<?> aValue = map.get("a");
 		assertEquals(3, aValue.size());
 		assertNull(aValue.get(0));
 		assertEquals("5", aValue.get(1));
 		assertNull(aValue.get(2));
-		
+
 		List<?> bValue = map.get("b");
 		assertEquals(1, bValue.size());
 		assertEquals("4", bValue.get(0));
@@ -323,7 +327,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 	}
 	/**
 	 * This test and the one above might look identical, but they are not.
-	 * This test injected 5 into the list as int resulting in 
+	 * This test injected 5 into the list as int resulting in
 	 * Content-type being multipart/form-data
 	 * @throws Exception
 	 */
@@ -353,13 +357,13 @@ public class HttpRequestExecutingMessageHandlerTests {
 		Object body = request.getBody();
 		assertTrue(body instanceof MultiValueMap<?, ?>);
 		MultiValueMap<?, ?> map = (MultiValueMap <?, ?>) body;
-		
+
 		List<?> aValue = map.get("a");
 		assertEquals(3, aValue.size());
 		assertNull(aValue.get(0));
 		assertEquals(5, aValue.get(1));
 		assertNull(aValue.get(2));
-		
+
 		List<?> bValue = map.get("b");
 		assertEquals(1, bValue.size());
 		assertEquals("4", bValue.get(0));
@@ -393,23 +397,23 @@ public class HttpRequestExecutingMessageHandlerTests {
 		Object body = request.getBody();
 		assertTrue(body instanceof MultiValueMap<?, ?>);
 		MultiValueMap<?, ?> map = (MultiValueMap <?, ?>) body;
-		
-		
+
+
 		List<?> aValue = map.get("a");
 		assertEquals(2, aValue.size());
 		assertEquals("1", aValue.get(0));
 		assertEquals("2", aValue.get(1));
-		
+
 		List<?> bValue = map.get("b");
 		assertEquals(0, bValue.size());
-		
+
 		List<?> cValue = map.get("c");
 		assertEquals(1, cValue.size());
 		assertEquals("3", cValue.get(0));
-		
+
 		assertEquals(MediaType.APPLICATION_FORM_URLENCODED, request.getHeaders().getContentType());
 	}
-	
+
 	@Test
 	public void stringKeyObjectCollectionValueFormData() throws Exception {
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
@@ -436,20 +440,20 @@ public class HttpRequestExecutingMessageHandlerTests {
 		Object body = request.getBody();
 		assertTrue(body instanceof MultiValueMap<?, ?>);
 		MultiValueMap<?, ?> map = (MultiValueMap <?, ?>) body;
-		
-		
+
+
 		List<?> aValue = map.get("a");
 		assertEquals(2, aValue.size());
 		assertEquals("Philadelphia", aValue.get(0).toString());
 		assertEquals("Ambler", aValue.get(1).toString());
-		
+
 		List<?> bValue = map.get("b");
 		assertEquals(0, bValue.size());
-		
+
 		List<?> cValue = map.get("c");
 		assertEquals(1, cValue.size());
 		assertEquals("Mohnton", cValue.get(0).toString());
-		
+
 		assertEquals(MediaType.MULTIPART_FORM_DATA, request.getHeaders().getContentType());
 	}
 
@@ -486,7 +490,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		assertNull(map.get("c").get(0));
 		assertEquals(MediaType.APPLICATION_FORM_URLENCODED, request.getHeaders().getContentType());
 	}
-	
+
 	@SuppressWarnings("cast")
 	@Test
 	public void contentAsByteArray() throws Exception {
@@ -494,7 +498,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		MockRestTemplate template = new MockRestTemplate();
 		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
 		handler.setHttpMethod(HttpMethod.POST);
-		
+
 		byte[] bytes = "Hello World".getBytes();
 		Message<?> message = MessageBuilder.withPayload(bytes).build();
 		Exception exception = null;
@@ -511,14 +515,14 @@ public class HttpRequestExecutingMessageHandlerTests {
 		assertEquals("Hello World", new String((byte[])bytes));
 		assertEquals(MediaType.APPLICATION_OCTET_STREAM, request.getHeaders().getContentType());
 	}
-	
+
 	@Test
 	public void contentAsXmlSource() throws Exception {
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
 		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
 		handler.setHttpMethod(HttpMethod.POST);
-		
+
 		Message<?> message = MessageBuilder.withPayload(mock(Source.class)).build();
 		Exception exception = null;
 		try {
@@ -533,28 +537,28 @@ public class HttpRequestExecutingMessageHandlerTests {
 		assertTrue(body instanceof Source);
 		assertEquals(MediaType.TEXT_XML, request.getHeaders().getContentType());
 	}
-	
+
 	@Test // no asertions just a warn message in a log
 	public void testWarnMessageForNonPostPutAndExtractPayload() throws Exception {
 		// should see a warn message
-		
+
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
 		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
 		handler.setHttpMethod(HttpMethod.GET);
 		handler.setExtractPayload(true);
 		handler.afterPropertiesSet();
-		
+
 		// should not see  a warn message since 'setExtractPayload' is not set explicitly
-		
+
 		handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
 		template = new MockRestTemplate();
 		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
 		handler.setHttpMethod(HttpMethod.GET);
 		handler.afterPropertiesSet();
-		
+
 		// should not see  a warn message since HTTP method is not GET
-		
+
 		handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
 		template = new MockRestTemplate();
 		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
@@ -562,7 +566,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		handler.setExtractPayload(true);
 		handler.afterPropertiesSet();
 	}
-	
+
 	@Test
 	public void contentTypeIsNotSetForGetRequest() throws Exception {
 		//GET
@@ -570,7 +574,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		MockRestTemplate template = new MockRestTemplate();
 		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
 		handler.setHttpMethod(HttpMethod.GET);
-		
+
 		Message<?> message = MessageBuilder.withPayload(mock(Source.class)).build();
 		Exception exception = null;
 		try {
@@ -582,18 +586,18 @@ public class HttpRequestExecutingMessageHandlerTests {
 		assertEquals("intentional", exception.getCause().getMessage());
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		assertNull(request.getHeaders().getContentType());
-		
+
 		/* TODO: reconsider the inclusion of content-type for various HttpMethods (only ignoring for GET as of 2.0.5)
 		 *       uncomment code below accordingly (see INT-1951)
-		 */ 
-		
+		 */
+
 		/*
 		//HEAD
 		handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
 		template = new MockRestTemplate();
 		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
 		handler.setHttpMethod(HttpMethod.HEAD);
-		
+
 		message = MessageBuilder.withPayload(mock(Source.class)).build();
 		exception = null;
 		try {
@@ -605,13 +609,13 @@ public class HttpRequestExecutingMessageHandlerTests {
 		assertEquals("intentional", exception.getCause().getMessage());
 		request = template.lastRequestEntity.get();
 		assertNull(request.getHeaders().getContentType());
-		
+
 		//DELETE
 		handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
 		template = new MockRestTemplate();
 		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
 		handler.setHttpMethod(HttpMethod.DELETE);
-		
+
 		message = MessageBuilder.withPayload(mock(Source.class)).build();
 		exception = null;
 		try {
@@ -623,13 +627,13 @@ public class HttpRequestExecutingMessageHandlerTests {
 		assertEquals("intentional", exception.getCause().getMessage());
 		request = template.lastRequestEntity.get();
 		assertNull(request.getHeaders().getContentType());
-		
+
 		//TRACE
 		handler = new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
 		template = new MockRestTemplate();
 		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
 		handler.setHttpMethod(HttpMethod.TRACE);
-		
+
 		message = MessageBuilder.withPayload(mock(Source.class)).build();
 		exception = null;
 		try {
@@ -652,11 +656,24 @@ public class HttpRequestExecutingMessageHandlerTests {
 //		It's just enough if it was sent successfully from chain without any failures
 	}
 
+	@Test
+	public void testUriExpression() {
+		RestTemplate restTemplate = new MockRestTemplate3();
+		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
+				new SpelExpressionParser().parseExpression("headers['foo']"),
+				restTemplate);
+		String theURL = "http://bar/baz";
+		Message<?> message = MessageBuilder.withPayload("").setHeader("foo", theURL).build();
+		handler.handleRequestMessage(message);
+		assertEquals(theURL, this.resolvedUri);
+	}
+
 	public static class City{
 		private String name;
 		public City(String name){
 			this.name = name;
 		}
+		@Override
 		public String toString(){
 			return name;
 		}
@@ -674,6 +691,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		}
 	}
 
+	@SuppressWarnings("unused")
 	private static class MockRestTemplate2 extends RestTemplate {
 
 		@Override
@@ -683,5 +701,14 @@ public class HttpRequestExecutingMessageHandlerTests {
 		}
 	}
 
+	private class MockRestTemplate3 extends RestTemplate {
+
+		@Override
+		public <T> ResponseEntity<T> exchange(String url, HttpMethod method, HttpEntity<?> requestEntity,
+											  Class<T> responseType, Map<String, ?> uriVariables) throws RestClientException {
+			resolvedUri = url;
+			return new ResponseEntity<T>(HttpStatus.OK);
+		}
+	}
 
 }

--- a/src/reference/docbook/http.xml
+++ b/src/reference/docbook/http.xml
@@ -279,6 +279,22 @@ In the case of the Outbound Gateway, the reply message produced by the gateway w
       order="3"
       auto-startup="false"/>]]></programlisting>
   </para>
+  <note>
+    <para>
+      2.2. Introduced a second method to specify the URL; you can use either the 'url' attribute
+      or the 'url-expression' attribute. The 'url' is a simple string (with placedholders for
+      URI variables, as
+      described below); the 'url-expression' is a SpEL expression, with the Message as the
+      root object, enabling dynamic urls. The url resulting from the expression evaluation can
+      still have placeholders for URI variables.
+    </para>
+    <para>
+      Some users, previously, used the place holders to replace the entire URL with a URI variable.
+      Changes in Spring 3.1 can cause some issues with escaped characters, such as '?'. For this
+      reason, it is recommended that if you wish to generate the URL entirely at runtime, you
+      use the 'url-expression' attribute.
+    </para>
+  </note>
   <para>
   	<emphasis>Mapping URI variables</emphasis>
   </para>


### PR DESCRIPTION
Add url-expression as an alternative to url for outbound
http adapters. One of url or url-expression must be
provided (but not both).

The Message is the root object for the expression's
evaluation context; the bean factory can also be
used to resolve '@beanName' expressions.
