### PR TITLE
INT-1141 Improved on how MessageHandlers are stored

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AbstractDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AbstractDispatcher.java
@@ -43,8 +43,8 @@ public abstract class AbstractDispatcher implements MessageDispatcher {
 
 	protected final Log logger = LogFactory.getLog(this.getClass());
 
-	private final OrderedAwareLinkedHashSet<MessageHandler> handlers =
-			new OrderedAwareLinkedHashSet<MessageHandler>();
+	private final OrderedAwareCopyOnWriteArraySet<MessageHandler> handlers =
+			new OrderedAwareCopyOnWriteArraySet<MessageHandler>();
 
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AbstractDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AbstractDispatcher.java
@@ -16,9 +16,6 @@
 
 package org.springframework.integration.dispatcher;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
@@ -35,31 +32,32 @@ import org.springframework.util.Assert;
  * dispatching strategies may invoke handles in different ways (e.g. round-robin
  * vs. failover), this class does maintain the order of the underlying
  * collection. See the {@link OrderedAwareLinkedHashSet} for more detail.
- * 
+ *
  * @author Mark Fisher
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Diego Belfer
  */
 public abstract class AbstractDispatcher implements MessageDispatcher {
 
 	protected final Log logger = LogFactory.getLog(this.getClass());
 
-	private final Set<MessageHandler> handlers = new OrderedAwareLinkedHashSet<MessageHandler>();
+	private final OrderedAwareLinkedHashSet<MessageHandler> handlers =
+			new OrderedAwareLinkedHashSet<MessageHandler>();
 
 
 	/**
-	 * Returns a copied, unmodifiable List of this dispatcher's handlers. This
+	 * Returns an unmodifiable {@link Set} of this dispatcher's handlers. This
 	 * is provided for access by subclasses.
 	 */
-	protected List<MessageHandler> getHandlers() {
-		return Collections.<MessageHandler>unmodifiableList(Arrays.<MessageHandler>asList(
-				this.handlers.toArray(new MessageHandler[this.handlers.size()])));
+	protected Set<MessageHandler> getHandlers() {
+		return handlers.asUnmodifiableSet();
 	}
 
 	/**
 	 * Add the handler to the internal Set.
-	 * 
+	 *
 	 * @return the result of {@link Set#add(Object)}
 	 */
 	public boolean addHandler(MessageHandler handler) {
@@ -69,7 +67,7 @@ public abstract class AbstractDispatcher implements MessageDispatcher {
 
 	/**
 	 * Remove the handler from the internal handler Set.
-	 * 
+	 *
 	 * @return the result of {@link Set#remove(Object)}
 	 */
 	public boolean removeHandler(MessageHandler handler) {
@@ -77,6 +75,7 @@ public abstract class AbstractDispatcher implements MessageDispatcher {
 		return this.handlers.remove(handler);
 	}
 
+	@Override
 	public String toString() {
 		return this.getClass().getSimpleName() + " with handlers: " + this.handlers.toString();
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/BroadcastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/BroadcastingDispatcher.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.dispatcher;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.concurrent.Executor;
 
 import org.springframework.integration.Message;
@@ -34,10 +34,11 @@ import org.springframework.integration.support.MessageBuilder;
  * If the 'ignoreFailures' flag is set to <code>true</code> on the other hand, it will make a best effort to send the
  * message to each of its handlers. In other words, when 'ignoreFailures' is <code>true</code>, if it fails to send to
  * any one handler, it will simply log a warn-level message but continue to send the Message to any other handlers.
- * 
+ *
  * @author Mark Fisher
  * @author Iwein Fuld
  * @author Gary Russell
+ * @author Oleg Zhurakousky
  */
 public class BroadcastingDispatcher extends AbstractDispatcher {
 
@@ -91,7 +92,7 @@ public class BroadcastingDispatcher extends AbstractDispatcher {
 	public boolean dispatch(Message<?> message) {
 		boolean dispatched = false;
 		int sequenceNumber = 1;
-		List<MessageHandler> handlers = this.getHandlers();
+		Collection<MessageHandler> handlers = this.getHandlers();
 		if (this.requireSubscribers && handlers.size() == 0) {
 			throw new MessageDispatchingException(message, "Dispatcher has no subscribers");
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/LoadBalancingStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/LoadBalancingStrategy.java
@@ -1,4 +1,4 @@
-/* Copyright 2002-2009 the original author or authors.
+/* Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,21 @@
 
 package org.springframework.integration.dispatcher;
 
+import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 
 import org.springframework.integration.Message;
 import org.springframework.integration.core.MessageHandler;
 
 /**
  * Strategy for determining the iteration order of a MessageHandler list.
- * 
+ *
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  * @since 1.0.3
  */
 public interface LoadBalancingStrategy {
 
-	public Iterator<MessageHandler> getHandlerIterator(Message<?> message, List<MessageHandler> handlers);
+	public Iterator<MessageHandler> getHandlerIterator(Message<?> message, Collection<MessageHandler> handlers);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/OrderedAwareCopyOnWriteArraySet.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/OrderedAwareCopyOnWriteArraySet.java
@@ -37,13 +37,13 @@ import org.springframework.util.StringUtils;
 /**
  * Special Set that maintains the following semantics:
  * All elements that are un-ordered (do not implement {@link Ordered} interface or annotated
- * {@link Order} annotation) will be stored in the order in which they were added, maintaining the
- * semantics of the {@link LinkedHashSet}. However, for all {@link Ordered} elements a
+ * {@link Order} annotation) will be stored in the order in which they were added.
+ * However, for all {@link Ordered} elements a
  * {@link Comparator} (instantiated by default) for this implementation of {@link Set}, will be
  * used. Those elements will have precedence over un-ordered elements. If elements have the same
  * order but themselves do not equal to one another the more recent addition will be placed to the
  * right of (appended next to) the existing element with the same order, thus preserving the order
- * of the insertion  and maintaining {@link LinkedHashSet} semantics for the un-ordered elements.
+ * of the insertion while maintaining the order of insertion for the un-ordered elements.
  * <p>
  * The class is package-protected and only intended for use by the AbstractDispatcher. It
  * <emphasis>must</emphasis> enforce safe concurrent access for all usage by the dispatcher.
@@ -64,9 +64,9 @@ class OrderedAwareCopyOnWriteArraySet<E> implements Set<E> {
 
 	private final WriteLock writeLock = rwl.writeLock();
 
-	private final transient CopyOnWriteArraySet<E> elements;
+	private final CopyOnWriteArraySet<E> elements;
 
-    private final transient Set<E> unmodifiableElements;
+    private final Set<E> unmodifiableElements;
 
     public OrderedAwareCopyOnWriteArraySet() {
         elements = new CopyOnWriteArraySet<E>();

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/OrderedAwareCopyOnWriteArraySet.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/OrderedAwareCopyOnWriteArraySet.java
@@ -54,7 +54,7 @@ import org.springframework.util.StringUtils;
  * @since 1.0.3
  */
 @SuppressWarnings({"unchecked"})
-class OrderedAwareLinkedHashSet<E> implements Set<E> {
+class OrderedAwareCopyOnWriteArraySet<E> implements Set<E> {
 
 	private final OrderComparator comparator = new OrderComparator();
 
@@ -68,7 +68,7 @@ class OrderedAwareLinkedHashSet<E> implements Set<E> {
 
     private final transient Set<E> unmodifiableElements;
 
-    public OrderedAwareLinkedHashSet() {
+    public OrderedAwareCopyOnWriteArraySet() {
         elements = new CopyOnWriteArraySet<E>();
         unmodifiableElements = Collections.unmodifiableSet(elements);
     }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/OrderedAwareLinkedHashSet.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/OrderedAwareLinkedHashSet.java
@@ -53,8 +53,8 @@ import org.springframework.util.StringUtils;
  * @author Diego Belfer
  * @since 1.0.3
  */
-@SuppressWarnings({"unchecked", "serial"})
-class OrderedAwareLinkedHashSet<E> extends LinkedHashSet<E> {
+@SuppressWarnings({"unchecked"})
+class OrderedAwareLinkedHashSet<E> implements Set<E> {
 
 	private final OrderComparator comparator = new OrderComparator();
 
@@ -83,7 +83,6 @@ class OrderedAwareLinkedHashSet<E> extends LinkedHashSet<E> {
 	 * Set will be re-sorted, otherwise the element is simply added
 	 * to the end. Added element must not be null.
 	 */
-	@Override
 	public boolean add(E o) {
 		Assert.notNull(o,"Can not add NULL object");
 		writeLock.lock();
@@ -105,7 +104,6 @@ class OrderedAwareLinkedHashSet<E> extends LinkedHashSet<E> {
 	/**
 	 * Adds all elements in this Collection.
 	 */
-	@Override
 	public boolean addAll(Collection<? extends E> c) {
 		Assert.notNull(c,"Can not merge with NULL set");
 		writeLock.lock();
@@ -123,7 +121,6 @@ class OrderedAwareLinkedHashSet<E> extends LinkedHashSet<E> {
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override
 	public boolean remove(Object o) {
 		writeLock.lock();
 		try {
@@ -139,7 +136,6 @@ class OrderedAwareLinkedHashSet<E> extends LinkedHashSet<E> {
 	/**
 	 * {@inheritDoc}
 	 */
-	@Override
 	public boolean removeAll(Collection<?> c){
 		if (CollectionUtils.isEmpty(c)){
 			return false;
@@ -153,7 +149,6 @@ class OrderedAwareLinkedHashSet<E> extends LinkedHashSet<E> {
 		}
 	}
 
-	@Override
 	public <T> T[] toArray(T[] a) {
 		readLock.lock();
 		try {
@@ -213,13 +208,35 @@ class OrderedAwareLinkedHashSet<E> extends LinkedHashSet<E> {
 		return added;
 	}
 
-	@Override
     public Iterator<E> iterator() {
         return this.elements.iterator();
     }
 
-	@Override
 	public int size(){
-		return elements.size();
+		return this.elements.size();
+	}
+
+	public boolean isEmpty() {
+		return this.elements.isEmpty();
+	}
+
+	public boolean contains(Object o) {
+		return this.elements.contains(o);
+	}
+
+	public Object[] toArray() {
+		return this.elements.toArray();
+	}
+
+	public boolean containsAll(Collection<?> c) {
+		return this.elements.containsAll(c);
+	}
+
+	public boolean retainAll(Collection<?> c) {
+		return this.elements.retainAll(c);
+	}
+
+	public void clear() {
+		this.elements.clear();
 	}
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/RoundRobinLoadBalancingStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/RoundRobinLoadBalancingStrategy.java
@@ -49,7 +49,7 @@ public class RoundRobinLoadBalancingStrategy implements LoadBalancingStrategy {
 			return handlers.iterator();
 		}
 
-		return this.buildHandlerIterator(size, handlers.toArray(new MessageHandler[]{}));
+		return this.buildHandlerIterator(size, handlers.toArray(new MessageHandler[size]));
 	}
 
 	private Iterator<MessageHandler> buildHandlerIterator(int size, final MessageHandler[] handlers){

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/RoundRobinLoadBalancingStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/RoundRobinLoadBalancingStrategy.java
@@ -45,9 +45,10 @@ public class RoundRobinLoadBalancingStrategy implements LoadBalancingStrategy {
 	 */
 	public final Iterator<MessageHandler> getHandlerIterator(final Message<?> message, final Collection<MessageHandler> handlers) {
 		int size = handlers.size();
-		if (size == 0) {
+		if (size < 2) {
 			return handlers.iterator();
 		}
+
 		return this.buildHandlerIterator(size, handlers.toArray(new MessageHandler[]{}));
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/RoundRobinLoadBalancingStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/RoundRobinLoadBalancingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,8 @@
 
 package org.springframework.integration.dispatcher;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.integration.Message;
@@ -31,30 +30,51 @@ import org.springframework.integration.core.MessageHandler;
  *
  * @author Iwein Fuld
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  * @since 1.0.3
  */
 public class RoundRobinLoadBalancingStrategy implements LoadBalancingStrategy {
 
 	private final AtomicInteger currentHandlerIndex = new AtomicInteger();
 
-
 	/**
-	 * Returns an iterator that starts at a new point in the list every time the
+	 * Returns an iterator that starts at a new point in the collection every time the
 	 * first part of the list that is skipped will be used at the end of the
 	 * iteration, so it guarantees all handlers are returned once on subsequent
 	 * <code>next()</code> invocations.
 	 */
-	public final Iterator<MessageHandler> getHandlerIterator(final Message<?> message, final List<MessageHandler> handlers) {
+	public final Iterator<MessageHandler> getHandlerIterator(final Message<?> message, final Collection<MessageHandler> handlers) {
 		int size = handlers.size();
 		if (size == 0) {
 			return handlers.iterator();
 		}
+		return this.buildHandlerIterator(size, handlers.toArray(new MessageHandler[]{}));
+	}
+
+	private Iterator<MessageHandler> buildHandlerIterator(int size, final MessageHandler[] handlers){
 
 		int nextHandlerStartIndex = getNextHandlerStartIndex(size);
-		List<MessageHandler> reorderedHandlers = new ArrayList<MessageHandler>(
-				handlers.subList(nextHandlerStartIndex, size));
-		reorderedHandlers.addAll(handlers.subList(0, nextHandlerStartIndex));
-		return reorderedHandlers.iterator();
+
+		final MessageHandler[] reorderedHandlers = new MessageHandler[size];
+
+		System.arraycopy(handlers, nextHandlerStartIndex, reorderedHandlers, 0, size-nextHandlerStartIndex);
+		System.arraycopy(handlers, 0, reorderedHandlers, size-nextHandlerStartIndex, 0+nextHandlerStartIndex);
+
+		return new Iterator<MessageHandler>() {
+			int currentIndex = 0;
+
+			public boolean hasNext() {
+				return currentIndex < reorderedHandlers.length;
+			}
+
+			public MessageHandler next() {
+				return reorderedHandlers[currentIndex++];
+			}
+
+			public void remove() {
+				throw new UnsupportedOperationException("Remove is not supported by this Iterator");
+			}
+		};
 	}
 
 	/**
@@ -66,5 +86,4 @@ public class RoundRobinLoadBalancingStrategy implements LoadBalancingStrategy {
 		int indexTail = currentHandlerIndex.getAndIncrement() % size;
 		return indexTail < 0 ? indexTail + size : indexTail;
 	}
-
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/RoundRobinLoadBalancingStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/RoundRobinLoadBalancingStrategy.java
@@ -46,6 +46,7 @@ public class RoundRobinLoadBalancingStrategy implements LoadBalancingStrategy {
 	public final Iterator<MessageHandler> getHandlerIterator(final Message<?> message, final Collection<MessageHandler> handlers) {
 		int size = handlers.size();
 		if (size < 2) {
+			this.getNextHandlerStartIndex(size);
 			return handlers.iterator();
 		}
 
@@ -84,7 +85,12 @@ public class RoundRobinLoadBalancingStrategy implements LoadBalancingStrategy {
 	 * <code>size</code>.
 	 */
 	private int getNextHandlerStartIndex(int size) {
-		int indexTail = currentHandlerIndex.getAndIncrement() % size;
-		return indexTail < 0 ? indexTail + size : indexTail;
+		if (size > 0){
+			int indexTail = currentHandlerIndex.getAndIncrement() % size;
+			return indexTail < 0 ? indexTail + size : indexTail;
+		}
+		else {
+			return size;
+		}
 	}
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/RoundRobinLoadBalancingStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/RoundRobinLoadBalancingStrategy.java
@@ -28,7 +28,7 @@ import org.springframework.integration.core.MessageHandler;
  * Round-robin implementation of {@link LoadBalancingStrategy}. This
  * implementation will keep track of the index of the handler that has been
  * tried first and use a different starting handler every dispatch.
- * 
+ *
  * @author Iwein Fuld
  * @author Mark Fisher
  * @since 1.0.3
@@ -49,6 +49,7 @@ public class RoundRobinLoadBalancingStrategy implements LoadBalancingStrategy {
 		if (size == 0) {
 			return handlers.iterator();
 		}
+
 		int nextHandlerStartIndex = getNextHandlerStartIndex(size);
 		List<MessageHandler> reorderedHandlers = new ArrayList<MessageHandler>(
 				handlers.subList(nextHandlerStartIndex, size));

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
@@ -42,7 +42,7 @@ import org.springframework.integration.core.MessageHandler;
  * <p/>
  * A load-balancing strategy may be provided to this class to control the order in
  * which the handlers will be tried.
- * 
+ *
  * @author Iwein Fuld
  * @author Mark Fisher
  * @author Gary Russell
@@ -52,7 +52,7 @@ import org.springframework.integration.core.MessageHandler;
 public class UnicastingDispatcher extends AbstractDispatcher {
 
 	private volatile boolean failover = true;
-	private ReadWriteLock rwLock = new ReentrantReadWriteLock();
+	private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
 	private volatile LoadBalancingStrategy loadBalancingStrategy;
 
 	private final Executor executor;
@@ -84,7 +84,7 @@ public class UnicastingDispatcher extends AbstractDispatcher {
 		lock.lock();
 		try {
 			this.loadBalancingStrategy = loadBalancingStrategy;
-		} 
+		}
 		finally {
 			lock.unlock();
 		}
@@ -141,11 +141,11 @@ public class UnicastingDispatcher extends AbstractDispatcher {
 		lock.lock();
 		try {
 			if (this.loadBalancingStrategy != null) {
-				return this.loadBalancingStrategy.getHandlerIterator(message, this.getHandlers());
+				return this.loadBalancingStrategy.getHandlerIterator(message, new ArrayList<MessageHandler>(this.getHandlers()));
 			}
 		} finally {
 			lock.unlock();
-		}	
+		}
 		return this.getHandlers().iterator();
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
@@ -141,7 +141,7 @@ public class UnicastingDispatcher extends AbstractDispatcher {
 		lock.lock();
 		try {
 			if (this.loadBalancingStrategy != null) {
-				return this.loadBalancingStrategy.getHandlerIterator(message, new ArrayList<MessageHandler>(this.getHandlers()));
+				return this.loadBalancingStrategy.getHandlerIterator(message, this.getHandlers());
 			}
 		} finally {
 			lock.unlock();

--- a/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/OrderedAwareCopyOnWriteArraySetTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/OrderedAwareCopyOnWriteArraySetTests.java
@@ -16,20 +16,21 @@
 
 package org.springframework.integration.dispatcher;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
-import org.springframework.core.Ordered;
 
-import static org.junit.Assert.assertEquals;
+import org.springframework.core.Ordered;
 
 /**
  * @author Oleg Zhurakousky
  * @since 1.0.3
  */
 @SuppressWarnings("unchecked")
-public class OrderedAwareLinkedHashSetTests {
+public class OrderedAwareCopyOnWriteArraySetTests {
 
 	/**
 	 * Tests that semantics of the LinkedHashSet were not broken
@@ -37,7 +38,7 @@ public class OrderedAwareLinkedHashSetTests {
 	@SuppressWarnings("rawtypes")
 	@Test
 	public void testAddUnordered(){
-		OrderedAwareLinkedHashSet setToTest = new OrderedAwareLinkedHashSet();
+		OrderedAwareCopyOnWriteArraySet setToTest = new OrderedAwareCopyOnWriteArraySet();
 		setToTest.add("foo");
 		setToTest.add("bar");
 		setToTest.add("baz");
@@ -49,16 +50,16 @@ public class OrderedAwareLinkedHashSetTests {
 	}
 	/**
 	 * Tests that semantics of TreeSet(Comparator) were not broken.
-	 * However, there is a special Comparator (instantiated by default) for this implementation of Set, 
+	 * However, there is a special Comparator (instantiated by default) for this implementation of Set,
 	 * which allows elements with the same "order" as long as these elements themselves are not equal.
-	 * In this case element with the same order will be placed to the right (appended next to) of 
-	 * the already existing element, thus preserving the order of insertion (LinkedHashset semantics) 
-	 * within the elements that have the same "order" value. 
+	 * In this case element with the same order will be placed to the right (appended next to) of
+	 * the already existing element, thus preserving the order of insertion (LinkedHashset semantics)
+	 * within the elements that have the same "order" value.
 	 */
 	@SuppressWarnings("rawtypes")
 	@Test
 	public void testAddOrdered(){
-		OrderedAwareLinkedHashSet setToTest = new OrderedAwareLinkedHashSet();
+		OrderedAwareCopyOnWriteArraySet setToTest = new OrderedAwareCopyOnWriteArraySet();
 		Object o1 = new Foo(3);
 		Object o2 = new Foo(1);
 		Object o3 = new Foo(2);
@@ -78,7 +79,7 @@ public class OrderedAwareLinkedHashSetTests {
 		setToTest.add(o7);
 		setToTest.add(o8);
 		setToTest.add(o9);
-		setToTest.add(o10);		
+		setToTest.add(o10);
 		assertEquals(10, setToTest.size());
 		Object[] elements = setToTest.toArray();
 		assertEquals(o7, elements[0]);
@@ -92,7 +93,7 @@ public class OrderedAwareLinkedHashSetTests {
 		assertEquals(o5, elements[8]);
 		assertEquals(o6, elements[9]);
 	}
-	
+
 	@SuppressWarnings("rawtypes")
 	@Test
 	public void testAddAllOrderedUnordered(){
@@ -116,9 +117,9 @@ public class OrderedAwareLinkedHashSetTests {
 		tempList.add(o7);
 		tempList.add(o8);
 		tempList.add(o9);
-		tempList.add(o10);		
+		tempList.add(o10);
 		assertEquals(10, tempList.size());
-		OrderedAwareLinkedHashSet orderAwareSet = new OrderedAwareLinkedHashSet();
+		OrderedAwareCopyOnWriteArraySet orderAwareSet = new OrderedAwareCopyOnWriteArraySet();
 		orderAwareSet.addAll(tempList);
 		Object[] elements = orderAwareSet.toArray();
 		assertEquals(o7, elements[0]);
@@ -132,7 +133,7 @@ public class OrderedAwareLinkedHashSetTests {
 		assertEquals(o3, elements[8]);
 		assertEquals(o10, elements[9]);
 	}
-	
+
 	@Test
 	public void testConcurrent(){
 		for(int i = 0; i < 1000; i++){
@@ -141,7 +142,7 @@ public class OrderedAwareLinkedHashSetTests {
 	}
 	@SuppressWarnings("rawtypes")
 	private void doConcurrent(){
-		final OrderedAwareLinkedHashSet setToTest = new OrderedAwareLinkedHashSet();
+		final OrderedAwareCopyOnWriteArraySet setToTest = new OrderedAwareCopyOnWriteArraySet();
 		final Object o1 = new Foo(3);
 		final Object o2 = new Foo(1);
 		final Object o3 = new Foo(2);
@@ -163,20 +164,20 @@ public class OrderedAwareLinkedHashSetTests {
 		});
 		Thread t2 = new Thread(new Runnable() {
 			public void run() {
-				setToTest.add(o2);				
-				setToTest.add(o4);				
-				setToTest.add(o6);				
-				setToTest.add(o8);			
-				setToTest.add(o10);	
+				setToTest.add(o2);
+				setToTest.add(o4);
+				setToTest.add(o6);
+				setToTest.add(o8);
+				setToTest.add(o10);
 			}
 		});
 		Thread t3 = new Thread(new Runnable() {
 			public void run() {
-				setToTest.add(1);				
-				setToTest.add(new Foo(2));				
-				setToTest.add(3);				
-				setToTest.add(new Foo(9));			
-				setToTest.add(8);	
+				setToTest.add(1);
+				setToTest.add(new Foo(2));
+				setToTest.add(3);
+				setToTest.add(new Foo(9));
+				setToTest.add(8);
 			}
 		});
 		t1.start();
@@ -190,8 +191,8 @@ public class OrderedAwareLinkedHashSetTests {
 			e.printStackTrace();
 			throw new RuntimeException(e);
 		}
-		
-			
+
+
 		assertEquals(15, setToTest.size());
 	}
 	/**
@@ -216,7 +217,7 @@ public class OrderedAwareLinkedHashSetTests {
 		Object o8 = new Foo(Ordered.HIGHEST_PRECEDENCE);
 		Object o9 = new Foo(4);
 		Object o10 = "Baz";
-		
+
 		tempList.add(o1);
 		tempList.add(o2);
 		tempList.add(o3);
@@ -226,8 +227,8 @@ public class OrderedAwareLinkedHashSetTests {
 		tempList.add(o7);
 		tempList.add(o8);
 		tempList.add(o9);
-		tempList.add(o10);		
-		final OrderedAwareLinkedHashSet orderAwareSet = new OrderedAwareLinkedHashSet();
+		tempList.add(o10);
+		final OrderedAwareCopyOnWriteArraySet orderAwareSet = new OrderedAwareCopyOnWriteArraySet();
 		Thread t1 = new Thread(new Runnable() {
 			public void run() {
 				orderAwareSet.addAll(tempList);
@@ -256,9 +257,9 @@ public class OrderedAwareLinkedHashSetTests {
 		Thread t3 = new Thread(new Runnable() {
 			public void run() {
 				orderAwareSet.add("hello");
-				orderAwareSet.add("hello again");	
+				orderAwareSet.add("hello again");
 			}
-		});		
+		});
 
 		t1.start();
 		t2.start();
@@ -275,13 +276,14 @@ public class OrderedAwareLinkedHashSetTests {
 		assertEquals(18, elements.length);
 	}
 	private static class Foo implements Ordered {
-		private int order;
+		private final int order;
 		public Foo(int order){
 			this.order = order;
 		}
 		public int getOrder() {
 			return order;
-		}	
+		}
+		@Override
 		public String toString(){
 			return "Foo-" + order;
 		}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 
 import java.util.Iterator;
-import java.util.Set;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -47,7 +47,7 @@ public class FtpOutboundChannelAdapterParserTests {
 
 	@Test
 	public void testFtpOutboundChannelAdapterComplete() throws Exception{
-		ApplicationContext ac = 
+		ApplicationContext ac =
 			new ClassPathXmlApplicationContext("FtpOutboundChannelAdapterParserTests-context.xml", this.getClass());
 		Object consumer = ac.getBean("ftpOutbound");
 		assertTrue(consumer instanceof EventDrivenConsumer);
@@ -70,9 +70,9 @@ public class FtpOutboundChannelAdapterParserTests {
 		assertEquals("localhost", TestUtils.getPropertyValue(sessionFactory, "host"));
 		assertEquals(22, TestUtils.getPropertyValue(sessionFactory, "port"));
 		assertEquals(23, TestUtils.getPropertyValue(handler, "order"));
-		//verify subscription order		
+		//verify subscription order
 		@SuppressWarnings("unchecked")
-		Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils
+		List<MessageHandler> handlers = (List<MessageHandler>) TestUtils
 				.getPropertyValue(
 						TestUtils.getPropertyValue(channel, "dispatcher"),
 						"handlers");
@@ -80,7 +80,7 @@ public class FtpOutboundChannelAdapterParserTests {
 		assertSame(TestUtils.getPropertyValue(ac.getBean("ftpOutbound2"), "handler"), iterator.next());
 		assertSame(handler, iterator.next());
 	}
-	
+
 	@Test(expected=BeanCreationException.class)
 	public void testFailWithEmptyRfsAndAcdTrue() throws Exception{
 		new ClassPathXmlApplicationContext("FtpOutboundChannelAdapterParserTests-fail.xml", this.getClass());

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 
 import java.util.Iterator;
-import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -72,7 +72,7 @@ public class FtpOutboundChannelAdapterParserTests {
 		assertEquals(23, TestUtils.getPropertyValue(handler, "order"));
 		//verify subscription order
 		@SuppressWarnings("unchecked")
-		List<MessageHandler> handlers = (List<MessageHandler>) TestUtils
+		Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils
 				.getPropertyValue(
 						TestUtils.getPropertyValue(channel, "dispatcher"),
 						"handlers");

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -25,10 +25,11 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Iterator;
-import java.util.Set;
+import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -327,7 +328,7 @@ public class ParserUnitTests {
 	@Test
 	public void testUdpOrder() {
 		@SuppressWarnings("unchecked")
-		Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils
+		List<MessageHandler> handlers = (List<MessageHandler>) TestUtils
 				.getPropertyValue(
 						TestUtils.getPropertyValue(this.udpChannel, "dispatcher"),
 						"handlers");
@@ -518,7 +519,7 @@ public class ParserUnitTests {
 		this.outGateway.start();
 		this.testOutTcpNio.start();
 		@SuppressWarnings("unchecked")
-		Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils
+		List<MessageHandler> handlers = (List<MessageHandler>) TestUtils
 				.getPropertyValue(
 						TestUtils.getPropertyValue(this.tcpChannel, "dispatcher"),
 						"handlers");

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Iterator;
-import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,6 +66,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Oleg Zhurakousky
  * @since 2.0
  */
 @ContextConfiguration
@@ -328,7 +329,7 @@ public class ParserUnitTests {
 	@Test
 	public void testUdpOrder() {
 		@SuppressWarnings("unchecked")
-		List<MessageHandler> handlers = (List<MessageHandler>) TestUtils
+		Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils
 				.getPropertyValue(
 						TestUtils.getPropertyValue(this.udpChannel, "dispatcher"),
 						"handlers");
@@ -519,7 +520,7 @@ public class ParserUnitTests {
 		this.outGateway.start();
 		this.testOutTcpNio.start();
 		@SuppressWarnings("unchecked")
-		List<MessageHandler> handlers = (List<MessageHandler>) TestUtils
+		Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils
 				.getPropertyValue(
 						TestUtils.getPropertyValue(this.tcpChannel, "dispatcher"),
 						"handlers");

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
@@ -19,13 +19,12 @@ package org.springframework.integration.sftp.config;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import java.util.Iterator;
-import java.util.Set;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -53,7 +52,7 @@ public class OutboundChannelAdapterParserTests {
 
 	@Test
 	public void testOutboundChannelAdapterWithId(){
-		ApplicationContext context = 
+		ApplicationContext context =
 				new ClassPathXmlApplicationContext("OutboundChannelAdapterParserTests-context.xml", this.getClass());
 		Object consumer = context.getBean("sftpOutboundAdapter");
 		assertTrue(consumer instanceof EventDrivenConsumer);
@@ -79,7 +78,7 @@ public class OutboundChannelAdapterParserTests {
 		assertEquals(23, TestUtils.getPropertyValue(handler, "order"));
 		//verify subscription order
 		@SuppressWarnings("unchecked")
-		Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils
+		List<MessageHandler> handlers = (List<MessageHandler>) TestUtils
 				.getPropertyValue(
 						TestUtils.getPropertyValue(channel, "dispatcher"),
 						"handlers");
@@ -90,7 +89,7 @@ public class OutboundChannelAdapterParserTests {
 
 	@Test
 	public void testOutboundChannelAdapterWithWithRemoteDirectoryAndFileExpression(){
-		ApplicationContext context = 
+		ApplicationContext context =
 			new ClassPathXmlApplicationContext("OutboundChannelAdapterParserTests-context.xml", this.getClass());
 		Object consumer = context.getBean("sftpOutboundAdapterWithExpression");
 		assertTrue(consumer instanceof EventDrivenConsumer);
@@ -106,9 +105,9 @@ public class OutboundChannelAdapterParserTests {
 		assertEquals("UTF-8", TestUtils.getPropertyValue(handler, "charset"));
 		assertNotNull(TestUtils.getPropertyValue(handler, "temporaryDirectory"));
 		assertNull(TestUtils.getPropertyValue(handler, "temporaryDirectoryExpressionProcessor"));
-		
+
 	}
-	
+
 	@Test
 	public void testOutboundChannelAdapterWithNoTemporaryFileName(){
 		ApplicationContext context =
@@ -121,12 +120,12 @@ public class OutboundChannelAdapterParserTests {
 	@Test(expected=BeanDefinitionStoreException.class)
 	public void testFailWithRemoteDirAndExpression(){
 		new ClassPathXmlApplicationContext("OutboundChannelAdapterParserTests-context-fail.xml", this.getClass());
-		
+
 	}
-	
+
 	@Test(expected=BeanDefinitionStoreException.class)
 	public void testFailWithFileExpressionAndFileGenerator(){
 		new ClassPathXmlApplicationContext("OutboundChannelAdapterParserTests-context-fail-fileFileGen.xml", this.getClass());
-		
+
 	}
 }

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import java.util.Iterator;
-import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -78,7 +78,7 @@ public class OutboundChannelAdapterParserTests {
 		assertEquals(23, TestUtils.getPropertyValue(handler, "order"));
 		//verify subscription order
 		@SuppressWarnings("unchecked")
-		List<MessageHandler> handlers = (List<MessageHandler>) TestUtils
+		Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils
 				.getPropertyValue(
 						TestUtils.getPropertyValue(channel, "dispatcher"),
 						"handlers");

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/support/MessageScenariosTests.java
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/support/MessageScenariosTests.java
@@ -18,6 +18,8 @@ package org.springframework.integration.test.support;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.springframework.integration.test.matcher.HeaderMatcher.hasHeader;
+import static org.springframework.integration.test.matcher.PayloadMatcher.hasPayload;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,27 +28,24 @@ import org.springframework.integration.Message;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.test.context.ContextConfiguration;
 
-import static org.springframework.integration.test.matcher.PayloadMatcher.hasPayload;
-import static org.springframework.integration.test.matcher.HeaderMatcher.hasHeader;
-
-@ContextConfiguration 
+@ContextConfiguration
 public class MessageScenariosTests extends AbstractRequestResponseScenarioTests {
-   
+
     @Override
     protected List<RequestResponseScenario> defineRequestResponseScenarios() {
         List<RequestResponseScenario> scenarios= new ArrayList<RequestResponseScenario>();
         RequestResponseScenario scenario1 = new RequestResponseScenario(
                 "inputChannel","outputChannel")
             .setPayload("hello")
-            .setResponseValidator(new PayloadValidator<String>() {    
+            .setResponseValidator(new PayloadValidator<String>() {
                 @Override
                 protected void validateResponse(String response) {
                     assertEquals("HELLO",response);
                 }
             });
-        
-        scenarios.add(scenario1);   
-        
+
+        scenarios.add(scenario1);
+
         RequestResponseScenario scenario2 = new RequestResponseScenario(
                 "inputChannel","outputChannel")
         .setMessage(MessageBuilder.withPayload("hello").setHeader("foo", "bar").build())
@@ -55,11 +54,11 @@ public class MessageScenariosTests extends AbstractRequestResponseScenarioTests 
             protected void validateMessage(Message<?> message) {
                assertThat(message,hasPayload("HELLO"));
                assertThat(message,hasHeader("foo","bar"));
-            }    
+            }
         });
-    
-        scenarios.add(scenario2);   
-        
+
+        scenarios.add(scenario2);
+
         RequestResponseScenario scenario3 = new RequestResponseScenario(
                 "inputChannel2","outputChannel2")
         .setMessage(MessageBuilder.withPayload("hello").setHeader("foo", "bar").build())
@@ -68,11 +67,11 @@ public class MessageScenariosTests extends AbstractRequestResponseScenarioTests 
             protected void validateMessage(Message<?> message) {
                 assertThat(message,hasPayload("HELLO"));
                 assertThat(message,hasHeader("foo","bar"));
-            }    
+            }
         });
-        
-        scenarios.add(scenario3); 
-        
+
+        scenarios.add(scenario3);
+
         return scenarios;
     }
 }

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/PresenceOutboundChannelAdapterParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/PresenceOutboundChannelAdapterParserTests.java
@@ -19,7 +19,7 @@ package org.springframework.integration.xmpp.config;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,7 +56,7 @@ public class PresenceOutboundChannelAdapterParserTests {
 				.getPropertyValue(pollingConsumer, "handler");
 		assertEquals(23, TestUtils.getPropertyValue(handler, "order"));
 	}
-	
+
 	@Test
 	public void testRosterEventOutboundChannelAdapterParserEventConsumer(){
 		Object eventConsumer = context.getBean("eventOutboundRosterAdapter");
@@ -65,7 +65,7 @@ public class PresenceOutboundChannelAdapterParserTests {
 				.getPropertyValue(eventConsumer, "handler");
 		assertEquals(34, TestUtils.getPropertyValue(handler, "order"));
 	}
-	
+
 	@Test
 	public void testRosterEventOutboundChannel(){
 		Object channel = context.getBean("eventOutboundRosterChannel");
@@ -73,7 +73,7 @@ public class PresenceOutboundChannelAdapterParserTests {
 		UnicastingDispatcher dispatcher = (UnicastingDispatcher) TestUtils
 				.getPropertyValue(channel, "dispatcher");
 		@SuppressWarnings("unchecked")
-		Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils
+		List<MessageHandler> handlers = (List<MessageHandler>) TestUtils
 				.getPropertyValue(dispatcher, "handlers");
 		assertEquals(45, TestUtils.getPropertyValue(handlers.toArray()[0], "order"));
 	}

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/PresenceOutboundChannelAdapterParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/PresenceOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.springframework.integration.xmpp.config;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,7 +73,7 @@ public class PresenceOutboundChannelAdapterParserTests {
 		UnicastingDispatcher dispatcher = (UnicastingDispatcher) TestUtils
 				.getPropertyValue(channel, "dispatcher");
 		@SuppressWarnings("unchecked")
-		List<MessageHandler> handlers = (List<MessageHandler>) TestUtils
+		Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils
 				.getPropertyValue(dispatcher, "handlers");
 		assertEquals(45, TestUtils.getPropertyValue(handlers.toArray()[0], "order"));
 	}


### PR DESCRIPTION
Thanks to Diego for bringing this up, but the resulting approach combined ideas from the code submitted by Diego with our curent approach of maintaining Set and here are the performance results

The latest performance figures I ran are
Elapsed time to add to the list with 100000 is 23080
Elapsed time to add to the set with 100000 is 21163
Elapsed time to get iterator from the list: 4
Elapsed time to get iterator from the set: 2

Which are also available if you reset to the following commit - https://github.com/olegz/spring-integration/tree/INT-1141-perf

The main changes are in 
_OrderedAwareLinkedHashSet_ where CopyOnWriteArraySet
 and its unmodifiable version are created to hold the elements instead of relying on 'super' as before. Also _asUnmodifiableSet()_ method was added to return the unmodifiable view into the current state of element which drastically improved performance of accessing and iterating through elements (see performance figures above) while taking a slight performance hit on add. However considering that this is a very specialized Collection and is only used by the AbstractDispatcher the performance improvement we mainly care about is on read while writes in this particular case mainly happen during initialization time anyway.

AbstractDispatcher now calls asUnmodifiableSet() method to obtain a collection of handlers to distribute message to.

Tests and other classes were adjusted.

The performance figures above show the comparison between modified OrderedAwareLinkedHashSet and reporter submitted OrderedAwareCopyOnWriteArrayList
