### PR TITLE
INT-2765 Remove Obsolete Annotation from Docs

### DIFF
--- a/src/reference/docbook/configuration.xml
+++ b/src/reference/docbook/configuration.xml
@@ -220,10 +220,9 @@ public class FooService {
     </para>
     <para>
       Exactly what it means for the method to "handle" the Message depends on the 
-      particular annotation. The following annotations are available in Spring Integration: 
+      particular annotation. Annotations available in Spring Integration include:
       <itemizedlist>
         <listitem>@Aggregator</listitem>
-        <listitem>@ChannelAdapter</listitem>
         <listitem>@Filter</listitem>
 		<listitem>@Router</listitem>
 		<listitem>@ServiceActivator</listitem>


### PR DESCRIPTION
@ChannelAdapter was removed in '08.

https://github.com/SpringSource/spring-integration/commit/c16c3abb304eaab599087526bac2fe4a520c2794
