### PR TITLE
INT-2747 Change Bundlor Spring Minimums

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,12 +158,12 @@ project('spring-integration-amqp') {
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.apache.commons.lang.*;version="[2.5.0, 3.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.transaction.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.transaction.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
 			'org.springframework.amqp.*;version="[1.0.0, 2.0.0)"',
 			'org.aopalliance.*;version="[1.0.0, 2.0.0)"',
 			'javax.*;version="0"',
@@ -186,8 +186,8 @@ project('spring-integration-core') {
 	bundlor {
 		bundleSymbolicName = 'org.springframework.integration'
 		importTemplate += [
-			'org.springframework.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.transaction;version="[3.1.1, 4.0.0)";resolution:=optional',
+			'org.springframework.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.transaction;version="[3.0.7, 4.0.0)";resolution:=optional',
 			'org.springframework.retry;version="[1.0.2, 2.0.0)"',
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.aopalliance.*;version="[1.0.0, 2.0.0)"',
@@ -208,10 +208,10 @@ project('spring-integration-event') {
 		bundleSymbolicName = 'org.springframework.integration.event'
 		importTemplate += [
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.w3c.dom.*;version="0"'
 		]
@@ -235,11 +235,11 @@ project('spring-integration-feed') {
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.apache.commons.lang.*;version="[2.5.0, 3.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.scheduling.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
+			'org.springframework.scheduling.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
 			'com.sun.syndication.*;version="[1.0.0, 2.0.0)"',
 			'javax.*;version="0"',
 			'org.w3c.dom.*;version="0"'
@@ -259,16 +259,16 @@ project('spring-integration-file') {
 		importTemplate += [
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.scheduling.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.transaction.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util.xml;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.scheduling.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.transaction.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util.xml;version="[3.0.7, 4.0.0)"',
 			'org.w3c.dom.*;version="0"'
 		]
 	}
@@ -289,11 +289,11 @@ project('spring-integration-ftp') {
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.apache.commons.net.*;version="[2.0.0, 3.1.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.scheduling.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.scheduling.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
 			'javax.*;version="0"',
 			'org.w3c.dom.*;version="0"'
 		]
@@ -322,11 +322,11 @@ project('spring-integration-gemfire') {
 		importTemplate += [
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util.*;version="[3.0.7, 4.0.0)"',
 			'org.springframework.data.gemfire.*;version="[1.0.1, 2.0.0)"',
 			'com.gemstone.gemfire.*;version="[6.5.1, 7.0.0)"',
 			'javax.*;version="0"',
@@ -350,7 +350,7 @@ project('spring-integration-groovy') {
 		importTemplate += [
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.*;version="[3.0.7, 4.0.0)"',
 			'groovy.*;version="[1.7.3, 2.0.0)"',
 			'org.w3c.dom.*;version="0"'
 		]
@@ -384,14 +384,14 @@ project('spring-integration-http') {
 		bundleSymbolicName = 'org.springframework.integration.http'
 		importTemplate += [
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.http.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.validation.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.web.*;version="[3.1.1, 4.0.0)";resolution:=optional',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.http.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.validation.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.web.*;version="[3.0.7, 4.0.0)";resolution:=optional',
 			'org.apache.commons.httpclient.*;version="[3.0.5, 4.0.0)"',
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'javax.servlet.*;version="[2.4.0, 3.0.0)";resolution:=optional',
@@ -414,12 +414,12 @@ project('spring-integration-ip') {
 		importTemplate += [
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.scheduling.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
-			'org.springframework.jmx.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.scheduling.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
+			'org.springframework.jmx.*;version="[3.0.7, 4.0.0)"',
 			'org.w3c.dom.*;version="0"',
 			'javax.net.*;version="0"'
 		]
@@ -447,7 +447,7 @@ project('spring-integration-jdbc') {
 		bundleSymbolicName = 'org.springframework.integration.jdbc'
 		importTemplate += [
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.*;version="[3.0.7, 4.0.0)"',
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.aopalliance.*;version="[1.0.0, 2.0.0)"',
 			'javax.sql.*;version="0"',
@@ -478,14 +478,14 @@ project('spring-integration-jms') {
 		bundleSymbolicName = 'org.springframework.integration.jms'
 		importTemplate += [
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.jms.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.scheduling.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.transaction.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.jms.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.scheduling.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.transaction.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util.*;version="[3.0.7, 4.0.0)"',
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'javax.jms;version="[1.1.0, 2.0.0)";resolution:=optional',
 			'org.w3c.dom.*;version="0"'
@@ -506,7 +506,7 @@ project('spring-integration-jmx') {
 		bundleSymbolicName = 'org.springframework.integration.jmx'
 		importTemplate += [
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.*;version="[3.0.7, 4.0.0)"',
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.aopalliance.*;version="[1.0.0, 2.0.0)"',
 			'javax.management.*;version="0"',
@@ -576,15 +576,15 @@ project('spring-integration-mail') {
 		bundleSymbolicName = 'org.springframework.integration.mail'
 		importTemplate += [
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.aop.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.scheduling.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.mail.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.transaction.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.aop.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.scheduling.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.mail.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.transaction.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util.*;version="[3.0.7, 4.0.0)"',
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.aopalliance.*;version="[1.0.0, 2.0.0)"',
 			'javax.mail.*;version="[1.4.0, 2.0.0)"',
@@ -618,13 +618,13 @@ project('spring-integration-mongodb') {
 		importTemplate += [
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.transaction.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
-			'org.springframework.jmx.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.transaction.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
+			'org.springframework.jmx.*;version="[3.0.7, 4.0.0)"',
 			'org.springframework.data.mongodb.*;version="[1.0.0, 2.0.0)"',
 			'org.springframework.data.mapping.*;version="[1.0.0, 2.0.0)"',
 			'org.springframework.data.annotation.*;version="[1.0.0, 2.0.0)"',
@@ -655,12 +655,12 @@ project('spring-integration-redis') {
 		importTemplate += [
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.transaction.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.transaction.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
 			'org.springframework.data.redis.*;version="[1.0.0, 2.0.0)"',
 			'javax.*;version="0"',
 			'org.w3c.dom.*;version="0"'
@@ -680,11 +680,11 @@ project('spring-integration-rmi') {
 		bundleSymbolicName = 'org.springframework.integration.rmi'
 		importTemplate += [
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.remoting.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.remoting.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.w3c.dom.*;version="0"'
 		]
@@ -708,7 +708,7 @@ project('spring-integration-scripting') {
 		importTemplate += [
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.*;version="[3.0.7, 4.0.0)"',
 			'org.w3c.dom.*;version="0"',
 			'javax.script.*;version="0"'
 		]
@@ -733,10 +733,10 @@ project('spring-integration-security') {
 		importTemplate += [
 			'org.aopalliance.*;version="[1.0.0, 2.0.0)"',
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
-			'org.springframework.aop.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.aop.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util.*;version="[3.0.7, 4.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
 			'org.springframework.security.*;version="[3.0.3, 4.0.0)"',
 			'org.w3c.dom.*;version="0"'
@@ -760,11 +760,11 @@ project('spring-integration-sftp') {
 		importTemplate += [
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.scheduling.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.scheduling.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
 			'com.jcraft.jsch.*;version="[0.1.41, 0.1.50)"',
 			'javax.*;version="0"',
 			'org.w3c.dom.*;version="0"'
@@ -782,8 +782,8 @@ project('spring-integration-stream') {
 		bundleSymbolicName = 'org.springframework.integration.stream'
 		importTemplate += [
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
 			'org.w3c.dom.*;version="0"'
 		]
@@ -803,7 +803,7 @@ project('spring-integration-test') {
 		bundleSymbolicName = 'org.springframework.integration.test'
 		importTemplate += [
 			'org.apache.tools.ant.*;version="[1.7.0, 2.0.0)"',
-			'org.springframework.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.*;version="[3.0.7, 4.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
 			'javax.net.*;version="0"',
 			'junit.framework.*;version="[4.6.0, 4.7.0)"',
@@ -838,15 +838,15 @@ project('spring-integration-twitter') {
 			'org.aopalliance.*;version="[1.0.0, 2.0.0)"',
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.scheduling.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.aop.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.scheduling.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.aop.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
 			'org.springframework.social.*;version="[1.0.0, 1.1.0)"',
 			'org.springframework.security.crypto.*;version="[3.1.0, 3.2.0)"',
-			'org.springframework.scheduling.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
+			'org.springframework.scheduling.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
 			'javax.*;version="0"',
 			'org.w3c.dom.*;version="0"'
 		]
@@ -879,13 +879,13 @@ project('spring-integration-ws') {
 		bundleSymbolicName = 'org.springframework.integration.ws'
 		importTemplate += [
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.core.convert;version="[3.1.1, 4.0.0)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.scheduling.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.web.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.core.convert;version="[3.0.7, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.scheduling.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.web.*;version="[3.0.7, 4.0.0)"',
 			'org.springframework.oxm;version="[1.5.9, 3.1.0)"',
 			'org.springframework.ws.*;version="[2.0.0, 2.1.0)"',
 			'org.springframework.xml.*;version="[1.5.9, 2.1.0)"',
@@ -917,11 +917,11 @@ project('spring-integration-xml') {
 		bundleSymbolicName = 'org.springframework.integration.xml'
 		importTemplate += [
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.expression.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util.*;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.expression.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util.*;version="[3.0.7, 4.0.0)"',
 			'org.springframework.oxm;version="[1.5.9, 3.1.0)";resolution:=optional',
 			'org.springframework.xml.*;version="[1.5.9, 2.1.0)"',
 			'org.apache.commons.logging.*;version="[1.0, 2.0)"',
@@ -948,10 +948,10 @@ project('spring-integration-xmpp') {
 		importTemplate += [
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.springframework.integration.*;version="[2.2.0, 2.2.1)"',
-			'org.springframework.beans.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.context;version="[3.1.1, 4.0.0)"',
-			'org.springframework.core.*;version="[3.1.1, 4.0.0)"',
-			'org.springframework.util;version="[3.1.1, 4.0.0)"',
+			'org.springframework.beans.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.context;version="[3.0.7, 4.0.0)"',
+			'org.springframework.core.*;version="[3.0.7, 4.0.0)"',
+			'org.springframework.util;version="[3.0.7, 4.0.0)"',
 			'org.jivesoftware.*;version="[3.0.5, 4.0.0)"',
 			'javax.*;version="0"',
 			'org.w3c.dom.*;version="0"'


### PR DESCRIPTION
While Spring Framework 3.1 is recommended for Spring
Integration  2.2, it continues to support Spring 3.0.

Change build.gradle to use 3.0.7 as the minimum instead
of 3.1.1.
