### PR TITLE
INT-2583 Update Reference Copyright

### DIFF
--- a/src/reference/docbook/index.xml
+++ b/src/reference/docbook/index.xml
@@ -71,7 +71,14 @@
       </author>
     </authorgroup>
 
-    <legalnotice><para>© SpringSource Inc., 2012</para></legalnotice>
+		<copyright>
+      <year>2009</year>
+      <year>2010</year>
+      <year>2011</year>
+      <year>2012</year>
+      <holder>VMware, Inc. All rights reserved. VMware is a registered trademark or trademark of VMware, Inc. in the United States and/or other jurisdictions. All other marks and names mentioned herein may be trademarks of their respective companies.
+      </holder>
+    </copyright>
   </bookinfo>
 
   <toc></toc>


### PR DESCRIPTION
Updated the copyright message to the text contained within the JIRA
issue.

Idiomatic docbook seems to reference each individual year w/ an
opening/closing <year/> tag, rather than listing the years as a range
as indicated in the JIRA issue. I took this approach.
