### PR TITLE
INT-2214 Add Disposition After Write/Transfer

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/MessageHeaders.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/MessageHeaders.java
@@ -34,7 +34,7 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * The headers for a {@link Message}.<br>
- * IMPORTANT: MessageHeaders are immutable. Any mutating operation (e.g., put(..), putAll(..) etc.) 
+ * IMPORTANT: MessageHeaders are immutable. Any mutating operation (e.g., put(..), putAll(..) etc.)
  * will result in {@link UnsupportedOperationException}
  * To create MessageHeaders instance use fluent MessageBuilder API
  * <pre>
@@ -47,17 +47,18 @@ import org.apache.commons.logging.LogFactory;
  * headers.put("key2", "value2");
  * new GenericMessage("foo", headers);
  * </pre>
- * 
+ *
  * @author Arjen Poutsma
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
 public final class MessageHeaders implements Map<String, Object>, Serializable {
 
 	private static final long serialVersionUID = 6901029029524535147L;
 
 	private static final Log logger = LogFactory.getLog(MessageHeaders.class);
-	
+
 	private static volatile IdGenerator idGenerator = null;
 
 	/**
@@ -88,6 +89,7 @@ public final class MessageHeaders implements Map<String, Object>, Serializable {
 
 	public static final String CONTENT_TYPE = "content-type";
 
+	public static final String DISPOSITION_RESULT = "dispositionResult";
 
 	private final Map<String, Object> headers;
 
@@ -100,7 +102,7 @@ public final class MessageHeaders implements Map<String, Object>, Serializable {
 		else {
 			this.headers.put(ID, MessageHeaders.idGenerator.generateId());
 		}
-		
+
 		this.headers.put(TIMESTAMP, new Long(System.currentTimeMillis()));
 	}
 
@@ -155,10 +157,12 @@ public final class MessageHeaders implements Map<String, Object>, Serializable {
 		return (T) value;
 	}
 
+	@Override
 	public int hashCode() {
 		return this.headers.hashCode();
 	}
 
+	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {
 			return true;
@@ -170,6 +174,7 @@ public final class MessageHeaders implements Map<String, Object>, Serializable {
 		return false;
 	}
 
+	@Override
 	public String toString() {
 		return this.headers.toString();
 	}

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -3729,4 +3729,44 @@ endpoint itself is a Polling Consumer for a channel with a queue.
 		<xsd:attributeGroup ref="inputOutputChannelGroup"/>
 	</xsd:attributeGroup>
 
+	<xsd:attributeGroup name="dispositionAttributeGroup">
+		<xsd:attribute name="disposition-expression" type="xsd:string">
+		    <xsd:annotation>
+		      <xsd:documentation>
+		        SpEL expression to be executed. On an inbound endpoint, executed after the message has been sent
+		        if running in a transactional poller, it will be executed after the transaction commits;
+		        if running in a non-transactional poller it will execute after the message is sent.
+		        Note that the actual point of execution depends on any asynchronous handoffs on the
+		        downstream flow. It will be executed when the current thread returns from the channel send.
+		        On an outbound endpoint, the expression is executed after the message has been handled
+		        but before the result is sent to the output channel (if any).
+		        The root object of the expression is the original message. Examples: for a File payload,
+		        "payload.delete()", "payload.renameTo('/foo/bar/' + payload.name)", "@someBean.doSomething(payload)".
+		      </xsd:documentation>
+		    </xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="disposition-result-channel" type="xsd:string" default="nullChannel">
+		    <xsd:annotation>
+		      <xsd:documentation>
+		        If a 'disposition-expression' is provided, and that expression returns a result, the result
+		        is sent to this channel, with the original message payload and a 'dispositionResult'
+		        header containing the result of the expression execution.
+		        <xsd:appinfo>
+		            <tool:annotation kind="ref">
+		                <tool:expected-type type="org.springframework.integration.MessageChannel"/>
+		            </tool:annotation>
+		        </xsd:appinfo>
+		      </xsd:documentation>
+		    </xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="disposition-send-timeout" type="xsd:string">
+		    <xsd:annotation>
+		      <xsd:documentation>
+		        If a 'disposition-expression' is provided, and that expression returns a result, the result
+		        is sent to this disposition-result-channel. This timeout specifies how long to wait if
+		        that channel might block (such as a bounded queue channel that is full). Default infinity.
+		      </xsd:documentation>
+		    </xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
 </xsd:schema>

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileHeaders.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileHeaders.java
@@ -35,6 +35,4 @@ public abstract class FileHeaders {
 
 	public static final String REMOTE_FILE = PREFIX + "remoteFile";
 
-	public static final String DISPOSITION_RESULT = PREFIX + "dispositionResult";
-
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerBeanDefinitionBuilder.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerBeanDefinitionBuilder.java
@@ -16,13 +16,13 @@
 
 package org.springframework.integration.file.config;
 
-import org.w3c.dom.Element;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.ExpressionFactoryBean;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.file.DefaultFileNameGenerator;
 import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
 
 /**
  * A common helper class for the 'outbound-channel-adapter' and 'outbound-gateway'
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gunnar Hillert
+ * @author Gary Russell
  *
  * @since 1.0.3
  */
@@ -83,6 +84,7 @@ abstract class FileWritingMessageHandlerBeanDefinitionBuilder {
 				builder.addPropertyValue("fileNameGenerator", fileNameGeneratorBuilder.getBeanDefinition());
 			}
 		}
+		FileNamespaceUtils.setDispositionAttributes(element, builder);
 		return builder;
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerFactoryBean.java
@@ -19,6 +19,7 @@ package org.springframework.integration.file.config;
 import java.io.File;
 
 import org.springframework.expression.Expression;
+import org.springframework.integration.MessageChannel;
 import org.springframework.integration.config.AbstractSimpleMessageHandlerFactoryBean;
 import org.springframework.integration.file.FileNameGenerator;
 import org.springframework.integration.file.FileWritingMessageHandler;
@@ -58,6 +59,13 @@ public class FileWritingMessageHandlerFactoryBean extends AbstractSimpleMessageH
 	private volatile boolean append;
 
 	private volatile boolean expectReply = true;
+
+	private volatile Expression dispositionExpression;
+
+	private volatile MessageChannel dispositionResultChannel;
+
+	private Long dispositionSendTimeout;
+
 
 	public void setAppend(boolean append) {
 		this.append = append;
@@ -103,6 +111,18 @@ public class FileWritingMessageHandlerFactoryBean extends AbstractSimpleMessageH
 		this.expectReply = expectReply;
 	}
 
+	public void setDispositionExpression(Expression dispositionExpression) {
+		this.dispositionExpression = dispositionExpression;
+	}
+
+	public void setDispositionResultChannel(MessageChannel dispositionResultChannel) {
+		this.dispositionResultChannel = dispositionResultChannel;
+	}
+
+	public void setDispositionSendTimeout(Long dispositionSendTimeout) {
+		this.dispositionSendTimeout = dispositionSendTimeout;
+	}
+
 	@Override
 	protected FileWritingMessageHandler createHandler() {
 
@@ -143,6 +163,15 @@ public class FileWritingMessageHandlerFactoryBean extends AbstractSimpleMessageH
 		}
 		handler.setExpectReply(this.expectReply);
 		handler.setAppend(this.append);
+		if (this.dispositionExpression != null) {
+			handler.setDispositionExpression(this.dispositionExpression);
+		}
+		if (this.dispositionResultChannel != null) {
+			handler.setDispositionResultChannel(this.dispositionResultChannel);
+		}
+		if (this.dispositionSendTimeout != null) {
+			handler.setDispositionSendTimeout(this.dispositionSendTimeout);
+		}
 		return handler;
 	}
 }

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-2.2.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-2.2.xsd
@@ -166,42 +166,7 @@ Only files matching this regular expression will be picked up by this adapter.
                   </xsd:documentation>
                 </xsd:annotation>
             </xsd:attribute>
-            <xsd:attribute name="disposition-expression" type="xsd:string">
-                <xsd:annotation>
-                  <xsd:documentation>
-                    SpEL expression to be executed after the message has been sent. If running in a transactional
-                    poller, it will be executed after the transaction commits. If running in a non-transactional
-                    poller it will execute after the message is sent. Note that the actual point of execution
-                    depends on any asynchronous handoffs on the downstream flow. It will be executed when the
-                    current thread returns from the channel send. The root object of the expression is the
-                    original message (with a File payload). Examples: "payload.delete()",
-                    "payload.renameTo('/foo/bar/' + payload.name)", "@someBean.doSomething(payload)".
-                  </xsd:documentation>
-                </xsd:annotation>
-            </xsd:attribute>
-            <xsd:attribute name="disposition-result-channel" type="xsd:string" default="nullChannel">
-                <xsd:annotation>
-                  <xsd:documentation>
-                    If a 'disposition-expression' is provided, and that expression returns a result, the result
-                    is sent to this channel, with the original message payload and a 'file_dispositionResult'
-                    header containing the result of the expression execution.
-                    <xsd:appinfo>
-                        <tool:annotation kind="ref">
-                            <tool:expected-type type="org.springframework.integration.MessageChannel"/>
-                        </tool:annotation>
-                    </xsd:appinfo>
-                  </xsd:documentation>
-                </xsd:annotation>
-            </xsd:attribute>
-            <xsd:attribute name="disposition-send-timeout" type="xsd:string">
-                <xsd:annotation>
-                  <xsd:documentation>
-                    If a 'disposition-expression' is provided, and that expression returns a result, the result
-                    is sent to this disposition-result-channel. This timeout specifies how long to wait if
-                    that channel might block (such as a bounded queue channel that is full). Default infinity.
-                  </xsd:documentation>
-                </xsd:annotation>
-            </xsd:attribute>
+            <xsd:attributeGroup ref="integration:dispositionAttributeGroup" />
         </xsd:complexType>
     </xsd:element>
 
@@ -384,6 +349,7 @@ Only files matching this regular expression will be picked up by this adapter.
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:attributeGroup ref="integration:dispositionAttributeGroup" />
     </xsd:complexType>
 
     <xsd:element name="file-to-string-transformer">

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileOutboundChannelAdapterIntegrationTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileOutboundChannelAdapterIntegrationTests-context.xml
@@ -21,6 +21,8 @@
 	<int:channel id="inputChannelSaveToSubDirWithHeader" />
 	<int:channel id="inputChannelSaveToSubDirWithFile" />
 	<int:channel id="inputChannelSaveToSubDirEmptyStringExpression" />
+	<int:channel id="inputChannelSaveToBaseDirAndRename" />
+	<int:channel id="inputChannelSaveToBaseDirAndDeleteWithDelete" />
 
 	<int-file:outbound-channel-adapter id="save-to-base-directory"
 		channel="inputChannelSaveToBaseDir" auto-create-directory="true"
@@ -59,4 +61,20 @@
 		directory-expression="headers['subDirectory']"
 		filename-generator-expression="'foo.txt'" />
 
+	<int-file:outbound-channel-adapter id="save-to-base-directory-and-rename"
+		channel="inputChannelSaveToBaseDirAndRename" auto-create-directory="true"
+		filename-generator-expression="'foo.txt'" directory="target/base-directory"
+		disposition-expression="payload.renameTo(payload.absolutePath + '.foo')"
+		disposition-result-channel="dispoChannel"/>
+
+	<int-file:outbound-channel-adapter id="save-to-base-directory-and-delete-with-delete"
+		channel="inputChannelSaveToBaseDirAndDeleteWithDelete" auto-create-directory="true"
+		filename-generator-expression="'foo.txt'" directory="target/base-directory"
+		disposition-expression="payload.renameTo(payload.absolutePath + '.foo')"
+		disposition-result-channel="dispoChannel"
+		delete-source-files="true"/>
+
+	<int:channel id="dispoChannel">
+		<int:queue />
+	</int:channel>
 </beans:beans>

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileOutboundGatewayIntegrationTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileOutboundGatewayIntegrationTests-context.xml
@@ -15,6 +15,8 @@
 
 	<si:channel id="copyInput" />
 
+	<si:channel id="copyRenameInput" />
+
 	<si:channel id="moveInput" />
 
 	<si:channel id="output">
@@ -31,6 +33,17 @@
 		reply-channel="output"
 		directory="${java.io.tmpdir}/anyDir"
 		delete-source-files="true"/>
+
+	<outbound-gateway id="copyandrename"
+		request-channel="copyRenameInput"
+		reply-channel="output"
+		directory="${java.io.tmpdir}/anyDir"
+		disposition-expression="payload.renameTo(payload.absolutePath + '.foo')"
+		disposition-result-channel="dispoChannel" />
+
+	<si:channel id="dispoChannel">
+		<si:queue />
+	</si:channel>
 
 	<si:chain input-channel="fileOutboundGatewayInsideChain" output-channel="output">
 		<outbound-gateway directory="${java.io.tmpdir}/anyDir" delete-source-files="true"/>

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileReadingMessageSourceTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileReadingMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,12 +39,14 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.Message;
+import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.message.GenericMessage;
 
 /**
  * @author Iwein Fuld
  * @author Mark Fisher
+ * @author Gary Russell
  */
 @RunWith(MockitoJUnitRunner.class)
 public class FileReadingMessageSourceTests {
@@ -170,6 +172,6 @@ public class FileReadingMessageSourceTests {
         source.afterCommit(resource);
         Message<?> result = channel.receive(10000);
         assertSame(file, result.getPayload());
-        assertEquals("foo", result.getHeaders().get(FileHeaders.DISPOSITION_RESULT));
+        assertEquals("foo", result.getHeaders().get(MessageHeaders.DISPOSITION_RESULT));
     }
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileToChannelIntegrationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileToChannelIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,12 +27,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.Message;
+import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Iwein Fuld
+ * @author Gary Russell
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -58,7 +60,7 @@ public class FileToChannelIntegrationTests {
 		assertNotNull(received.getPayload());
 		Message<?> result = resultChannel.receive(10000);
 		assertNotNull(result);
-		assertEquals(Boolean.TRUE, result.getHeaders().get(FileHeaders.DISPOSITION_RESULT));
+		assertEquals(Boolean.TRUE, result.getHeaders().get(MessageHeaders.DISPOSITION_RESULT));
 		assertTrue(!file.exists());
 	}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests-context.xml
@@ -17,7 +17,12 @@
 								   channel="testChannel"
 								   directory="${java.io.tmpdir}"
 								   temporary-file-suffix=".foo"
-								   filename-generator-expression="'foo.txt'"/>
+								   filename-generator-expression="'foo.txt'"
+								   disposition-expression="'foo'"
+								   disposition-result-channel="dispoChannel"
+								   disposition-send-timeout="123"/>
+
+	<si:channel id="dispoChannel" />
 
 	<file:outbound-channel-adapter id="adapterWithCustomNameGenerator"
 								   channel="testChannel"

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests.java
@@ -16,9 +16,10 @@
 
 package org.springframework.integration.file.config;
 
+import static junit.framework.Assert.assertEquals;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -28,11 +29,10 @@ import java.nio.charset.Charset;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.integration.MessageChannel;
 import org.springframework.expression.Expression;
+import org.springframework.integration.MessageChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.file.DefaultFileNameGenerator;
 import org.springframework.integration.file.FileWritingMessageHandler;
@@ -80,6 +80,9 @@ public class FileOutboundChannelAdapterParserTests {
 	@Autowired
 	MessageChannel usageChannelConcurrent;
 
+	@Autowired
+	MessageChannel dispoChannel;
+
 	@Test
 	public void simpleAdapter() {
 		DirectFieldAccessor adapterAccessor = new DirectFieldAccessor(simpleAdapter);
@@ -98,6 +101,12 @@ public class FileOutboundChannelAdapterParserTests {
 		assertNotNull(expression);
 		assertEquals("'foo.txt'", expression);
 		assertEquals(Boolean.FALSE, handlerAccessor.getPropertyValue("deleteSourceFiles"));
+		Object processor = TestUtils.getPropertyValue(handler, "dispositionMessageProcessor");
+		assertEquals("foo", (String) TestUtils.getPropertyValue(processor, "expression", Expression.class).getValue());
+		assertSame(dispoChannel, TestUtils.getPropertyValue(
+				TestUtils.getPropertyValue(handler, "dispositionMessagingTemplate"), "defaultChannel"));
+		assertEquals(123L, ((Long) TestUtils.getPropertyValue(
+				TestUtils.getPropertyValue(handler, "dispositionMessagingTemplate"), "sendTimeout")).longValue());
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests-context.xml
@@ -18,7 +18,12 @@
 		directory="${java.io.tmpdir}"
 		auto-startup="false"
 		order="777"
-		filename-generator-expression="'foo.txt'"/>
+		filename-generator-expression="'foo.txt'"
+		disposition-expression="'foo'"
+		disposition-result-channel="dispoChannel"
+		disposition-send-timeout="123"/>
+
+	<si:channel id="dispoChannel" />
 
 	<outbound-gateway id="gatewayWithDirectoryExpression"
 		request-channel="someChannel"

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests.java
@@ -18,11 +18,14 @@ package org.springframework.integration.file.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.expression.Expression;
+import org.springframework.integration.MessageChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.file.DefaultFileNameGenerator;
 import org.springframework.integration.file.FileWritingMessageHandler;
@@ -44,6 +47,9 @@ public class FileOutboundGatewayParserTests {
 	@Autowired
 	private EventDrivenConsumer gatewayWithDirectoryExpression;
 
+	@Autowired
+	private MessageChannel dispoChannel;
+
 	@Test
 	public void checkOrderedGateway() throws Exception {
 
@@ -58,6 +64,12 @@ public class FileOutboundGatewayParserTests {
 		String expression = (String) TestUtils.getPropertyValue(fileNameGenerator, "expression");
 		assertNotNull(expression);
 		assertEquals("'foo.txt'", expression);
+		Object processor = TestUtils.getPropertyValue(handler, "dispositionMessageProcessor");
+		assertEquals("foo", TestUtils.getPropertyValue(processor, "expression", Expression.class).getValue());
+		assertSame(dispoChannel, TestUtils.getPropertyValue(
+				TestUtils.getPropertyValue(handler, "dispositionMessagingTemplate"), "defaultChannel"));
+		assertEquals(123L, ((Long) TestUtils.getPropertyValue(
+				TestUtils.getPropertyValue(handler, "dispositionMessagingTemplate"), "sendTimeout")).longValue());
 	}
 
 	@Test

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-2.2.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-2.2.xsd
@@ -107,6 +107,7 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attributeGroup ref="integration:dispositionAttributeGroup" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -218,42 +219,7 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
-					<xsd:attribute name="disposition-expression" type="xsd:string">
-						<xsd:annotation>
-							<xsd:documentation>
-								SpEL expression to be executed after the message has been sent. If running in a transactional
-								poller, it will be executed after the transaction commits. If running in a non-transactional
-								poller it will execute after the message is sent. Note that the actual point of execution
-								depends on any asynchronous handoffs on the downstream flow. It will be executed when the
-								current thread returns from the channel send. The root object of the expression is the
-								original message (with a File payload). Examples: "payload.delete()",
-								"payload.renameTo('/foo/bar/' + payload.name)", "@someBean.doSomething(payload)".
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
-					<xsd:attribute name="disposition-result-channel" type="xsd:string" default="nullChannel">
-						<xsd:annotation>
-							<xsd:documentation>
-								If a 'disposition-expression' is provided, and that expression returns a result, the result
-								is sent to this channel, with the original message payload and a 'file_dispositionResult'
-								header containing the result of the expression execution.
-								<xsd:appinfo>
-									<tool:annotation kind="ref">
-										<tool:expected-type type="org.springframework.integration.MessageChannel"/>
-									</tool:annotation>
-								</xsd:appinfo>
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
-					<xsd:attribute name="disposition-send-timeout" type="xsd:string">
-						<xsd:annotation>
-							<xsd:documentation>
-								If a 'disposition-expression' is provided, and that expression returns a result, the result
-								is sent to this disposition-result-channel. This timeout specifies how long to wait if
-								that channel might block (such as a bounded queue channel that is full). Default infinity.
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
+					<xsd:attributeGroup ref="integration:dispositionAttributeGroup" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests-context.xml
@@ -33,7 +33,12 @@
 				remote-file-separator=""
 				temporary-file-suffix=".foo"
 				remote-filename-generator="fileNameGenerator"
-				order="23"/>
+				order="23"
+				disposition-expression="'foo'"
+				disposition-result-channel="dispoChannel"
+				disposition-send-timeout="123"/>
+
+	<int:channel id="dispoChannel" />
 				
 	<int-ftp:outbound-channel-adapter id="ftpOutbound2"
 				channel="ftpChannel" 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests.java
@@ -26,10 +26,10 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.junit.Test;
-
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.expression.Expression;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
@@ -79,6 +79,12 @@ public class FtpOutboundChannelAdapterParserTests {
 		Iterator<MessageHandler> iterator = handlers.iterator();
 		assertSame(TestUtils.getPropertyValue(ac.getBean("ftpOutbound2"), "handler"), iterator.next());
 		assertSame(handler, iterator.next());
+		Object processor = TestUtils.getPropertyValue(handler, "dispositionMessageProcessor");
+		assertEquals("foo", TestUtils.getPropertyValue(processor, "expression", Expression.class).getValue());
+		assertSame(ac.getBean("dispoChannel"), TestUtils.getPropertyValue(
+				TestUtils.getPropertyValue(handler, "dispositionMessagingTemplate"), "defaultChannel"));
+		assertEquals(123L, TestUtils.getPropertyValue(
+				TestUtils.getPropertyValue(handler, "dispositionMessagingTemplate"), "sendTimeout"));
 	}
 
 	@Test(expected=BeanCreationException.class)

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-2.2.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-2.2.xsd
@@ -110,6 +110,7 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attributeGroup ref="integration:dispositionAttributeGroup" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -221,42 +222,7 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
-					<xsd:attribute name="disposition-expression" type="xsd:string">
-						<xsd:annotation>
-							<xsd:documentation>
-								SpEL expression to be executed after the message has been sent. If running in a transactional
-								poller, it will be executed after the transaction commits. If running in a non-transactional
-								poller it will execute after the message is sent. Note that the actual point of execution
-								depends on any asynchronous handoffs on the downstream flow. It will be executed when the
-								current thread returns from the channel send. The root object of the expression is the
-								original message (with a File payload). Examples: "payload.delete()",
-								"payload.renameTo('/foo/bar/' + payload.name)", "@someBean.doSomething(payload)".
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
-					<xsd:attribute name="disposition-result-channel" type="xsd:string" default="nullChannel">
-						<xsd:annotation>
-							<xsd:documentation>
-								If a 'disposition-expression' is provided, and that expression returns a result, the result
-								is sent to this channel, with the original message payload and a 'file_dispositionResult'
-								header containing the result of the expression execution.
-								<xsd:appinfo>
-									<tool:annotation kind="ref">
-										<tool:expected-type type="org.springframework.integration.MessageChannel"/>
-									</tool:annotation>
-								</xsd:appinfo>
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
-					<xsd:attribute name="disposition-send-timeout" type="xsd:string">
-						<xsd:annotation>
-							<xsd:documentation>
-								If a 'disposition-expression' is provided, and that expression returns a result, the result
-								is sent to this disposition-result-channel. This timeout specifies how long to wait if
-								that channel might block (such as a bounded queue channel that is full). Default infinity.
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
+					<xsd:attributeGroup ref="integration:dispositionAttributeGroup" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests-context.xml
@@ -28,7 +28,12 @@
 				temporary-file-suffix=".bar"
 				remote-directory="foo/bar"
 				temporary-remote-directory="foo/baz"
-				order="23"/>
+				order="23"
+				disposition-expression="'foo'"
+				disposition-result-channel="dispoChannel"
+				disposition-send-timeout="123" />
+
+	<int:channel id="dispoChannel" />
 
 	<int-sftp:outbound-channel-adapter id="sftpOutboundAdapterWithExpression"
 				session-factory="sftpSessionFactory"

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
@@ -27,7 +27,6 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.junit.Test;
-
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -85,6 +84,12 @@ public class OutboundChannelAdapterParserTests {
 		Iterator<MessageHandler> iterator = handlers.iterator();
 		assertSame(TestUtils.getPropertyValue(context.getBean("sftpOutboundAdapterWithExpression"), "handler"), iterator.next());
 		assertSame(handler, iterator.next());
+		Object processor = TestUtils.getPropertyValue(handler, "dispositionMessageProcessor");
+		assertEquals("foo", TestUtils.getPropertyValue(processor, "expression", Expression.class).getValue());
+		assertSame(context.getBean("dispoChannel"), TestUtils.getPropertyValue(
+				TestUtils.getPropertyValue(handler, "dispositionMessagingTemplate"), "defaultChannel"));
+		assertEquals(123L, TestUtils.getPropertyValue(
+				TestUtils.getPropertyValue(handler, "dispositionMessagingTemplate"), "sendTimeout"));
 	}
 
 	@Test

--- a/src/reference/docbook/file.xml
+++ b/src/reference/docbook/file.xml
@@ -301,6 +301,22 @@
 				better option is to rely on a <classname>Transformer</classname>.
 			</para>
 		</section>
+		<section id="file-post-processing">
+			<title>Post Processing</title>
+			<para>After the file has been written, and before the response (if any) is sent,
+			it is possible to perform some action on the original message. Typically, one might want
+			to rename, or delete the source file. <emphasis>delete-source-files</emphasis> is mentioned above,
+			but, since 2.2, there is a more flexible mechanism, provided by three attributes:
+			<emphasis>disposition-expression</emphasis>, <emphasis>disposition-result-channel</emphasis>, and
+			<emphasis>disposition-send-timeout</emphasis>. If, supplied, the expression is evaluated with
+			the original message as the root object. Typical expressions for <classname>java.io.File</classname> payloads might be
+			<classname>payload.delete()</classname>, <classname>payload.renameTo(payload.absolutePath + '.renamed')</classname>
+			etc. The result of evaluating the expression is sent to the disposition result channel, in a copy of the message, in the
+			<classname>dispositionResult</classname> header. By default the disposition result channel is nullChannel.
+			The <empahsis>disposition-send-timeout</empahsis> applies if the result channel might block, for example
+			if it is a bounded queue channel that is currently full.
+		</para>
+		</section>
 	</section>
 >>>>>>> INT-2618 - Document directory-expression attribute
 

--- a/src/reference/docbook/ftp.xml
+++ b/src/reference/docbook/ftp.xml
@@ -151,7 +151,10 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/ftp
 				remote-directory="some/remote/path"
 				remote-file-separator="/"
 				local-filename-generator-expression="#this.toUpperCase() + '.a'"
-				local-directory=".">
+				local-directory="."
+				disposition-expression="payload.delete()"
+				disposition-result-channel="dispositions"
+				disposition-send-timeout="1000">
 			<int:poller fixed-rate="1000"/>
 </int-ftp:inbound-channel-adapter>]]></programlisting>
 
@@ -177,11 +180,23 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/ftp
 	list of files.
   	</para>
   	<note>
-	As of Spring Integration 2.0.2, we have added a 'remote-file-separator' attribute. That allows you to configure a
-	file separator character to use if the default '/' is not applicable for your particular environment.
+	The 'remote-file-separator' attribute allows you to configure a
+	file separator character to use, if the default '/' is not applicable for your particular environment.
 	</note>
+	<para>
+	The <emphasis>disposition-*</emphasis> attributes are used to take action after the file has been processed. If the poller is
+	transactional (and synchronized), the action is taken after the transaction commits; otherwise the action
+	is taken after the message is sent to the channel. If all channels in the flow are Direct, this means the
+	action is taken after the flow completes. The <emphasis>dispostion-expression</emphasis> is a SpEL expression
+	with the root object being the original message; the bean factory is also available, allowing expressions such
+	as <classname>@someBean.doSomething(payload)</classname>. The result of the evaluation (if any) is sent to
+	the <emphasis>disposition-result-channel</emphasis> if supplied (the default is <emphasis>nullChannel</emphasis>).
+	The message is the original message with the result contained in the <classname>dispositionResult</classname> header
+	The <emphasis>disposition-send-timeout</emphasis> is used if the result channel can block (such as a QueueChannel
+	that is currently full).
+	</para>
   	<para>
-  	Please refer to the schema for more details on these attributes. 
+	Please refer to the schema for more details on all attributes.
   	</para>
   	<para>
   	It is also important to understand that the <emphasis>FTP Inbound Channel Adapter</emphasis> is a <emphasis>Polling Consumer</emphasis> and 
@@ -266,7 +281,10 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/ftp
 				auto-create-directory="true"
 				remote-directory-expression="headers.['remote_dir']"
 				temporary-remote-directory-expression="headers.['temp_remote_dir']"
-				filename-generator="fileNameGenerator"/>]]></programlisting>	
+				filename-generator="fileNameGenerator"
+				disposition-expression="payload.renameTo('/foo/bar/' + payload.name)"
+				disposition-result-channel="dispositions"
+				disposition-send-timeout="1000" />]]></programlisting>
 
 	As you can see from the configuration above you can configure an <emphasis>FTP Outbound Channel Adapter</emphasis> via the
 	<code>outbound-channel-adapter</code> element while also providing values for various attributes such as <code>filename-generator</code> 
@@ -276,6 +294,27 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/ftp
 	to configure things like <code>remote-directory-expression</code>, <code>temporary-remote-directory-expression</code> and <code>remote-filename-generator-expression</code> 
 	(a SpEL alternative to <code>filename-generator</code> shown above). As with any component that allows the usage of SpEL, access to Payload and Message Headers is available via 
 	'payload' and 'headers' variables.
+	</para>
+	<para>
+	The <emphasis>disposition-*</emphasis> attributes are used to take action after the file has been transferred.
+	The <emphasis>dispostion-expression</emphasis> is a SpEL expression
+	with the root object being the original message; the bean factory is also available, allowing expressions such
+	as <classname>@someBean.doSomething(payload)</classname>. The result of the evaluation (if any) is sent to
+	the <emphasis>disposition-result-channel</emphasis> if supplied (the default is <emphasis>nullChannel</emphasis>).
+	The message is the original message with the result contained in the <classname>dispositionResult</classname> header
+	The <emphasis>disposition-send-timeout</emphasis> is used if the result channel can block (such as a QueueChannel
+	that is currently full).
+	</para>
+	<note>
+	If the expression evaluation fails, the flow is not terminated; the <classname>dispostionResult</classname> header
+	in the disposition result will contain the exception.
+	</note>
+	<para>
+	The example above assumes the payload is a <classname>java.io.File</classname> and renames it. The result
+	of the renameTo() method is sent in the dispositionResultHeader to the <emphasis>dispositions</emphasis>
+	channel.
+	</para>
+	<para>
 	Please refer to the schema for more details on
     the available attributes.
 	 <note>

--- a/src/reference/docbook/sftp.xml
+++ b/src/reference/docbook/sftp.xml
@@ -228,7 +228,10 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 			local-directory="file:target/foo"
 			auto-create-local-directory="true"
 			local-filename-generator-expression="#this.toUpperCase() + '.a'"
-			delete-remote-files="false">
+			delete-remote-files="false"
+			disposition-expression="payload.delete()"
+			disposition-result-channel="dispositions"
+			disposition-send-timeout="1000">
 		<int:poller fixed-rate="1000"/>
 </int-sftp:inbound-channel-adapter>]]></programlisting>
 
@@ -254,6 +257,18 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 	<classname>org.springframework.integration.file.filters.FileListFilter</classname> - a strategy interface for filtering a
 	list of files.
   	</para>
+	<para>
+	The <emphasis>disposition-*</emphasis> attributes are used to take action after the file has been processed. If the poller is
+	transactional (and synchronized), the action is taken after the transaction commits; otherwise the action
+	is taken after the message is sent to the channel. If all channels in the flow are Direct, this means the
+	action is taken after the flow completes. The <emphasis>dispostion-expression</emphasis> is a SpEL expression
+	with the root object being the original message; the bean factory is also available, allowing expressions such
+	as <classname>@someBean.doSomething(payload)</classname>. The result of the evaluation (if any) is sent to
+	the <emphasis>disposition-result-channel</emphasis> if supplied (the default is <emphasis>nullChannel</emphasis>).
+	The message is the original message with the result contained in the <classname>dispositionResult</classname> header
+	The <emphasis>disposition-send-timeout</emphasis> is used if the result channel can block (such as a QueueChannel
+	that is currently full).
+	</para>
   	<para>
   	Please refer to the schema for more detail on these attributes.
   	</para>
@@ -301,17 +316,41 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
   	Similar to the FTP outbound adapter, the <emphasis>SFTP Outbound Channel Adapter</emphasis> supports the following payloads:
   	1) <classname>java.io.File</classname> - the actual file object; 2) <classname>byte[]</classname> - byte array that represents
   	the file contents; 3) <classname>java.lang.String</classname> - text that represents the file contents.
-
+	
   	<programlisting language="xml"><![CDATA[<int-sftp:outbound-channel-adapter id="sftpOutboundAdapter"
 				session-factory="sftpSessionFactory"
 				channel="inputChannel"
 				charset="UTF-8"
 				remote-directory="foo/bar"
-				remote-filename-generator-expression="payload.getName() + '-foo'"/>]]></programlisting>
+				remote-filename-generator-expression="payload.getName() + '-foo'"
+				disposition-expression="payload.renameTo('/foo/bar/' + payload.name)"
+				disposition-result-channel="dispositions"
+				disposition-send-timeout="1000" />]]></programlisting>
 
 	As you can see from the configuration above you can configure the <emphasis>SFTP Outbound Channel Adapter</emphasis> via
 	the <code>outbound-channel-adapter</code> element.
-	Please refer to the schema for more detail on these attributes.
+	</para>
+	<para>
+	The <emphasis>disposition-*</emphasis> attributes are used to take action after the file has been transferred.
+	The <emphasis>dispostion-expression</emphasis> is a SpEL expression
+	with the root object being the original message; the bean factory is also available, allowing expressions such
+	as <classname>@someBean.doSomething(payload)</classname>. The result of the evaluation (if any) is sent to
+	the <emphasis>disposition-result-channel</emphasis> if supplied (the default is <emphasis>nullChannel</emphasis>).
+	The message is the original message with the result contained in the <classname>dispositionResult</classname> header
+	The <emphasis>disposition-send-timeout</emphasis> is used if the result channel can block (such as a QueueChannel
+	that is currently full).
+	</para>
+	<note>
+	If the expression evaluation fails, the flow is not terminated; the <classname>dispostionResult</classname> header
+	in the disposition result will contain the exception.
+	</note>
+	<para>
+	The example above assumes the payload is a <classname>java.io.File</classname> and renames it. The result
+	of the renameTo() method is sent in the dispositionResultHeader to the <emphasis>dispositions</emphasis>
+	channel.
+	</para>
+	<para>
+	Please refer to the schema for more detail on available attributes.
   	</para>
   	<para>
   		<emphasis>SpEL and the SFTP Outbound Adapter</emphasis>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -72,6 +72,30 @@
 				mail inbound adapters can be configured to update the mailbox only
 				if the transaction commits.
 			</para>
+			<para>
+				Similarly File, FTP and SFTP inbound adapters can be configured
+				to execute an expression (e.g. payload.delete(), payload.renameTo(...))
+				after the transaction commits.
+			</para>
+		</section>
+		<section id="2.2-dispo">
+			<title>File Disposition</title>
+			<para>
+				Similar to transaction synchronization,
+				File, FTP and SFTP inbound adapters can be configured
+				to execute an expression (e.g. payload.delete(), payload.renameTo(...))
+				after the message is sent to the channel.
+			</para>
+			<para>
+				Also,
+				File, FTP and SFTP outbound adapters can be configured
+				to execute an expression (e.g. payload.delete(), payload.renameTo(...))
+				after the message is processed.
+			</para>
+			<para>
+				Therefore, it is no longer necessary to add components to your flow
+				to take these actions.
+			</para>
 		</section>
 		<section id="2.2-shutdown">
 			<title>Orderly Shutdown</title>


### PR DESCRIPTION
Inbound adapters have disposition-\* attributes to
allow things like deleting/renaming the file after completion.

Add these attributes to outbound adapters as well
so the outbound file can be acted upon after sending.

Applies to File, FTP, SFTP adapters.
