### PR TITLE
INT-2779 upgraded to spring-data-mongo 1.1.1.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects { subproject ->
 		springVersion = project.hasProperty('springVersion') ? getProperty('springVersion') : springVersionDefault
 
 		springAmqpVersion = '1.1.2.RELEASE'
-		springDataMongoVersion = '1.1.0.M1'
+		springDataMongoVersion = '1.1.1.RELEASE'
 		springDataRedisVersion = '1.0.2.RELEASE'
 		springGemfireVersion = '1.1.1.RELEASE'
 		springSecurityVersion = '3.1.0.RELEASE'

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -16,6 +16,11 @@
 
 package org.springframework.integration.mongodb.store;
 
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.integration.history.MessageHistory.NAME_PROPERTY;
+import static org.springframework.integration.history.MessageHistory.TIMESTAMP_PROPERTY;
+import static org.springframework.integration.history.MessageHistory.TYPE_PROPERTY;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -28,6 +33,8 @@ import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.annotation.Transient;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -36,7 +43,6 @@ import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentEntity;
 import org.springframework.data.mongodb.core.mapping.MongoPersistentProperty;
-import org.springframework.data.mongodb.core.query.Order;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.integration.Message;
@@ -58,15 +64,10 @@ import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 
-import static org.springframework.data.mongodb.core.query.Criteria.where;
-import static org.springframework.integration.history.MessageHistory.NAME_PROPERTY;
-import static org.springframework.integration.history.MessageHistory.TIMESTAMP_PROPERTY;
-import static org.springframework.integration.history.MessageHistory.TYPE_PROPERTY;
-
 /**
  * An implementation of both the {@link MessageStore} and {@link MessageGroupStore}
  * strategies that relies upon MongoDB for persistence.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Sean Brandt
@@ -271,7 +272,7 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore implements Me
 
 	private static Query whereGroupIdIs(Object groupId) {
 		Query q = new Query(where(GROUP_ID_KEY).is(groupId));
-		q.sort().on(GROUP_UPDATE_TIMESTAMP_KEY, Order.DESCENDING);
+		q.with(new Sort(Direction.DESC, GROUP_UPDATE_TIMESTAMP_KEY));
 		return q;
 	}
 
@@ -281,7 +282,7 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore implements Me
 
 	private static Query whereGroupIdIsOrdered(Object groupId) {
 		Query q = new Query(where(GROUP_ID_KEY).is(groupId)).limit(1);
-		q.sort().on(CREATED_DATE, Order.ASCENDING);
+		q.with(new Sort(Direction.ASC, CREATED_DATE));
 		return q;
 	}
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundChannelAdapterIntegrationTests.java
@@ -98,6 +98,23 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 
 	@Test
 	@MongoDbAvailable
+	public void testSavingJSONString() throws Exception{
+
+		String object = "{'foo' : 'bar'}";
+
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory("foo");
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("outbound-adapter-config.xml", this.getClass());
+
+		MessageChannel channel = context.getBean("simpleAdapterWithTemplate", MessageChannel.class);
+		Message<String> message = MessageBuilder.withPayload(object).setHeader("collectionName", "foo").build();
+		channel.send(message);
+
+		MongoTemplate template = new MongoTemplate(mongoDbFactory);
+		assertNotNull(template.find(new BasicQuery("{'foo' : 'bar'}"), BasicDBObject.class, "foo"));
+	}
+
+	@Test
+	@MongoDbAvailable
 	public void testWithMongoConverter() throws Exception{
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("outbound-adapter-config.xml", this.getClass());
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSourceTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSourceTests.java
@@ -245,8 +245,9 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
-		template.save(JSON.parse("{'name' : 'Manny', 'id' : 1}"), "data");
 
+		template.save(JSON.parse("{'name' : 'Manny', 'id' : 1}"), "data");
+		
 		Expression queryExpression = new LiteralExpression("{'name' : 'Manny'}");
 		MongoDbMessageSource messageSource = new MongoDbMessageSource(mongoDbFactory, queryExpression);
 		messageSource.setExpectSingleResult(true);
@@ -254,7 +255,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 		DBObject result = (DBObject) messageSource.receive().getPayload();
 		Object id = result.get("_id");
 		result.put("company","PepBoys");
-		template.save(result, "data");
+		template.save(result, "data"); 
 		result = (DBObject) messageSource.receive().getPayload();
 		assertEquals(id, result.get("_id"));
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandlerTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandlerTests.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.Mockito;
-
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;


### PR DESCRIPTION
upgraded to spring-data-mongo-1.1.1.RELEASE
removed safety logic that was put temporarily to address DATAMONGO-550/551
