### PR TITLE
INT-2745 - Delayer: Disallow "id" attribute within a Chain

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
@@ -28,6 +28,8 @@ import org.w3c.dom.Element;
  *
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Gunnar Hillert
+ *
  * @since 1.0.3
  */
 public class DelayerParser extends AbstractConsumerEndpointParser {
@@ -37,8 +39,22 @@ public class DelayerParser extends AbstractConsumerEndpointParser {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(DelayHandler.class);
 
 		String id = element.getAttribute(ID_ATTRIBUTE);
-		if (!StringUtils.hasText(id)) {
-			parserContext.getReaderContext().error("The 'id' attribute is required.", element);
+		String name = element.getAttribute("name");
+
+		if (StringUtils.hasText(id) && StringUtils.hasText(name)) {
+			parserContext.getReaderContext().error("Either the 'id' attribute or " +
+				"the 'name' attribute is required but not both.", element);
+		}
+
+		if (StringUtils.hasText(id)) {
+			builder.addConstructorArgValue(id + ".messageGroupId");
+		}
+		else if (StringUtils.hasText(name)) {
+			builder.addConstructorArgValue(name + ".messageGroupId");
+		}
+		else {
+			parserContext.getReaderContext().error("Either the 'id' attribute or " +
+				"the 'name' attribute is required.", element);
 		}
 
 		String defaultDelay = element.getAttribute("default-delay");
@@ -51,8 +67,6 @@ public class DelayerParser extends AbstractConsumerEndpointParser {
 			parserContext.getReaderContext()
 					.error("The 'default-delay' or 'delay-header-name' attributes should be provided.", element);
 		}
-
-		builder.addConstructorArgValue(id + ".messageGroupId");
 
 		String scheduler = element.getAttribute("scheduler");
 		if (StringUtils.hasText(scheduler)) {

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -34,24 +34,24 @@
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:element name="transaction-synchronization-factory">
 		<xsd:annotation>
 			<xsd:documentation>
 				Allows you to configure org.springframework.integration.transaction.DefaultTransactionSynchronizationFactory
 				This implementation of org.springframework.integration.transaction.TransactionSynchronizationFactory
-				allows you to configure SpEL expressions, with their execution being coordinated (synchronized) with a 
-				transaction - see {TransactionSynchronization}. Expressions for before-commit, after.-commit, and after-rollback 
+				allows you to configure SpEL expressions, with their execution being coordinated (synchronized) with a
+				transaction - see {TransactionSynchronization}. Expressions for before-commit, after.-commit, and after-rollback
 				are supported, together with a channel for each where the evaluation result  (if any) will be sent.
 				For each sub-element you can specify 'expression' and/or 'channel' attributes.
 				If only the 'channel' attribute is present the received Message will be sent there as part of a particular synchronization scenario.
-				If only the 'expression' attribute is present and the result of an expression is a non-Null value, a Message with the 
-				result as the payload will be generated and sent to a default channel (NullChannel) and will appear in the logs. 
-				If you want the evaluation result to go to a specific channel add a 'channel' attribute. If the result of an expression is null 
+				If only the 'expression' attribute is present and the result of an expression is a non-Null value, a Message with the
+				result as the payload will be generated and sent to a default channel (NullChannel) and will appear in the logs.
+				If you want the evaluation result to go to a specific channel add a 'channel' attribute. If the result of an expression is null
 				or void, no Message will be generated.
 			</xsd:documentation>
 		</xsd:annotation>
-		<xsd:complexType>	
+		<xsd:complexType>
 			<xsd:sequence>
 					<xsd:element name="before-commit" minOccurs="0" maxOccurs="1">
 						<xsd:complexType>
@@ -72,7 +72,7 @@
 			<xsd:attribute name="id" type="xsd:string" use="required"/>
 		</xsd:complexType>
 	</xsd:element>
-	
+
 	<xsd:attributeGroup name="synchronizationAttributeGroup">
 		<xsd:attribute name="expression" type="xsd:string">
 			<xsd:annotation>
@@ -1335,29 +1335,42 @@
 		</xsd:attribute>
 	</xsd:complexType>
 
-	<xsd:element name="delayer">
+	<xsd:element name="delayer" type="delayerType">
 		<xsd:annotation>
 			<xsd:documentation>
-				Defines an endpoint that passes a Message to the output-channel after a
-				delay. The delay may
-				be
-				retrieved from a Message header or else fallback to the
-				'default-delay' of this endpoint.
+				Defines an endpoint that passes a Message to the output-channel
+				after a delay. The delay may be retrieved from a Message header
+				or else fallback to the 'default-delay' of this endpoint.
 			</xsd:documentation>
 		</xsd:annotation>
-		<xsd:complexType>
-			<xsd:complexContent>
-				<xsd:extension base="delayer-type">
-					<xsd:sequence minOccurs="0" maxOccurs="1">
-						<xsd:element name="poller" type="basePollerType" />
-					</xsd:sequence>
-					<xsd:attributeGroup ref="inputOutputChannelGroup"/>
-				</xsd:extension>
-			</xsd:complexContent>
-		</xsd:complexType>
 	</xsd:element>
 
-	<xsd:complexType name="delayer-type">
+	<xsd:complexType name="delayerType">
+		<xsd:complexContent>
+			<xsd:extension base="commonDelayerType">
+				<xsd:sequence>
+					<xsd:element ref="poller" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attributeGroup ref="inputOutputChannelGroup"/>
+				<xsd:attribute name="id" type="xsd:string" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							'id' value is used:
+							- as the 'AbstractEndpoint' bean 'id' if this tag is defined as root element.
+							- as the DelayHandler bean alias together with suffix '.handler'
+							- as the 'messageGroupId' property of DelayHandler together with suffix '.messageGroupId'
+							  in the operations of the MessageGroupStore for scheduling delayed messages.
+
+							Either this attribute or the equivalent 'name' attribute
+							must be specified.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="commonDelayerType">
 		<xsd:choice>
 			<xsd:annotation>
 				<xsd:documentation>
@@ -1368,14 +1381,18 @@
 			<xsd:element name="transactional" type="transactionalType" minOccurs="0" maxOccurs="1" />
 			<xsd:element name="advice-chain" type="adviceChainType" minOccurs="0" maxOccurs="1" />
 		</xsd:choice>
-		<xsd:attribute name="id" type="xsd:string" use="required">
+		<xsd:attribute name="name" type="xsd:string" use="optional">
 			<xsd:annotation>
 				<xsd:documentation>
-					'id' value is used:
+					'name' value is used:
 					- as the 'AbstractEndpoint' bean 'id' if this tag is defined as root element.
 					- as the DelayHandler bean alias together with suffix '.handler'
 					- as the 'messageGroupId' property of DelayHandler together with suffix '.messageGroupId'
 					  in the operations of the MessageGroupStore for scheduling delayed messages.
+
+					Either this attribute or the equivalent 'id' attribute
+					must be specified. Contrary to the 'id' attribute, the 'name'
+					attribute is available inside of Chains.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
@@ -1499,7 +1516,7 @@
 					<xsd:element name="recipient-list-router" type="recipientListRouterTypeChain"/>
 					<xsd:element name="exception-type-router" type="exceptionTypeRouterTypeChain"/>
 					<xsd:element name="header-value-router" type="headerValueRouterTypeChain"/>
-					<xsd:element name="delayer" type="delayer-type"/>
+					<xsd:element name="delayer" type="commonDelayerType"/>
 					<xsd:element name="gateway" type="innerGatewayType"/>
 					<xsd:element name="payload-serializing-transformer" type="payload-serializing-transformer-type"/>
 					<xsd:element name="payload-deserializing-transformer"
@@ -3453,7 +3470,7 @@ is provided, the return value is expected to match a channel name exactly.
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 	Reference to an instance of org.springframework.integration.transaction.TransactionSynchronizationFactory
-	which will return an instance of org.springframework.transaction.support.TransactionSynchronization via its create(..) method. 
+	which will return an instance of org.springframework.transaction.support.TransactionSynchronization via its create(..) method.
 				]]></xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
@@ -3491,7 +3508,7 @@ is provided, the return value is expected to match a channel name exactly.
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 	Reference to an instance of org.springframework.integration.transaction.TransactionSynchronizationFactory
-	which will return an instance of org.springframework.transaction.support.TransactionSynchronization via its create(..) method. 
+	which will return an instance of org.springframework.transaction.support.TransactionSynchronization via its create(..) method.
 	Setting of this attribute will only have an affect if a Transaction advice is present in the chain.
 				]]></xsd:documentation>
 				<xsd:appinfo>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ChainElementsFailureTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ChainElementsFailureTests.java
@@ -92,6 +92,26 @@ public class ChainElementsFailureTests {
 	}
 
 	@Test
+	public void chainDelayerWithId() throws Exception {
+
+		try {
+			this.bootStrap("delayer-with-id");
+			fail("Expected a XmlBeanDefinitionStoreException to be thrown.");
+		}
+		catch (XmlBeanDefinitionStoreException e) {
+			assertEquals("cvc-complex-type.3.2.2: Attribute 'id' is not" +
+					" allowed to appear in element 'int:delayer'.", e.getCause().getMessage());
+		}
+	}
+
+	@Test
+	public void chainDelayerWithName() throws Exception {
+
+		this.bootStrap("delayer-with-name");
+
+	}
+
+	@Test
 	public void chainFilter() throws Exception {
 
 		try {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerFailureTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerFailureTests.java
@@ -1,0 +1,89 @@
+package org.springframework.integration.config.xml;
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.ByteArrayInputStream;
+import java.util.Properties;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.springframework.beans.factory.config.PropertiesFactoryBean;
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionStoreException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.InputStreamResource;
+
+
+/**
+ * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
+ *
+ */
+public class DelayerFailureTests {
+
+	@Test
+	public void delayerWithoutIdAndName() throws Exception {
+
+		try {
+			this.bootStrap("delayer-without-id-and-name");
+			fail("Expected a BeanDefinitionParsingException to be thrown.");
+		}
+		catch (BeanDefinitionParsingException e) {
+			assertTrue(e.getMessage().startsWith("Configuration problem: Either the 'id' attribute or the 'name' attribute is required."));
+		}
+
+	}
+
+	@Test
+	public void delayerWithIdAndName() throws Exception {
+
+		try {
+			this.bootStrap("delayer-with-id-and-name");
+			fail("Expected a BeanDefinitionParsingException to be thrown.");
+		}
+		catch (BeanDefinitionParsingException e) {
+
+			String expectedMessage = "Configuration problem: Either the 'id' attribute or the 'name' attribute is required but not both.";
+			String actualMessage = e.getMessage();
+			assertTrue("Expected message: '" + expectedMessage + "'; but got '" + actualMessage + "'", actualMessage.startsWith(expectedMessage));
+		}
+
+	}
+
+	private ApplicationContext bootStrap(String configProperty) throws Exception {
+		PropertiesFactoryBean pfb = new PropertiesFactoryBean();
+		pfb.setLocation(new ClassPathResource("org/springframework/integration/config/xml/delayer-config.properties"));
+		pfb.afterPropertiesSet();
+		Properties prop = pfb.getObject();
+		StringBuffer buffer = new StringBuffer();
+		buffer.append(prop.getProperty("xmlheaders")).append(prop.getProperty(configProperty)).append(prop.getProperty("xmlfooter"));
+
+		System.out.println(buffer);
+
+		ByteArrayInputStream stream = new ByteArrayInputStream(buffer.toString().getBytes());
+		GenericApplicationContext ac = new GenericApplicationContext();
+		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(ac);
+		reader.setValidationMode(XmlBeanDefinitionReader.VALIDATION_XSD);
+		reader.loadBeanDefinitions(new InputStreamResource(stream));
+		ac.refresh();
+		return ac;
+	}
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests-context.xml
@@ -37,7 +37,7 @@
 
 	<chain input-channel="delayerInsideChain" output-channel="outputA">
 		<transformer expression="payload.toUpperCase()"/>
-		<delayer id="delayerInsideChain" default-delay="1000">
+		<delayer name="delayerInsideChain" default-delay="1000">
 			<advice-chain>
 				<beans:bean class="org.springframework.integration.config.xml.TestAdviceBean">
 					<beans:constructor-arg value="0"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/chain-elements-config.properties
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/chain-elements-config.properties
@@ -31,6 +31,16 @@ delayer=\
 		<int:delayer default-delay="1000" input-channel="fail"/> \
 	</int:chain>
 
+delayer-with-id=\
+	<int:chain input-channel="input"> \
+		<int:delayer default-delay="1000" id="fail"/> \
+	</int:chain>
+
+delayer-with-name=\
+	<int:chain input-channel="input"> \
+		<int:delayer default-delay="1000" name="success"/> \
+	</int:chain>
+
 filter=\
 	<int:chain input-channel="input"> \
 		<int:filter input-channel="fail"/> \

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/delayer-config.properties
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/delayer-config.properties
@@ -1,0 +1,18 @@
+xmlheaders=\
+<?xml version="1.0" encoding="UTF-8"?> \
+<beans:beans xmlns="http://www.springframework.org/schema/integration" \
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" \
+	xmlns:beans="http://www.springframework.org/schema/beans" \
+	xmlns:p="http://www.springframework.org/schema/p" \
+	xsi:schemaLocation="http://www.springframework.org/schema/beans \
+			http://www.springframework.org/schema/beans/spring-beans.xsd \
+			http://www.springframework.org/schema/integration \
+			http://www.springframework.org/schema/integration/spring-integration.xsd">
+xmlfooter= </beans:beans>
+
+delayer-without-id-and-name=\
+		<delayer default-delay="1000">\
+		</delayer>
+delayer-with-id-and-name=\
+		<delayer default-delay="1000" id="myId" name="myName">\
+		</delayer>

--- a/src/reference/docbook/delayer.xml
+++ b/src/reference/docbook/delayer.xml
@@ -24,11 +24,16 @@
       but the delayer also has 'default-delay' and 'delay-header-name' attributes that are used to
       determine the number of milliseconds
       that each Message should be delayed. The following delays all messages by 3 seconds:
-      <programlisting language="xml"><![CDATA[ <int:delayer id="delayer" input-channel="input" default-delay="3000" output-channel="output"/>]]></programlisting>
+	</para>
+      <programlisting language="xml"><![CDATA[<int:delayer id="delayer" input-channel="input" default-delay="3000"
+             output-channel="output"/>]]></programlisting>
+	<para>
       If you need per-Message determination of the delay, then you can also provide the name of a header
       using the 'delay-header-name' attribute:
-      <programlisting language="xml"><![CDATA[ <int:delayer id="delayer" input-channel="input" output-channel="output"
-          default-delay="3000" delay-header-name="delay"/>]]></programlisting>
+	</para>
+      <programlisting language="xml"><![CDATA[<int:delayer id="delayer" input-channel="input" output-channel="output"
+             default-delay="3000" delay-header-name="delay"/>]]></programlisting>
+	<para>
       In the example above the 3 second delay would only apply in the case that the header value is
       not present for a given inbound Message. If you only want to apply a delay to Messages that have
       an explicit header value, then you can set the 'default-delay' to 0 or don't use it at all (by default it is 0).
@@ -46,6 +51,28 @@
         sender's Thread. If the header is not a Date, and can not be parsed as a Long, the default
         delay (if any) will be applied.
       </tip>
+	<important>
+		<para>
+			For the <emphasis>Delayer</emphasis> you have to provide either the
+			<emphasis>id</emphasis> or <emphasis>name</emphasis> attribute. These
+			mutually exclusive attributes are used to create the delayer's
+			<emphasis>messageGroupId</emphasis> that is used as the <emphasis>key</emphasis>
+			for the <interfacename>MessageGroup</interfacename>. The
+			<emphasis>messageGroupId</emphasis> is a concatenation of the
+			<emphasis>id</emphasis> or <emphasis>name</emphasis> attribute's value
+			and the <classname>String</classname> <quote>.messageGroupId</quote>.
+		</para>
+		<para>
+			When using the <emphasis>Delayer</emphasis> within in a
+			<emphasis><link linkend="chain">Chain</link></emphasis> you can provide
+			the <emphasis>name</emphasis>
+			attribute only. The <emphasis>name</emphasis> attribute was introduced
+			with <emphasis>Spring Integration 2.2</emphasis> as the XML namespace
+			parser became more consistent in regards to permissible attributes
+			within chains and generally disallows the usage of <emphasis>id</emphasis>
+			attributes within chains now.
+		</para>
+	</important>
     </para>
     <para>
       The delayer delegates to an instance of Spring's <interfacename>TaskScheduler</interfacename> abstraction.
@@ -68,13 +95,15 @@
          instance and <code>waitForTasksToCompleteOnShutdown</code> was deleted; you should use the scheduler's own configuration.
       </tip>
       <tip>
-         Also keep in mind <classname>ThreadPoolTaskScheduler</classname> has a property <code>errorHandler</code> which
+         Also keep in mind
+         <classname><ulink url="http://static.springsource.org/spring/docs/current/javadoc-api/org/springframework/scheduling/concurrent/ThreadPoolTaskScheduler.html">ThreadPoolTaskScheduler</ulink></classname>
+         has a property <code>errorHandler</code> which
          can be injected with some implementation of <classname>org.springframework.util.ErrorHandler</classname>.
          This handler allows to process an <classname>Exception</classname> from the thread of the scheduled task sending
          the delayed message.
          By default it uses an <classname>org.springframework.scheduling.support.TaskUtils$LoggingErrorHandler</classname>
          and you will see a stack trace in the logs. You might want to consider using an
-         <classname>org.springframework.integration.channel.MessagePublishingErrorHandler</classname>,
+         <classname><ulink url="http://static.springsource.org/spring-integration/api/org/springframework/integration/channel/MessagePublishingErrorHandler.html">MessagePublishingErrorHandler</ulink></classname>,
          which sends an <classname>ErrorMessage</classname> into an <code>error-channel</code>, either from the failed Message's header or
          into the default <code>error-channel</code>.
       </tip>
@@ -123,10 +152,10 @@
       which allows the rescheduling of delayed persisted Messages at runtime, for example, if the
       <interfacename>TaskScheduler</interfacename> has previously been stopped.
       These operations can be invoked via a <code>Control Bus</code> command:
-      <programlisting language="java"><![CDATA[ Message<String> delayerReschedulingMessage =
-                MessageBuilder.withPayload("@'delayer.handler'.reschedulePersistedMessages()").build();
- controlBusChannel.send(delayerReschedulingMessage);]]></programlisting>
-    </para>
+	</para>
+	<programlisting language="java"><![CDATA[Message<String> delayerReschedulingMessage =
+    MessageBuilder.withPayload("@'delayer.handler'.reschedulePersistedMessages()").build();
+controlBusChannel.send(delayerReschedulingMessage);]]></programlisting>
     <note>
       For more information regarding the Message Store, JMX and the Control Bus, please read <xref linkend="system-management-chapter"/>.
     </note>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -138,6 +138,24 @@
 				For more information, see <xref linkend="message-handler-advice-chain"/>.
 			</para>
 		</section>
+		<section id="2.2-delayer">
+			<title>Delayer - Name Attribute Added</title>
+			<para>
+				A <emphasis>name</emphasis> attribute was added to the delayer.
+				This new attribute is mutually exclusive to the <emphasis>id</emphasis>
+				attribute. However, unlike the <emphasis>id</emphasis>
+				attribute, the new <emphasis>name</emphasis> attribute is also
+				available inside of chains.
+			</para>
+			<para>
+				To be more consistent with the rest of Spring Integration, the
+				delayer's <emphasis>id</emphasis> attribute cannot be used inside
+				of chains any longer.
+			</para>
+			<para>
+				For more information, see <xref linkend="delayer-namespace"/>.
+			</para>
+		</section>
 	</section>
 
 	<section id="2.2-new-components">


### PR DESCRIPTION
For reference see: https://jira.springsource.org/browse/INT-2745

This issue also addresses:
INT-2746 - Add a "name" attribute to the delayer that serves as a mutually exclusive alias to the "id" attribute
For reference see: https://jira.springsource.org/browse/INT-2746
