### PR TITLE
INT-2748 Change CircuitBreaker Exception

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerCircuitBreakerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerCircuitBreakerAdvice.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.integration.Message;
-import org.springframework.integration.MessagingException;
 
 /**
  * A circuit breaker that stops calling a failing service after threshold
@@ -56,7 +55,7 @@ public class RequestHandlerCircuitBreakerAdvice extends AbstractRequestHandlerAd
 		}
 		if (metadata.getFailures().get() >= this.threshold &&
 				System.currentTimeMillis() - metadata.getLastFailure() < this.halfOpenAfter) {
-			throw new MessagingException("Circuit Breaker is Open for " + target);
+			throw new CircuitBreakerOpenException("Circuit Breaker is Open for " + target);
 		}
 		try {
 			Object result = callback.execute();
@@ -89,6 +88,15 @@ public class RequestHandlerCircuitBreakerAdvice extends AbstractRequestHandlerAd
 
 		private AtomicInteger getFailures() {
 			return failures;
+		}
+	}
+
+	private class CircuitBreakerOpenException extends RuntimeException {
+
+		private static final long serialVersionUID = 1L;
+
+		public CircuitBreakerOpenException(String message) {
+			super(message);
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -304,7 +304,7 @@ public class AdvisedMessageHandlerTests {
 			fail("Expected failure");
 		}
 		catch (Exception e) {
-			assertEquals("Circuit Breaker is Open for baz", e.getMessage());
+			assertEquals("Circuit Breaker is Open for baz", e.getCause().getMessage());
 		}
 		Thread.sleep(100);
 		try {
@@ -319,7 +319,7 @@ public class AdvisedMessageHandlerTests {
 			fail("Expected failure");
 		}
 		catch (Exception e) {
-			assertEquals("Circuit Breaker is Open for baz", e.getMessage());
+			assertEquals("Circuit Breaker is Open for baz", e.getCause().getMessage());
 		}
 		Thread.sleep(100);
 		doFail.set(false);
@@ -344,7 +344,7 @@ public class AdvisedMessageHandlerTests {
 			fail("Expected failure");
 		}
 		catch (Exception e) {
-			assertEquals("Circuit Breaker is Open for baz", e.getMessage());
+			assertEquals("Circuit Breaker is Open for baz", e.getCause().getMessage());
 		}
 	}
 


### PR DESCRIPTION
Previously, when the breaker was open, it threw a
MessagingException. This was not wrapped so normal
error-channel processing 'payload.cause.message'
failed because the cause was null.

Change the exception to a new private
CircuitBreakerOpenException.
