### PR TITLE
INT-1819 Mail pseudo-tx support

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
@@ -24,8 +24,8 @@ import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.history.TrackableComponent;
-import org.springframework.integration.transaction.MessageSourceResourceHolder;
 import org.springframework.integration.transaction.TransactionSynchronizationFactory;
+import org.springframework.integration.transaction.TransactionalResourceHolder;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
 
@@ -100,10 +100,10 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint impleme
 	protected boolean doPoll() {
 
 		Message<?> message;
-		MessageSourceResourceHolder holder = null;
+		TransactionalResourceHolder holder = null;
 
 		if (TransactionSynchronizationManager.isActualTransactionActive()) {
-			holder = new MessageSourceResourceHolder(source);
+			holder = new TransactionalResourceHolder();
 			TransactionSynchronizationManager.bindResource(source, holder);
 
 			if (transactionSynchronizationFactory != null){

--- a/spring-integration-core/src/main/java/org/springframework/integration/transaction/DefaultTransactionSynchronizationFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transaction/DefaultTransactionSynchronizationFactory.java
@@ -14,6 +14,7 @@ package org.springframework.integration.transaction;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.transaction.support.ResourceHolderSynchronization;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -41,18 +42,18 @@ public class DefaultTransactionSynchronizationFactory implements TransactionSync
 	public TransactionSynchronization create(Object key) {
 		Assert.notNull(key, "'key' must not be null");
 		Object resourceHolder = TransactionSynchronizationManager.getResource(key);
-		Assert.isInstanceOf(MessageSourceResourceHolder.class, resourceHolder);
-		return new DefaultTransactionalResourceSynchronization((MessageSourceResourceHolder) resourceHolder, key);
+		Assert.isInstanceOf(TransactionalResourceHolder.class, resourceHolder);
+		return new DefaultTransactionalResourceSynchronization((TransactionalResourceHolder) resourceHolder, key);
 	}
 
 	/**
 	 */
 	private class DefaultTransactionalResourceSynchronization
-		extends ResourceHolderSynchronization<MessageSourceResourceHolder, Object> {
+		extends ResourceHolderSynchronization<TransactionalResourceHolder, Object> {
 
-		private final MessageSourceResourceHolder messageSourceHolder;
+		private final TransactionalResourceHolder messageSourceHolder;
 
-		public DefaultTransactionalResourceSynchronization(MessageSourceResourceHolder messageSourceHolder,
+		public DefaultTransactionalResourceSynchronization(TransactionalResourceHolder messageSourceHolder,
 				Object resourceKey) {
 			super(messageSourceHolder, resourceKey);
 			this.messageSourceHolder = messageSourceHolder;
@@ -72,7 +73,7 @@ public class DefaultTransactionSynchronizationFactory implements TransactionSync
 		}
 
 		@Override
-		protected void processResourceAfterCommit(MessageSourceResourceHolder resourceHolder) {
+		protected void processResourceAfterCommit(TransactionalResourceHolder resourceHolder) {
 
 			if (logger.isTraceEnabled()) {
 				logger.trace("'Committing' transactional resource");

--- a/spring-integration-core/src/main/java/org/springframework/integration/transaction/ExpressionEvaluatingTransactionSynchronizationProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transaction/ExpressionEvaluatingTransactionSynchronizationProcessor.java
@@ -87,19 +87,19 @@ public class ExpressionEvaluatingTransactionSynchronizationProcessor extends Int
 		this.afterRollbackExpression = afterRollbackExpression;
 	}
 
-	public void processBeforeCommit(MessageSourceResourceHolder holder) {
+	public void processBeforeCommit(TransactionalResourceHolder holder) {
 		this.doProcess(holder, this.beforeCommitExpression, this.beforeCommitChannel, "beforeCommit");
 	}
 
-	public void processAfterCommit(MessageSourceResourceHolder holder) {
+	public void processAfterCommit(TransactionalResourceHolder holder) {
 		this.doProcess(holder, this.afterCommitExpression, this.afterCommitChannel, "afterCommit");
 	}
 
-	public void processAfterRollback(MessageSourceResourceHolder holder) {
+	public void processAfterRollback(TransactionalResourceHolder holder) {
 		this.doProcess(holder, this.afterRollbackExpression, this.afterRollbackChannel, "afterRollback");
 	}
 
-	private void doProcess(MessageSourceResourceHolder holder, Expression expression, MessageChannel messageChannel, String expressionType) {
+	private void doProcess(TransactionalResourceHolder holder, Expression expression, MessageChannel messageChannel, String expressionType) {
 		Message<?> message = holder.getMessage();
 		if (message != null){
 			if (expression != null){
@@ -161,14 +161,13 @@ public class ExpressionEvaluatingTransactionSynchronizationProcessor extends Int
 		StandardEvaluationContext evaluationContextToUse;
 		if (resource != null) {
 			evaluationContextToUse = this.createEvaluationContext();
-			if (resource instanceof MessageSourceResourceHolder) {
-				MessageSourceResourceHolder holder = (MessageSourceResourceHolder) resource;
+			if (resource instanceof TransactionalResourceHolder) {
+				TransactionalResourceHolder holder = (TransactionalResourceHolder) resource;
 				for (Entry<String, Object> entry : holder.getAttributes().entrySet()) {
 					String key = entry.getKey();
 					Assert.state(!("messageSource".equals(key)), "'messageSource' is reserved and cannot be used as an attribute name");
 					evaluationContextToUse.setVariable(key, entry.getValue());
 				}
-				evaluationContextToUse.setVariable("messageSource", holder.getMessageSource());
 			}
 		}
 		else {

--- a/spring-integration-core/src/main/java/org/springframework/integration/transaction/TransactionSynchronizationProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transaction/TransactionSynchronizationProcessor.java
@@ -22,10 +22,10 @@ package org.springframework.integration.transaction;
  */
 public interface TransactionSynchronizationProcessor {
 
-	public abstract void processBeforeCommit(MessageSourceResourceHolder holder);
+	public abstract void processBeforeCommit(TransactionalResourceHolder holder);
 
-	public abstract void processAfterCommit(MessageSourceResourceHolder holder);
+	public abstract void processAfterCommit(TransactionalResourceHolder holder);
 
-	public abstract void processAfterRollback(MessageSourceResourceHolder holder);
+	public abstract void processAfterRollback(TransactionalResourceHolder holder);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/transaction/TransactionalResourceHolder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transaction/TransactionalResourceHolder.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.integration.Message;
-import org.springframework.integration.core.MessageSource;
 import org.springframework.transaction.support.ResourceHolder;
 
 /**
@@ -29,21 +28,11 @@ import org.springframework.transaction.support.ResourceHolder;
  * @since 2.2
  *
  */
-public class MessageSourceResourceHolder implements ResourceHolder {
-
-	private final MessageSource<?> source;
+public class TransactionalResourceHolder implements ResourceHolder {
 
 	private volatile Message<?> message;
 
 	private final Map<String, Object> attributes = new HashMap<String, Object>();
-
-	public MessageSourceResourceHolder(MessageSource<?> source) {
-		this.source = source;
-	}
-
-	protected MessageSource<?> getMessageSource() {
-		return this.source;
-	}
 
 	public void setMessage(Message<?> message) {
 		this.message = message;

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -35,6 +35,8 @@
 		</xsd:complexType>
 	</xsd:element>
 	
+	<xsd:element name="transactional" type="transactionalType"/>
+	
 	<xsd:element name="transaction-synchronization-factory">
 		<xsd:annotation>
 			<xsd:documentation>

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PseudoTransactionalMessageSourceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PseudoTransactionalMessageSourceTests.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
+
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.Message;
 import org.springframework.integration.channel.QueueChannel;
@@ -27,8 +28,8 @@ import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.transaction.DefaultTransactionSynchronizationFactory;
 import org.springframework.integration.transaction.ExpressionEvaluatingTransactionSynchronizationProcessor;
-import org.springframework.integration.transaction.MessageSourceResourceHolder;
 import org.springframework.integration.transaction.PseudoTransactionManager;
+import org.springframework.integration.transaction.TransactionalResourceHolder;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -66,8 +67,8 @@ public class PseudoTransactionalMessageSourceTests {
 
 			public Message<String> receive() {
 				GenericMessage<String> message = new GenericMessage<String>("foo");
-				((MessageSourceResourceHolder) TransactionSynchronizationManager.getResource(this)).addAttribute("baz", "qux");
-				((MessageSourceResourceHolder) TransactionSynchronizationManager.getResource(this)).addAttribute("bix", "qox");
+				((TransactionalResourceHolder) TransactionSynchronizationManager.getResource(this)).addAttribute("baz", "qux");
+				((TransactionalResourceHolder) TransactionSynchronizationManager.getResource(this)).addAttribute("bix", "qox");
 				return message;
 			}
 		});
@@ -108,7 +109,7 @@ public class PseudoTransactionalMessageSourceTests {
 
 			public Message<String> receive() {
 				GenericMessage<String> message = new GenericMessage<String>("foo");
-				((MessageSourceResourceHolder) TransactionSynchronizationManager.getResource(this)).addAttribute("baz", "qux");
+				((TransactionalResourceHolder) TransactionSynchronizationManager.getResource(this)).addAttribute("baz", "qux");
 				return message;
 			}
 		});
@@ -150,8 +151,8 @@ public class PseudoTransactionalMessageSourceTests {
 
 					public Message<String> receive() {
 						GenericMessage<String> message = new GenericMessage<String>("foo");
-						((MessageSourceResourceHolder) TransactionSynchronizationManager.getResource(this)).addAttribute("baz", "qux");
-						((MessageSourceResourceHolder) TransactionSynchronizationManager.getResource(this)).addAttribute("bix", "qox");
+						((TransactionalResourceHolder) TransactionSynchronizationManager.getResource(this)).addAttribute("baz", "qux");
+						((TransactionalResourceHolder) TransactionSynchronizationManager.getResource(this)).addAttribute("bix", "qox");
 						return message;
 					}
 				});
@@ -193,7 +194,7 @@ public class PseudoTransactionalMessageSourceTests {
 
 						public Message<String> receive() {
 							GenericMessage<String> message = new GenericMessage<String>("foo");
-							((MessageSourceResourceHolder) TransactionSynchronizationManager.getResource(this))
+							((TransactionalResourceHolder) TransactionSynchronizationManager.getResource(this))
 									.addAttribute("baz", "qux");
 							return message;
 						}
@@ -236,7 +237,7 @@ public class PseudoTransactionalMessageSourceTests {
 
 					public Message<String> receive() {
 						GenericMessage<String> message = new GenericMessage<String>("foo");
-						((MessageSourceResourceHolder) TransactionSynchronizationManager.getResource(this))
+						((TransactionalResourceHolder) TransactionSynchronizationManager.getResource(this))
 								.addAttribute("baz", "qux");
 						return message;
 					}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
@@ -17,20 +17,30 @@
 package org.springframework.integration.mail;
 
 import java.util.Date;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 
 import javax.mail.FolderClosedException;
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import javax.mail.Store;
-import javax.mail.internet.MimeMessage;
 
+import org.aopalliance.aop.Advice;
+
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.transaction.TransactionSynchronizationFactory;
+import org.springframework.integration.transaction.TransactionalResourceHolder;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.TriggerContext;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 
 /**
  * An event-driven Channel Adapter that receives mail messages from a mail
@@ -38,16 +48,22 @@ import org.springframework.util.Assert;
  * messages will be converted and sent as Spring Integration Messages to the
  * output channel. The Message payload will be the {@link javax.mail.Message}
  * instance that was received.
- * 
+ *
  * @author Arjen Poutsma
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  */
-public class ImapIdleChannelAdapter extends MessageProducerSupport {
+public class ImapIdleChannelAdapter extends MessageProducerSupport implements BeanClassLoaderAware {
 
 	private final IdleTask idleTask = new IdleTask();
 
+	private final Executor sendingTaskExecutor = Executors.newFixedThreadPool(1);
+
 	private volatile boolean shouldReconnectAutomatically = true;
+
+	private volatile ClassLoader classLoader;
+
+	private volatile List<Advice> adviceChain;
 
 	private final ImapMailReceiver mailReceiver;
 
@@ -58,15 +74,24 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport {
 	private volatile ScheduledFuture<?> pingTask;
 
 	private volatile long connectionPingInterval = 10000;
-	
+
 	private final ExceptionAwarePeriodicTrigger receivingTaskTrigger = new ExceptionAwarePeriodicTrigger();
 
+	private volatile TransactionSynchronizationFactory transactionSynchronizationFactory;
 
 	public ImapIdleChannelAdapter(ImapMailReceiver mailReceiver) {
 		Assert.notNull(mailReceiver, "'mailReceiver' must not be null");
 		this.mailReceiver = mailReceiver;
 	}
 
+	public void setTransactionSynchronizationFactory(
+			TransactionSynchronizationFactory transactionSynchronizationFactory) {
+		this.transactionSynchronizationFactory = transactionSynchronizationFactory;
+	}
+
+	public void setAdviceChain(List<Advice> adviceChain) {
+		this.adviceChain = adviceChain;
+	}
 
 	/**
 	 * Specify whether the IDLE task should reconnect automatically after
@@ -77,10 +102,14 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport {
 		this.shouldReconnectAutomatically = shouldReconnectAutomatically;
 	}
 
+	@Override
 	public String getComponentType() {
 		return "mail:imap-idle-channel-adapter";
 	}
 
+	public void setBeanClassLoader(ClassLoader classLoader) {
+		this.classLoader = classLoader;
+	}
 
 	/*
 	 * Lifecycle implementation
@@ -140,9 +169,11 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport {
 					if (logger.isDebugEnabled()) {
 						logger.debug("received " + mailMessages.length + " mail messages");
 					}
-					for (Message mailMessage : mailMessages) {
-						final MimeMessage copied = new MimeMessage((MimeMessage) mailMessage);
-						sendMessage(MessageBuilder.withPayload(copied).build());
+					for (final Message mailMessage : mailMessages) {
+
+						Runnable messageSendingTask = createMessageSendingTask(mailMessage);
+
+						sendingTaskExecutor.execute(messageSendingTask);
 					}
 				}
 			}
@@ -162,6 +193,39 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport {
 		}
 	}
 
+	private Runnable createMessageSendingTask(final Message mailMessage){
+		Runnable sendingTask = new Runnable() {
+			public void run() {
+				org.springframework.integration.Message<?> message =
+						MessageBuilder.withPayload(mailMessage).build();
+
+				if (TransactionSynchronizationManager.isActualTransactionActive()) {
+
+					TransactionalResourceHolder holder = new TransactionalResourceHolder();
+					holder.setMessage(message);
+					TransactionSynchronizationManager.bindResource(ImapIdleChannelAdapter.this, holder);
+
+					if (transactionSynchronizationFactory != null){
+						TransactionSynchronizationManager.
+							registerSynchronization(transactionSynchronizationFactory.create(ImapIdleChannelAdapter.this));
+					}
+				}
+				sendMessage(message);
+			}
+		};
+
+		// wrap in the TX proxy if neccessery
+		if (!CollectionUtils.isEmpty(adviceChain)) {
+			ProxyFactory proxyFactory = new ProxyFactory(sendingTask);
+			if (!CollectionUtils.isEmpty(adviceChain)) {
+				for (Advice advice : adviceChain) {
+					proxyFactory.addAdvice(advice);
+				}
+			}
+			sendingTask = (Runnable) proxyFactory.getProxy(classLoader);
+		}
+		return sendingTask;
+	}
 
 	private class PingTask implements Runnable {
 
@@ -176,9 +240,9 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport {
 			}
 		}
 	}
-	
+
 	private class ExceptionAwarePeriodicTrigger implements Trigger {
-		
+
 		private volatile boolean delayNextExecution;
 
 
@@ -186,15 +250,14 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport {
 			if (delayNextExecution){
 				delayNextExecution = false;
 				return new Date(System.currentTimeMillis() + reconnectDelay);
-			} 
+			}
 			else {
 				return new Date(System.currentTimeMillis());
-			}		
+			}
 		}
-		
+
 		public void delayNextExecution() {
 			this.delayNextExecution = true;
 		}
 	}
-
 }

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParser.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParser.java
@@ -28,6 +28,7 @@ import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.mail.ImapIdleChannelAdapter;
 import org.springframework.integration.mail.ImapMailReceiver;
 import org.springframework.util.StringUtils;
+import org.springframework.util.xml.DomUtils;
 
 /**
  * Parser for the &lt;imap-idle-channel-adapter&gt; element in the 'mail' namespace.
@@ -46,6 +47,14 @@ public class ImapIdleChannelAdapterParser extends AbstractChannelAdapterParser {
 		builder.addPropertyReference("outputChannel", channelName);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel", "errorChannel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-startup");
+
+		Element txElement = DomUtils.getChildElementByTagName(element, "transactional");
+		if (txElement != null){
+			IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, txElement,
+					"synchronization-factory", "transactionSynchronizationFactory");
+		}
+		IntegrationNamespaceUtils.configureAndSetAdviceChainIfPresent(null,
+				DomUtils.getChildElementByTagName(element, "transactional"), builder, parserContext);
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-mail/src/main/resources/org/springframework/integration/mail/config/spring-integration-mail-2.2.xsd
+++ b/spring-integration-mail/src/main/resources/org/springframework/integration/mail/config/spring-integration-mail-2.2.xsd
@@ -108,6 +108,9 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="inboundMailAdapterType">
+				<xsd:choice minOccurs="0" maxOccurs="2">
+					<xsd:element ref="integration:transactional" minOccurs="0" maxOccurs="1" />
+				</xsd:choice>
 					<xsd:attribute name="error-channel" type="xsd:string">
 						<xsd:annotation>
 							<xsd:appinfo>

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdelIntegrationTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdelIntegrationTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.mail.config;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.mail.Folder;
+import javax.mail.Message;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.mail.ImapIdleChannelAdapter;
+import org.springframework.integration.mail.ImapMailReceiver;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.util.ReflectionUtils;
+/**
+ * @author Oleg Zhurakousky
+ */
+public class ImapIdelIntegrationTests {
+
+	@Test
+	//@Ignore
+	public void testWithTransactionSynchronization() throws Exception{
+		final AtomicBoolean block = new AtomicBoolean(false);
+		ClassPathXmlApplicationContext context =
+				new ClassPathXmlApplicationContext("imap-idle-mock-integration-config.xml", this.getClass());
+		PostTransactionProcessor processor = context.getBean("syncProcessor", PostTransactionProcessor.class);
+		ImapIdleChannelAdapter adapter = context.getBean("customAdapter", ImapIdleChannelAdapter.class);
+		ImapMailReceiver receiver = TestUtils.getPropertyValue(adapter, "mailReceiver", ImapMailReceiver.class);
+
+		// setup mock scenario
+		receiver = spy(receiver);
+
+		doAnswer(new Answer<Object>() { // ensures that waitFornewMessages call blocks after a first execution
+			// to emulate the behavior of IDLE
+
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				if (block.get()){
+					Thread.sleep(5000);
+				}
+				block.set(true);
+				return null;
+			}
+		}).when(receiver).waitForNewMessages();
+
+		Message m1 = mock(Message.class);
+		doReturn(new Message[]{m1}).when(receiver).receive();
+
+		Folder folder = mock(Folder.class);
+		when(folder.isOpen()).thenReturn(true);
+		Field folderField = ReflectionUtils.findField(ImapMailReceiver.class, "folder");
+		folderField.setAccessible(true);
+		folderField.set(receiver, folder);
+
+		Field mrField = ImapIdleChannelAdapter.class.getDeclaredField("mailReceiver");
+		mrField.setAccessible(true);
+		mrField.set(adapter, receiver);
+		// end mock setup
+
+		adapter.start();
+
+		Thread.sleep(1000);
+		// validating that TXpost processor was invoked
+
+		adapter.stop();
+		context.destroy();
+		verify(processor, Mockito.times(1)).process(m1);
+	}
+
+	public static interface PostTransactionProcessor {
+		public void process(Message mailMessage);
+	}
+}

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/imap-idle-mock-integration-config.xml
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/imap-idle-mock-integration-config.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.2.xsd
+		http://www.springframework.org/schema/integration/mail http://www.springframework.org/schema/integration/mail/spring-integration-mail-2.2.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-mail="http://www.springframework.org/schema/integration/mail"
+	xmlns:util="http://www.springframework.org/schema/util">
+	
+	<int-mail:imap-idle-channel-adapter id="customAdapter"
+					store-uri="imaps://foo.com:password@imap.foo.com/INBOX"
+					channel="nullChannel"
+					auto-startup="false"
+					should-delete-messages="false">
+			<int:transactional synchronization-factory="syncFactory"/>
+	</int-mail:imap-idle-channel-adapter>
+
+	<int:transaction-synchronization-factory id="syncFactory">
+		<int:before-commit expression="@syncProcessor.process(payload)"/>
+	</int:transaction-synchronization-factory>
+	
+	<bean id="syncProcessor" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.integration.mail.config.ImapIdelIntegrationTests.PostTransactionProcessor"/>
+	</bean>
+	
+	<bean id="transactionManager" class="org.springframework.integration.transaction.PseudoTransactionManager"/>
+	
+</beans>

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSource.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSource.java
@@ -31,7 +31,7 @@ import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.mongodb.support.MongoHeaders;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.transaction.MessageSourceResourceHolder;
+import org.springframework.integration.transaction.TransactionalResourceHolder;
 import org.springframework.integration.util.ExpressionUtils;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
@@ -218,8 +218,8 @@ public class MongoDbMessageSource extends IntegrationObjectSupport
 
 		Object holder = TransactionSynchronizationManager.getResource(this);
 		if (holder != null) {
-			Assert.isInstanceOf(MessageSourceResourceHolder.class, holder);
-			((MessageSourceResourceHolder) holder).addAttribute("mongoTemplate", this.mongoTemplate);
+			Assert.isInstanceOf(TransactionalResourceHolder.class, holder);
+			((TransactionalResourceHolder) holder).addAttribute("mongoTemplate", this.mongoTemplate);
 		}
 
 		return message;

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisStoreMessageSource.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisStoreMessageSource.java
@@ -31,7 +31,7 @@ import org.springframework.integration.Message;
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.transaction.MessageSourceResourceHolder;
+import org.springframework.integration.transaction.TransactionalResourceHolder;
 import org.springframework.integration.util.ExpressionUtils;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
@@ -122,8 +122,8 @@ public class RedisStoreMessageSource extends IntegrationObjectSupport
 
 		Object holder = TransactionSynchronizationManager.getResource(this);
 		if (holder != null) {
-			Assert.isInstanceOf(MessageSourceResourceHolder.class, holder);
-			((MessageSourceResourceHolder) holder).addAttribute("store", store);
+			Assert.isInstanceOf(TransactionalResourceHolder.class, holder);
+			((TransactionalResourceHolder) holder).addAttribute("store", store);
 		}
 
 		if (store instanceof Collection<?> && ((Collection<Object>)store).size() < 1){

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/zset-inbound-adapter.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/zset-inbound-adapter.xml
@@ -46,7 +46,7 @@
 	</int-redis:store-inbound-channel-adapter>
 	
 	<int:transaction-synchronization-factory id="syncFactory">
-		 <int:after-commit expression="#resource.attributes['store'].removeByScore(18, 18)"/>
+		 <int:after-commit expression="#store.removeByScore(18, 18)"/>
 	</int:transaction-synchronization-factory>
 
 	<int:channel id="redisChannel">


### PR DESCRIPTION
Added pseudo-tx support for Mail inbound adapters
For polling adapters no changes have been made other then returning a javax.mail.Message instead of its copy so
post-tx dispositions could be performed on it.
For Imap IDLE adapter changes are simiar to the once present in SPCA where TX synchronization logic was added to ImapIdleChannelAdapter
Couple of things to note:
First IDLE receives an array of messages while Polling task receives one message which means i need to sendMessage in the Polling task in the separate thread, so for maintaining single thread semantics we have now it uses single thread executor to send Messages
Renamed MSRH to TransactionalResourceHolder since we no longer use 'source' anywhere and in the case of IDLE there is no MessageSource. Its is truly a holder of attributes we want to make available for use (e.g., SpEL)
