### PR TITLE
INT-2706: fix 'expected-response-type' primitives

### DIFF
--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context-fail.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context-fail.xml
@@ -5,16 +5,16 @@
 	xmlns:int-http="http://www.springframework.org/schema/integration/http"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd">
+		http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http.xsd">
 
-				   
+
 	<int-http:outbound-gateway url="http://localhost:51235/testApps/outboundResponse"
 							   request-channel="resTypeSetChannel"
 							   reply-channel="replyChannel"
 							   expected-response-type="java.lang.String"
 							   expected-response-type-expression="payload"/>
-							   
-	
+
+
 	<int:channel id="replyChannel">
 		<int:queue/>
 	</int:channel>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context.xml
@@ -5,18 +5,23 @@
 	xmlns:int-http="http://www.springframework.org/schema/integration/http"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd">
+		http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http.xsd">
 
 
 	<int-http:outbound-gateway url="http://localhost:51235/testApps/outboundResponse"
 							   request-channel="requestChannel"
 							   reply-channel="replyChannel"/>
-							   
+
 	<int-http:outbound-gateway url="http://localhost:51235/testApps/outboundResponse"
 							   request-channel="resTypeSetChannel"
 							   reply-channel="replyChannel"
 							   expected-response-type="java.lang.String"/>
-							   
+
+	<int-http:outbound-gateway url="http://localhost:51235/testApps/outboundResponse"
+							   request-channel="resPrimitiveStringPresentationChannel"
+							   reply-channel="replyChannel"
+							   expected-response-type="[B"/>
+
 	<int-http:outbound-gateway url="http://localhost:51235/testApps/outboundResponse"
 							   request-channel="resTypeExpressionSetChannel"
 							   reply-channel="replyChannel"


### PR DESCRIPTION
- HttpRequestExecutingMessageHandler: change Class.forName() to ClassUtils.forName()
- HttpRequestExecutingMessageHandler: some polishing about DRY
- OutboundResponseTypeTests: tests about "byte[]" & "[B" values for 'expectedResponseTypeExpression'
- OutboundResponseTypeTests: polishing to make it more quickly
- OutboundResponseTypeTests contexts: versionless XSD

JIRA: https://jira.springsource.org/browse/INT-2706
