### PR TITLE
INT-2603 Fix TCP Shutdown Delay

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -430,10 +430,10 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 	 * Creates a taskExecutor (if one was not provided).
 	 */
 	protected Executor getTaskExecutor() {
+		if (!this.active) {
+			throw new MessagingException("Connection Factory not started");
+		}
 		synchronized (this.lifecycleMonitor) {
-			if (!this.active) {
-				throw new MessagingException("Connection Factory not started");
-			}
 			if (this.taskExecutor == null) {
 				this.privateExecutor = true;
 				this.taskExecutor = Executors.newCachedThreadPool();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryShutDownTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryShutDownTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.ip.tcp.connection;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.springframework.integration.MessagingException;
+import org.springframework.util.StopWatch;
+
+/**
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+public class ConnectionFactoryShutDownTests {
+
+	@Test
+	public void testShutdownDoesntDeadlock() throws Exception {
+		final AbstractConnectionFactory factory = new AbstractConnectionFactory(0) {
+
+			public TcpConnection getConnection() throws Exception {
+				return null;
+			}
+
+			@Override
+			public void close() {
+			}
+		};
+		factory.setActive(true);
+		Executor executor = factory.getTaskExecutor();
+		final CountDownLatch latch1 = new CountDownLatch(1);
+		final CountDownLatch latch2 = new CountDownLatch(1);
+		executor.execute(new Runnable() {
+
+			public void run() {
+				latch1.countDown();
+				try {
+					while (true) {
+						factory.getTaskExecutor();
+						Thread.sleep(100);
+					}
+				}
+				catch (MessagingException e) {
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				latch2.countDown();
+			}
+		});
+		assertTrue(latch1.await(10, TimeUnit.SECONDS));
+		StopWatch watch = new StopWatch();
+		watch.start();
+		factory.stop();
+		watch.stop();
+		assertTrue("Expected < 1000, was:" + watch.getLastTaskTimeMillis(), watch.getLastTaskTimeMillis() < 1000);
+		assertTrue(latch1.await(10, TimeUnit.SECONDS));
+	}
+}


### PR DESCRIPTION
A taskExecutor thread could deadlock in getTaskExector() if
stop() is attempting to shut down the task executor.

This could delay the stop by up to 20 seconds.

Move the if(isActive) test outside of the synchronized
block.
