### PR TITLE
INT-2264, INT-2263 TCP GW Reconcile reply-timeout

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/IpAdapterParserUtils.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/IpAdapterParserUtils.java
@@ -95,6 +95,8 @@ public abstract class IpAdapterParserUtils {
 
 	public static final String REQUEST_TIMEOUT = "request-timeout";
 
+	public static final String REMOTE_TIMEOUT = "remote-timeout";
+
 	public static final String REPLY_TIMEOUT = "reply-timeout";
 
 	public static final String REPLY_CHANNEL = "reply-channel";

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpOutboundGatewayParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.w3c.dom.Element;
  * @since 2.0
  */
 public class TcpOutboundGatewayParser extends AbstractConsumerEndpointParser {
-	
+
 	private static final String BASE_PACKAGE = "org.springframework.integration.ip.tcp";
 
 	@Override
@@ -41,14 +41,16 @@ public class TcpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(BASE_PACKAGE +
 				".TcpOutboundGateway");
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, 
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.TCP_CONNECTION_FACTORY);
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, 
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.REPLY_CHANNEL);
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, 
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.REQUEST_TIMEOUT);
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, 
-				IpAdapterParserUtils.REPLY_TIMEOUT);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.REMOTE_TIMEOUT);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.REPLY_TIMEOUT, "sendTimeout");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.AUTO_STARTUP);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,

--- a/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-2.2.xsd
+++ b/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-2.2.xsd
@@ -329,8 +329,38 @@ task executors such as a WorkManagerTaskExecutor.
 							</xsd:appinfo>
 						</xsd:annotation>
 					</xsd:attribute>
-					<xsd:attribute name="request-timeout" type="xsd:string"/>
-					<xsd:attribute name="reply-timeout" type="xsd:string"/>
+					<xsd:attribute name="request-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								When using a shared socket, specifies the time the gateway will wait
+								to get access to the socket to send the request.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the time the gateway will wait while sending
+								the reply to the reply channel; only applies when the
+								channel might block (such as a bounded queue channel that
+								is currently full).
+								Prior to 2.2, this attribute served the function of
+								the remote-timeout attribute; it has been changed
+								to make it consistent with other endpoints.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="remote-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the time the gateway will wait for a reply
+								from the remote system. Prior to 2.2, this was specified
+								with the reply-timeout attribute. To provide easier migration,
+								this attribute defaults to the same value of the reply-timeout,
+								if supplied, or 10 seconds otherwise.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="order">
 						<xsd:annotation>
 							<xsd:documentation>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
@@ -184,6 +184,7 @@
 		connection-factory="cfC2"
 		request-timeout="234"
 		reply-timeout="567"
+		remote-timeout="789"
 		order="24"
 		auto-startup="false"
 		phase="127"

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -39,6 +39,7 @@ import org.springframework.core.task.TaskExecutor;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.core.MessageHandler;
+import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.ip.tcp.TcpInboundGateway;
 import org.springframework.integration.ip.tcp.TcpOutboundGateway;
@@ -382,7 +383,10 @@ public class ParserUnitTests {
 		DirectFieldAccessor dfa = new DirectFieldAccessor(tcpOutboundGateway);
 		assertSame(cfC2, dfa.getPropertyValue("connectionFactory"));
 		assertEquals(234L, dfa.getPropertyValue("requestTimeout"));
-		assertEquals(567L, dfa.getPropertyValue("replyTimeout"));
+		MessagingTemplate messagingTemplate = TestUtils.getPropertyValue(tcpOutboundGateway, "messagingTemplate",
+				MessagingTemplate.class);
+		assertEquals(Long.valueOf(567), TestUtils.getPropertyValue(messagingTemplate, "sendTimeout", Long.class));
+		assertEquals(789L, dfa.getPropertyValue("remoteTimeout"));
 		assertEquals("outGateway",tcpOutboundGateway.getComponentName());
 		assertEquals("ip:tcp-outbound-gateway", tcpOutboundGateway.getComponentType());
 		assertTrue(cfC2.isLookupHost());

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.ip.tcp;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -46,6 +47,7 @@ import org.springframework.integration.ip.tcp.connection.AbstractConnectionFacto
 import org.springframework.integration.ip.tcp.connection.TcpNetClientConnectionFactory;
 import org.springframework.integration.ip.util.SocketTestUtils;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 
 /**
  * @author Gary Russell
@@ -90,7 +92,15 @@ public class TcpOutboundGatewayTests {
 		QueueChannel replyChannel = new QueueChannel();
 		gateway.setRequiresReply(true);
 		gateway.setOutputChannel(replyChannel);
-		gateway.setReplyTimeout(60000);
+		// check the default remote timeout
+		assertEquals(Long.valueOf(10000), TestUtils.getPropertyValue(gateway, "remoteTimeout", Long.class));
+		gateway.setSendTimeout(123);
+		// ensure this also changed the remote timeout
+		assertEquals(Long.valueOf(123), TestUtils.getPropertyValue(gateway, "remoteTimeout", Long.class));
+		gateway.setRemoteTimeout(60000);
+		gateway.setSendTimeout(61000);
+		// ensure this did NOT change the remote timeout
+		assertEquals(Long.valueOf(60000), TestUtils.getPropertyValue(gateway, "remoteTimeout", Long.class));
 		gateway.setRequestTimeout(60000);
 		for (int i = 100; i < 200; i++) {
 			gateway.handleMessage(MessageBuilder.withPayload("Test" + i).build());

--- a/src/reference/docbook/ip.xml
+++ b/src/reference/docbook/ip.xml
@@ -627,7 +627,7 @@
     reply-channel="replyChannel"
     connection-factory="cfClient"
     request-timeout="10000"
-    reply-timeout="10000"
+    remote-timeout="10000"
     />]]></programlisting>
         A simple outbound TCP gateway.
   </para>
@@ -1669,16 +1669,24 @@
                      </entry>
             </row>
             <row>
-              <entry>reply-timeout</entry>
+              <entry>remote-timeout</entry>
               <entry></entry>
-              <entry>The time in milliseconds for which the gateway will wait for a reply.
-                     Default: 10000 (10 seconds).</entry>
+              <entry>The time in milliseconds for which the gateway will wait for a reply from the
+                     remote system.
+                     Default: Same value as reply-timeout, if specified, or 10000 (10 seconds) otherwise.</entry>
             </row>
             <row>
               <entry>request-timeout</entry>
               <entry></entry>
               <entry>If a single-use connection factory is not being used, The time in milliseconds 
                      for which the gateway will wait to get access to the shared connection.</entry>
+            </row>
+            <row>
+              <entry>reply-timeout</entry>
+              <entry></entry>
+              <entry>The time in milliseconds for which the gateway will wait when sending the reply
+                     to the reply-channel. Only applies if the reply-channel might block, such as a
+                     bounded QueueChannel that is currently full.</entry>
             </row>
           </tbody>
         </tgroup>


### PR DESCRIPTION
reply-timeout had the wrong function, when compared to
other gateways.

Add remote-timeout to reflect the time we will wait
for a reply from the remote system

Make reply-timeout set the sendTimeout on the messaging template

Set remore-timeout to reply-timeout (if set) unless remote-timeout
is explicitly set.

Update reference doc, and migration guide on Wiki.
