### PR TITLE
INT-2660 NPE When Using SSL and NIO with Defaults

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
@@ -183,7 +183,14 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 			return new DefaultTcpNetSocketFactorySupport();
 		}
 		else {
-			return new DefaultTcpNetSSLSocketFactorySupport(this.sslContextSupport);
+			DefaultTcpNetSSLSocketFactorySupport socketFactorySupport = new DefaultTcpNetSSLSocketFactorySupport(this.sslContextSupport);
+			try {
+				socketFactorySupport.afterPropertiesSet();
+			}
+			catch (Exception e) {
+				throw new IllegalStateException("Failed to set up TcpSocketFactorySupport", e);
+			}
+			return socketFactorySupport;
 		}
 	}
 
@@ -195,7 +202,14 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 			return new DefaultTcpNioConnectionSupport();
 		}
 		else {
-			return new DefaultTcpNioSSLConnectionSupport(this.sslContextSupport);
+			DefaultTcpNioSSLConnectionSupport connectionSupport = new DefaultTcpNioSSLConnectionSupport(this.sslContextSupport);
+			try {
+				connectionSupport.afterPropertiesSet();
+			}
+			catch (Exception e) {
+				throw new IllegalStateException("Failed to set up TcpConnectionSupport", e);
+			}
+			return connectionSupport;
 		}
 
 	}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
@@ -61,6 +61,15 @@
 		ssl-context-support="sslContextSupport"
 		/>
 
+	<ip:tcp-connection-factory id="cfS1Nio"
+		type="server"
+		port="#{tcpIpUtils.findAvailableServerSocket(5210)}"
+		lookup-host="false"
+		apply-sequence="true"
+		using-nio="true"
+		ssl-context-support="sslContextSupport"
+		/>
+
 	<bean id="sslContextSupport" class="org.springframework.integration.ip.tcp.connection.support.DefaultTcpSSLContextSupport">
 		<constructor-arg value="test.ks"/>
 		<constructor-arg value="test.truststore.ks"/>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -29,7 +29,6 @@ import java.util.Set;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -52,6 +51,7 @@ import org.springframework.integration.ip.tcp.connection.TcpNetServerConnectionF
 import org.springframework.integration.ip.tcp.connection.TcpNioClientConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.TcpNioServerConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.support.DefaultTcpNetSSLSocketFactorySupport;
+import org.springframework.integration.ip.tcp.connection.support.DefaultTcpNioSSLConnectionSupport;
 import org.springframework.integration.ip.tcp.connection.support.TcpSocketFactorySupport;
 import org.springframework.integration.ip.tcp.connection.support.TcpSocketSupport;
 import org.springframework.integration.ip.udp.DatagramPacketMessageMapper;
@@ -167,6 +167,9 @@ public class ParserUnitTests {
 	AbstractConnectionFactory cfS1;
 
 	@Autowired
+	AbstractConnectionFactory cfS1Nio;
+
+	@Autowired
 	AbstractConnectionFactory cfS2;
 
 	@Autowired
@@ -278,7 +281,19 @@ public class ParserUnitTests {
 		assertEquals(124, tcpIn.getPhase());
 		assertTrue((Boolean) TestUtils.getPropertyValue(
 				TestUtils.getPropertyValue(cfS1, "mapper"), "applySequence"));
-		assertTrue(TestUtils.getPropertyValue(cfS1, "tcpSocketFactorySupport") instanceof DefaultTcpNetSSLSocketFactorySupport);
+		Object socketSupport = TestUtils.getPropertyValue(cfS1, "tcpSocketFactorySupport");
+		assertTrue(socketSupport instanceof DefaultTcpNetSSLSocketFactorySupport);
+		assertNotNull(TestUtils.getPropertyValue(socketSupport, "sslContext"));
+	}
+
+	@Test
+	public void testInTcpNioSSLDefaultConfig() {
+		assertFalse(cfS1Nio.isLookupHost());
+		assertTrue((Boolean) TestUtils.getPropertyValue(
+				TestUtils.getPropertyValue(cfS1Nio, "mapper"), "applySequence"));
+		Object connectionSupport = TestUtils.getPropertyValue(cfS1Nio, "tcpNioConnectionSupport");
+		assertTrue(connectionSupport instanceof DefaultTcpNioSSLConnectionSupport);
+		assertNotNull(TestUtils.getPropertyValue(connectionSupport, "sslContext"));
 	}
 
 	@Test


### PR DESCRIPTION
https://jira.springsource.org/browse/INT-2660

DefaultTcpNioSSLConnectionSupport and DefaultTcpNetSSLSocketFactorySupport need
an SSLContext which is set up in afterPropertiesSet(). However, when configuring
the connection factories with default strategies, afterPropertiesSet() is not
called. Result: NullPointerException.

Add call to afterPropertiesSet() where appropriate and tests to verify.
