### PR TITLE
INT-2604 Remove Deprecated Header

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/IpHeaders.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/IpHeaders.java
@@ -42,13 +42,6 @@ public abstract class IpHeaders {
 
 	public static final String CONNECTION_ID = IP + "connectionId";
 
-	/**
-	 * Use apply-sequence and sequenceNumber instead
-	 * @deprecated
-	 */
-	@Deprecated
-	public static final String CONNECTION_SEQ = IP + "connection_seq";
-
 	public static final String ACTUAL_CONNECTION_ID = IP + "actualConnectionId";
 
 	private IpHeaders() {}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
@@ -29,7 +29,7 @@ import org.springframework.integration.support.MessageBuilder;
  * If StringToBytes is true (default),
  * payloads of type String are converted to a byte[] using the supplied
  * charset (UTF-8 by default).
- * Inbound messages include headers representing the remote end of the 
+ * Inbound messages include headers representing the remote end of the
  * connection as well as a connection id that can be used by a {@link TcpSender}
  * to correlate which connection to send a reply.
  * @author Gary Russell
@@ -37,7 +37,7 @@ import org.springframework.integration.support.MessageBuilder;
  *
  */
 public class TcpMessageMapper implements
-		InboundMessageMapper<TcpConnection>, 
+		InboundMessageMapper<TcpConnection>,
 		OutboundMessageMapper<Object> {
 
 	private volatile String charset = "UTF-8";
@@ -46,7 +46,6 @@ public class TcpMessageMapper implements
 
 	private volatile boolean applySequence = false;
 
-	@SuppressWarnings("deprecation")
 	public Message<Object> toMessage(TcpConnection connection) throws Exception {
 		Message<Object> message = null;
 		Object payload = connection.getPayload();
@@ -67,7 +66,6 @@ public class TcpMessageMapper implements
 						.setHeader(IpHeaders.IP_ADDRESS, connection.getHostAddress())
 						.setHeader(IpHeaders.REMOTE_PORT, connection.getPort())
 						.setHeader(IpHeaders.CONNECTION_ID, connectionId)
-						.setHeader(IpHeaders.CONNECTION_SEQ, connection.incrementAndGetConnectionSequence())
 						.build();
 			}
 		}
@@ -102,7 +100,7 @@ public class TcpMessageMapper implements
 			}
 		}
 		else {
-			throw new MessageHandlingException(message, 
+			throw new MessageHandlingException(message,
 					"When using a byte array serializer, the socket mapper expects " +
 					"either a byte array or String payload, but received: " + payload.getClass());
 		}
@@ -121,7 +119,7 @@ public class TcpMessageMapper implements
 	/**
 	 * Sets whether outbound String payloads are to be converted
 	 * to byte[]. Default is true.
-	 * @param stringToBytes 
+	 * @param stringToBytes
 	 */
 	public void setStringToBytes(boolean stringToBytes) {
 		this.stringToBytes = stringToBytes;

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
@@ -16,7 +16,6 @@
 package org.springframework.integration.ip.tcp.connection;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -36,13 +35,13 @@ import org.springframework.integration.support.MessageBuilder;
 public class TcpMessageMapperTests {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final String TEST_PAYLOAD = "abcdefghijkl";
 
 	@Test
 	public void testToMessage() throws Exception {
-		
+
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		TcpConnection connection = mock(TcpConnection.class);
 		when(connection.getPayload()).thenReturn(TEST_PAYLOAD.getBytes());
@@ -59,10 +58,9 @@ public class TcpMessageMapperTests {
 				.getHeaders().get(IpHeaders.REMOTE_PORT));
 	}
 
-	@SuppressWarnings("deprecation")
 	@Test
 	public void testToMessageSequence() throws Exception {
-		
+
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		Socket socket = SocketFactory.getDefault().createSocket();
 		TcpConnection connection = new AbstractTcpConnection(socket, false, false) {
@@ -79,12 +77,15 @@ public class TcpMessageMapperTests {
 			public Object getPayload() throws Exception {
 				return TEST_PAYLOAD.getBytes();
 			}
+			@Override
 			public String getHostName() {
 				return "MyHost";
 			}
+			@Override
 			public String getHostAddress() {
 				return "1.1.1.1";
 			}
+			@Override
 			public String getConnectionId() {
 				return "anId";
 			}
@@ -97,8 +98,7 @@ public class TcpMessageMapperTests {
 				.getHeaders().get(IpHeaders.IP_ADDRESS));
 		assertEquals(1234, message
 				.getHeaders().get(IpHeaders.REMOTE_PORT));
-		assertEquals(1L, message
-				.getHeaders().get(IpHeaders.CONNECTION_SEQ));
+		assertEquals(Integer.valueOf(0), message.getHeaders().getSequenceNumber());
 		message = mapper.toMessage(connection);
 		assertEquals(TEST_PAYLOAD, new String((byte[]) message.getPayload()));
 		assertEquals("MyHost", message
@@ -107,11 +107,9 @@ public class TcpMessageMapperTests {
 				.getHeaders().get(IpHeaders.IP_ADDRESS));
 		assertEquals(1234, message
 				.getHeaders().get(IpHeaders.REMOTE_PORT));
-		assertEquals(2L, message
-				.getHeaders().get(IpHeaders.CONNECTION_SEQ));		
+		assertEquals(Integer.valueOf(0), message.getHeaders().getSequenceNumber());
 	}
 
-	@SuppressWarnings("deprecation")
 	@Test
 	public void testToMessageSequenceNew() throws Exception {
 		TcpMessageMapper mapper = new TcpMessageMapper();
@@ -131,12 +129,15 @@ public class TcpMessageMapperTests {
 			public Object getPayload() throws Exception {
 				return TEST_PAYLOAD.getBytes();
 			}
+			@Override
 			public String getHostName() {
 				return "MyHost";
 			}
+			@Override
 			public String getHostAddress() {
 				return "1.1.1.1";
 			}
+			@Override
 			public String getConnectionId() {
 				return "anId";
 			}
@@ -149,8 +150,6 @@ public class TcpMessageMapperTests {
 				.getHeaders().get(IpHeaders.IP_ADDRESS));
 		assertEquals(1234, message
 				.getHeaders().get(IpHeaders.REMOTE_PORT));
-		assertNull(message
-				.getHeaders().get(IpHeaders.CONNECTION_SEQ));
 		assertEquals(Integer.valueOf(1), message
 				.getHeaders().getSequenceNumber());
 		assertEquals(message.getHeaders().get(IpHeaders.CONNECTION_ID), message
@@ -163,8 +162,6 @@ public class TcpMessageMapperTests {
 				.getHeaders().get(IpHeaders.IP_ADDRESS));
 		assertEquals(1234, message
 				.getHeaders().get(IpHeaders.REMOTE_PORT));
-		assertNull(message
-				.getHeaders().get(IpHeaders.CONNECTION_SEQ));
 		assertEquals(Integer.valueOf(2), message
 				.getHeaders().getSequenceNumber());
 		assertEquals(message.getHeaders().get(IpHeaders.CONNECTION_ID), message
@@ -180,7 +177,7 @@ public class TcpMessageMapperTests {
 		mapper.setStringToBytes(true);
 		byte[] bArray = (byte[]) mapper.fromMessage(message);
 		assertEquals(s, new String(bArray));
-		
+
 	}
 
 	@Test
@@ -191,8 +188,8 @@ public class TcpMessageMapperTests {
 		mapper.setStringToBytes(false);
 		String out = (String) mapper.fromMessage(message);
 		assertEquals(s, out);
-		
+
 	}
-	
-	
+
+
 }


### PR DESCRIPTION
The IPHeaders.CONNECTION_SEQ was replaced by the
standard sequenceNumber header (when applySequence is true)
in 2.1, in order to facilitate resequencing using the
standard resequencer.

This header was deprecated at that time. It is now
removed.

Users that were relying on this header should set
applySequence to true on the connection factory.

Wiki Updated
