### PR TITLE
INT-2597 - Fix the static port in Http Test

### DIFF
--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayWithMethodExpression.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayWithMethodExpression.java
@@ -25,13 +25,13 @@ import java.net.InetSocketAddress;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.util.SocketUtils;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -49,8 +49,11 @@ public class HttpOutboundGatewayWithMethodExpression {
 
 	@Before
 	public void createServer() throws Exception {
+		int httpPort = SocketUtils.findAvailableServerSocket();
+		System.setProperty("httpPort", String.valueOf(httpPort));
+
 		httpHandler = new MyHandler();
-		server = HttpServer.create(new InetSocketAddress(51234), 0);
+		server = HttpServer.create(new InetSocketAddress(httpPort), 0);
 		server.createContext("/testApps/httpMethod", httpHandler);
 		server.start();
 	}

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/http-outbound-gateway-with-httpmethod-expression-fail.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/http-outbound-gateway-with-httpmethod-expression-fail.xml
@@ -5,10 +5,10 @@
 	xmlns:int-http="http://www.springframework.org/schema/integration/http"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd">
+		http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http.xsd">
 
 
-	<int-http:outbound-gateway url="http://localhost:51234/testApps/httpMethod"
+	<int-http:outbound-gateway url="http://localhost:#{systemProperties.httpPort}/testApps/httpMethod"
 							   request-channel="requestChannel"
 							   reply-channel="replyChannel"
 							   expected-response-type="java.lang.String"

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/http-outbound-gateway-with-httpmethod-expression.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/http-outbound-gateway-with-httpmethod-expression.xml
@@ -5,16 +5,16 @@
 	xmlns:int-http="http://www.springframework.org/schema/integration/http"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd">
+		http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http.xsd">
 
 
-	<int-http:outbound-gateway url="http://localhost:51234/testApps/httpMethod"
+	<int-http:outbound-gateway url="http://localhost:#{systemProperties.httpPort}/testApps/httpMethod"
 							   request-channel="requestChannel"
 							   reply-channel="replyChannel"
 							   expected-response-type="java.lang.String"
 							   http-method-expression="payload"/>
 
-	<int-http:outbound-gateway url="http://localhost:51234/testApps/httpMethod"
+	<int-http:outbound-gateway url="http://localhost:#{systemProperties.httpPort}/testApps/httpMethod"
 							   request-channel="defaultChannel"
 							   reply-channel="replyChannel"
 							   expected-response-type="java.lang.String"/>


### PR DESCRIPTION
- Use _SocketUtils_ to determine port dynamically rather than hard-coding it

Reference: https://jira.springsource.org/browse/INT-2597
