### PR TITLE
INT-2593 Upgrade to Spring WS 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects { subproject ->
 		springGemfireVersion = '1.1.1.RELEASE'
 		springSecurityVersion = '3.1.0.RELEASE'
 		springSocialTwitterVersion = '1.0.1.RELEASE'
-		springWsVersion = '2.0.3.RELEASE'
+		springWsVersion = '2.1.0.RELEASE'
 	}
 
 	eclipse {

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
@@ -39,8 +39,8 @@ import org.springframework.integration.handler.AbstractReplyProducingMessageHand
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriTemplate;
+import org.springframework.web.util.UriUtils;
 import org.springframework.ws.WebServiceMessage;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.FaultMessageResolver;
@@ -256,10 +256,12 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 			super(uriTemplate);
 		}
 
+		@SuppressWarnings("deprecation")
 		@Override
 		protected URI encodeUri(String uri) {
 			try {
-				return UriComponentsBuilder.fromUri(new URI(uri)).build().encode("UTF-8").toUri();
+				String encoded = UriUtils.encodeHttpUrl(uri, "UTF-8");
+				return new URI(encoded);
 			}
 			catch (UnsupportedEncodingException ex) {
 				// should not happen, UTF-8 is always supported


### PR DESCRIPTION
Upgraded spring-integration-ws to use Spring WS 2.1.0, fixed the deprecation warning in AbstractWebServiceOutboundGateway.encodeUri(..) method
