### PR TITLE
INT-2781 Retry Advice; Fix Recovery For Zero Tries

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -17,6 +17,7 @@ package org.springframework.integration.handler.advice;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessagingException;
 import org.springframework.integration.core.MessagingTemplate;
@@ -49,6 +50,13 @@ public class ErrorMessageSendingRecoverer implements RecoveryCallback<Object> {
 
 	public Object recover(RetryContext context) throws Exception {
 		Throwable lastThrowable = context.getLastThrowable();
+		if (lastThrowable == null) {
+			lastThrowable = new RetryExceptionNotAvailableException(
+					(Message<?>) context.getAttribute("message"),
+					"No retry exception available; " +
+					"this can occur, for example, if the RetryPolicy allowed zero attempts to execute the handler; " +
+					"RetryContext: " + context.toString());
+		}
 		if (logger.isDebugEnabled()) {
 			String supplement = "";
 			if (lastThrowable instanceof MessagingException) {
@@ -60,4 +68,12 @@ public class ErrorMessageSendingRecoverer implements RecoveryCallback<Object> {
 		return null;
 	}
 
+	public static class RetryExceptionNotAvailableException extends MessagingException {
+
+		private static final long serialVersionUID = 1L;
+
+		public RetryExceptionNotAvailableException(Message<?> message, String description) {
+			super(message, description);
+		}
+	}
 }


### PR DESCRIPTION
Retry Advice (ErrorMessageSendingRecoverer) tried to send a message
with a null payload when the RetryPolicy allowed zero attempts.

Create a MessageHandlingException with the failedMessage, when
no attempts were made to call the handler.
