### PR TITLE
INT-2570 Fix Failing Tests

### DIFF
--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
@@ -96,7 +96,8 @@ public class HttpOutboundChannelAdapterParserTests {
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertTrue(requestFactory instanceof SimpleClientHttpRequestFactory);
-		assertEquals("http://localhost/test1", handlerAccessor.getPropertyValue("uri"));
+		Expression uriExpression = (Expression) handlerAccessor.getPropertyValue("uriExpression");
+		assertEquals("http://localhost/test1", uriExpression.getValue());
 		assertEquals(HttpMethod.POST, handlerAccessor.getPropertyValue("httpMethod"));
 		assertEquals("UTF-8", handlerAccessor.getPropertyValue("charset"));
 		assertEquals(true, handlerAccessor.getPropertyValue("extractPayload"));
@@ -124,7 +125,8 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertEquals(requestFactoryBean, requestFactory);
 		Object errorHandlerBean = this.applicationContext.getBean("testErrorHandler");
 		assertEquals(errorHandlerBean, templateAccessor.getPropertyValue("errorHandler"));
-		assertEquals("http://localhost/test2/{foo}", handlerAccessor.getPropertyValue("uri"));
+		Expression uriExpression = (Expression) handlerAccessor.getPropertyValue("uriExpression");
+		assertEquals("http://localhost/test2/{foo}", uriExpression.getValue());
 		assertEquals(HttpMethod.GET, handlerAccessor.getPropertyValue("httpMethod"));
 		assertEquals("UTF-8", handlerAccessor.getPropertyValue("charset"));
 		assertEquals(false, handlerAccessor.getPropertyValue("extractPayload"));
@@ -168,7 +170,8 @@ public class HttpOutboundChannelAdapterParserTests {
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertTrue(requestFactory instanceof SimpleClientHttpRequestFactory);
-		assertEquals("http://localhost/test1", handlerAccessor.getPropertyValue("uri"));
+		Expression uriExpression = (Expression) handlerAccessor.getPropertyValue("uriExpression");
+		assertEquals("http://localhost/test1", uriExpression.getValue());
 		assertEquals(HttpMethod.POST, handlerAccessor.getPropertyValue("httpMethod"));
 		assertEquals("UTF-8", handlerAccessor.getPropertyValue("charset"));
 		assertEquals(true, handlerAccessor.getPropertyValue("extractPayload"));

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
@@ -78,7 +78,8 @@ public class HttpOutboundGatewayParserTests {
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertTrue(requestFactory instanceof SimpleClientHttpRequestFactory);
-		assertEquals("http://localhost/test1", handlerAccessor.getPropertyValue("uri"));
+		Expression uriExpression = (Expression) handlerAccessor.getPropertyValue("uriExpression");
+		assertEquals("http://localhost/test1", uriExpression.getValue());
 		assertEquals(HttpMethod.POST, handlerAccessor.getPropertyValue("httpMethod"));
 		assertEquals("UTF-8", handlerAccessor.getPropertyValue("charset"));
 		assertEquals(true, handlerAccessor.getPropertyValue("extractPayload"));
@@ -106,7 +107,8 @@ public class HttpOutboundGatewayParserTests {
 		Object converterListBean = this.applicationContext.getBean("converterList");
 		assertEquals(converterListBean, templateAccessor.getPropertyValue("messageConverters"));
 		assertEquals(String.class, handlerAccessor.getPropertyValue("expectedResponseType"));
-		assertEquals("http://localhost/test2", handlerAccessor.getPropertyValue("uri"));
+		Expression uriExpression = (Expression) handlerAccessor.getPropertyValue("uriExpression");
+		assertEquals("http://localhost/test2", uriExpression.getValue());
 		assertEquals(HttpMethod.PUT, handlerAccessor.getPropertyValue("httpMethod"));
 		assertEquals("UTF-8", handlerAccessor.getPropertyValue("charset"));
 		assertEquals(false, handlerAccessor.getPropertyValue("extractPayload"));


### PR DESCRIPTION
Renamed field from uri to uriExpression and it now
contains an expression.

DirectFieldAccessor in tests failed.
