### PR TITLE
INT-2652 Fix mget for FTP

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -46,7 +46,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Base class for Outbound Gateways that perform remote file operations.
- * 
+ *
  * @author Gary Russell
  * @since 2.1
  */
@@ -196,7 +196,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 
 	@Override
 	protected Object handleRequestMessage(Message<?> requestMessage) {
-		Session<F> session = this.sessionFactory.getSession(); 
+		Session<F> session = this.sessionFactory.getSession();
 		try {
 			if (COMMAND_LS.equals(this.command)) {
 				String dir = this.processor.processMessage(requestMessage);
@@ -376,7 +376,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 
 	protected List<File> mGet(Session<F> session, String remoteDirectory,
 			String remoteFilename) throws IOException {
-		String path = fixPath(remoteDirectory, remoteFilename);
+		String path = generateFullPath(remoteDirectory, remoteFilename);
 		String[] fileNames = session.listNames(path);
 		if (fileNames == null) {
 			fileNames = new String[0];
@@ -387,12 +387,21 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 		}
 		List<File> files = new ArrayList<File>();
 		for (String fileName : fileNames) {
-			files.add(this.get(session, fixPath(remoteDirectory, fileName), fileName, false));
+			File file;
+			if (fileName.contains(this.remoteFileSeparator) &&
+					fileName.startsWith(remoteDirectory)) { // the server returned the full path
+				file = this.get(session, fileName,
+						fileName.substring(fileName.lastIndexOf(this.remoteFileSeparator)), false);
+			}
+			else {
+				file = this.get(session, generateFullPath(remoteDirectory, fileName), fileName, false);
+			}
+			files.add(file);
 		}
 		return files;
 	}
 
-	private String fixPath(String remoteDirectory, String remoteFilename) {
+	private String generateFullPath(String remoteDirectory, String remoteFilename) {
 		String path;
 		if (this.remoteFileSeparator.equals(remoteDirectory)) {
 			path = remoteFilename;
@@ -414,7 +423,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 		int index = remoteFilePath.lastIndexOf(this.remoteFileSeparator);
 		if (index < 0) {
 			remoteFileName = remoteFilePath;
-		} 
+		}
 		else {
 			remoteFileName = remoteFilePath.substring(index + 1);
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/test/BigMGetTests.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/test/BigMGetTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.file.test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.Message;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.core.PollableChannel;
+import org.springframework.integration.message.GenericMessage;
+
+/**
+ * Created this test because a customer reported hanging with large mget.
+ *
+ * Could not reproduce; code is checked in, but test is @Ignored.
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+public abstract class BigMGetTests {
+
+	protected static final int FILES = 600;
+
+	@Autowired
+	private MessageChannel inbound;
+
+	@Autowired
+	private PollableChannel resultChannel;
+
+	protected Message<List<File>> mgetManyFiles() throws Exception {
+		byte[] buff = new byte[150];
+		for (int i = 0; i < FILES; i++) {
+			File f = new File("/tmp/bigmget/file" + i);
+			f.createNewFile();
+			FileOutputStream fos = new FileOutputStream(f);
+			fos.write(buff);
+			fos.close();
+		}
+		inbound.send(new GenericMessage<String>("/tmp/bigmget/f*"));
+		for (int i = 0; i < FILES; i++) {
+			new File("/tmp/bigmget/file" + i).delete();
+			new File("/tmp/out/file" + i).delete();
+		}
+		@SuppressWarnings("unchecked")
+		Message<List<File>> results = (Message<List<File>>) resultChannel.receive(600000);
+		return results;
+	}
+}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/BigMGetTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/BigMGetTests-context.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int-ftp="http://www.springframework.org/schema/integration/ftp"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/ftp http://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="ftpSessionFactory"
+		class="org.springframework.integration.ftp.session.DefaultFtpSessionFactory">
+		<property name="host" value="localhost"/>
+		<property name="username" value="ftptest"/>
+		<property name="password" value="ftptest"/>
+	</bean>
+
+	<int:channel id="inbound" />
+
+	<int-ftp:outbound-gateway id="gatewayLS" cache-sessions="false"
+		session-factory="ftpSessionFactory"
+		request-channel="inbound"
+		command="mget"
+		command-options=""
+		expression="payload"
+		local-directory="/tmp/out"
+		reply-channel="resultChannel"/>
+
+	<int:channel id="resultChannel">
+		<int:queue />
+	</int:channel>
+</beans>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/BigMGetTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/BigMGetTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.ftp.outbound;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class BigMGetTests extends org.springframework.integration.file.test.BigMGetTests {
+
+	@Test @Ignore // needs directories and server (FTP and SFTP)
+	public void doTest() throws Exception {
+		assertEquals(FILES, this.mgetManyFiles().getPayload().size());
+	}
+}

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/BigMGetTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/BigMGetTests-context.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-sftp="http://www.springframework.org/schema/integration/sftp"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/sftp http://www.springframework.org/schema/integration/sftp/spring-integration-sftp-2.2.xsd">
+
+	<bean id="ftpSessionFactory"
+		class="org.springframework.integration.sftp.session.DefaultSftpSessionFactory">
+		<property name="host" value="localhost"/>
+		<property name="user" value="ftptest"/>
+		<property name="password" value="ftptest"/>
+	</bean>
+
+	<int:channel id="inbound" />
+
+	<int-sftp:outbound-gateway id="gatewayLS" cache-sessions="false"
+		session-factory="ftpSessionFactory"
+		request-channel="inbound"
+		command="mget"
+		command-options=""
+		expression="payload"
+		local-directory="/tmp/out"
+		reply-channel="resultChannel"/>
+
+	<int:channel id="resultChannel">
+		<int:queue />
+	</int:channel>
+</beans>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/BigMGetTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/BigMGetTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.sftp.outbound;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class BigMGetTests extends org.springframework.integration.file.test.BigMGetTests {
+
+	@Test @Ignore // needs directories and server (FTP and SFTP)
+	public void doTest() throws Exception {
+		assertEquals(FILES, this.mgetManyFiles().getPayload().size());
+	}
+}


### PR DESCRIPTION
FTP servers return full path from listNames() whereas SFTP
returns just the filename. mget logic assumed SFTP behavior.

Add a test to see if the filename already starts with the remote
directory and remove it before calling get() (which assumes just
the filename).

Includes an @Ignored test for FTP and SFTP that runs an mget
against a server.
