### PR TITLE
INT-2733/4/6 Redis Serializers

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisCollectionsInboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisCollectionsInboundChannelAdapterParser.java
@@ -64,6 +64,8 @@ public class RedisCollectionsInboundChannelAdapterParser extends AbstractPolling
 
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "collection-type");
 
+		RedisParserUtils.setRedisSerializers(StringUtils.hasText(redisTemplate), element, parserContext, builder);
+
 		String beanName = BeanDefinitionReaderUtils.registerWithGeneratedName(
 				builder.getBeanDefinition(), parserContext.getRegistry());
 		return new RuntimeBeanReference(beanName);

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisCollectionsOutboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisCollectionsOutboundChannelAdapterParser.java
@@ -62,10 +62,7 @@ public class RedisCollectionsOutboundChannelAdapterParser extends AbstractOutbou
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "collection-type");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "extract-payload-elements");
 
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "key-serializer");
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "value-serializer");
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "hash-key-serializer");
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "hash-value-serializer");
+		RedisParserUtils.setRedisSerializers(StringUtils.hasText(redisTemplateRef), element, parserContext, builder);
 
 		if (expressionDef != null){
 			builder.addConstructorArgValue(expressionDef);

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
 
 package org.springframework.integration.redis.config;
 
+import org.w3c.dom.Element;
+
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.util.StringUtils;
-import org.w3c.dom.Element;
 
 /**
  * @author Oleg Zhurakousky
@@ -46,6 +47,7 @@ public class RedisInboundChannelAdapterParser extends AbstractChannelAdapterPars
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-startup");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "serializer");
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
 
 package org.springframework.integration.redis.config;
 
+import org.w3c.dom.Element;
+
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractOutboundChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.util.StringUtils;
-import org.w3c.dom.Element;
 
 /**
  * @author Oleg Zhurakousky
@@ -42,6 +43,7 @@ public class RedisOutboundChannelAdapterParser extends AbstractOutboundChannelAd
 		builder.addConstructorArgReference(connectionFactory);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "topic", "defaultTopic");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "serializer");
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisParserUtils.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisParserUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2007-2012 the original author or authors
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+package org.springframework.integration.redis.config;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+
+/**
+ *
+ * @author Oleg Zhurakousky
+ * @since 2.2
+ */
+public class RedisParserUtils {
+
+	public static void setRedisSerializers(boolean redisTemplateSet, Element element, ParserContext parserContext, BeanDefinitionBuilder builder){
+		if (redisTemplateSet){
+			if (element.hasAttribute("key-serializer") ||
+				element.hasAttribute("value-serializer") ||
+				element.hasAttribute("hash-key-serializer") ||
+				element.hasAttribute("hash-value-serializer")){
+
+				parserContext.getReaderContext().error("Serializers can not be provided if this adapter is initailized " +
+						"with RedisTemplate. You may set serializers directly on RedisTemplate", element);
+			}
+		}
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "key-serializer");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "value-serializer");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "hash-key-serializer");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "hash-value-serializer");
+	}
+}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisParserUtils.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisParserUtils.java
@@ -35,8 +35,8 @@ public class RedisParserUtils {
 				element.hasAttribute("hash-key-serializer") ||
 				element.hasAttribute("hash-value-serializer")){
 
-				parserContext.getReaderContext().error("Serializers can not be provided if this adapter is initailized " +
-						"with RedisTemplate. You may set serializers directly on RedisTemplate", element);
+				parserContext.getReaderContext().error("Serializers can not be provided if this adapter is initialized " +
+						"with an external RedisTemplate. You may set serializers directly on the RedisTemplate", element);
 			}
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "key-serializer");

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisStoreMessageSource.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisStoreMessageSource.java
@@ -66,7 +66,7 @@ public class RedisStoreMessageSource extends IntegrationObjectSupport
 
 	private volatile RedisSerializer<?> hashValueSerializer;
 
-	private volatile boolean redisTemplateNotSet = true;
+	private volatile boolean usingDefaultTemplate;
 
 	/**
 	 * Creates this instance with provided {@link RedisTemplate} and SpEL expression
@@ -84,7 +84,7 @@ public class RedisStoreMessageSource extends IntegrationObjectSupport
 		Assert.notNull(redisTemplate, "'redisTemplate' must not be null");
 
 		this.redisTemplate = redisTemplate;
-		this.redisTemplateNotSet = false;
+		this.usingDefaultTemplate = true;
 		this.keyExpression = keyExpression;
 	}
 
@@ -114,25 +114,25 @@ public class RedisStoreMessageSource extends IntegrationObjectSupport
 	}
 
 	public void setKeySerializer(RedisSerializer<?> keySerializer) {
-		Assert.state(this.redisTemplateNotSet, "'keySerializer' can not be set if RedisTemplate provided");
+		Assert.state(!this.usingDefaultTemplate, "'keySerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(keySerializer, "'keySerializer' must not be null");
 		this.keySerializer = keySerializer;
 	}
 
 	public void setValueSerializer(RedisSerializer<?> valueSerializer) {
-		Assert.state(this.redisTemplateNotSet, "'valueSerializer' can not be set if RedisTemplate provided");
+		Assert.state(!this.usingDefaultTemplate, "'valueSerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(valueSerializer, "'valueSerializer' must not be null");
 		this.valueSerializer = valueSerializer;
 	}
 
 	public void setHashKeySerializer(RedisSerializer<?> hashKeySerializer) {
-		Assert.state(this.redisTemplateNotSet, "'hashKeySerializer' can not be set if RedisTemplate provided");
+		Assert.state(!this.usingDefaultTemplate, "'hashKeySerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(hashKeySerializer, "'hashKeySerializer' must not be null");
 		this.hashKeySerializer = hashKeySerializer;
 	}
 
 	public void setHashValueSerializer(RedisSerializer<?> hashValueSerializer) {
-		Assert.state(this.redisTemplateNotSet, "'hashValueSerializer' can not be set if RedisTemplate provided");
+		Assert.state(!this.usingDefaultTemplate, "'hashValueSerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(hashValueSerializer, "'hashValueSerializer' must not be null");
 		this.hashValueSerializer = hashValueSerializer;
 	}
@@ -185,7 +185,7 @@ public class RedisStoreMessageSource extends IntegrationObjectSupport
 			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext();
 		}
 
-		if (this.redisTemplateNotSet){
+		if (!this.usingDefaultTemplate){
 			if (this.keySerializer != null){
 				redisTemplate.setKeySerializer(this.keySerializer);
 			}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisStoreMessageSource.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisStoreMessageSource.java
@@ -66,7 +66,7 @@ public class RedisStoreMessageSource extends IntegrationObjectSupport
 
 	private volatile RedisSerializer<?> hashValueSerializer;
 
-	private volatile boolean usingDefaultTemplate;
+	private volatile boolean usingDefaultTemplate = true;
 
 	/**
 	 * Creates this instance with provided {@link RedisTemplate} and SpEL expression
@@ -114,25 +114,25 @@ public class RedisStoreMessageSource extends IntegrationObjectSupport
 	}
 
 	public void setKeySerializer(RedisSerializer<?> keySerializer) {
-		Assert.state(!this.usingDefaultTemplate, "'keySerializer' can not be set if RedisTemplate provided");
+		Assert.state(this.usingDefaultTemplate, "'keySerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(keySerializer, "'keySerializer' must not be null");
 		this.keySerializer = keySerializer;
 	}
 
 	public void setValueSerializer(RedisSerializer<?> valueSerializer) {
-		Assert.state(!this.usingDefaultTemplate, "'valueSerializer' can not be set if RedisTemplate provided");
+		Assert.state(this.usingDefaultTemplate, "'valueSerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(valueSerializer, "'valueSerializer' must not be null");
 		this.valueSerializer = valueSerializer;
 	}
 
 	public void setHashKeySerializer(RedisSerializer<?> hashKeySerializer) {
-		Assert.state(!this.usingDefaultTemplate, "'hashKeySerializer' can not be set if RedisTemplate provided");
+		Assert.state(this.usingDefaultTemplate, "'hashKeySerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(hashKeySerializer, "'hashKeySerializer' must not be null");
 		this.hashKeySerializer = hashKeySerializer;
 	}
 
 	public void setHashValueSerializer(RedisSerializer<?> hashValueSerializer) {
-		Assert.state(!this.usingDefaultTemplate, "'hashValueSerializer' can not be set if RedisTemplate provided");
+		Assert.state(this.usingDefaultTemplate, "'hashValueSerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(hashValueSerializer, "'hashValueSerializer' must not be null");
 		this.hashValueSerializer = hashValueSerializer;
 	}
@@ -185,7 +185,7 @@ public class RedisStoreMessageSource extends IntegrationObjectSupport
 			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext();
 		}
 
-		if (!this.usingDefaultTemplate){
+		if (this.usingDefaultTemplate){
 			if (this.keySerializer != null){
 				redisTemplate.setKeySerializer(this.keySerializer);
 			}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisStoreMessageSource.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisStoreMessageSource.java
@@ -84,7 +84,7 @@ public class RedisStoreMessageSource extends IntegrationObjectSupport
 		Assert.notNull(redisTemplate, "'redisTemplate' must not be null");
 
 		this.redisTemplate = redisTemplate;
-		this.usingDefaultTemplate = true;
+		this.usingDefaultTemplate = false;
 		this.keyExpression = keyExpression;
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisCollectionPopulatingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisCollectionPopulatingMessageHandler.java
@@ -122,7 +122,7 @@ public class RedisCollectionPopulatingMessageHandler extends AbstractMessageHand
 	public RedisCollectionPopulatingMessageHandler(RedisTemplate<String, ?> redisTemplate, Expression keyExpression) {
 		Assert.notNull(redisTemplate, "'redisTemplate' must not be null");
 		this.redisTemplate = redisTemplate;
-		this.usingDefaultTemplate = true;
+		this.usingDefaultTemplate = false;
 		if (keyExpression != null) {
 			this.keyExpression = keyExpression;
 		}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisCollectionPopulatingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisCollectionPopulatingMessageHandler.java
@@ -95,7 +95,7 @@ public class RedisCollectionPopulatingMessageHandler extends AbstractMessageHand
 
 	private volatile RedisSerializer<?> hashValueSerializer;
 
-	private volatile boolean redisTemplateNotSet = true;
+	private volatile boolean usingDefaultTemplate;
 
 	/**
 	 * Will construct this instance using fully created and initialized instance of
@@ -122,7 +122,7 @@ public class RedisCollectionPopulatingMessageHandler extends AbstractMessageHand
 	public RedisCollectionPopulatingMessageHandler(RedisTemplate<String, ?> redisTemplate, Expression keyExpression) {
 		Assert.notNull(redisTemplate, "'redisTemplate' must not be null");
 		this.redisTemplate = redisTemplate;
-		this.redisTemplateNotSet = false;
+		this.usingDefaultTemplate = true;
 		if (keyExpression != null) {
 			this.keyExpression = keyExpression;
 		}
@@ -165,25 +165,25 @@ public class RedisCollectionPopulatingMessageHandler extends AbstractMessageHand
 	}
 
 	public void setKeySerializer(RedisSerializer<?> keySerializer) {
-		Assert.state(this.redisTemplateNotSet, "'keySerializer' can not be set if RedisTemplate provided");
+		Assert.state(!this.usingDefaultTemplate, "'keySerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(keySerializer, "'keySerializer' must not be null");
 		this.keySerializer = keySerializer;
 	}
 
 	public void setValueSerializer(RedisSerializer<?> valueSerializer) {
-		Assert.state(this.redisTemplateNotSet, "'valueSerializer' can not be set if RedisTemplate provided");
+		Assert.state(!this.usingDefaultTemplate, "'valueSerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(valueSerializer, "'valueSerializer' must not be null");
 		this.valueSerializer = valueSerializer;
 	}
 
 	public void setHashKeySerializer(RedisSerializer<?> hashKeySerializer) {
-		Assert.state(this.redisTemplateNotSet, "'hashKeySerializer' can not be set if RedisTemplate provided");
+		Assert.state(!this.usingDefaultTemplate, "'hashKeySerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(hashKeySerializer, "'hashKeySerializer' must not be null");
 		this.hashKeySerializer = hashKeySerializer;
 	}
 
 	public void setHashValueSerializer(RedisSerializer<?> hashValueSerializer) {
-		Assert.state(this.redisTemplateNotSet, "'hashValueSerializer' can not be set if RedisTemplate provided");
+		Assert.state(!this.usingDefaultTemplate, "'hashValueSerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(hashValueSerializer, "'hashValueSerializer' must not be null");
 		this.hashValueSerializer = hashValueSerializer;
 	}
@@ -242,7 +242,7 @@ public class RedisCollectionPopulatingMessageHandler extends AbstractMessageHand
 				(this.collectionType == CollectionType.MAP || this.collectionType == CollectionType.PROPERTIES),
 				"'mapKeyExpression' can only be set for CollectionType.MAP or CollectionType.PROPERTIES");
 
-		if (this.redisTemplateNotSet){
+		if (!this.usingDefaultTemplate){
 			if (this.keySerializer != null){
 				redisTemplate.setKeySerializer(this.keySerializer);
 			}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisCollectionPopulatingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisCollectionPopulatingMessageHandler.java
@@ -95,7 +95,7 @@ public class RedisCollectionPopulatingMessageHandler extends AbstractMessageHand
 
 	private volatile RedisSerializer<?> hashValueSerializer;
 
-	private volatile boolean usingDefaultTemplate;
+	private volatile boolean usingDefaultTemplate = true;
 
 	/**
 	 * Will construct this instance using fully created and initialized instance of
@@ -165,25 +165,25 @@ public class RedisCollectionPopulatingMessageHandler extends AbstractMessageHand
 	}
 
 	public void setKeySerializer(RedisSerializer<?> keySerializer) {
-		Assert.state(!this.usingDefaultTemplate, "'keySerializer' can not be set if RedisTemplate provided");
+		Assert.state(this.usingDefaultTemplate, "'keySerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(keySerializer, "'keySerializer' must not be null");
 		this.keySerializer = keySerializer;
 	}
 
 	public void setValueSerializer(RedisSerializer<?> valueSerializer) {
-		Assert.state(!this.usingDefaultTemplate, "'valueSerializer' can not be set if RedisTemplate provided");
+		Assert.state(this.usingDefaultTemplate, "'valueSerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(valueSerializer, "'valueSerializer' must not be null");
 		this.valueSerializer = valueSerializer;
 	}
 
 	public void setHashKeySerializer(RedisSerializer<?> hashKeySerializer) {
-		Assert.state(!this.usingDefaultTemplate, "'hashKeySerializer' can not be set if RedisTemplate provided");
+		Assert.state(this.usingDefaultTemplate, "'hashKeySerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(hashKeySerializer, "'hashKeySerializer' must not be null");
 		this.hashKeySerializer = hashKeySerializer;
 	}
 
 	public void setHashValueSerializer(RedisSerializer<?> hashValueSerializer) {
-		Assert.state(!this.usingDefaultTemplate, "'hashValueSerializer' can not be set if RedisTemplate provided");
+		Assert.state(this.usingDefaultTemplate, "'hashValueSerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(hashValueSerializer, "'hashValueSerializer' must not be null");
 		this.hashValueSerializer = hashValueSerializer;
 	}
@@ -242,7 +242,7 @@ public class RedisCollectionPopulatingMessageHandler extends AbstractMessageHand
 				(this.collectionType == CollectionType.MAP || this.collectionType == CollectionType.PROPERTIES),
 				"'mapKeyExpression' can only be set for CollectionType.MAP or CollectionType.PROPERTIES");
 
-		if (!this.usingDefaultTemplate){
+		if (this.usingDefaultTemplate){
 			if (this.keySerializer != null){
 				redisTemplate.setKeySerializer(this.keySerializer);
 			}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisCollectionPopulatingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisCollectionPopulatingMessageHandler.java
@@ -95,6 +95,8 @@ public class RedisCollectionPopulatingMessageHandler extends AbstractMessageHand
 
 	private volatile RedisSerializer<?> hashValueSerializer;
 
+	private volatile boolean redisTemplateNotSet = true;
+
 	/**
 	 * Will construct this instance using fully created and initialized instance of
 	 * provided {@link RedisTemplate}
@@ -120,6 +122,7 @@ public class RedisCollectionPopulatingMessageHandler extends AbstractMessageHand
 	public RedisCollectionPopulatingMessageHandler(RedisTemplate<String, ?> redisTemplate, Expression keyExpression) {
 		Assert.notNull(redisTemplate, "'redisTemplate' must not be null");
 		this.redisTemplate = redisTemplate;
+		this.redisTemplateNotSet = false;
 		if (keyExpression != null) {
 			this.keyExpression = keyExpression;
 		}
@@ -162,21 +165,25 @@ public class RedisCollectionPopulatingMessageHandler extends AbstractMessageHand
 	}
 
 	public void setKeySerializer(RedisSerializer<?> keySerializer) {
+		Assert.state(this.redisTemplateNotSet, "'keySerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(keySerializer, "'keySerializer' must not be null");
 		this.keySerializer = keySerializer;
 	}
 
 	public void setValueSerializer(RedisSerializer<?> valueSerializer) {
+		Assert.state(this.redisTemplateNotSet, "'valueSerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(valueSerializer, "'valueSerializer' must not be null");
 		this.valueSerializer = valueSerializer;
 	}
 
 	public void setHashKeySerializer(RedisSerializer<?> hashKeySerializer) {
+		Assert.state(this.redisTemplateNotSet, "'hashKeySerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(hashKeySerializer, "'hashKeySerializer' must not be null");
 		this.hashKeySerializer = hashKeySerializer;
 	}
 
 	public void setHashValueSerializer(RedisSerializer<?> hashValueSerializer) {
+		Assert.state(this.redisTemplateNotSet, "'hashValueSerializer' can not be set if RedisTemplate provided");
 		Assert.notNull(hashValueSerializer, "'hashValueSerializer' must not be null");
 		this.hashValueSerializer = hashValueSerializer;
 	}
@@ -234,19 +241,22 @@ public class RedisCollectionPopulatingMessageHandler extends AbstractMessageHand
 		Assert.state(!this.mapKeyExpressionExplicitlySet ||
 				(this.collectionType == CollectionType.MAP || this.collectionType == CollectionType.PROPERTIES),
 				"'mapKeyExpression' can only be set for CollectionType.MAP or CollectionType.PROPERTIES");
-		if (this.keySerializer != null){
-			redisTemplate.setKeySerializer(this.keySerializer);
+
+		if (this.redisTemplateNotSet){
+			if (this.keySerializer != null){
+				redisTemplate.setKeySerializer(this.keySerializer);
+			}
+			if (this.valueSerializer != null){
+				redisTemplate.setValueSerializer(this.valueSerializer);
+			}
+			if (this.hashKeySerializer != null){
+				redisTemplate.setHashKeySerializer(this.hashKeySerializer);
+			}
+			if (this.hashValueSerializer != null){
+				redisTemplate.setHashValueSerializer(this.hashValueSerializer);
+			}
+			this.redisTemplate.afterPropertiesSet();
 		}
-		if (this.valueSerializer != null){
-			redisTemplate.setValueSerializer(this.valueSerializer);
-		}
-		if (this.hashKeySerializer != null){
-			redisTemplate.setHashKeySerializer(this.hashKeySerializer);
-		}
-		if (this.hashValueSerializer != null){
-			redisTemplate.setHashValueSerializer(this.hashValueSerializer);
-		}
-		this.redisTemplate.afterPropertiesSet();
 	}
 
 	/**

--- a/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-2.2.xsd
+++ b/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-2.2.xsd
@@ -191,6 +191,18 @@
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="serializer" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<xsd:documentation>
+						Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer 
+						</xsd:documentation>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 
@@ -235,6 +247,18 @@
 	Specifies the order for invocation when this adapter is connected as a
 	subscriber to a SubscribableChannel.
 							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="serializer" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer 
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+								</tool:annotation>
+							</xsd:appinfo>
 						</xsd:annotation>
 					</xsd:attribute>
 				</xsd:extension>
@@ -392,6 +416,54 @@
 			determined per each poll use 'key-expression' attribute. 
 			This attribute is mutually exclusive with the 'key-expression' attribute.
 							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="key-serializer" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer 
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="value-serializer" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer 
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="hash-key-serializer" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer 
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="hash-value-serializer" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer 
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+								</tool:annotation>
+							</xsd:appinfo>
 						</xsd:annotation>
 					</xsd:attribute>
 					<xsd:attribute name="error-channel" type="xsd:string">

--- a/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-2.2.xsd
+++ b/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-2.2.xsd
@@ -422,7 +422,9 @@
 						<xsd:annotation>
 							<xsd:appinfo>
 								<xsd:documentation>
-								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer 
+								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer
+								to serialize the 'key' value for this collection. Please refer to the JavaDoc of RedisTemplate 
+								for more detail.
 								</xsd:documentation>
 								<tool:annotation kind="ref">
 									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
@@ -435,6 +437,8 @@
 							<xsd:appinfo>
 								<xsd:documentation>
 								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer 
+								to serialize the 'value' entered into the collection. Please refer to the JavaDoc of RedisTemplate 
+								for more detail.
 								</xsd:documentation>
 								<tool:annotation kind="ref">
 									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
@@ -447,6 +451,8 @@
 							<xsd:appinfo>
 								<xsd:documentation>
 								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer 
+								to be used when serializing hash keys (only relevant for hash-typed collections). 
+								Please refer to the JavaDoc of RedisTemplate for more detail.
 								</xsd:documentation>
 								<tool:annotation kind="ref">
 									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
@@ -459,6 +465,8 @@
 							<xsd:appinfo>
 								<xsd:documentation>
 								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer 
+								to be used when serializing hash values (only relevant for hash-typed collections). 
+								Please refer to the JavaDoc of RedisTemplate for more detail.
 								</xsd:documentation>
 								<tool:annotation kind="ref">
 									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisCollectionsInboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisCollectionsInboundChannelAdapterIntegrationTests.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.redis.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.support.collections.RedisList;
+import org.springframework.data.redis.support.collections.RedisZSet;
+import org.springframework.integration.Message;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
+import org.springframework.integration.redis.rules.RedisAvailable;
+import org.springframework.integration.redis.rules.RedisAvailableTests;
+
+/**
+ * @author Oleg Zhurakousky
+ * @since 2.2
+ */
+public class RedisCollectionsInboundChannelAdapterIntegrationTests extends RedisAvailableTests{
+
+	@Test
+	@RedisAvailable
+	@SuppressWarnings("unchecked")
+	public void testListInboundConfiguration() throws Exception{
+		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.prepareList(jcf);
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml", this.getClass());
+		SourcePollingChannelAdapter spca = context.getBean("listAdapter", SourcePollingChannelAdapter.class);
+		spca.start();
+		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
+
+
+		Message<RedisList<Object>> message = (Message<RedisList<Object>>) redisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(13, message.getPayload().size());
+
+		//poll again, should get the same stuff
+		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(13, message.getPayload().size());
+		context.close();
+	}
+
+	@Test
+	@RedisAvailable
+	@SuppressWarnings("unchecked")
+	public void testListInboundConfigurationWithSynchronization() throws Exception{
+		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.prepareList(jcf);
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml", this.getClass());
+		SourcePollingChannelAdapter spca = context.getBean("listAdapterWithSynchronization", SourcePollingChannelAdapter.class);
+		spca.start();
+		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
+
+
+		Message<RedisList<Object>> message = (Message<RedisList<Object>>) redisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(13, message.getPayload().size());
+
+		//poll again, should get nothing since the collection was removed during synchronization
+		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
+		assertNull(message);
+
+		spca.stop();
+		context.close();
+	}
+
+	@Test
+	@RedisAvailable
+	@SuppressWarnings("unchecked")
+	public void testListInboundConfigurationWithSynchronizationAndTemplate() throws Exception{
+		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.prepareList(jcf);
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml", this.getClass());
+		SourcePollingChannelAdapter spca = context.getBean("listAdapterWithSynchronizationAndRedisTemplate", SourcePollingChannelAdapter.class);
+		spca.start();
+		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
+
+		Message<RedisList<Object>> message = (Message<RedisList<Object>>) redisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(13, message.getPayload().size());
+
+		//poll again, should get nothing since the collection was removed during synchronization
+		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
+		assertNull(message);
+
+		spca.stop();
+		context.close();
+	}
+
+	@Test
+	@RedisAvailable
+	@SuppressWarnings("unchecked")
+	public void testZsetInboundConfiguration(){
+		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.prepareZset(jcf);
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("zset-inbound-adapter.xml", this.getClass());
+		SourcePollingChannelAdapter zsetAdapterNoScore =
+				context.getBean("zsetAdapterNoScore", SourcePollingChannelAdapter.class);
+		zsetAdapterNoScore.start();
+
+		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
+
+		Message<RedisZSet<Object>> message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(13, message.getPayload().size());
+
+		//poll again, should get the same stuff
+		message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(13, message.getPayload().size());
+
+		zsetAdapterNoScore.stop();
+		context.close();
+	}
+
+	@Test
+	@RedisAvailable
+	@SuppressWarnings("unchecked")
+	public void testZsetInboundConfigurationWithScoreRange(){
+		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.prepareZset(jcf);
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("zset-inbound-adapter.xml", this.getClass());
+		SourcePollingChannelAdapter zsetAdapterWithScoreRange =
+				context.getBean("zsetAdapterWithScoreRange", SourcePollingChannelAdapter.class);
+		zsetAdapterWithScoreRange.start();
+
+		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
+
+		Message<RedisZSet<Object>> message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(11, message.getPayload().rangeByScore(18, 20).size());
+
+		//poll again, should get the same stuff
+		message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(11, message.getPayload().rangeByScore(18, 20).size());
+
+		zsetAdapterWithScoreRange.stop();
+		context.close();
+	}
+
+	@Test
+	@RedisAvailable
+	@SuppressWarnings("unchecked")
+	public void testZsetInboundConfigurationWithSingleScore(){
+		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.prepareZset(jcf);
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("zset-inbound-adapter.xml", this.getClass());
+		SourcePollingChannelAdapter zsetAdapterWithSingleScore =
+				context.getBean("zsetAdapterWithSingleScore", SourcePollingChannelAdapter.class);
+		zsetAdapterWithSingleScore.start();
+
+		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
+
+		Message<RedisZSet<Object>> message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(2, message.getPayload().rangeByScore(18, 18).size());
+
+		//poll again, should get the same stuff
+		message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(2, message.getPayload().rangeByScore(18, 18).size());
+
+		zsetAdapterWithSingleScore.stop();
+		context.close();
+	}
+
+	@Test
+	@RedisAvailable
+	@SuppressWarnings("unchecked")
+	public void testZsetInboundConfigurationWithSingleScoreAndSynchronization() throws Exception{
+		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.prepareZset(jcf);
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("zset-inbound-adapter.xml", this.getClass());
+		SourcePollingChannelAdapter zsetAdapterWithSingleScoreAndSynchronization =
+				context.getBean("zsetAdapterWithSingleScoreAndSynchronization", SourcePollingChannelAdapter.class);
+
+		SourcePollingChannelAdapter zsetAdapterNoScore =
+				context.getBean("zsetAdapterNoScore", SourcePollingChannelAdapter.class);
+
+		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
+		QueueChannel otherRedisChannel = context.getBean("otherRedisChannel", QueueChannel.class);
+		// get all 13 presidents
+		zsetAdapterNoScore.start();
+
+		Message<RedisZSet<Object>> message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(13, message.getPayload().size());
+
+		zsetAdapterNoScore.stop();
+		Thread.sleep(1000);
+		// get only presidents for 18th century
+		zsetAdapterWithSingleScoreAndSynchronization.start();
+
+		message = (Message<RedisZSet<Object>>) otherRedisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(2, message.getPayload().rangeByScore(18, 18).size());
+		//message.getPayload().remo
+		zsetAdapterWithSingleScoreAndSynchronization.stop();
+		Thread.sleep(1000);
+
+		// ... however other elements are still available 13-2=11
+		zsetAdapterNoScore.start();
+		message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
+		assertNotNull(message);
+		assertEquals(11, message.getPayload().size());
+
+		zsetAdapterNoScore.stop();
+		context.close();
+	}
+
+	@Test(expected=BeanDefinitionParsingException.class)
+	public void testTemplateAndCfMutualExclusivity(){
+		new ClassPathXmlApplicationContext("inbound-template-cf-fail.xml", this.getClass());
+	}
+}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisCollectionsInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisCollectionsInboundChannelAdapterParserTests.java
@@ -16,288 +16,36 @@
 package org.springframework.integration.redis.config;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
-import org.springframework.data.redis.core.BoundListOperations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.data.redis.support.collections.RedisList;
-import org.springframework.data.redis.support.collections.RedisZSet;
-import org.springframework.integration.Message;
-import org.springframework.integration.MessagingException;
-import org.springframework.integration.channel.QueueChannel;
-import org.springframework.integration.core.MessageHandler;
-import org.springframework.integration.core.SubscribableChannel;
-import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
-import org.springframework.integration.redis.rules.RedisAvailable;
-import org.springframework.integration.redis.rules.RedisAvailableTests;
+import org.springframework.data.redis.support.collections.RedisCollectionFactoryBean.CollectionType;
+import org.springframework.expression.spel.standard.SpelExpression;
+import org.springframework.integration.redis.inbound.RedisStoreMessageSource;
+import org.springframework.integration.test.util.TestUtils;
 
 /**
  * @author Oleg Zhurakousky
  * @since 2.2
  */
-public class RedisCollectionsInboundChannelAdapterParserTests extends RedisAvailableTests{
-
+public class RedisCollectionsInboundChannelAdapterParserTests {
 	@Test
-	@RedisAvailable
-	@SuppressWarnings("unchecked")
-	public void testListInboundConfiguration() throws Exception{
-		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		this.prepareList(jcf);
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml", this.getClass());
-		SourcePollingChannelAdapter spca = context.getBean("listAdapter", SourcePollingChannelAdapter.class);
-		spca.start();
-		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
-
-
-		Message<RedisList<Object>> message = (Message<RedisList<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(13, message.getPayload().size());
-
-		//poll again, should get the same stuff
-		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(13, message.getPayload().size());
-		context.close();
-	}
-
-	@Test
-	@RedisAvailable
-	@SuppressWarnings("unchecked")
-	public void testListInboundConfigurationWithSynchronization() throws Exception{
-		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		this.prepareList(jcf);
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml", this.getClass());
-		SourcePollingChannelAdapter spca = context.getBean("listAdapterWithSynchronization", SourcePollingChannelAdapter.class);
-		spca.start();
-		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
-
-
-		Message<RedisList<Object>> message = (Message<RedisList<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(13, message.getPayload().size());
-
-		//poll again, should get nothing since the collection was removed during synchronization
-		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
-		assertNull(message);
-
-		spca.stop();
-		context.close();
-	}
-
-	@Test
-	@RedisAvailable
-	public void testListInboundConfigurationWithSynchronizationAndRollback() throws Exception{
-		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		this.prepareList(jcf);
-
-		RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<Object, Object>();
-		redisTemplate.setConnectionFactory(jcf);
-		redisTemplate.setKeySerializer(new StringRedisSerializer());
-		redisTemplate.setValueSerializer(new JdkSerializationRedisSerializer());
-
-		BoundListOperations<Object, Object> ops = redisTemplate.boundListOps("baz");
-
-		assertTrue(ops.size() == 0);
-
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml", this.getClass());
-		SourcePollingChannelAdapter spca = context.getBean("listAdapterWithSynchronizationAndRollback", SourcePollingChannelAdapter.class);
-		SubscribableChannel redisFailChannel = context.getBean("redisFailChannel", SubscribableChannel.class);
-		redisFailChannel.subscribe(new MessageHandler() {
-
-			public void handleMessage(Message<?> message) throws MessagingException {
-				throw new MessagingException("intentional");
-			}
-		});
-		spca.start();
-
-		Thread.sleep(1000);
-		ops = redisTemplate.boundListOps("baz");
-		assertTrue(ops.size() == 13);
-		ops = redisTemplate.boundListOps("bar");
-		assertTrue(ops.size() == 0);
-
-		spca.stop();
-		context.close();
-	}
-
-	@Test
-	@RedisAvailable
-	@SuppressWarnings("unchecked")
-	public void testListInboundConfigurationWithSynchronizationAndTemplate() throws Exception{
-		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		this.prepareList(jcf);
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml", this.getClass());
-		SourcePollingChannelAdapter spca = context.getBean("listAdapterWithSynchronizationAndRedisTemplate", SourcePollingChannelAdapter.class);
-		spca.start();
-		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
-
-
-		Message<RedisList<Object>> message = (Message<RedisList<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(13, message.getPayload().size());
-
-		//poll again, should get nothing since the collection was removed during synchronization
-		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
-		assertNull(message);
-
-		spca.stop();
-		context.close();
-	}
-
-	@Test
-	@RedisAvailable
-	@SuppressWarnings("unchecked")
-	public void testListInboundConfigurationWithBeforeCommit() throws Exception{
-		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		this.prepareList(jcf);
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml", this.getClass());
-		SourcePollingChannelAdapter spca = context.getBean("listAdapterWithSynchronizationBeforeCommit", SourcePollingChannelAdapter.class);
-		spca.start();
-		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
-
-		QueueChannel adapterErrors = context.getBean("adapterErrors", QueueChannel.class);
-
-		Message<RedisList<Object>> message = (Message<RedisList<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertNotNull(adapterErrors.receive(2000));
-		spca.stop();
-		context.close();
-	}
-
-
-	@Test
-	@RedisAvailable
-	@SuppressWarnings("unchecked")
-	public void testZsetInboundConfiguration(){
-		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		this.prepareZset(jcf);
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("zset-inbound-adapter.xml", this.getClass());
-		SourcePollingChannelAdapter zsetAdapterNoScore =
-				context.getBean("zsetAdapterNoScore", SourcePollingChannelAdapter.class);
-		zsetAdapterNoScore.start();
-
-		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
-
-		Message<RedisZSet<Object>> message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(13, message.getPayload().size());
-
-		//poll again, should get the same stuff
-		message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(13, message.getPayload().size());
-
-		zsetAdapterNoScore.stop();
-		context.close();
-	}
-
-	@Test
-	@RedisAvailable
-	@SuppressWarnings("unchecked")
-	public void testZsetInboundConfigurationWithScoreRange(){
-		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		this.prepareZset(jcf);
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("zset-inbound-adapter.xml", this.getClass());
-		SourcePollingChannelAdapter zsetAdapterWithScoreRange =
-				context.getBean("zsetAdapterWithScoreRange", SourcePollingChannelAdapter.class);
-		zsetAdapterWithScoreRange.start();
-
-		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
-
-		Message<RedisZSet<Object>> message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(11, message.getPayload().rangeByScore(18, 20).size());
-
-		//poll again, should get the same stuff
-		message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(11, message.getPayload().rangeByScore(18, 20).size());
-
-		zsetAdapterWithScoreRange.stop();
-		context.close();
-	}
-
-	@Test
-	@RedisAvailable
-	@SuppressWarnings("unchecked")
-	public void testZsetInboundConfigurationWithSingleScore(){
-		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		this.prepareZset(jcf);
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("zset-inbound-adapter.xml", this.getClass());
-		SourcePollingChannelAdapter zsetAdapterWithSingleScore =
-				context.getBean("zsetAdapterWithSingleScore", SourcePollingChannelAdapter.class);
-		zsetAdapterWithSingleScore.start();
-
-		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
-
-		Message<RedisZSet<Object>> message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(2, message.getPayload().rangeByScore(18, 18).size());
-
-		//poll again, should get the same stuff
-		message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(2, message.getPayload().rangeByScore(18, 18).size());
-
-		zsetAdapterWithSingleScore.stop();
-		context.close();
-	}
-
-	@Test
-	@RedisAvailable
-	@SuppressWarnings("unchecked")
-	public void testZsetInboundConfigurationWithSingleScoreAndSynchronization() throws Exception{
-		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		this.prepareZset(jcf);
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("zset-inbound-adapter.xml", this.getClass());
-		SourcePollingChannelAdapter zsetAdapterWithSingleScoreAndSynchronization =
-				context.getBean("zsetAdapterWithSingleScoreAndSynchronization", SourcePollingChannelAdapter.class);
-
-		SourcePollingChannelAdapter zsetAdapterNoScore =
-				context.getBean("zsetAdapterNoScore", SourcePollingChannelAdapter.class);
-
-		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
-		QueueChannel otherRedisChannel = context.getBean("otherRedisChannel", QueueChannel.class);
-		// get all 13 presidents
-		zsetAdapterNoScore.start();
-
-		Message<RedisZSet<Object>> message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(13, message.getPayload().size());
-
-		zsetAdapterNoScore.stop();
-		Thread.sleep(1000);
-		// get only presidents for 18th century
-		zsetAdapterWithSingleScoreAndSynchronization.start();
-
-		message = (Message<RedisZSet<Object>>) otherRedisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(2, message.getPayload().rangeByScore(18, 18).size());
-		//message.getPayload().remo
-		zsetAdapterWithSingleScoreAndSynchronization.stop();
-		Thread.sleep(1000);
-
-		// ... however other elements are still available 13-2=11
-		zsetAdapterNoScore.start();
-		message = (Message<RedisZSet<Object>>) redisChannel.receive(1000);
-		assertNotNull(message);
-		assertEquals(11, message.getPayload().size());
-
-		zsetAdapterNoScore.stop();
-		context.close();
+	public void validateFullConfiguration(){
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("inbound-store-adapter-parser.xml", this.getClass());
+		RedisStoreMessageSource source =
+				TestUtils.getPropertyValue(context.getBean("adapterWithConnectionFactory"), "source", RedisStoreMessageSource.class);
+		assertEquals(TestUtils.getPropertyValue(source, "keySerializer"), context.getBean("serializer"));
+		assertEquals(TestUtils.getPropertyValue(source, "valueSerializer"), context.getBean("serializer"));
+		assertEquals(TestUtils.getPropertyValue(source, "hashKeySerializer"), context.getBean("serializer"));
+		assertEquals(TestUtils.getPropertyValue(source, "hashValueSerializer"), context.getBean("serializer"));
+		assertEquals("'presidents'", ((SpelExpression)TestUtils.getPropertyValue(source, "keyExpression")).getExpressionString());
+		assertEquals("LIST", ((CollectionType)TestUtils.getPropertyValue(source, "collectionType")).toString());
 	}
 
 	@Test(expected=BeanDefinitionParsingException.class)
-	public void testTemplateAndCfMutualExclusivity(){
-		new ClassPathXmlApplicationContext("inbound-template-cf-fail.xml", this.getClass());
+	public void validateFailureIfTemplateAndSerializers(){
+		new ClassPathXmlApplicationContext("inbound-store-adapter-parser-fail.xml", this.getClass());
 	}
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisCollectionsInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisCollectionsInboundChannelAdapterParserTests.java
@@ -36,10 +36,10 @@ public class RedisCollectionsInboundChannelAdapterParserTests {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("inbound-store-adapter-parser.xml", this.getClass());
 		RedisStoreMessageSource source =
 				TestUtils.getPropertyValue(context.getBean("adapterWithConnectionFactory"), "source", RedisStoreMessageSource.class);
-		assertEquals(TestUtils.getPropertyValue(source, "keySerializer"), context.getBean("serializer"));
-		assertEquals(TestUtils.getPropertyValue(source, "valueSerializer"), context.getBean("serializer"));
-		assertEquals(TestUtils.getPropertyValue(source, "hashKeySerializer"), context.getBean("serializer"));
-		assertEquals(TestUtils.getPropertyValue(source, "hashValueSerializer"), context.getBean("serializer"));
+		assertEquals(context.getBean("keySerializer"), TestUtils.getPropertyValue(source, "keySerializer"));
+		assertEquals(context.getBean("valueSerializer"), TestUtils.getPropertyValue(source, "valueSerializer"));
+		assertEquals(context.getBean("hashKeySerializer"), TestUtils.getPropertyValue(source, "hashKeySerializer"));
+		assertEquals(context.getBean("hashValueSerializer"), TestUtils.getPropertyValue(source, "hashValueSerializer"));
 		assertEquals("'presidents'", ((SpelExpression)TestUtils.getPropertyValue(source, "keyExpression")).getExpressionString());
 		assertEquals("LIST", ((CollectionType)TestUtils.getPropertyValue(source, "collectionType")).toString());
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisCollectionsOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisCollectionsOutboundChannelAdapterParserTests.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.data.redis.support.collections.RedisCollectionFactoryBean.CollectionType;
 import org.springframework.expression.common.LiteralExpression;
@@ -40,5 +41,10 @@ public class RedisCollectionsOutboundChannelAdapterParserTests {
 		assertEquals(TestUtils.getPropertyValue(handler, "hashValueSerializer"), context.getBean("hashValueSerializer"));
 		assertEquals("pepboys", ((LiteralExpression)TestUtils.getPropertyValue(handler, "keyExpression")).getExpressionString());
 		assertEquals("PROPERTIES", ((CollectionType)TestUtils.getPropertyValue(handler, "collectionType")).toString());
+	}
+
+	@Test(expected=BeanDefinitionParsingException.class)
+	public void validateFailureIfTemplateAndSerializers(){
+		new ClassPathXmlApplicationContext("store-outbound-adapter-parser-fail.xml", this.getClass());
 	}
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisCollectionsOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisCollectionsOutboundChannelAdapterParserTests.java
@@ -35,10 +35,10 @@ public class RedisCollectionsOutboundChannelAdapterParserTests {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("store-outbound-adapter-parser.xml", this.getClass());
 		RedisCollectionPopulatingMessageHandler handler =
 				TestUtils.getPropertyValue(context.getBean("storeAdapter.adapter"), "handler", RedisCollectionPopulatingMessageHandler.class);
-		assertEquals(TestUtils.getPropertyValue(handler, "keySerializer"), context.getBean("keySerializer"));
-		assertEquals(TestUtils.getPropertyValue(handler, "valueSerializer"), context.getBean("valueSerializer"));
-		assertEquals(TestUtils.getPropertyValue(handler, "hashKeySerializer"), context.getBean("hashKeySerializer"));
-		assertEquals(TestUtils.getPropertyValue(handler, "hashValueSerializer"), context.getBean("hashValueSerializer"));
+		assertEquals(context.getBean("keySerializer"), TestUtils.getPropertyValue(handler, "keySerializer"));
+		assertEquals(context.getBean("valueSerializer"), TestUtils.getPropertyValue(handler, "valueSerializer"));
+		assertEquals(context.getBean("hashKeySerializer"), TestUtils.getPropertyValue(handler, "hashKeySerializer"));
+		assertEquals(context.getBean("hashValueSerializer"), TestUtils.getPropertyValue(handler, "hashValueSerializer"));
 		assertEquals("pepboys", ((LiteralExpression)TestUtils.getPropertyValue(handler, "keyExpression")).getExpressionString());
 		assertEquals("PROPERTIES", ((CollectionType)TestUtils.getPropertyValue(handler, "collectionType")).toString());
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests-context.xml
@@ -8,7 +8,8 @@
 
 	<int-redis:inbound-channel-adapter
 		id="adapter" topics="foo, bar" channel="receiveChannel" error-channel="testErrorChannel"
-		message-converter="testConverter" />
+		message-converter="testConverter" 
+		serializer="serializer"/>
 
 	<int:channel id="receiveChannel">
 		<int:queue />
@@ -26,6 +27,8 @@
 	<int-redis:inbound-channel-adapter
 		id="autoChannel" topics="foo, bar" error-channel="testErrorChannel"
 		message-converter="testConverter" />
+		
+	<bean id="serializer" class="org.springframework.data.redis.serializer.StringRedisSerializer"/>
 
 	<int:bridge input-channel="autoChannel" output-channel="nullChannel"/>
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -65,6 +66,7 @@ public class RedisInboundChannelAdapterParserTests extends RedisAvailableTests{
 		assertEquals(errorChannelBean, accessor.getPropertyValue("errorChannel"));
 		Object converterBean = context.getBean("testConverter");
 		assertEquals(converterBean, accessor.getPropertyValue("messageConverter"));
+		assertEquals(context.getBean("serializer"), accessor.getPropertyValue("serializer"));
 	}
 
 	@Test

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests-context.xml
@@ -12,7 +12,8 @@
 	<int-redis:outbound-channel-adapter id="outboundAdapter"
 			channel="sendChannel"
 			topic="foo"
-			message-converter="testConverter"/>
+			message-converter="testConverter"
+			serializer="serializer"/>
 
 	<int-redis:inbound-channel-adapter channel="receiveChannel" topics="foo"/>
 
@@ -29,5 +30,7 @@
 	<int:chain input-channel="redisOutboudChain">
 		<int-redis:outbound-channel-adapter topic="foo"/>
 	</int:chain>
+	
+	<bean id="serializer" class="org.springframework.data.redis.serializer.StringRedisSerializer"/>
 
 </beans>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.redis.config;
 
+import static junit.framework.Assert.assertEquals;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,8 +35,6 @@ import org.springframework.integration.support.converter.SimpleMessageConverter;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static junit.framework.Assert.assertEquals;
-
 /**
  * @author Oleg Zhurakousky
  * @author Mark Fisher
@@ -46,8 +46,8 @@ public class RedisOutboundChannelAdapterParserTests extends RedisAvailableTests{
 
 	@Autowired
 	private ApplicationContext context;
-	
-	@Test 
+
+	@Test
 	@RedisAvailable
 	public void validateConfiguration() {
 		EventDrivenConsumer adapter = context.getBean("outboundAdapter", EventDrivenConsumer.class);
@@ -58,9 +58,10 @@ public class RedisOutboundChannelAdapterParserTests extends RedisAvailableTests{
 		assertEquals("foo", accessor.getPropertyValue("defaultTopic"));
 		Object converterBean = context.getBean("testConverter");
 		assertEquals(converterBean, accessor.getPropertyValue("messageConverter"));
+		assertEquals(context.getBean("serializer"), accessor.getPropertyValue("serializer"));
 	}
- 
-	@Test 
+
+	@Test
 	@RedisAvailable
 	public void testOutboundChannelAdapterMessaging() throws Exception{
 		MessageChannel sendChannel = context.getBean("sendChannel", MessageChannel.class);

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/inbound-store-adapter-parser-fail.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/inbound-store-adapter-parser-fail.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-redis="http://www.springframework.org/schema/integration/redis"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/redis http://www.springframework.org/schema/integration/redis/spring-integration-redis-2.2.xsd">
+
+	<int-redis:store-inbound-channel-adapter id="adapterWithTemplate"
+											redis-template="redisTemplate"
+											key-expression="'presidents'"
+											channel="redisChannel"
+											auto-startup="false"
+											collection-type="LIST"
+											key-serializer="serializer"
+											value-serializer="serializer"
+											hash-key-serializer="serializer"
+											hash-value-serializer="serializer">
+		<int:poller fixed-rate="2000" max-messages-per-poll="10"/>
+	</int-redis:store-inbound-channel-adapter>
+	
+	<bean id="redisTemplate" class="org.springframework.data.redis.core.RedisTemplate"/>
+
+	<int:channel id="redisChannel"/>
+	
+	<bean id="serializer" class="org.springframework.data.redis.serializer.JdkSerializationRedisSerializer"/>
+	
+	<bean id="redisConnectionFactory" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.data.redis.connection.RedisConnectionFactory"/>
+	</bean>
+
+</beans>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/inbound-store-adapter-parser.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/inbound-store-adapter-parser.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-redis="http://www.springframework.org/schema/integration/redis"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/redis http://www.springframework.org/schema/integration/redis/spring-integration-redis-2.2.xsd">
+
+	<int-redis:store-inbound-channel-adapter id="adapterWithConnectionFactory"
+											connection-factory="redisConnectionFactory"
+											key-expression="'presidents'"
+											channel="redisChannel"
+											auto-startup="false"
+											collection-type="LIST"
+											key-serializer="serializer"
+											value-serializer="serializer"
+											hash-key-serializer="serializer"
+											hash-value-serializer="serializer">
+		<int:poller fixed-rate="2000" max-messages-per-poll="10"/>
+	</int-redis:store-inbound-channel-adapter>
+
+	<bean id="redisTemplate" class="org.springframework.data.redis.core.RedisTemplate">
+		<property name="connectionFactory" ref="redisConnectionFactory"/>
+	</bean>
+
+	<int:channel id="redisChannel"/>
+		
+	<bean id="serializer" class="org.springframework.data.redis.serializer.JdkSerializationRedisSerializer"/>
+	
+	<bean id="redisConnectionFactory" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.data.redis.connection.RedisConnectionFactory"/>
+	</bean>
+
+</beans>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/inbound-store-adapter-parser.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/inbound-store-adapter-parser.xml
@@ -13,10 +13,10 @@
 											channel="redisChannel"
 											auto-startup="false"
 											collection-type="LIST"
-											key-serializer="serializer"
-											value-serializer="serializer"
-											hash-key-serializer="serializer"
-											hash-value-serializer="serializer">
+											key-serializer="keySerializer"
+											value-serializer="valueSerializer"
+											hash-key-serializer="hashKeySerializer"
+											hash-value-serializer="hashValueSerializer">
 		<int:poller fixed-rate="2000" max-messages-per-poll="10"/>
 	</int-redis:store-inbound-channel-adapter>
 
@@ -26,7 +26,10 @@
 
 	<int:channel id="redisChannel"/>
 		
-	<bean id="serializer" class="org.springframework.data.redis.serializer.JdkSerializationRedisSerializer"/>
+	<bean id="keySerializer" class="org.springframework.data.redis.serializer.JdkSerializationRedisSerializer"/>
+	<bean id="valueSerializer" class="org.springframework.data.redis.serializer.JdkSerializationRedisSerializer"/>
+	<bean id="hashKeySerializer" class="org.springframework.data.redis.serializer.JdkSerializationRedisSerializer"/>
+	<bean id="hashValueSerializer" class="org.springframework.data.redis.serializer.JdkSerializationRedisSerializer"/>
 	
 	<bean id="redisConnectionFactory" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.data.redis.connection.RedisConnectionFactory"/>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/list-inbound-adapter.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/list-inbound-adapter.xml
@@ -72,12 +72,6 @@
 	</int:transaction-synchronization-factory>
 
 	<bean id="redisTemplate" class="org.springframework.data.redis.core.RedisTemplate">
-		<property name="keySerializer">
-			<bean class="org.springframework.data.redis.serializer.StringRedisSerializer"/>
-		</property>
-		<property name="valueSerializer">
-			<bean class="org.springframework.data.redis.serializer.JdkSerializationRedisSerializer"/>
-		</property>
 		<property name="connectionFactory" ref="redisConnectionFactory"/>
 	</bean>
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/store-outbound-adapter-parser-fail.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/store-outbound-adapter-parser-fail.xml
@@ -12,6 +12,7 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
 	<int-redis:store-outbound-channel-adapter id="storeAdapter"
+											  redis-template="redisTemplate"
 											  collection-type="PROPERTIES"
 											  key="pepboys"
 											  key-serializer="keySerializer"
@@ -25,6 +26,10 @@
 	<bean id="hashKeySerializer" class="org.springframework.data.redis.serializer.JdkSerializationRedisSerializer"/>
 	<bean id="hashValueSerializer" class="org.springframework.data.redis.serializer.JdkSerializationRedisSerializer"/>
 
+	<bean id="redisTemplate" class="org.springframework.data.redis.core.RedisTemplate">
+		<property name="connectionFactory" ref="redisConnectionFactory"/>
+	</bean>
+	
 	<bean id="redisConnectionFactory" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.data.redis.connection.RedisConnectionFactory"/>
 	</bean>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/zset-inbound-adapter.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/zset-inbound-adapter.xml
@@ -46,7 +46,7 @@
 	</int-redis:store-inbound-channel-adapter>
 	
 	<int:transaction-synchronization-factory id="syncFactory">
-		 <int:after-commit expression="#resource.attributes['store'].removeByScore(18, 18)"/>
+		 <int:after-commit expression="#store.removeByScore(18, 18)"/>
 	</int:transaction-synchronization-factory>
 
 	<int:channel id="redisChannel">

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/rules/RedisAvailableTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/rules/RedisAvailableTests.java
@@ -26,8 +26,6 @@ import org.springframework.data.redis.core.BoundListOperations;
 import org.springframework.data.redis.core.BoundZSetOperations;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 /**
  * @author Oleg Zhurakousky
@@ -59,9 +57,7 @@ public class RedisAvailableTests {
 
 		RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<Object, Object>();
 		redisTemplate.setConnectionFactory(jcf);
-		redisTemplate.setKeySerializer(new StringRedisSerializer());
-		redisTemplate.setValueSerializer(new JdkSerializationRedisSerializer());
-
+		redisTemplate.afterPropertiesSet();
 		BoundListOperations<Object, Object> ops = redisTemplate.boundListOps("presidents");
 
 		ops.rightPush("John Adams");
@@ -85,8 +81,7 @@ public class RedisAvailableTests {
 
 		RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<Object, Object>();
 		redisTemplate.setConnectionFactory(jcf);
-		redisTemplate.setKeySerializer(new StringRedisSerializer());
-		redisTemplate.setValueSerializer(new JdkSerializationRedisSerializer());
+		redisTemplate.afterPropertiesSet();
 
 		BoundZSetOperations<Object, Object> ops = redisTemplate.boundZSetOps("presidents");
 


### PR DESCRIPTION
Added support for serializers to RedisStore Inbound adapters
Fixed the serializer support for RedisStore outbound adapters to ensure that serializers can not be set of adapter is bootstrapped with RedisTemplate
Added support for serializers to Redis Inbound/Outbound adapters. NOTE: unlike RedisStore adapters Redis in/out adapters only deal with one serializer, so you will see that the name of the attribute is 'serializer' and on the Redis Outbound adapter it corresponds to RedisTemplate.valueSerializer
