### PR TITLE
INT-2630 MessageHeaders/History Conversion Issue

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/MessageHistoryParameterTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/MessageHistoryParameterTests-context.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<int:message-history />
+
+	<int:channel id="input" />
+
+	<int:transformer input-channel="input" output-channel="output">
+		<bean class="org.springframework.integration.transformer.MessageHistoryParameterTests$MessageHistoryAwareTransformer"/>
+	</int:transformer>
+
+	<int:channel id="output">
+		<int:queue />
+	</int:channel>
+
+</beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/MessageHistoryParameterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/MessageHistoryParameterTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.transformer;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.MessageHeaders;
+import org.springframework.integration.annotation.Header;
+import org.springframework.integration.annotation.Headers;
+import org.springframework.integration.annotation.Payload;
+import org.springframework.integration.annotation.Transformer;
+import org.springframework.integration.core.PollableChannel;
+import org.springframework.integration.history.MessageHistory;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class MessageHistoryParameterTests {
+
+	@Autowired
+	private MessageChannel input;
+
+	@Autowired
+	private PollableChannel output;
+
+	@Test
+	public void test() {
+		input.send(new GenericMessage<String>("foo"));
+		assertNotNull(output.receive(10000));
+	}
+
+	public static class MessageHistoryAwareTransformer {
+
+		@Transformer
+		public Object transform(@Headers MessageHeaders headers,
+							    @Header("history") MessageHistory history, @Payload Object payload) {
+
+	        return payload;
+	    }
+	}
+
+}


### PR DESCRIPTION
Spring-expression 3.1 unconditionally converts all arguments for
method calls; MessageHeaders and MessageHistory do not have
no-arg constructors and the MapToMapConverter always attempts
conversion, in case any elements require conversion.

We are exploring a Spring 3.1 change but, in the meantime, we
have a detour in BeanFactoryTypeConverter in that we
can skip conversion of these types.
