### PR TITLE
INT-2751 Jdbc Message Store Group Id Issues

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -38,6 +38,7 @@ import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.integration.util.DefaultLockRegistry;
 import org.springframework.integration.util.LockRegistry;
+import org.springframework.integration.util.UUIDConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 
@@ -197,7 +198,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageH
 		}
 
 		// TODO: INT-1117 - make the lock global?
-		Lock lock = this.lockRegistry.obtain(correlationKey);
+		Lock lock = this.lockRegistry.obtain(UUIDConverter.getUUID(correlationKey).toString());
 
 		lock.lockInterruptibly();
 		try {
@@ -243,7 +244,8 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageH
 	private final boolean forceComplete(MessageGroup group) {
 
 		Object correlationKey = group.getGroupId();
-		Lock lock = this.lockRegistry.obtain(correlationKey);
+		// UUIDConverter is no-op if already converted
+		Lock lock = this.lockRegistry.obtain(UUIDConverter.getUUID(correlationKey).toString());
 		boolean removeGroup = true;
 		try {
 			lock.lockInterruptibly();

--- a/spring-integration-core/src/test/java/org/springframework/integration/util/UUIDConverterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/util/UUIDConverterTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.integration.util;
 
 import static org.junit.Assert.assertEquals;
@@ -13,6 +29,7 @@ import org.junit.Test;
 
 /**
  * @author Dave Syer
+ * @author Gary Russell
  *
  */
 public class UUIDConverterTests {
@@ -49,7 +66,11 @@ public class UUIDConverterTests {
 
 	@Test
 	public void testConvertRandomString() throws Exception {
-		assertNotNull(UUIDConverter.getUUID("foo"));
+		UUID uuid = UUIDConverter.getUUID("foo");
+		assertNotNull(uuid);
+		String uuidString = uuid.toString();
+		assertEquals(uuidString, UUIDConverter.getUUID("foo").toString());
+		assertEquals(uuidString, UUIDConverter.getUUID(uuid).toString());
 	}
 
 	@Test


### PR DESCRIPTION
Jdbc Message Store always converts the correlation id
to a UUID string, even if it's already a String.

This causes reaper issues with the correlating message
handler because the reap occurs under
a different lock to normal group processing.

This change ensures the lock is properly mutually
exclusive.
