### PR TITLE
INT-2546 Move method PollerParser.configureTransactionAttributes to IntegrationNamespaceUtils

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PollerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PollerParser.java
@@ -39,15 +39,12 @@ import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.PeriodicTrigger;
-import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
-import org.springframework.transaction.interceptor.MatchAlwaysTransactionAttributeSource;
-import org.springframework.transaction.interceptor.TransactionInterceptor;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 
 /**
  * Parser for the &lt;poller&gt; element.
- * 
+ *
  * @author Mark Fisher
  * @author Marius Bogoevici
  * @author Oleg Zhurakousky
@@ -163,25 +160,6 @@ public class PollerParser extends AbstractBeanDefinitionParser {
 	}
 
 	/**
-	 * Parse a "transactional" element and configure a TransactionInterceptor with "transactionManager"
-	 * and other "transactionDefinition" properties. This advisor will be applied on the Polling Task proxy
-	 * (see {@link org.springframework.integration.endpoint.AbstractPollingEndpoint}).
-	 */
-	private BeanDefinition configureTransactionAttributes(Element txElement) {
-		BeanDefinitionBuilder txDefinitionBuilder = BeanDefinitionBuilder.genericBeanDefinition(DefaultTransactionAttribute.class);
-		txDefinitionBuilder.addPropertyValue("propagationBehaviorName", "PROPAGATION_" + txElement.getAttribute("propagation"));
-		txDefinitionBuilder.addPropertyValue("isolationLevelName", "ISOLATION_" + txElement.getAttribute("isolation"));
-		txDefinitionBuilder.addPropertyValue("timeout", txElement.getAttribute("timeout"));
-		txDefinitionBuilder.addPropertyValue("readOnly", txElement.getAttribute("read-only"));
-		BeanDefinitionBuilder attributeSourceBuilder = BeanDefinitionBuilder.genericBeanDefinition(MatchAlwaysTransactionAttributeSource.class);
-		attributeSourceBuilder.addPropertyValue("transactionAttribute", txDefinitionBuilder.getBeanDefinition());
-		BeanDefinitionBuilder txInterceptorBuilder = BeanDefinitionBuilder.genericBeanDefinition(TransactionInterceptor.class);
-		txInterceptorBuilder.addPropertyReference("transactionManager", txElement.getAttribute("transaction-manager"));
-		txInterceptorBuilder.addPropertyValue("transactionAttributeSource", attributeSourceBuilder.getBeanDefinition());
-		return txInterceptorBuilder.getBeanDefinition();
-	}
-
-	/**
 	 * Parses the 'advice-chain' element's sub-elements.
 	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -189,7 +167,7 @@ public class PollerParser extends AbstractBeanDefinitionParser {
 		ManagedList adviceChain = new ManagedList();
 		// Schema validation ensures txElement and adviceChainElement are mutually exclusive
 		if (txElement != null) {
-			adviceChain.add(this.configureTransactionAttributes(txElement));
+			adviceChain.add(IntegrationNamespaceUtils.configureTransactionAttributes(txElement));
 		}
 		if (adviceChainElement != null) {
 			NodeList childNodes = adviceChainElement.getChildNodes();

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/AbstractJpaOutboundGatewayParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/AbstractJpaOutboundGatewayParser.java
@@ -56,7 +56,7 @@ public abstract class AbstractJpaOutboundGatewayParser extends AbstractConsumerE
 		final Element transactionalElement = DomUtils.getChildElementByTagName(gatewayElement, "transactional");
 
 		if (transactionalElement != null) {
-			BeanDefinition txAdviceDefinition = JpaParserUtils.configureTransactionAttributes(transactionalElement);
+			BeanDefinition txAdviceDefinition = IntegrationNamespaceUtils.configureTransactionAttributes(transactionalElement);
 			ManagedList<BeanDefinition> adviceChain = new ManagedList<BeanDefinition>();
 			adviceChain.add(txAdviceDefinition);
 			jpaOutboundGatewayBuilder.addPropertyValue("adviceChain", adviceChain);

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/JpaOutboundChannelAdapterParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/JpaOutboundChannelAdapterParser.java
@@ -70,7 +70,7 @@ public class JpaOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 		final Element transactionalElement = DomUtils.getChildElementByTagName(element, "transactional");
 
 		if(transactionalElement != null) {
-			BeanDefinition txAdviceDefinition = JpaParserUtils.configureTransactionAttributes(transactionalElement);
+			BeanDefinition txAdviceDefinition = IntegrationNamespaceUtils.configureTransactionAttributes(transactionalElement);
 			ManagedList<BeanDefinition> adviceChain = new ManagedList<BeanDefinition>();
 			adviceChain.add(txAdviceDefinition);
 			jpaOutboundChannelAdapterBuilder.addPropertyValue("adviceChain", adviceChain);

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/JpaParserUtils.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/JpaParserUtils.java
@@ -25,12 +25,8 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
-import org.springframework.integration.endpoint.AbstractPollingEndpoint;
 import org.springframework.integration.jpa.core.JpaExecutor;
 import org.springframework.integration.jpa.support.JpaParameter;
-import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
-import org.springframework.transaction.interceptor.MatchAlwaysTransactionAttributeSource;
-import org.springframework.transaction.interceptor.TransactionInterceptor;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
@@ -212,27 +208,6 @@ public final class JpaParserUtils {
 
 		return parameterList;
 
-	}
-
-	/**
-	 * Parse a "transactional" element and configure a TransactionInterceptor with "transactionManager"
-	 * and other "transactionDefinition" properties. This advisor will be applied on the Polling Task proxy
-	 * (see {@link AbstractPollingEndpoint}).
-	 *
-	 * FIXME Copied from {@link org.springframework.integration.config.xml.PollerParser} - should be refactored.
-	 */
-	public static BeanDefinition configureTransactionAttributes(Element txElement) {
-		BeanDefinitionBuilder txDefinitionBuilder = BeanDefinitionBuilder.genericBeanDefinition(DefaultTransactionAttribute.class);
-		txDefinitionBuilder.addPropertyValue("propagationBehaviorName", "PROPAGATION_" + txElement.getAttribute("propagation"));
-		txDefinitionBuilder.addPropertyValue("isolationLevelName", "ISOLATION_" + txElement.getAttribute("isolation"));
-		txDefinitionBuilder.addPropertyValue("timeout", txElement.getAttribute("timeout"));
-		txDefinitionBuilder.addPropertyValue("readOnly", txElement.getAttribute("read-only"));
-		BeanDefinitionBuilder attributeSourceBuilder = BeanDefinitionBuilder.genericBeanDefinition(MatchAlwaysTransactionAttributeSource.class);
-		attributeSourceBuilder.addPropertyValue("transactionAttribute", txDefinitionBuilder.getBeanDefinition());
-		BeanDefinitionBuilder txInterceptorBuilder = BeanDefinitionBuilder.genericBeanDefinition(TransactionInterceptor.class);
-		txInterceptorBuilder.addPropertyReference("transactionManager", txElement.getAttribute("transaction-manager"));
-		txInterceptorBuilder.addPropertyValue("transactionAttributeSource", attributeSourceBuilder.getBeanDefinition());
-		return txInterceptorBuilder.getBeanDefinition();
 	}
 
 }


### PR DESCRIPTION
- Move method _PollerParser.configureTransactionAttributes_ to _IntegrationNamespaceUtils_
- Remove method _configureTransactionAttributes_ from class _JpaParserUtils_

For reference see: https://jira.springsource.org/browse/INT-2546
