### PR TITLE
INT-1132: eliminate delayer's tests sensitive

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
@@ -393,10 +393,7 @@ public class DelayHandlerTests {
 		this.delayHandler.setMessageStore(messageGroupStore);
 		this.startDelayerHandler();
 
-		long timeBeforeReceive = System.currentTimeMillis();
 		assertTrue(this.latch.await(10, TimeUnit.SECONDS));
-		long timeAfterReceive = System.currentTimeMillis();
-		assertThat(timeAfterReceive - timeBeforeReceive, Matchers.lessThanOrEqualTo(100L));
 
 		assertSame(message.getPayload(), this.resultHandler.lastMessage.getPayload());
 		assertNotSame(Thread.currentThread(), this.resultHandler.lastThread);


### PR DESCRIPTION
- If there is no guaranty that Message will be delayed after restart exactly remaining time,
  it makes sense to remove assert around 'receive time'
- Remove redundant LIFO test-case: now `DelayHandler` just uses simple iteration over `MessageGroup`

JIRA: https://jira.springsource.org/browse/INT-1132
Build report: https://build.springsource.org/browse/INT-B22X-JOB1-91/test/case/110952529
