### PR TITLE
INT-2695 WS Support URI Schemes Other than http(s)

### DIFF
--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -18,8 +18,10 @@ package org.springframework.integration.ws.config;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.net.URI;
 import java.util.List;
 
 import org.junit.Test;
@@ -45,6 +47,7 @@ import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.FaultMessageResolver;
 import org.springframework.ws.client.core.SourceExtractor;
 import org.springframework.ws.client.core.WebServiceMessageCallback;
+import org.springframework.ws.client.support.destination.DestinationProvider;
 import org.springframework.ws.client.support.interceptor.ClientInterceptor;
 import org.springframework.ws.transport.WebServiceMessageSender;
 
@@ -380,13 +383,25 @@ public class WebServiceOutboundGatewayParserTests {
 	}
 
 	@Test
-	public void testInt2718AdvisedInsideTheChain() {
+	public void testInt2718AdvisedInsideAChain() {
 		adviceCalled = 0;
 		ApplicationContext context = new ClassPathXmlApplicationContext(
 				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		MessageChannel channel = context.getBean("gatewayWithAdviceInsideAChain", MessageChannel.class);
 		channel.send(new GenericMessage<String>("foo"));
 		assertEquals(1, adviceCalled);
+	}
+
+	@Test
+	public void jmsUri() {
+		ApplicationContext context = new ClassPathXmlApplicationContext(
+				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
+		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithJmsUri");
+		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
+		MessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler", MessageHandler.class);
+		DestinationProvider destinationProvider = TestUtils.getPropertyValue(handler, "destinationProvider", DestinationProvider.class);
+		assertNotNull(destinationProvider);
+		assertEquals(URI.create("jms:wsQueue"), destinationProvider.getDestination());
 	}
 
     @Test(expected = BeanDefinitionParsingException.class)

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/simpleWebServiceOutboundGatewayParserTests.xml
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/simpleWebServiceOutboundGatewayParserTests.xml
@@ -112,7 +112,6 @@
 		</ws:request-handler-advice-chain>
 	</ws:outbound-gateway>
 
-
 	<si:chain input-channel="gatewayWithAdviceInsideAChain">
 		<ws:outbound-gateway destination-provider="destinationProvider">
 			<ws:request-handler-advice-chain>
@@ -120,6 +119,10 @@
 			</ws:request-handler-advice-chain>
 		</ws:outbound-gateway>
 	</si:chain>
+
+	<ws:outbound-gateway id="gatewayWithJmsUri"
+	                     request-channel="inputChannel"
+	                     uri="jms:wsQueue" />
 
 	<bean id="sourceExtractor" class="org.springframework.integration.ws.config.StubSourceExtractor"/>
 

--- a/src/reference/docbook/ws.xml
+++ b/src/reference/docbook/ws.xml
@@ -130,5 +130,20 @@ as per standard Spring Web Services configuration.
       when a custom Transformer works against the <interfacename>WebServiceMessage</interfacename> directly.
     </para>
   </section>
-
+  <section id="outbound-uri">
+    <title>Outbound URI Configuration</title>
+    <para>
+      For URIs with an <emphasis>http:</emphasis> (or <emphasis>https:</emphasis>) scheme,
+      &lt;uri-variable/&gt; substitution is supported:
+    </para>
+    <programlisting><![CDATA[<ws:outbound-gateway id="gateway" request-channel="input" uri="http://springsource.org/{foo}-{bar}">
+	<ws:uri-variable name="foo" expression="payload.substring(1,7)"/>
+	<ws:uri-variable name="bar" expression="headers.x"/>
+</ws:outbound-gateway>]]></programlisting>
+	<para>
+	  For other schemes, such as <emphasis>jms:</emphasis>, or if a <classname>DestinationProvider</classname>
+	  is supplied, variable substitution is not supported and a configuration error will result if variables
+	  are provided.
+	</para>
+  </section>
 </chapter>


### PR DESCRIPTION
Previously, only http: or https: URI schemes were supported
by the uri attribute. To use other schemes (such as jms:),
you had to provide a DestinationProvider.

Add support for schemes other than http and https by
creating a DestinationProvider internally when such a
URI is detected.

Note: &lt;uri-variable/>s are NOT supported except when
a URI with an http(s) scheme is provided. An exception
is thrown if variables are provided with an incompatible
URI, or if a DestinationProvider is supplied.

This could break existing applications that provide an
external DestinationProvider and have configured
&lt;uri-variable/>s. Previously, these variables were
simply ignored.
