### PR TITLE
INT-2713 AMQP Content-Type mapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,7 @@ project('spring-integration-amqp') {
 		}
 		testCompile project(":spring-integration-stream")
 		testCompile project(":spring-integration-test")
+		testCompile project(":spring-integration-http") // need to test INT-2713
 	}
 	bundlor {
 		bundleSymbolicName = 'org.springframework.integration.amqp'

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.integration.amqp.support;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,15 +31,14 @@ import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.JsonMessageConverter;
+import org.springframework.http.MediaType;
 import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.amqp.AmqpHeaders;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Oleg Zhurakousky
  * @since 2.1
  */
 public class DefaultAmqpHeaderMapperTests {
@@ -94,6 +96,21 @@ public class DefaultAmqpHeaderMapperTests {
 		assertEquals("test.userId", amqpProperties.getUserId());
 		assertEquals("test.correlation", amqpProperties.getHeaders().get(RabbitTemplate.STACKED_CORRELATION_HEADER));
 		assertEquals("test.replyTo2", amqpProperties.getHeaders().get(RabbitTemplate.STACKED_REPLY_TO_HEADER));
+	}
+
+	@Test
+	public void fromHeadersWithContentTypeAsMediaType() {
+		DefaultAmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
+		Map<String, Object> headerMap = new HashMap<String, Object>();
+
+		MediaType contentType = MediaType.parseMediaType("text/html");
+		headerMap.put(AmqpHeaders.CONTENT_TYPE, contentType);
+
+		MessageHeaders integrationHeaders = new MessageHeaders(headerMap);
+		MessageProperties amqpProperties = new MessageProperties();
+		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
+
+		assertEquals("text/html", amqpProperties.getContentType());
 	}
 
 	@Test

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -135,7 +135,7 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	public Map<String, Object> toHeadersFromReply(T source) {
 		return this.toHeaders(source, this.replyHeaderNames);
 	}
-	
+
 	private void fromHeaders(MessageHeaders headers, T target, List<String> headerPatterns){
 		try {
 			Map<String, Object> subset = new HashMap<String, Object>();
@@ -250,10 +250,11 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 			if (logger.isWarnEnabled()) {
 				logger.warn("skipping header '" + name + "' since it is not of expected type [" + type + "]");
 			}
+			return null;
 		}
 		return (V) value;
 	}
-	
+
 	private boolean containsElementIgnoreCase(List<String> headerNames, String name) {
 		for (String headerName : headerNames) {
 			if (headerName.equalsIgnoreCase(name)){
@@ -287,7 +288,7 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	protected List<String> getStandardRequestHeaderNames(){
 		return Collections.emptyList();
 	}
-	
+
 	/**
 	 * Returns the list of standard REPLY headers. Implementation provided by a subclass
 	 */


### PR DESCRIPTION
Adjusted DefaultAmqpHeaderMapper to recognize and convert Content-Type to String is the incoming Content-Type headers is of type org.springframework.http.MediaType
