### PR TITLE
INT-2704 Exception Processing in TCP Adapter

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ExpressionEvaluatingRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ExpressionEvaluatingRequestHandlerAdvice.java
@@ -122,15 +122,17 @@ public class ExpressionEvaluatingRequestHandlerAdvice extends AbstractRequestHan
 	protected Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) throws Exception {
 		try {
 			Object result = callback.execute();
-			if (onSuccessMessageProcessor != null) {
+			if (this.onSuccessMessageProcessor != null) {
 				evaluateExpression(message, this.onSuccessMessageProcessor, this.successChannel, this.propagateOnSuccessEvaluationFailures);
 			}
 			return result;
 		}
 		catch (Exception e) {
-			Object evalResult = evaluateExpression(message, this.onFailureMessageProcessor, this.failureChannel, false);
-			if (this.returnFailureExpressionResult) {
-				return evalResult;
+			if (this.onFailureMessageProcessor != null) {
+				Object evalResult = evaluateExpression(message, this.onFailureMessageProcessor, this.failureChannel, false);
+				if (this.returnFailureExpressionResult) {
+					return evalResult;
+				}
 			}
 			if (!this.trapException) {
 				throw e;

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingNoSocketTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingNoSocketTests-context.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int-ip="http://www.springframework.org/schema/integration/ip"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/ip http://www.springframework.org/schema/integration/ip/spring-integration-ip-2.2.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="mockCf" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory" />
+	</bean>
+
+	<int-ip:tcp-outbound-channel-adapter
+		connection-factory="mockCf" channel="shouldFail" />
+
+	<int-ip:tcp-outbound-channel-adapter
+		connection-factory="mockCf" channel="advised">
+		<int-ip:request-handler-advice-chain>
+			<bean class="org.springframework.integration.handler.advice.ExpressionEvaluatingRequestHandlerAdvice">
+				<constructor-arg value=""/>
+				<constructor-arg ref="nullChannel"/>
+				<constructor-arg value=""/>
+				<constructor-arg ref="nullChannel"/>
+				<property name="trapException" value="true" />
+			</bean>
+		</int-ip:request-handler-advice-chain>
+	</int-ip:tcp-outbound-channel-adapter>
+
+	<int:channel id="shouldFail" />
+
+	<int:channel id="advised" />
+</beans>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingNoSocketTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingNoSocketTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.ip.tcp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.MessageHandlingException;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class TcpSendingNoSocketTests {
+
+	@Autowired
+	private MessageChannel shouldFail;
+
+	@Autowired
+	private MessageChannel advised;
+
+	@Test
+	public void exceptionExpected() {
+		try {
+			shouldFail.send(new GenericMessage<String>("foo"));
+			fail("Exception expected");
+		}
+		catch (MessageHandlingException e) {
+			assertEquals("Unable to find outbound socket", e.getMessage());
+		}
+	}
+
+	@Test
+	public void exceptionTrapped() {
+		advised.send(new GenericMessage<String>("foo"));
+	}
+}


### PR DESCRIPTION
**\* MERGE AFTER PR #572 ***

When using an outbound adapter with a server connection factory
(an inbound adapter 'owns' the connections), the outbound adapter
simply logged exceptions.

There are use cases where flows need to know the exception occurs.

Change the adapter to throw a MessagingException.

Update the 2.1 to 2.2. Migration guide explaining that the
ExpressionEvaluatingRequestHandlerAdvice can be used to restore
2.1 behavior, and trap the exception.
