### PR TITLE
INT-2280 fixed broken JDBC test

### DIFF
--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreChannelTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreChannelTests-context.xml
@@ -32,7 +32,7 @@
 
 	<service-activator id="service-activator" input-channel="input" output-channel="output" xmlns="http://www.springframework.org/schema/integration">
 		<beans:bean class="org.springframework.integration.jdbc.JdbcMessageStoreChannelTests$Service" />
-		<poller fixed-rate="200">
+		<poller fixed-rate="2000">
 			<transactional />
 		</poller>
 	</service-activator>


### PR DESCRIPTION
Fixxed JdbcMessageStoreChannelTests.testSendAndActivateWithRollback as well as others by changing poller interval
Poller was polling too quick so even slightest delay before assertion would result in another Message in the Service.messages thus the intermittent assertion error.
