### PR TITLE
INT-2647 spring-tx Needed as Transitive Dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ project('spring-integration-core') {
 	dependencies {
 		compile "org.springframework:spring-aop:$springVersion"
 		compile "org.springframework:spring-context:$springVersion"
-		compile("org.springframework:spring-tx:$springVersion", optional)
+		compile "org.springframework:spring-tx:$springVersion"
 		compile("org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion", optional)
 		testCompile "org.aspectj:aspectjrt:$aspectjVersion"
 		testCompile "org.aspectj:aspectjweaver:$aspectjVersion"


### PR DESCRIPTION
Pseudo transaction support means some projects now
need a transitive dependency to spring-tx. Previously
the project was marked as optional in the POM.
