### PR TITLE
INT-2631: remove BD logic from GroovyControlBus

### DIFF
--- a/spring-integration-groovy/src/main/java/org/springframework/integration/groovy/config/GroovyControlBusFactoryBean.java
+++ b/spring-integration-groovy/src/main/java/org/springframework/integration/groovy/config/GroovyControlBusFactoryBean.java
@@ -20,7 +20,6 @@ import groovy.lang.Binding;
 import groovy.lang.MissingPropertyException;
 import org.springframework.beans.factory.BeanCreationNotAllowedException;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.Lifecycle;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -86,7 +85,7 @@ public class GroovyControlBusFactoryBean extends AbstractSimpleMessageHandlerFac
 	 * in the original Groovy script {@link Binding}.
 	 * In additionally beans should be 'managed' with specific properties which
 	 * are allowed in the Control Bus operations.
-	*/
+	 */
 	private static class ManagedBeansBinding extends Binding {
 
 		private final ConfigurableListableBeanFactory beanFactory;
@@ -96,26 +95,36 @@ public class GroovyControlBusFactoryBean extends AbstractSimpleMessageHandlerFac
 					? (ConfigurableListableBeanFactory) beanFactory : null;
 		}
 
+		/**
+		 * Method is invoked from {@link groovy.lang.Script#getProperty(String)} to resolve Groovy script variable
+		 * into real object. For backward compatibility with original 'Script's binding' in the 'catch' block it
+		 * checks <code>"out".equals(name)</code> to rethrow {@link MissingPropertyException}. Otherwise this method
+		 * tries to resolve <code>name</code> parameter into 'managed bean' via provided {@link ConfigurableListableBeanFactory}
+		 *
+		 * @param name - the of Groovy script variable. In this case in the end it will be delegated to
+		 *             <code>this.beanFactory.getBean(name)</code>
+		 * @return - the variable value from 'binding variables' or managed bean from <code>beanFactory</code>,
+		 *         if <code>name</code> parameter doesn't present in the 'binding variables'
+		 * @see {@link groovy.lang.Script#println()}
+		 */
 		@Override
 		public Object getVariable(String name) {
 			try {
 				return super.getVariable(name);
 			}
 			catch (MissingPropertyException e) {
-//      Original {@link Binding} doesn't have 'variable' for the given 'name'.
-//      Try to resolve it as 'managed bean' from the given <code>beanFactory</code>.
+				if ("out".equals(name)) {
+					throw e;
+				}
 			}
 			if (this.beanFactory == null) {
 				throw new MissingPropertyException(name, this.getClass());
 			}
-			BeanDefinition def = this.beanFactory.getBeanDefinition(name);
-			if (!def.isAbstract() && !def.isPrototype()) {
-				Object bean = this.beanFactory.getBean(name);
-				if (bean instanceof Lifecycle ||
-						bean instanceof CustomizableThreadCreator ||
-						(AnnotationUtils.findAnnotation(bean.getClass(), ManagedResource.class) != null)) {
-					return bean;
-				}
+			Object bean = this.beanFactory.getBean(name);
+			if (bean instanceof Lifecycle ||
+					bean instanceof CustomizableThreadCreator ||
+					(AnnotationUtils.findAnnotation(bean.getClass(), ManagedResource.class) != null)) {
+				return bean;
 			}
 			throw new BeanCreationNotAllowedException(name, "Only beans with @ManagedResource or beans which implement " +
 					"org.springframework.context.Lifecycle or org.springframework.util.CustomizableThreadCreator " +

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/GroovyControlBusDelayerManagementTest.groovy
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/GroovyControlBusDelayerManagementTest.groovy
@@ -1,9 +1,8 @@
-import org.springframework.integration.test.util.TestUtils
-import org.springframework.integration.handler.DelayHandler
-
-def delayHandler = TestUtils.getPropertyValue(testDelayer, 'handler', DelayHandler)
-
+def delayHandler = this.'testDelayer.handler'
 def delayedMessageCount = delayHandler.delayedMessageCount
+
+println delayedMessageCount
+
 assert 2 == delayedMessageCount
 
 delayHandler.reschedulePersistedMessages()

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/GroovyControlBusIntegrationTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/GroovyControlBusIntegrationTests.java
@@ -13,7 +13,6 @@
 
 package org.springframework.integration.groovy;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyControlBusTests-context.xml
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyControlBusTests-context.xml
@@ -35,6 +35,12 @@
 
 	<beans:bean id="nonManagedService" class="org.springframework.integration.groovy.config.GroovyControlBusTests$NonManagedService" />
 
+	<beans:bean id="abstractService" class="org.springframework.integration.groovy.config.GroovyControlBusTests$Service"
+			abstract="true"/>
+
+	<beans:bean id="prototypeService" class="org.springframework.integration.groovy.config.GroovyControlBusTests$Service"
+			scope="prototype"/>
+
 	<beans:bean id="groovyCustomizer"
 			class="org.springframework.integration.groovy.config.GroovyControlBusTests$MyGroovyCustomizer"/>
 


### PR DESCRIPTION
- make 'Groovy Control Bus' similar to 'Expression Control Bus'
- add tests about `abstract` & `prototype` Beans
- fix about lost `groovy.lang.Script#println()` functionality in the `GroovyControlBusFactoryBean$ManagedBeansBinding`
- polishing `GroovyControlBusDelayerManagementTest` to show abilities & fixes with this issue

JIRA: https://jira.springsource.org/browse/INT-2631
