### PR TITLE
INT-1849/INT-2214 Add Disposition to File Adapter

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/core/PseudoTransactionalMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/PseudoTransactionalMessageSource.java
@@ -61,4 +61,17 @@ public interface PseudoTransactionalMessageSource<T> extends MessageSource<T> {
 	 */
 	void afterRollback(Object resource);
 
+	/**
+	 * Called when there is no transaction and the receive() call completed.
+	 * @param resource
+	 */
+	void afterReceiveNoTX(Object resource);
+
+	/**
+	 * Called when there is no transaction and after the message was
+	 * sent to the channel.
+	 * @param resource
+	 */
+	void afterSendNoTX(Object resource);
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/PseudoTransactionalMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/PseudoTransactionalMessageSource.java
@@ -65,13 +65,13 @@ public interface PseudoTransactionalMessageSource<T> extends MessageSource<T> {
 	 * Called when there is no transaction and the receive() call completed.
 	 * @param resource
 	 */
-	void afterReceiveNoTX(Object resource);
+	void afterReceiveNoTx(Object resource);
 
 	/**
 	 * Called when there is no transaction and after the message was
 	 * sent to the channel.
 	 * @param resource
 	 */
-	void afterSendNoTX(Object resource);
+	void afterSendNoTx(Object resource);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
@@ -122,7 +122,7 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint impleme
 		}
 		finally {
 			if (this.isPseudoTxMessageSource && !isInTx) {
-				messageSource.afterReceiveNoTX(resource);
+				messageSource.afterReceiveNoTx(resource);
 			}
 		}
 		if (this.logger.isDebugEnabled()){
@@ -134,7 +134,7 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint impleme
 			}
 			this.messagingTemplate.send(this.outputChannel, message);
 			if (this.isPseudoTxMessageSource && !isInTx) {
-				messageSource.afterSendNoTX(resource);
+				messageSource.afterSendNoTx(resource);
 			}
 			return true;
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
@@ -122,17 +122,7 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint impleme
 		}
 		finally {
 			if (this.isPseudoTxMessageSource && !isInTx) {
-				/*
-				 * If the message source implements PseudoTransactionalMessageSource and
-				 * we're running from a transactional poller, the message source's afterCommit
-				 * method will be called by the transaction interceptor, using the transaction
-				 * synchronization callback, after the transaction is committed.
-				 *
-				 * If we are not running in a transaction, we invoke it manually, so the message
-				 * source can take the appropriate action, immediately after the receive;
-				 * this was the behavior before pseudo transaction support was added.
-				 */
-				messageSource.afterCommit(resource);
+				messageSource.afterReceiveNoTX(resource);
 			}
 		}
 		if (this.logger.isDebugEnabled()){
@@ -143,6 +133,9 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint impleme
 				message = MessageHistory.write(message, this);
 			}
 			this.messagingTemplate.send(this.outputChannel, message);
+			if (this.isPseudoTxMessageSource && !isInTx) {
+				messageSource.afterSendNoTX(resource);
+			}
 			return true;
 		}
 		if (this.logger.isDebugEnabled()){

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/ExpressionUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/ExpressionUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.util;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.context.expression.MapAccessor;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.expression.spel.support.StandardTypeConverter;
+
+/**
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+public class ExpressionUtils {
+
+	public static StandardEvaluationContext createStandardEvaluationContext() {
+		return createStandardEvaluationContext(null, null);
+	}
+
+	public static StandardEvaluationContext createStandardEvaluationContext(BeanFactory beanFactory) {
+		return createStandardEvaluationContext(beanFactory, null);
+	}
+
+	public static StandardEvaluationContext createStandardEvaluationContext(ConversionService conversionService) {
+		return createStandardEvaluationContext(null, conversionService);
+	}
+
+	public static StandardEvaluationContext createStandardEvaluationContext(BeanFactory beanFactory,
+			ConversionService conversionService) {
+		StandardEvaluationContext evaluationContext = new StandardEvaluationContext();
+		evaluationContext.addPropertyAccessor(new MapAccessor());
+		if (beanFactory != null) {
+			evaluationContext.setBeanResolver(new BeanFactoryResolver(beanFactory));
+		}
+		if (conversionService != null) {
+			evaluationContext.setTypeConverter(new StandardTypeConverter(conversionService));
+		}
+		return evaluationContext;
+	}
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/ExpressionUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/ExpressionUtils.java
@@ -23,24 +23,55 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.expression.spel.support.StandardTypeConverter;
 
 /**
+ * Utility class with static methods for helping with establishing environments for
+ * SpEL expressions.
+ *
  * @author Gary Russell
  * @since 2.2
  *
  */
 public class ExpressionUtils {
 
+	/**
+	 * Create a {@link StandardEvaluationContext} with a {@link MapAccessor} in its
+	 * property accessor property.
+	 * @return the evaluation context.
+	 */
 	public static StandardEvaluationContext createStandardEvaluationContext() {
 		return createStandardEvaluationContext(null, null);
 	}
 
+	/**
+	 * Create a {@link StandardEvaluationContext} with a {@link MapAccessor} in its
+	 * property accessor property and the supplied {@link BeanFactory} in its
+	 * beanFactory property.
+	 * @param beanFactory the bean factory.
+	 * @return the evaluation context.
+	 */
 	public static StandardEvaluationContext createStandardEvaluationContext(BeanFactory beanFactory) {
 		return createStandardEvaluationContext(beanFactory, null);
 	}
 
+	/**
+	 * Create a {@link StandardEvaluationContext} with a {@link MapAccessor} in its
+	 * property accessor property and the supplied {@link ConversionService} in its
+	 * conversionService property.
+	 * @param conversionService the conversion service.
+	 * @return the evaluation context.
+	 */
 	public static StandardEvaluationContext createStandardEvaluationContext(ConversionService conversionService) {
 		return createStandardEvaluationContext(null, conversionService);
 	}
 
+	/**
+	 * Create a {@link StandardEvaluationContext} with a {@link MapAccessor} in its
+	 * property accessor property, the supplied {@link BeanFactory} in its
+	 * beanFactory property, and the supplied {@link ConversionService} in its
+	 * conversionService property.
+	 * @param beanFactory the bean factory.
+	 * @param conversionService the conversion service.
+	 * @return the evaluation context.
+	 */
 	public static StandardEvaluationContext createStandardEvaluationContext(BeanFactory beanFactory,
 			ConversionService conversionService) {
 		StandardEvaluationContext evaluationContext = new StandardEvaluationContext();

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PseudoTransactionalMessageSourceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PseudoTransactionalMessageSourceTests.java
@@ -62,10 +62,10 @@ public class PseudoTransactionalMessageSourceTests {
 				rolledBack.set(resource);
 			}
 
-			public void afterReceiveNoTX(Object resource) {
+			public void afterReceiveNoTx(Object resource) {
 			}
 
-			public void afterSendNoTX(Object resource) {
+			public void afterSendNoTx(Object resource) {
 			}
 		});
 
@@ -105,10 +105,10 @@ public class PseudoTransactionalMessageSourceTests {
 				rolledBack.set(resource);
 			}
 
-			public void afterReceiveNoTX(Object resource) {
+			public void afterReceiveNoTx(Object resource) {
 			}
 
-			public void afterSendNoTX(Object resource) {
+			public void afterSendNoTx(Object resource) {
 			}
 		});
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PseudoTransactionalMessageSourceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PseudoTransactionalMessageSourceTests.java
@@ -61,6 +61,12 @@ public class PseudoTransactionalMessageSourceTests {
 			public void afterRollback(Object resource) {
 				rolledBack.set(resource);
 			}
+
+			public void afterReceiveNoTX(Object resource) {
+			}
+
+			public void afterSendNoTX(Object resource) {
+			}
 		});
 
 		TransactionSynchronizationManager.initSynchronization();
@@ -97,6 +103,12 @@ public class PseudoTransactionalMessageSourceTests {
 
 			public void afterRollback(Object resource) {
 				rolledBack.set(resource);
+			}
+
+			public void afterReceiveNoTX(Object resource) {
+			}
+
+			public void afterSendNoTX(Object resource) {
 			}
 		});
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileHeaders.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@ package org.springframework.integration.file;
 /**
  * Pre-defined header names to be used when storing or retrieving
  * File-related values to/from integration Message Headers.
- * 
+ *
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public abstract class FileHeaders {
 
@@ -33,5 +34,7 @@ public abstract class FileHeaders {
 	public static final String REMOTE_DIRECTORY = PREFIX + "remoteDirectory";
 
 	public static final String REMOTE_FILE = PREFIX + "remoteFile";
+
+	public static final String DISPOSITION_RESULT = PREFIX + "dispositionResult";
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ import org.springframework.util.Assert;
  * @author Iwein Fuld
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
 public class FileReadingMessageSource extends IntegrationObjectSupport implements PseudoTransactionalMessageSource<File> {
 
@@ -238,10 +239,12 @@ public class FileReadingMessageSource extends IntegrationObjectSupport implement
 	}
 
 	public void setDispositionExpression(Expression dispositionExpression) {
+		Assert.notNull(dispositionExpression, "Disposition Expression must not be null");
 		this.dispositionExpression = dispositionExpression;
 	}
 
 	public void setDispositionResultChannel(MessageChannel dispositionResultChannel) {
+		Assert.notNull(dispositionResultChannel, "Disposition Result Channel must not be null");
 		this.dispositionMessagingTemplate.setDefaultChannel(dispositionResultChannel);
 		this.dispostionResultChannelSet = true;
 	}
@@ -383,11 +386,11 @@ public class FileReadingMessageSource extends IntegrationObjectSupport implement
 		// no op
 	}
 
-	public void afterReceiveNoTX(Object resource) {
+	public void afterReceiveNoTx(Object resource) {
 		// no op
 	}
 
-	public void afterSendNoTX(Object resource) {
+	public void afterSendNoTx(Object resource) {
 		this.afterCommit(resource);
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileReadingMessageSourceFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileReadingMessageSourceFactoryBean.java
@@ -21,8 +21,9 @@ import java.util.Comparator;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.expression.Expression;
+import org.springframework.integration.MessageChannel;
 import org.springframework.integration.file.DirectoryScanner;
 import org.springframework.integration.file.FileReadingMessageSource;
 import org.springframework.integration.file.filters.CompositeFileListFilter;
@@ -55,6 +56,12 @@ public class FileReadingMessageSourceFactoryBean implements FactoryBean<FileRead
 	private volatile Boolean autoCreateDirectory;
 
 	private volatile Integer queueSize;
+
+	private volatile Expression dispositionExpression;
+
+	private volatile MessageChannel dispositionResultChannel;
+
+	private volatile Long dispositionSendTimeout;
 
 	private final Object initializationMonitor = new Object();
 
@@ -92,6 +99,18 @@ public class FileReadingMessageSourceFactoryBean implements FactoryBean<FileRead
 
 	public void setLocker(AbstractFileLockerFilter locker) {
 		this.locker = locker;
+	}
+
+	public void setDispositionExpression(Expression dispositionExpression) {
+		this.dispositionExpression = dispositionExpression;
+	}
+
+	public void setDispositionResultChannel(MessageChannel dispositionResultChannel) {
+		this.dispositionResultChannel = dispositionResultChannel;
+	}
+
+	public void setDispositionSendTimeout(Long dispositionSendTimeout) {
+		this.dispositionSendTimeout = dispositionSendTimeout;
 	}
 
 	public FileReadingMessageSource getObject() throws Exception {
@@ -149,6 +168,15 @@ public class FileReadingMessageSourceFactoryBean implements FactoryBean<FileRead
 			}
 			if (this.autoCreateDirectory != null) {
 				this.source.setAutoCreateDirectory(this.autoCreateDirectory);
+			}
+			if (this.dispositionExpression != null) {
+				this.source.setDispositionExpression(this.dispositionExpression);
+			}
+			if (this.dispositionResultChannel != null) {
+				this.source.setDispositionResultChannel(this.dispositionResultChannel);
+			}
+			if (this.dispositionSendTimeout != null) {
+				this.source.setDispositionSendTimeout(this.dispositionSendTimeout);
 			}
 			this.source.afterPropertiesSet();
 		}

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-2.2.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-2.2.xsd
@@ -166,6 +166,42 @@ Only files matching this regular expression will be picked up by this adapter.
                   </xsd:documentation>
                 </xsd:annotation>
             </xsd:attribute>
+            <xsd:attribute name="disposition-expression" type="xsd:string">
+                <xsd:annotation>
+                  <xsd:documentation>
+                    SpEL expression to be executed after the message has been sent. If running in a transactional
+                    poller, it will be executed after the transaction commits. If running in a non-transactional
+                    poller it will execute after the message is sent. Note that the actual point of execution
+                    depends on any asynchronous handoffs on the downstream flow. It will be executed when the
+                    current thread returns from the channel send. The root object of the expression is the
+                    original message (with a File payload). Examples: "payload.delete()",
+                    "payload.renameTo('/foo/bar/' + payload.name)", "@someBean.doSomething(payload)".
+                  </xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="disposition-result-channel" type="xsd:string" default="nullChannel">
+                <xsd:annotation>
+                  <xsd:documentation>
+                    If a 'disposition-expression' is provided, and that expression returns a result, the result
+                    is sent to this channel, with the original message payload and a header 'file_dispositionResult'
+                    header.
+                    <xsd:appinfo>
+                        <tool:annotation kind="ref">
+                            <tool:expected-type type="org.springframework.integration.MessageChannel"/>
+                        </tool:annotation>
+                    </xsd:appinfo>
+                  </xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="disposition-send-timeout" type="xsd:string">
+                <xsd:annotation>
+                  <xsd:documentation>
+                    If a 'disposition-expression' is provided, and that expression returns a result, the result
+                    is sent to this disposition-result-channel. This timeout specifies how long to wait if
+                    that channel might block (such as a bounded queue channel that is full). Default infinity.
+                  </xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
         </xsd:complexType>
     </xsd:element>
 

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-2.2.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-2.2.xsd
@@ -183,8 +183,8 @@ Only files matching this regular expression will be picked up by this adapter.
                 <xsd:annotation>
                   <xsd:documentation>
                     If a 'disposition-expression' is provided, and that expression returns a result, the result
-                    is sent to this channel, with the original message payload and a header 'file_dispositionResult'
-                    header.
+                    is sent to this channel, with the original message payload and a 'file_dispositionResult'
+                    header containing the result of the expression execution.
                     <xsd:appinfo>
                         <tool:annotation kind="ref">
                             <tool:expected-type type="org.springframework.integration.MessageChannel"/>

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileToChannelIntegrationTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileToChannelIntegrationTests-context.xml
@@ -12,6 +12,8 @@
     <!-- under test -->
     <file:inbound-channel-adapter
             directory="#{inputDirectory.path}"
+            disposition-expression="payload.delete()"
+            disposition-result-channel="resultChannel"
             channel="fileMessages" filter="compositeFilter"/>
 
     <bean id="temp" class="org.junit.rules.TemporaryFolder"
@@ -39,4 +41,7 @@
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"/>
 
+	<si:channel id="resultChannel">
+		<si:queue />
+	</si:channel>
 </beans>

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests-context.xml
@@ -14,9 +14,14 @@
                              directory="${java.io.tmpdir}"
                              filter="filter"
                              comparator="testComparator"
+                             disposition-expression="payload.delete()"
+                             disposition-result-channel="resultChannel"
+                             disposition-send-timeout="123"
                              auto-startup="false">
         <integration:poller fixed-rate="5000"/>
     </inbound-channel-adapter>
+
+	<integration:channel id="resultChannel" />
 
     <beans:bean id="filter" class="org.springframework.integration.file.config.FileListFilterFactoryBean"/>
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests.java
@@ -27,14 +27,16 @@ import java.util.concurrent.PriorityBlockingQueue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.file.DefaultDirectoryScanner;
 import org.springframework.integration.file.FileReadingMessageSource;
 import org.springframework.integration.file.filters.AcceptOnceFileListFilter;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -92,6 +94,14 @@ public class FileInboundChannelAdapterParserTests {
         assertSame("comparator reference not set, ", expected, actual);
     }
 
+    @Test
+    public void disposition() throws Exception {
+        Object dispositionExpression = accessor.getPropertyValue("dispositionExpression");
+        assertEquals(SpelExpression.class, dispositionExpression.getClass());
+        assertEquals("payload.delete()", ((Expression) dispositionExpression).getExpressionString());
+        assertSame(TestUtils.getPropertyValue(source, "dispositionMessagingTemplate.defaultChannel"), context.getBean("resultChannel"));
+        assertEquals(123L, TestUtils.getPropertyValue(source, "dispositionMessagingTemplate.sendTimeout"));
+    }
 
     static class TestComparator implements Comparator<File> {
 

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -27,12 +27,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.context.expression.BeanFactoryResolver;
-import org.springframework.context.expression.MapAccessor;
-import org.springframework.core.convert.ConversionService;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
-import org.springframework.expression.spel.support.StandardTypeConverter;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -59,6 +55,7 @@ import org.springframework.integration.http.multipart.MultipartHttpInputMessage;
 import org.springframework.integration.http.support.DefaultHttpHeaderMapper;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.util.ExpressionUtils;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -502,17 +499,7 @@ abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySuppor
 	}
 
 	protected StandardEvaluationContext createEvaluationContext(){
-		StandardEvaluationContext evaluationContext = new StandardEvaluationContext();
-		evaluationContext.addPropertyAccessor(new MapAccessor());
-		BeanFactory beanFactory = this.getBeanFactory();
-		if (beanFactory != null) {
-			evaluationContext.setBeanResolver(new BeanFactoryResolver(beanFactory));
-		}
-		ConversionService conversionService = this.getConversionService();
-		if (conversionService != null) {
-			evaluationContext.setTypeConverter(new StandardTypeConverter(conversionService));
-		}
-		return evaluationContext;
+		return ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory(), this.getConversionService());
 	}
 
 	private void validateSupportedMethods() {

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/PseudoTransactionalMessageSourceTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/PseudoTransactionalMessageSourceTests.java
@@ -83,5 +83,11 @@ public class PseudoTransactionalMessageSourceTests {
 			latch2.countDown();
 		}
 
+		public void afterReceiveNoTX(Object resource) {
+		}
+
+		public void afterSendNoTX(Object resource) {
+		}
+
 	}
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/PseudoTransactionalMessageSourceTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/PseudoTransactionalMessageSourceTests.java
@@ -83,10 +83,10 @@ public class PseudoTransactionalMessageSourceTests {
 			latch2.countDown();
 		}
 
-		public void afterReceiveNoTX(Object resource) {
+		public void afterReceiveNoTx(Object resource) {
 		}
 
-		public void afterSendNoTX(Object resource) {
+		public void afterSendNoTx(Object resource) {
 		}
 
 	}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailReceivingMessageSource.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailReceivingMessageSource.java
@@ -94,14 +94,14 @@ public class MailReceivingMessageSource implements PseudoTransactionalMessageSou
 	/**
 	 * For backwards-compatibility; the mail adapter updates the status before the send.
 	 */
-	public void afterReceiveNoTX(Object resource) {
+	public void afterReceiveNoTx(Object resource) {
 		this.afterCommit(resource);
 	}
 
 	/**
 	 * For backwards-compatibility; the mail adapter updates the status before the send.
 	 */
-	public void afterSendNoTX(Object resource) {
+	public void afterSendNoTx(Object resource) {
 		// No op
 	}
 }

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailReceivingMessageSource.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailReceivingMessageSource.java
@@ -90,4 +90,18 @@ public class MailReceivingMessageSource implements PseudoTransactionalMessageSou
 		Assert.isTrue(context instanceof MailReceiverContext, "Expected a MailReceiverContext");
 		this.mailReceiver.closeContextAfterFailure((MailReceiverContext) context);
 	}
+
+	/**
+	 * For backwards-compatibility; the mail adapter updates the status before the send.
+	 */
+	public void afterReceiveNoTX(Object resource) {
+		this.afterCommit(resource);
+	}
+
+	/**
+	 * For backwards-compatibility; the mail adapter updates the status before the send.
+	 */
+	public void afterSendNoTX(Object resource) {
+		// No op
+	}
 }


### PR DESCRIPTION
Add disposition-expression to the inbound file adapter.
This allows for operations such as payload.delete(),
payload.renameTo() after the file is processed.

The result of executing the expression (if any)
is sent to the disposition-result-channel.
