### PR TITLE
INT-2616 - Fix Spelling Error in Schema

### DIFF
--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.0.xsd
@@ -50,12 +50,15 @@
 			<xsd:attribute name="task-executor" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages
-	to this channel's subscribers. Also, when using a TaskExecutor.
-	Keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the
- 	TaskExecutor dispatches to the handler on a separate Thread.
-	Usually configured using 'task' namespace support provided by Spring (e.g., &lt;task:executor/&gt;)
-				]]></xsd:documentation>
+						Provides a reference to a bean that implements
+						org.springframework.core.task.TaskExecutor which is used when
+						dispatching Messages to this channel's subscribers. Also,
+						when using a TaskExecutor, keep in mind that any transaction
+						active for the sender will NOT propagate to the handler
+						invocation, since the TaskExecutor dispatches to the
+						handler on a separate Thread. Usually configured using the
+						'task' namespace support provided by Spring (e.g., <task:executor/>)
+					]]></xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
 							<tool:expected-type type="org.springframework.core.task.TaskExecutor" />
@@ -198,8 +201,10 @@
 			<xsd:annotation>
 				<xsd:documentation>
 					<![CDATA[
-	Allows you to specify the reference to the bean which implements java.util.Comparator&lt;Message&lt;?&gt;&gt;
-	interface and provides logic based on which Messages will be prioritized.
+						Allows you to specify the reference to the bean which
+						implements the java.util.Comparator<Message<?>>
+						interface and provides the logic based on which Messages
+						will be prioritized.
 					]]>
 				</xsd:documentation>
 			</xsd:annotation>
@@ -281,11 +286,14 @@
 		<xsd:attribute name="task-executor" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages
-	to this channel's subscribers. Also, when using a TaskExecutor.
-	Keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the
- 	TaskExecutor dispatches to the handler on a separate Thread.
-	Usually configured using 'task' namespace support provided by Spring (e.g., &lt;task:executor/&gt;)
+					Provides a reference to a bean that implements
+					org.springframework.core.task.TaskExecutor which is used when
+					dispatching Messages to this channel's subscribers. Also,
+					when using a TaskExecutor, keep in mind that any transaction
+					active for the sender will NOT propagate to the handler
+					invocation, since the TaskExecutor dispatches to the
+					handler on a separate Thread. Usually configured using the
+					'task' namespace support provided by Spring (e.g., <task:executor/>)
 				]]></xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
@@ -326,11 +334,14 @@
 						<xsd:annotation>
 							<xsd:documentation>
 								<![CDATA[
-	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages
-	to this channel's subscribers. Also, when using a TaskExecutor.
-	Keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the
- 	TaskExecutor dispatches to the handler on a separate Thread.
-	Usually configured using 'task' namespace support provided by Spring (e.g., &lt;task:executor/&gt;)
+									Provides a reference to a bean that implements
+									org.springframework.core.task.TaskExecutor which is used when
+									dispatching Messages to this channel's subscribers. Also,
+									when using a TaskExecutor, keep in mind that any transaction
+									active for the sender will NOT propagate to the handler
+									invocation, since the TaskExecutor dispatches to the
+									handler on a separate Thread. Usually configured using the
+									'task' namespace support provided by Spring (e.g., <task:executor/>)
 								]]>
 							</xsd:documentation>
 							<xsd:appinfo>
@@ -343,11 +354,16 @@
 					<xsd:attribute name="error-handler" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
-						       <![CDATA[
-	Provides reference to bean that implements org.springframework.util.ErrorHandler and provides a strategy for handling errors.
-	This is especially useful for handling errors that occur during asynchronous execution
-	of tasks that have been submitted to a TaskScheduler where it may not be possible to throw the error to the original caller
-								]]>
+							<![CDATA[
+								Provides reference to a bean that implements
+								org.springframework.util.ErrorHandler and
+								provides a strategy for handling errors.
+								This is especially useful for handling errors
+								that occur during asynchronous execution of tasks
+								that have been submitted to a TaskScheduler, where
+								it may not be possible to throw the error to the
+								original caller.
+							]]>
 							</xsd:documentation>
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
@@ -390,9 +406,11 @@
 			<xsd:annotation>
 				<xsd:documentation>
 					<![CDATA[
-	Allows you to identify this channel as Datatype channel and specify the type of the Message
-	payload this channel accepts (e.g., datatype="java.lang.String"). Datatype channel
-	is a channel that accepts messages cotaining payload of certain type.
+						Allows you to identify this channel as a Datatype channel
+						and specify the type of the Message payload this channel
+						accepts (e.g., datatype="java.lang.String"). A Datatype
+						channel is a channel that accepts messages containing
+						payloads of a certain type.
 					]]>
 				</xsd:documentation>
 			</xsd:annotation>
@@ -484,10 +502,12 @@
 						<xsd:attribute name="reply-channel" type="xsd:string">
 							<xsd:annotation>
 								<xsd:documentation>
-										<![CDATA[
-								Identifies channel this gateway will subscribe to to recieve reply Message.
-								The reply Message which will then be converted to the return type of the method signature.
-										]]>
+									<![CDATA[
+									Identifies the channel this gateway will
+									subscribe to, to recieve a reply Message. The
+									reply Message will then be converted to the
+									return type of the method signature.
+									]]>
 								</xsd:documentation>
 							</xsd:annotation>
 						</xsd:attribute>
@@ -549,10 +569,11 @@
 			<xsd:attribute name="default-reply-channel" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>
-										<![CDATA[
-								Identifies default channel this gateway will subscribe to to recieve reply Messages, which will then be
-								converted to the return type of the method signature.
-										]]>
+						<![CDATA[
+							Identifies the default channel this gateway will subscribe to,
+							to receive reply Messages, which will then be
+							converted to the return type of the method signature.
+						]]>
 					</xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
@@ -600,7 +621,8 @@
 	<xsd:complexType name="headerSubElementType">
 		<xsd:annotation>
 			<xsd:documentation>	<![CDATA[
-				Provides mechanism to enrich content of the message with custom message headers. When this method is going to be invoked
+				Provides a mechanism to enrich content of the message with
+				custom message headers. When this method is going to be invoked,
 				the generated message will be enriched with these headers.
 			]]></xsd:documentation>
 		</xsd:annotation>
@@ -825,9 +847,10 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 					</tool:annotation>
 				</xsd:appinfo>
 				<xsd:documentation>
-					Identifies channel attached to this adapter. Depending on the type of the adapter
-					this channel could be the receiving channel (e.g., outbound-channel-adapter) or channel where
-					messages will be sent to by this adapter (e.g., inbound-channel-adapter).
+					Identifies the channel attached to this adapter. Depending on
+					the type of the adapter this channel could be the
+					receiving channel (e.g. outbound-channel-adapter) or the channel
+					where messages will be sent to by this adapter (e.g. inbound-channel-adapter).
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -1647,11 +1670,14 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 		<xsd:attribute name="pattern-match" type="xsd:boolean" default="true">
 			<xsd:annotation>
 				<xsd:documentation>
-					Boolean flag that specifies whether values provided in 'header-names' should be treated as
-					match patterns or literal values. For example header-names='foo*' would mean remove all
-					headers that begin with 'foo' including the header named 'foo*'. However if you want to
-					treat '*' as literal value setting this flag to FALSE will not perform pattern match and
-					the only header that will be removed is the one that is an exact match.
+					Boolean flag that specifies whether values provided in 'header-names'
+					should be treated as match patterns or literal values. For
+					example header-names='foo*' would mean:
+					remove all headers that begin with 'foo' including the header
+					named 'foo*'. However if you want to treat '*' as literal
+					value, setting this flag to FALSE will not perform a pattern
+					match and the only header that will be removed is the one
+					that is an exact match.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -1916,8 +1942,10 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 					<xsd:attribute name="remove-message" type="xsd:boolean" default="false">
 						<xsd:annotation>
 							<xsd:documentation>
-								If set to 'true' the Message will be removed from the MessageStore by
-								this transformer. Useful when Message can be 'claimed' only once. DEFAULT is 'false'.
+								If set to 'true' the Message will be removed from
+								the MessageStore by this transformer. Useful
+								when the Message can be 'claimed' only once.
+								DEFAULT is 'false'.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
@@ -1957,8 +1985,8 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 	<xsd:element name="filter">
 		<xsd:annotation>
 			<xsd:documentation>
-				Defines a Message Filters that is used to decide whether a Message should be passed
-				along or dropped based on some criteria
+				Defines a Message Filter that is used to decide, whether a Message
+				should be passed along or dropped, based on some criteria.
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
@@ -2466,9 +2494,11 @@ Name of the header whose value will be used to route messages
 				</xsd:attribute>
 				<xsd:attribute name="correlation-strategy-expression" type="xsd:string">
 					<xsd:annotation>
-						<xsd:documentation>A SpEL expression which implements correlation decision
-						algorithm to apply to the Message (e.g., payload.getPerson().getId() - correlate
-						 based on the 'id' of the 'person' attribute of the message payload object)</xsd:documentation>
+						<xsd:documentation>A SpEL expression which implements a
+						correlation decision algorithm to apply to the Message
+						(e.g. payload.getPerson().getId() - correlate
+						 based on the 'id' of the 'person' attribute of the
+						 message payload object)</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 				<xsd:attribute name="discard-channel" type="xsd:string">

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.0.xsd
@@ -50,9 +50,9 @@
 			<xsd:attribute name="task-executor" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages 
-	to this channel's subscribers. Also, when using a TaskExecutor. 
-	Keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the 
+	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages
+	to this channel's subscribers. Also, when using a TaskExecutor.
+	Keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the
  	TaskExecutor dispatches to the handler on a separate Thread.
 	Usually configured using 'task' namespace support provided by Spring (e.g., &lt;task:executor/&gt;)
 				]]></xsd:documentation>
@@ -102,7 +102,7 @@
 							<xsd:element name="rendezvous-queue" type="rendezvousQueueType" />
 							<xsd:element name="dispatcher" type="dispatcherType" >
 								<xsd:annotation>
-									<xsd:documentation>Provides MessageDispatcher configuration 
+									<xsd:documentation>Provides MessageDispatcher configuration
 									(i.e., failover, load-balancing, task-executor)</xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
@@ -199,7 +199,7 @@
 				<xsd:documentation>
 					<![CDATA[
 	Allows you to specify the reference to the bean which implements java.util.Comparator&lt;Message&lt;?&gt;&gt;
-	interface and provides logic based on which Messages will be prioritized. 
+	interface and provides logic based on which Messages will be prioritized.
 					]]>
 				</xsd:documentation>
 			</xsd:annotation>
@@ -281,9 +281,9 @@
 		<xsd:attribute name="task-executor" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages 
-	to this channel's subscribers. Also, when using a TaskExecutor. 
-	Keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the 
+	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages
+	to this channel's subscribers. Also, when using a TaskExecutor.
+	Keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the
  	TaskExecutor dispatches to the handler on a separate Thread.
 	Usually configured using 'task' namespace support provided by Spring (e.g., &lt;task:executor/&gt;)
 				]]></xsd:documentation>
@@ -326,9 +326,9 @@
 						<xsd:annotation>
 							<xsd:documentation>
 								<![CDATA[
-	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages 
-	to this channel's subscribers. Also, when using a TaskExecutor. 
-	Keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the 
+	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages
+	to this channel's subscribers. Also, when using a TaskExecutor.
+	Keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the
  	TaskExecutor dispatches to the handler on a separate Thread.
 	Usually configured using 'task' namespace support provided by Spring (e.g., &lt;task:executor/&gt;)
 								]]>
@@ -342,10 +342,10 @@
 					</xsd:attribute>
 					<xsd:attribute name="error-handler" type="xsd:string">
 						<xsd:annotation>
-							<xsd:documentation>	
-						       <![CDATA[  
-	Provides reference to bean that implements org.springframework.util.ErrorHandler and provides a strategy for handling errors. 
-	This is especially useful for handling errors that occur during asynchronous execution 
+							<xsd:documentation>
+						       <![CDATA[
+	Provides reference to bean that implements org.springframework.util.ErrorHandler and provides a strategy for handling errors.
+	This is especially useful for handling errors that occur during asynchronous execution
 	of tasks that have been submitted to a TaskScheduler where it may not be possible to throw the error to the original caller
 								]]>
 							</xsd:documentation>
@@ -388,10 +388,10 @@
 		<xsd:attribute name="scope" type="xsd:string" />
 		<xsd:attribute name="datatype" type="xsd:string">
 			<xsd:annotation>
-				<xsd:documentation>	
-					<![CDATA[  
-	Allows you to identify this channel as Datatype channel and specify the type of the Message 
-	payload this channel accepts (e.g., datatype="java.lang.String"). Datatype channel 
+				<xsd:documentation>
+					<![CDATA[
+	Allows you to identify this channel as Datatype channel and specify the type of the Message
+	payload this channel accepts (e.g., datatype="java.lang.String"). Datatype channel
 	is a channel that accepts messages cotaining payload of certain type.
 					]]>
 				</xsd:documentation>
@@ -430,8 +430,8 @@
 			<xsd:sequence>
 				<xsd:element name="method" minOccurs="0" maxOccurs="unbounded">
 					<xsd:annotation>
-						<xsd:documentation>	
-							<![CDATA[  
+						<xsd:documentation>
+							<![CDATA[
 	Provides mechanism to define method per channel mappings for this gateway
 							]]>
 						</xsd:documentation>
@@ -440,10 +440,10 @@
 						<xsd:sequence>
 							<xsd:element name="header" minOccurs="0" maxOccurs="unbounded" type="headerSubElementType">
 								<xsd:annotation>
-									<xsd:documentation>	
-										<![CDATA[  
+									<xsd:documentation>
+										<![CDATA[
 				Provides mechanism to enrich content of the message with custom message headers. When this method is going to be invoked
-				the generated message will be enriched with these headers. 
+				the generated message will be enriched with these headers.
 										]]>
 									</xsd:documentation>
 								</xsd:annotation>
@@ -451,7 +451,7 @@
 						</xsd:sequence>
 						<xsd:attribute name="name" type="xsd:string">
 							<xsd:annotation>
-								<xsd:documentation>	
+								<xsd:documentation>
 									<![CDATA[
 										The name of the method
 									]]>
@@ -465,8 +465,8 @@
 						</xsd:attribute>
 						<xsd:attribute name="payload-expression" type="xsd:string">
 							<xsd:annotation>
-								<xsd:documentation>	
-									<![CDATA[  
+								<xsd:documentation>
+									<![CDATA[
 										Expression that should be evaluated to generate the payload.
 									]]>
 								</xsd:documentation>
@@ -474,7 +474,7 @@
 						</xsd:attribute>
 						<xsd:attribute name="request-channel" type="xsd:string">
 							<xsd:annotation>
-								<xsd:documentation>	
+								<xsd:documentation>
 									<![CDATA[
 										Identifies channel the message will be sent to upon invocation of this method
 									]]>
@@ -483,9 +483,9 @@
 						</xsd:attribute>
 						<xsd:attribute name="reply-channel" type="xsd:string">
 							<xsd:annotation>
-								<xsd:documentation>	
-										<![CDATA[  
-								Identifies channel this gateway will subscribe to to recieve reply Message. 
+								<xsd:documentation>
+										<![CDATA[
+								Identifies channel this gateway will subscribe to to recieve reply Message.
 								The reply Message which will then be converted to the return type of the method signature.
 										]]>
 								</xsd:documentation>
@@ -493,10 +493,10 @@
 						</xsd:attribute>
 						<xsd:attribute name="request-timeout" type="xsd:string">
 							<xsd:annotation>
-								<xsd:documentation>	
-										<![CDATA[  
+								<xsd:documentation>
+										<![CDATA[
 								Provides the amount of time dispatcher would wait to send a message.
-								This timeout would only apply if there is a potential to block in the send call. 
+								This timeout would only apply if there is a potential to block in the send call.
 								For example if this gateway is hooked up to a Queue channel. 
 								Value is specified in milliseconds.
 										]]>
@@ -505,10 +505,10 @@
 						</xsd:attribute>
 						<xsd:attribute name="reply-timeout" type="xsd:string">
 							<xsd:annotation>
-								<xsd:documentation>	
-										<![CDATA[  
-								Allows you to specify how long this gateway will wait for the reply message 
-								before throwing an exception. By default it will wait indefinitely. 
+								<xsd:documentation>
+										<![CDATA[
+								Allows you to specify how long this gateway will wait for the reply message
+								before throwing an exception. By default it will wait indefinitely.
 								Value is specified in milliseconds
 										]]>
 								</xsd:documentation>
@@ -520,9 +520,9 @@
 			<xsd:attribute name="id" type="xsd:ID" use="optional" />
 			<xsd:attribute name="service-interface" type="xsd:string" use="optional">
 				<xsd:annotation>
-					<xsd:documentation>	
-						<![CDATA[  
-							The name of the interface which will be exposed by this gateway. 
+					<xsd:documentation>
+						<![CDATA[
+							The name of the interface which will be exposed by this gateway.
 						]]>
 					</xsd:documentation>
 					<xsd:appinfo>
@@ -534,8 +534,8 @@
 			</xsd:attribute>
 			<xsd:attribute name="default-request-channel" type="xsd:string">
 				<xsd:annotation>
-					<xsd:documentation>	
-										<![CDATA[  
+					<xsd:documentation>
+										<![CDATA[
 								Identifies default channel the messages will be sent to upon invocation of methods of this gateway
 										]]>
 					</xsd:documentation>
@@ -548,9 +548,9 @@
 			</xsd:attribute>
 			<xsd:attribute name="default-reply-channel" type="xsd:string">
 				<xsd:annotation>
-					<xsd:documentation>	
-										<![CDATA[  
-								Identifies default channel this gateway will subscribe to to recieve reply Messages, which will then be 
+					<xsd:documentation>
+										<![CDATA[
+								Identifies default channel this gateway will subscribe to to recieve reply Messages, which will then be
 								converted to the return type of the method signature.
 										]]>
 					</xsd:documentation>
@@ -573,10 +573,10 @@
 			</xsd:attribute>
 			<xsd:attribute name="default-request-timeout" type="xsd:string">
 				<xsd:annotation>
-					<xsd:documentation>	
-							<![CDATA[  
+					<xsd:documentation>
+							<![CDATA[
 					Provides the amount of time dispatcher would wait to send a message.
-					This timeout would only apply if there is a potential to block in the send call. 
+					This timeout would only apply if there is a potential to block in the send call.
 					For example if this gateway is hooked up to a Queue channel. 
 					Value is specified in milliseconds.
 							]]>
@@ -585,10 +585,10 @@
 			</xsd:attribute>
 			<xsd:attribute name="default-reply-timeout" type="xsd:string">
 				<xsd:annotation>
-					<xsd:documentation>	
-							<![CDATA[  
-					Allows you to specify how long this gateway will wait for the reply message 
-					before throwing an exception. By default it will wait indefinitely. 
+					<xsd:documentation>
+							<![CDATA[
+					Allows you to specify how long this gateway will wait for the reply message
+					before throwing an exception. By default it will wait indefinitely.
 					Value is specified in milliseconds.
 							]]>
 					</xsd:documentation>
@@ -599,9 +599,9 @@
 
 	<xsd:complexType name="headerSubElementType">
 		<xsd:annotation>
-			<xsd:documentation>	<![CDATA[  
+			<xsd:documentation>	<![CDATA[
 				Provides mechanism to enrich content of the message with custom message headers. When this method is going to be invoked
-				the generated message will be enriched with these headers. 
+				the generated message will be enriched with these headers.
 			]]></xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="name" type="xsd:string" use="required">
@@ -613,14 +613,14 @@
 		</xsd:attribute>
 		<xsd:attribute name="value" type="xsd:string">
 			<xsd:annotation>
-				<xsd:documentation><![CDATA[  
+				<xsd:documentation><![CDATA[
 					The value of the header. Either this or 'expression' must be provided.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="expression" type="xsd:string">
 			<xsd:annotation>
-				<xsd:documentation><![CDATA[  
+				<xsd:documentation><![CDATA[
 					Expression to be evaluated to produce a value for the header.
 					Either this or 'value' must be provided.
 				]]></xsd:documentation>
@@ -636,8 +636,8 @@
 		</xsd:annotation>
 		<xsd:attribute name="request-channel" type="xsd:string">
 			<xsd:annotation>
-				<xsd:documentation>	
-						<![CDATA[  
+				<xsd:documentation>
+						<![CDATA[
 				Identifies channel the message will be sent to upon invocation of methods of this gateway
 						]]>
 				</xsd:documentation>
@@ -650,10 +650,10 @@
 		</xsd:attribute>
 		<xsd:attribute name="request-timeout" type="xsd:string">
 			<xsd:annotation>
-				<xsd:documentation>	
-							<![CDATA[  
+				<xsd:documentation>
+							<![CDATA[
 					Provides the amount of time dispatcher would wait to send a message.
-					This timeout would only apply if there is a potential to block in the send call. 
+					This timeout would only apply if there is a potential to block in the send call.
 					For example if this gateway is hooked up to a Queue channel. 
 					Value is specified in milliseconds.
 							]]>
@@ -681,14 +681,14 @@
 		<xsd:complexType>
 			<xsd:sequence>
 				<xsd:choice minOccurs="0" maxOccurs="1" >
-					<xsd:sequence> 
-						<xsd:element name="poller" type="basePollerType" /> 
-						<xsd:element ref="beans:bean" minOccurs="0" maxOccurs="1" /> 
-					</xsd:sequence> 
-					<xsd:sequence> 
-						<xsd:element ref="beans:bean" /> 
-						<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1" /> 
-					</xsd:sequence> 
+					<xsd:sequence>
+						<xsd:element name="poller" type="basePollerType" />
+						<xsd:element ref="beans:bean" minOccurs="0" maxOccurs="1" />
+					</xsd:sequence>
+					<xsd:sequence>
+						<xsd:element ref="beans:bean" />
+						<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1" />
+					</xsd:sequence>
 				</xsd:choice>
 				<xsd:element name="header" type="headerSubElementType" minOccurs="0" maxOccurs="unbounded" />
 			</xsd:sequence>
@@ -787,7 +787,7 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 					</tool:annotation>
 				</xsd:appinfo>
 				<xsd:documentation>
-				A reference to a bean defined in the application context. 
+				A reference to a bean defined in the application context.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -825,8 +825,8 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 					</tool:annotation>
 				</xsd:appinfo>
 				<xsd:documentation>
-					Identifies channel attached to this adapter. Depending on the type of the adapter 
-					this channel could be the receiving channel (e.g., outbound-channel-adapter) or channel where 
+					Identifies channel attached to this adapter. Depending on the type of the adapter
+					this channel could be the receiving channel (e.g., outbound-channel-adapter) or channel where
 					messages will be sent to by this adapter (e.g., inbound-channel-adapter).
 				</xsd:documentation>
 			</xsd:annotation>
@@ -1194,8 +1194,8 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 		<xsd:attribute name="ref" type="xsd:string" use="optional">
 			<xsd:annotation>
 				<xsd:documentation>
-					Allows this poller to reference another instance of a top-level poller. 
-					[IMPORTANT] - This attribute is only allowed on inner poller definitions. 
+					Allows this poller to reference another instance of a top-level poller.
+					[IMPORTANT] - This attribute is only allowed on inner poller definitions.
 					Defining this attribute on a top-level poller definition will result in a configuration exception.
 				</xsd:documentation>
 			</xsd:annotation>
@@ -1467,7 +1467,7 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 					provided, then the specified header values will NOT overwrite any
 					existing ones with the same
 					header
-					names. 
+					names.
 					</xsd:documentation>
 			</xsd:annotation>
 			<xsd:simpleType>
@@ -1647,10 +1647,10 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 		<xsd:attribute name="pattern-match" type="xsd:boolean" default="true">
 			<xsd:annotation>
 				<xsd:documentation>
-					Boolean flag that specifies whether values provided in 'header-names' should be treated as 
-					match patterns or literal values. For example header-names='foo*' would mean remove all 
-					headers that begin with 'foo' including the header named 'foo*'. However if you want to 
-					treat '*' as literal value setting this flag to FALSE will not perform pattern match and 
+					Boolean flag that specifies whether values provided in 'header-names' should be treated as
+					match patterns or literal values. For example header-names='foo*' would mean remove all
+					headers that begin with 'foo' including the header named 'foo*'. However if you want to
+					treat '*' as literal value setting this flag to FALSE will not perform pattern match and
 					the only header that will be removed is the one that is an exact match.
 				</xsd:documentation>
 			</xsd:annotation>
@@ -1916,7 +1916,7 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 					<xsd:attribute name="remove-message" type="xsd:boolean" default="false">
 						<xsd:annotation>
 							<xsd:documentation>
-								If set to 'true' the Message will be removed from the MessageStore by 
+								If set to 'true' the Message will be removed from the MessageStore by
 								this transformer. Useful when Message can be 'claimed' only once. DEFAULT is 'false'.
 							</xsd:documentation>
 						</xsd:annotation>
@@ -1957,7 +1957,7 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 	<xsd:element name="filter">
 		<xsd:annotation>
 			<xsd:documentation>
-				Defines a Message Filters that is used to decide whether a Message should be passed 
+				Defines a Message Filters that is used to decide whether a Message should be passed
 				along or dropped based on some criteria
 			</xsd:documentation>
 		</xsd:annotation>
@@ -2025,7 +2025,7 @@ Name of the header whose value will be used to route messages
 	<xsd:element name="recipient-list-router">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[
-	Defines a Recipient List Router. 
+	Defines a Recipient List Router.
 			]]></xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
@@ -2108,7 +2108,7 @@ Name of the header whose value will be used to route messages
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
-	
+
 	<xsd:element name="exception-type-router">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[
@@ -2125,7 +2125,7 @@ Name of the header whose value will be used to route messages
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:complexType name="exception-type-router-type">
 		<xsd:complexContent>
 			<xsd:extension base="channelResolvingRouterType">
@@ -2218,15 +2218,15 @@ Name of the header whose value will be used to route messages
 						<xsd:annotation>
 							<xsd:documentation>
 							<![CDATA[
-	Defines mapping rules for this router 
-	(e.g., mapping value='foo' channel='myChannel')]]>	
+	Defines mapping rules for this router
+	(e.g., mapping value='foo' channel='myChannel')]]>
 							</xsd:documentation>
 						</xsd:annotation>
 						<xsd:complexType>
 							<xsd:attribute name="value" type="xsd:string">
 								<xsd:annotation>
 									<xsd:documentation>
-									A value of the evaluation token that will be mapped to a channel reference 
+									A value of the evaluation token that will be mapped to a channel reference
 									(e.g., mapping value='foo' channel='myChannel')
 									</xsd:documentation>
 								</xsd:annotation>
@@ -2413,7 +2413,7 @@ Name of the header whose value will be used to route messages
 							</tool:annotation>
 						</xsd:appinfo>
 						<xsd:documentation>
-							A reference to a bean that implements the release strategy. 
+							A reference to a bean that implements the release strategy.
 							The bean can be an implementation of the
 							ReleaseStrategy interface or a POJO
 						</xsd:documentation>
@@ -2445,8 +2445,8 @@ Name of the header whose value will be used to route messages
 							</tool:annotation>
 						</xsd:appinfo>
 						<xsd:documentation>
-							A reference to a bean that implements the decision algorithm as to whether a given 
-							message group is complete. The bean can be an implementation of the 
+							A reference to a bean that implements the decision algorithm as to whether a given
+							message group is complete. The bean can be an implementation of the
 							CorrelationStrategy interface or a POJO.
 							</xsd:documentation>
 					</xsd:annotation>
@@ -2466,7 +2466,7 @@ Name of the header whose value will be used to route messages
 				</xsd:attribute>
 				<xsd:attribute name="correlation-strategy-expression" type="xsd:string">
 					<xsd:annotation>
-						<xsd:documentation>A SpEL expression which implements correlation decision 
+						<xsd:documentation>A SpEL expression which implements correlation decision
 						algorithm to apply to the Message (e.g., payload.getPerson().getId() - correlate
 						 based on the 'id' of the 'person' attribute of the message payload object)</xsd:documentation>
 					</xsd:annotation>
@@ -2503,9 +2503,9 @@ Name of the header whose value will be used to route messages
 				<xsd:attribute name="send-partial-result-on-expiry" type="xsd:string">
 					<xsd:annotation>
 						<xsd:documentation>
-						Specifies whether messages that expired should be aggregated and sent to the 'output-channel' or 'replyChannel'. 
-						Messages are expired when their containing MessageGroup expires. One of the ways of expiring MessageGroups is by 
-						configuring a MessageGroupStoreReaper. However MessageGroups can alternatively be expired by simply calling 
+						Specifies whether messages that expired should be aggregated and sent to the 'output-channel' or 'replyChannel'.
+						Messages are expired when their containing MessageGroup expires. One of the ways of expiring MessageGroups is by
+						configuring a MessageGroupStoreReaper. However MessageGroups can alternatively be expired by simply calling
 						MessageGroupStore.expireMessageGroup(groupId). That could be accomplished via a ControlBus operation
 						or by simply invoking that method if you have a reference to the MessageGroupStore instance.
 						</xsd:documentation>
@@ -2577,7 +2577,7 @@ Name of the header whose value will be used to route messages
 						<xsd:documentation>
 							Reference to a bean in this Application Context that implements ChannelInterceptor
 						</xsd:documentation>
-					</xsd:annotation>  
+					</xsd:annotation>
 					<xsd:complexType>
 						<xsd:attribute name="bean" use="required">
 							<xsd:annotation>
@@ -2596,7 +2596,7 @@ Name of the header whose value will be used to route messages
 				<xsd:element name="wire-tap" type="wireTapType" minOccurs="0" maxOccurs="unbounded">
 					<xsd:annotation>
 						<xsd:documentation>
-						Alows you to configure a Wire Tap interceptor that will send a copy of the message to a 
+						Alows you to configure a Wire Tap interceptor that will send a copy of the message to a
 						channel identified by 'channel' attribute.
 						</xsd:documentation>
 					</xsd:annotation>
@@ -2836,7 +2836,7 @@ Name of the header whose value will be used to route messages
         </xsd:complexContent>
       </xsd:complexType>
     </xsd:element>
-    
+
 	<xsd:element name="channel-interceptor">
 		<xsd:annotation>
 			<xsd:documentation>
@@ -2845,7 +2845,7 @@ Name of the header whose value will be used to route messages
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:sequence>
-			    <xsd:any namespace="##any" processContents="strict" minOccurs="0" maxOccurs="1" />				
+			    <xsd:any namespace="##any" processContents="strict" minOccurs="0" maxOccurs="1" />
 			</xsd:sequence>
 			<xsd:attribute name="pattern" type="xsd:string" use="optional">
 				<xsd:annotation>
@@ -2885,7 +2885,7 @@ Name of the header whose value will be used to route messages
 		<xsd:annotation>
 			<xsd:documentation>
 			Allows you to register Converters (implementation of the Converter interface) that will
-be automatically registered with the ConversionService. ConversionService itself does not have to be 
+be automatically registered with the ConversionService. ConversionService itself does not have to be
 explicitly defined since the default ConversionService will be registered under the name 'integrationConversionService'
 unless bean with this name is already registered.
 			</xsd:documentation>
@@ -2915,7 +2915,7 @@ unless bean with this name is already registered.
 		<xsd:annotation>
 			<xsd:documentation>
 				<![CDATA[
-Will register Message History writer which will track message hostory. There can 
+Will register a Message History writer which will track the message history. There can
 only be one Message History writer per ApplicationContext hierarchy.
 					]]>
 			</xsd:documentation>
@@ -2955,7 +2955,7 @@ The list of component name patterns you want to track (e.g.,  tracked-components
 				that will be available include:
 				   1) any that are annotated with @ManagedAttribute or @ManagedOperation
 				   2) Lifecycle methods
-				   3) get/set or shutdown methods on configurable TaskExecutors or TaskSchedulers 
+				   3) get/set or shutdown methods on configurable TaskExecutors or TaskSchedulers
 			]]></xsd:documentation>
 		</xsd:annotation>
 	</xsd:complexType>
@@ -2979,7 +2979,7 @@ The list of component name patterns you want to track (e.g.,  tracked-components
 				<xsd:documentation>
 					Specify the maximum amount of time in milliseconds to wait when sending a reply
 					Message to the
-					output channel. By default the send will block for one second. 
+					output channel. By default the send will block for one second.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
@@ -716,7 +716,7 @@
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="resource-inbound-channel-adapter">
 		<xsd:annotation>
 			<xsd:documentation>
@@ -770,11 +770,11 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
-			
+
 			<xsd:attribute name="pattern-resolver" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>
-						Reference to a org.springframework.core.io.support.ResourcePatternResolver. 
+						Reference to a org.springframework.core.io.support.ResourcePatternResolver.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -1118,7 +1118,7 @@ endpoint itself is a Polling Consumer for a channel with a queue.
         <xsd:attribute name="request-timeout" type="xsd:string">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[
-                    Set the timeout value for sending request messages in milliseconds. 
+                    Set the timeout value for sending request messages in milliseconds.
                     If not explicitly configured, the default is one second.
                     ]]>
                 </xsd:documentation>
@@ -1127,7 +1127,7 @@ endpoint itself is a Polling Consumer for a channel with a queue.
         <xsd:attribute name="reply-timeout" type="xsd:string">
             <xsd:annotation>
                 <xsd:documentation><![CDATA[
-                    Set the timeout value for receiving reply messages in milliseconds. 
+                    Set the timeout value for receiving reply messages in milliseconds.
                     If not explicitly configured, the default is one second.
                     ]]>
                 </xsd:documentation>
@@ -1136,25 +1136,25 @@ endpoint itself is a Polling Consumer for a channel with a queue.
         <xsd:attribute name="requires-reply" use="optional" default="true">
         <xsd:annotation>
             <xsd:documentation><![CDATA[
-                If you specify a 'request-channel' you can optionally set the 
-                'requires-reply' attribute as well. If you set this attribute to 
-                'true', a reply must return a non-null value. 
-                
+                If you specify a 'request-channel' you can optionally set the
+                'requires-reply' attribute as well. If you set this attribute to
+                'true', a reply must return a non-null value.
+
                 For example, you dispatch a message to the request-channel
                 (backed by a 'QueueChannel'). If the reply does not return within
-                the specified 'replyTimeout', then the reply message will end up 
+                the specified 'replyTimeout', then the reply message will end up
                 being Null.
-                
+
                 By setting 'requires-reply' to 'true', a 'ReplyRequiredException'
-                will be raised for null reply messages. If 'requires-reply' is set 
-                to false, those messages are silently dropped. 
-                
+                will be raised for null reply messages. If 'requires-reply' is set
+                to false, those messages are silently dropped.
+
                 This attribute defaults to 'true', if not specified.]]>
                 </xsd:documentation>
             </xsd:annotation>
             <xsd:simpleType>
                 <xsd:union memberTypes="xsd:boolean xsd:string" />
-            </xsd:simpleType>            
+            </xsd:simpleType>
         </xsd:attribute>
 		<xsd:attribute name="should-clone-payload">
 			<xsd:annotation>
@@ -3530,7 +3530,7 @@ unless bean with this name is already registered.
 		<xsd:annotation>
 			<xsd:documentation>
 				<![CDATA[
-Will register Message History writer which will track message hostory. There can
+Will register a Message History writer which will track the message history. There can
 only be one Message History writer per ApplicationContext hierarchy.
 					]]>
 			</xsd:documentation>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
@@ -50,12 +50,16 @@
 			<xsd:attribute name="task-executor" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages
-	to this channel's subscribers. Also, when using a TaskExecutor,
-	keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the
- 	TaskExecutor dispatches to the handler on a separate Thread.
-	Usually configured using 'task' namespace support provided by Spring (e.g., &lt;task:executor/&gt;)
-				]]></xsd:documentation>
+						Provides the reference to a bean that implements
+						org.springframework.core.task.TaskExecutor which is used
+						when dispatching Messages to this channel's subscribers.
+						Also, when using a TaskExecutor, keep in mind that any
+						transaction active for the sender will NOT propagate to
+						the handler invocation since the TaskExecutor dispatches
+						to the handler on a separate Thread. Usually configured
+						using the 'task' namespace support provided by Spring
+						(e.g., <task:executor/>).
+					]]></xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
 							<tool:expected-type type="org.springframework.core.task.TaskExecutor" />
@@ -281,11 +285,15 @@
 		<xsd:attribute name="task-executor" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages
-	to this channel's subscribers. Also, when using a TaskExecutor,
-	keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the
- 	TaskExecutor dispatches to the handler on a separate Thread.
-	Usually configured using 'task' namespace support provided by Spring (e.g., &lt;task:executor/&gt;)
+					Provides the reference to a bean that implements
+					org.springframework.core.task.TaskExecutor which is used
+					when dispatching Messages to this channel's subscribers.
+					Also, when using a TaskExecutor, keep in mind that any
+					transaction active for the sender will NOT propagate to
+					the handler invocation since the TaskExecutor dispatches
+					to the handler on a separate Thread. Usually configured
+					using the 'task' namespace support provided by Spring
+					(e.g., <task:executor/>).
 				]]></xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
@@ -324,15 +332,17 @@
 					</xsd:sequence>
 					<xsd:attribute name="task-executor" type="xsd:string">
 						<xsd:annotation>
-							<xsd:documentation>
-								<![CDATA[
-	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages
-	to this channel's subscribers. Also, when using a TaskExecutor,
-	keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the
- 	TaskExecutor dispatches to the handler on a separate Thread.
-	Usually configured using 'task' namespace support provided by Spring (e.g., &lt;task:executor/&gt;)
-								]]>
-							</xsd:documentation>
+							<xsd:documentation><![CDATA[
+								Provides the reference to a bean that implements
+								org.springframework.core.task.TaskExecutor which is used
+								when dispatching Messages to this channel's subscribers.
+								Also, when using a TaskExecutor, keep in mind that any
+								transaction active for the sender will NOT propagate to
+								the handler invocation since the TaskExecutor dispatches
+								to the handler on a separate Thread. Usually configured
+								using the 'task' namespace support provided by Spring
+								(e.g., <task:executor/>).
+							]]></xsd:documentation>
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
 									<tool:expected-type type="org.springframework.core.task.TaskExecutor" />
@@ -343,11 +353,16 @@
 					<xsd:attribute name="error-handler" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
-						       <![CDATA[
-	Provides reference to bean that implements org.springframework.util.ErrorHandler and provides a strategy for handling errors.
-	This is especially useful for handling errors that occur during asynchronous execution
-	of tasks that have been submitted to a TaskScheduler where it may not be possible to throw the error to the original caller
-								]]>
+							<![CDATA[
+								Provides reference to a bean that implements
+								org.springframework.util.ErrorHandler and
+								provides a strategy for handling errors.
+								This is especially useful for handling errors
+								that occur during asynchronous execution of tasks
+								that have been submitted to a TaskScheduler, where
+								it may not be possible to throw the error to the
+								original caller.
+							]]>
 							</xsd:documentation>
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
@@ -390,9 +405,11 @@
 			<xsd:annotation>
 				<xsd:documentation>
 					<![CDATA[
-	Allows you to identify this channel as Datatype channel and specify the type of the Message
-	payload this channel accepts (e.g., datatype="java.lang.String"). Datatype channel
-	is a channel that accepts messages cotaining payload of certain type.
+						Allows you to identify this channel as a Datatype channel
+						and specify the type of the Message payload this channel
+						accepts (e.g., datatype="java.lang.String"). A Datatype
+						channel is a channel that accepts messages containing
+						payloads of a certain type.
 					]]>
 				</xsd:documentation>
 			</xsd:annotation>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -50,12 +50,16 @@
 			<xsd:attribute name="task-executor" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages
-	to this channel's subscribers. Also, when using a TaskExecutor,
-	keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the
- 	TaskExecutor dispatches to the handler on a separate Thread.
-	Usually configured using 'task' namespace support provided by Spring (e.g., &lt;task:executor/&gt;)
-				]]></xsd:documentation>
+						Provides the reference to a bean that implements
+						org.springframework.core.task.TaskExecutor which is used
+						when dispatching Messages to this channel's subscribers.
+						Also, when using a TaskExecutor, keep in mind that any
+						transaction active for the sender will NOT propagate to
+						the handler invocation since the TaskExecutor dispatches
+						to the handler on a separate Thread. Usually configured
+						using the 'task' namespace support provided by Spring
+						(e.g., <task:executor/>).
+					]]></xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
 							<tool:expected-type type="org.springframework.core.task.TaskExecutor" />
@@ -281,11 +285,15 @@
 		<xsd:attribute name="task-executor" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages
-	to this channel's subscribers. Also, when using a TaskExecutor,
-	keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the
- 	TaskExecutor dispatches to the handler on a separate Thread.
-	Usually configured using 'task' namespace support provided by Spring (e.g., &lt;task:executor/&gt;)
+					Provides the reference to a bean that implements
+					org.springframework.core.task.TaskExecutor which is used
+					when dispatching Messages to this channel's subscribers.
+					Also, when using a TaskExecutor, keep in mind that any
+					transaction active for the sender will NOT propagate to
+					the handler invocation since the TaskExecutor dispatches
+					to the handler on a separate Thread. Usually configured
+					using the 'task' namespace support provided by Spring
+					(e.g., <task:executor/>).
 				]]></xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
@@ -324,15 +332,17 @@
 					</xsd:sequence>
 					<xsd:attribute name="task-executor" type="xsd:string">
 						<xsd:annotation>
-							<xsd:documentation>
-								<![CDATA[
-	Provides reference to bean that implements org.springframework.core.task.TaskExecutor to use when dispatching Messages
-	to this channel's subscribers. Also, when using a TaskExecutor,
-	keep in mind that any transaction active for the sender will NOT propagate to the handler invocation since the
- 	TaskExecutor dispatches to the handler on a separate Thread.
-	Usually configured using 'task' namespace support provided by Spring (e.g., &lt;task:executor/&gt;)
-								]]>
-							</xsd:documentation>
+							<xsd:documentation><![CDATA[
+								Provides the reference to a bean that implements
+								org.springframework.core.task.TaskExecutor which is used
+								when dispatching Messages to this channel's subscribers.
+								Also, when using a TaskExecutor, keep in mind that any
+								transaction active for the sender will NOT propagate to
+								the handler invocation since the TaskExecutor dispatches
+								to the handler on a separate Thread. Usually configured
+								using the 'task' namespace support provided by Spring
+								(e.g., <task:executor/>).
+							]]></xsd:documentation>
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
 									<tool:expected-type type="org.springframework.core.task.TaskExecutor" />
@@ -343,11 +353,16 @@
 					<xsd:attribute name="error-handler" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
-						       <![CDATA[
-	Provides reference to bean that implements org.springframework.util.ErrorHandler and provides a strategy for handling errors.
-	This is especially useful for handling errors that occur during asynchronous execution
-	of tasks that have been submitted to a TaskScheduler where it may not be possible to throw the error to the original caller
-								]]>
+							<![CDATA[
+								Provides reference to a bean that implements
+								org.springframework.util.ErrorHandler and
+								provides a strategy for handling errors.
+								This is especially useful for handling errors
+								that occur during asynchronous execution of tasks
+								that have been submitted to a TaskScheduler, where
+								it may not be possible to throw the error to the
+								original caller.
+							]]>
 							</xsd:documentation>
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
@@ -390,9 +405,11 @@
 			<xsd:annotation>
 				<xsd:documentation>
 					<![CDATA[
-	Allows you to identify this channel as Datatype channel and specify the type of the Message
-	payload this channel accepts (e.g., datatype="java.lang.String"). Datatype channel
-	is a channel that accepts messages cotaining payload of certain type.
+						Allows you to identify this channel as a Datatype channel
+						and specify the type of the Message payload this channel
+						accepts (e.g., datatype="java.lang.String"). A Datatype
+						channel is a channel that accepts messages containing
+						payloads of a certain type.
 					]]>
 				</xsd:documentation>
 			</xsd:annotation>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -3581,7 +3581,7 @@ unless bean with this name is already registered.
 		<xsd:annotation>
 			<xsd:documentation>
 				<![CDATA[
-Will register Message History writer which will track message hostory. There can
+Will register a Message History writer which will track the message history. There can
 only be one Message History writer per ApplicationContext hierarchy.
 					]]>
 			</xsd:documentation>


### PR DESCRIPTION
- Fix spelling error - `hostory`
- Remove trailing white-space

Fore reference see: https://jira.springsource.org/browse/INT-2616
