### PR TITLE
INT-2588/2527 Remove Deprecation

### DIFF
--- a/spring-integration-event/src/test/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducerTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducerTests.java
@@ -19,7 +19,6 @@ package org.springframework.integration.event.inbound;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 import org.junit.Test;
 import org.springframework.context.ApplicationEvent;
@@ -36,7 +35,6 @@ import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.event.core.MessagingEvent;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.message.GenericMessage;
-import org.springframework.test.annotation.ExpectedException;
 
 /**
  * @author Mark Fisher
@@ -150,10 +148,11 @@ public class ApplicationEventListeningMessageProducerTests {
 		assertEquals("test", message2.getPayload());
 	}
 
-	@Test @ExpectedException(value=MessageHandlingException.class)
+	@Test(expected=MessageHandlingException.class)
 	public void anyApplicationEventCausesExceptionWithErrorHandling() {
 		DirectChannel channel = new DirectChannel();
 		channel.subscribe(new AbstractReplyProducingMessageHandler() {
+			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				throw new RuntimeException("Failed");
 			}
@@ -168,10 +167,7 @@ public class ApplicationEventListeningMessageProducerTests {
 		assertNotNull(message);
 		assertEquals("Failed", ((Exception) message.getPayload()).getCause().getMessage());
 		adapter.setErrorChannel(null);
-		try {
-			adapter.onApplicationEvent(new TestApplicationEvent1());
-			fail("Expected MessageHandlingException");
-		} catch (MessageHandlingException e) { }
+		adapter.onApplicationEvent(new TestApplicationEvent1());
 	}
 
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ClientModeControlBusTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ClientModeControlBusTests-context.xml
@@ -40,6 +40,7 @@
 		id="tcpIn"
 		connection-factory="client1"
 		channel="in"
+		retry-interval="1000"
 		client-mode="true"/>
 
 	<int:channel id="cbChannel" />

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -40,7 +40,6 @@ import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.test.util.TestUtils;
-import org.springframework.test.annotation.ExpectedException;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -130,7 +129,7 @@ public class CachingClientConnectionFactoryTests {
 		conn2a.close();
 	}
 
-	@Test @ExpectedException(MessagingException.class)
+	@Test(expected=MessagingException.class)
 	public void testLimit() throws Exception {
 		AbstractClientConnectionFactory factory = mock(AbstractClientConnectionFactory.class);
 		when(factory.isRunning()).thenReturn(true);


### PR DESCRIPTION
@ExpectedException is deprecated.

Also fixes a sporadic timing issue in the client mode test;
the default retry interval is 60 seconds and we only wait
10 seconds for the connection. If the initial connection
fails, we don't retry before the timeout.
