### PR TITLE
INT-2683, INT-2684 JmsOutboundGateway improvements

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
@@ -47,18 +47,18 @@ import org.springframework.util.Assert;
  * Message and sends that Message to a channel. If the 'expectReply' value is
  * <code>true</code>, it will also wait for a Spring Integration reply Message
  * and convert that into a JMS reply.
- * 
+ *
  * @author Mark Fisher
  * @author Juergen Hoeller
  * @author Oleg Zhurakousky
  */
-public class ChannelPublishingJmsMessageListener 
+public class ChannelPublishingJmsMessageListener
 		implements SessionAwareMessageListener<javax.jms.Message>, InitializingBean, TrackableComponent {
-	
+
 	protected final Log logger = LogFactory.getLog(getClass());
-	
+
 	private volatile boolean expectReply;
-	
+
 	private volatile MessageConverter messageConverter = new SimpleMessageConverter();
 
 	private volatile boolean extractRequestPayload = true;
@@ -80,7 +80,7 @@ public class ChannelPublishingJmsMessageListener
 	private volatile DestinationResolver destinationResolver = new DynamicDestinationResolver();
 
 	private volatile JmsHeaderMapper headerMapper = new DefaultJmsHeaderMapper();
-	
+
 	private final GatewayDelegate gatewayDelegate = new GatewayDelegate();
 
 	/**
@@ -93,27 +93,27 @@ public class ChannelPublishingJmsMessageListener
 	public void setComponentName(String componentName){
 		this.gatewayDelegate.setComponentName(componentName);
 	}
-	
+
 	public void setRequestChannel(MessageChannel requestChannel){
 		this.gatewayDelegate.setRequestChannel(requestChannel);
 	}
-	
+
 	public void setReplyChannel(MessageChannel replyChannel){
 		this.gatewayDelegate.setReplyChannel(replyChannel);
 	}
-	
+
 	public void setErrorChannel(MessageChannel errorChannel){
 		this.gatewayDelegate.setErrorChannel(errorChannel);
 	}
-	
+
 	public void setRequestTimeout(long requestTimeout){
 		this.gatewayDelegate.setRequestTimeout(requestTimeout);
 	}
-	
+
 	public void setReplyTimeout(long replyTimeout){
 		this.gatewayDelegate.setReplyTimeout(replyTimeout);
 	}
-	
+
 	public void setShouldTrack(boolean shouldTrack) {
 		this.gatewayDelegate.setShouldTrack(shouldTrack);
 	}
@@ -125,7 +125,7 @@ public class ChannelPublishingJmsMessageListener
 	public String getComponentType() {
 		return this.gatewayDelegate.getComponentType();
 	}
-	
+
 	/**
 	 * Set the default reply destination to send reply messages to. This will
 	 * be applied in case of a request message that does not carry a
@@ -189,7 +189,7 @@ public class ChannelPublishingJmsMessageListener
 	 * JMSMessageID from the request will be copied into the JMSCorrelationID of the reply
 	 * unless there is already a value in the JMSCorrelationID property of the newly created
 	 * reply Message in which case nothing will be copied. If the JMSCorrelationID of the
-	 * request Message should be copied into the JMSCorrelationID of the reply Message 
+	 * request Message should be copied into the JMSCorrelationID of the reply Message
 	 * instead, then this value should be set to "JMSCorrelationID".
 	 * Any other value will be treated as a JMS String Property to be copied as-is
 	 * from the request Message into the reply Message with the same property name.
@@ -200,7 +200,7 @@ public class ChannelPublishingJmsMessageListener
 
 	/**
 	 * Specify whether explicit QoS should be enabled for replies
-	 * (for timeToLive, priority, and deliveryMode settings). 
+	 * (for timeToLive, priority, and deliveryMode settings).
 	 */
 	public void setExplicitQosEnabledForReplies(boolean explicitQosEnabledForReplies) {
 		this.explicitQosEnabledForReplies = explicitQosEnabledForReplies;
@@ -224,7 +224,7 @@ public class ChannelPublishingJmsMessageListener
 	 * converting between JMS Messages and Spring Integration Messages.
 	 * If none is provided, a {@link SimpleMessageConverter} will
 	 * be used.
-	 * 
+	 *
 	 * @param messageConverter
 	 */
 	public void setMessageConverter(MessageConverter messageConverter) {
@@ -268,10 +268,10 @@ public class ChannelPublishingJmsMessageListener
 				logger.debug("converted JMS Message [" + jmsMessage + "] to integration Message payload [" + result + "]");
 			}
 		}
-	
+
 		Map<String, Object> headers = headerMapper.toHeaders(jmsMessage);
 		Message<?> requestMessage = (result instanceof Message<?>) ?
-				MessageBuilder.fromMessage((Message<?>) result).copyHeaders(headers).build() : 
+				MessageBuilder.fromMessage((Message<?>) result).copyHeaders(headers).build() :
 				MessageBuilder.withPayload(result).copyHeaders(headers).build();
 		if (!this.expectReply) {
 			this.gatewayDelegate.send(requestMessage);
@@ -292,7 +292,11 @@ public class ChannelPublishingJmsMessageListener
 						headerMapper.fromHeaders(replyMessage.getHeaders(), jmsReply);
 						this.copyCorrelationIdFromRequestToReply(jmsMessage, jmsReply);
 						this.sendReply(jmsReply, destination, session);
-					}
+				    }
+					catch (javax.jms.IllegalStateException e) {
+					    logger.debug("Reply can no longer be sent because: '" + e.getMessage() +
+							"'. Most likely cause is that the reply destination '" + destination + "' may no longer exist");
+				    }
 					catch (RuntimeException e) {
 						logger.error("Failed to generate JMS Reply Message from: " + replyResult, e);
 						throw e;
@@ -308,15 +312,15 @@ public class ChannelPublishingJmsMessageListener
 	public void afterPropertiesSet()  {
 		this.gatewayDelegate.afterPropertiesSet();
 	}
-	
+
 	protected void start(){
 		this.gatewayDelegate.start();
 	}
-	
+
 	protected void stop(){
 		this.gatewayDelegate.stop();
 	}
-	
+
 	private void copyCorrelationIdFromRequestToReply(javax.jms.Message requestMessage, javax.jms.Message replyMessage) throws JMSException {
 		if (this.correlationKey != null) {
 			if (this.correlationKey.equals("JMSCorrelationID")) {
@@ -416,17 +420,20 @@ public class ChannelPublishingJmsMessageListener
 			this.isTopic = isTopic;
 		}
 	}
-	
+
 	private class GatewayDelegate extends MessagingGatewaySupport {
 
+		@Override
 		protected void send(Object request) {
 			super.send(request);
 		}
-		
+
+		@Override
 		protected Message<?> sendAndReceiveMessage(Object request) {
 			return super.sendAndReceiveMessage(request);
 		}
 
+		@Override
 		public String getComponentType() {
 			if (expectReply) {
 				return "jms:inbound-gateway";

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
@@ -293,10 +293,6 @@ public class ChannelPublishingJmsMessageListener
 						this.copyCorrelationIdFromRequestToReply(jmsMessage, jmsReply);
 						this.sendReply(jmsReply, destination, session);
 				    }
-					catch (javax.jms.IllegalStateException e) {
-					    logger.debug("Reply can no longer be sent because: '" + e.getMessage() +
-							"'. Most likely cause is that the reply destination '" + destination + "' may no longer exist");
-				    }
 					catch (RuntimeException e) {
 						logger.error("Failed to generate JMS Reply Message from: " + replyResult, e);
 						throw e;

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.jms;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -23,6 +24,7 @@ import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.DeliveryMode;
 import javax.jms.Destination;
+import javax.jms.InvalidDestinationException;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
@@ -40,6 +42,7 @@ import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.jms.connection.CachingConnectionFactory;
 import org.springframework.jms.connection.ConnectionFactoryUtils;
 import org.springframework.jms.support.JmsUtils;
 import org.springframework.jms.support.converter.MessageConverter;
@@ -47,16 +50,24 @@ import org.springframework.jms.support.converter.SimpleMessageConverter;
 import org.springframework.jms.support.destination.DestinationResolver;
 import org.springframework.jms.support.destination.DynamicDestinationResolver;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * An outbound Messaging Gateway for request/reply JMS.
- * 
+ *
  * @author Mark Fisher
  * @author Arjen Poutsma
  * @author Juergen Hoeller
  * @author Oleg Zhurakousky
  */
 public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
+
+	private final String gatewayId = UUID.randomUUID().toString();
+
+	private volatile boolean cachedConsumers;
+
+	private final Map<Long, Destination> tempQueuePerSessionMap = new HashMap<Long, Destination>(10);
 
 	private volatile Destination requestDestination;
 
@@ -182,7 +193,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	 * Specify whether the request destination is a Topic. This value is
 	 * necessary when providing a destination name for a Topic rather than
 	 * a destination reference.
-	 * 
+	 *
 	 * @param requestPubSubDomain true if the request destination is a Topic
 	 */
 	public void setRequestPubSubDomain(boolean requestPubSubDomain) {
@@ -193,7 +204,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	 * Specify whether the reply destination is a Topic. This value is
 	 * necessary when providing a destination name for a Topic rather than
 	 * a destination reference.
-	 * 
+	 *
 	 * @param replyPubSubDomain true if the reply destination is a Topic
 	 */
 	public void setReplyPubSubDomain(boolean replyPubSubDomain) {
@@ -240,15 +251,21 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	}
 
 	/**
-	 * Provide the name of a JMS property that should hold a generated UUID that
-	 * the receiver of the JMS Message would expect to represent the CorrelationID.
-	 * When waiting for the reply Message, a MessageSelector will be configured
-	 * to match this property name and the UUID value that was sent in the request.
-	 * If this value is NULL (the default) then the reply consumer's MessageSelector
-	 * will be expecting the JMSCorrelationID to equal the Message ID of the request.
-	 * If you want to store the outbound correlation UUID value in the actual
-	 * JMSCorrelationID property, then set this value to "JMSCorrelationID".
-	 * However, any other value will be treated as a JMS String Property.
+	 * Provide the name of a JMS property that should hold a generated CorrelationID.
+	 * If NO value is provided for this attribute, then the reply consumer's
+	 * MessageSelector will be expecting the JMSCorrelationID to equal the Message ID
+	 * of the request. However this would also mean that the MessageSelector will be different
+	 * for each new message, thus requiring a new reply consumer to be created for each Message sent.
+	 * Although this is a very common JMS exchange pattern it is not optimal for high throughput	 request/reply
+	 * applications. Most MOMs (including Spring Integration's Inbound Gateway) also support propagation
+	 * of the 'CorrelationID' of the consumed request message into the 'CorrelationID' of the newly produced
+	 * reply message. This also allows us to use an optimized value generation algorithm which results in caching
+	 * and reuse of reply consumers resulting in significant performance improvement of the request/reply
+	 * scenarios. So if you have a Spring JMS consumer (e.g.,  Spring Integration's Inbound Gateway) or
+	 * you know that your MOM supports propagation of the 'CorrelationID' it is highly recommended to set this
+	 * value to 'JMSCorrelationID'. If you set this value to something else the receiving end must now how
+	 * to propagate it. For example: if the receiving end is an inbound-gateway its correlation-key attribute
+	 * must have the same value.
 	 */
 	public void setCorrelationKey(String correlationKey) {
 		this.correlationKey = correlationKey;
@@ -275,8 +292,8 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	}
 
 	/**
-	 * This property describes how a JMS Message should be generated from the 
-	 * Spring Integration Message. If set to 'true', the body of the JMS Message will be 
+	 * This property describes how a JMS Message should be generated from the
+	 * Spring Integration Message. If set to 'true', the body of the JMS Message will be
 	 * created from the Spring Integration Message's payload (via the MessageConverter).
 	 * If set to 'false', then the entire Spring Integration Message will serve as
 	 * the base for JMS Message creation. Since the JMS Message is created by the
@@ -284,7 +301,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	 * the entire Spring Integration Message or only its payload.
 	 * <br>
 	 * Default is 'true'
-	 * 
+	 *
 	 * @param extractRequestPayload
 	 */
 	public void setExtractRequestPayload(boolean extractRequestPayload) {
@@ -297,7 +314,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	 * created from the JMS Reply Message's body (via MessageConverter).
 	 * Otherwise, the entire JMS Message will become the payload of the
 	 * Spring Integration Message.
-	 * 
+	 *
 	 * @param extractReplyPayload
 	 */
 	public void setExtractReplyPayload(boolean extractReplyPayload) {
@@ -312,50 +329,9 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 		this.setOutputChannel(replyChannel);
 	}
 
+	@Override
 	public String getComponentType() {
 		return "jms:outbound-gateway";
-	}
-
-	private Destination getRequestDestination(Message<?> message, Session session) throws JMSException {
-		if (this.requestDestination != null) {
-			return this.requestDestination;
-		}
-		if (this.requestDestinationName != null) {
-			return this.resolveRequestDestination(this.requestDestinationName, session);
-		}
-		if (this.requestDestinationExpressionProcessor != null) {
-			Object result = this.requestDestinationExpressionProcessor.processMessage(message);
-			if (result instanceof Destination) {
-				return (Destination) result;
-			}
-			if (result instanceof String) {
-				return this.resolveRequestDestination((String) result, session);
-			}
-			throw new MessageDeliveryException(message,
-					"Evaluation of requestDestinationExpression failed to produce a Destination or destination name. Result was: " + result);
-		}
-		throw new MessageDeliveryException(message,
-				"No requestDestination, requestDestinationName, or requestDestinationExpression has been configured.");
-	}
-
-	private Destination resolveRequestDestination(String requestDestinationName, Session session) throws JMSException {
-		Assert.notNull(this.destinationResolver,
-				"DestinationResolver is required when relying upon the 'requestDestinationName' property.");
-		return this.destinationResolver.resolveDestinationName(
-				session, requestDestinationName, this.requestPubSubDomain);
-	}
-
-	private Destination getReplyDestination(Session session) throws JMSException {
-		if (this.replyDestination != null) {
-			return this.replyDestination;
-		}
-		if (this.replyDestinationName != null) {
-			Assert.notNull(this.destinationResolver,
-					"DestinationResolver is required when relying upon the 'replyDestinationName' property.");
-			return this.destinationResolver.resolveDestinationName(
-					session, this.replyDestinationName, this.replyPubSubDomain);
-		}
-		return session.createTemporaryQueue();
 	}
 
 	@Override
@@ -374,6 +350,21 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 				this.requestDestinationExpressionProcessor.setConversionService(getConversionService());
 			}
 			this.initialized = true;
+			if (this.connectionFactory instanceof CachingConnectionFactory){
+				this.cachedConsumers = ((CachingConnectionFactory)this.connectionFactory).isCacheConsumers();
+			}
+
+			if (this.cachedConsumers && !StringUtils.hasText(this.correlationKey)){
+				logger.warn("Caching consumers  without custom correlation-key can lead to " +
+						"significant performance degradation and OutOfMemoryError. Either do not use consumer caching " +
+						"by setting 'cacheConsumers' attribute to FALSE in the CachingConnectionFactory or set 'correlation-key'" +
+						"to a value (e.g., correlation-key=\"JMSCorrelationID\")");
+			}
+			else if (!this.cachedConsumers && StringUtils.hasText(this.correlationKey)){
+				logger.warn("Using custom 'correlationKey' without caching consumers can lead to " +
+						"significant performance degradation. Consider using the CachingConnectionFactory " +
+						"with 'cacheConsumers' attribute set to TRUE");
+			}
 		}
 	}
 
@@ -411,161 +402,6 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 		}
 	}
 
-	private javax.jms.Message sendAndReceive(Message<?> requestMessage) throws JMSException {
-		Connection connection = this.createConnection();
-		Session session = null;
-		Destination replyTo = null;
-		try {
-			session = this.createSession(connection);
-
-			// convert to JMS Message
-			Object objectToSend = requestMessage;
-			if (this.extractRequestPayload) {
-				objectToSend = requestMessage.getPayload();
-			}
-			javax.jms.Message jmsRequest = this.messageConverter.toMessage(objectToSend, session);
-
-			// map headers
-			headerMapper.fromHeaders(requestMessage.getHeaders(), jmsRequest);
-
-			// TODO: support a JmsReplyTo header in the SI Message?
-			replyTo = this.getReplyDestination(session);
-			jmsRequest.setJMSReplyTo(replyTo);
-			connection.start();
-
-			Integer priority = requestMessage.getHeaders().getPriority();
-			if (priority == null) {
-				priority = this.priority;
-			}
-			javax.jms.Message replyMessage = null;
-			Destination requestDestination = this.getRequestDestination(requestMessage, session);
-			if (this.correlationKey != null) {
-				replyMessage = this.doSendAndReceiveWithGeneratedCorrelationId(requestDestination, jmsRequest, replyTo, session, priority);
-			}
-			else if (replyTo instanceof TemporaryQueue || replyTo instanceof TemporaryTopic) {
-				replyMessage = this.doSendAndReceiveWithTemporaryReplyToDestination(requestDestination, jmsRequest, replyTo, session, priority);
-			}
-			else {
-				replyMessage = this.doSendAndReceiveWithMessageIdCorrelation(requestDestination, jmsRequest, replyTo, session, priority);
-			}
-			return replyMessage;
-		}
-		finally {
-			JmsUtils.closeSession(session);
-			this.deleteDestinationIfTemporary(replyTo);
-			ConnectionFactoryUtils.releaseConnection(connection, this.connectionFactory, true);
-		}
-	}
-
-	/**
-	 * Creates the MessageConsumer before sending the request Message since we are generating our own correlationId value for the MessageSelector.
-	 */
-	private javax.jms.Message doSendAndReceiveWithGeneratedCorrelationId(Destination requestDestination,
-			javax.jms.Message jmsRequest, Destination replyTo, Session session, int priority) throws JMSException {
-		MessageProducer messageProducer = null;
-		MessageConsumer messageConsumer = null;
-		try {
-			messageProducer = session.createProducer(requestDestination);
-			String correlationId = UUID.randomUUID().toString().replaceAll("'", "''");
-			Assert.state(this.correlationKey != null, "correlationKey must not be null");
-			String messageSelector = null;
-			if (this.correlationKey.equals("JMSCorrelationID")) {
-				jmsRequest.setJMSCorrelationID(correlationId);
-				messageSelector = "JMSCorrelationID = '" + correlationId + "'";
-			}
-			else {
-				jmsRequest.setStringProperty(this.correlationKey, correlationId);
-				messageSelector = this.correlationKey + " = '" + correlationId + "'";
-			}
-			messageConsumer = session.createConsumer(replyTo, messageSelector);
-			this.sendRequestMessage(jmsRequest, messageProducer, priority);
-			return this.receiveReplyMessage(messageConsumer);
-		}
-		finally {
-			JmsUtils.closeMessageProducer(messageProducer);
-			JmsUtils.closeMessageConsumer(messageConsumer);
-		}
-	}
-
-	/**
-	 * Creates the MessageConsumer before sending the request Message since we do not need any correlation.
-	 */
-	private javax.jms.Message doSendAndReceiveWithTemporaryReplyToDestination(Destination requestDestination,
-			javax.jms.Message jmsRequest, Destination replyTo, Session session, int priority) throws JMSException {
-		MessageProducer messageProducer = null;
-		MessageConsumer messageConsumer = null;
-		try {
-			messageProducer = session.createProducer(requestDestination);
-			messageConsumer = session.createConsumer(replyTo);
-			this.sendRequestMessage(jmsRequest, messageProducer, priority);
-			return this.receiveReplyMessage(messageConsumer);
-		}
-		finally {
-			JmsUtils.closeMessageProducer(messageProducer);
-			JmsUtils.closeMessageConsumer(messageConsumer);
-		}
-	}
-
-	/**
-	 * Creates the MessageConsumer after sending the request Message since we need the MessageID for correlation with a MessageSelector.
-	 */
-	private javax.jms.Message doSendAndReceiveWithMessageIdCorrelation(Destination requestDestination,
-			javax.jms.Message jmsRequest, Destination replyTo, Session session, int priority) throws JMSException {
-		if (replyTo instanceof Topic && logger.isWarnEnabled()) {
-			logger.warn("Relying on the MessageID for correlation is not recommended when using a Topic as the replyTo Destination " +
-					"because that ID can only be provided to a MessageSelector after the reuqest Message has been sent thereby " +
-					"creating a race condition where a fast response might be sent before the MessageConsumer has been created. " +
-					"Consider providing a value to the 'correlationKey' property of this gateway instead. Then the MessageConsumer " +
-					"will be created before the request Message is sent."); 
-		}
-		MessageProducer messageProducer = null;
-		MessageConsumer messageConsumer = null;
-		try {
-			messageProducer = session.createProducer(requestDestination);
-			this.sendRequestMessage(jmsRequest, messageProducer, priority);
-			String messageId = jmsRequest.getJMSMessageID().replaceAll("'", "''");
-			String messageSelector = "JMSCorrelationID = '" + messageId + "'";
-			messageConsumer = session.createConsumer(replyTo, messageSelector);
-			return this.receiveReplyMessage(messageConsumer);
-		}
-		finally {
-			JmsUtils.closeMessageProducer(messageProducer);
-			JmsUtils.closeMessageConsumer(messageConsumer);
-		}
-	}
-
-	private void sendRequestMessage(javax.jms.Message jmsRequest, MessageProducer messageProducer, int priority) throws JMSException {
-		if (this.explicitQosEnabled) {
-			messageProducer.send(jmsRequest, this.deliveryMode, priority, this.timeToLive);
-		}
-		else {
-			messageProducer.send(jmsRequest);
-		}
-	}
-
-	private javax.jms.Message receiveReplyMessage(MessageConsumer messageConsumer) throws JMSException {
-		return (this.receiveTimeout >= 0) ? messageConsumer.receive(receiveTimeout) : messageConsumer.receive();
-	}
-
-	/**
-	 * Deletes either a {@link TemporaryQueue} or {@link TemporaryTopic}.
-	 * Ignores any other {@link Destination} type and also ignores any
-	 * {@link JMSException}s that may be thrown when attempting to delete.
-	 */
-	private void deleteDestinationIfTemporary(Destination destination) {
-		try {
-			if (destination instanceof TemporaryQueue) { 
-				((TemporaryQueue) destination).delete();
-			}
-			else if (destination instanceof TemporaryTopic) {
-				((TemporaryTopic) destination).delete();
-			}
-		}
-		catch (JMSException e) {
-			// ignore
-		}
-	}
-
 	/**
 	 * Create a new JMS Connection for this JMS gateway.
 	 */
@@ -580,4 +416,293 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 		return connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
 	}
 
+	private Destination determineRequestDestination(Message<?> message, Session session) throws JMSException {
+		if (this.requestDestination != null) {
+			return this.requestDestination;
+		}
+
+		if (this.requestDestinationName != null) {
+			return this.resolveRequestDestination(this.requestDestinationName, session);
+		}
+
+		if (this.requestDestinationExpressionProcessor != null) {
+			Object result = this.requestDestinationExpressionProcessor.processMessage(message);
+			if (result instanceof Destination) {
+				return (Destination) result;
+			}
+			if (result instanceof String) {
+				return this.resolveRequestDestination((String) result, session);
+			}
+			throw new MessageDeliveryException(message,
+					"Evaluation of requestDestinationExpression failed to produce a Destination or destination name. Result was: " + result);
+		}
+		throw new MessageDeliveryException(message,
+				"No requestDestination, requestDestinationName, or requestDestinationExpression has been configured.");
+	}
+
+	private Destination resolveRequestDestination(String requestDestinationName, Session session) throws JMSException {
+		Assert.notNull(this.destinationResolver,
+				"DestinationResolver is required when relying upon the 'requestDestinationName' property.");
+		return this.destinationResolver.resolveDestinationName(
+				session, requestDestinationName, this.requestPubSubDomain);
+	}
+
+	private Destination determineReplyDestination(Session session, long sessionId) throws JMSException {
+		if (this.replyDestination != null){
+			return this.replyDestination;
+		}
+		if (StringUtils.hasText(this.replyDestinationName)) {
+			Assert.notNull(this.destinationResolver,
+					"DestinationResolver is required when relying upon the 'replyDestinationName' property.");
+			return this.destinationResolver.resolveDestinationName(
+					session, this.replyDestinationName, this.replyPubSubDomain);
+		}
+
+		if (this.tempQueuePerSessionMap.containsKey(sessionId)){
+			return this.tempQueuePerSessionMap.get(sessionId);
+		}
+
+		if (this.cachedConsumers && StringUtils.hasText(this.correlationKey)){
+			// will rely on LIKE  MessageSelector. Only need one TemporaryQueue for reply
+			// as if the replyDestinationName was specified
+			this.replyDestination = session.createTemporaryQueue();
+			return this.replyDestination;
+		}
+		return session.createTemporaryQueue();
+	}
+
+	private javax.jms.Message sendAndReceive(Message<?> requestMessage) throws JMSException {
+		Connection connection = this.createConnection();
+		Session session = null;
+		Destination replyTo = null;
+		long sessionId = 0;
+		try {
+			session = this.createSession(connection);
+			sessionId = ObjectUtils.getIdentityHexString(session).hashCode();
+
+			// convert to JMS Message
+			Object objectToSend = requestMessage;
+			if (this.extractRequestPayload) {
+				objectToSend = requestMessage.getPayload();
+			}
+			javax.jms.Message jmsRequest = this.messageConverter.toMessage(objectToSend, session);
+
+			// map headers
+			headerMapper.fromHeaders(requestMessage.getHeaders(), jmsRequest);
+
+			// TODO: support a JmsReplyTo header in the SI Message?
+			replyTo = this.determineReplyDestination(session, sessionId);
+
+			connection.start();
+
+			Integer priority = requestMessage.getHeaders().getPriority();
+			if (priority == null) {
+				priority = this.priority;
+			}
+
+			Destination requestDestinationToUse = this.determineRequestDestination(requestMessage, session);
+
+			javax.jms.Message replyMessage = this.doSendAndReceive(requestDestinationToUse, jmsRequest, replyTo, session, priority, sessionId);
+
+			return replyMessage;
+		}
+		finally {
+			JmsUtils.closeSession(session);
+			if (this.deleteDestinationIfTemporary(replyTo)){
+				this.tempQueuePerSessionMap.remove(sessionId);
+			}
+			else {
+				this.tempQueuePerSessionMap.put(sessionId, replyTo);
+			}
+			ConnectionFactoryUtils.releaseConnection(connection, this.connectionFactory, true);
+		}
+	}
+
+	/**
+	 * Creates the MessageConsumer after sending the request Message since we need the MessageID for correlation with a MessageSelector.
+	 */
+	private javax.jms.Message doSendAndReceive(Destination requestDestinationToUse,
+			javax.jms.Message jmsRequest, Destination replyTo, Session session, int priority, long sessionId) throws JMSException {
+
+		MessageProducer messageProducer = session.createProducer(requestDestinationToUse);
+
+		try {
+			if (StringUtils.hasText(this.correlationKey)){
+
+				String messageCorrelationId = String.valueOf(System.currentTimeMillis() +
+    					                      String.valueOf(System.nanoTime()));
+
+				String consumerCorrelationId = gatewayId + "_" + sessionId;
+
+				if (this.correlationKey.equals("JMSCorrelationID")) {
+					jmsRequest.setJMSCorrelationID(consumerCorrelationId + "$" + messageCorrelationId);
+				}
+				else {
+					jmsRequest.setStringProperty(correlationKey, consumerCorrelationId + "$" + messageCorrelationId);
+				}
+				String messageSelector = correlationKey + " LIKE '" + consumerCorrelationId + "%'";
+
+				return this.exchange(messageProducer, jmsRequest, session, sessionId, replyTo, priority, messageSelector, messageCorrelationId);
+			}
+			else {
+				if (replyTo instanceof Topic && logger.isWarnEnabled()) {
+					logger.warn("Relying on the MessageID for correlation is not recommended when using a Topic as the replyTo Destination " +
+							"because that ID can only be provided to a MessageSelector after the request Message has been sent thereby " +
+							"creating a race condition where a fast response might be sent before the MessageConsumer has been created. " +
+							"Consider providing a value to the 'correlationKey' property of this gateway instead. Then the MessageConsumer " +
+							"will be created before the request Message is sent.");
+				}
+				return this.exchange(messageProducer, jmsRequest, session, sessionId, replyTo, priority, null, null);
+			}
+		}
+		finally {
+			JmsUtils.closeMessageProducer(messageProducer);
+		}
+	}
+
+	private MessageConsumer createMessageConsumer(Session session, Destination replyTo, String messageSelector, long sessionId) throws JMSException{
+		try {
+			if (StringUtils.hasText(messageSelector)){
+				if (this.cachedConsumers && replyTo instanceof TemporaryQueue){
+					return TemporaryConsumerUtils.createConsumer(session, replyTo, messageSelector);
+				}
+				return session.createConsumer(replyTo, messageSelector);
+			}
+			else {
+				if (this.cachedConsumers && replyTo instanceof TemporaryQueue){
+					return TemporaryConsumerUtils.createConsumer(session, replyTo, null);
+				}
+				return session.createConsumer(replyTo);
+			}
+		}
+		catch (InvalidDestinationException e) {
+			if (this.tempQueuePerSessionMap.containsKey(sessionId)){
+				this.tempQueuePerSessionMap.remove(sessionId);
+			}
+			if (this.replyDestination instanceof TemporaryQueue){
+				this.replyDestination = null;
+			}
+			throw e;
+		}
+	}
+
+	private javax.jms.Message exchange(MessageProducer messageProducer, javax.jms.Message jmsRequest,
+			Session session, long sessionId, Destination replyTo, int priority,
+			String messageSelector, String messageCorrelationId) throws JMSException {
+
+		MessageConsumer messageConsumer = null;
+		jmsRequest.setJMSReplyTo(replyTo);
+		try {
+			if (StringUtils.hasText(messageSelector)){
+				messageConsumer = this.createMessageConsumer(session, replyTo, messageSelector, sessionId);
+				this.sendRequestMessage(jmsRequest, messageProducer, priority);
+			}
+			else {
+				this.sendRequestMessage(jmsRequest, messageProducer, priority);
+				messageCorrelationId = jmsRequest.getJMSMessageID().replaceAll("'", "''");
+				if (replyTo instanceof TemporaryQueue){
+					messageConsumer = this.createMessageConsumer(session, replyTo, null, sessionId);
+				}
+				else {
+					messageSelector = "JMSCorrelationID = '" + messageCorrelationId + "'";
+					messageConsumer = this.createMessageConsumer(session, replyTo, messageSelector, sessionId);
+				}
+			}
+
+			try {
+				javax.jms.Message jmsMessage = this.receiveCorrelatedReplyMessage(messageConsumer, messageCorrelationId, correlationKey);
+				return jmsMessage;
+			}
+			catch (javax.jms.IllegalStateException e) {
+				// clear up the temp queue cache
+				if (this.replyDestination != null && this.replyDestination instanceof TemporaryQueue){
+					this.replyDestination = null;
+				}
+				if (this.replyDestination instanceof TemporaryQueue){
+					this.replyDestination = null;
+				}
+				throw e;
+			}
+		}
+		finally  {
+			JmsUtils.closeMessageConsumer(messageConsumer);
+		}
+	}
+
+	private javax.jms.Message receiveCorrelatedReplyMessage(MessageConsumer messageConsumer,
+			String messageCorrelationIdToMatch, String correlationKey) throws JMSException {
+
+		long timeout = this.receiveTimeout;
+		long startTime = System.currentTimeMillis();
+		javax.jms.Message replyMessage = (this.receiveTimeout >= 0) ? messageConsumer.receive(receiveTimeout) : messageConsumer.receive();
+		long elapsedTime = System.currentTimeMillis() - startTime;
+		while (replyMessage != null){
+
+			String jmsCorrelationId = null;
+			if (correlationKey != null && !correlationKey.equals("JMSCorrelationID")){
+				jmsCorrelationId = replyMessage.getStringProperty(correlationKey);
+			}
+			else {
+				jmsCorrelationId = replyMessage.getJMSCorrelationID();
+			}
+
+			if (StringUtils.hasText(jmsCorrelationId) && StringUtils.hasText(messageCorrelationIdToMatch)){
+				boolean messageMatched = jmsCorrelationId.contains(messageCorrelationIdToMatch);
+
+				if (messageMatched){
+					return replyMessage;
+				}
+				else {
+					// Essentially we are discarding the uncorrelated message here and moving on to
+					// the next one since we can no longer communicate with its originating producer
+					// since it has already timed out waiting for the reply. We are also honoring the original timeout
+					if (this.logger.isDebugEnabled()){
+						this.logger.debug("Discarded late arriving reply: " + replyMessage);
+					}
+					if (timeout > 0){
+						timeout = timeout - elapsedTime;
+						replyMessage = messageConsumer.receive(timeout);
+					}
+					else {
+						return null;
+					}
+				}
+			}
+			else {
+				return replyMessage;
+			}
+		}
+
+		return null;
+	}
+
+	private void sendRequestMessage(javax.jms.Message jmsRequest, MessageProducer messageProducer, int priority) throws JMSException {
+		if (this.explicitQosEnabled) {
+			messageProducer.send(jmsRequest, this.deliveryMode, priority, this.timeToLive);
+		}
+		else {
+			messageProducer.send(jmsRequest);
+		}
+	}
+
+	/**
+	 * Deletes either a {@link TemporaryQueue} or {@link TemporaryTopic}.
+	 * Ignores any other {@link Destination} type and also ignores any
+	 * {@link JMSException}s that may be thrown when attempting to delete.
+	 */
+	private boolean deleteDestinationIfTemporary(Destination destination) {
+		try {
+			if (destination instanceof TemporaryQueue) {
+				((TemporaryQueue) destination).delete();
+			}
+			else if (destination instanceof TemporaryTopic) {
+				((TemporaryTopic) destination).delete();
+			}
+			return true;
+		}
+		catch (JMSException e) {
+			// ignore
+		}
+		return false;
+	}
 }

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
@@ -795,7 +795,8 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	 */
 	private boolean isCachedSession(Session session){
 		try {
-			if (this.cachedSessionView.containsKey(Session.AUTO_ACKNOWLEDGE)){
+			// this.cacheConsumers means we are using CCF
+			if (this.cachedConsumers && this.cachedSessionView.containsKey(Session.AUTO_ACKNOWLEDGE)){
 				List<Session> cachedSessions = this.cachedSessionView.get(Session.AUTO_ACKNOWLEDGE);
 				if (cachedSessions != null){
 					return cachedSessions.contains(session);

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
@@ -695,6 +695,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 						timeLeft = timeLeft - (System.currentTimeMillis() - startTime);
 						if (timeLeft < 0){
 							theOneIWant = true;
+							replyMessage = null;
 						}
 						else {
 							replyMessage = messageConsumer.receive(timeLeft);

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
@@ -589,7 +589,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 
 			this.sendRequestMessage(jmsRequest, messageProducer, priority);
 
-			return this.doReceive(messageConsumer, this.correlationKey, messageCorrelationId, sessionId);
+			return this.doReceive(messageConsumer, this.correlationKey, messageCorrelationId, sessionId, false);
 		}
 		finally  {
 			JmsUtils.closeMessageConsumer(messageConsumer);
@@ -600,6 +600,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 			Session session, long sessionId, Destination replyTo, int priority) throws JMSException {
 
 		MessageConsumer messageConsumer = null;
+		boolean correlationIdPropagated = false;
 		try {
 			String messageCorrelationId = null;
 
@@ -612,17 +613,30 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 							"will be created before the request Message is sent.");
 				}
 				this.sendRequestMessage(jmsRequest, messageProducer, priority);
-				messageCorrelationId = jmsRequest.getJMSMessageID().replaceAll("'", "''");
+
+				if (jmsRequest.getJMSCorrelationID() != null){
+					messageCorrelationId = jmsRequest.getJMSCorrelationID();
+					correlationIdPropagated = true;
+				}
+				else {
+					messageCorrelationId = jmsRequest.getJMSMessageID().replaceAll("'", "''");
+				}
 				String messageSelector = "JMSCorrelationID = '" + messageCorrelationId + "'";
 				messageConsumer = this.createMessageConsumer(session, replyTo, messageSelector, sessionId);
 			}
 			else {
 				messageConsumer = this.createMessageConsumer(session, replyTo, null, sessionId);
 				this.sendRequestMessage(jmsRequest, messageProducer, priority);
-				messageCorrelationId = jmsRequest.getJMSMessageID().replaceAll("'", "''");
+				if (jmsRequest.getJMSCorrelationID() != null){
+					messageCorrelationId = jmsRequest.getJMSCorrelationID();
+					correlationIdPropagated = true;
+				}
+				else {
+					messageCorrelationId = jmsRequest.getJMSMessageID().replaceAll("'", "''");
+				}
 			}
 
-			return this.doReceive(messageConsumer, null, messageCorrelationId, sessionId);
+			return this.doReceive(messageConsumer, null, messageCorrelationId, sessionId, correlationIdPropagated);
 		}
 		finally  {
 			JmsUtils.closeMessageConsumer(messageConsumer);
@@ -632,9 +646,10 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	/**
 	 * Will perform clean up if failures detected during message receive
 	 */
-	private javax.jms.Message doReceive(MessageConsumer messageConsumer, String correlationKey, String messageCorrelationIdToMatch, long sessionId) throws JMSException{
+	private javax.jms.Message doReceive(MessageConsumer messageConsumer, String correlationKey, String messageCorrelationIdToMatch, long sessionId,
+			boolean correlationIdPropagated) throws JMSException{
 		try {
-			return this.receiveCorrelatedReplyMessage(messageConsumer, correlationKey, messageCorrelationIdToMatch);
+			return this.receiveCorrelatedReplyMessage(messageConsumer, correlationKey, messageCorrelationIdToMatch, correlationIdPropagated);
 		}
 		catch (javax.jms.IllegalStateException e) {
 			this.clearDestination(sessionId);
@@ -643,12 +658,11 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 	}
 
 	private javax.jms.Message receiveCorrelatedReplyMessage(MessageConsumer messageConsumer,
-			String correlationKey, String messageCorrelationIdToMatch) throws JMSException {
+			String correlationKey, String messageCorrelationIdToMatch, boolean correlationIdPropagated) throws JMSException {
 
 		long timeout = this.receiveTimeout;
 		long startTime = System.currentTimeMillis();
 		javax.jms.Message replyMessage = (this.receiveTimeout >= 0) ? messageConsumer.receive(receiveTimeout) : messageConsumer.receive();
-
 		while (replyMessage != null){
 
 			String jmsCorrelationId = null;
@@ -662,6 +676,9 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler {
 			if (StringUtils.hasText(jmsCorrelationId) && StringUtils.hasText(messageCorrelationIdToMatch)){
 
 				if (jmsCorrelationId.contains(messageCorrelationIdToMatch)){
+					if (!correlationIdPropagated){
+						replyMessage.setJMSCorrelationID(null);
+					}
 					return replyMessage;
 				}
 				else {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/TemporaryConsumerUtils.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/TemporaryConsumerUtils.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.Map;
+
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.DirectFieldAccessor;
+/**
+ * NOT A PUBLIC API
+ *
+ * Temporary class, will be removed as soon as
+ * https://jira.springsource.org/browse/SPR-9648 is addressed
+ *
+ * @author Oleg Zhurakousky
+ * @since 2.2
+ */
+class TemporaryConsumerUtils {
+
+	private static volatile Constructor<?> consumerCacheKeyConstructor;
+
+	private static volatile Constructor<?> cachedMessageConsumerConstructor;
+
+	private final static Log logger = LogFactory.getLog(TemporaryConsumerUtils.class);
+
+	public static MessageConsumer createConsumer(Session session, Destination destination, String messageSelector)
+			throws JMSException {
+		if (Proxy.isProxyClass(session.getClass())){
+			InvocationHandler invocationHandler = Proxy.getInvocationHandler(session);
+			DirectFieldAccessor ihDa = new DirectFieldAccessor(invocationHandler);
+			ihDa.getPropertyValue("cachedConsumers");
+			@SuppressWarnings("unchecked")
+			Map<Object, MessageConsumer> cachedConsumers =
+				(Map<Object, MessageConsumer>) ihDa.getPropertyValue("cachedConsumers");
+			return getCachedConsumer(cachedConsumers, session, destination, messageSelector, false);
+		}
+		else {
+			return session.createConsumer(destination);
+		}
+	}
+
+	private static MessageConsumer getCachedConsumer(Map<Object, MessageConsumer> cachedConsumers, Session targetSession,
+			Destination destination, String selector, boolean noLocal) throws JMSException {
+
+		Object cacheKey = createConsumerCacheKey(destination, selector, noLocal, null);
+		MessageConsumer consumer = cachedConsumers.get(cacheKey);
+		if (consumer != null) {
+			if (logger.isTraceEnabled()) {
+				logger.trace("Found cached JMS MessageConsumer for destination [" + destination + "]: " + consumer);
+			}
+		}
+		else {
+			consumer = targetSession.createConsumer(destination, selector);
+			if (logger.isDebugEnabled()) {
+				logger.debug("Creating cached JMS MessageConsumer for destination [" + destination + "]: " + consumer);
+			}
+			cachedConsumers.put(cacheKey, consumer);
+		}
+		return createCachedMessageConsumer(consumer);
+	}
+
+	private static MessageConsumer createCachedMessageConsumer(MessageConsumer messageConsumer){
+		try {
+			if (cachedMessageConsumerConstructor == null){
+				Class<?> cachedMessageConsumerClass =
+						Class.forName("org.springframework.jms.connection.CachedMessageConsumer",
+								true, Thread.currentThread().getContextClassLoader());
+				cachedMessageConsumerConstructor = cachedMessageConsumerClass.getConstructor(MessageConsumer.class);
+				cachedMessageConsumerConstructor.setAccessible(true);
+			}
+			return (MessageConsumer) cachedMessageConsumerConstructor.newInstance(messageConsumer);
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to create org.springframework.jms.connection.CachedMessageConsumer", e);
+		}
+	}
+
+	private static Object createConsumerCacheKey(Destination destination, String selector, boolean noLocal, String subscription){
+		try {
+			if (consumerCacheKeyConstructor == null){
+				Class<?> consumerCacheKeyClass =
+						Class.forName("org.springframework.jms.connection.CachingConnectionFactory$ConsumerCacheKey",
+								true, Thread.currentThread().getContextClassLoader());
+				consumerCacheKeyConstructor =
+						consumerCacheKeyClass.getConstructor(Destination.class, String.class, boolean.class, String.class);
+				consumerCacheKeyConstructor.setAccessible(true);
+			}
+			return consumerCacheKeyConstructor.newInstance(destination, selector, noLocal, subscription);
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to create org.springframework.jms.connection.CachedMessageConsumer", e);
+		}
+	}
+}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/TemporaryConsumerUtils.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/TemporaryConsumerUtils.java
@@ -51,7 +51,6 @@ class TemporaryConsumerUtils {
 		if (Proxy.isProxyClass(session.getClass())){
 			InvocationHandler invocationHandler = Proxy.getInvocationHandler(session);
 			DirectFieldAccessor ihDa = new DirectFieldAccessor(invocationHandler);
-			ihDa.getPropertyValue("cachedConsumers");
 			@SuppressWarnings("unchecked")
 			Map<Object, MessageConsumer> cachedConsumers =
 				(Map<Object, MessageConsumer>) ihDa.getPropertyValue("cachedConsumers");

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
@@ -65,7 +65,6 @@ public class JmsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 			builder.addPropertyValue("requestDestinationExpression", expressionBuilder.getBeanDefinition());
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-destination");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "optimize-correlation");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-destination-name");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "correlation-key");

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.ExpressionFactoryBean;
 import org.springframework.integration.config.xml.AbstractConsumerEndpointParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.jms.JmsOutboundGateway;
 import org.springframework.util.StringUtils;
 
 /**
@@ -40,8 +41,7 @@ public class JmsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-				"org.springframework.integration.jms.JmsOutboundGateway");
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(JmsOutboundGateway.class);
 		builder.addPropertyReference("connectionFactory", element.getAttribute("connection-factory"));
 		String requestDestination = element.getAttribute("request-destination");
 		String requestDestinationName = element.getAttribute("request-destination-name");
@@ -65,6 +65,7 @@ public class JmsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 			builder.addPropertyValue("requestDestinationExpression", expressionBuilder.getBeanDefinition());
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-destination");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "optimize-correlation");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-destination-name");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "correlation-key");

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.1.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.1.xsd
@@ -900,9 +900,7 @@
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="correlation-key-ext">
-		<xsd:restriction base="xsd:string">
-			<xsd:pattern value="([a-zA-Z0-9])*"/>
-		</xsd:restriction>
+		<xsd:restriction base="xsd:string"/>
 	</xsd:simpleType>
 
 	<xsd:element name="outbound-channel-adapter">

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.1.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.1.xsd
@@ -792,20 +792,29 @@
 			</xsd:attribute>
 			<xsd:attribute name="reply-destination-name" type="xsd:string"/>
 			<xsd:attribute name="reply-pub-sub-domain" type="xsd:string"/>
-			<xsd:attribute name="correlation-key" type="xsd:string">
+			<xsd:attribute name="correlation-key">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-						Provide the name of a JMS property that should hold a generated UUID that
-						the receiver of the JMS Message would expect to represent the CorrelationID.
-						When waiting for the reply Message, a MessageSelector will be configured
-						to match this property name and the UUID value that was sent in the request.
+						Provide the name of a JMS property that should hold a generated CorrelationID.
 						If NO value is provided for this attribute, then the reply consumer's
 						MessageSelector will be expecting the JMSCorrelationID to equal the Message ID
-						of the request. If you want to store the outbound correlation UUID value in the
-						actual "JMSCorrelationID" property, then set this value to "JMSCorrelationID".
-						However, any other value will be treated as a JMS String Property.
+						of the request. However this would also mean that the MessageSelector will be different 
+						for each new message, thus requiring a new reply consumer to be created for each Message sent.
+						Although this is a very common JMS exchange pattern it is not optimal for high thru-put request/reply 
+						applications. Most MOMs (including Spring Integration's Inbound Gateway) also support propagation 
+						of the 'CorrelationID' of the consumed request message into the 'CorrelationID' of the newly produced 
+						reply message. This also allows us to use an optimized value generation algorithm which results in caching 
+						and reuse of reply consumers resulting in significant performance improvement of the request/reply 
+						scenarios. So if you have a Spring JMS consumer (e.g.,  Spring Integration's Inbound Gateway) or
+						you know that your MOM supports propagation of the 'CorrelationID' it is highly recommended to set this 
+						value to 'JMSCorrelationID'. If you set this value to something else the receiving end must now how 
+						to propagate it. For example: if the receiving end is an inbound-gateway its correlation-key attribute 
+						must have the same value.
 					]]></xsd:documentation>
 				</xsd:annotation>
+				<xsd:simpleType>
+				    <xsd:union memberTypes="correlation-key-enum-type correlation-key-ext"/>
+				</xsd:simpleType>
 			</xsd:attribute>
 			<xsd:attribute name="destination-resolver" type="xsd:string">
 				<xsd:annotation>
@@ -884,6 +893,17 @@
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
+	
+	<xsd:simpleType name="correlation-key-enum-type">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="JMSCorrelationID"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="correlation-key-ext">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="([a-zA-Z0-9])*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
 
 	<xsd:element name="outbound-channel-adapter">
 		<xsd:annotation>

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
@@ -843,20 +843,29 @@
 			</xsd:attribute>
 			<xsd:attribute name="reply-destination-name" type="xsd:string"/>
 			<xsd:attribute name="reply-pub-sub-domain" type="xsd:string"/>
-			<xsd:attribute name="correlation-key" type="xsd:string">
+			<xsd:attribute name="correlation-key">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-						Provide the name of a JMS property that should hold a generated UUID that
-						the receiver of the JMS Message would expect to represent the CorrelationID.
-						When waiting for the reply Message, a MessageSelector will be configured
-						to match this property name and the UUID value that was sent in the request.
+						Provide the name of a JMS property that should hold a generated CorrelationID.
 						If NO value is provided for this attribute, then the reply consumer's
 						MessageSelector will be expecting the JMSCorrelationID to equal the Message ID
-						of the request. If you want to store the outbound correlation UUID value in the
-						actual "JMSCorrelationID" property, then set this value to "JMSCorrelationID".
-						However, any other value will be treated as a JMS String Property.
+						of the request. However this would also mean that the MessageSelector will be different 
+						for each new message, thus requiring a new reply consumer to be created for each Message sent.
+						Although this is a very common JMS exchange pattern it is not optimal for high thru-put request/reply 
+						applications. Most MOMs (including Spring Integration's Inbound Gateway) also support propagation 
+						of the 'CorrelationID' of the consumed request message into the 'CorrelationID' of the newly produced 
+						reply message. This also allows us to use an optimized value generation algorithm which results in caching 
+						and reuse of reply consumers resulting in significant performance improvement of the request/reply 
+						scenarios. So if you have a Spring JMS consumer (e.g.,  Spring Integration's Inbound Gateway) or
+						you know that your MOM supports propagation of the 'CorrelationID' it is highly recommended to set this 
+						value to 'JMSCorrelationID'. If you set this value to something else the receiving end must now how 
+						to propagate it. For example: if the receiving end is an inbound-gateway its correlation-key attribute 
+						must have the same value.
 					]]></xsd:documentation>
 				</xsd:annotation>
+				<xsd:simpleType>
+				    <xsd:union memberTypes="correlation-key-enum-type correlation-key-ext"/>
+				</xsd:simpleType>
 			</xsd:attribute>
 			<xsd:attribute name="destination-resolver" type="xsd:string">
 				<xsd:annotation>
@@ -957,6 +966,17 @@
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
+	
+	<xsd:simpleType name="correlation-key-enum-type">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="JMSCorrelationID"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="correlation-key-ext">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="([a-zA-Z0-9])*"/>
+		</xsd:restriction>
+	</xsd:simpleType>
 
 	<xsd:element name="outbound-channel-adapter">
 		<xsd:annotation>

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
@@ -973,9 +973,7 @@
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="correlation-key-ext">
-		<xsd:restriction base="xsd:string">
-			<xsd:pattern value="([a-zA-Z0-9])*"/>
-		</xsd:restriction>
+		<xsd:restriction base="xsd:string"/>
 	</xsd:simpleType>
 
 	<xsd:element name="outbound-channel-adapter">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsWithMarshallingMessageConverterTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsWithMarshallingMessageConverterTests.java
@@ -44,7 +44,7 @@ import org.springframework.oxm.XmlMappingException;
  * @author Oleg Zhurakousky
  */
 public class JmsWithMarshallingMessageConverterTests {
-	
+
 	@Test
 	@SuppressWarnings("unchecked")
 	public void demoWithMarshallingConverter() {
@@ -58,7 +58,6 @@ public class JmsWithMarshallingMessageConverterTests {
 		MessageHeaders headers = replyMessage.getHeaders();
 		// check for couple of JMS headers, make sure they are present
 		assertNotNull(headers.get("jms_redelivered"));
-		assertNotNull(headers.get("jms_correlationId"));
 		assertEquals("HELLO", replyMessage.getPayload());
 	}
 
@@ -86,7 +85,7 @@ public class JmsWithMarshallingMessageConverterTests {
 
 		public boolean supports(Class<?> clazz) {
 			return true;
-		}	
+		}
 	}
 
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/MiscellaneousTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/MiscellaneousTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.integration.jms.request_reply;
 
 import static org.junit.Assert.assertEquals;
@@ -13,13 +28,15 @@ import org.springframework.integration.gateway.RequestReplyExchanger;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.util.StopWatch;
-
+/**
+ * @author Oleg Zhurakousky
+ */
 public class MiscellaneousTests {
 
 	/**
-	 * jms:out -> jms:in -> randomTimeoutProcess ->
-	 * jms:out -> jms:in
-	 * All reply queues are TEMPORARY
+	 * Asserts that receive-timeout is honored even if
+	 * requests (once in process), takes less then receive-timeout value
+	 * when requests are queued up (e.g., single consumer receiver)
 	 */
 	@Test
 	public void testTimeoutHonoringWhenRequestsQueuedUp() throws Exception{

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/MiscellaneousTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/MiscellaneousTests.java
@@ -1,0 +1,56 @@
+package org.springframework.integration.jms.request_reply;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.config.ActiveMqTestUtils;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.util.StopWatch;
+
+public class MiscellaneousTests {
+
+	/**
+	 * jms:out -> jms:in -> randomTimeoutProcess ->
+	 * jms:out -> jms:in
+	 * All reply queues are TEMPORARY
+	 */
+	@Test
+	public void testTimeoutHonoringWhenRequestsQueuedUp() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("honor-timeout.xml", this.getClass());
+		final RequestReplyExchanger gateway = context.getBean(RequestReplyExchanger.class);
+		final CountDownLatch latch = new CountDownLatch(3);
+		final AtomicInteger replies = new AtomicInteger();
+		StopWatch stopWatch = new StopWatch();
+		stopWatch.start();
+		for (int i = 0; i < 3; i++) {
+			this.exchange(latch, gateway, replies);
+		}
+		latch.await();
+		stopWatch.stop();
+		assertTrue(stopWatch.getTotalTimeMillis() <= 11000);
+		assertEquals(1, replies.get());
+	}
+
+
+	private void exchange(final CountDownLatch latch, final RequestReplyExchanger gateway, final AtomicInteger replies) {
+		new Thread(new Runnable() {
+			public void run() {
+				try {
+					gateway.exchange(new GenericMessage<String>(""));
+					replies.incrementAndGet();
+				} catch (Exception e) {
+					//ignore
+				}
+				latch.countDown();
+			}
+		}).start();
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineJmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineJmsTests.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms.request_reply;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.MessageTimeoutException;
+import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.config.ActiveMqTestUtils;
+import org.springframework.integration.message.GenericMessage;
+/**
+ * @author Oleg Zhurakousky
+ */
+public class PipelineJmsTests {
+
+	private final Executor executor = Executors.newFixedThreadPool(30);
+
+	int requests = 50;
+
+	/**
+	 * jms:out -> jms:in -> randomTimeoutProcess ->
+	 * jms:out -> jms:in
+	 * All reply queues are TEMPORARY
+	 */
+	@Test
+	public void testPipeline1() throws Exception{
+		this.test("pipeline-01.xml");
+	}
+
+	/**
+	 * jms:out(correlation-key="JMSCorrelationID") -> jms:in -> randomTimeoutProcess ->
+	 * jms:out -> jms:in
+	 * All reply queues are TEMPORARY
+	 */
+	@Test
+	public void testPipeline2() throws Exception{
+		this.test("pipeline-02.xml");
+	}
+
+	/**
+	 * jms:out(correlation-key="JMSCorrelationID") -> jms:in -> randomTimeoutProcess ->
+	 * jms:out(correlation-key="JMSCorrelationID") -> jms:in
+	 * All reply queues are TEMPORARY
+	 */
+	@Test
+	public void testPipeline3() throws Exception{
+		this.test("pipeline-03.xml");
+	}
+
+	/**
+	 * jms:out -> jms:in -> randomTimeoutProcess ->
+	 * jms:out(correlation-key="JMSCorrelationID") -> jms:in
+	 * All reply queues are TEMPORARY
+	 */
+	@Test
+	public void testPipeline4() throws Exception{
+		this.test("pipeline-04.xml");
+	}
+
+	/**
+	 * jms:out(correlation-key="foo") -> jms:in(correlation-key="foo") -> randomTimeoutProcess ->
+	 * jms:out -> jms:in
+	 * All reply queues are TEMPORARY
+	 */
+	@Test
+	public void testPipeline5() throws Exception{
+		this.test("pipeline-05.xml");
+	}
+
+	/**
+	 * jms:out -> jms:in -> randomTimeoutProcess ->
+	 * jms:out(correlation-key="foo") -> jms:in(correlation-key="foo")
+	 * All reply queues are TEMPORARY
+	 */
+	@Test
+	public void testPipeline6() throws Exception{
+		this.test("pipeline-06.xml");
+	}
+
+	/**
+	 * jms:out(correlation-key="JMSCorrelationID") -> jms:in -> randomTimeoutProcess ->
+	 * jms:out(correlation-key="foo") -> jms:in(correlation-key="foo")
+	 * All reply queues are TEMPORARY
+	 */
+	@Test
+	public void testPipeline7() throws Exception{
+		this.test("pipeline-07.xml");
+	}
+
+	/**
+	 * jms:out(correlation-key="foo") -> jms:in(correlation-key="foo") -> randomTimeoutProcess ->
+	 * jms:out(correlation-key="JMSCorrelationID") -> jms:in
+	 * All reply queues are TEMPORARY
+	 */
+	@Test
+	public void testPipeline8() throws Exception{
+		this.test("pipeline-08.xml");
+	}
+
+	public void test(String contextConfig) throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(contextConfig, this.getClass());
+		final RequestReplyExchanger gateway = context.getBean(RequestReplyExchanger.class);
+		final CountDownLatch latch = new CountDownLatch(requests);
+		final AtomicInteger successCounter = new AtomicInteger();
+		final AtomicInteger timeoutCounter = new AtomicInteger();
+		final AtomicInteger failureCounter = new AtomicInteger();
+
+		for (int i = 0; i < requests; i++) {
+			final int y = i;
+			executor.execute(new Runnable() {
+				public void run() {
+					try {
+						assertEquals(y, gateway.exchange(new GenericMessage<Integer>(y)).getPayload());
+						successCounter.incrementAndGet();
+					} catch (MessageTimeoutException e) {
+						timeoutCounter.incrementAndGet();
+					} catch (Throwable t) {
+						failureCounter.incrementAndGet();
+					} finally {
+						latch.countDown();
+					}
+				}
+			});
+		}
+		latch.await();
+		System.out.println("Success: " + successCounter.get());
+		System.out.println("Timeout: " + timeoutCounter.get());
+		System.out.println("Failure: " + failureCounter.get());
+		// technically all we care that its > 0,
+		// but reality of this test it has to be something more then 0
+		assertTrue(successCounter.get() > 10);
+		assertEquals(0, failureCounter.get());
+		assertEquals(requests, successCounter.get() + timeoutCounter.get());
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineJmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineJmsTests.java
@@ -119,6 +119,16 @@ public class PipelineJmsTests {
 		this.test("pipeline-08.xml");
 	}
 
+	/**
+	 * jms:out(correlation-key="foo") -> jms:in(correlation-key="foo") -> randomTimeoutProcess ->
+	 * jms:out(correlation-key="bar") -> jms:in(correlation-key="bar")
+	 * All reply queues are TEMPORARY
+	 */
+	@Test
+	public void testPipeline9() throws Exception{
+		this.test("pipeline-09.xml");
+	}
+
 	public void test(String contextConfig) throws Exception{
 		ActiveMqTestUtils.prepare();
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(contextConfig, this.getClass());

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineNamReplyQueuesJmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineNamReplyQueuesJmsTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms.request_reply;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.MessageTimeoutException;
+import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.config.ActiveMqTestUtils;
+import org.springframework.integration.message.GenericMessage;
+/**
+ * @author Oleg Zhurakousky
+ */
+public class PipelineNamReplyQueuesJmsTests {
+
+	private final Executor executor = Executors.newFixedThreadPool(30);
+
+	int requests = 50;
+
+	/**
+	 * jms:out(reply-destination-name="pipeline01-01") -> jms:in -> randomTimeoutProcess ->
+	 * jms:out -> jms:in
+	 */
+	@Test
+	public void testPipeline1() throws Exception{
+		this.test("pipeline-named-queue-01.xml");
+	}
+
+	/**
+	 * jms:out(reply-destination-name="pipeline02-01") -> jms:in -> randomTimeoutProcess ->
+	 * jms:out(reply-destination-name="pipeline02-02") -> jms:in
+	 */
+	@Test
+	public void testPipeline2() throws Exception{
+		this.test("pipeline-named-queue-02.xml");
+	}
+
+	/**
+	 * jms:out(reply-destination-name="pipeline03-01", correlation-key="JMSCorrelationID") -> jms:in -> randomTimeoutProcess ->
+	 * jms:out(reply-destination-name="pipeline03-02") -> jms:in
+	 */
+	@Test
+	public void testPipeline3() throws Exception{
+		this.test("pipeline-named-queue-03.xml");
+	}
+
+	/**
+	 * jms:out(reply-destination-name="pipeline04-01", correlation-key="foo") -> jms:in(correlation-key="foo") -> randomTimeoutProcess ->
+	 * jms:out(reply-destination-name="pipeline04-02") -> jms:in
+	 */
+	@Test
+	public void testPipeline4() throws Exception{
+		this.test("pipeline-named-queue-04.xml");
+	}
+
+	/**
+	 * jms:out(reply-destination-name="pipeline05-01", correlation-key="foo") -> jms:in(correlation-key="foo") -> randomTimeoutProcess ->
+	 * jms:out(reply-destination-name="pipeline05-02", correlation-key="JMSCorrelationID") -> jms:in
+	 */
+	@Test
+	public void testPipeline5() throws Exception{
+		this.test("pipeline-named-queue-05.xml");
+	}
+
+	/**
+	 * jms:out(reply-destination-name="pipeline05-01", correlation-key="JMSCorrelationID") -> jms:in -> randomTimeoutProcess ->
+	 * jms:out(reply-destination-name="pipeline05-02", correlation-key="foo") -> jms:in(correlation-key="foo")
+	 */
+	@Test
+	public void testPipeline6() throws Exception{
+		this.test("pipeline-named-queue-06.xml");
+	}
+
+	public void test(String contextConfig) throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(contextConfig, this.getClass());
+		final RequestReplyExchanger gateway = context.getBean(RequestReplyExchanger.class);
+		final CountDownLatch latch = new CountDownLatch(requests);
+		final AtomicInteger successCounter = new AtomicInteger();
+		final AtomicInteger timeoutCounter = new AtomicInteger();
+		final AtomicInteger failureCounter = new AtomicInteger();
+
+		for (int i = 0; i < requests; i++) {
+			final int y = i;
+			executor.execute(new Runnable() {
+				public void run() {
+					try {
+						assertEquals(y, gateway.exchange(new GenericMessage<Integer>(y)).getPayload());
+						successCounter.incrementAndGet();
+					} catch (MessageTimeoutException e) {
+						timeoutCounter.incrementAndGet();
+					} catch (Throwable t) {
+						failureCounter.incrementAndGet();
+					} finally {
+						latch.countDown();
+					}
+				}
+			});
+		}
+		latch.await();
+		System.out.println("Success: " + successCounter.get());
+		System.out.println("Timeout: " + timeoutCounter.get());
+		System.out.println("Failure: " + failureCounter.get());
+		// technically all we care that its > 0,
+		// but reality of this test it has to be something more then 0
+		assertTrue(successCounter.get() > 10);
+		assertEquals(0, failureCounter.get());
+		assertEquals(requests, successCounter.get() + timeoutCounter.get());
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineNamReplyQueuesJmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineNamReplyQueuesJmsTests.java
@@ -85,12 +85,21 @@ public class PipelineNamReplyQueuesJmsTests {
 	}
 
 	/**
-	 * jms:out(reply-destination-name="pipeline05-01", correlation-key="JMSCorrelationID") -> jms:in -> randomTimeoutProcess ->
-	 * jms:out(reply-destination-name="pipeline05-02", correlation-key="foo") -> jms:in(correlation-key="foo")
+	 * jms:out(reply-destination-name="pipeline06-01", correlation-key="JMSCorrelationID") -> jms:in -> randomTimeoutProcess ->
+	 * jms:out(reply-destination-name="pipeline06-02", correlation-key="foo") -> jms:in(correlation-key="foo")
 	 */
 	@Test
 	public void testPipeline6() throws Exception{
 		this.test("pipeline-named-queue-06.xml");
+	}
+
+	/**
+	 * jms:out(reply-destination-name="pipeline07-01", correlation-key="JMSCorrelationID") -> jms:in -> randomTimeoutProcess ->
+	 * jms:out(reply-destination-name="pipeline07-02", correlation-key="foo") -> jms:in(correlation-key="foo")
+	 */
+	@Test
+	public void testPipeline7() throws Exception{
+		this.test("pipeline-named-queue-07.xml");
 	}
 
 	public void test(String contextConfig) throws Exception{

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCachedConsumersTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCachedConsumersTests.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms.request_reply;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.MessageTimeoutException;
+import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.JmsOutboundGateway;
+import org.springframework.integration.jms.config.ActiveMqTestUtils;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.jms.connection.CachingConnectionFactory;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+import org.springframework.jms.listener.DefaultMessageListenerContainer;
+import org.springframework.jms.listener.SessionAwareMessageListener;
+import org.springframework.jms.support.converter.SimpleMessageConverter;
+/**
+ * @author Oleg Zhurakousky
+ */
+public class RequestReplyScenariosWithCachedConsumersTests {
+
+	private final SimpleMessageConverter converter = new SimpleMessageConverter();
+
+	@Test(expected=MessageTimeoutException.class)
+	public void messageCorrelationBasedOnRequestMessageIdOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("producer-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("standardMessageIdCopyingConsumerWithOptimization", RequestReplyExchanger.class);
+		CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+
+		final Destination requestDestination = context.getBean("siOutQueueOptimizedA", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueOptimizedA", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSMessageID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		gateway.exchange(new GenericMessage<String>("foo"));
+		context.close();
+	}
+
+	@Test
+	public void messageCorrelationBasedOnRequestMessageIdNonOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("producer-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("standardMessageIdCopyingConsumerWithoutOptimization", RequestReplyExchanger.class);
+		CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+
+		final Destination requestDestination = context.getBean("siOutQueueNonOptimizedB", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueNonOptimizedB", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSMessageID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+		context.close();
+	}
+
+	@Test
+	public void messageCorrelationBasedOnRequestCorrelationIdOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("producer-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("correlationPropagatingConsumerWithOptimization", RequestReplyExchanger.class);
+		CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
+
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueueOptimizedC", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueOptimizedC", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSCorrelationID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+		context.close();
+	}
+
+	@Test(expected=MessageTimeoutException.class)
+	public void messageCorrelationBasedOnRequestCorrelationIdNonOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("producer-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("correlationPropagatingConsumerWithoutOptimization", RequestReplyExchanger.class);
+		CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
+
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueueNonOptimizedD", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueNonOptimizedD", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSCorrelationID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+		context.close();
+	}
+
+	@Test
+	public void messageCorrelationBasedOnRequestCorrelationIdTimedOutFirstReplyOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context =
+				new ClassPathXmlApplicationContext("producer-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway =
+				context.getBean("correlationPropagatingConsumerWithOptimizationDelayFirstReply", RequestReplyExchanger.class);
+		final ConnectionFactory connectionFactory = context.getBean("connectionFactory", ConnectionFactory.class);
+
+		final Destination requestDestination = context.getBean("siOutQueueE", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueE", Destination.class);
+
+		for (int i = 0; i < 3; i++) {
+			System.out.println("#### " + i);
+			try {
+				gateway.exchange(gateway.exchange(new GenericMessage<String>("foo")));
+			} catch (Exception e) {/*ignore*/}
+
+		}
+
+		final CountDownLatch latch = new CountDownLatch(1);
+		new Thread(new Runnable() {
+
+			public void run() {
+				DefaultMessageListenerContainer dmlc = new DefaultMessageListenerContainer();
+				dmlc.setConnectionFactory(connectionFactory);
+				dmlc.setDestination(requestDestination);
+				dmlc.setMessageListener(new SessionAwareMessageListener<Message>() {
+
+					public void onMessage(Message message, Session session) {
+						String requestPayload = (String) extractPayload(message);
+						try {
+							TextMessage replyMessage = session.createTextMessage();
+							replyMessage.setText(requestPayload);
+							replyMessage.setJMSCorrelationID(message.getJMSCorrelationID());
+							MessageProducer producer = session.createProducer(replyDestination);
+							producer.send(replyMessage);
+						} catch (Exception e) {
+							// ignore. the test will fail
+						}
+					}
+				});
+				dmlc.afterPropertiesSet();
+				dmlc.start();
+				latch.countDown();
+			}
+		}).start();
+
+		latch.await();
+
+
+
+		TestUtils.getPropertyValue(context.getBean("fastGateway"), "handler", JmsOutboundGateway.class).setReceiveTimeout(10000);
+		Thread.sleep(1000);
+		assertEquals("bar", gateway.exchange(new GenericMessage<String>("bar")).getPayload());
+
+		context.close();
+	}
+
+	private Object extractPayload(Message jmsMessage) {
+		try {
+			return converter.fromMessage(jmsMessage);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		}
+		return null;
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCorrelationKeyProvidedTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCorrelationKeyProvidedTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms.request_reply;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.JmsOutboundGateway;
+import org.springframework.integration.jms.config.ActiveMqTestUtils;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
+/**
+ * @author Oleg Zhurakousky
+ */
+public class RequestReplyScenariosWithCorrelationKeyProvidedTests {
+
+	@Test
+	public void messageCorrelationBasedCustomCorrelationKey() throws Exception{
+		ActiveMqTestUtils.prepare();
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("explicit-correlation-key.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("explicitCorrelationKeyGateway", RequestReplyExchanger.class);
+
+		gateway.exchange(MessageBuilder.withPayload("foo").build());
+		context.close();
+	}
+
+	@Test
+	public void messageCorrelationBasedCustomCorrelationKeyAsJMSCorrelationID() throws Exception{
+		ActiveMqTestUtils.prepare();
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("explicit-correlation-key.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("explicitCorrelationKeyGatewayB", RequestReplyExchanger.class);
+
+		gateway.exchange(MessageBuilder.withPayload("foo").build());
+		context.close();
+	}
+
+	@Test
+	public void messageCorrelationBasedCustomCorrelationKeyDelayedReplies() throws Exception{
+		ActiveMqTestUtils.prepare();
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("explicit-correlation-key.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("explicitCorrelationKeyGatewayC", RequestReplyExchanger.class);
+
+
+		for (int i = 0; i < 3; i++) {
+			try {
+				gateway.exchange(MessageBuilder.withPayload("hello").build());
+			} catch (Exception e) {
+				// ignore
+			}
+		}
+
+		JmsOutboundGateway outGateway = TestUtils.getPropertyValue(context.getBean("outGateway"), "handler", JmsOutboundGateway.class);
+		outGateway.setReceiveTimeout(5000);
+		assertEquals("foo", gateway.exchange(MessageBuilder.withPayload("foo").build()).getPayload());
+		context.close();
+	}
+
+
+	public static class DelayedService {
+		public String echo(String s) throws Exception{
+			Thread.sleep(200);
+			return s;
+		}
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithNonCachedConsumersTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithNonCachedConsumersTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms.request_reply;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.junit.Test;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.MessageTimeoutException;
+import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.config.ActiveMqTestUtils;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+/**
+ * @author Oleg Zhurakousky
+ */
+public class RequestReplyScenariosWithNonCachedConsumersTests {
+
+	@Test(expected=MessageTimeoutException.class)
+	public void messageCorrelationBasedOnRequestMessageIdOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ApplicationContext context = new ClassPathXmlApplicationContext("producer-no-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("optimizedMessageId", RequestReplyExchanger.class);
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueueC", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueC", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSMessageID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+	}
+
+	@Test
+	public void messageCorrelationBasedOnRequestMessageIdNonOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ApplicationContext context = new ClassPathXmlApplicationContext("producer-no-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("nonoptimizedMessageId", RequestReplyExchanger.class);
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueueD", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueD", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSMessageID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+	}
+
+	@Test
+	public void messageCorrelationBasedOnRequestCorrelationIdOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ApplicationContext context = new ClassPathXmlApplicationContext("producer-no-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("optimized", RequestReplyExchanger.class);
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueueA", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueA", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSCorrelationID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+	}
+
+	@Test(expected=MessageTimeoutException.class)
+	public void messageCorrelationBasedOnRequestCorrelationIdNonOptimized() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ApplicationContext context = new ClassPathXmlApplicationContext("producer-no-cached-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean("nonoptimized", RequestReplyExchanger.class);
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueueB", Destination.class);
+		final Destination replyDestination = context.getBean("siInQueueB", Destination.class);
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				jmsTemplate.send(replyDestination, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						TextMessage message = session.createTextMessage();
+						message.setText("bar");
+						message.setJMSCorrelationID(requestMessage.getJMSCorrelationID());
+						return message;
+					}
+				});
+			}
+		}).start();
+		org.springframework.integration.Message<?> siReplyMessage = gateway.exchange(new GenericMessage<String>("foo"));
+		assertEquals("bar", siReplyMessage.getPayload());
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithTempReplyQueuesTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithTempReplyQueuesTests.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms.request_reply;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.MessageDeliveryException;
+import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.config.ActiveMqTestUtils;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.jms.connection.CachingConnectionFactory;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+import org.springframework.jms.listener.DefaultMessageListenerContainer;
+import org.springframework.jms.listener.SessionAwareMessageListener;
+import org.springframework.jms.support.converter.SimpleMessageConverter;
+/**
+ * @author Oleg Zhurakousky
+ */
+public class RequestReplyScenariosWithTempReplyQueuesTests {
+
+	private final SimpleMessageConverter converter = new SimpleMessageConverter();
+
+	@Test
+	public void messageCorrelationBasedOnRequestMessageId() throws Exception{
+		ActiveMqTestUtils.prepare();
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("producer-temp-reply-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean(RequestReplyExchanger.class);
+		CachingConnectionFactory connectionFactory = context.getBean(CachingConnectionFactory.class);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+
+		final Destination requestDestination = context.getBean("siOutQueue", Destination.class);
+
+		new Thread(new Runnable() {
+
+			public void run() {
+				final Message requestMessage = jmsTemplate.receive(requestDestination);
+				Destination replyTo = null;
+				try {
+					replyTo = requestMessage.getJMSReplyTo();
+				} catch (Exception e) {
+					fail();
+				}
+				jmsTemplate.send(replyTo, new MessageCreator() {
+
+					public Message createMessage(Session session) throws JMSException {
+						try {
+							TextMessage message = session.createTextMessage();
+							message.setText("bar");
+							message.setJMSCorrelationID(requestMessage.getJMSMessageID());
+							return message;
+						} catch (Exception e) {
+							// ignore
+						}
+						return null;
+					}
+				});
+			}
+		}).start();
+		gateway.exchange(new GenericMessage<String>("foo"));
+		context.close();
+	}
+
+	@Test
+	public void messageCorrelationBasedOnRequestCorrelationIdTimedOutFirstReply() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context =
+				new ClassPathXmlApplicationContext("producer-temp-reply-consumers.xml", this.getClass());
+		RequestReplyExchanger gateway = context.getBean(RequestReplyExchanger.class);
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+
+		final Destination requestDestination = context.getBean("siOutQueue", Destination.class);
+
+		DefaultMessageListenerContainer dmlc = new DefaultMessageListenerContainer();
+		dmlc.setConnectionFactory(connectionFactory);
+		dmlc.setDestination(requestDestination);
+		dmlc.setMessageListener(new SessionAwareMessageListener<Message>() {
+
+			public void onMessage(Message message, Session session) {
+				Destination replyTo = null;
+				try {
+					replyTo = message.getJMSReplyTo();
+				} catch (Exception e) {
+					fail();
+				}
+				String requestPayload = (String) extractPayload(message);
+				if (requestPayload.equals("foo")){
+					try {
+						Thread.sleep(6000);
+					} catch (Exception e) {/*ignore*/}
+				}
+				try {
+					TextMessage replyMessage = session.createTextMessage();
+					replyMessage.setText(requestPayload);
+					replyMessage.setJMSCorrelationID(message.getJMSMessageID());
+					MessageProducer producer = session.createProducer(replyTo);
+					producer.send(replyMessage);
+				} catch (Exception e) {
+					// ignore. the test will fail
+				}
+			}
+		});
+		dmlc.afterPropertiesSet();
+		dmlc.start();
+
+		try {
+			gateway.exchange(new GenericMessage<String>("foo"));
+		} catch (Exception e) {
+			// ignore
+		}
+		Thread.sleep(1000);
+		try {
+			assertEquals("bar", gateway.exchange(new GenericMessage<String>("bar")).getPayload());
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		}
+		context.close();
+	}
+
+	/**
+	 * Validates that JOG will recreate a temporary queue
+	 * once a failure detected and that the messages will still be properly correlated
+	 */
+	@Test
+	public void brokenBrokerTest() throws Exception{
+
+		BrokerService broker = new BrokerService();
+		broker.setPersistent(false);
+		broker.setUseJmx(false);
+		broker.setTransportConnectorURIs(new String[]{"tcp://localhost:61623"});
+		broker.setDeleteAllMessagesOnStartup(true);
+		broker.start();
+
+		ClassPathXmlApplicationContext context =
+				new ClassPathXmlApplicationContext("broken-broker.xml", this.getClass());
+
+		final RequestReplyExchanger gateway = context.getBean(RequestReplyExchanger.class);
+
+		int replyCounter = 0;
+		int timeoutCounter = 0;
+		for (int i = 0; i < 50; i++) {
+			try {
+				assertEquals(i+"", gateway.exchange(new GenericMessage<String>(String.valueOf(i))).getPayload());
+				replyCounter++;
+			} catch (Exception e) {
+				timeoutCounter++;
+			}
+			if (i == 0 || i == 20 || i == 40){
+				Destination replyDestination = TestUtils.getPropertyValue(context.getBean("jog"), "handler.replyDestination", Destination.class);
+				broker.removeDestination((ActiveMQDestination) replyDestination);
+			}
+		}
+		assertEquals(50, replyCounter + timeoutCounter);
+	}
+
+	@Test
+	public void testConcurrently() throws Exception{
+		ActiveMqTestUtils.prepare();
+		ClassPathXmlApplicationContext context =
+				new ClassPathXmlApplicationContext("mult-producer-and-consumers-temp-reply.xml", this.getClass());
+		final RequestReplyExchanger gateway = context.getBean(RequestReplyExchanger.class);
+		Executor executor = Executors.newFixedThreadPool(10);
+		final int testNumbers = 100;
+		final CountDownLatch latch = new CountDownLatch(testNumbers);
+		final AtomicInteger failures = new AtomicInteger();
+		final AtomicInteger timeouts = new AtomicInteger();
+		final AtomicInteger missmatches = new AtomicInteger();
+		for (int i = 0; i < testNumbers; i++) {
+			final int y = i;
+			executor.execute(new Runnable() {
+				public void run() {
+					try {
+
+						String reply = (String) gateway.exchange(new GenericMessage<String>(String.valueOf(y))).getPayload();
+						if (!String.valueOf(y).equals(reply)){
+							missmatches.incrementAndGet();
+						}
+					} catch (Exception e) {
+						if (e instanceof MessageDeliveryException) {
+							timeouts.incrementAndGet();
+						}
+						else {
+							failures.incrementAndGet();
+						}
+					}
+//					if (latch.getCount()%100 == 0){
+//						long count = testNumbers-latch.getCount();
+//						if (count > 0){
+//							print(failures, timeouts, missmatches, testNumbers-latch.getCount());
+//						}
+//					}
+					latch.countDown();
+				}
+			});
+		}
+		latch.await();
+		print(failures, timeouts, missmatches, testNumbers);
+		Thread.sleep(1000);
+		assertEquals(0, missmatches.get());
+		assertEquals(0, failures.get());
+		assertEquals(0, timeouts.get());
+	}
+
+	private void print(AtomicInteger failures, AtomicInteger timeouts, AtomicInteger missmatches, long echangesProcessed){
+		System.out.println("============================");
+		System.out.println(echangesProcessed + " exchanges processed");
+		System.out.println("Failures: " + failures.get());
+		System.out.println("Timeouts: " + timeouts.get());
+		System.out.println("Missmatches: " + missmatches.get());
+		System.out.println("============================");
+	}
+
+	public static class MyRandomlySlowService{
+		Random random = new Random();
+		List<Integer> list = new ArrayList<Integer>();
+		public String secho(String value) throws Exception{
+			int i = random.nextInt(2000);
+//			if (i >= 2000){
+//				System.out.println("SLEEPIING: " + i);
+//			}
+			Thread.sleep(i);
+			return value;
+		}
+	}
+
+	private Object extractPayload(Message jmsMessage) {
+		try {
+			return converter.fromMessage(jmsMessage);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		}
+		return null;
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithTempReplyQueuesTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithTempReplyQueuesTests.java
@@ -184,8 +184,10 @@ public class RequestReplyScenariosWithTempReplyQueuesTests {
 				timeoutCounter++;
 			}
 			if (i == 0 || i == 20 || i == 40){
-				Destination replyDestination = TestUtils.getPropertyValue(context.getBean("jog"), "handler.replyDestination", Destination.class);
-				broker.removeDestination((ActiveMQDestination) replyDestination);
+				Object replyDestination = TestUtils.getPropertyValue(context.getBean("jog"), "handler.replyDestination");
+				if (replyDestination != null){
+					broker.removeDestination((ActiveMQDestination) replyDestination);
+				}
 			}
 		}
 		assertEquals(50, replyCounter + timeoutCounter);
@@ -233,7 +235,7 @@ public class RequestReplyScenariosWithTempReplyQueuesTests {
 		}
 		latch.await();
 		print(failures, timeouts, missmatches, testNumbers);
-		Thread.sleep(1000);
+		Thread.sleep(5000);
 		assertEquals(0, missmatches.get());
 		assertEquals(0, failures.get());
 		assertEquals(0, timeouts.get());

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/broken-broker.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/broken-broker.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<int:gateway id="brkenBrokerGateway" default-request-channel="outGatewayInChannel"/>
+	
+	<int-jms:outbound-gateway id="jog" request-channel="outGatewayInChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="brokenBrokerRequestQueue"
+		correlation-key="JMSCorrelationID"
+		receive-timeout="1000"/>
+		
+	<int-jms:inbound-gateway request-channel="jmsInChannel" 
+						     request-destination-name="brokenBrokerRequestQueue"
+							 connection-factory="connectionFactory"
+							 concurrent-consumers="10"
+							 reply-timeout="10000"/>
+							 
+	<int:channel id="jmsInChannel">
+		<int:dispatcher task-executor="executor"/>
+	</int:channel>
+							 		 
+	<int:service-activator input-channel="jmsInChannel" expression="payload"/>
+		
+	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="tcp://localhost:61623"/>		
+			</bean>
+		</property>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+		<property name="sessionCacheSize" value="10" />
+	</bean>
+	
+	<task:executor id="executor" pool-size="20"/>
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/explicit-correlation-key.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/explicit-correlation-key.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd">
+
+	<int:gateway id="explicitCorrelationKeyGateway" default-request-channel="explicitCorrelationIn"/>
+
+	<int-jms:outbound-gateway request-channel="explicitCorrelationIn"
+	    connection-factory="connectionFactory" 
+		request-destination="explicitCorrelationJmsOut"
+		correlation-key="bar"/>
+		
+	<bean id="explicitCorrelationJmsOut" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="explicitCorrelationJmsOut"/>
+	</bean>
+	
+	<int-jms:inbound-gateway request-channel="requestIn" 
+	    request-destination="explicitCorrelationJmsOut"
+	    correlation-key="bar"
+		connection-factory="connectionFactory"/>
+	
+	<int:transformer input-channel="requestIn" expression="payload"/>
+	
+	<!--  -->
+	
+	<int:gateway id="explicitCorrelationKeyGatewayB" default-request-channel="explicitCorrelationInB"/>
+
+	<int-jms:outbound-gateway request-channel="explicitCorrelationInB"
+	    connection-factory="connectionFactory" 
+		request-destination="explicitCorrelationJmsOutB"
+		correlation-key="JMSCorrelationID"/>
+		
+	<bean id="explicitCorrelationJmsOutB" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="explicitCorrelationJmsOutB"/>
+	</bean>
+	
+	<int-jms:inbound-gateway request-channel="requestInB" 
+	    request-destination="explicitCorrelationJmsOutB"
+	    correlation-key="JMSCorrelationID"
+		connection-factory="connectionFactory"/>
+	
+	<int:transformer input-channel="requestInB" expression="payload"/>
+	
+	<!--  -->
+	
+	<int:gateway id="explicitCorrelationKeyGatewayC" default-request-channel="explicitCorrelationInC"/>
+
+	<int-jms:outbound-gateway id="outGateway" request-channel="explicitCorrelationInC"
+	    connection-factory="connectionFactory" 
+		request-destination="explicitCorrelationJmsOutC"
+		reply-destination-name="explicitCorrelationJmsInC"
+		correlation-key="foo"
+		receive-timeout="100"/>
+		
+	<bean id="explicitCorrelationJmsOutC" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="explicitCorrelationJmsOutC"/>
+	</bean>
+	
+	<int-jms:inbound-gateway id="inGateway" request-channel="requestInC" 
+	    request-destination="explicitCorrelationJmsOutC"
+	    correlation-key="foo"
+		connection-factory="connectionFactory"/>
+	
+	<int:transformer input-channel="requestInC">
+		<bean class="org.springframework.integration.jms.request_reply.RequestReplyScenariosWithCorrelationKeyProvidedTests.DelayedService"/>
+	</int:transformer>
+	
+	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>		
+			</bean>
+		</property>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+		<property name="sessionCacheSize" value="10" />
+	</bean>
+	
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/honor-timeout.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/honor-timeout.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="in" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="in"
+	    connection-factory="connectionFactory" 
+		request-destination-name="honorTimeoutQueue"
+		receive-timeout="10000"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="honorTimeoutQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="1"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn">
+		<int:header-enricher>
+			<int:header name="delay" expression="9000"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/mult-producer-and-consumers-temp-reply.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/mult-producer-and-consumers-temp-reply.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<int:gateway id="multiOutGateway" default-request-channel="outGatewayInChannel"/>
+	
+	<int:channel id="outGatewayInChannel">
+		<int:dispatcher task-executor="executor"/>
+	</int:channel>
+	
+	<int-jms:outbound-gateway request-channel="outGatewayInChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="multiOutGatewayTempQueue"
+		correlation-key="JMSCorrelationID"/>
+		
+	<int-jms:inbound-gateway request-channel="jmsInChannel" 
+						     request-destination-name="multiOutGatewayTempQueue"
+							 connection-factory="connectionFactory"
+							 concurrent-consumers="10"
+							 reply-timeout="10000"/>
+							 
+	<int:channel id="jmsInChannel">
+		<int:dispatcher task-executor="executor"/>
+	</int:channel>
+							 
+	<int:service-activator input-channel="jmsInChannel">
+		<bean class="org.springframework.integration.jms.request_reply.RequestReplyScenariosWithTempReplyQueuesTests.MyRandomlySlowService"/>
+	</int:service-activator>
+		
+	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>		
+			</bean>
+		</property>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+		<property name="sessionCacheSize" value="10" />
+	</bean>
+	
+	<task:executor id="executor" pool-size="20"/>
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-01.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-01.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline01" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline01"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline01-queue-01"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="pipeline01-queue-01"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline01-queue-02"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="pipeline01-queue-02"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-02.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-02.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline02" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline02"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline02-queue-01"
+		correlation-key="JMSCorrelationID"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="pipeline02-queue-01"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline02-queue-02"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="pipeline02-queue-02"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-03.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-03.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline03" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline03"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline03-queue-01"
+		correlation-key="JMSCorrelationID"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="pipeline03-queue-01"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline03-queue-02"
+		correlation-key="JMSCorrelationID"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="pipeline03-queue-02"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-04.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-04.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline04" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline04"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline04-queue-01"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="pipeline04-queue-01"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline04-queue-02"
+		correlation-key="JMSCorrelationID"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="pipeline04-queue-02"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-05.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-05.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline05" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline05"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline05-queue-01"
+		correlation-key="foo"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="pipeline05-queue-01"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"
+		correlation-key="foo"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline05-queue-02"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="pipeline05-queue-02"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-06.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-06.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline06" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline06"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline06-queue-01"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="pipeline06-queue-01"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline06-queue-02"
+		correlation-key="foo"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="pipeline06-queue-02"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"
+		correlation-key="foo"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-07.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-07.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline07" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline07"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline07-queue-01"
+		correlation-key="JMSCorrelationID"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="pipeline07-queue-01"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline07-queue-02"
+		correlation-key="foo"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="pipeline07-queue-02"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"
+		correlation-key="foo"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-08.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-08.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline08" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline08"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline08-queue-01"
+		correlation-key="foo"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="pipeline08-queue-01"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"
+		correlation-key="foo"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="pipeline08-queue-02"
+		correlation-key="JMSCorrelationID"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="pipeline08-queue-02"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"
+		correlation-key="foo"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-09.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-09.xml
@@ -11,15 +11,15 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-	<int:gateway default-request-channel="pipeline08" default-request-timeout="10000" default-reply-timeout="10000"/>
+	<int:gateway default-request-channel="pipeline09" default-request-timeout="10000" default-reply-timeout="10000"/>
 
-	<int-jms:outbound-gateway request-channel="pipeline08"
+	<int-jms:outbound-gateway request-channel="pipeline09"
 	    connection-factory="connectionFactory" 
-		request-destination-name="pipeline08-queue-01"
+		request-destination-name="pipeline09-queue-01"
 		correlation-key="foo"/>
 	
 	<int-jms:inbound-gateway request-channel="jmsIn"
-		request-destination-name="pipeline08-queue-01"
+		request-destination-name="pipeline09-queue-01"
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"
@@ -35,14 +35,15 @@
 	
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
 	    connection-factory="connectionFactory" 
-		request-destination-name="pipeline08-queue-02"
-		correlation-key="JMSCorrelationID"/>
+		request-destination-name="pipeline09-queue-02"
+		correlation-key="bar"/>
 		
 	<int-jms:inbound-gateway request-channel="anotherIn"
-		request-destination-name="pipeline08-queue-02"
+		request-destination-name="pipeline09-queue-02"
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
-		reply-timeout="10000"/>
+		reply-timeout="10000"
+		correlation-key="bar"/>
 		
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-01.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-01.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline01" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline01"
+	    connection-factory="connectionFactory" 
+	    reply-destination-name="pipeline01-01"
+		request-destination-name="siOutQueue"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="siOutQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+		request-destination-name="anotherGatewayQueue"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="anotherGatewayQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline02" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline02"
+	    connection-factory="connectionFactory" 
+	    reply-destination-name="pipeline02-01"
+		request-destination-name="siOutQueue"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="siOutQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+	    reply-destination-name="pipeline02-02"
+		request-destination-name="anotherGatewayQueue"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="anotherGatewayQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline03" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline03"
+	    connection-factory="connectionFactory" 
+	    reply-destination-name="pipeline03-01"
+	    correlation-key="JMSCorrelationID"
+		request-destination-name="siOutQueue"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="siOutQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+	    reply-destination-name="pipeline03-02"
+		request-destination-name="anotherGatewayQueue"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="anotherGatewayQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-04.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-04.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline04" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline04"
+	    connection-factory="connectionFactory" 
+	    reply-destination-name="pipeline04-01"
+	    correlation-key="foo"
+		request-destination-name="siOutQueue"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="siOutQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		correlation-key="foo"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+	    reply-destination-name="pipeline04-02"
+		request-destination-name="anotherGatewayQueue"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="anotherGatewayQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-05.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-05.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline05" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline05"
+	    connection-factory="connectionFactory" 
+	    reply-destination-name="pipeline05-01"
+	    correlation-key="foo"
+		request-destination-name="siOutQueue"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="siOutQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		correlation-key="foo"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+	    reply-destination-name="pipeline05-02"
+		request-destination-name="anotherGatewayQueue"
+		correlation-key="JMSCorrelationID"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="anotherGatewayQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-06.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-06.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:task="http://www.springframework.org/schema/task"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+
+	<int:gateway default-request-channel="pipeline06" default-request-timeout="10000" default-reply-timeout="10000"/>
+
+	<int-jms:outbound-gateway request-channel="pipeline06"
+	    connection-factory="connectionFactory" 
+	    reply-destination-name="pipeline06-01"
+	    correlation-key="JMSCorrelationID"
+		request-destination-name="siOutQueue"/>
+	
+	<int-jms:inbound-gateway request-channel="jmsIn"
+		request-destination-name="siOutQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		correlation-key="JMSCorrelationID"
+		reply-timeout="10000"/>
+
+	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
+		<int:header-enricher>
+			<int:header name="delay" expression="new java.util.Random().nextInt(3000)"/>
+		</int:header-enricher>
+		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
+		<int:transformer expression="payload"/>
+	</int:chain>
+	
+	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
+	    connection-factory="connectionFactory" 
+	    reply-destination-name="pipeline06-02"
+		request-destination-name="anotherGatewayQueue"
+		correlation-key="foo"/>
+		
+	<int-jms:inbound-gateway request-channel="anotherIn"
+		request-destination-name="anotherGatewayQueue"
+		connection-factory="connectionFactory"
+		concurrent-consumers="10"
+		reply-timeout="10000"
+		correlation-key="foo"/>
+		
+	<int:transformer input-channel="anotherIn" expression="payload"/>
+
+	<bean id="connectionFactory"
+		class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>
+			</bean>
+		</property>
+		<property name="sessionCacheSize" value="10"/>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+	</bean>
+
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-07.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-07.xml
@@ -11,19 +11,20 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
-	<int:gateway default-request-channel="pipeline08" default-request-timeout="10000" default-reply-timeout="10000"/>
+	<int:gateway default-request-channel="pipeline07" default-request-timeout="10000" default-reply-timeout="10000"/>
 
-	<int-jms:outbound-gateway request-channel="pipeline08"
+	<int-jms:outbound-gateway request-channel="pipeline07"
 	    connection-factory="connectionFactory" 
-		request-destination-name="pipeline08-queue-01"
-		correlation-key="foo"/>
+	    reply-destination-name="pipeline07-01"
+	    correlation-key="foo"
+		request-destination-name="siOutQueue"/>
 	
 	<int-jms:inbound-gateway request-channel="jmsIn"
-		request-destination-name="pipeline08-queue-01"
+		request-destination-name="siOutQueue"
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
-		reply-timeout="10000"
-		correlation-key="foo"/>
+		correlation-key="foo"
+		reply-timeout="10000"/>
 
 	<int:chain input-channel="jmsIn" output-channel="anotherGatewayChannel">
 		<int:header-enricher>
@@ -35,14 +36,16 @@
 	
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
 	    connection-factory="connectionFactory" 
-		request-destination-name="pipeline08-queue-02"
-		correlation-key="JMSCorrelationID"/>
+	    reply-destination-name="pipeline07-02"
+		request-destination-name="anotherGatewayQueue"
+		correlation-key="bar"/>
 		
 	<int-jms:inbound-gateway request-channel="anotherIn"
-		request-destination-name="pipeline08-queue-02"
+		request-destination-name="anotherGatewayQueue"
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
-		reply-timeout="10000"/>
+		reply-timeout="10000"
+		correlation-key="bar"/>
 		
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-cached-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-cached-consumers.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd">
+
+	<int:gateway id="standardMessageIdCopyingConsumerWithOptimization" default-request-channel="jmsInOptimizedA"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInOptimizedA"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueOptimizedA"
+		reply-destination="siInQueueOptimizedA"
+		correlation-key="JMSCorrelationID"/>
+		
+	<bean id="siOutQueueOptimizedA" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueOptimizedA"/>
+	</bean>
+	
+	<bean id="siInQueueOptimizedA" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueOptimizedA"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="standardMessageIdCopyingConsumerWithoutOptimization" default-request-channel="jmsInNonOptimizedB"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedB"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueNonOptimizedB"
+		reply-destination="siInQueueNonOptimizedB"/>
+		
+	<bean id="siOutQueueNonOptimizedB" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueNonOptimizedB"/>
+	</bean>
+	
+	<bean id="siInQueueNonOptimizedB" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueNonOptimizedB"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="correlationPropagatingConsumerWithOptimization" default-request-channel="jmsInOptimizedC"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInOptimizedC"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueOptimizedC"
+		reply-destination="siInQueueOptimizedC"
+		correlation-key="JMSCorrelationID"/>
+		
+	<bean id="siOutQueueOptimizedC" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueOptimizedC"/>
+	</bean>
+	
+	<bean id="siInQueueOptimizedC" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueOptimizedC"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="correlationPropagatingConsumerWithoutOptimization" default-request-channel="jmsInNonOptimizedD"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedD"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueNonOptimizedD"
+		reply-destination="siInQueueNonOptimizedD"/>
+		
+	<bean id="siOutQueueNonOptimizedD" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueNonOptimizedD"/>
+	</bean>
+	
+	<bean id="siInQueueNonOptimizedD" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueNonOptimizedD"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="correlationPropagatingConsumerWithOptimizationDelayFirstReply" default-request-channel="jmsInE"/>
+
+	<int-jms:outbound-gateway id="fastGateway" request-channel="jmsInE"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueE"
+		reply-destination="siInQueueE"
+		receive-timeout="500"
+		correlation-key="JMSCorrelationID"/>
+		
+	<bean id="siOutQueueE" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueE"/>
+	</bean>
+	
+	<bean id="siInQueueE" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueE"/>
+	</bean>
+	 
+	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>		
+			</bean>
+		</property>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+		<property name="sessionCacheSize" value="10" />
+	</bean>
+	
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-no-cached-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-no-cached-consumers.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd">
+
+	<int:gateway id="optimized" default-request-channel="jmsInOptimized"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInOptimized"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueA"
+		reply-destination="siInQueueA"
+		correlation-key="JMSCorrelationID"/>
+		
+	<bean id="siOutQueueA" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueA.not.cached"/>
+	</bean>
+	
+	<bean id="siInQueueA" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueA.not.cached"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="nonoptimized" default-request-channel="jmsInNonOptimized"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInNonOptimized"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueB"
+		reply-destination="siInQueueB"/>
+		
+	<bean id="siOutQueueB" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueB.not.cached"/>
+	</bean>
+	
+	<bean id="siInQueueB" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueB.not.cached"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="optimizedMessageId" default-request-channel="jmsInOptimizedC"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInOptimizedC"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueC"
+		reply-destination="siInQueueC"
+		correlation-key="JMSCorrelationID"/>
+		
+	<bean id="siOutQueueC" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueC.not.cached"/>
+	</bean>
+	
+	<bean id="siInQueueC" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueC.not.cached"/>
+	</bean>
+	
+	<!--  -->
+	
+	<int:gateway id="nonoptimizedMessageId" default-request-channel="jmsInNonOptimizedD"/>
+
+	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedD"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueueD"
+		reply-destination="siInQueueD"/>
+		
+	<bean id="siOutQueueD" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueD.not.cached"/>
+	</bean>
+	
+	<bean id="siInQueueD" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siInQueueD.not.cached"/>
+	</bean>
+	 
+	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>		
+			</bean>
+		</property>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="false" />
+		<property name="sessionCacheSize" value="10" />
+	</bean>
+</beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-temp-reply-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-temp-reply-consumers.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd">
+
+	<int:gateway default-request-channel="jmsIn"/>
+
+	<int-jms:outbound-gateway request-channel="jmsIn"
+	    connection-factory="connectionFactory" 
+		request-destination="siOutQueue"/>
+		
+	<bean id="siOutQueue" class="org.apache.activemq.command.ActiveMQQueue">
+		<constructor-arg value="siOutQueueA"/>
+	</bean>
+	 
+	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+		<property name="targetConnectionFactory">
+			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
+				<property name="brokerURL" value="vm://localhost"/>		
+			</bean>
+		</property>
+		<property name="cacheProducers" value="true" />
+		<property name="cacheConsumers" value="true" />
+		<property name="sessionCacheSize" value="10" />
+	</bean>
+	
+</beans>

--- a/spring-integration-jms/src/test/resources/log4j.properties
+++ b/spring-integration-jms/src/test/resources/log4j.properties
@@ -1,11 +1,11 @@
-log4j.rootCategory=WARN, stdout
+log4j.rootCategory=ERROR, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c{2}:%L - %m%n
 
 
-log4j.category.org.springframework=WARN
-# log4j.category.org.springframework.integration=DEBUG
+log4j.category.org.springframework=ERROR
+#log4j.category.org.springframework.integration.jms=DEBUG
 # log4j.category.org.springframework.integration.jdbc=DEBUG
-log4j.category.org.springframework.jms=DEBUG
+log4j.category.org.springframework.jms=ERROR


### PR DESCRIPTION
Added support for caching reply consumers in the JmsOutboundGateway
Added support for reuse of temporary Reply queues in the JmsOutboundGateway

INT-2683, INT-2684 removed 'si' package with perf numbers, will go into samples

INT-2683 polishing

INT-2683 polishing

INT-2683 polishing

INT-2683
created IntegrationCachingConnectionFactory as a wrapper over CachingConnectionFactory
removed local Session and Consumer Caching since we can now rely on CCF
cleaned up JmsOutboundGateway (consolidated code that was different for tempReplyQueue and named replyQueeu scenarios)
added concurrency tests

INT-2683 minor improvements to IntegrationCachingConnectionFactory.java

INT-2683 set DEBUG level for SI JMS code, polished test

INT-2683 polished JmsOutboundGateway to ensure it creates only one temp-reply-queue

INT-2683 polishing

INT-2683 updated JmsOutboundGateway with
ability to detect and recreate invalid temporary destinations, added test to valide

INT-2683 polishing

INT-2683 fixed schema

INT-2683 Jms Request/Reply improvements

INT-2683 Jms Request/Reply improvements
