### PR TITLE
INT-2592 Fix Memory Leak in SimpleMessageStore

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -153,14 +153,6 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageH
 			this.messagingTemplate.setBeanFactory(beanFactory);
 		}
 		/*
-		 * If we have a custom lock registry, it probably has a different
-		 * sized pool of locks than the default, so pass it into the
-		 * message store.
-		 */
-		if (this.lockRegistrySet && this.messageStore instanceof SimpleMessageStore) {
-			((SimpleMessageStore) this.messageStore).setLockRegistry(this.lockRegistry);
-		}
-		/*
 		 * Disallow any further changes to the lock registry
 		 * (checked in the setter).
 		 */

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
@@ -70,11 +70,8 @@ public class SimpleMessageStore extends AbstractMessageGroupStore implements Mes
 	}
 
 	/**
-	 * Creates a SimpleMessageStore with a maximum size limited by the given capacity, or unlimited size if the given
-	 * capacity is less than 1. The capacities are applied independently to messages stored via
-	 * {@link #addMessage(Message)} and to those stored via {@link #addMessageToGroup(Object, Message)}. In both cases
-	 * the capacity applies to the number of messages that can be stored, and once that limit is reached attempting to
-	 * store another will result in an exception. Also allows the provision of a {@link LockRegistry}
+	 * See {@link #SimpleMessageStore(int, int, LockRegistry)}.
+	 * Also allows the provision of a custom {@link LockRegistry}
 	 * rather than using the default.
 	 */
 	public SimpleMessageStore(int individualCapacity, int groupCapacity, LockRegistry lockRegistry) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2011 the original author or authors.
- * 
+ * Copyright 2002-2012 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -19,9 +19,12 @@ import java.util.Iterator;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
 
 import org.springframework.integration.Message;
 import org.springframework.integration.MessagingException;
+import org.springframework.integration.util.DefaultLockRegistry;
+import org.springframework.integration.util.LockRegistry;
 import org.springframework.integration.util.UpperBound;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
@@ -31,27 +34,30 @@ import org.springframework.util.CollectionUtils;
 /**
  * Map-based in-memory implementation of {@link MessageStore} and {@link MessageGroupStore}. Enforces a maximum capacity for the
  * store.
- * 
+ *
  * @author Iwein Fuld
  * @author Mark Fisher
  * @author Dave Syer
  * @author Oleg Zhurakousky
- * 
+ * @author Gary Russell
+ *
  * @since 2.0
  */
 @ManagedResource
 public class SimpleMessageStore extends AbstractMessageGroupStore implements MessageStore, MessageGroupStore {
-	
-	private final ConcurrentMap<Object, Object> locks = new ConcurrentHashMap<Object, Object>();
+
+	private volatile LockRegistry lockRegistry;
 
 	private final ConcurrentMap<UUID, Message<?>> idToMessage;
 
 	private final ConcurrentMap<Object, SimpleMessageGroup> groupIdToMessageGroup;
-	
+
 	private final UpperBound individualUpperBound;
 
 	private final UpperBound groupUpperBound;
-	
+
+	private volatile boolean isUsed;
+
 	/**
 	 * Creates a SimpleMessageStore with a maximum size limited by the given capacity, or unlimited size if the given
 	 * capacity is less than 1. The capacities are applied independently to messages stored via
@@ -60,10 +66,24 @@ public class SimpleMessageStore extends AbstractMessageGroupStore implements Mes
 	 * store another will result in an exception.
 	 */
 	public SimpleMessageStore(int individualCapacity, int groupCapacity) {
+		this(individualCapacity, groupCapacity, new DefaultLockRegistry());
+	}
+
+	/**
+	 * Creates a SimpleMessageStore with a maximum size limited by the given capacity, or unlimited size if the given
+	 * capacity is less than 1. The capacities are applied independently to messages stored via
+	 * {@link #addMessage(Message)} and to those stored via {@link #addMessageToGroup(Object, Message)}. In both cases
+	 * the capacity applies to the number of messages that can be stored, and once that limit is reached attempting to
+	 * store another will result in an exception. Also allows the provision of a {@link LockRegistry}
+	 * rather than using the default.
+	 */
+	public SimpleMessageStore(int individualCapacity, int groupCapacity, LockRegistry lockRegistry) {
+		Assert.notNull(lockRegistry, "The LockRegistry cannot be null");
 		this.idToMessage = new ConcurrentHashMap<UUID, Message<?>>();
 		this.groupIdToMessageGroup = new ConcurrentHashMap<Object, SimpleMessageGroup>();
 		this.individualUpperBound = new UpperBound(individualCapacity);
 		this.groupUpperBound = new UpperBound(groupCapacity);
+		this.lockRegistry = lockRegistry;
 	}
 
 	/**
@@ -80,12 +100,19 @@ public class SimpleMessageStore extends AbstractMessageGroupStore implements Mes
 		this(0);
 	}
 
+	public void setLockRegistry(LockRegistry lockRegistry) {
+		Assert.notNull(lockRegistry, "The LockRegistry cannot be null");
+		Assert.isTrue(!(this.isUsed), "Cannot change the lock registry after the store has been used");
+		this.lockRegistry = lockRegistry;
+	}
+
 	@ManagedAttribute
 	public long getMessageCount() {
 		return idToMessage.size();
 	}
 
 	public <T> Message<T> addMessage(Message<T> message) {
+		this.isUsed = true;
 		if (!individualUpperBound.tryAcquire(0)) {
 			throw new MessagingException(this.getClass().getSimpleName()
 					+ " was out of capacity at, try constructing it with a larger capacity.");
@@ -122,62 +149,112 @@ public class SimpleMessageStore extends AbstractMessageGroupStore implements Mes
 			throw new MessagingException(this.getClass().getSimpleName()
 					+ " was out of capacity at, try constructing it with a larger capacity.");
 		}
-		Object lock = this.obtainLock(groupId);
-		synchronized (lock) {
-			SimpleMessageGroup group = this.groupIdToMessageGroup.get(groupId);
-			if (group == null) {
-				group = new SimpleMessageGroup(groupId);
-				this.groupIdToMessageGroup.putIfAbsent(groupId, group);
+		Lock lock = this.lockRegistry.obtain(groupId);
+		try {
+			lock.lockInterruptibly();
+			try {
+				SimpleMessageGroup group = this.groupIdToMessageGroup.get(groupId);
+				if (group == null) {
+					group = new SimpleMessageGroup(groupId);
+					this.groupIdToMessageGroup.putIfAbsent(groupId, group);
+				}
+				group.add(message);
+				return group;
 			}
-			group.add(message);
-			return group;
+			finally {
+				lock.unlock();
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new MessagingException("Interrupted while obtaining lock", e);
 		}
 	}
 
 	public void removeMessageGroup(Object groupId) {
-		Object lock = this.obtainLock(groupId);
-		synchronized (lock) {
-			if (!groupIdToMessageGroup.containsKey(groupId)) {
-				return;
+		Lock lock = this.lockRegistry.obtain(groupId);
+		try {
+			lock.lockInterruptibly();
+			try {
+				if (!groupIdToMessageGroup.containsKey(groupId)) {
+					return;
+				}
+
+				groupUpperBound.release(groupIdToMessageGroup.get(groupId).size());
+				groupIdToMessageGroup.remove(groupId);
 			}
-				
-			groupUpperBound.release(groupIdToMessageGroup.get(groupId).size());
-			groupIdToMessageGroup.remove(groupId);
+			finally {
+				lock.unlock();
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new MessagingException("Interrupted while obtaining lock", e);
 		}
 	}
 
 	public MessageGroup removeMessageFromGroup(Object groupId, Message<?> messageToRemove) {
-		Object lock = this.obtainLock(groupId);
-		synchronized (lock) {
-			SimpleMessageGroup group = this.groupIdToMessageGroup.get(groupId);
-			Assert.notNull(group, "MessageGroup for groupId '" + groupId + "' " +
-					"can not be located while attempting to remove Message from the MessageGroup");
-			group.remove(messageToRemove);			
-			return group;
+		Lock lock = this.lockRegistry.obtain(groupId);
+		try {
+			lock.lockInterruptibly();
+			try {
+				SimpleMessageGroup group = this.groupIdToMessageGroup.get(groupId);
+				Assert.notNull(group, "MessageGroup for groupId '" + groupId + "' " +
+						"can not be located while attempting to remove Message from the MessageGroup");
+				group.remove(messageToRemove);
+				return group;
+			}
+			finally {
+				lock.unlock();
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new MessagingException("Interrupted while obtaining lock", e);
 		}
 	}
 
 	public Iterator<MessageGroup> iterator() {
 		return new HashSet<MessageGroup>(groupIdToMessageGroup.values()).iterator();
 	}
-	
+
 	public void setLastReleasedSequenceNumberForGroup(Object groupId, int sequenceNumber) {
-		Object lock = this.obtainLock(groupId);
-		synchronized (lock) {
-			SimpleMessageGroup group = this.groupIdToMessageGroup.get(groupId);
-			Assert.notNull(group, "MessageGroup for groupId '" + groupId + "' " +
-					"can not be located while attempting to set 'lastReleasedSequenceNumber'");
-			group.setLastReleasedMessageSequenceNumber(sequenceNumber);
+		Lock lock = this.lockRegistry.obtain(groupId);
+		try {
+			lock.lockInterruptibly();
+			try {
+				SimpleMessageGroup group = this.groupIdToMessageGroup.get(groupId);
+				Assert.notNull(group, "MessageGroup for groupId '" + groupId + "' " +
+						"can not be located while attempting to set 'lastReleasedSequenceNumber'");
+				group.setLastReleasedMessageSequenceNumber(sequenceNumber);
+			}
+			finally {
+				lock.unlock();
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new MessagingException("Interrupted while obtaining lock", e);
 		}
 	}
 
 	public void completeGroup(Object groupId) {
-		Object lock = this.obtainLock(groupId);
-		synchronized (lock) {
-			SimpleMessageGroup group = this.groupIdToMessageGroup.get(groupId);
-			Assert.notNull(group, "MessageGroup for groupId '" + groupId + "' " +
-					"can not be located while attempting to complete the MessageGroup");
-			group.complete();	
+		Lock lock = this.lockRegistry.obtain(groupId);
+		try {
+			lock.lockInterruptibly();
+			try {
+				SimpleMessageGroup group = this.groupIdToMessageGroup.get(groupId);
+				Assert.notNull(group, "MessageGroup for groupId '" + groupId + "' " +
+						"can not be located while attempting to complete the MessageGroup");
+				group.complete();
+			}
+			finally {
+				lock.unlock();
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new MessagingException("Interrupted while obtaining lock", e);
 		}
 	}
 
@@ -189,18 +266,8 @@ public class SimpleMessageStore extends AbstractMessageGroupStore implements Mes
 			if (message != null){
 				this.removeMessageFromGroup(groupId, message);
 			}
-		}	
-		return message;
-	}
-	
-	private Object obtainLock(Object groupId){
-		Object lock = this.locks.get(groupId);
-		if (lock == null){
-			Object newLock = new Object();
-			Object previousLock = this.locks.putIfAbsent(groupId, newLock);
-			lock = (previousLock == null) ? newLock : previousLock;
 		}
-		return lock;
+		return message;
 	}
 
 	public int messageGroupSize(Object groupId) {


### PR DESCRIPTION
https://jira.springsource.org/browse/INT-2592

**Note: May be easier to review on the command line
with 'git log -p -b' because locking code changed
the indentation of the business code.**

Locks used to control access to a group of messages were
never removed from the collection.

Converted to use LockRegistry, which (by default) uses
a pool of reentrant locks, using the hashcode of the group id
as an index into the pool.

Given that the pool is fixed, there is nothing to remove, thus
avoiding the memory leak.

When used within AbstractCorrelatingMessageHandler, any
custom LockRegistry supplied will also be used by the message
store, thus allowing the user to increase or decrease the
size of the lock pool. The registry can not be changed
once the SimpleMessageGroup has been used.

Also, the ACMH had some protection to avoid setting the
LockRegistry more than once, but this did not protect
against the default lock registry being replaced after
it had been used. Added additional protection to avoid
this condition by setting lockRegistrySet to true in
onInit().
