### PR TITLE
INT-1849/INT-2606 Pseudo Transactional Message Src

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,9 +33,10 @@ import org.springframework.util.Assert;
 
 /**
  * FactoryBean for creating a SourcePollingChannelAdapter instance.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
 public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<SourcePollingChannelAdapter>,
 		BeanFactoryAware, BeanNameAware, BeanClassLoaderAware, InitializingBean, SmartLifecycle {
@@ -47,7 +48,7 @@ public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<Sourc
 	private volatile PollerMetadata pollerMetadata;
 
 	private volatile boolean autoStartup = true;
-	
+
 	private volatile Long sendTimeout;
 
 	private volatile String beanName;
@@ -65,7 +66,7 @@ public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<Sourc
 	public void setSource(MessageSource<?> source) {
 		this.source = source;
 	}
-	
+
 	public void setSendTimeout(long sendTimeout) {
 		this.sendTimeout = sendTimeout;
 	}
@@ -138,11 +139,12 @@ public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<Sourc
 			spca.setMaxMessagesPerPoll(this.pollerMetadata.getMaxMessagesPerPoll());
 			if (this.sendTimeout != null){
 				spca.setSendTimeout(this.sendTimeout);
-			}		
+			}
 			spca.setTaskExecutor(this.pollerMetadata.getTaskExecutor());
 			spca.setAdviceChain(this.pollerMetadata.getAdviceChain());
 			spca.setTrigger(this.pollerMetadata.getTrigger());
 			spca.setErrorHandler(this.pollerMetadata.getErrorHandler());
+			spca.setSynchronized(this.pollerMetadata.isSynchronized());
 			spca.setBeanClassLoader(this.beanClassLoader);
 			spca.setAutoStartup(this.autoStartup);
 			spca.setBeanName(this.beanName);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractPollingInboundChannelAdapterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractPollingInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,19 @@
 
 package org.springframework.integration.config.xml;
 
-import org.w3c.dom.Element;
-
 import org.springframework.beans.BeanMetadataElement;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.config.SourcePollingChannelAdapterFactoryBean;
 import org.springframework.util.xml.DomUtils;
+import org.w3c.dom.Element;
 
 /**
  * Base parser for inbound Channel Adapters that poll a source.
- * 
+ *
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public abstract class AbstractPollingInboundChannelAdapterParser extends AbstractChannelAdapterParser {
 
@@ -37,8 +38,8 @@ public abstract class AbstractPollingInboundChannelAdapterParser extends Abstrac
 		if (source == null) {
 			parserContext.getReaderContext().error("failed to parse source", element);
 		}
-		BeanDefinitionBuilder adapterBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-				IntegrationNamespaceUtils.BASE_PACKAGE + ".config.SourcePollingChannelAdapterFactoryBean");
+		BeanDefinitionBuilder adapterBuilder = BeanDefinitionBuilder
+				.genericBeanDefinition(SourcePollingChannelAdapterFactoryBean.class);
 		adapterBuilder.addPropertyValue("source", source);
 		adapterBuilder.addPropertyReference("outputChannel", channelName);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(adapterBuilder, element, "send-timeout");

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PollerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PollerParser.java
@@ -19,10 +19,6 @@ package org.springframework.integration.config.xml;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
@@ -34,13 +30,16 @@ import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
 import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.channel.MessagePublishingErrorHandler;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.PeriodicTrigger;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * Parser for the &lt;poller&gt; element.
@@ -101,6 +100,7 @@ public class PollerParser extends AbstractBeanDefinitionParser {
 			errorHandler.addPropertyReference("defaultErrorChannel", errorChannel);
 			metadataBuilder.addPropertyValue("errorHandler", errorHandler.getBeanDefinition());
 		}
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(metadataBuilder, element, "synchronized");
 		return metadataBuilder.getBeanDefinition();
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/PseudoTransactionalMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/PseudoTransactionalMessageSource.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.core;
+
+import org.springframework.transaction.support.TransactionSynchronization;
+
+/**
+ * {@link MessageSource}s implementing this sub-interface can participate in
+ * a Spring transaction. While the underlying resource is not strictly
+ * transactional, the final disposition of the resource will be
+ * synchronized with any encompassing transaction. For example, when
+ * a message source is used with a transactional poller, if any upstream
+ * activity causes the transaction to roll back, then the {@link #afterRollback(Object)}
+ * method will be called, allowing the message source to reset the state of
+ * whatever. If the transaction commits, the {@link #afterCommit(Object)} method
+ * is called.<p/>
+ * For example, with a MailReceivingMessageSource, the email can be deleted
+ * on successful commit, but not deleted if the transaction rolls back.
+ * <p/>
+ * This implements the 'Best Chance 1PC' pattern where there is only a
+ * small (but present) window in which a transaction might commit but the
+ * resource is not updated to reflect that. This could result in
+ * duplicate messages.
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+public interface PseudoTransactionalMessageSource<T> extends MessageSource<T> {
+
+	/**
+	 * Obtain the resource on which appropriate action needs
+	 * to be taken.
+	 * @return The resource.
+	 */
+	Object getResource();
+
+	/**
+	 * Invoked via {@link TransactionSynchronization} when the
+	 * transaction commits.
+	 * @param resource The resource to be "committed"
+	 */
+	void afterCommit(Object resource);
+
+	/**
+	 * Invoked via {@link TransactionSynchronization} when the
+	 * transaction rolls back.
+	 * @param resource
+	 */
+	void afterRollback(Object resource);
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/scheduling/PollerMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/scheduling/PollerMetadata.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.concurrent.Executor;
 
 import org.aopalliance.aop.Advice;
-
 import org.springframework.scheduling.Trigger;
 import org.springframework.util.ErrorHandler;
 
@@ -31,18 +30,20 @@ import org.springframework.util.ErrorHandler;
 public class PollerMetadata {
 
 	public static final int MAX_MESSAGES_UNBOUNDED = Integer.MIN_VALUE;
-	
+
 	private volatile Trigger trigger;
 
 	private volatile long maxMessagesPerPoll = MAX_MESSAGES_UNBOUNDED;
 
 	private volatile long receiveTimeout = 1000;
-	
+
 	private volatile ErrorHandler errorHandler;
 
 	private List<Advice> adviceChain;
 
 	private volatile Executor taskExecutor;
+
+	private volatile boolean synchronizedTx = true;
 
 	public void setTrigger(Trigger trigger) {
 		this.trigger = trigger;
@@ -51,7 +52,7 @@ public class PollerMetadata {
 	public Trigger getTrigger() {
 		return this.trigger;
 	}
-	
+
 	public ErrorHandler getErrorHandler() {
 		return errorHandler;
 	}
@@ -64,9 +65,9 @@ public class PollerMetadata {
 	 * Set the maximum number of messages to receive for each poll.
 	 * A non-positive value indicates that polling should repeat as long
 	 * as non-null messages are being received and successfully sent.
-	 * 
+	 *
 	 * <p>The default is unbounded.
-	 * 
+	 *
 	 * @see #MAX_MESSAGES_UNBOUNDED
 	 */
 	public void setMaxMessagesPerPoll(long maxMessagesPerPoll) {
@@ -99,5 +100,13 @@ public class PollerMetadata {
 
 	public Executor getTaskExecutor() {
 		return this.taskExecutor;
+	}
+
+	public boolean isSynchronized() {
+		return synchronizedTx;
+	}
+
+	public void setSynchronized(boolean synchronizedTx) {
+		this.synchronizedTx = synchronizedTx;
 	}
 }

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -1541,6 +1541,20 @@
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="synchronized" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specifies whether the resource, used by the MessageSource that this poller
+					polls, is synchronized with the transaction. The resource may be disposed of
+					in different manners, depending on whether the transaction commits,
+					or rolls back. Only applied if a transaction subelement (or
+					an advice-chain that contains a transaction advice)	is provided.
+					Also, only applies if the MessageSource implements
+					PseudoTransactionalMessageSource.
+					Default true.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:element name="selector-chain">

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PollerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PollerParserTests.java
@@ -18,16 +18,14 @@ package org.springframework.integration.config.xml;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
-
 import org.aopalliance.aop.Advice;
-
+import org.junit.Test;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -95,6 +93,7 @@ public class PollerParserTests {
 		assertEquals(TransactionInterceptor.class, txAdvice.getClass());
 		TransactionAttributeSource transactionAttributeSource = ((TransactionInterceptor) txAdvice).getTransactionAttributeSource();
 		assertEquals(NameMatchTransactionAttributeSource.class, transactionAttributeSource.getClass());
+		@SuppressWarnings("rawtypes")
 		HashMap nameMap = TestUtils.getPropertyValue(transactionAttributeSource, "nameMap", HashMap.class);
 		assertEquals(1, nameMap.size());
 		assertEquals("{*=PROPAGATION_REQUIRES_NEW,ISOLATION_DEFAULT,readOnly}", nameMap.toString());
@@ -122,13 +121,13 @@ public class PollerParserTests {
 		PollerMetadata metadata = (PollerMetadata) poller;
 		assertTrue(metadata.getTrigger() instanceof TestTrigger);
 	}
-    
+
     @Test(expected=BeanDefinitionParsingException.class)
 	public void pollerWithCronTriggerAndTimeUnit() {
 		new ClassPathXmlApplicationContext(
 				"cronTriggerWithTimeUnit-fail.xml", PollerParserTests.class);
 	}
-    
+
     @Test(expected=BeanDefinitionParsingException.class)
 	public void topLevelPollerWithRef() {
 		new ClassPathXmlApplicationContext(
@@ -139,6 +138,26 @@ public class PollerParserTests {
 	public void pollerWithCronAndFixedDelay() {
 		new ClassPathXmlApplicationContext(
 				"pollerWithCronAndFixedDelay.xml", PollerParserTests.class);
+	}
+
+	@Test
+	public void pollerWithSync() {
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"pollerWithSynchronization.xml", PollerParserTests.class);
+		Object poller = context.getBean("noSync");
+		assertNotNull(poller);
+		PollerMetadata metadata = (PollerMetadata) poller;
+		assertEquals(true, metadata.isSynchronized());
+
+		poller = context.getBean("syncTrue");
+		assertNotNull(poller);
+		metadata = (PollerMetadata) poller;
+		assertEquals(true, metadata.isSynchronized());
+
+		poller = context.getBean("syncFalse");
+		assertNotNull(poller);
+		metadata = (PollerMetadata) poller;
+		assertEquals(false, metadata.isSynchronized());
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/pollerWithSynchronization.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/pollerWithSynchronization.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+			http://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/integration
+			http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<poller id="noSync" fixed-delay="3000"/>
+
+	<poller id="syncTrue" fixed-delay="3000" synchronized="true" />
+
+	<poller id="syncFalse" fixed-delay="3000" synchronized="false" />
+
+</beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PseudoTransactionalMessageSourceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PseudoTransactionalMessageSourceTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.endpoint;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.springframework.integration.Message;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.core.PseudoTransactionalMessageSource;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionSynchronizationUtils;
+
+/**
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+public class PseudoTransactionalMessageSourceTests {
+
+	@Test
+	public void testCommit() {
+		SourcePollingChannelAdapter adapter = new SourcePollingChannelAdapter();
+		QueueChannel outputChannel = new QueueChannel();
+		adapter.setOutputChannel(outputChannel);
+		final Object object = new Object();
+		final AtomicReference<Object> committed = new AtomicReference<Object>();
+		final AtomicReference<Object> rolledBack = new AtomicReference<Object>();
+		adapter.setSource(new PseudoTransactionalMessageSource<String>() {
+
+			public Message<String> receive() {
+				return new GenericMessage<String>("foo");
+			}
+
+			public Object getResource() {
+				return object;
+			}
+
+			public void afterCommit(Object resource) {
+				committed.set(resource);
+			}
+
+			public void afterRollback(Object resource) {
+				rolledBack.set(resource);
+			}
+		});
+
+		TransactionSynchronizationManager.initSynchronization();
+		TransactionSynchronizationManager.setActualTransactionActive(true);
+		adapter.doPoll();
+		TransactionSynchronizationUtils.triggerAfterCommit();
+		assertSame(object, committed.get());
+		TransactionSynchronizationUtils.triggerAfterCompletion(TransactionSynchronization.STATUS_COMMITTED);
+		TransactionSynchronizationManager.clearSynchronization();
+		assertNull(rolledBack.get());
+	}
+
+	@Test
+	public void testRollback() {
+		SourcePollingChannelAdapter adapter = new SourcePollingChannelAdapter();
+		QueueChannel outputChannel = new QueueChannel();
+		adapter.setOutputChannel(outputChannel);
+		final Object object = new Object();
+		final AtomicReference<Object> committed = new AtomicReference<Object>();
+		final AtomicReference<Object> rolledBack = new AtomicReference<Object>();
+		adapter.setSource(new PseudoTransactionalMessageSource<String>() {
+
+			public Message<String> receive() {
+				return new GenericMessage<String>("foo");
+			}
+
+			public Object getResource() {
+				return object;
+			}
+
+			public void afterCommit(Object resource) {
+				committed.set(resource);
+			}
+
+			public void afterRollback(Object resource) {
+				rolledBack.set(resource);
+			}
+		});
+
+		TransactionSynchronizationManager.initSynchronization();
+		TransactionSynchronizationManager.setActualTransactionActive(true);
+		adapter.doPoll();
+		TransactionSynchronizationUtils.triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+		assertSame(object, rolledBack.get());
+		TransactionSynchronizationManager.clearSynchronization();
+		assertNull(committed.get());
+	}
+
+}

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/PseudoTransactionalMessageSourceTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/PseudoTransactionalMessageSourceTests-context.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:tx="http://www.springframework.org/schema/tx"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+
+	<int:inbound-channel-adapter channel="queue">
+		<bean class="org.springframework.integration.jdbc.PseudoTransactionalMessageSourceTests$MessageSource"/>
+		<int:poller fixed-delay="2000">
+			<int:transactional />
+		</int:poller>
+	</int:inbound-channel-adapter>
+
+	<int:channel id="queue">
+		<int:queue />
+	</int:channel>
+
+	<jdbc:embedded-database id="dataSource" type="HSQL" />
+
+	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+		<property name="dataSource" ref="dataSource" />
+	</bean>
+</beans>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/PseudoTransactionalMessageSourceTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/PseudoTransactionalMessageSourceTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.integration.Message;
+import org.springframework.integration.core.PseudoTransactionalMessageSource;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class PseudoTransactionalMessageSourceTests {
+
+	private static CountDownLatch latch1 = new CountDownLatch(1);
+
+	private static boolean committed;
+
+	private static CountDownLatch latch2 = new CountDownLatch(1);
+
+	private static boolean rolledBack;
+
+	private static boolean doRollback;
+
+	@Test
+	public void testCommit() throws Exception {
+		assertTrue(latch1.await(10, TimeUnit.SECONDS));
+		assertTrue(committed);
+	}
+
+	@Test
+	public void testRollback() throws Exception {
+		doRollback = true;
+		assertTrue(latch2.await(10, TimeUnit.SECONDS));
+		assertTrue(rolledBack);
+	}
+
+	public static class MessageSource implements PseudoTransactionalMessageSource<String> {
+
+		public Message<String> receive() {
+			if (doRollback) {
+				throw new RuntimeException("Expected");
+			}
+			return new GenericMessage<String>("foo");
+		}
+
+		public Object getResource() {
+			return new Object();
+		}
+
+		public void afterCommit(Object resource) {
+			committed = true;
+			latch1.countDown();
+		}
+
+		public void afterRollback(Object resource) {
+			rolledBack = true;
+			latch2.countDown();
+		}
+
+	}
+}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -165,8 +165,19 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 		return this.shouldDeleteMessages;
 	}
 
-	public Folder getFolder() {
-		if (this.contextHolder.get() == null) {
+	protected Folder getFolder() {
+		return this.getTransactionContext().getFolder();
+	}
+
+	public MailReceiverContext getTransactionContext() {
+		return doObtainTransactionContext();
+	}
+
+	private MailReceiverContext doObtainTransactionContext() {
+		MailReceiverContext mailReceiverContext = this.contextHolder.get();
+		if (mailReceiverContext == null ||
+				mailReceiverContext.getFolder() == null ||
+				!mailReceiverContext.getFolder().isOpen()) {
 			try {
 				this.openFolder();
 			}
@@ -174,14 +185,7 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 				throw new org.springframework.integration.MessagingException("Failed to open folder", e);
 			}
 		}
-		return this.contextHolder.get().getFolder();
-	}
-
-	public MailReceiverContext getTransactionContext() {
-		if (this.contextHolder.get() == null) {
-			this.getFolder();
-		}
-		return this.contextHolder.get();
+		return mailReceiverContext;
 	}
 
 	/**

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
@@ -45,6 +45,7 @@ import com.sun.mail.imap.IMAPMessage;
  * @author Arjen Poutsma
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
 public class ImapMailReceiver extends AbstractMailReceiver {
 
@@ -102,9 +103,10 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 	 */
 	public void waitForNewMessages() throws MessagingException {
 		this.openFolder();
-		Assert.state(this.getFolder() instanceof IMAPFolder,
+		Folder folder = this.getFolder();
+		Assert.state(folder instanceof IMAPFolder,
 				"folder is not an instance of [" + IMAPFolder.class.getName() + "]");
-		IMAPFolder imapFolder = (IMAPFolder) this.getFolder();
+		IMAPFolder imapFolder = (IMAPFolder) folder;
 		if (imapFolder.hasNewMessages()) {
 			return;
 		}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,50 @@
 
 package org.springframework.integration.mail;
 
+import javax.mail.Folder;
+import javax.mail.Message;
+
+import org.springframework.util.Assert;
+
+
 /**
  * Strategy interface for receiving mail {@link javax.mail.Message Messages}.
- * 
+ *
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public interface MailReceiver {
 
 	javax.mail.Message[] receive() throws javax.mail.MessagingException;
 
+	MailReceiverContext getTransactionContext();
+
+	void closeContextAfterSuccess(MailReceiverContext context);
+
+	void closeContextAfterFailure(MailReceiverContext context);
+
+	public static class MailReceiverContext {
+
+		private final Folder folder;
+
+		private volatile Message[] messages = new Message[0];
+
+		MailReceiverContext(Folder folder) {
+			this.folder = folder;
+		}
+
+		Message[] getMessages() {
+			return messages;
+		}
+
+		void setMessages(Message[] messages) {
+			Assert.noNullElements(messages, "messages cannot be null");
+			this.messages = messages;
+		}
+
+		Folder getFolder() {
+			return folder;
+		}
+
+	}
 }

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/SearchTermStrategy.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/SearchTermStrategy.java
@@ -35,7 +35,7 @@ public interface SearchTermStrategy {
 	 *
 	 * @param supportedFlags
 	 * @param folder
-	 * @return
+	 * @return The search term
 	 */
 	SearchTerm generateSearchTerm(Flags supportedFlags, Folder folder);
 

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailSearchTermsTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailSearchTermsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,8 @@ package org.springframework.integration.mail;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 import javax.mail.Flags;
@@ -32,11 +30,12 @@ import javax.mail.search.NotTerm;
 import javax.mail.search.SearchTerm;
 
 import org.junit.Test;
-
+import org.springframework.integration.mail.MailReceiver.MailReceiverContext;
 import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  *
  */
 public class ImapMailSearchTermsTests {
@@ -45,13 +44,11 @@ public class ImapMailSearchTermsTests {
 	public void validateSearchTermsWhenShouldMarkAsReadNoExistingFlags() throws Exception {
 		ImapMailReceiver receiver = new ImapMailReceiver();
 		receiver.setShouldMarkMessagesAsRead(true);
-		
-		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
-		folderField.setAccessible(true);
-		Folder folder = mock(Folder.class);
+
+		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
+		Folder folder = context.getFolder();
 		when(folder.getPermanentFlags()).thenReturn(new Flags(Flags.Flag.USER));
-		folderField.set(receiver, folder);
-		
+
 		Method compileSearchTerms = ReflectionUtils.findMethod(receiver.getClass(), "compileSearchTerms", Flags.class);
 		compileSearchTerms.setAccessible(true);
 		Flags flags = new Flags();
@@ -66,14 +63,12 @@ public class ImapMailSearchTermsTests {
 	public void validateSearchTermsWhenShouldMarkAsReadWithExistingFlags() throws Exception {
 		ImapMailReceiver receiver = new ImapMailReceiver();
 		receiver.setShouldMarkMessagesAsRead(true);
-		
+
 		receiver.afterPropertiesSet();
-		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
-		folderField.setAccessible(true);
-		Folder folder = mock(Folder.class);
+		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
+		Folder folder = context.getFolder();
 		when(folder.getPermanentFlags()).thenReturn(new Flags(Flags.Flag.USER));
-		folderField.set(receiver, folder);
-		
+
 		Method compileSearchTerms = ReflectionUtils.findMethod(receiver.getClass(), "compileSearchTerms", Flags.class);
 		compileSearchTerms.setAccessible(true);
 		Flags flags = new Flags();
@@ -90,19 +85,17 @@ public class ImapMailSearchTermsTests {
 		siFlags.add(AbstractMailReceiver.SI_USER_FLAG);
 		assertTrue(((FlagTerm)notTerm.getTerm()).getFlags().contains(siFlags));
 	}
-	
+
 	@Test
 	public void validateSearchTermsWhenShouldNotMarkAsReadNoExistingFlags() throws Exception {
 		ImapMailReceiver receiver = new ImapMailReceiver();
 		receiver.setShouldMarkMessagesAsRead(false);
 		receiver.afterPropertiesSet();
-		
-		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
-		folderField.setAccessible(true);
-		Folder folder = mock(Folder.class);
+
+		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
+		Folder folder = context.getFolder();
 		when(folder.getPermanentFlags()).thenReturn(new Flags(Flags.Flag.USER));
-		folderField.set(receiver, folder);
-		
+
 		Method compileSearchTerms = ReflectionUtils.findMethod(receiver.getClass(), "compileSearchTerms", Flags.class);
 		compileSearchTerms.setAccessible(true);
 		Flags flags = new Flags();

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailSearchTermsTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailSearchTermsTests.java
@@ -47,6 +47,7 @@ public class ImapMailSearchTermsTests {
 
 		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
 		Folder folder = context.getFolder();
+		when(folder.isOpen()).thenReturn(true);
 		when(folder.getPermanentFlags()).thenReturn(new Flags(Flags.Flag.USER));
 
 		Method compileSearchTerms = ReflectionUtils.findMethod(receiver.getClass(), "compileSearchTerms", Flags.class);
@@ -67,6 +68,7 @@ public class ImapMailSearchTermsTests {
 		receiver.afterPropertiesSet();
 		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
 		Folder folder = context.getFolder();
+		when(folder.isOpen()).thenReturn(true);
 		when(folder.getPermanentFlags()).thenReturn(new Flags(Flags.Flag.USER));
 
 		Method compileSearchTerms = ReflectionUtils.findMethod(receiver.getClass(), "compileSearchTerms", Flags.class);
@@ -94,6 +96,7 @@ public class ImapMailSearchTermsTests {
 
 		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
 		Folder folder = context.getFolder();
+		when(folder.isOpen()).thenReturn(true);
 		when(folder.getPermanentFlags()).thenReturn(new Flags(Flags.Flag.USER));
 
 		Method compileSearchTerms = ReflectionUtils.findMethod(receiver.getClass(), "compileSearchTerms", Flags.class);

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/MailReceivingMessageSourceTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/MailReceivingMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.junit.Test;
 /**
  * @author Jonas Partner
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public class MailReceivingMessageSourceTests {
 
@@ -71,6 +72,17 @@ public class MailReceivingMessageSourceTests {
 
 		public void stop() {
 		}
+
+		public MailReceiverContext getTransactionContext() {
+			return null;
+		}
+
+		public void closeContextAfterSuccess(MailReceiverContext context) {
+		}
+
+		public void closeContextAfterFailure(MailReceiverContext context) {
+		}
+
 	}
 
 }

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/MailTestsHelper.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/MailTestsHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,19 @@
 
 package org.springframework.integration.mail;
 
+import static org.mockito.Mockito.mock;
+
+import javax.mail.Folder;
+
 import org.springframework.integration.Message;
+import org.springframework.integration.mail.MailReceiver.MailReceiverContext;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.mail.SimpleMailMessage;
 
 /**
  * @author Marius Bogoevici
+ * @author Gary Russell
  */
 public class MailTestsHelper {
 
@@ -64,6 +71,15 @@ public class MailTestsHelper {
 				.setHeader(MailHeaders.FROM, MailTestsHelper.FROM)
 				.setHeader(MailHeaders.REPLY_TO, MailTestsHelper.REPLY_TO)
 				.build();
+	}
+
+	public static MailReceiverContext setupContextHolder(AbstractMailReceiver receiver) {
+		@SuppressWarnings("unchecked")
+		ThreadLocal<MailReceiverContext> contextHolder = TestUtils.getPropertyValue(receiver, "contextHolder",ThreadLocal.class);
+		Folder folder = mock(Folder.class);
+		MailReceiverContext context = new MailReceiverContext(folder);
+		contextHolder.set(context);
+		return context;
 	}
 
 }

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/Pop3MailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/Pop3MailReceiverTests.java
@@ -214,7 +214,6 @@ public class Pop3MailReceiverTests {
 		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
 		Folder folder = context.getFolder();
 		when(folder.isOpen()).thenReturn(true);
-		when(receiver.getFolder()).thenReturn(folder);
 		doAnswer(new Answer<Object>() {
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return null;
@@ -257,8 +256,6 @@ public class Pop3MailReceiverTests {
 				return null;
 			}
 		}).when(receiver).openFolder();
-		when(receiver.getFolder()).thenReturn(folder);
-		when(receiver.getTransactionContext()).thenReturn(new MailReceiverContext(folder));
 		adapter.setSource(new MailReceivingMessageSource(receiver));
 
 		TransactionSynchronizationManager.initSynchronization();

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/Pop3MailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/Pop3MailReceiverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicReference;
 
-import javax.mail.Flags.Flag;
 import javax.mail.Flags;
+import javax.mail.Flags.Flag;
 import javax.mail.Folder;
 import javax.mail.Message;
 import javax.mail.internet.MimeMessage;
@@ -35,9 +36,18 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
+import org.springframework.integration.mail.MailReceiver.MailReceiverContext;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionSynchronizationUtils;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.ReflectionUtils.MethodCallback;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  *
  */
 public class Pop3MailReceiverTests {
@@ -47,13 +57,11 @@ public class Pop3MailReceiverTests {
 		((Pop3MailReceiver)receiver).setShouldDeleteMessages(true);
 		receiver = spy(receiver);
 		receiver.afterPropertiesSet();
-		
-		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
-		folderField.setAccessible(true);
-		Folder folder = mock(Folder.class);
+
+		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
+		Folder folder = context.getFolder();
 		when(folder.getPermanentFlags()).thenReturn(new Flags(Flags.Flag.USER));
-		folderField.set(receiver, folder);
-		
+
 		Message msg1 = mock(MimeMessage.class);
 		Message msg2 = mock(MimeMessage.class);
 		final Message[] messages = new Message[]{msg1, msg2};
@@ -67,13 +75,13 @@ public class Pop3MailReceiverTests {
 				return null;
 			}
 		}).when(receiver).openFolder();
-		
+
 		doAnswer(new Answer<Object>() {
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return messages;
 			}
 		}).when(receiver).searchForNewMessages();
-		
+
 		doAnswer(new Answer<Object>() {
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return null;
@@ -81,6 +89,7 @@ public class Pop3MailReceiverTests {
 		}).when(receiver).fetchMessages(messages);
 		receiver.afterPropertiesSet();
 		receiver.receive();
+		receiver.closeContextAfterSuccess(context);
 		verify(msg1, times(1)).setFlag(Flag.DELETED, true);
 		verify(msg2, times(1)).setFlag(Flag.DELETED, true);
 	}
@@ -90,13 +99,11 @@ public class Pop3MailReceiverTests {
 		((Pop3MailReceiver)receiver).setShouldDeleteMessages(false);
 		receiver = spy(receiver);
 		receiver.afterPropertiesSet();
-		
-		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
-		folderField.setAccessible(true);
-		Folder folder = mock(Folder.class);
+
+		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
+		Folder folder = context.getFolder();
 		when(folder.getPermanentFlags()).thenReturn(new Flags(Flags.Flag.USER));
-		folderField.set(receiver, folder);
-		
+
 		Message msg1 = mock(MimeMessage.class);
 		Message msg2 = mock(MimeMessage.class);
 		final Message[] messages = new Message[]{msg1, msg2};
@@ -105,13 +112,13 @@ public class Pop3MailReceiverTests {
 				return null;
 			}
 		}).when(receiver).openFolder();
-		
+
 		doAnswer(new Answer<Object>() {
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return messages;
 			}
 		}).when(receiver).searchForNewMessages();
-		
+
 		doAnswer(new Answer<Object>() {
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return null;
@@ -119,6 +126,7 @@ public class Pop3MailReceiverTests {
 		}).when(receiver).fetchMessages(messages);
 		receiver.afterPropertiesSet();
 		receiver.receive();
+		receiver.closeContextAfterFailure(context);
 		verify(msg1, times(0)).setFlag(Flag.DELETED, true);
 		verify(msg2, times(0)).setFlag(Flag.DELETED, true);
 	}
@@ -127,13 +135,11 @@ public class Pop3MailReceiverTests {
 		AbstractMailReceiver receiver = new Pop3MailReceiver("pop3://some.host");
 		receiver = spy(receiver);
 		receiver.afterPropertiesSet();
-		
-		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
-		folderField.setAccessible(true);
-		Folder folder = mock(Folder.class);
+
+		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
+		Folder folder = context.getFolder();
 		when(folder.getPermanentFlags()).thenReturn(new Flags(Flags.Flag.USER));
-		folderField.set(receiver, folder);
-		
+
 		Message msg1 = mock(MimeMessage.class);
 		Message msg2 = mock(MimeMessage.class);
 		final Message[] messages = new Message[]{msg1, msg2};
@@ -142,13 +148,13 @@ public class Pop3MailReceiverTests {
 				return null;
 			}
 		}).when(receiver).openFolder();
-		
+
 		doAnswer(new Answer<Object>() {
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return messages;
 			}
 		}).when(receiver).searchForNewMessages();
-		
+
 		doAnswer(new Answer<Object>() {
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return null;
@@ -156,6 +162,7 @@ public class Pop3MailReceiverTests {
 		}).when(receiver).fetchMessages(messages);
 		receiver.afterPropertiesSet();
 		receiver.receive();
+		receiver.closeContextAfterFailure(context);
 		verify(msg1, times(0)).setFlag(Flag.DELETED, true);
 		verify(msg2, times(0)).setFlag(Flag.DELETED, true);
 	}
@@ -164,13 +171,11 @@ public class Pop3MailReceiverTests {
 		AbstractMailReceiver receiver = new Pop3MailReceiver();
 		receiver = spy(receiver);
 		receiver.afterPropertiesSet();
-		
-		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
-		folderField.setAccessible(true);
-		Folder folder = mock(Folder.class);
+
+		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
+		Folder folder = context.getFolder();
 		when(folder.getPermanentFlags()).thenReturn(new Flags(Flags.Flag.USER));
-		folderField.set(receiver, folder);
-		
+
 		Message msg1 = mock(MimeMessage.class);
 		Message msg2 = mock(MimeMessage.class);
 		final Message[] messages = new Message[]{msg1, msg2};
@@ -179,13 +184,13 @@ public class Pop3MailReceiverTests {
 				return null;
 			}
 		}).when(receiver).openFolder();
-		
+
 		doAnswer(new Answer<Object>() {
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return messages;
 			}
 		}).when(receiver).searchForNewMessages();
-		
+
 		doAnswer(new Answer<Object>() {
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return null;
@@ -193,7 +198,85 @@ public class Pop3MailReceiverTests {
 		}).when(receiver).fetchMessages(messages);
 		receiver.afterPropertiesSet();
 		receiver.receive();
+		receiver.closeContextAfterFailure(context);
 		verify(msg1, times(0)).setFlag(Flag.DELETED, true);
 		verify(msg2, times(0)).setFlag(Flag.DELETED, true);
 	}
+
+	@Test
+	public void testCommit() throws Exception {
+		SourcePollingChannelAdapter adapter = new SourcePollingChannelAdapter();
+		QueueChannel outputChannel = new QueueChannel();
+		adapter.setOutputChannel(outputChannel);
+		Pop3MailReceiver receiver = new Pop3MailReceiver("pop3://some.host");
+		receiver.setShouldDeleteMessages(true);
+		receiver = spy(receiver);
+		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
+		Folder folder = context.getFolder();
+		when(folder.isOpen()).thenReturn(true);
+		when(receiver.getFolder()).thenReturn(folder);
+		doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				return null;
+			}
+		}).when(receiver).openFolder();
+		adapter.setSource(new MailReceivingMessageSource(receiver));
+
+		TransactionSynchronizationManager.initSynchronization();
+		TransactionSynchronizationManager.setActualTransactionActive(true);
+		final AtomicReference<Method> doPollMethod = new AtomicReference<Method>();
+		ReflectionUtils.doWithMethods(SourcePollingChannelAdapter.class, new MethodCallback() {
+
+			public void doWith(Method method) throws IllegalArgumentException, IllegalAccessException {
+				if (method.getName() == "doPoll") {
+					doPollMethod.set(method);
+					method.setAccessible(true);
+				}
+			}
+		});
+		doPollMethod.get().invoke(adapter, (Object[]) null);
+		TransactionSynchronizationUtils.triggerAfterCommit();
+		TransactionSynchronizationUtils.triggerAfterCompletion(TransactionSynchronization.STATUS_COMMITTED);
+		TransactionSynchronizationManager.clearSynchronization();
+		verify(folder).close(true);
+	}
+
+	@Test
+	public void testRollback() throws Exception {
+		SourcePollingChannelAdapter adapter = new SourcePollingChannelAdapter();
+		QueueChannel outputChannel = new QueueChannel();
+		adapter.setOutputChannel(outputChannel);
+		Pop3MailReceiver receiver = new Pop3MailReceiver("pop3://some.host");
+		receiver.setShouldDeleteMessages(true);
+		receiver = spy(receiver);
+		MailReceiverContext context = MailTestsHelper.setupContextHolder(receiver);
+		Folder folder = context.getFolder();
+		when(folder.isOpen()).thenReturn(true);
+		doAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				return null;
+			}
+		}).when(receiver).openFolder();
+		when(receiver.getFolder()).thenReturn(folder);
+		when(receiver.getTransactionContext()).thenReturn(new MailReceiverContext(folder));
+		adapter.setSource(new MailReceivingMessageSource(receiver));
+
+		TransactionSynchronizationManager.initSynchronization();
+		TransactionSynchronizationManager.setActualTransactionActive(true);
+		final AtomicReference<Method> doPollMethod = new AtomicReference<Method>();
+		ReflectionUtils.doWithMethods(SourcePollingChannelAdapter.class, new MethodCallback() {
+
+			public void doWith(Method method) throws IllegalArgumentException, IllegalAccessException {
+				if (method.getName() == "doPoll") {
+					doPollMethod.set(method);
+					method.setAccessible(true);
+				}
+			}
+		});
+		doPollMethod.get().invoke(adapter, (Object[]) null);
+		TransactionSynchronizationUtils.triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+		TransactionSynchronizationManager.clearSynchronization();
+		verify(folder).close(false);
+	}
+
 }

--- a/src/reference/docbook/transactions.xml
+++ b/src/reference/docbook/transactions.xml
@@ -150,7 +150,7 @@
 </tx:advice>
 ]]></programlisting>
 
-As yo can see from the example above, we have provided a very basic XML-based configuration of Spring Transaction advice  - "txAdvice" and
+As you can see from the example above, we have provided a very basic XML-based configuration of Spring Transaction advice  - "txAdvice" and
 included it within the <emphasis>&lt;advice-chain&gt;</emphasis> defined by the Poller.
 If you only need to address transactional concerns of the Poller, then you can still use the <emphasis>&lt;transactional&gt;</emphasis> element
 as a convinience.
@@ -171,6 +171,19 @@ as a convinience.
       be thrown back to the initiator of the Message flow who is also the initiator of the transactional context and the transaction would result in a ROLLBACK.
       The middle ground is to use transactional channels at any point where a thread boundary is being broken. For example, you can use a Queue-backed Channel
       that delegates to a transactional MessageStore strategy, or you could use a JMS-backed channel.
+      </para>
+    </section>
+
+    <section id="poller-synch">
+      <title>Pollers and Transaction Synchronization</title>
+      <para>
+        Certain inbound adapters are capable of synchronizing their updates with a transaction. For example, the mail
+        inbound adapters, if running in a transaction and configured to mark or delete messages, will only take those
+        actions on a mail message if the transaction commits; otherwise the mail message is left in the inbox.
+      </para>
+      <para>
+        For all message sources that implement PseudoTransactionalMessageSource, this is the default behavior (commit and
+        rollback detection). It can be disabled by setting the synchronized attribute on the poller to false.
       </para>
     </section>
 </chapter>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -56,7 +56,15 @@
               <listitem>Stored Procedure Name Expression</listitem>
               <listitem>JdbcCallOperations Cache Statistics</listitem>
             </itemizedlist>
-		</section>
+        </section>
+        <section id="2.2-tx">
+            <title>Transaction Synchronization</title>
+            <para>
+              When running from a transactional poller,
+              mail inbound adapters can be configured to update the mailbox only
+              if the transaction commits.
+            </para>
+        </section>
     </section>
 
     <section id="2.2-new-components">


### PR DESCRIPTION
Initial commit.

Tested with POP3 and IMAP (James) with Sample app.

Essentially moved all the flagging and deleting code
from receive() to closeContextAfterSuccess().

For non-transactional cases, this new method is
called immediately after receiving the message(s),
essentially working as before.

When run from a <transactional/> poller it is
called using TransactionSynchronization after
the transaction commits.

This behavior can be changed by setting
'symchronized="false"' on the poller, which
removes the synchronization and the update
is called immediately after the receive().
