### PR TITLE
INT-2540 AbstractJmsChannel wasn't Marked Abstract

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/AbstractJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/AbstractJmsChannel.java
@@ -25,7 +25,7 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @since 2.0
  */
-public class AbstractJmsChannel extends AbstractMessageChannel {
+public abstract class AbstractJmsChannel extends AbstractMessageChannel {
 
 	private final JmsTemplate jmsTemplate;
 


### PR DESCRIPTION
Class should have been abstract. In any case,
it could not be used in any meaningful way
as a concrete class so changing it would
not represent a breaking change.
