### PR TITLE
INT-2607: refactor 'resolveId' with pC.isNested()

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractChannelAdapterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractChannelAdapterParser.java
@@ -52,7 +52,7 @@ public abstract class AbstractChannelAdapterParser extends AbstractBeanDefinitio
 			id = id + ".adapter";
 		}
 		else if (!StringUtils.hasText(id)) {
-			id = parserContext.getReaderContext().generateBeanName(definition);
+			id = BeanDefinitionReaderUtils.generateBeanName(definition, parserContext.getRegistry(), parserContext.isNested());
 		}
 		return id;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractConsumerEndpointParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractConsumerEndpointParser.java
@@ -32,15 +32,18 @@ import org.springframework.beans.factory.support.ManagedSet;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 
 /**
  * Base class parser for elements that create Message Endpoints.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinitionParser {
 
@@ -51,13 +54,16 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 	protected static final String EXPRESSION_ATTRIBUTE = "expression";
 
 	@Override
-	protected boolean shouldGenerateId() {
-		return false;
-	}
-
-	@Override
-	protected boolean shouldGenerateIdAsFallback() {
-		return true;
+	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
+			throws BeanDefinitionStoreException {
+		String id = element.getAttribute(ID_ATTRIBUTE);
+		if (!StringUtils.hasText(id)) {
+			id = element.getAttribute("name");
+		}
+		if (!StringUtils.hasText(id)) {
+			id = BeanDefinitionReaderUtils.generateBeanName(definition, parserContext.getRegistry(), parserContext.isNested());
+		}
+		return id;
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractOutboundGatewayParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.util.StringUtils;
 
 /**
- * Base class for url-based outbound gateway parsers. 
- * 
+ * Base class for url-based outbound gateway parsers.
+ *
  * @author Mark Fisher
  */
 public abstract class AbstractOutboundGatewayParser extends AbstractConsumerEndpointParser {
@@ -36,19 +36,6 @@ public abstract class AbstractOutboundGatewayParser extends AbstractConsumerEndp
 	@Override
 	protected String getInputChannelAttributeName() {
 		return "request-channel";
-	}
-
-	@Override
-	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
-			throws BeanDefinitionStoreException {
-		String id = super.resolveId(element, definition, parserContext);
-		if (!StringUtils.hasText(id)) {
-			id = element.getAttribute("name");
-		}
-		if (!StringUtils.hasText(id)) {
-			id = parserContext.getReaderContext().generateBeanName(definition);
-		}
-		return id;
 	}
 
 	@Override

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParser.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParser.java
@@ -30,14 +30,6 @@ import org.w3c.dom.Element;
  */
 public class JdbcOutboundGatewayParser extends AbstractConsumerEndpointParser {
 
-	protected boolean shouldGenerateId() {
-		return false;
-	}
-
-	protected boolean shouldGenerateIdAsFallback() {
-		return true;
-	}
-
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
 		String dataSourceRef = element.getAttribute("data-source");

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/StoredProcOutboundGatewayParser.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/StoredProcOutboundGatewayParser.java
@@ -32,14 +32,6 @@ import org.w3c.dom.Element;
  */
 public class StoredProcOutboundGatewayParser extends AbstractConsumerEndpointParser {
 
-	protected boolean shouldGenerateId() {
-		return false;
-	}
-
-	protected boolean shouldGenerateIdAsFallback() {
-		return true;
-	}
-
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
 

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayTests-context.xml
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayTests-context.xml
@@ -208,9 +208,7 @@
 	</int:chain>
 
 	<int:chain input-channel="updatingGatewayInsideChain" output-channel="studentReplyChannel">
-		<!--TODO JPA outbound-gateway must have 'id' inside the chain because
-			 'org.springframework.integration.jpa.outbound.JpaOutboundGatewayFactoryBean#0' isn't registered as bean-->
-		<jpa:updating-outbound-gateway id="gatewayInsideChain" entity-manager="entityManager"
+		<jpa:updating-outbound-gateway entity-manager="entityManager"
 									   entity-class="org.springframework.integration.jpa.test.entity.StudentDomain"/>
 	</int:chain>
 

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/config/XPathMessageSplitterParser.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/config/XPathMessageSplitterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,17 +34,6 @@ import org.springframework.util.StringUtils;
 public class XPathMessageSplitterParser extends AbstractConsumerEndpointParser {
 
 	private final XPathExpressionParser xpathParser = new XPathExpressionParser();
-
-
-	@Override
-	protected boolean shouldGenerateId() {
-		return false;
-	}
-
-	@Override
-	protected boolean shouldGenerateIdAsFallback() {
-		return true;
-	}
 
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {


### PR DESCRIPTION
- add delegation to 

`````` BeanDefinitionReaderUtils.generateBeanName(definition,
                                                    parserContext.getRegistry(), 
                                                    parserContext.isNested())```
in the `AbstractBeanDefinitionParser#resolveId()` implementations when it is necessary.

* remove redundant `shouldGenerateId()` & `shouldGenerateIdAsFallback()` when they don't make sense.

* additional simple polishing in the affected classes.

* remove TODO & forced 'id' attribute from 'JpaOutboundGatewayTests-context.xml' to check that this solution works as was booked.

JIRA: https://jira.springsource.org/browse/INT-2607
``````
