### PR TITLE
INT-2774/75 RedisCollectionPopulatingMessageHandler fix

### DIFF
--- a/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-2.2.xsd
+++ b/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-2.2.xsd
@@ -219,15 +219,6 @@
 						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
 					</xsd:sequence>
 					<xsd:attribute name="topic" type="xsd:string"/>
-					<xsd:attribute name="channel" type="xsd:string">
-						<xsd:annotation>
-							<xsd:appinfo>
-								<tool:annotation kind="ref">
-									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
-								</tool:annotation>
-							</xsd:appinfo>
-						</xsd:annotation>
-					</xsd:attribute>
 					<xsd:attribute name="message-converter" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
@@ -368,6 +359,18 @@
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="auto-startup" type="xsd:string" default="true"/>
+		<xsd:attribute name="channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				Channel to which Messages will be sent. 
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:complexType name="redisCollectionInboundAdapterType">
@@ -384,18 +387,6 @@
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
 									<tool:expected-type type="org.springframework.data.redis.core.RedisTemplate"/>
-								</tool:annotation>
-							</xsd:appinfo>
-						</xsd:annotation>
-					</xsd:attribute>
-					<xsd:attribute name="channel" type="xsd:string">
-						<xsd:annotation>
-							<xsd:documentation>
-			Channel to which Messages will be sent. 
-							</xsd:documentation>
-							<xsd:appinfo>
-								<tool:annotation kind="ref">
-									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
 								</tool:annotation>
 							</xsd:appinfo>
 						</xsd:annotation>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/store-outbound-adapter.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/store-outbound-adapter.xml
@@ -11,12 +11,18 @@
 		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
+	<int:channel id="someChannel"/>
 
 	<int-redis:store-outbound-channel-adapter id="listWithKeyAsHeader"/>
 
 	<int-redis:store-outbound-channel-adapter id="listWithKeyProvided"
 											  collection-type="LIST"
 											  key="pepboys"/>
+											  
+	<int-redis:store-outbound-channel-adapter id="listWithKeyProvidedAndChannel"
+											  channel="someChannel"
+											  collection-type="LIST"
+											  key="pepboys"/>										  
 
 	<int-redis:store-outbound-channel-adapter id="mapToZset"
 											  collection-type="ZSET"

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisCollectionPopulatingMessageHandlerTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisCollectionPopulatingMessageHandlerTests.java
@@ -235,6 +235,49 @@ public class RedisCollectionPopulatingMessageHandlerTests extends RedisAvailable
 	@SuppressWarnings("unchecked")
 	@Test
 	@RedisAvailable
+	public void testZsetWithListPayloadParsedAndProvidedKeyScoreIncrementAsStringHeader() {// see INT-2775
+		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		String key = "foo";
+		RedisZSet<String> redisZset =
+				new DefaultRedisZSet<String>(key,
+						(RedisOperations<String, String>) this.initTemplate(jcf, new RedisTemplate<String, String>()));
+
+		assertEquals(0, redisZset.size());
+
+		RedisCollectionPopulatingMessageHandler handler =
+				new RedisCollectionPopulatingMessageHandler(jcf, new LiteralExpression(key));
+
+		handler.setCollectionType(CollectionType.ZSET);
+		handler.afterPropertiesSet();
+
+		List<String> list = new ArrayList<String>();
+		list.add("Manny");
+		list.add("Moe");
+		list.add("Jack");
+		Message<List<String>> message = MessageBuilder.withPayload(list)
+				.setHeader(RedisHeaders.ZSET_INCREMENT_SCORE, "true")
+				.build();
+
+		handler.handleMessage(message);
+
+		assertEquals(3, redisZset.size());
+		Set<TypedTuple<String>> pepboys = redisZset.rangeByScoreWithScores(1, 1);
+		for (TypedTuple<String> pepboy : pepboys) {
+			assertTrue(pepboy.getScore() == 1);
+		}
+
+		handler.handleMessage(message);
+		assertEquals(3, redisZset.size());
+		pepboys = redisZset.rangeByScoreWithScores(1, 2);
+		// should have incremented
+		for (TypedTuple<String> pepboy : pepboys) {
+			assertTrue(pepboy.getScore() == 2);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	@RedisAvailable
 	public void testZsetWithListPayloadAsSingleEntryAndHeaderKeyHeaderScore() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		String key = "foo";


### PR DESCRIPTION
Added support for 'channel' attribute for RedisStore outbound adapter
Fixed logic in RedisCollectionPopulatingMessageHandler to ensure that RedisHeaders.ZSET_INCREMENT_SCORE can be passed as Boolean true/false as well as String true/false. The current solution is based on relyiong oin ConversionService registered with SpEL Context (see RedisCollectionPopulatingMessageHandler.extractZsetIncrementHeader method). This way other types could be supported without introducing any code changes.
