### PR TITLE
INT-2744 Mechanism to Suppress Standard Headers

### DIFF
--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageInboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageInboundTests.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNull;
 import java.net.URI;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -542,6 +543,18 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 		assertNotNull(headers.get("X-customHeaderB"));
 		assertEquals("TestClass.class", headers.get("X-customHeaderB").get(0));
 	}
+
+    @Test
+    public void dontPropagateContentLength() {
+        HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.inboundMapper();
+        HttpHeaders headers = new HttpHeaders();
+        // suppressed in response on inbound, by default
+        headers.put("Content-Length", Arrays.asList(new String[] {"3"}));
+        Map<String, Object> messageHeaders = mapper.toHeaders(headers);
+        headers = new HttpHeaders();
+        mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
+        assertNull(headers.get("Content-Length"));
+    }
 
 	public static class TestClass {
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
@@ -32,7 +32,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Test;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.integration.MessageHeaders;
@@ -645,5 +644,17 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
             assertEquals(1, headers.get("x-bar").size());
             assertEquals(1, headers.get("X-baz").size());
             assertEquals(1, headers.get("x-baz").size());
+    }
+    @Test
+    public void dontPropagateContentLength() {
+        DefaultHttpHeaderMapper mapper  = DefaultHttpHeaderMapper.outboundMapper();
+        // not suppressed on outbound request, by default
+        mapper.setExcludedOutboundStandardRequestHeaderNames(new String[] {"Content-Length"});
+        Map<String, Object> messageHeaders = new HashMap<String, Object>();
+        messageHeaders.put("Content-Length", 4);
+
+        HttpHeaders headers = new HttpHeaders();
+        mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
+        assertNull(headers.get("Content-Length"));
     }
 }


### PR DESCRIPTION
This might be considered a little kludgy but it works, and
it does provide a mechanism to relatively easily suppress
additional headers as needed, without requiring an SI release.

Currently, HTTP mappers don't know if they are inbound
or outbound. This causes problems with mapping certain
headers.

For example, on an inbound adapter, a mapped Content-Length
header should not be re-mapped to an HTTP Header during
response header mapping. However, the Content-Length
does need to be mapped on an outbound adapter response.

Introduce the notion of an exclusion list for both
request and response standard headers.

If a mapper has been configured to use standard headers,
we can detect whether the mapper is being used for inbound
or outbound mapping. We can then apply an 'exclusion' for
certain headers.

Currently, no request headers are suppressed on outbound
mappers and only the 'Content-Length' response header
is suppressed on inbound mappers.

The default mappers created via the static factory
methods use these defaults. Exposing the exclusion setters
will allow users to suppress additional headers, if
deemed necessary.
