### PR TITLE
INT-2740 MessageSelector w/ Pollable JMS Channel

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/PollableJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/PollableJmsChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,21 +24,33 @@ import org.springframework.jms.core.JmsTemplate;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.0
  */
 public class PollableJmsChannel extends AbstractJmsChannel implements PollableChannel {
+
+	private volatile String messageSelector;
 
 	public PollableJmsChannel(JmsTemplate jmsTemplate) {
 		super(jmsTemplate);
 	}
 
+	public void setMessageSelector(String messageSelector) {
+		this.messageSelector = messageSelector;
+	}
 
 	public Message<?> receive() {
 		if (!this.getInterceptors().preReceive(this)) {
  			return null;
  		}
-		Object object = this.getJmsTemplate().receiveAndConvert();
-		
+		Object object;
+		if (this.messageSelector == null) {
+			object = this.getJmsTemplate().receiveAndConvert();
+		}
+		else {
+			object = this.getJmsTemplate().receiveSelectedAndConvert(this.messageSelector);
+		}
+
 		if (object == null) {
 			return null;
 		}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
@@ -341,7 +341,11 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 		else {
 			Assert.isTrue(!Boolean.TRUE.equals(this.pubSubDomain),
 					"A JMS Topic-backed 'publish-subscribe-channel' must be message-driven.");
-			this.channel = new PollableJmsChannel(this.jmsTemplate);
+			PollableJmsChannel pollableJmschannel = new PollableJmsChannel(this.jmsTemplate);
+			if (this.messageSelector != null) {
+				pollableJmschannel.setMessageSelector(this.messageSelector);
+			}
+			this.channel = pollableJmschannel;
 		}
 		if (!CollectionUtils.isEmpty(this.interceptors)) {
 			this.channel.setInterceptors(this.interceptors);

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests-context.xml
@@ -47,6 +47,9 @@
 
 	<jms:channel id="pollableQueueNameChannel" queue-name="foo" message-driven="false"/>
 
+	<jms:channel id="pollableWithSelectorChannel" queue="testQueue" message-driven="false"
+		selector="foo='bar'" />
+
 	<bean id="testQueue" class="org.apache.activemq.command.ActiveMQQueue">
 		<property name="physicalName" value="test.queue"/>
 	</bean>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
@@ -95,6 +95,9 @@ public class JmsChannelParserTests {
 	private MessageChannel pollableQueueNameChannel;
 
 	@Autowired
+	private MessageChannel pollableWithSelectorChannel;
+
+	@Autowired
 	private Topic topic;
 
 	@Autowired
@@ -243,6 +246,16 @@ public class JmsChannelParserTests {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(channel);
 		JmsTemplate jmsTemplate = (JmsTemplate) accessor.getPropertyValue("jmsTemplate");
 		assertEquals("foo", jmsTemplate.getDefaultDestinationName());
+	}
+
+	@Test
+	public void selectorPollableChannel() {
+		assertEquals(PollableJmsChannel.class, pollableWithSelectorChannel.getClass());
+		PollableJmsChannel channel = (PollableJmsChannel) pollableWithSelectorChannel;
+		DirectFieldAccessor accessor = new DirectFieldAccessor(channel);
+		JmsTemplate jmsTemplate = (JmsTemplate) accessor.getPropertyValue("jmsTemplate");
+		assertEquals(queue, jmsTemplate.getDefaultDestination());
+		assertEquals("foo='bar'", accessor.getPropertyValue("messageSelector"));
 	}
 
 	@Test


### PR DESCRIPTION
Previously, the 'selector' attribute was ignored when
a JMS Channel was pollable rather than message-driven.

Add support for MessageSelector to PollableJmsChannel.
