### PR TITLE
INT-2610 Gateway method mapping

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapperToMessageTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapperToMessageTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,11 +31,11 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.Message;
 import org.springframework.integration.annotation.Header;
 import org.springframework.integration.annotation.Headers;
-import org.springframework.integration.gateway.GatewayMethodInboundMessageMapper;
 import org.springframework.integration.support.MessageBuilder;
 
 /**
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  */
 public class GatewayMethodInboundMessageMapperToMessageTests {
 
@@ -192,7 +192,7 @@ public class GatewayMethodInboundMessageMapperToMessageTests {
 		GatewayMethodInboundMessageMapper mapper = new GatewayMethodInboundMessageMapper(method);
 		mapper.toMessage(new Object[] { "abc", "def" });
 	}
-	
+
 	@Test
 	public void toMessageWithPayloadAndHeaders() throws Exception {
 		Method method = TestService.class.getMethod("sendPayload", String.class);
@@ -207,16 +207,64 @@ public class GatewayMethodInboundMessageMapperToMessageTests {
 		assertEquals(42, message.getHeaders().get("bar"));
 	}
 
+	@Test
+	public void toMessageWithPayloadMap() throws Exception {
+		Method method = TestService.class.getMethod("sendPayloadMap", Map.class);
+		Map<Object, Object> map = new HashMap<Object, Object>();
+		map.put(1, "hello");
+
+		GatewayMethodInboundMessageMapper mapper = new GatewayMethodInboundMessageMapper(method);
+		Message<?> message = mapper.toMessage(new Object[] { map });
+		assertEquals(map, message.getPayload());
+		assertNull(message.getHeaders().get(1));
+	}
+
+	@Test
+	public void toMessageWithPayloadMapAndHeaders() throws Exception {
+		Method method = TestService.class.getMethod("sendPayloadMapAndHeadersMap", Map.class, Map.class);
+		Map<Object, Object> map = new HashMap<Object, Object>();
+		map.put(1, "hello");
+
+		Map<String, Object> headers = new HashMap<String, Object>();
+		headers.put("foo", "FOO");
+
+		GatewayMethodInboundMessageMapper mapper = new GatewayMethodInboundMessageMapper(method);
+		Message<?> message = mapper.toMessage(new Object[] { map, headers });
+		assertEquals(map, message.getPayload());
+		assertEquals("FOO", message.getHeaders().get("foo"));
+	}
+
+	@Test
+	public void toMessageWithPayloadMapAndHeaders2() throws Exception {
+		Method method = TestService.class.getMethod("sendPayloadMapAndHeadersMap2", Map.class, Map.class);
+		Map<Object, Object> map = new HashMap<Object, Object>();
+		map.put(1, "hello");
+
+		Map<String, Object> headers = new HashMap<String, Object>();
+		headers.put("foo", "FOO");
+
+		GatewayMethodInboundMessageMapper mapper = new GatewayMethodInboundMessageMapper(method);
+		Message<?> message = mapper.toMessage(new Object[] { headers, map });
+		assertEquals(map, message.getPayload());
+		assertEquals("FOO", message.getHeaders().get("foo"));
+	}
+
 
 	private static interface TestService {
 
 		void sendPayload(String payload);
 
 		void sendPayloadAndHeader(String payload, @Header("foo") String foo);
-		
+
 		void sendPayloadAndOptionalHeader(String payload, @Header(value="foo", required=false) String foo);
 
 		void sendPayloadAndHeadersMap(String payload, @Headers Map<String, Object> headers);
+
+		void sendPayloadMap(Map<Object, Object> map);
+
+		void sendPayloadMapAndHeadersMap(Map<Object, Object> map, Map<String, Object> headers);
+
+		void sendPayloadMapAndHeadersMap2(Map<String, Object> headers, Map<Object, Object> map);
 
 		void sendMessage(Message<?> message);
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyMessageMappingTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyMessageMappingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.integration.channel.QueueChannel;
 
 /**
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  * @since 2.0
  */
 public class GatewayProxyMessageMappingTests {
@@ -173,7 +174,7 @@ public class GatewayProxyMessageMappingTests {
 		assertNull(channel.receive(0));
 	}
 
-	@Test(expected = MessagingException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void twoMapsWithoutAnnotations() {
 		Map<String, Object> map1 = new HashMap<String, Object>();
 		Map<String, Object> map2 = new HashMap<String, Object>();

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithPayloadExpressionTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithPayloadExpressionTests-context.xml
@@ -11,6 +11,9 @@
 		<int:method name="send1" request-channel="input" payload-expression="#args[0] + 'bar'"/>
 		<int:method name="send2" request-channel="input" payload-expression="@testBean.sum(#args[0])"/>
 		<int:method name="send3" request-channel="input" payload-expression="#method"/>
+		<int:method name="send4" request-channel="input" payload-expression="new java.lang.Object[]{#args[0]}"/>
+		<int:method name="send5" request-channel="input" payload-expression="new java.lang.Object[]{#args[0], #args[1]}"/>
+		<int:method name="send6" request-channel="input" payload-expression="new java.lang.Object[]{#args[0], #args[1]}"/>
 	</int:gateway>
 
 	<int:gateway id="annotatedGateway"

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithPayloadExpressionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithPayloadExpressionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,10 @@
 package org.springframework.integration.gateway;
 
 import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +34,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Oleg Zhurakousky
  * @since 2.0
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -74,6 +79,41 @@ public class GatewayWithPayloadExpressionTests {
 		assertEquals("send3", result.getPayload());
 	}
 
+	@Test
+	public void payloadExpressionMap() throws Exception {
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put("foo", "FOO");
+		gateway.send4(map);
+		Message<?> result = input.receive(0);
+		assertEquals(map, ((Object[])result.getPayload())[0]);
+		assertNull(result.getHeaders().get("foo"));
+	}
+
+	@Test
+	public void payloadExpressionMaps() throws Exception {
+		Map<String, Object> mapA = new HashMap<String, Object>();
+		mapA.put("foo", "FOO");
+		Map<String, Object> mapB = new HashMap<String, Object>();
+		mapB.put("bar", "BAR");
+		gateway.send5(mapA, mapB);
+		Message<?> result = input.receive(0);
+		assertEquals(mapA, ((Object[])result.getPayload())[0]);
+		assertEquals(mapB, ((Object[])result.getPayload())[1]);
+	}
+
+	@Test
+	public void payloadExpressionMapsOneIsNotHeaders() throws Exception {
+		Map<String, Object> mapA = new HashMap<String, Object>();
+		mapA.put("foo", "FOO");
+		Map<Object, Object> mapB = new HashMap<Object, Object>();
+		mapB.put(1, "1");
+		gateway.send6(mapA, mapB);
+		Message<?> result = input.receive(0);
+		System.out.println(result);
+		assertEquals(mapA, ((Object[])result.getPayload())[0]);
+		assertEquals(mapB, ((Object[])result.getPayload())[1]);
+	}
+
 
 	public static interface SampleGateway {
 
@@ -82,6 +122,12 @@ public class GatewayWithPayloadExpressionTests {
 		void send2(String value);
 
 		void send3();
+
+		void send4(Map<String, ?> map);
+
+		void send5(Map<String, ?> mapA, Map<String, ?> mapB);
+
+		void send6(Map<String, ?> mapA, Map<Object, ?> mapB);
 	}
 
 


### PR DESCRIPTION
fixed GatewayMethodInboundMessageMapper to ensure that:
- it looks at the Map key type and does not attempt to map Maps that have keys other than String to MessageHeaders
- does not attempt to map Map to a payload if payoad has already been set via expression
