### PR TITLE
INT-2649: DelayHandler: tx & adviceChain support

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
@@ -16,7 +16,10 @@
 
 package org.springframework.integration.config.xml;
 
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.integration.handler.DelayHandler;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.util.xml.DomUtils;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -68,6 +71,9 @@ public class DelayerParser extends AbstractConsumerEndpointParser {
 
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-store");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "send-timeout");
+
+		builder.addPropertyValue("adviceChain", IntegrationNamespaceUtils.configureAdviceChain(element, builder, parserContext));
+
 		return builder;
 	}
 

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -1295,6 +1295,16 @@
 	</xsd:element>
 
 	<xsd:complexType name="delayer-type">
+		<xsd:choice>
+			<xsd:annotation>
+				<xsd:documentation>
+					'transactional' and 'advice-chain' elements specify the configuration List of AOP Advice
+					to proxying DelayHandler's 'release Message task'.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:element name="transactional" type="transactionalType" minOccurs="0" maxOccurs="1" />
+			<xsd:element name="advice-chain" type="adviceChainType" minOccurs="0" maxOccurs="1" />
+		</xsd:choice>
 		<xsd:attribute name="id" type="xsd:string" use="required">
 			<xsd:annotation>
 				<xsd:documentation>
@@ -1479,28 +1489,7 @@
 		<xsd:sequence>
 			<xsd:choice>
 				<xsd:element name="transactional" type="transactionalType" minOccurs="0" maxOccurs="1" />
-				<xsd:element name="advice-chain" minOccurs="0" maxOccurs="1">
-					<xsd:complexType>
-						<xsd:sequence>
-							<xsd:choice minOccurs="0" maxOccurs="unbounded">
-								<xsd:element name="ref" minOccurs="0" maxOccurs="unbounded">
-									<xsd:complexType>
-										<xsd:attribute name="bean" type="xsd:string" use="required">
-											<xsd:annotation>
-												<xsd:appinfo>
-													<tool:annotation kind="ref">
-														<tool:expected-type type="java.lang.Object" />
-													</tool:annotation>
-												</xsd:appinfo>
-											</xsd:annotation>
-										</xsd:attribute>
-									</xsd:complexType>
-								</xsd:element>
-								<xsd:any namespace="##other" processContents="strict" minOccurs="0" maxOccurs="unbounded" />
-							</xsd:choice>
-						</xsd:sequence>
-					</xsd:complexType>
-				</xsd:element>
+				<xsd:element name="advice-chain" type="adviceChainType" minOccurs="0" maxOccurs="1" />
 			</xsd:choice>
 		</xsd:sequence>
 		<xsd:attribute name="fixed-delay" type="xsd:string">
@@ -3728,5 +3717,24 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 		</xsd:attribute>
 		<xsd:attributeGroup ref="inputOutputChannelGroup"/>
 	</xsd:attributeGroup>
+
+	<xsd:complexType name="adviceChainType">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="ref" minOccurs="0" maxOccurs="unbounded">
+				<xsd:complexType>
+					<xsd:attribute name="bean" type="xsd:string" use="required">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="java.lang.Object" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:any namespace="##other" processContents="strict" minOccurs="0" maxOccurs="unbounded" />
+		</xsd:choice>
+	</xsd:complexType>
 
 </xsd:schema>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests-context.xml
@@ -2,11 +2,13 @@
 <beans:beans xmlns="http://www.springframework.org/schema/integration"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:p="http://www.springframework.org/schema/p"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
 			http://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd">
+			http://www.springframework.org/schema/integration/spring-integration.xsd
+			http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
 
 	<channel id="input"/>
 
@@ -34,10 +36,37 @@
 			 default-delay="0"
 			 message-store="testMessageStore"/>
 
+	<delayer id="delayerWithTransactional"
+			 input-channel="input"
+			 output-channel="output"
+			 default-delay="0">
+		<transactional/>
+	</delayer>
+
+	<delayer id="delayerWithAdviceChain"
+			 input-channel="input"
+			 output-channel="output"
+			 default-delay="0">
+		<advice-chain>
+			<ref bean="testAdviceBean"/>
+			<tx:advice>
+				<tx:attributes>
+					<tx:method name="*" read-only="true" propagation="REQUIRES_NEW"/>
+				</tx:attributes>
+			</tx:advice>
+		</advice-chain>
+	</delayer>
+
 	<beans:bean id="testScheduler" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler"
 				p:poolSize="7"
 				p:waitForTasksToCompleteOnShutdown="true"/>
 
 	<beans:bean id="testMessageStore" class="org.springframework.integration.store.SimpleMessageStore"/>
+
+	<beans:bean id="testAdviceBean" class="org.springframework.integration.config.xml.TestAdviceBean">
+		<beans:constructor-arg value="-1"/>
+	</beans:bean>
+
+	<beans:bean id="transactionManager" class="org.springframework.integration.util.TestTransactionManager"/>
 
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests-context.xml
@@ -37,7 +37,13 @@
 
 	<chain input-channel="delayerInsideChain" output-channel="outputA">
 		<transformer expression="payload.toUpperCase()"/>
-		<delayer id="delayerInsideChain" default-delay="1000"/>
+		<delayer id="delayerInsideChain" default-delay="1000">
+			<advice-chain>
+				<beans:bean class="org.springframework.integration.config.xml.TestAdviceBean">
+					<beans:constructor-arg value="0"/>
+				</beans:bean>
+			</advice-chain>
+		</delayer>
 		<transformer expression="payload.toLowerCase()"/>
 	</chain>
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
@@ -2,11 +2,16 @@
 <beans:beans xmlns:beans="http://www.springframework.org/schema/beans"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns="http://www.springframework.org/schema/integration"
+			 xmlns:p="http://www.springframework.org/schema/p"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 	http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<beans:bean id="messageStore"
 				class="org.springframework.integration.jdbc.DelayerHandlerRescheduleIntegrationTests$TestJdbcMessageStore"/>
+
+	<beans:bean id="transactionManager"
+				class="org.springframework.jdbc.datasource.DataSourceTransactionManager"
+				p:dataSource="#{T (org.springframework.integration.jdbc.DelayerHandlerRescheduleIntegrationTests).dataSource}"/>
 
 	<channel id="output">
 		<queue/>
@@ -17,5 +22,20 @@
 			 output-channel="output"
 			 default-delay="200"
 			 message-store="messageStore"/>
+
+	<channel id="transactionalDelayerOutput"/>
+
+	<delayer id="transactionalDelayer"
+			 input-channel="transactionalDelayerInput"
+			 output-channel="transactionalDelayerOutput"
+			 default-delay="10"
+			 message-store="messageStore">
+		<transactional/>
+	</delayer>
+
+	<service-activator input-channel="transactionalDelayerOutput" ref="exceptionHandler"/>
+
+	<beans:bean id="exceptionHandler"
+				class="org.springframework.integration.jdbc.DelayerHandlerRescheduleIntegrationTests$ExceptionMessageHandler"/>
 
 </beans:beans>


### PR DESCRIPTION
- 'delayer-type' XSD: add `<transactional>` & `<advice-chain>`
- move `PollerParser#configureAdviceChain` into `IntegrationNamespaceUtils`
- DelayerParser: parsing `<transactional>` & `<advice-chain>` via `IntegrationNamespaceUtils#configureAdviceChain`
- DelayHandler: add `adviceChain` property
- DelayHandler: introduce `ReleaseMessageHandler` to apply `adviceChain` capabilities around `DelayHandler#doReleaseMessage`
- DelayerParserTests: tests for introduced sub-elements
- DelayerHandlerRescheduleIntegrationTests: test for transaction boundaries with intentional rollback in the message-flow after message release

JIRA: https://jira.springsource.org/browse/INT-2649
