### PR TITLE
INT-2262 - Add reply-timeout to Outbound Gateways

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -28,6 +28,8 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
+ *
  * @since 2.1
  */
 public class AmqpOutboundGatewayParser extends AbstractConsumerEndpointParser {

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParser.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2002-2011 the original author or authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -25,7 +25,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Parser for the AMQP 'outbound-channel-adapter' element.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @since 2.1
@@ -50,11 +50,12 @@ public class AmqpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "exchange-name-expression");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "routing-key");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "routing-key-expression");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel", "outputChannel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "return-channel");
 
 		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultAmqpHeaderMapper.class, null);
-		
+
 		return builder;
 	}
 

--- a/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-2.2.xsd
+++ b/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-2.2.xsd
@@ -161,6 +161,29 @@
 							</xsd:appinfo>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+									Allows you to specify how long this gateway will wait for
+									the reply message to be sent successfully to the reply channel
+									before throwing an exception. This attribute only applies when the
+									channel might block, for example when using a bounded queue channel that
+									is currently full.
+
+									Also, keep in mind that when sending to a DirectChannel, the
+									invocation will occur in the sender's thread. Therefore,
+									the failing of the send operation may be caused by other
+									components further downstream.
+
+									The "reply-timeout" attribute maps to the "sendTimeout" property of the
+									underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+									The attribute will default, if not specified, to '-1', meaning that
+									by default, the Gateway will wait indefinitely. The value is
+									specified in milliseconds.
+								]]></xsd:documentation>
+							</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="mapped-reply-headers" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests-context.xml
@@ -11,6 +11,7 @@
 
 	<amqp:outbound-gateway id="rabbitGateway" request-channel="toRabbit"
 		reply-channel="fromRabbit"
+		reply-timeout="777"
 		exchange-name="si.test.exchange"
 		routing-key="si.test.binding"
 		amqp-template="amqpTemplate"

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
@@ -31,7 +31,6 @@ import org.springframework.integration.MessageChannel;
 import org.springframework.integration.amqp.AmqpHeaders;
 import org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.util.ReflectionUtils;
@@ -47,6 +46,8 @@ import static org.junit.Assert.assertTrue;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Gunnar Hillert
+ *
  * @since 2.1
  *
  */

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
@@ -31,6 +31,7 @@ import org.springframework.integration.MessageChannel;
 import org.springframework.integration.amqp.AmqpHeaders;
 import org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.util.ReflectionUtils;
@@ -62,6 +63,10 @@ public class AmqpOutboundGatewayParserTests {
 		assertEquals("amqp:outbound-gateway", gateway.getComponentType());
 		MessageChannel returnChannel = context.getBean("returnChannel", MessageChannel.class);
 		assertSame(returnChannel, TestUtils.getPropertyValue(gateway, "returnChannel"));
+
+		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout", Long.class);
+
+		assertEquals(Long.valueOf(777), sendTimeout);
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import org.springframework.util.StringUtils;
 /**
  * @author Gary Russell
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
+ *
  * @since 2.1
  */
 public abstract class AbstractRemoteFileOutboundGatewayParser extends AbstractConsumerEndpointParser {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
@@ -30,7 +30,7 @@ import org.springframework.util.StringUtils;
  * @since 2.1
  */
 public abstract class AbstractRemoteFileOutboundGatewayParser extends AbstractConsumerEndpointParser {
-	
+
 	@Override
 	protected String getInputChannelAttributeName() {
 		return "request-channel";
@@ -44,13 +44,14 @@ public abstract class AbstractRemoteFileOutboundGatewayParser extends AbstractCo
 		BeanDefinitionBuilder sessionFactoryBuilder = BeanDefinitionBuilder.genericBeanDefinition(SessionFactoryFactoryBean.class);
 		sessionFactoryBuilder.addConstructorArgReference(element.getAttribute("session-factory"));
 		sessionFactoryBuilder.addConstructorArgValue(element.getAttribute("cache-sessions"));
-		
+
 		builder.addConstructorArgValue(sessionFactoryBuilder.getBeanDefinition());
 
 		builder.addConstructorArgValue(element.getAttribute("command"));
 		builder.addConstructorArgValue(element.getAttribute(EXPRESSION_ATTRIBUTE));
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "command-options", "options");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "temporary-file-suffix");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel", "outputChannel");
 		this.configureFilter(builder, element, parserContext);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "remote-file-separator");

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileOutboundGatewayParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileOutboundGatewayParser.java
@@ -29,6 +29,8 @@ import org.springframework.integration.config.xml.AbstractConsumerEndpointParser
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Gunnar Hillert
+ *
  * @since 1.0.3
  */
 public class FileOutboundGatewayParser extends AbstractConsumerEndpointParser {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileOutboundGatewayParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileOutboundGatewayParser.java
@@ -25,7 +25,7 @@ import org.springframework.integration.config.xml.AbstractConsumerEndpointParser
 
 /**
  * Parser for the 'outbound-gateway' element of the file namespace.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Artem Bilan
@@ -41,6 +41,7 @@ public class FileOutboundGatewayParser extends AbstractConsumerEndpointParser {
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder handlerBuilder = FileWritingMessageHandlerBeanDefinitionBuilder.configure(element, true, parserContext);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(handlerBuilder, element, "reply-timeout", "sendTimeout");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(handlerBuilder, element, "reply-channel", "outputChannel");
  		return handlerBuilder;
 	}

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-2.2.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-2.2.xsd
@@ -262,6 +262,29 @@ Only files matching this regular expression will be picked up by this adapter.
                             </xsd:appinfo>
                         </xsd:annotation>
                     </xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Allows you to specify how long this gateway will wait for
+								the reply message to be sent successfully to the reply channel
+								before throwing an exception. This attribute only applies when the
+								channel might block, for example when using a bounded queue channel that
+								is currently full.
+
+								Also, keep in mind that when sending to a DirectChannel, the
+								invocation will occur in the sender's thread. Therefore,
+								the failing of the send operation may be caused by other
+								components further downstream.
+
+								The "reply-timeout" attribute maps to the "sendTimeout" property of the
+								underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+								The attribute will default, if not specified, to '-1', meaning that
+								by default, the Gateway will wait indefinitely. The value is
+								specified in milliseconds.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
                 </xsd:extension>
             </xsd:complexContent>
         </xsd:complexType>

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests-context.xml
@@ -15,6 +15,7 @@
 
 	<outbound-gateway id="ordered"
 		request-channel="someChannel"
+		reply-timeout="777"
 		directory="${java.io.tmpdir}"
 		auto-startup="false"
 		order="777"

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests.java
@@ -58,6 +58,10 @@ public class FileOutboundGatewayParserTests {
 		String expression = (String) TestUtils.getPropertyValue(fileNameGenerator, "expression");
 		assertNotNull(expression);
 		assertEquals("'foo.txt'", expression);
+
+		Long sendTimeout = TestUtils.getPropertyValue(handler, "messagingTemplate.sendTimeout", Long.class);
+		assertEquals(Long.valueOf(777), sendTimeout);
+
 	}
 
 	@Test

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-2.2.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-2.2.xsd
@@ -329,6 +329,29 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Allows you to specify how long this gateway will wait for
+								the reply message to be sent successfully to the reply channel
+								before throwing an exception. This attribute only applies when the
+								channel might block, for example when using a bounded queue channel that
+								is currently full.
+
+								Also, keep in mind that when sending to a DirectChannel, the
+								invocation will occur in the sender's thread. Therefore,
+								the failing of the send operation may be caused by other
+								components further downstream.
+
+								The "reply-timeout" attribute maps to the "sendTimeout" property of the
+								underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+								The attribute will default, if not specified, to '-1', meaning that
+								by default, the Gateway will wait indefinitely. The value is
+								specified in milliseconds.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="filter" type="xsd:string">
 						<xsd:annotation>
 							<xsd:appinfo>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
@@ -16,6 +16,7 @@
 		session-factory="sf"
 		request-channel="inbound1"
 		reply-channel="outbound"
+		reply-timeout="777"
 		auto-create-local-directory="false"
 		auto-startup="false"
 		cache-sessions="false"

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
@@ -63,6 +63,9 @@ public class FtpOutboundGatewayParserTests {
 		Set<String> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
 		assertTrue(options.contains("-1"));
 		assertTrue(options.contains("-f"));
+
+		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout", Long.class);
+		assertEquals(Long.valueOf(777), sendTimeout);
 	}
 
 	@Test

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Gunnar Hillert
+ *
  * @since 2.1
  *
  */

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.2.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.2.xsd
@@ -411,7 +411,7 @@ The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Re
 			<xsd:attribute name="expected-response-type" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>
-						The expected type to which the response body should be converted. 
+						The expected type to which the response body should be converted.
 						Default is 'org.springframework.http.ResponseEntity'.
 						This attribute cannot be provided if expected-response-type-expression has a value
 					</xsd:documentation>
@@ -607,7 +607,7 @@ The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Re
 					<xsd:attribute name="expected-response-type" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
-								The expected type to which the response body should be converted. 
+								The expected type to which the response body should be converted.
 								Default is 'org.springframework.http.ResponseEntity'.
 								This attribute cannot be provided if expected-response-type-expression has a value
 							</xsd:documentation>
@@ -671,17 +671,25 @@ The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Re
 						</xsd:annotation>
 					</xsd:attribute>
 					<xsd:attribute name="reply-timeout" type="xsd:string">
-					<xsd:annotation>
+						<xsd:annotation>
 							<xsd:documentation><![CDATA[
-	The "reply-timeout" attribute maps to the "sendTimeout" property of the
-	unerlying "MessagingTemplate" instance (org.springframework.integration.core.MessagingTemplate).
-	The attribute will default, if not specified, to "-1"; it is used when
-	sending the reply message (HTTP Response) to the reply channel.
+								Allows you to specify how long this gateway will wait for
+								the reply message to be sent successfully to the reply channel
+								before throwing an exception. This attribute only applies when the
+								channel might block, for example when using a bounded queue channel that
+								is currently full.
 
-	This means, that depending on the implementation, the Message Channel's "send"
-	method may block indefinitely, by default. Note, though, that the "reply-timeout" attribute is
-	only used, when the actual MessageChannel implementation has a blocking send,
-	such as when a bounded QueueChannel is "full".
+								Also, keep in mind that when sending to a DirectChannel, the
+								invocation will occur in the sender's thread. Therefore,
+								the failing of the send operation may be caused by other
+								components further downstream.
+
+								The "reply-timeout" attribute maps to the "sendTimeout" property of the
+								underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+								The attribute will default, if not specified, to '-1', meaning that
+								by default, the Gateway will wait indefinitely. The value is
+								specified in milliseconds.
 							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>

--- a/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-2.1.xsd
+++ b/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-2.1.xsd
@@ -330,7 +330,29 @@ task executors such as a WorkManagerTaskExecutor.
 						</xsd:annotation>
 					</xsd:attribute>
 					<xsd:attribute name="request-timeout" type="xsd:string"/>
-					<xsd:attribute name="reply-timeout" type="xsd:string"/>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Allows you to specify how long this gateway will wait for
+								the reply message to be sent successfully to the reply channel
+								before throwing an exception. This attribute only applies when the
+								channel might block, for example when using a bounded queue channel that
+								is currently full.
+
+								Also, keep in mind that when sending to a DirectChannel, the
+								invocation will occur in the sender's thread. Therefore,
+								the failing of the send operation may be caused by other
+								components further downstream.
+
+								The "reply-timeout" attribute maps to the "sendTimeout" property of the
+								underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+								The attribute will default, if not specified, to '-1', meaning that
+								by default, the Gateway will wait indefinitely. The value is
+								specified in milliseconds.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="order">
 						<xsd:annotation>
 							<xsd:documentation>

--- a/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-2.2.xsd
+++ b/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-2.2.xsd
@@ -339,15 +339,29 @@ task executors such as a WorkManagerTaskExecutor.
 					</xsd:attribute>
 					<xsd:attribute name="reply-timeout" type="xsd:string">
 						<xsd:annotation>
-							<xsd:documentation>
-								Specifies the time the gateway will wait while sending
-								the reply to the reply channel; only applies when the
-								channel might block (such as a bounded queue channel that
-								is currently full).
+							<xsd:documentation><![CDATA[
+								Allows you to specify how long this gateway will wait for
+								the reply message to be sent successfully to the reply channel
+								before throwing an exception. This attribute only applies when the
+								channel might block, for example when using a bounded queue channel that
+								is currently full.
+
+								Also, keep in mind that when sending to a DirectChannel, the
+								invocation will occur in the sender's thread. Therefore,
+								the failing of the send operation may be caused by other
+								components further downstream.
+
+								The "reply-timeout" attribute maps to the "sendTimeout" property of the
+								underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+								The attribute will default, if not specified, to '-1', meaning that
+								by default, the Gateway will wait indefinitely. The value is
+								specified in milliseconds.
+
 								Prior to 2.2, this attribute served the function of
 								the remote-timeout attribute; it has been changed
 								to make it consistent with other endpoints.
-							</xsd:documentation>
+							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
 					<xsd:attribute name="remote-timeout" type="xsd:string">

--- a/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-2.2.xsd
+++ b/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-2.2.xsd
@@ -452,14 +452,23 @@
 							<xsd:annotation>
 								<xsd:documentation><![CDATA[
 									Allows you to specify how long this gateway will wait for
-									the reply message to be sent successfully before throwing
-									an exception. Keep in mind that when sending to a
-									DirectChannel, the invocation will occur in the sender's thread
-									so the failing of the send operation may be caused by other
-									components further downstream. By default the Gateway will
-									wait indefinitely. The value is specified in milliseconds.
-								]]>
-								</xsd:documentation>
+									the reply message to be sent successfully to the reply channel
+									before throwing an exception. This attribute only applies when the
+									channel might block, for example when using a bounded queue channel that
+									is currently full.
+
+									Also, keep in mind that when sending to a DirectChannel, the
+									invocation will occur in the sender's thread. Therefore,
+									the failing of the send operation may be caused by other
+									components further downstream.
+
+									The "reply-timeout" attribute maps to the "sendTimeout" property of the
+									underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+									The attribute will default, if not specified, to '-1', meaning that
+									by default, the Gateway will wait indefinitely. The value is
+									specified in milliseconds.
+								]]></xsd:documentation>
 							</xsd:annotation>
 					</xsd:attribute>
 					<xsd:attribute name="keys-generated" type="xsd:boolean">
@@ -916,14 +925,23 @@
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
 						Allows you to specify how long this gateway will wait for
-						the reply message to be sent successfully before throwing
-						an exception. Keep in mind that when sending to a
-						DirectChannel, the invocation will occur in the sender's thread
-						so the failing of the send operation may be caused by other
-						components further downstream. By default the Gateway will
-						wait indefinitely. The value is specified in milliseconds.
-					]]>
-					</xsd:documentation>
+						the reply message to be sent successfully to the reply channel
+						before throwing an exception. This attribute only applies when the
+						channel might block, for example when using a bounded queue channel that
+						is currently full.
+
+						Also, keep in mind that when sending to a DirectChannel, the
+						invocation will occur in the sender's thread. Therefore,
+						the failing of the send operation may be caused by other
+						components further downstream.
+
+						The "reply-timeout" attribute maps to the "sendTimeout" property of the
+						underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+						The attribute will default, if not specified, to '-1', meaning that
+						by default, the Gateway will wait indefinitely. The value is
+						specified in milliseconds.
+					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="order">

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
@@ -133,7 +133,7 @@
 	ID for this channel. Required.
 				</xsd:documentation>
 			</xsd:annotation>
-		</xsd:attribute>		
+		</xsd:attribute>
 		<xsd:attribute name="connection-factory" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation>
@@ -392,7 +392,7 @@
 							<xsd:documentation>
 	A reference to a javax.jms.Destination by bean name. As an alternative to a bean
 	reference, use 'destination-name' and 'pub-sub-domain' which will rely upon the
-	DestinationResolver strategy (DynamicDestinationResolver by default). 
+	DestinationResolver strategy (DynamicDestinationResolver by default).
 							</xsd:documentation>
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
@@ -405,9 +405,9 @@
 					<xsd:attribute name="pub-sub-domain" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
-	The boolean property used to configure the JmsTemplate with knowledge of what JMS domain is being used. By default the value of this property is 'false'', 
-	indicating that the point-to-point domain, Queues, will be used. This property used by JmsTemplate determines the behavior of dynamic destination resolution 
-	via implementations of the DestinationResolver interface.			
+	The boolean property used to configure the JmsTemplate with knowledge of what JMS domain is being used. By default the value of this property is 'false'',
+	indicating that the point-to-point domain, Queues, will be used. This property used by JmsTemplate determines the behavior of dynamic destination resolution
+	via implementations of the DestinationResolver interface.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
@@ -417,17 +417,17 @@
 	Boolean property indicating whether to make the subscription durable. The durable subscription name to be used can be specified
 	through the "durableSubscriptionName" property. Default is "false". Set this to "true" to register a durable subscription,
 	typically in combination with a "durableSubscriptionName" value (unless your message listener class name is good enough as
-	subscription name). Only makes sense when listening to a topic (pub-sub domain).	
+	subscription name). Only makes sense when listening to a topic (pub-sub domain).
 							</xsd:documentation>
 						</xsd:annotation>
-					</xsd:attribute>					
+					</xsd:attribute>
 					<xsd:attribute name="durable-subscription-name" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
 	The name of a durable subscription to create. To be applied in case of a topic (pub-sub domain) with subscription durability
 	activated. The durable subscription name needs to be unique within this client's JMS client id. Default is the class name of the
 	specified message listener. Note: Only 1 concurrent consumer (which is the default of this message listener container) is allowed
-	for each durable subscription.	
+	for each durable subscription.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
@@ -439,7 +439,7 @@
 	hasn't already assigned one.
 							</xsd:documentation>
 						</xsd:annotation>
-					</xsd:attribute>					
+					</xsd:attribute>
 					<xsd:attribute name="channel" type="xsd:string">
 						<xsd:annotation>
 							<xsd:appinfo>
@@ -485,11 +485,11 @@
 							</xsd:appinfo>
 						</xsd:annotation>
 					</xsd:attribute>
-					
+
 					<xsd:attribute name="receive-timeout" type="xsd:string"/>
-					
+
 					<xsd:attributeGroup ref="dmlcAttributeGroup"/>
-					
+
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -512,7 +512,7 @@
 							<xsd:documentation>
 	A reference to a javax.jms.Destination by bean name. As an alternative to a bean
 	reference, use 'destination-name' and 'pub-sub-domain' which will rely upon the
-	DestinationResolver strategy (DynamicDestinationResolver by default). 
+	DestinationResolver strategy (DynamicDestinationResolver by default).
 							</xsd:documentation>
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
@@ -578,7 +578,7 @@
 							<xsd:documentation>
 	A reference to a javax.jms.Destination by bean name. As an alternative to a bean
 	reference, use 'request-destination-name' and 'request-pub-sub-domain' which will rely
-	upon the DestinationResolver strategy (DynamicDestinationResolver by default). 
+	upon the DestinationResolver strategy (DynamicDestinationResolver by default).
 							</xsd:documentation>
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
@@ -594,7 +594,7 @@
 							<xsd:documentation>
 	A reference to a javax.jms.Destination by bean name. As an alternative to a bean
 	reference, use either 'default-reply-queue-name' or 'default-reply-topic-name'  which
-	will rely upon the DestinationResolver strategy (DynamicDestinationResolver by default). 
+	will rely upon the DestinationResolver strategy (DynamicDestinationResolver by default).
 							</xsd:documentation>
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
@@ -613,7 +613,7 @@
 								JMSMessageID from the request will be copied into the JMSCorrelationID of the reply
 								unless there is already a value in the JMSCorrelationID property of the newly created
 								reply Message in which case nothing will be copied. If the JMSCorrelationID of the
-								request Message should be copied into the JMSCorrelationID of the reply Message 
+								request Message should be copied into the JMSCorrelationID of the reply Message
 								instead, then this value should be set to "JMSCorrelationID".
 								Any other value will be treated as a JMS String Property to be copied as-is
 								from the request Message into the reply Message with the same property name.
@@ -627,7 +627,7 @@
 									<tool:expected-type type="org.springframework.integration.jms.JmsHeaderMapper"/>
 								</tool:annotation>
 								<xsd:documentation>
-								Allows to specify custom implementation of JmsHeaderMapper to map Message Headers to JMS Message. 
+								Allows to specify custom implementation of JmsHeaderMapper to map Message Headers to JMS Message.
 								</xsd:documentation>
 							</xsd:appinfo>
 						</xsd:annotation>
@@ -664,7 +664,7 @@
 							<xsd:documentation>
 								If a (synchronous) downstream exception is thrown and an "error-channel" is specified,
 								the MessagingException will be sent to this channel; any response from
-								which will be returned as a reply by the gateway. If an "error-channel" is not 
+								which will be returned as a reply by the gateway. If an "error-channel" is not
 								supplied, any such exception
 								will be propagated to the listener container and any JMS transaction will be
 								rolled back. Any synchronous downstream exceptions in the error flow will
@@ -687,17 +687,17 @@
 	Boolean property indicating whether to make the subscription durable. The durable subscription name to be used can be specified
 	through the "durableSubscriptionName" property. Default is "false". Set this to "true" to register a durable subscription,
 	typically in combination with a "durableSubscriptionName" value (unless your message listener class name is good enough as
-	subscription name). Only makes sense when listening to a topic (pub-sub domain).	
+	subscription name). Only makes sense when listening to a topic (pub-sub domain).
 							</xsd:documentation>
 						</xsd:annotation>
-					</xsd:attribute>					
+					</xsd:attribute>
 					<xsd:attribute name="durable-subscription-name" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
 	The name of a durable subscription to create. To be applied in case of a topic (pub-sub domain) with subscription durability
 	activated. The durable subscription name needs to be unique within this client's JMS client id. Default is the class name of the
 	specified message listener. Note: Only 1 concurrent consumer (which is the default of this message listener container) is allowed
-	for each durable subscription.	
+	for each durable subscription.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
@@ -711,9 +711,9 @@
 						</xsd:annotation>
 					</xsd:attribute>
 					<xsd:attribute name="receive-timeout" type="xsd:string"/>
-					
+
 					<xsd:attributeGroup ref="dmlcAttributeGroup"/>
-					
+
 					<xsd:attribute name="reply-time-to-live" type="xsd:string"/>
 					<xsd:attribute name="reply-priority" type="xsd:string"/>
 					<xsd:attribute name="reply-delivery-persistent" type="xsd:string"/>
@@ -755,15 +755,31 @@
 			<xsd:attribute name="receive-timeout" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>
-	Timeout for the JMS MessageConsumer to receive the JMS reply Message. Default is 5 seconds. 
+	Timeout for the JMS MessageConsumer to receive the JMS reply Message. Default is 5 seconds.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="reply-timeout" type="xsd:string">
 				<xsd:annotation>
-					<xsd:documentation>
-	Timeout for sending the mapped integration Message to this gateway's reply-channel. Default is indefinite.
-					</xsd:documentation>
+					<xsd:documentation><![CDATA[
+						Allows you to specify how long this gateway will wait for
+						the reply message to be sent successfully to the reply channel
+						before throwing an exception. This attribute only applies when the
+						channel might block, for example when using a bounded queue channel that
+						is currently full.
+
+						Also, keep in mind that when sending to a DirectChannel, the
+						invocation will occur in the sender's thread. Therefore,
+						the failing of the send operation may be caused by other
+						components further downstream.
+
+						The "reply-timeout" attribute maps to the "sendTimeout" property of the
+						underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+						The attribute will default, if not specified, to '-1', meaning that
+						by default, the Gateway will wait indefinitely. The value is
+						specified in milliseconds.
+					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="request-destination" type="xsd:string">
@@ -800,13 +816,13 @@
 	This attribute is mutually exclusive with 'request-destination' and 'request-destination-name'.
 					</xsd:documentation>
 				</xsd:annotation>
-			</xsd:attribute>			
+			</xsd:attribute>
 			<xsd:attribute name="request-pub-sub-domain" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>
 	When resolving a request destination name (rather than having a 'request-destination' reference),
 	a true value here specifies that the DestinationResolver should resolve Topics rather than Queues.
-	Default is false.  
+	Default is false.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -815,7 +831,7 @@
 							<xsd:documentation>
 	A reference to a javax.jms.Destination by bean name. As an alternative to a bean
 	reference, use 'reply-destination-name' and 'reply-pub-sub-domain' which will rely
-	upon the DestinationResolver strategy (DynamicDestinationResolver by default). 
+	upon the DestinationResolver strategy (DynamicDestinationResolver by default).
 							</xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
@@ -879,7 +895,7 @@
 							<tool:expected-type type="org.springframework.integration.jms.JmsHeaderMapper"/>
 						</tool:annotation>
 						<xsd:documentation>
-						Allows to specify custom implementation of JmsHeaderMapper to map Message Headers to JMS Message. 
+						Allows to specify custom implementation of JmsHeaderMapper to map Message Headers to JMS Message.
 						</xsd:documentation>
 					</xsd:appinfo>
 				</xsd:annotation>
@@ -1156,12 +1172,12 @@
 							<xsd:documentation>
 	Specify the default boolean value for whether to overwrite existing header values. This will only take effect for
 	sub-elements that do not provide their own 'overwrite' attribute. If the 'default-overwrite' attribute is not
-	provided, then the specified header values will NOT overwrite any existing ones with the same header names. 
+	provided, then the specified header values will NOT overwrite any existing ones with the same header names.
 							</xsd:documentation>
 						</xsd:annotation>
 						<xsd:simpleType>
 							<xsd:union memberTypes="xsd:boolean xsd:string"/>
-						</xsd:simpleType> 
+						</xsd:simpleType>
 					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
@@ -1253,7 +1269,7 @@
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
-	
+
 	<xsd:attributeGroup name="dmlcAttributeGroup">
 		<xsd:attribute name="concurrent-consumers" type="xsd:string">
 			<xsd:annotation>
@@ -1303,11 +1319,11 @@
 				Specify the maximum number of messages to process in one task.
 					More concretely, this limits the number of message reception attempts
 					per task, which includes receive iterations that did not actually
-					pick up a message until they hit their timeout 
+					pick up a message until they hit their timeout
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		
+
 		<xsd:attribute name="recovery-interval" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation>
@@ -1334,11 +1350,11 @@
 					received any message within its execution. If this limit is reached,
 					the task will shut down and leave receiving to other executing tasks.
 					The default is 1, closing idle resources early once a task didn't
-					receive a message. 
+					receive a message.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-		
+
 	</xsd:attributeGroup>
 
 </xsd:schema>

--- a/spring-integration-jpa/src/main/resources/org/springframework/integration/jpa/config/xml/spring-integration-jpa-2.2.xsd
+++ b/spring-integration-jpa/src/main/resources/org/springframework/integration/jpa/config/xml/spring-integration-jpa-2.2.xsd
@@ -319,14 +319,23 @@
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 					Allows you to specify how long this gateway will wait for
-					the reply message to be sent successfully before throwing
-					an exception. Keep in mind that when sending to a
-					DirectChannel, the invocation will occur in the sender's thread
-					so the failing of the send operation may be caused by other
-					components further downstream. By default the Gateway will
-					wait indefinitely. The value is specified in milliseconds.
-					]]>
-				</xsd:documentation>
+					the reply message to be sent successfully to the reply channel
+					before throwing an exception. This attribute only applies when the
+					channel might block, for example when using a bounded queue channel that
+					is currently full.
+
+					Also, keep in mind that when sending to a DirectChannel, the
+					invocation will occur in the sender's thread. Therefore,
+					the failing of the send operation may be caused by other
+					components further downstream.
+
+					The "reply-timeout" attribute maps to the "sendTimeout" property of the
+					underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+					The attribute will default, if not specified, to '-1', meaning that
+					by default, the Gateway will wait indefinitely. The value is
+					specified in milliseconds.
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="parameter-source-factory" type="xsd:string">

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-2.2.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-2.2.xsd
@@ -332,6 +332,29 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Allows you to specify how long this gateway will wait for
+								the reply message to be sent successfully to the reply channel
+								before throwing an exception. This attribute only applies when the
+								channel might block, for example when using a bounded queue channel that
+								is currently full.
+
+								Also, keep in mind that when sending to a DirectChannel, the
+								invocation will occur in the sender's thread. Therefore,
+								the failing of the send operation may be caused by other
+								components further downstream.
+
+								The "reply-timeout" attribute maps to the "sendTimeout" property of the
+								underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+								The attribute will default, if not specified, to '-1', meaning that
+								by default, the Gateway will wait indefinitely. The value is
+								specified in milliseconds.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="filter" type="xsd:string">
 						<xsd:annotation>
 							<xsd:appinfo>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests-context.xml
@@ -16,6 +16,7 @@
 		session-factory="sf"
 		request-channel="inbound1"
 		reply-channel="outbound"
+		reply-timeout="777"
 		auto-create-local-directory="false"
 		auto-startup="false"
 		cache-sessions="false"

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
@@ -63,6 +63,9 @@ public class SftpOutboundGatewayParserTests {
 		Set<String> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
 		assertTrue(options.contains("-1"));
 		assertTrue(options.contains("-f"));
+
+		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout", Long.class);
+		assertEquals(Long.valueOf(777), sendTimeout);
 	}
 
 	@Test

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Gunnar Hillert
+ *
  * @since 2.1
  *
  */

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,8 @@ import org.springframework.util.xml.DomUtils;
  *
  * @author Mark Fisher
  * @author Jonas Partner
+ * @author Gunnar Hillert
+ *
  */
 public class WebServiceOutboundGatewayParser extends AbstractOutboundGatewayParser {
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
@@ -34,8 +34,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 
 /**
- * Parser for the &lt;outbound-gateway/&gt; element in the 'ws' namespace. 
- * 
+ * Parser for the &lt;outbound-gateway/&gt; element in the 'ws' namespace.
+ *
  * @author Mark Fisher
  * @author Jonas Partner
  */
@@ -83,11 +83,12 @@ public class WebServiceOutboundGatewayParser extends AbstractOutboundGatewayPars
 			}
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "ignore-empty-responses");
 		this.postProcessGateway(builder, element, parserContext);
-		
+
 		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultSoapHeaderMapper.class, null);
-		
+
 		return builder;
 	}
 

--- a/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws-2.2.xsd
+++ b/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws-2.2.xsd
@@ -63,6 +63,29 @@
 					</xsd:appinfo>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="reply-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Allows you to specify how long this gateway will wait for
+						the reply message to be sent successfully to the reply channel
+						before throwing an exception. This attribute only applies when the
+						channel might block, for example when using a bounded queue channel that
+						is currently full.
+
+						Also, keep in mind that when sending to a DirectChannel, the
+						invocation will occur in the sender's thread. Therefore,
+						the failing of the send operation may be caused by other
+						components further downstream.
+
+						The "reply-timeout" attribute maps to the "sendTimeout" property of the
+						underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+						The attribute will default, if not specified, to '-1', meaning that
+						by default, the Gateway will wait indefinitely. The value is
+						specified in milliseconds.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="uri" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
@@ -85,7 +108,7 @@
 							<tool:expected-type type="org.springframework.ws.client.support.destination.DestinationProvider"/>
 						</tool:annotation>
 					</xsd:appinfo>
-				</xsd:annotation>    
+				</xsd:annotation>
             </xsd:attribute>
             <xsd:attribute name="marshaller" type="xsd:string">
 				<xsd:annotation>
@@ -137,7 +160,7 @@
 					<xsd:documentation>
 	Reference to a Spring Web Services WebServiceMessageCallback. This enables changing
 	the Web Service request message after the payload has been written to it but prior
-	to invocation of the actual Web Service. 
+	to invocation of the actual Web Service.
 					</xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
@@ -209,7 +232,7 @@
 					<xsd:documentation>
 						Reference to a HeaderMapper&lt;SoapHeader&gt; implementation
 						that this gateway will use to map between Spring Integration
-						MessageHeaders and the SoapHeader. 
+						MessageHeaders and the SoapHeader.
 					</xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
@@ -229,7 +252,7 @@
 			</xsd:attribute>
 			<xsd:attribute name="mapped-reply-headers" type="xsd:string">
 				<xsd:annotation>
-					<xsd:documentation><![CDATA[							
+					<xsd:documentation><![CDATA[
 Comma-separated list of names of MessageHeaders to be mapped into the SOAP Headers of the SOAP reply.
 This can only be provided if the 'header-mapper' reference is not being set directly. The values in
 this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
@@ -307,7 +330,7 @@ this list can also be simple patterns to be matched against the header names (e.
 					</xsd:appinfo>
 					<xsd:documentation>
 						If a (synchronous) downstream exception is thrown and an error-channel is specified,
-						the MessagingException will be sent to this channel. 
+						the MessagingException will be sent to this channel.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
@@ -335,7 +358,7 @@ this list can also be simple patterns to be matched against the header names (e.
 					<xsd:documentation>
 						Reference to a HeaderMapper&lt;SoapHeader&gt; implementation
 						that this gateway will use to map between Spring Integration
-						MessageHeaders and the SoapHeader. 
+						MessageHeaders and the SoapHeader.
 					</xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
@@ -355,7 +378,7 @@ this list can also be simple patterns to be matched against the header names (e.
 			</xsd:attribute>
 			<xsd:attribute name="mapped-reply-headers" type="xsd:string">
 				<xsd:annotation>
-					<xsd:documentation><![CDATA[							
+					<xsd:documentation><![CDATA[
 Comma-separated list of names of MessageHeaders to be mapped into the SOAP Headers of the SOAP reply.
 This can only be provided if the 'header-mapper' reference is not being set directly. The values in
 this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
@@ -382,12 +405,12 @@ this list can also be simple patterns to be matched against the header names (e.
 							<xsd:documentation>
 	Specify the default boolean value for whether to overwrite existing header values. This will only take effect for
 	sub-elements that do not provide their own 'overwrite' attribute. If the 'default-overwrite' attribute is not
-	provided, then the specified header values will NOT overwrite any existing ones with the same header names. 
+	provided, then the specified header values will NOT overwrite any existing ones with the same header names.
 							</xsd:documentation>
 						</xsd:annotation>
 						<xsd:simpleType>
 							<xsd:union memberTypes="xsd:boolean xsd:string"/>
-						</xsd:simpleType> 
+						</xsd:simpleType>
 					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.assertNull;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class WebServiceOutboundGatewayParserTests {
 

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -71,6 +71,9 @@ public class WebServiceOutboundGatewayParserTests {
 		assertEquals(1, replyHeaders.size());
 		assertTrue(requestHeaders.contains("testRequest"));
 		assertTrue(replyHeaders.contains("testReply"));
+
+		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout", Long.class);
+		assertEquals(Long.valueOf(777), sendTimeout);
 	}
 
 	@Test
@@ -179,7 +182,7 @@ public class WebServiceOutboundGatewayParserTests {
 		assertEquals(resolver, accessor.getPropertyValue("faultMessageResolver"));
 	}
 
-	
+
 	@Test
 	public void simpleGatewayWithCustomMessageSender() {
 		ApplicationContext context = new ClassPathXmlApplicationContext(
@@ -188,7 +191,7 @@ public class WebServiceOutboundGatewayParserTests {
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
 		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
 		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
-		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);		
+		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
 		accessor = new DirectFieldAccessor(accessor.getPropertyValue("webServiceTemplate"));
 		WebServiceMessageSender messageSender = (WebServiceMessageSender) context.getBean("messageSender");
 		assertEquals(messageSender, ((WebServiceMessageSender[])accessor.getPropertyValue("messageSenders"))[0]);
@@ -217,7 +220,7 @@ public class WebServiceOutboundGatewayParserTests {
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
 		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
 		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
-		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);		
+		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
 		accessor = new DirectFieldAccessor(accessor.getPropertyValue("webServiceTemplate"));
 		ClientInterceptor interceptor = context.getBean("interceptor", ClientInterceptor.class);
 		assertEquals(interceptor, ((ClientInterceptor[]) accessor.getPropertyValue("interceptors"))[0]);
@@ -318,7 +321,7 @@ public class WebServiceOutboundGatewayParserTests {
 		Marshaller marshaller = (Marshaller) context.getBean("marshallerAndUnmarshaller");
 		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "marshaller", Marshaller.class));
 		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "unmarshaller", Unmarshaller.class));
-		
+
 		WebServiceMessageFactory messageFactory = (WebServiceMessageFactory) context.getBean("messageFactory");
 		assertEquals(messageFactory, TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageFactory"));
 	}
@@ -330,7 +333,7 @@ public class WebServiceOutboundGatewayParserTests {
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithSeparateMarshallerAndUnmarshallerAndMessageFactory");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
 		MarshallingWebServiceOutboundGateway gateway = (MarshallingWebServiceOutboundGateway) new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		
+
 		Marshaller marshaller = (Marshaller) context.getBean("marshaller");
 		Unmarshaller unmarshaller = (Unmarshaller) context.getBean("unmarshaller");
 		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "marshaller", Marshaller.class));
@@ -365,5 +368,5 @@ public class WebServiceOutboundGatewayParserTests {
     public void invalidGatewayWithNeitherUriNorDestinationProvider() {
     	new ClassPathXmlApplicationContext("invalidGatewayWithNeitherUriNorDestinationProvider.xml", this.getClass());
     }
-    
+
 }

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/simpleWebServiceOutboundGatewayParserTests.xml
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/simpleWebServiceOutboundGatewayParserTests.xml
@@ -10,7 +10,7 @@
 			http://www.springframework.org/schema/integration/spring-integration.xsd
 			http://www.springframework.org/schema/integration/ws
 			http://www.springframework.org/schema/integration/ws/spring-integration-ws.xsd
-			http://www.springframework.org/schema/util 
+			http://www.springframework.org/schema/util
 			http://www.springframework.org/schema/util/spring-util.xsd">
 
 	<si:channel id="inputChannel"/>
@@ -27,6 +27,7 @@
 	                     request-channel="inputChannel"
 	                     uri="http://example.org"
 	                     reply-channel="outputChannel"
+	                     reply-timeout="777"
 	                     mapped-request-headers="testRequest"
 	                     mapped-reply-headers="testReply"/>
 
@@ -64,12 +65,12 @@
 	                     request-channel="inputChannel"
 	                     uri="http://example.org"
 	                     fault-message-resolver="faultMessageResolver"/>
-	                      
+
 	<ws:outbound-gateway id="gatewayWithCustomMessageSender"
 	                     request-channel="inputChannel"
 	                     uri="http://example.org"
 	                     message-sender="messageSender"/>
-	                      
+
 	<ws:outbound-gateway id="gatewayWithCustomMessageSenderList"
 	                     request-channel="inputChannel"
 	                     uri="http://example.org"
@@ -79,12 +80,12 @@
 	                     request-channel="inputChannel"
 	                     uri="http://example.org"
 	                     interceptor="interceptor"/>
-	                      
+
 	<ws:outbound-gateway id="gatewayWithCustomInterceptorList"
 	                     request-channel="inputChannel"
 	                     uri="http://example.org"
 	                     interceptors="interceptors"/>
-	                      
+
 	<ws:outbound-gateway id="gatewayWithPoller"
 		                 request-channel="pollableInputChannel"
 	                     uri="http://example.org">

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -18,6 +18,20 @@
 			  Spring Integration now uses Spring 3.1.
 			</para>
 		</section>
+		<section id="2.2-outbound-gateways">
+			<title>Outbound Gateways</title>
+			<para>
+				The XML Namespace support adds the <emphasis>reply-timeout</emphasis>
+				attribute to the following <emphasis>Outbound Gateways</emphasis>:
+			</para>
+			<itemizedlist>
+				<listitem>Amqp Outbound Gateway</listitem>
+				<listitem>File Outbound Gateway</listitem>
+				<listitem>Ftp Outbound Gateway</listitem>
+				<listitem>Sftp Outbound Gateway</listitem>
+				<listitem>Ws Outbound Gateway</listitem>
+			</itemizedlist>
+		</section>
 		<section id="2.2-amqp-11">
 			<title>Spring-AMQP 1.1</title>
 			<para>


### PR DESCRIPTION
For reference see: https://jira.springsource.org/browse/INT-2262

Add reply-timeout attribute to:
- Amqp Outbound Gateway
- File Outbound Gateway
- Ftp Outbound Gateway
- Sftp Outbound Gateway
- Ws Outbound Gateway

Update Schema Documentation for reply-timeout attribute:
- spring-integration-jpa-2.2.xsd
- spring-integration-jms-2.2.xsd
- spring-integration-jdbc-2.2.xsd
- spring-integration-ip-2.2.xsd
- spring-integration-http-2.2.xsd

Update the _What's new in Spring Integration 2.2_ section in the reference manual
