### PR TITLE
INT-2635 Set Buffer Size for Piped Streams 

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -74,7 +74,11 @@ public class TcpNioConnection extends AbstractTcpConnection {
 	public TcpNioConnection(SocketChannel socketChannel, boolean server, boolean lookupHost) throws Exception {
 		super(socketChannel.socket(), server, lookupHost);
 		this.socketChannel = socketChannel;
-		this.pipedInputStream = new PipedInputStream();
+		int receiveBufferSize = socketChannel.socket().getReceiveBufferSize();
+		if (receiveBufferSize <= 0) {
+			receiveBufferSize = this.maxMessageSize;
+		}
+		this.pipedInputStream = new PipedInputStream(receiveBufferSize);
 		this.pipedOutputStream = new PipedOutputStream(this.pipedInputStream);
 		this.channelOutputStream = new ChannelOutputStream();
 	}


### PR DESCRIPTION
Backport to 2.1.x

Improve performance.

For NIO sockets, a pair of PipedInput/OutputStreams are
used to transfer data from the reading thread to the
assembling thread.

The stream used the default buffer size (1024) which was
inefficient for large messages.

This change uses the underlying socket's receiveBufferSize
attribute to set the size of the piped stream, allowing
for more efficient data transfer.
