### PR TITLE
INT-2718 & INT-2721: fixes for <chain> & fix bugs

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,8 +42,11 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.support.CorrelationData;
 import org.springframework.amqp.rabbit.support.PublisherCallbackChannel;
 import org.springframework.amqp.rabbit.support.PublisherCallbackChannelImpl;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.amqp.AmqpHeaders;
@@ -220,6 +224,18 @@ public class AmqpOutboundChannelAdapterParserTests {
 		assertEquals("anExchange", returned.getHeaders().get(AmqpHeaders.RETURN_EXCHANGE));
 		assertEquals("bar", returned.getHeaders().get(AmqpHeaders.RETURN_ROUTING_KEY));
 		assertEquals("hello", returned.getPayload());
+	}
+
+	@Test
+	public void testInt2718FailForOutboundAdapterChannelAttribute() {
+		try {
+			new ClassPathXmlApplicationContext("AmqpOutboundChannelAdapterWithinChainParserTests-fail-context.xml", this.getClass());
+			fail("Expected BeanDefinitionParsingException");
+		}
+		catch (BeansException e) {
+			assertTrue(e instanceof BeanDefinitionParsingException);
+			assertTrue(e.getMessage().contains("'channel' attribute isn't allowed for outbound-channel-adapter when it uses as nested element"));
+		}
 	}
 
 	public static class FooAdvice extends AbstractRequestHandlerAdvice {

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterWithinChainParserTests-fail-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterWithinChainParserTests-fail-context.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:amqp="http://www.springframework.org/schema/integration/amqp"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<int:chain input-channel="inputChannel">
+		<amqp:outbound-channel-adapter channel="someChannel"/>
+	</int:chain>
+
+</beans>

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractConsumerEndpointParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractConsumerEndpointParser.java
@@ -79,22 +79,31 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 		BeanDefinitionBuilder handlerBuilder = this.parseHandler(element, parserContext);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(handlerBuilder, element, "output-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(handlerBuilder, element, "order");
+
+		Element adviceChainElement = DomUtils.getChildElementByTagName(element,
+				IntegrationNamespaceUtils.REQUEST_HANDLER_ADVICE_CHAIN);
+		IntegrationNamespaceUtils.configureAndSetAdviceChainIfPresent(adviceChainElement, null,
+				handlerBuilder.getRawBeanDefinition(), parserContext);
+
 		AbstractBeanDefinition handlerBeanDefinition = handlerBuilder.getBeanDefinition();
 		String inputChannelAttributeName = this.getInputChannelAttributeName();
-		if (!element.hasAttribute(inputChannelAttributeName)) {
-			if (!parserContext.isNested()) {
+		boolean hasInputChannelAttribute = element.hasAttribute(inputChannelAttributeName);
+		if (parserContext.isNested()) {
+			if (hasInputChannelAttribute) {
+				String elementDescription = IntegrationNamespaceUtils.createElementDescription(element);
+				parserContext.getReaderContext().error("The '" + inputChannelAttributeName
+						+ "' attribute isn't allowed for the nested (e.g. inside the <chain>) endpoint element "
+						+ elementDescription + ".", element);
+			}
+			return handlerBeanDefinition;
+		} else {
+			if (!hasInputChannelAttribute) {
 				String elementDescription = IntegrationNamespaceUtils.createElementDescription(element);
 				parserContext.getReaderContext().error("The '" + inputChannelAttributeName
 						+ "' attribute is required for the top-level endpoint element "
 						+ elementDescription + ".", element);
 			}
-			return handlerBeanDefinition;
 		}
-
-		Element adviceChainElement = DomUtils.getChildElementByTagName(element,
-				IntegrationNamespaceUtils.REQUEST_HANDLER_ADVICE_CHAIN);
-		IntegrationNamespaceUtils.configureAndSetAdviceChainIfPresent(adviceChainElement, null,
-				handlerBuilder, parserContext);
 
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(ConsumerEndpointFactoryBean.class);
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
@@ -72,8 +72,8 @@ public class DelayerParser extends AbstractConsumerEndpointParser {
 		Element txElement = DomUtils.getChildElementByTagName(element, "transactional");
 		Element adviceChainElement = DomUtils.getChildElementByTagName(element, "advice-chain");
 
-		IntegrationNamespaceUtils.configureAndSetAdviceChainIfPresent(adviceChainElement, txElement, builder,
-				parserContext, "delayedAdviceChain");
+		IntegrationNamespaceUtils.configureAndSetAdviceChainIfPresent(adviceChainElement, txElement,
+				builder.getRawBeanDefinition(), parserContext, "delayedAdviceChain");
 
 		return builder;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
@@ -328,22 +328,22 @@ public abstract class IntegrationNamespaceUtils {
 	}
 
 	public static void configureAndSetAdviceChainIfPresent(Element adviceChainElement, Element txElement,
-			BeanDefinitionBuilder parentBuilder, ParserContext parserContext) {
-		configureAndSetAdviceChainIfPresent(adviceChainElement, txElement, parentBuilder, parserContext, "adviceChain");
+			BeanDefinition parentBeanDefinition, ParserContext parserContext) {
+		configureAndSetAdviceChainIfPresent(adviceChainElement, txElement, parentBeanDefinition, parserContext, "adviceChain");
 	}
 
 	@SuppressWarnings({ "rawtypes" })
 	public static void configureAndSetAdviceChainIfPresent(Element adviceChainElement, Element txElement,
-			BeanDefinitionBuilder parentBuilder, ParserContext parserContext, String propertyName) {
-		ManagedList adviceChain = configureAdviceChain(adviceChainElement, txElement, parentBuilder, parserContext);
+			BeanDefinition parentBeanDefinition, ParserContext parserContext, String propertyName) {
+		ManagedList adviceChain = configureAdviceChain(adviceChainElement, txElement, parentBeanDefinition, parserContext);
 		if (adviceChain != null) {
-			parentBuilder.addPropertyValue(propertyName, adviceChain);
+			parentBeanDefinition.getPropertyValues().add(propertyName, adviceChain);
 		}
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public static ManagedList configureAdviceChain(Element adviceChainElement, Element txElement,
-			BeanDefinitionBuilder parentBuilder, ParserContext parserContext) {
+			BeanDefinition parentBeanDefinition, ParserContext parserContext) {
 		ManagedList adviceChain = null;
 		// Schema validation ensures txElement and adviceChainElement are mutually exclusive
 		if (txElement != null) {
@@ -360,7 +360,7 @@ public abstract class IntegrationNamespaceUtils {
 					String localName = child.getLocalName();
 					if ("bean".equals(localName)) {
 						BeanDefinitionHolder holder = parserContext.getDelegate().parseBeanDefinitionElement(
-								childElement, parentBuilder.getBeanDefinition());
+								childElement, parentBeanDefinition);
 						parserContext.registerBeanComponent(new BeanComponentDefinition(holder));
 						adviceChain.add(new RuntimeBeanReference(holder.getBeanName()));
 					}
@@ -370,7 +370,7 @@ public abstract class IntegrationNamespaceUtils {
 					}
 					else {
 						BeanDefinition customBeanDefinition = parserContext.getDelegate().parseCustomElement(
-								childElement, parentBuilder.getBeanDefinition());
+								childElement, parentBeanDefinition);
 						if (customBeanDefinition == null) {
 							parserContext.getReaderContext().error(
 									"failed to parse custom element '" + localName + "'", childElement);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PollerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PollerParser.java
@@ -91,7 +91,7 @@ public class PollerParser extends AbstractBeanDefinitionParser {
 		Element txElement = DomUtils.getChildElementByTagName(element, "transactional");
 		Element adviceChainElement = DomUtils.getChildElementByTagName(element, "advice-chain");
 		IntegrationNamespaceUtils.configureAndSetAdviceChainIfPresent(adviceChainElement, txElement,
-				metadataBuilder, parserContext);
+				metadataBuilder.getRawBeanDefinition(), parserContext);
 
 		Element pseudoTxElement = DomUtils.getChildElementByTagName(element, "pseudo-transactional");
 		if (pseudoTxElement != null && txElement != null) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/SyslogTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/SyslogTransformerParserTests.java
@@ -34,6 +34,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.2
  *
  */
@@ -53,10 +54,10 @@ public class SyslogTransformerParserTests {
 		Map<?, ?> map = (Map<?, ?>) out.receive(1000).getPayload();
 		assertNotNull(map);
 		assertEquals(6, map.size());
-		System.out.println(map);
 		assertEquals(19, map.get(SyslogToMapTransformer.FACILITY));
 		assertEquals(5, map.get(SyslogToMapTransformer.SEVERITY));
-		assertTrue(map.get(SyslogToMapTransformer.TIMESAMP) instanceof Date);
+		Object date = map.get(SyslogToMapTransformer.TIMESAMP);
+		assertTrue(date instanceof Date || date instanceof String);
 		assertEquals("WEBERN", map.get(SyslogToMapTransformer.HOST));
 		assertEquals("TESTING[70729]", map.get(SyslogToMapTransformer.TAG));
 		assertEquals("TEST SYSLOG MESSAGE", map.get(SyslogToMapTransformer.MESSAGE));

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/SysLogTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/SysLogTransformerTests.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.2
  *
  */
@@ -36,10 +37,10 @@ public class SysLogTransformerTests {
 		Map<String, ?> transformed = t.transformPayload(
 				"<158>JUL 26 22:08:35 WEBERN TESTING[70729]: TEST SYSLOG MESSAGE".getBytes());
 		assertEquals(6, transformed.size());
-//		System.out.println(transformed);
 		assertEquals(19, transformed.get(SyslogToMapTransformer.FACILITY));
 		assertEquals(6, transformed.get(SyslogToMapTransformer.SEVERITY));
-		assertTrue(transformed.get(SyslogToMapTransformer.TIMESAMP) instanceof Date);
+		Object date = transformed.get(SyslogToMapTransformer.TIMESAMP);
+		assertTrue(date instanceof Date || date instanceof String);
 		assertEquals("WEBERN", transformed.get(SyslogToMapTransformer.HOST));
 		assertEquals("TESTING[70729]", transformed.get(SyslogToMapTransformer.TAG));
 		assertEquals("TEST SYSLOG MESSAGE", transformed.get(SyslogToMapTransformer.MESSAGE));

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
@@ -12,7 +12,7 @@
 	</bean>
 
 	<int-ftp:outbound-gateway id="gateway1"
-		local-directory="/tmp"
+		local-directory="local-test-dir"
 		session-factory="sf"
 		request-channel="inbound1"
 		reply-channel="outbound"
@@ -29,7 +29,7 @@
 		/>
 
 	<int-ftp:outbound-gateway id="gateway2"
-		local-directory="/tmp"
+		local-directory="local-test-dir"
 		session-factory="sf"
 		request-channel="inbound2"
 		reply-channel="outbound"

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
@@ -39,6 +39,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Gary Russell
  * @author Gunnar Hillert
+ * @author Artem Bilan
  *
  * @since 2.1
  *
@@ -62,7 +63,7 @@ public class FtpOutboundGatewayParserTests {
 		assertEquals("X", TestUtils.getPropertyValue(gateway, "remoteFileSeparator"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
-		assertEquals(new File("/tmp"), TestUtils.getPropertyValue(gateway, "localDirectory"));
+		assertEquals(new File("local-test-dir"), TestUtils.getPropertyValue(gateway, "localDirectory"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "filter"));
 		assertEquals("ls", TestUtils.getPropertyValue(gateway, "command"));
@@ -83,7 +84,7 @@ public class FtpOutboundGatewayParserTests {
 		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
 		assertTrue(TestUtils.getPropertyValue(gateway, "sessionFactory") instanceof CachingSessionFactory);
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
-		assertEquals(new File("/tmp"), TestUtils.getPropertyValue(gateway, "localDirectory"));
+		assertEquals(new File("local-test-dir"), TestUtils.getPropertyValue(gateway, "localDirectory"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
 		assertEquals("get", TestUtils.getPropertyValue(gateway, "command"));
 		@SuppressWarnings("unchecked")

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/GroovyScriptExecutingMessageProcessorTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/GroovyScriptExecutingMessageProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import org.springframework.test.annotation.Repeat;
  * @author Mark Fisher
  * @author Dave Syer
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  * @since 2.0
  */
 public class GroovyScriptExecutingMessageProcessorTests {
@@ -63,7 +64,7 @@ public class GroovyScriptExecutingMessageProcessorTests {
 		Object result = processor.processMessage(message);
 		assertEquals("payload is foo, header is bar"+count, result.toString());
 	}
-	
+
 	@Test
 	public void testSimpleExecutionWithScriptVariableGenerator() throws Exception {
 		int count = countHolder.getAndIncrement();
@@ -82,7 +83,7 @@ public class GroovyScriptExecutingMessageProcessorTests {
 			}
 		}
 		for (int i = 0; i < 5; i++) {
-			ScriptVariableGenerator scriptVariableGenerator = new CustomScriptVariableGenerator();		
+			ScriptVariableGenerator scriptVariableGenerator = new CustomScriptVariableGenerator();
 			MessageProcessor<Object> processor = new GroovyScriptExecutingMessageProcessor(scriptSource, scriptVariableGenerator);
 			Object newResult = processor.processMessage(message);
 			assertFalse(newResult.equals(result)); // make sure that we get different nanotime verifying that generateScriptVariables() is invoked
@@ -153,7 +154,7 @@ public class GroovyScriptExecutingMessageProcessorTests {
 		result = processor.processMessage(message);
 		assertEquals("payload is foo, header is bar", result.toString());
 	}
-	
+
 	@Test
 	public void testRefreshableScriptExecutionWithAlwaysRefresh() throws Exception {
 		String script = "return \"payload is $payload, header is $headers.testHeader\"";
@@ -178,26 +179,26 @@ public class GroovyScriptExecutingMessageProcessorTests {
 
 	private static class TestResource extends AbstractResource {
 
-		private String script;
+		private volatile String script;
 
 		private final String filename;
 
-		private long lastModified;
+		private volatile long lastModified;
 
 		private TestResource(String script, String filename) {
 			setScript(script);
 			this.filename = filename;
 		}
-		
+
 		public long lastModified() throws IOException {
 			return lastModified;
 		}
-		
+
 		public void setScript(String script) {
-			this.lastModified = System.currentTimeMillis();
+			this.lastModified = System.nanoTime();
 			this.script = script;
 		}
-		
+
 		public String getDescription() {
 			return "test";
 		}
@@ -208,8 +209,8 @@ public class GroovyScriptExecutingMessageProcessorTests {
 		}
 
 		public InputStream getInputStream() throws IOException {
-			return new ByteArrayInputStream(script.getBytes("UTF-8")); 
+			return new ByteArrayInputStream(script.getBytes("UTF-8"));
 		}
-	} 
+	}
 
 }

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
@@ -20,16 +20,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.http.HttpMethod;
@@ -51,6 +55,7 @@ import org.springframework.web.client.ResponseErrorHandler;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -174,6 +179,20 @@ public class HttpOutboundGatewayParserTests {
 		handler.handleMessage(new GenericMessage<String>("foo"));
 		assertEquals(1, adviceCalled);
 	}
+
+	@Test
+	public void testInt2718FailForGatewayRequestChannelAttribute() {
+		try {
+			new ClassPathXmlApplicationContext("HttpOutboundGatewayWithinChainTests-fail-context.xml", this.getClass());
+			fail("Expected BeanDefinitionParsingException");
+		}
+		catch (BeansException e) {
+			assertTrue(e instanceof BeanDefinitionParsingException);
+			assertTrue(e.getMessage().contains("'request-channel' attribute isn't allowed for the nested"));
+		}
+	}
+
+
 
 	public static class StubErrorHandler implements ResponseErrorHandler {
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayWithinChainTests-fail-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayWithinChainTests-fail-context.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans
+	xmlns="http://www.springframework.org/schema/integration/http"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:si="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<si:chain input-channel="httpOutboundGatewayWithinChain">
+		<outbound-gateway url="http://test.org" request-channel="someRequestChannel"/>
+	</si:chain>
+
+</beans:beans>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
@@ -28,7 +28,7 @@
 	<delayer id="transactionalDelayer"
 			 input-channel="transactionalDelayerInput"
 			 output-channel="transactionalDelayerOutput"
-			 default-delay="10"
+			 default-delay="50"
 			 message-store="messageStore">
 		<transactional/>
 	</delayer>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
@@ -133,7 +133,7 @@ public class DelayerHandlerRescheduleIntegrationTests {
 
 		input.send(MessageBuilder.withPayload("test").build());
 
-		Thread.sleep(30);
+		Thread.sleep(100);
 
 		assertEquals(1, messageStore.messageGroupSize(delayerMessageGroupId));
 
@@ -141,7 +141,7 @@ public class DelayerHandlerRescheduleIntegrationTests {
 		context.destroy();
 		context.refresh();
 
-		assertTrue(RollbackTxSync.latch.await(2, TimeUnit.SECONDS));
+		assertTrue(RollbackTxSync.latch.await(20, TimeUnit.SECONDS));
 
 		//On transaction rollback the delayed Message should remain in the persistent MessageStore
 		assertEquals(1, messageStore.messageGroupSize(delayerMessageGroupId));

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/StoredProcOutboundGatewayWithNamespaceIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/StoredProcOutboundGatewayWithNamespaceIntegrationTests.java
@@ -28,6 +28,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,7 +55,7 @@ import javax.sql.DataSource;
 public class StoredProcOutboundGatewayWithNamespaceIntegrationTests {
 
 	@Autowired
-	DataSource dataSource;
+	JdbcTemplate jdbcTemplate;
 
 	@Autowired
 	private Consumer consumer;
@@ -67,6 +68,11 @@ public class StoredProcOutboundGatewayWithNamespaceIntegrationTests {
 
 	@Autowired
 	PollableChannel replyChannel;
+
+	@Before
+	public void setUp() {
+		this.jdbcTemplate.execute("delete from USERS");
+	}
 
 	@Test
 	public void test() throws Exception {
@@ -96,10 +102,6 @@ public class StoredProcOutboundGatewayWithNamespaceIntegrationTests {
 
 	@Test //INT-1029
 	public void testStoredProcOutboundGatewayInsideChain() throws Exception {
-
-		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-
-		jdbcTemplate.execute("delete from USERS");
 
 		Message<User> requestMessage = MessageBuilder.withPayload(new User("myUsername", "myPassword", "myEmail")).build();
 

--- a/spring-integration-jdbc/src/test/resources/derby-stored-procedures-setup-context.xml
+++ b/spring-integration-jdbc/src/test/resources/derby-stored-procedures-setup-context.xml
@@ -2,13 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xmlns:tx="http://www.springframework.org/schema/tx"
-	xmlns:util="http://www.springframework.org/schema/util"
-	xmlns:p="http://www.springframework.org/schema/p"
 	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<jdbc:embedded-database id="dataSource" type="DERBY"/>
 
@@ -16,6 +11,10 @@
 		<jdbc:script location="classpath:derby-stored-procedures-drops.sql"/>
 		<jdbc:script location="classpath:derby-stored-procedures.sql"/>
 	</jdbc:initialize-database>
+
+	<bean class="org.springframework.jdbc.core.JdbcTemplate">
+		<constructor-arg ref="dataSource"/>
+	</bean>
 
 	<bean id="transactionManager"
 			class="org.springframework.jdbc.datasource.DataSourceTransactionManager">

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests-context.xml
@@ -12,7 +12,7 @@
 	</bean>
 
 	<int-sftp:outbound-gateway id="gateway1"
-		local-directory="/tmp"
+		local-directory="local-test-dir"
 		session-factory="sf"
 		request-channel="inbound1"
 		reply-channel="outbound"
@@ -29,7 +29,7 @@
 		/>
 
 	<int-sftp:outbound-gateway id="gateway2"
-		local-directory="/tmp"
+		local-directory="local-test-dir"
 		session-factory="sf"
 		request-channel="inbound2"
 		reply-channel="outbound"
@@ -44,7 +44,7 @@
 		/>
 
 	<int-sftp:outbound-gateway id="advised"
-		local-directory="/tmp"
+		local-directory="local-test-dir"
 		session-factory="sf"
 		request-channel="inbound2"
 		reply-channel="outbound"

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
@@ -39,6 +39,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Gary Russell
  * @author Gunnar Hillert
+ * @author Artem Bilan
  *
  * @since 2.1
  *
@@ -65,7 +66,7 @@ public class SftpOutboundGatewayParserTests {
 		assertEquals("X", TestUtils.getPropertyValue(gateway, "remoteFileSeparator"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
-		assertEquals(new File("/tmp"), TestUtils.getPropertyValue(gateway, "localDirectory"));
+		assertEquals(new File("local-test-dir"), TestUtils.getPropertyValue(gateway, "localDirectory"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "filter"));
 		assertEquals("ls", TestUtils.getPropertyValue(gateway, "command"));
@@ -86,7 +87,7 @@ public class SftpOutboundGatewayParserTests {
 		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
 		assertTrue(TestUtils.getPropertyValue(gateway, "sessionFactory") instanceof CachingSessionFactory);
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
-		assertEquals(new File("/tmp"), TestUtils.getPropertyValue(gateway, "localDirectory"));
+		assertEquals(new File("local-test-dir"), TestUtils.getPropertyValue(gateway, "localDirectory"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
 		assertEquals("get", TestUtils.getPropertyValue(gateway, "command"));
 		@SuppressWarnings("unchecked")

--- a/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/config/OutboundAdapterWithRHACWithinChain-fail-context.xml
+++ b/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/config/OutboundAdapterWithRHACWithinChain-fail-context.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+		xmlns:beans="http://www.springframework.org/schema/beans"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns:twitter="http://www.springframework.org/schema/integration/twitter"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+						http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-twitter.xsd">
+
+	<beans:bean id="twitter" class="org.springframework.social.twitter.api.impl.TwitterTemplate"/>
+
+   	<chain input-channel="inputChannel">
+		<twitter:outbound-channel-adapter twitter-template="twitter">
+			<twitter:request-handler-advice-chain>
+				<beans:bean class="org.springframework.integration.twitter.config.TestSendingMessageHandlerParserTests$FooAdvice" />
+			</twitter:request-handler-advice-chain>
+		</twitter:outbound-channel-adapter>
+	</chain>
+
+</beans:beans>
+
+

--- a/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/config/TestSendingMessageHandlerParserTests.java
+++ b/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/config/TestSendingMessageHandlerParserTests.java
@@ -18,8 +18,12 @@ package org.springframework.integration.twitter.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
@@ -33,6 +37,7 @@ import org.springframework.integration.twitter.outbound.DirectMessageSendingMess
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.0
  */
 public class TestSendingMessageHandlerParserTests {
@@ -55,6 +60,20 @@ public class TestSendingMessageHandlerParserTests {
 		handler2.handleMessage(new GenericMessage<String>("foo"));
 		assertEquals(2, adviceCalled);
 	}
+
+	@Test
+	public void testInt2718FailForOutboundAdapterWithRequestHandlerAdviceChainWithinChainConfig() {
+		try {
+			new ClassPathXmlApplicationContext("OutboundAdapterWithRHACWithinChain-fail-context.xml", this.getClass());
+			fail("Expected BeanDefinitionParsingException");
+		}
+		catch (BeansException e) {
+			assertTrue(e instanceof BeanDefinitionParsingException);
+			assertTrue(e.getMessage().contains("'request-handler-advice-chain' isn't allowed " +
+					"for 'outbound-channel-adapter' within <chain>, when its Handler isn't instanceOf AbstractReplyProducingMessageHandler"));
+		}
+	}
+
 
 	public static class FooAdvice extends AbstractRequestHandlerAdvice {
 

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
+import org.springframework.integration.MessageChannel;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
@@ -52,6 +53,7 @@ import org.springframework.ws.transport.WebServiceMessageSender;
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class WebServiceOutboundGatewayParserTests {
 
@@ -367,12 +369,23 @@ public class WebServiceOutboundGatewayParserTests {
 
 	@Test
 	public void advised() {
+		adviceCalled = 0;
 		ApplicationContext context = new ClassPathXmlApplicationContext(
 				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithAdvice");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
 		MessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler", MessageHandler.class);
 		handler.handleMessage(new GenericMessage<String>("foo"));
+		assertEquals(1, adviceCalled);
+	}
+
+	@Test
+	public void testInt2718AdvisedInsideTheChain() {
+		adviceCalled = 0;
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
+		MessageChannel channel = context.getBean("gatewayWithAdviceInsideTheChain", MessageChannel.class);
+		channel.send(new GenericMessage<String>("foo"));
 		assertEquals(1, adviceCalled);
 	}
 

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/simpleWebServiceOutboundGatewayParserTests.xml
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/simpleWebServiceOutboundGatewayParserTests.xml
@@ -102,13 +102,24 @@
 		                 request-channel="inputChannel"
 	                     destination-provider="destinationProvider" />
 
-    <ws:outbound-gateway id="gatewayWithAdvice"
+	<bean id="fooAdvice" class="org.springframework.integration.ws.config.WebServiceOutboundGatewayParserTests$FooAdvice"/>
+
+	<ws:outbound-gateway id="gatewayWithAdvice"
 		                 request-channel="inputChannel"
 	                     destination-provider="destinationProvider">
 		<ws:request-handler-advice-chain>
-			<bean class="org.springframework.integration.ws.config.WebServiceOutboundGatewayParserTests$FooAdvice"/>		
+			<ref bean="fooAdvice"/>
 		</ws:request-handler-advice-chain>
 	</ws:outbound-gateway>
+
+
+	<si:chain input-channel="gatewayWithAdviceInsideTheChain">
+		<ws:outbound-gateway destination-provider="destinationProvider">
+			<ws:request-handler-advice-chain>
+				<ref bean="fooAdvice"/>
+			</ws:request-handler-advice-chain>
+		</ws:outbound-gateway>
+	</si:chain>
 
 	<bean id="sourceExtractor" class="org.springframework.integration.ws.config.StubSourceExtractor"/>
 


### PR DESCRIPTION
- ban to use 'channel' and 'request-channel' attributes for 'outbound-channel-adapters' and 'outbound-gateways' when they are declared inside the `<chain>`
- fix usage of `<request-handler-advice-chain>` for components when they are declared inside the `<chain>`
- ban to use `<request-handler-advice-chain>` for 'outbound-channel-adapters' when they are declared inside the `<chain>` don't implement `AbstractReplyProducingMessageHandler`
- refactor `IntegrationNamespaceUtils` to use `BeanDefinition` instead of `BeanDefinitionBuilder` for 'advice-chain' parsing
- tests for new logic for 'channel' and 'request-channel' attributes within `<chain>`
- tests for new logic for `<request-handler-advice-chain>` within `<chain>`
- fix failed test on slow machine
- fix `SysLogTransformer` tests

For reference:
https://jira.springsource.org/browse/INT-2718
https://jira.springsource.org/browse/INT-2721
https://jira.springsource.org/browse/INT-2719
