### PR TITLE
INT-2742 Fix TCP Test Case Race Condition

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
@@ -594,11 +594,11 @@ public class TcpReceivingChannelAdapterTests {
 		adapter.setOutputChannel(channel);
 		ServiceActivatingHandler handler = new ServiceActivatingHandler(new FailingService());
 		channel.subscribe(handler);
+		QueueChannel errorChannel = new QueueChannel();
+		adapter.setErrorChannel(errorChannel);
 		Socket socket = SocketFactory.getDefault().createSocket("localhost", port);
 		socket.getOutputStream().write("Test1\r\n".getBytes());
 		socket.getOutputStream().write("Test2\r\n".getBytes());
-		QueueChannel errorChannel = new QueueChannel();
-		adapter.setErrorChannel(errorChannel);
 		Message<?> message = errorChannel.receive(10000);
 		assertNotNull(message);
 		assertEquals("Failed", ((Exception) message.getPayload()).getCause().getMessage());


### PR DESCRIPTION
Test data was sent before the error-channel was added to
the inbound adapter; the expected error could occur before
the error-channel was in place and the test failed
because the expected error message was absent.

Move the error-channel setup to before the test
data is sent.
