### PR TITLE
INT-2712 fixed initialization logic in HttpRequestExecutingMessageHandle...

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -32,7 +32,7 @@ import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.context.expression.MapAccessor;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.core.convert.support.ConfigurableConversionService;
+import org.springframework.core.convert.converter.ConverterRegistry;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
@@ -291,17 +291,17 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 		if (conversionService == null){
 			conversionService = new GenericConversionService();
 		}
-		if (conversionService instanceof ConfigurableConversionService){
-			ConfigurableConversionService configurableConversionService =
-					(ConfigurableConversionService) conversionService;
+		if (conversionService instanceof ConverterRegistry){
+			ConverterRegistry converterRegistry =
+					(ConverterRegistry) conversionService;
 
-			configurableConversionService.addConverter(new ClassToStringConverter());
-			configurableConversionService.addConverter(new ObjectToStringConverter());
+			converterRegistry.addConverter(new ClassToStringConverter());
+			converterRegistry.addConverter(new ObjectToStringConverter());
 
-			this.evaluationContext.setTypeConverter(new StandardTypeConverter(configurableConversionService));
+			this.evaluationContext.setTypeConverter(new StandardTypeConverter((ConversionService) converterRegistry));
 		}
 		else {
-			logger.warn("ConversionService is not an instance of ConfigurableConversionService therefore" +
+			logger.warn("ConversionService is not an instance of ConverterRegistry therefore" +
 					"ClassToStringConverter and ObjectToStringConverter will not be registered");
 		}
 	}

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -21,10 +21,7 @@ import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,14 +34,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.xml.transform.Source;
 
 import org.junit.Test;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.core.convert.ConversionService;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -709,19 +705,6 @@ public class HttpRequestExecutingMessageHandlerTests {
 			fail("Unexpected exception during initialization " + e.getMessage());
 		}
 		assertSame(mockConversionService, TestUtils.getPropertyValue(handler, "conversionService"));
-	}
-
-	@Test
-	public void compatibleConversionService() throws Exception {
-		HttpRequestExecutingMessageHandler handler =
-				new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
-		ConfigurableListableBeanFactory bf = new DefaultListableBeanFactory();
-		ConfigurableConversionService mockConfigurableConversionService = mock(ConfigurableConversionService.class);
-		bf.registerSingleton("integrationConversionService", mockConfigurableConversionService);
-		handler.setBeanFactory(bf);
-		handler.afterPropertiesSet();
-		verify(mockConfigurableConversionService, times(2)).addConverter(any(Converter.class));
-		assertSame(mockConfigurableConversionService, TestUtils.getPropertyValue(handler, "conversionService"));
 	}
 
 	public static class City{


### PR DESCRIPTION
...r

Fix initialization of the ConversionService logic in HttpRequestExecutingMessageHandler to NOT throw an exception if
ConversionService is not an instance of ConfigurableConversionService

INT-2712
fixed previous commit to be compatible with Spring 3.0, by dependiing on ConverterRegistry instead of ConfigurableConversionService which was introduced in Spring 3.1
