### PR TITLE
INT-2776 Add Sender's UDP Port To Headers

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/IpHeaders.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/IpHeaders.java
@@ -34,6 +34,8 @@ public abstract class IpHeaders {
 
 	public static final String IP_ADDRESS = IP + "address";
 
+	public static final String PORT = IP + "port";
+
 	public static final String ACK_ADDRESS = IP + "ackTo";
 
 	public static final String ACK_ID = IP + "ackId";


### PR DESCRIPTION
User code can use the existing host and this new
header to send a reply over UDP.
