### PR TITLE
INT-2717: add 'view-expression' to <http:I-C-A>

### DIFF
--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.2.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.2.xsd
@@ -75,7 +75,9 @@
 					<xsd:documentation>
 						SpEL expression that resolves to a view to be resolved when rendering a response.
 						The expression can resolve to a view name or View object.
-						The root object of the evaluation context is the reply message.
+						However the 'evaluationContext' for this expression is very lightweight, it has only
+						'BeanFactoryResolver', so the usage of this attribute has limited abilities.
+						E.g. to resolve at runtime some scoped Bean, which returns as view name or View object.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.2.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-2.2.xsd
@@ -70,6 +70,15 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="view-expression" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						SpEL expression that resolves to a view to be resolved when rendering a response.
+						The expression can resolve to a view name or View object.
+						The root object of the evaluation context is the reply message.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="errors-key" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests-context.xml
@@ -23,27 +23,29 @@
 	<inbound-channel-adapter id="putOrDeleteAdapter" channel="requests" supported-methods="PUT, delete"/>
 
 	<inbound-channel-adapter id="inboundController" channel="requests" view-name="foo" error-code="oops"/>
-	
+
+	<inbound-channel-adapter id="inboundControllerViewExp" channel="requests" view-expression="'foo'"/>
+
 	<inbound-channel-adapter id="withMappedHeaders" channel="requests"
 								mapped-request-headers="foo,bar"/>
-								
-	<inbound-channel-adapter id="inboundAdapterWithExpressions" 
+
+	<inbound-channel-adapter id="inboundAdapterWithExpressions"
 	                         path="/fname/{f}/lname/{l}"
 	                         channel="requests"
 							 mapped-request-headers="foo,bar"
 							 payload-expression="#pathVariables.f">
 		<header name="lname" expression="#pathVariables.l"/>
 	</inbound-channel-adapter>
-	
-	<inbound-channel-adapter name="/fname/{blah}/lname/{boo}" 
+
+	<inbound-channel-adapter name="/fname/{blah}/lname/{boo}"
 	                         path="/fname/{f}/lname/{l}"
 	                         channel="requests"
 							 mapped-request-headers="foo,bar"
 							 payload-expression="#pathVariables.f">
 		<header name="lname" expression="#pathVariables.l"/>
 	</inbound-channel-adapter>
-	
-	<inbound-channel-adapter name="/fname/{f}/lname/{l}" 
+
+	<inbound-channel-adapter name="/fname/{f}/lname/{l}"
 	                         channel="requests"
 							 mapped-request-headers="foo,bar"
 							 payload-expression="#pathVariables.f">

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests.java
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.expression.Expression;
 import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -58,6 +59,7 @@ import org.springframework.util.MultiValueMap;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Gunnar Hillert
+ * @author Artem Bilan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -91,6 +93,9 @@ public class HttpInboundChannelAdapterParserTests {
 
 	@Autowired
 	private HttpRequestHandlingController inboundController;
+
+	@Autowired
+	private HttpRequestHandlingController inboundControllerViewExp;
 
 	@Autowired
 	private MessageChannel autoChannel;
@@ -268,9 +273,16 @@ public class HttpInboundChannelAdapterParserTests {
 
 	@Test
 	public void testController() throws Exception {
-		DirectFieldAccessor accessor = new DirectFieldAccessor(inboundController);
-		String errorCode =  (String) accessor.getPropertyValue("errorCode");
+		String errorCode = TestUtils.getPropertyValue(inboundController, "errorCode", String.class);
 		assertEquals("oops", errorCode);
+		Expression viewExpression = TestUtils.getPropertyValue(inboundController, "viewExpression", Expression.class);
+		assertEquals("foo", viewExpression.getExpressionString());
+	}
+
+	@Test
+	public void testInt2717ControllerWithViewExpression() throws Exception {
+		Expression viewExpression = TestUtils.getPropertyValue(inboundControllerViewExp, "viewExpression", Expression.class);
+		assertEquals("'foo'", viewExpression.getExpressionString());
 	}
 
 	@Test


### PR DESCRIPTION
- XSD: add 'view-expression' attribute to the http:inbound-channel-adapter since `HttpRequestHandlingController` supports it.
- Parser test for 'view-expression' attribute

JIRA: https://jira.springsource.org/browse/INT-2717
