### PR TITLE
INT-2683, INT-2684 JmsOutboundGateway improvements

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/IntegrationCachingConnectionFactory.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/IntegrationCachingConnectionFactory.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.QueueSession;
+import javax.jms.Session;
+import javax.jms.Topic;
+import javax.jms.TopicSession;
+
+import org.springframework.jms.connection.CachingConnectionFactory;
+import org.springframework.jms.connection.SessionProxy;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.ReflectionUtils;
+/**
+ * Temporary extension to {@link CachingConnectionFactory}. It allows you to
+ * cache consummers for temporary queues.
+ * This class will be eliminated once https://jira.springsource.org/browse/SPR-9648 is addressed.
+ *
+ * @author Oleg Zhurakousky
+ * @since 2.2
+ */
+public class IntegrationCachingConnectionFactory extends CachingConnectionFactory {
+
+	@Override
+	protected Session getCachedSessionProxy(Session target, LinkedList<Session> sessionList) {
+		List<Class<?>> classes = new ArrayList<Class<?>>(3);
+		classes.add(SessionProxy.class);
+		if (target instanceof QueueSession) {
+			classes.add(QueueSession.class);
+		}
+		if (target instanceof TopicSession) {
+			classes.add(TopicSession.class);
+		}
+		return (Session) Proxy.newProxyInstance(
+				SessionProxy.class.getClassLoader(),
+				classes.toArray(new Class[classes.size()]),
+				new CachedSessionInvocationHandler(target, sessionList));
+	}
+
+	private boolean isActive(){
+		Field field = ReflectionUtils.findField(CachingConnectionFactory.class, "active");
+		field.setAccessible(true);
+		try {
+			return (Boolean) field.get(this);
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to check for 'active' status");
+		}
+	}
+
+	private class CachedSessionInvocationHandler implements InvocationHandler {
+
+		private final Session target;
+
+		private final LinkedList<Session> sessionList;
+
+		private final Map<DestinationCacheKey, MessageProducer> cachedProducers =
+				new HashMap<DestinationCacheKey, MessageProducer>(10);
+
+		private final Map<ConsumerCacheKey, MessageConsumer> cachedConsumers =
+				new HashMap<ConsumerCacheKey, MessageConsumer>(10);
+
+		private boolean transactionOpen = false;
+
+		public CachedSessionInvocationHandler(Session target, LinkedList<Session> sessionList) {
+			this.target = target;
+			this.sessionList = sessionList;
+		}
+
+		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+			String methodName = method.getName();
+		    if (methodName.startsWith("create")) {
+				this.transactionOpen = true;
+				if (isCacheProducers() && (methodName.equals("createProducer") ||
+						methodName.equals("createSender") || methodName.equals("createPublisher"))) {
+					// Destination argument being null is ok for a producer
+					return getCachedProducer((Destination) args[0]);
+				}
+				else if (isCacheConsumers()) {
+					// let raw JMS invocation throw an exception if Destination (i.e. args[0]) is null
+					if ((methodName.equals("createConsumer") || methodName.equals("createReceiver") ||
+							methodName.equals("createSubscriber"))) {
+						Destination dest = (Destination) args[0];
+						if (dest != null) {
+							return getCachedConsumer(dest,
+									(args.length > 1 ? (String) args[1] : null),
+									(args.length > 2 && (Boolean) args[2]),
+									null);
+						}
+					}
+					else if (methodName.equals("createDurableSubscriber")) {
+						Destination dest = (Destination) args[0];
+						if (dest != null) {
+							return getCachedConsumer(dest,
+									(args.length > 2 ? (String) args[2] : null),
+									(args.length > 3 && (Boolean) args[3]),
+									(String) args[1]);
+						}
+					}
+				}
+			}
+		    else if (methodName.equals("equals")) {
+				// Only consider equal when proxies are identical.
+				return (proxy == args[0]);
+			}
+			else if (methodName.equals("hashCode")) {
+				// Use hashCode of Session proxy.
+				return System.identityHashCode(proxy);
+			}
+			else if (methodName.equals("toString")) {
+				return "Cached JMS Session: " + this.target;
+			}
+			else if (methodName.equals("close")) {
+				// Handle close method: don't pass the call on.
+				if (isActive()) {
+					synchronized (this.sessionList) {
+						if (this.sessionList.size() < getSessionCacheSize()) {
+							logicalClose((Session) proxy);
+							// Remain open in the session list.
+							return null;
+						}
+					}
+				}
+				// If we get here, we're supposed to shut down.
+				physicalClose();
+				return null;
+			}
+			else if (methodName.equals("getTargetSession")) {
+				// Handle getTargetSession method: return underlying Session.
+				return this.target;
+			}
+			else if (methodName.equals("commit") || methodName.equals("rollback")) {
+				this.transactionOpen = false;
+			}
+
+			try {
+				return method.invoke(this.target, args);
+			}
+			catch (InvocationTargetException ex) {
+				throw ex.getTargetException();
+			}
+		}
+
+		private MessageProducer getCachedProducer(Destination dest) throws JMSException {
+			DestinationCacheKey cacheKey = (dest != null ? new DestinationCacheKey(dest) : null);
+			MessageProducer producer = this.cachedProducers.get(cacheKey);
+			if (producer != null) {
+				if (logger.isTraceEnabled()) {
+					logger.trace("Found cached JMS MessageProducer for destination [" + dest + "]: " + producer);
+				}
+			}
+			else {
+				producer = this.target.createProducer(dest);
+				if (logger.isDebugEnabled()) {
+					logger.debug("Creating cached JMS MessageProducer for destination [" + dest + "]: " + producer);
+				}
+				this.cachedProducers.put(cacheKey, producer);
+			}
+			//return new CachedMessageProducer(producer);
+			return createCachedMessageProducer(producer);
+		}
+
+		private MessageConsumer getCachedConsumer(
+				Destination dest, String selector, boolean noLocal, String subscription) throws JMSException {
+
+			ConsumerCacheKey cacheKey = new ConsumerCacheKey(dest, selector, noLocal, subscription);
+			MessageConsumer consumer = this.cachedConsumers.get(cacheKey);
+			if (consumer != null) {
+				if (logger.isTraceEnabled()) {
+					logger.trace("Found cached JMS MessageConsumer for destination [" + dest + "]: " + consumer);
+				}
+			}
+			else {
+				if (dest instanceof Topic) {
+					consumer = (subscription != null ?
+							this.target.createDurableSubscriber((Topic) dest, subscription, selector, noLocal) :
+							this.target.createConsumer(dest, selector, noLocal));
+				}
+				else {
+					consumer = this.target.createConsumer(dest, selector);
+				}
+				if (logger.isDebugEnabled()) {
+					logger.debug("Creating cached JMS MessageConsumer for destination [" + dest + "]: " + consumer);
+				}
+				this.cachedConsumers.put(cacheKey, consumer);
+			}
+			//return new CachedMessageConsumer(consumer);
+			return createCachedMessageConsumer(consumer);
+		}
+
+		private void logicalClose(Session proxy) throws JMSException {
+			// Preserve rollback-on-close semantics.
+			if (this.transactionOpen && this.target.getTransacted()) {
+				this.transactionOpen = false;
+				this.target.rollback();
+			}
+			// Physically close durable subscribers at time of Session close call.
+			for (Iterator<Map.Entry<ConsumerCacheKey, MessageConsumer>> it = this.cachedConsumers.entrySet().iterator(); it.hasNext();) {
+				Map.Entry<ConsumerCacheKey, MessageConsumer> entry = it.next();
+				if (entry.getKey().subscription != null) {
+					entry.getValue().close();
+					it.remove();
+				}
+			}
+			// Allow for multiple close calls...
+			boolean returned = false;
+			synchronized (this.sessionList) {
+				if (!this.sessionList.contains(proxy)) {
+					this.sessionList.addLast(proxy);
+					returned = true;
+				}
+			}
+			if (returned && logger.isTraceEnabled()) {
+				logger.trace("Returned cached Session: " + this.target);
+			}
+		}
+
+		private void physicalClose() throws JMSException {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Closing cached Session: " + this.target);
+			}
+			// Explicitly close all MessageProducers and MessageConsumers that
+			// this Session happens to cache...
+			try {
+				for (MessageProducer producer : this.cachedProducers.values()) {
+					producer.close();
+				}
+				for (MessageConsumer consumer : this.cachedConsumers.values()) {
+					consumer.close();
+				}
+			}
+			finally {
+				this.cachedProducers.clear();
+				this.cachedConsumers.clear();
+				// Now actually close the Session.
+				this.target.close();
+			}
+		}
+	}
+
+	private static class DestinationCacheKey {
+
+		private final Destination destination;
+
+		private String destinationString;
+
+		public DestinationCacheKey(Destination destination) {
+			Assert.notNull(destination, "Destination must not be null");
+			this.destination = destination;
+		}
+
+		private String getDestinationString() {
+			if (this.destinationString == null) {
+				this.destinationString = this.destination.toString();
+			}
+			return this.destinationString;
+		}
+
+		protected boolean destinationEquals(DestinationCacheKey otherKey) {
+			return (this.destination.getClass().equals(otherKey.destination.getClass()) &&
+					(this.destination.equals(otherKey.destination) ||
+							getDestinationString().equals(otherKey.getDestinationString())));
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			// Effectively checking object equality as well as toString equality.
+			// On WebSphere MQ, Destination objects do not implement equals...
+			return (other == this || destinationEquals((DestinationCacheKey) other));
+		}
+
+		@Override
+		public int hashCode() {
+			// Can't use a more specific hashCode since we can't rely on
+			// this.destination.hashCode() actually being the same value
+			// for equivalent destinations... Thanks a lot, WebSphere MQ!
+			return this.destination.getClass().hashCode();
+		}
+	}
+
+
+	/**
+	 * Simple wrapper class around a Destination and other consumer attributes.
+	 * Used as the cache key when caching MessageConsumer objects.
+	 */
+	private static class ConsumerCacheKey extends DestinationCacheKey {
+
+		private final String selector;
+
+		private final boolean noLocal;
+
+		private final String subscription;
+
+		public ConsumerCacheKey(Destination destination, String selector, boolean noLocal, String subscription) {
+			super(destination);
+			this.selector = selector;
+			this.noLocal = noLocal;
+			this.subscription = subscription;
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (other == this) {
+				return true;
+			}
+			ConsumerCacheKey otherKey = (ConsumerCacheKey) other;
+			return (destinationEquals(otherKey) &&
+					ObjectUtils.nullSafeEquals(this.selector, otherKey.selector) &&
+					this.noLocal == otherKey.noLocal &&
+					ObjectUtils.nullSafeEquals(this.subscription, otherKey.subscription));
+		}
+	}
+
+
+	//============
+	private MessageProducer createCachedMessageProducer(MessageProducer messageProducer){
+		try {
+			Class<?> cachedProducerClass =
+					Class.forName("org.springframework.jms.connection.CachedMessageProducer",
+							true, Thread.currentThread().getContextClassLoader());
+			Constructor<?> c = cachedProducerClass.getConstructor(MessageProducer.class);
+			c.setAccessible(true);
+			return (MessageProducer) c.newInstance(messageProducer);
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to create org.springframework.jms.connection.CachedMessageProducer", e);
+		}
+	}
+
+	private MessageConsumer createCachedMessageConsumer(MessageConsumer messageConsumer){
+		try {
+			Class<?> cachedProducerClass =
+					Class.forName("org.springframework.jms.connection.CachedMessageConsumer",
+							true, Thread.currentThread().getContextClassLoader());
+			Constructor<?> c = cachedProducerClass.getConstructor(MessageConsumer.class);
+			c.setAccessible(true);
+			return (MessageConsumer) c.newInstance(messageConsumer);
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to create org.springframework.jms.connection.CachedMessageConsumer", e);
+		}
+	}
+}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.DeliveryMode;
 import javax.jms.Destination;
+import javax.jms.InvalidDestinationException;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
@@ -31,6 +32,7 @@ import javax.jms.TemporaryQueue;
 import javax.jms.TemporaryTopic;
 import javax.jms.Topic;
 
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.expression.Expression;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
@@ -40,6 +42,7 @@ import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.jms.connection.CachingConnectionFactory;
 import org.springframework.jms.connection.ConnectionFactoryUtils;
 import org.springframework.jms.support.JmsUtils;
 import org.springframework.jms.support.converter.MessageConverter;
@@ -47,16 +50,21 @@ import org.springframework.jms.support.converter.SimpleMessageConverter;
 import org.springframework.jms.support.destination.DestinationResolver;
 import org.springframework.jms.support.destination.DynamicDestinationResolver;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * An outbound Messaging Gateway for request/reply JMS.
- * 
+ *
  * @author Mark Fisher
  * @author Arjen Poutsma
  * @author Juergen Hoeller
  * @author Oleg Zhurakousky
  */
-public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
+public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler implements DisposableBean{
+
+	private final String gatewayId = UUID.randomUUID().toString();
+
+	private volatile boolean cachedConsumers;
 
 	private volatile Destination requestDestination;
 
@@ -182,7 +190,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	 * Specify whether the request destination is a Topic. This value is
 	 * necessary when providing a destination name for a Topic rather than
 	 * a destination reference.
-	 * 
+	 *
 	 * @param requestPubSubDomain true if the request destination is a Topic
 	 */
 	public void setRequestPubSubDomain(boolean requestPubSubDomain) {
@@ -193,7 +201,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	 * Specify whether the reply destination is a Topic. This value is
 	 * necessary when providing a destination name for a Topic rather than
 	 * a destination reference.
-	 * 
+	 *
 	 * @param replyPubSubDomain true if the reply destination is a Topic
 	 */
 	public void setReplyPubSubDomain(boolean replyPubSubDomain) {
@@ -240,15 +248,21 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	}
 
 	/**
-	 * Provide the name of a JMS property that should hold a generated UUID that
-	 * the receiver of the JMS Message would expect to represent the CorrelationID.
-	 * When waiting for the reply Message, a MessageSelector will be configured
-	 * to match this property name and the UUID value that was sent in the request.
-	 * If this value is NULL (the default) then the reply consumer's MessageSelector
-	 * will be expecting the JMSCorrelationID to equal the Message ID of the request.
-	 * If you want to store the outbound correlation UUID value in the actual
-	 * JMSCorrelationID property, then set this value to "JMSCorrelationID".
-	 * However, any other value will be treated as a JMS String Property.
+	 * Provide the name of a JMS property that should hold a generated CorrelationID.
+	 * If NO value is provided for this attribute, then the reply consumer's
+	 * MessageSelector will be expecting the JMSCorrelationID to equal the Message ID
+	 * of the request. However this would also mean that the MessageSelector will be different
+	 * for each new message, thus requiring a new reply consumer to be created for each Message sent.
+	 * Although this is a very common JMS exchange pattern it is not optimal for high thru-put request/reply
+	 * applications.Most MOMs (including Spring Integration's Inbound Gateway) also support propagation
+	 * of the 'CorrelationID' of the consumed request message into the 'CorrelationID' of the newly produced
+	 * reply message. This also allows us to use optimized value generation algorithm which results in caching
+	 * and reuse of reply consumers resulting in significant performance improvement of the request/reply
+	 * scenarios. So if you have Spring JMS consumer (e.g.,  Spring Integration's Inbound Gateway) or
+	 * you know that your MOM supports propagation of the 'CorrelationID' it is highly recommended to set this
+	 * value to 'JMSCorrelationID'. If you set this value to something else the receiving end must now how
+	 * to propagate it. For example: if the receiving end is an inbound-gateway its correlation-key attribute
+	 * must have the same value.
 	 */
 	public void setCorrelationKey(String correlationKey) {
 		this.correlationKey = correlationKey;
@@ -275,8 +289,8 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	}
 
 	/**
-	 * This property describes how a JMS Message should be generated from the 
-	 * Spring Integration Message. If set to 'true', the body of the JMS Message will be 
+	 * This property describes how a JMS Message should be generated from the
+	 * Spring Integration Message. If set to 'true', the body of the JMS Message will be
 	 * created from the Spring Integration Message's payload (via the MessageConverter).
 	 * If set to 'false', then the entire Spring Integration Message will serve as
 	 * the base for JMS Message creation. Since the JMS Message is created by the
@@ -284,7 +298,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	 * the entire Spring Integration Message or only its payload.
 	 * <br>
 	 * Default is 'true'
-	 * 
+	 *
 	 * @param extractRequestPayload
 	 */
 	public void setExtractRequestPayload(boolean extractRequestPayload) {
@@ -297,7 +311,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	 * created from the JMS Reply Message's body (via MessageConverter).
 	 * Otherwise, the entire JMS Message will become the payload of the
 	 * Spring Integration Message.
-	 * 
+	 *
 	 * @param extractReplyPayload
 	 */
 	public void setExtractReplyPayload(boolean extractReplyPayload) {
@@ -312,50 +326,9 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 		this.setOutputChannel(replyChannel);
 	}
 
+	@Override
 	public String getComponentType() {
 		return "jms:outbound-gateway";
-	}
-
-	private Destination getRequestDestination(Message<?> message, Session session) throws JMSException {
-		if (this.requestDestination != null) {
-			return this.requestDestination;
-		}
-		if (this.requestDestinationName != null) {
-			return this.resolveRequestDestination(this.requestDestinationName, session);
-		}
-		if (this.requestDestinationExpressionProcessor != null) {
-			Object result = this.requestDestinationExpressionProcessor.processMessage(message);
-			if (result instanceof Destination) {
-				return (Destination) result;
-			}
-			if (result instanceof String) {
-				return this.resolveRequestDestination((String) result, session);
-			}
-			throw new MessageDeliveryException(message,
-					"Evaluation of requestDestinationExpression failed to produce a Destination or destination name. Result was: " + result);
-		}
-		throw new MessageDeliveryException(message,
-				"No requestDestination, requestDestinationName, or requestDestinationExpression has been configured.");
-	}
-
-	private Destination resolveRequestDestination(String requestDestinationName, Session session) throws JMSException {
-		Assert.notNull(this.destinationResolver,
-				"DestinationResolver is required when relying upon the 'requestDestinationName' property.");
-		return this.destinationResolver.resolveDestinationName(
-				session, requestDestinationName, this.requestPubSubDomain);
-	}
-
-	private Destination getReplyDestination(Session session) throws JMSException {
-		if (this.replyDestination != null) {
-			return this.replyDestination;
-		}
-		if (this.replyDestinationName != null) {
-			Assert.notNull(this.destinationResolver,
-					"DestinationResolver is required when relying upon the 'replyDestinationName' property.");
-			return this.destinationResolver.resolveDestinationName(
-					session, this.replyDestinationName, this.replyPubSubDomain);
-		}
-		return session.createTemporaryQueue();
 	}
 
 	@Override
@@ -374,7 +347,29 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 				this.requestDestinationExpressionProcessor.setConversionService(getConversionService());
 			}
 			this.initialized = true;
+			if (this.connectionFactory instanceof CachingConnectionFactory){
+				this.cachedConsumers = ((CachingConnectionFactory)this.connectionFactory).isCacheConsumers();
+			}
+
+			if (this.cachedConsumers && !StringUtils.hasText(this.correlationKey)){
+				logger.warn("Caching consumers  without custom correlation-key can lead to " +
+						"significant performance degradation and OutOfMemoryError. Either do not use consumer caching " +
+						"by setting 'cacheConsumers' attribute to FALSE in the CachingConnectionFactory or set 'correlation-key'" +
+						"to a value (e.g., correlation-key=\"JMSCorrelationID\")");
+			}
+			else if (!this.cachedConsumers && StringUtils.hasText(this.correlationKey)){
+				logger.warn("Using custom 'correlationKey' without caching consumers can lead to " +
+						"significant performance degradation. Consider using the CachingConnectionFactory " +
+						"with 'cacheConsumers' attribute set to TRUE");
+			}
+
+			this.ensureDefaultReplyDestinationExists();
 		}
+	}
+
+
+	public void destroy() throws Exception {
+		this.deleteDestinationIfTemporary(this.replyDestination);
 	}
 
 	@Override
@@ -411,6 +406,91 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 		}
 	}
 
+	/**
+	 * Create a new JMS Connection for this JMS gateway.
+	 */
+	protected Connection createConnection() throws JMSException {
+		return this.connectionFactory.createConnection();
+	}
+
+	/**
+	 * Create a new JMS Session using the provided Connection.
+	 */
+	protected Session createSession(Connection connection) throws JMSException {
+		return connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+	}
+
+	/**
+	 * Will ensure that replyDestination exists and always current.
+	 * This method is called from onInit at the startup. After that it is only invoked when
+	 * IllegalStateException detected during the receive call or InvalidDestinationException is detected
+	 * during the creation of the reply MessageConsumer.
+	 */
+	private void ensureDefaultReplyDestinationExists(){
+		if (this.replyDestination == null && !StringUtils.hasText(this.replyDestinationName)){
+			Connection connection = null;
+			Session session = null;
+			try {
+				connection = this.createConnection();
+				session = this.createSession(connection);
+				this.replyDestination = session.createTemporaryQueue();
+			}
+			catch (Exception e) {
+				throw new IllegalStateException("Failed to create Temporary Reply Destination", e);
+			}
+			finally {
+				JmsUtils.closeSession(session);
+				ConnectionFactoryUtils.releaseConnection(connection, this.connectionFactory, true);
+			}
+		}
+	}
+
+
+	private Destination determineRequestDestination(Message<?> message, Session session) throws JMSException {
+		if (this.requestDestination != null) {
+			return this.requestDestination;
+		}
+
+		if (this.requestDestinationName != null) {
+			return this.resolveRequestDestination(this.requestDestinationName, session);
+		}
+
+		if (this.requestDestinationExpressionProcessor != null) {
+			Object result = this.requestDestinationExpressionProcessor.processMessage(message);
+			if (result instanceof Destination) {
+				return (Destination) result;
+			}
+			if (result instanceof String) {
+				return this.resolveRequestDestination((String) result, session);
+			}
+			throw new MessageDeliveryException(message,
+					"Evaluation of requestDestinationExpression failed to produce a Destination or destination name. Result was: " + result);
+		}
+		throw new MessageDeliveryException(message,
+				"No requestDestination, requestDestinationName, or requestDestinationExpression has been configured.");
+	}
+
+	private Destination resolveRequestDestination(String requestDestinationName, Session session) throws JMSException {
+		Assert.notNull(this.destinationResolver,
+				"DestinationResolver is required when relying upon the 'requestDestinationName' property.");
+		return this.destinationResolver.resolveDestinationName(
+				session, requestDestinationName, this.requestPubSubDomain);
+	}
+
+	private Destination determineReplyDestination(Session session) throws JMSException {
+		if (this.replyDestination != null){
+			return this.replyDestination;
+		}
+		if (StringUtils.hasText(this.replyDestinationName)) {
+			Assert.notNull(this.destinationResolver,
+					"DestinationResolver is required when relying upon the 'replyDestinationName' property.");
+			return this.destinationResolver.resolveDestinationName(
+					session, this.replyDestinationName, this.replyPubSubDomain);
+		}
+
+		return null;
+	}
+
 	private javax.jms.Message sendAndReceive(Message<?> requestMessage) throws JMSException {
 		Connection connection = this.createConnection();
 		Session session = null;
@@ -429,109 +509,172 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 			headerMapper.fromHeaders(requestMessage.getHeaders(), jmsRequest);
 
 			// TODO: support a JmsReplyTo header in the SI Message?
-			replyTo = this.getReplyDestination(session);
-			jmsRequest.setJMSReplyTo(replyTo);
+			replyTo = this.determineReplyDestination(session);
+
 			connection.start();
 
 			Integer priority = requestMessage.getHeaders().getPriority();
 			if (priority == null) {
 				priority = this.priority;
 			}
-			javax.jms.Message replyMessage = null;
-			Destination requestDestination = this.getRequestDestination(requestMessage, session);
-			if (this.correlationKey != null) {
-				replyMessage = this.doSendAndReceiveWithGeneratedCorrelationId(requestDestination, jmsRequest, replyTo, session, priority);
-			}
-			else if (replyTo instanceof TemporaryQueue || replyTo instanceof TemporaryTopic) {
-				replyMessage = this.doSendAndReceiveWithTemporaryReplyToDestination(requestDestination, jmsRequest, replyTo, session, priority);
-			}
-			else {
-				replyMessage = this.doSendAndReceiveWithMessageIdCorrelation(requestDestination, jmsRequest, replyTo, session, priority);
-			}
+
+			Destination requestDestinationToUse = this.determineRequestDestination(requestMessage, session);
+
+			long sessionId = session.hashCode() + Thread.currentThread().getId();
+
+			javax.jms.Message replyMessage = this.doSendAndReceive(requestDestinationToUse, jmsRequest, replyTo, session, priority, sessionId);
+
 			return replyMessage;
 		}
 		finally {
 			JmsUtils.closeSession(session);
-			this.deleteDestinationIfTemporary(replyTo);
 			ConnectionFactoryUtils.releaseConnection(connection, this.connectionFactory, true);
-		}
-	}
-
-	/**
-	 * Creates the MessageConsumer before sending the request Message since we are generating our own correlationId value for the MessageSelector.
-	 */
-	private javax.jms.Message doSendAndReceiveWithGeneratedCorrelationId(Destination requestDestination,
-			javax.jms.Message jmsRequest, Destination replyTo, Session session, int priority) throws JMSException {
-		MessageProducer messageProducer = null;
-		MessageConsumer messageConsumer = null;
-		try {
-			messageProducer = session.createProducer(requestDestination);
-			String correlationId = UUID.randomUUID().toString().replaceAll("'", "''");
-			Assert.state(this.correlationKey != null, "correlationKey must not be null");
-			String messageSelector = null;
-			if (this.correlationKey.equals("JMSCorrelationID")) {
-				jmsRequest.setJMSCorrelationID(correlationId);
-				messageSelector = "JMSCorrelationID = '" + correlationId + "'";
-			}
-			else {
-				jmsRequest.setStringProperty(this.correlationKey, correlationId);
-				messageSelector = this.correlationKey + " = '" + correlationId + "'";
-			}
-			messageConsumer = session.createConsumer(replyTo, messageSelector);
-			this.sendRequestMessage(jmsRequest, messageProducer, priority);
-			return this.receiveReplyMessage(messageConsumer);
-		}
-		finally {
-			JmsUtils.closeMessageProducer(messageProducer);
-			JmsUtils.closeMessageConsumer(messageConsumer);
-		}
-	}
-
-	/**
-	 * Creates the MessageConsumer before sending the request Message since we do not need any correlation.
-	 */
-	private javax.jms.Message doSendAndReceiveWithTemporaryReplyToDestination(Destination requestDestination,
-			javax.jms.Message jmsRequest, Destination replyTo, Session session, int priority) throws JMSException {
-		MessageProducer messageProducer = null;
-		MessageConsumer messageConsumer = null;
-		try {
-			messageProducer = session.createProducer(requestDestination);
-			messageConsumer = session.createConsumer(replyTo);
-			this.sendRequestMessage(jmsRequest, messageProducer, priority);
-			return this.receiveReplyMessage(messageConsumer);
-		}
-		finally {
-			JmsUtils.closeMessageProducer(messageProducer);
-			JmsUtils.closeMessageConsumer(messageConsumer);
 		}
 	}
 
 	/**
 	 * Creates the MessageConsumer after sending the request Message since we need the MessageID for correlation with a MessageSelector.
 	 */
-	private javax.jms.Message doSendAndReceiveWithMessageIdCorrelation(Destination requestDestination,
-			javax.jms.Message jmsRequest, Destination replyTo, Session session, int priority) throws JMSException {
-		if (replyTo instanceof Topic && logger.isWarnEnabled()) {
-			logger.warn("Relying on the MessageID for correlation is not recommended when using a Topic as the replyTo Destination " +
-					"because that ID can only be provided to a MessageSelector after the reuqest Message has been sent thereby " +
-					"creating a race condition where a fast response might be sent before the MessageConsumer has been created. " +
-					"Consider providing a value to the 'correlationKey' property of this gateway instead. Then the MessageConsumer " +
-					"will be created before the request Message is sent."); 
-		}
-		MessageProducer messageProducer = null;
-		MessageConsumer messageConsumer = null;
+	private javax.jms.Message doSendAndReceive(Destination requestDestinationToUse,
+			javax.jms.Message jmsRequest, Destination replyTo, Session session, int priority, long sessionId) throws JMSException {
+
+		MessageProducer messageProducer = session.createProducer(requestDestinationToUse);
+
 		try {
-			messageProducer = session.createProducer(requestDestination);
-			this.sendRequestMessage(jmsRequest, messageProducer, priority);
-			String messageId = jmsRequest.getJMSMessageID().replaceAll("'", "''");
-			String messageSelector = "JMSCorrelationID = '" + messageId + "'";
-			messageConsumer = session.createConsumer(replyTo, messageSelector);
-			return this.receiveReplyMessage(messageConsumer);
+			if (StringUtils.hasText(this.correlationKey)){
+
+				String messageCorrelationId = String.valueOf(System.currentTimeMillis() +
+    					                      String.valueOf(System.nanoTime()));
+
+				String consumerCorrelationId = gatewayId + "_" + sessionId;
+
+				if (this.correlationKey.equals("JMSCorrelationID")) {
+					jmsRequest.setJMSCorrelationID(consumerCorrelationId + "$" + messageCorrelationId);
+				}
+				else {
+					jmsRequest.setStringProperty(correlationKey, consumerCorrelationId + "$" + messageCorrelationId);
+				}
+				String messageSelector = correlationKey + " LIKE '" + consumerCorrelationId + "%'";
+
+				return this.exchange(messageProducer, jmsRequest, session, replyTo, priority, messageSelector, messageCorrelationId);
+			}
+			else {
+				if (replyTo instanceof Topic && logger.isWarnEnabled()) {
+					logger.warn("Relying on the MessageID for correlation is not recommended when using a Topic as the replyTo Destination " +
+							"because that ID can only be provided to a MessageSelector after the request Message has been sent thereby " +
+							"creating a race condition where a fast response might be sent before the MessageConsumer has been created. " +
+							"Consider providing a value to the 'correlationKey' property of this gateway instead. Then the MessageConsumer " +
+							"will be created before the request Message is sent.");
+				}
+				return this.exchange(messageProducer, jmsRequest, session, replyTo, priority, null, null);
+			}
 		}
 		finally {
 			JmsUtils.closeMessageProducer(messageProducer);
+		}
+	}
+
+	private javax.jms.Message exchange(MessageProducer messageProducer, javax.jms.Message jmsRequest,
+			Session session, Destination replyTo, int priority,
+			String messageSelector, String messageCorrelationId) throws JMSException {
+
+		MessageConsumer messageConsumer = null;
+		jmsRequest.setJMSReplyTo(replyTo);
+		try {
+			if (StringUtils.hasText(messageSelector)){
+				try {
+					messageConsumer = session.createConsumer(replyTo, messageSelector);
+				}
+				catch (InvalidDestinationException e) {
+					if (this.replyDestination instanceof TemporaryQueue){
+						this.replyDestination = null;
+						this.ensureDefaultReplyDestinationExists();
+						messageConsumer = session.createConsumer(this.replyDestination, messageSelector);
+						jmsRequest.setJMSReplyTo(this.replyDestination);
+					}
+					else {
+						throw e;
+					}
+				}
+
+				this.sendRequestMessage(jmsRequest, messageProducer, priority);
+			}
+			else {
+				this.sendRequestMessage(jmsRequest, messageProducer, priority);
+				messageCorrelationId = jmsRequest.getJMSMessageID().replaceAll("'", "''");
+				if (replyTo instanceof TemporaryQueue){
+					messageConsumer = session.createConsumer(replyTo);
+				}
+				else {
+					messageSelector = "JMSCorrelationID = '" + messageCorrelationId + "'";
+					messageConsumer = session.createConsumer(replyTo, messageSelector);
+				}
+			}
+
+			try {
+				javax.jms.Message jmsMessage = this.receiveCorrelatedReplyMessage(messageConsumer, messageCorrelationId, correlationKey);
+				return jmsMessage;
+			}
+			catch (javax.jms.IllegalStateException e) {
+				// clear up the temp queue cache
+				if (this.replyDestination instanceof TemporaryQueue){
+					this.replyDestination = null;
+					logger.warn("Detected IllegalStateException. Clearing up temporary Reply Queue and creating a new one", e);
+					this.ensureDefaultReplyDestinationExists();
+				}
+			}
+		}
+		finally  {
 			JmsUtils.closeMessageConsumer(messageConsumer);
 		}
+		return null;
+	}
+
+	private javax.jms.Message receiveCorrelatedReplyMessage(MessageConsumer messageConsumer,
+			String messageCorrelationIdToMatch, String correlationKey) throws JMSException {
+
+		long timeout = this.receiveTimeout;
+		long startTime = System.currentTimeMillis();
+		javax.jms.Message replyMessage = (this.receiveTimeout >= 0) ? messageConsumer.receive(receiveTimeout) : messageConsumer.receive();
+		long elapsedTime = System.currentTimeMillis() - startTime;
+		while (replyMessage != null){
+
+			String jmsCorrelationId = null;
+			if (correlationKey != null && !correlationKey.equals("JMSCorrelationID")){
+				jmsCorrelationId = replyMessage.getStringProperty(correlationKey);
+			}
+			else {
+				jmsCorrelationId = replyMessage.getJMSCorrelationID();
+			}
+
+			if (StringUtils.hasText(jmsCorrelationId) && StringUtils.hasText(messageCorrelationIdToMatch)){
+				boolean messageMatched = jmsCorrelationId.contains(messageCorrelationIdToMatch);
+
+				if (messageMatched){
+					return replyMessage;
+				}
+				else {
+					// Essentially we are discarding the uncorrelated message here and moving on to
+					// the next one since we can no longer communicate with its originating producer
+					// since it has already timed out waiting for the reply. We are also honoring the original timeout
+					if (this.logger.isDebugEnabled()){
+						this.logger.debug("Discarded late arriving reply: " + replyMessage);
+					}
+					if (timeout > 0){
+						timeout = timeout - elapsedTime;
+						replyMessage = messageConsumer.receive(timeout);
+					}
+					else {
+						return null;
+					}
+				}
+			}
+			else {
+				return replyMessage;
+			}
+		}
+
+		return null;
 	}
 
 	private void sendRequestMessage(javax.jms.Message jmsRequest, MessageProducer messageProducer, int priority) throws JMSException {
@@ -543,10 +686,6 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 		}
 	}
 
-	private javax.jms.Message receiveReplyMessage(MessageConsumer messageConsumer) throws JMSException {
-		return (this.receiveTimeout >= 0) ? messageConsumer.receive(receiveTimeout) : messageConsumer.receive();
-	}
-
 	/**
 	 * Deletes either a {@link TemporaryQueue} or {@link TemporaryTopic}.
 	 * Ignores any other {@link Destination} type and also ignores any
@@ -554,7 +693,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	 */
 	private void deleteDestinationIfTemporary(Destination destination) {
 		try {
-			if (destination instanceof TemporaryQueue) { 
+			if (destination instanceof TemporaryQueue) {
 				((TemporaryQueue) destination).delete();
 			}
 			else if (destination instanceof TemporaryTopic) {
@@ -565,19 +704,4 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 			// ignore
 		}
 	}
-
-	/**
-	 * Create a new JMS Connection for this JMS gateway.
-	 */
-	protected Connection createConnection() throws JMSException {
-		return this.connectionFactory.createConnection();
-	}
-
-	/**
-	 * Create a new JMS Session using the provided Connection.
-	 */
-	protected Session createSession(Connection connection) throws JMSException {
-		return connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-	}
-
 }

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.ExpressionFactoryBean;
 import org.springframework.integration.config.xml.AbstractConsumerEndpointParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.jms.JmsOutboundGateway;
 import org.springframework.util.StringUtils;
 
 /**
@@ -40,8 +41,7 @@ public class JmsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-				"org.springframework.integration.jms.JmsOutboundGateway");
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(JmsOutboundGateway.class);
 		builder.addPropertyReference("connectionFactory", element.getAttribute("connection-factory"));
 		String requestDestination = element.getAttribute("request-destination");
 		String requestDestinationName = element.getAttribute("request-destination-name");
@@ -65,6 +65,7 @@ public class JmsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 			builder.addPropertyValue("requestDestinationExpression", expressionBuilder.getBeanDefinition());
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-destination");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "optimize-correlation");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-destination-name");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "correlation-key");

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.1.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.1.xsd
@@ -792,20 +792,29 @@
 			</xsd:attribute>
 			<xsd:attribute name="reply-destination-name" type="xsd:string"/>
 			<xsd:attribute name="reply-pub-sub-domain" type="xsd:string"/>
-			<xsd:attribute name="correlation-key" type="xsd:string">
+			<xsd:attribute name="correlation-key">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-						Provide the name of a JMS property that should hold a generated UUID that
-						the receiver of the JMS Message would expect to represent the CorrelationID.
-						When waiting for the reply Message, a MessageSelector will be configured
-						to match this property name and the UUID value that was sent in the request.
+						Provide the name of a JMS property that should hold a generated CorrelationID.
 						If NO value is provided for this attribute, then the reply consumer's
 						MessageSelector will be expecting the JMSCorrelationID to equal the Message ID
-						of the request. If you want to store the outbound correlation UUID value in the
-						actual "JMSCorrelationID" property, then set this value to "JMSCorrelationID".
-						However, any other value will be treated as a JMS String Property.
+						of the request. However this would also mean that the MessageSelector will be different 
+						for each new message, thus requiring a new reply consumer to be created for each Message sent.
+						Although this is a very common JMS exchange pattern it is not optimal for high thru-put request/reply 
+						applications.Most MOMs (including Spring Integration's Inbound Gateway) also support propagation 
+						of the 'CorrelationID' of the consumed request message into the 'CorrelationID' of the newly produced 
+						reply message. This also allows us to use optimized value generation algorithm which results in caching 
+						and reuse of reply consumers resulting in significant performance improvement of the request/reply 
+						scenarios. So if you have Spring JMS consumer (e.g.,  Spring Integration's Inbound Gateway) or
+						you know that your MOM supports propagation of the 'CorrelationID' it is highly recommended to set this 
+						value to 'JMSCorrelationID'. If you set this value to something else the receiving end must now how 
+						to propagate it. For example: if the receiving end is an inbound-gateway its correlation-key attribute 
+						must have the same value.
 					]]></xsd:documentation>
 				</xsd:annotation>
+				<xsd:simpleType>
+				    <xsd:union memberTypes="correlation-key-enum-type correlation-key-ext"/>
+				</xsd:simpleType>
 			</xsd:attribute>
 			<xsd:attribute name="destination-resolver" type="xsd:string">
 				<xsd:annotation>
@@ -884,6 +893,17 @@
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
+	
+	<xsd:simpleType name="correlation-key-enum-type">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="JMSCorrelationID"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="correlation-key-ext">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="([a-zA-Z0-9])*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
 
 	<xsd:element name="outbound-channel-adapter">
 		<xsd:annotation>

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.1.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.1.xsd
@@ -801,11 +801,11 @@
 						of the request. However this would also mean that the MessageSelector will be different 
 						for each new message, thus requiring a new reply consumer to be created for each Message sent.
 						Although this is a very common JMS exchange pattern it is not optimal for high thru-put request/reply 
-						applications.Most MOMs (including Spring Integration's Inbound Gateway) also support propagation 
+						applications. Most MOMs (including Spring Integration's Inbound Gateway) also support propagation 
 						of the 'CorrelationID' of the consumed request message into the 'CorrelationID' of the newly produced 
-						reply message. This also allows us to use optimized value generation algorithm which results in caching 
+						reply message. This also allows us to use an optimized value generation algorithm which results in caching 
 						and reuse of reply consumers resulting in significant performance improvement of the request/reply 
-						scenarios. So if you have Spring JMS consumer (e.g.,  Spring Integration's Inbound Gateway) or
+						scenarios. So if you have a Spring JMS consumer (e.g.,  Spring Integration's Inbound Gateway) or
 						you know that your MOM supports propagation of the 'CorrelationID' it is highly recommended to set this 
 						value to 'JMSCorrelationID'. If you set this value to something else the receiving end must now how 
 						to propagate it. For example: if the receiving end is an inbound-gateway its correlation-key attribute 

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
@@ -843,20 +843,29 @@
 			</xsd:attribute>
 			<xsd:attribute name="reply-destination-name" type="xsd:string"/>
 			<xsd:attribute name="reply-pub-sub-domain" type="xsd:string"/>
-			<xsd:attribute name="correlation-key" type="xsd:string">
+			<xsd:attribute name="correlation-key">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-						Provide the name of a JMS property that should hold a generated UUID that
-						the receiver of the JMS Message would expect to represent the CorrelationID.
-						When waiting for the reply Message, a MessageSelector will be configured
-						to match this property name and the UUID value that was sent in the request.
+						Provide the name of a JMS property that should hold a generated CorrelationID.
 						If NO value is provided for this attribute, then the reply consumer's
 						MessageSelector will be expecting the JMSCorrelationID to equal the Message ID
-						of the request. If you want to store the outbound correlation UUID value in the
-						actual "JMSCorrelationID" property, then set this value to "JMSCorrelationID".
-						However, any other value will be treated as a JMS String Property.
+						of the request. However this would also mean that the MessageSelector will be different 
+						for each new message, thus requiring a new reply consumer to be created for each Message sent.
+						Although this is a very common JMS exchange pattern it is not optimal for high thru-put request/reply 
+						applications.Most MOMs (including Spring Integration's Inbound Gateway) also support propagation 
+						of the 'CorrelationID' of the consumed request message into the 'CorrelationID' of the newly produced 
+						reply message. This also allows us to use optimized value generation algorithm which results in caching 
+						and reuse of reply consumers resulting in significant performance improvement of the request/reply 
+						scenarios. So if you have Spring JMS consumer (e.g.,  Spring Integration's Inbound Gateway) or
+						you know that your MOM supports propagation of the 'CorrelationID' it is highly recommended to set this 
+						value to 'JMSCorrelationID'. If you set this value to something else the receiving end must now how 
+						to propagate it. For example: if the receiving end is an inbound-gateway its correlation-key attribute 
+						must have the same value.
 					]]></xsd:documentation>
 				</xsd:annotation>
+				<xsd:simpleType>
+				    <xsd:union memberTypes="correlation-key-enum-type correlation-key-ext"/>
+				</xsd:simpleType>
 			</xsd:attribute>
 			<xsd:attribute name="destination-resolver" type="xsd:string">
 				<xsd:annotation>
@@ -957,6 +966,17 @@
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
+	
+	<xsd:simpleType name="correlation-key-enum-type">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="JMSCorrelationID"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="correlation-key-ext">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="([a-zA-Z0-9])*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
 
 	<xsd:element name="outbound-channel-adapter">
 		<xsd:annotation>

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
@@ -843,7 +843,7 @@
 			</xsd:attribute>
 			<xsd:attribute name="reply-destination-name" type="xsd:string"/>
 			<xsd:attribute name="reply-pub-sub-domain" type="xsd:string"/>
-			<xsd:attribute name="correlation-key">
+			<xsd:attribute name=" ">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
 						Provide the name of a JMS property that should hold a generated CorrelationID.
@@ -852,11 +852,11 @@
 						of the request. However this would also mean that the MessageSelector will be different 
 						for each new message, thus requiring a new reply consumer to be created for each Message sent.
 						Although this is a very common JMS exchange pattern it is not optimal for high thru-put request/reply 
-						applications.Most MOMs (including Spring Integration's Inbound Gateway) also support propagation 
+						applications. Most MOMs (including Spring Integration's Inbound Gateway) also support propagation 
 						of the 'CorrelationID' of the consumed request message into the 'CorrelationID' of the newly produced 
-						reply message. This also allows us to use optimized value generation algorithm which results in caching 
+						reply message. This also allows us to use an optimized value generation algorithm which results in caching 
 						and reuse of reply consumers resulting in significant performance improvement of the request/reply 
-						scenarios. So if you have Spring JMS consumer (e.g.,  Spring Integration's Inbound Gateway) or
+						scenarios. So if you have a Spring JMS consumer (e.g.,  Spring Integration's Inbound Gateway) or
 						you know that your MOM supports propagation of the 'CorrelationID' it is highly recommended to set this 
 						value to 'JMSCorrelationID'. If you set this value to something else the receiving end must now how 
 						to propagate it. For example: if the receiving end is an inbound-gateway its correlation-key attribute 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCachedConsumersTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCachedConsumersTests.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms.request_reply;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.MessageTimeoutException;
+import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.JmsOutboundGateway;
+import org.springframework.integration.jms.config.ActiveMqTestUtils;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.jms.connection.CachingConnectionFactory;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+import org.springframework.jms.listener.DefaultMessageListenerContainer;
+import org.springframework.jms.listener.SessionAwareMessageListener;
+import org.springframework.jms.support.converter.SimpleMessageConverter;
+/**
+ * @author Oleg Zhurakousky
+ */
+public class RequestReplyScenariosWithCachedConsumersTests {
+
+	private final SimpleMessageConverter converter = new SimpleMessageConverter();
+
+	@Test(expected=MessageTimeoutException.class)
+	public void messageCorrelationBasedOnRequestMessageIdOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("producer-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("standardMessageIdCopyingConsumerWithOptimization", RequestReplyExchanger.class);
+		CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+
+		final Destination requestDestination = context.getBean("siOutQueueOptimizedA", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueOptimizedA", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSMessageID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		gateway.exchange(new GenericMessage<String>("foo"));
+		context.close();
+	}
+
+	@Test
+	public void messageCorrelationBasedOnRequestMessageIdNonOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("producer-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("standardMessageIdCopyingConsumerWithoutOptimization", RequestReplyExchanger.class);
+		CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+
+		final Destination requestDestination = context.getBean("siOutQueueNonOptimizedB", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueNonOptimizedB", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSMessageID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+		context.close();
+	}
+
+	@Test
+	public void messageCorrelationBasedOnRequestCorrelationIdOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("producer-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("correlationPropagatingConsumerWithOptimization", RequestReplyExchanger.class);
+		CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
+
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueueOptimizedC", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueOptimizedC", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSCorrelationID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+		context.close();
+	}
+
+	@Test(expected=MessageTimeoutException.class)
+	public void messageCorrelationBasedOnRequestCorrelationIdNonOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("producer-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("correlationPropagatingConsumerWithoutOptimization", RequestReplyExchanger.class);
+		CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
+
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueueNonOptimizedD", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueNonOptimizedD", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSCorrelationID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+		context.close();
+	}
+
+	@Test
+	public void messageCorrelationBasedOnRequestCorrelationIdTimedOutFirstReplyOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context =
+				new ClassPathXmlApplicationContext("producer-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway =
+				context.getBean("correlationPropagatingConsumerWithOptimizationDelayFirstReply", RequestReplyExchanger.class);
+		final ConnectionFactory connectionFactory = context.getBean("connectionFactory", ConnectionFactory.class);
+
+		final Destination requestDestination = context.getBean("siOutQueueE", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueE", Destination.class);
+
+		for (int i = 0; i < 3; i++) {
+			System.out.println("#### " + i);
+			try {
+				gateway.exchange(gateway.exchange(new GenericMessage<String>("foo")));
+			} catch (Exception e) {/*ignore*/}
+
+		}
+
+		final CountDownLatch latch = new CountDownLatch(1);
+		new Thread(new Runnable() {
+
+			public void run() {
+				DefaultMessageListenerContainer dmlc = new DefaultMessageListenerContainer();
+				dmlc.setConnectionFactory(connectionFactory);
+				dmlc.setDestination(requestDestination);
+				dmlc.setMessageListener(new SessionAwareMessageListener<Message>() {
+
+					public void onMessage(Message message, Session session) {
+						String requestPayload = (String) extractPayload(message);
+						try {
+							TextMessage replyMessage = session.createTextMessage();
+							replyMessage.setText(requestPayload);
+							replyMessage.setJMSCorrelationID(message.getJMSCorrelationID());
+							MessageProducer producer = session.createProducer(replyDestination);
+							producer.send(replyMessage);
+						} catch (Exception e) {
+							// ignore. the test will fail
+						}
+					}
+				});
+				dmlc.afterPropertiesSet();
+				dmlc.start();
+				latch.countDown();
+			}
+		}).start();
+
+		latch.await();
+
+
+
+		TestUtils.getPropertyValue(context.getBean("fastGateway"), "handler", JmsOutboundGateway.class).setReceiveTimeout(10000);
+		Thread.sleep(1000);
+		assertEquals("bar", gateway.exchange(new GenericMessage<String>("bar")).getPayload());
+
+		context.close();
+	}
+
+	private Object extractPayload(Message jmsMessage) {
+		try {
+			return converter.fromMessage(jmsMessage);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		}
+		return null;
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCorrelationKeyProvidedTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCorrelationKeyProvidedTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms.request_reply;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.JmsOutboundGateway;
+import org.springframework.integration.jms.config.ActiveMqTestUtils;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
+/**
+ * @author Oleg Zhurakousky
+ */
+public class RequestReplyScenariosWithCorrelationKeyProvidedTests {
+
+	@Test
+	public void messageCorrelationBasedCustomCorrelationKey() throws Exception{
+		ActiveMqTestUtils.prepare();
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("explicit-correlation-key.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("explicitCorrelationKeyGateway", RequestReplyExchanger.class);
+
+		gateway.exchange(MessageBuilder.withPayload("foo").build());
+		context.close();
+	}
+
+	@Test
+	public void messageCorrelationBasedCustomCorrelationKeyAsJMSCorrelationID() throws Exception{
+		ActiveMqTestUtils.prepare();
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("explicit-correlation-key.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("explicitCorrelationKeyGatewayB", RequestReplyExchanger.class);
+
+		gateway.exchange(MessageBuilder.withPayload("foo").build());
+		context.close();
+	}
+
+	@Test
+	public void messageCorrelationBasedCustomCorrelationKeyDelayedReplies() throws Exception{
+		ActiveMqTestUtils.prepare();
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("explicit-correlation-key.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("explicitCorrelationKeyGatewayC", RequestReplyExchanger.class);
+
+
+		for (int i = 0; i < 3; i++) {
+			try {
+				gateway.exchange(MessageBuilder.withPayload("hello").build());
+			} catch (Exception e) {
+				// ignore
+			}
+		}
+
+		JmsOutboundGateway outGateway = TestUtils.getPropertyValue(context.getBean("outGateway"), "handler", JmsOutboundGateway.class);
+		outGateway.setReceiveTimeout(5000);
+		assertEquals("foo", gateway.exchange(MessageBuilder.withPayload("foo").build()).getPayload());
+		context.close();
+	}
+
+
+	public static class DelayedService {
+		public String echo(String s) throws Exception{
+			Thread.sleep(200);
+			return s;
+		}
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithNonCachedConsumersTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithNonCachedConsumersTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms.request_reply;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.junit.Test;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.MessageTimeoutException;
+import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.config.ActiveMqTestUtils;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+/**
+ * @author Oleg Zhurakousky
+ */
+public class RequestReplyScenariosWithNonCachedConsumersTests {
+
+	@Test(expected=MessageTimeoutException.class)
+	public void messageCorrelationBasedOnRequestMessageIdOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ApplicationContext context = new ClassPathXmlApplicationContext("producer-no-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("optimizedMessageId", RequestReplyExchanger.class);
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueueC", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueC", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSMessageID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+	}
+
+	@Test
+	public void messageCorrelationBasedOnRequestMessageIdNonOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ApplicationContext context = new ClassPathXmlApplicationContext("producer-no-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("nonoptimizedMessageId", RequestReplyExchanger.class);
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueueD", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueD", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSMessageID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+	}
+
+	@Test
+	public void messageCorrelationBasedOnRequestCorrelationIdOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ApplicationContext context = new ClassPathXmlApplicationContext("producer-no-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("optimized", RequestReplyExchanger.class);
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueueA", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueA", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSCorrelationID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+	}
+
+	@Test(expected=MessageTimeoutException.class)
+	public void messageCorrelationBasedOnRequestCorrelationIdNonOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ApplicationContext context = new ClassPathXmlApplicationContext("producer-no-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("nonoptimized", RequestReplyExchanger.class);
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueueB", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueB", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSCorrelationID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithTempReplyQueuesTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithTempReplyQueuesTests.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms.request_reply;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.MessageDeliveryException;
+import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.config.ActiveMqTestUtils;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.jms.connection.CachingConnectionFactory;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+import org.springframework.jms.listener.DefaultMessageListenerContainer;
+import org.springframework.jms.listener.SessionAwareMessageListener;
+import org.springframework.jms.support.converter.SimpleMessageConverter;
+/**
+ * @author Oleg Zhurakousky
+ */
+public class RequestReplyScenariosWithTempReplyQueuesTests {
+
+	private final SimpleMessageConverter converter = new SimpleMessageConverter();
+
+	@Test
+	public void messageCorrelationBasedOnRequestMessageId() throws Exception{
+		ActiveMqTestUtils.prepare();
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("producer-temp-reply-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean(RequestReplyExchanger.class);
+		CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueue", Destination.class);
+
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				Destination replyTo = null;
+				try {
+					replyTo = requestMessage.getJMSReplyTo();
+				} catch (Exception e) {
+					fail();
+				}
+				jmsTemplate.send(replyTo, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						try {
+							TextMessage message = session.createTextMessage();
+							message.setText("bar");
+							message.setJMSCorrelationID(requestMessage.getJMSMessageID());
+							return message;
+						} catch (Exception e) {
+							// ignore
+						}
+						return null;
+					}
+				});
+			}
+		}).start();
+		gateway.exchange(new GenericMessage<String>("foo"));
+		context.close();
+	}
+
+	@Test
+	public void messageCorrelationBasedOnRequestCorrelationIdTimedOutFirstReply() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context =
+				new ClassPathXmlApplicationContext("producer-temp-reply-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean(RequestReplyExchanger.class);
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+
+		final Destination requestDestination = context.getBean("siOutQueue", Destination.class);
+
+		DefaultMessageListenerContainer dmlc = new DefaultMessageListenerContainer();
+		dmlc.setConnectionFactory(connectionFactory);
+		dmlc.setDestination(requestDestination);
+		dmlc.setMessageListener(new SessionAwareMessageListener<Message>() {
+
+			public void onMessage(Message message, Session session) {
+				Destination replyTo = null;
+				try {
+					replyTo = message.getJMSReplyTo();
+				} catch (Exception e) {
+					fail();
+				}
+				String requestPayload = (String) extractPayload(message);
+				if (requestPayload.equals("foo")){
+					try {
+						Thread.sleep(6000);
+					} catch (Exception e) {/*ignore*/}
+				}
+				try {
+					TextMessage replyMessage = session.createTextMessage();
+					replyMessage.setText(requestPayload);
+					replyMessage.setJMSCorrelationID(message.getJMSMessageID());
+					MessageProducer producer = session.createProducer(replyTo);
+					producer.send(replyMessage);
+				} catch (Exception e) {
+					// ignore. the test will fail
+				}
+			}
+		});
+		dmlc.afterPropertiesSet();
+		dmlc.start();
+
+		try {
+			gateway.exchange(new GenericMessage<String>("foo"));
+		} catch (Exception e) {
+			// ignore
+		}
+		Thread.sleep(1000);
+		try {
+			assertEquals("bar", gateway.exchange(new GenericMessage<String>("bar")).getPayload());
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		}
+		context.close();
+	}
+
+	@Test
+	public void brokenBrokerTest() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context =
+				new ClassPathXmlApplicationContext("broken-broker.xml", this.getClass());
+		BrokerService broker = context.getBean(BrokerService.class);
+		final RequestReplyExchanger gateway = context.getBean(RequestReplyExchanger.class);
+		Destination replyDestination = TestUtils.getPropertyValue(context.getBean("jog"), "handler.replyDestination", Destination.class);
+		int replyCounter = 0;
+		for (int i = 0; i < 5; i++) {
+			try {
+				gateway.exchange(new GenericMessage<String>(String.valueOf(i))).getPayload();
+				replyCounter++;
+			} catch (Exception e) {
+				// ignore
+			}
+			if (i == 0){
+				broker.removeDestination((ActiveMQDestination) replyDestination);
+			}
+		}
+		assertEquals(4, replyCounter);
+	}
+
+	@Test
+	public void testConcurrently() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context =
+				new ClassPathXmlApplicationContext("mult-producer-and-consumers-temp-reply.xml", this.getClass());
+		final RequestReplyExchanger gateway = context.getBean(RequestReplyExchanger.class);
+		Executor executor = Executors.newFixedThreadPool(10);
+		final int testNumbers = 100;
+		final CountDownLatch latch = new CountDownLatch(testNumbers);
+		final AtomicInteger failures = new AtomicInteger();
+		final AtomicInteger timeouts = new AtomicInteger();
+		final AtomicInteger missmatches = new AtomicInteger();
+		for (int i = 0; i < testNumbers; i++) {
+			final int y = i;
+			executor.execute(new Runnable() {
+				public void run() {
+					try {
+
+						String reply = (String) gateway.exchange(new GenericMessage<String>(String.valueOf(y))).getPayload();
+						if (!String.valueOf(y).equals(reply)){
+							missmatches.incrementAndGet();
+						}
+					} catch (Exception e) {
+						if (e instanceof MessageDeliveryException) {
+							timeouts.incrementAndGet();
+						}
+						else {
+							failures.incrementAndGet();
+						}
+					}
+//					if (latch.getCount()%100 == 0){
+//						long count = testNumbers-latch.getCount();
+//						if (count > 0){
+//							print(failures, timeouts, missmatches, testNumbers-latch.getCount());
+//						}
+//					}
+					latch.countDown();
+				}
+			});
+		}
+		latch.await();
+		print(failures, timeouts, missmatches, testNumbers);
+		assertEquals(0, missmatches.get());
+		assertEquals(0, failures.get());
+		assertEquals(0, timeouts.get());
+	}
+
+	private void print(AtomicInteger failures, AtomicInteger timeouts, AtomicInteger missmatches, long echangesProcessed){
+		System.out.println("============================");
+		System.out.println(echangesProcessed + " exchanges processed");
+		System.out.println("Failures: " + failures.get());
+		System.out.println("Timeouts: " + timeouts.get());
+		System.out.println("Missmatches: " + missmatches.get());
+		System.out.println("============================");
+	}
+
+	public static class MyRandomlySlowService{
+		Random random = new Random();
+		List<Integer> list = new ArrayList<Integer>();
+		public String secho(String value) throws Exception{
+			int i = random.nextInt(2000);
+//			if (i >= 2000){
+//				System.out.println("SLEEPIING: " + i);
+//			}
+			Thread.sleep(i);
+			return value;
+		}
+	}
+
+	private Object extractPayload(Message jmsMessage) {
+		try {
+			return converter.fromMessage(jmsMessage);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		}
+		return null;
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/broken-broker.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/broken-broker.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<int:gateway id="brkenBrokerGateway" default-request-channel="outGatewayInChannel"/>
+	
+	<int-jms:outbound-gateway id="jog" request-channel="outGatewayInChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="brokenBrokerRequestQueue"
+		correlation-key="JMSCorrelationID"/>
+		
+	<int-jms:inbound-gateway request-channel="jmsInChannel" 
+						     request-destination-name="brokenBrokerRequestQueue"
+							 connection-factory="connectionFactory"
+							 concurrent-consumers="10"
+							 reply-timeout="10000"/>
+							 		 
+	<int:service-activator input-channel="jmsInChannel" expression="payload"/>
+		
+	<bean id="connectionFactory" class="org.springframework.integration.jms.IntegrationCachingConnectionFactory" depends-on="broker">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="tcp://localhost:61623"/>		
+			</bean>
+		</property>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+		<property name="sessionCacheSize" value="10" />
+	</bean>
+	
+	<bean id="broker" class="org.apache.activemq.broker.BrokerService"
+		init-method="start">
+		<property name="persistent" value="false" />
+		<property name="useJmx" value="false" />
+		<property name="transportConnectorURIs">
+			<list>
+				<value>tcp://localhost:61623</value>
+			</list>
+		</property> 
+		<property name="deleteAllMessagesOnStartup" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/explicit-correlation-key.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/explicit-correlation-key.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd">
+
+	<int:gateway id="explicitCorrelationKeyGateway" default-request-channel="explicitCorrelationIn"/>
+
+	<int-jms:outbound-gateway request-channel="explicitCorrelationIn"
+	    connection-factory="connectionFactory" 
+		request-destination="explicitCorrelationJmsOut"
+		correlation-key="bar"/>
+		
+	<bean id="explicitCorrelationJmsOut" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="explicitCorrelationJmsOut"/>
+	</bean>
+	
+	<int-jms:inbound-gateway request-channel="requestIn" 
+	    request-destination="explicitCorrelationJmsOut"
+	    correlation-key="bar"
+		connection-factory="connectionFactory"/>
+	
+	<int:transformer input-channel="requestIn" expression="payload"/>
+	
+	<!--  -->
+	
+	<int:gateway id="explicitCorrelationKeyGatewayB" default-request-channel="explicitCorrelationInB"/>
+
+	<int-jms:outbound-gateway request-channel="explicitCorrelationInB"
+	    connection-factory="connectionFactory" 
+		request-destination="explicitCorrelationJmsOutB"
+		correlation-key="JMSCorrelationID"/>
+		
+	<bean id="explicitCorrelationJmsOutB" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="explicitCorrelationJmsOutB"/>
+	</bean>
+	
+	<int-jms:inbound-gateway request-channel="requestInB" 
+	    request-destination="explicitCorrelationJmsOutB"
+	    correlation-key="JMSCorrelationID"
+		connection-factory="connectionFactory"/>
+	
+	<int:transformer input-channel="requestInB" expression="payload"/>
+	
+	<!--  -->
+	
+	<int:gateway id="explicitCorrelationKeyGatewayC" default-request-channel="explicitCorrelationInC"/>
+
+	<int-jms:outbound-gateway id="outGateway" request-channel="explicitCorrelationInC"
+	    connection-factory="connectionFactory" 
+		request-destination="explicitCorrelationJmsOutC"
+		reply-destination-name="explicitCorrelationJmsInC"
+		correlation-key="foo"
+		receive-timeout="100"/>
+		
+	<bean id="explicitCorrelationJmsOutC" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="explicitCorrelationJmsOutC"/>
+	</bean>
+	
+	<int-jms:inbound-gateway id="inGateway" request-channel="requestInC" 
+	    request-destination="explicitCorrelationJmsOutC"
+	    correlation-key="foo"
+		connection-factory="connectionFactory"/>
+	
+	<int:transformer input-channel="requestInC">
+		<bean class="org.springframework.integration.jms.request_reply.RequestReplyScenariosWithCorrelationKeyProvidedTests.DelayedService"/>
+	</int:transformer>
+	
+	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>		
+			</bean>
+		</property>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+		<property name="sessionCacheSize" value="10" />
+	</bean>
+	
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/mult-producer-and-consumers-temp-reply.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/mult-producer-and-consumers-temp-reply.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<int:gateway id="multiOutGateway" default-request-channel="outGatewayInChannel"/>
+	
+	<int:channel id="outGatewayInChannel">
+		<int:dispatcher task-executor="executor"/>
+	</int:channel>
+	
+	<int-jms:outbound-gateway request-channel="outGatewayInChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="multiOutGatewayTempQueue"
+		correlation-key="JMSCorrelationID"/>
+		
+	<int-jms:inbound-gateway request-channel="jmsInChannel" 
+						     request-destination-name="multiOutGatewayTempQueue"
+							 connection-factory="connectionFactory"
+							 concurrent-consumers="10"
+							 reply-timeout="10000"/>
+							 
+	<int:channel id="jmsInChannel">
+		<int:dispatcher task-executor="executor"/>
+	</int:channel>
+							 
+	<int:service-activator input-channel="jmsInChannel">
+		<bean class="org.springframework.integration.jms.request_reply.RequestReplyScenariosWithTempReplyQueuesTests.MyRandomlySlowService"/>
+	</int:service-activator>
+		
+	<bean id="connectionFactory" class="org.springframework.integration.jms.IntegrationCachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>		
+			</bean>
+		</property>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+		<property name="sessionCacheSize" value="10" />
+	</bean>
+	
+	<task:executor id="executor" pool-size="20"/>
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-cached-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-cached-consumers.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd">
+
+	<int:gateway id="standardMessageIdCopyingConsumerWithOptimization" default-request-channel="jmsInOptimizedA"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInOptimizedA"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueOptimizedA"
+		reply-destination="siInQueueOptimizedA"
+		correlation-key="JMSCorrelationID"/>
+		
+	<bean id="siOutQueueOptimizedA" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueOptimizedA"/>
+	</bean>
+	
+	<bean id="siInQueueOptimizedA" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueOptimizedA"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="standardMessageIdCopyingConsumerWithoutOptimization" default-request-channel="jmsInNonOptimizedB"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedB"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueNonOptimizedB"
+		reply-destination="siInQueueNonOptimizedB"/>
+		
+	<bean id="siOutQueueNonOptimizedB" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueNonOptimizedB"/>
+	</bean>
+	
+	<bean id="siInQueueNonOptimizedB" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueNonOptimizedB"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="correlationPropagatingConsumerWithOptimization" default-request-channel="jmsInOptimizedC"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInOptimizedC"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueOptimizedC"
+		reply-destination="siInQueueOptimizedC"
+		correlation-key="JMSCorrelationID"/>
+		
+	<bean id="siOutQueueOptimizedC" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueOptimizedC"/>
+	</bean>
+	
+	<bean id="siInQueueOptimizedC" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueOptimizedC"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="correlationPropagatingConsumerWithoutOptimization" default-request-channel="jmsInNonOptimizedD"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedD"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueNonOptimizedD"
+		reply-destination="siInQueueNonOptimizedD"/>
+		
+	<bean id="siOutQueueNonOptimizedD" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueNonOptimizedD"/>
+	</bean>
+	
+	<bean id="siInQueueNonOptimizedD" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueNonOptimizedD"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="correlationPropagatingConsumerWithOptimizationDelayFirstReply" default-request-channel="jmsInE"/>
+
+	<int-jms:outbound-gateway id="fastGateway" request-channel="jmsInE"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueE"
+		reply-destination="siInQueueE"
+		receive-timeout="500"
+		correlation-key="JMSCorrelationID"/>
+		
+	<bean id="siOutQueueE" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueE"/>
+	</bean>
+	
+	<bean id="siInQueueE" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueE"/>
+	</bean>
+	 
+	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>		
+			</bean>
+		</property>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+		<property name="sessionCacheSize" value="10" />
+	</bean>
+	
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-no-cached-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-no-cached-consumers.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd">
+
+	<int:gateway id="optimized" default-request-channel="jmsInOptimized"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInOptimized"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueA"
+		reply-destination="siInQueueA"
+		correlation-key="JMSCorrelationID"/>
+		
+	<bean id="siOutQueueA" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueA.not.cached"/>
+	</bean>
+	
+	<bean id="siInQueueA" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueA.not.cached"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="nonoptimized" default-request-channel="jmsInNonOptimized"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInNonOptimized"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueB"
+		reply-destination="siInQueueB"/>
+		
+	<bean id="siOutQueueB" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueB.not.cached"/>
+	</bean>
+	
+	<bean id="siInQueueB" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueB.not.cached"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="optimizedMessageId" default-request-channel="jmsInOptimizedC"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInOptimizedC"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueC"
+		reply-destination="siInQueueC"
+		correlation-key="JMSCorrelationID"/>
+		
+	<bean id="siOutQueueC" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueC.not.cached"/>
+	</bean>
+	
+	<bean id="siInQueueC" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueC.not.cached"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="nonoptimizedMessageId" default-request-channel="jmsInNonOptimizedD"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedD"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueD"
+		reply-destination="siInQueueD"/>
+		
+	<bean id="siOutQueueD" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueD.not.cached"/>
+	</bean>
+	
+	<bean id="siInQueueD" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueD.not.cached"/>
+	</bean>
+	 
+	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>		
+			</bean>
+		</property>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="false" />
+		<property name="sessionCacheSize" value="10" />
+	</bean>
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-temp-reply-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-temp-reply-consumers.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd">
+
+	<int:gateway default-request-channel="jmsIn"/>
+
+	<int-jms:outbound-gateway request-channel="jmsIn"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueue"/>
+		
+	<bean id="siOutQueue" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueA"/>
+	</bean>
+	 
+	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>		
+			</bean>
+		</property>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+		<property name="sessionCacheSize" value="10" />
+	</bean>
+	
+</beans>

--- a/spring-integration-jms/src/test/resources/log4j.properties
+++ b/spring-integration-jms/src/test/resources/log4j.properties
@@ -1,11 +1,11 @@
-log4j.rootCategory=WARN, stdout
+log4j.rootCategory=ERROR, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c{2}:%L - %m%n
 
 
-log4j.category.org.springframework=WARN
-# log4j.category.org.springframework.integration=DEBUG
+log4j.category.org.springframework=ERROR
+#log4j.category.org.springframework.integration.jms=DEBUG
 # log4j.category.org.springframework.integration.jdbc=DEBUG
-log4j.category.org.springframework.jms=DEBUG
+log4j.category.org.springframework.jms=ERROR


### PR DESCRIPTION
Added support for caching reply consumers in the JmsOutboundGateway
Added support for reuse of temporary Reply queues in the JmsOutboundGateway
created IntegrationCachingConnectionFactory as a wrapper over CachingConnectionFactory
removed local Session and Consumer Caching since we can now rely on CCF
cleaned up JmsOutboundGateway (consolidated code that was different for tempReplyQueue and named replyQueeu scenarios)
added concurrency tests
