### PR TITLE
INT-2636 Gateway Timeout Changes

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Gateway.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Gateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,21 +28,22 @@ import java.lang.annotation.Target;
  * or message payload. These method-level annotations are detected by the
  * {@link org.springframework.integration.gateway.GatewayProxyFactoryBean}
  * where the annotation attributes can override the default channel settings.
- * 
+ *
  * <p>A method annotated with @Gateway may accept a single non-annotated
  * parameter of type {@link org.springframework.integration.Message}
  * or of the intended Message payload type. Method parameters may be mapped
  * to individual Message header values by using the {@link Header @Header}
  * parameter annotation. Alternatively, to pass the entire Message headers
  * map, a Map-typed parameter may be annotated with {@link Headers}.
- * 
+ *
  * <p>Return values from the annotated method may be of any type. If the
  * declared return value is not a Message, the reply Message's payload will be
  * returned and any type conversion as supported by Spring's
  * {@link org.springframework.beans.SimpleTypeConverter} will be applied to
  * the return value if necessary.
- * 
+ *
  * @author Mark Fisher
+ * @author Gary Russell
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -54,8 +55,8 @@ public @interface Gateway {
 
 	String replyChannel() default "";
 
-	long requestTimeout() default -1;
+	long requestTimeout() default Long.MIN_VALUE;
 
-	long replyTimeout() default -1;
+	long replyTimeout() default Long.MIN_VALUE;
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayXmlAndAnnotationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayXmlAndAnnotationTests-context.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<int:gateway service-interface="org.springframework.integration.gateway.GatewayXmlAndAnnotationTests.AGateway"
+		default-reply-timeout="123" default-request-channel="nullChannel">
+		<int:method name="explicitTimeoutShouldOverrideDefault" reply-timeout="456" />
+	</int:gateway>
+
+</beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayXmlAndAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayXmlAndAnnotationTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.gateway;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.annotation.Gateway;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class GatewayXmlAndAnnotationTests {
+
+	@Autowired
+	GatewayProxyFactoryBean gatewayProxyFactoryBean;
+
+	@Test
+	public void test() {
+		assertEquals(123L, TestUtils.getPropertyValue(gatewayProxyFactoryBean, "defaultReplyTimeout"));
+		@SuppressWarnings("unchecked")
+		Map<Method, MessagingGatewaySupport> gatewayMap = TestUtils.getPropertyValue(gatewayProxyFactoryBean,
+				"gatewayMap", Map.class);
+		int assertions = 0;
+		for (Entry<Method, MessagingGatewaySupport> entry : gatewayMap.entrySet()) {
+			if (entry.getKey().getName().equals("annotationShouldntOverrideDefault")) {
+				assertEquals(123L, TestUtils.getPropertyValue(entry.getValue(),
+						"replyTimeout"));
+				assertions++;
+			}
+			else if (entry.getKey().getName().equals("annotationShouldOverrideDefault")) {
+				assertEquals(234L, TestUtils.getPropertyValue(entry.getValue(),
+						"replyTimeout"));
+				assertions++;
+			}
+			else if (entry.getKey().getName().equals("annotationShouldOverrideDefaultToInfinity")) {
+				assertEquals(-1L, TestUtils.getPropertyValue(entry.getValue(),
+						"replyTimeout"));
+				assertions++;
+			}
+			else if (entry.getKey().getName().equals("explicitTimeoutShouldOverrideDefault")) {
+				assertEquals(456L, TestUtils.getPropertyValue(entry.getValue(),
+						"replyTimeout"));
+				assertions++;
+			}
+		}
+		assertEquals(4, assertions);
+	}
+
+	public static interface AGateway {
+		@Gateway
+		String annotationShouldntOverrideDefault(String foo);
+
+		@Gateway(replyTimeout=234)
+		String annotationShouldOverrideDefault(String foo);
+
+		@Gateway(replyTimeout=-1)
+		String annotationShouldOverrideDefaultToInfinity(String foo);
+
+		String explicitTimeoutShouldOverrideDefault(String foo);
+	}
+}


### PR DESCRIPTION
Previously, the timeouts in @Gateway method annotations always
overrode the default timeout if specified in, say, XML.

Now, the @Gateway timeouts are applied only if
- The equivalent default was not set
- The annotation value is something other than the default (-1)

Note: This is a breaking change for one scenario:

<int:gateway ... default-reply-timeout=1000 ... />

where the interface has a method annotated with @Gateway(replyTimeout=-1)

In other words, when the user wants a default timeout on the gateway
but wants to override it for just the annotated method.

The @Gateway annotation does not allow us to detect whether its
attribute value came from the default or was explicitly set.

The work-around for this breaking change is to use a different negative
number to configure an infinite timeout:

@Gateway(replyTimeout=-2)

Updated migration guide on Wiki
