### PR TITLE
Do not provide fixed XMPP resource string

### DIFF
--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBean.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBean.java
@@ -40,7 +40,7 @@ public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnectio
 
 	private final ConnectionConfiguration connectionConfiguration;
 	
-	private volatile String resource = "Smack"; // default value used by Smack
+	private volatile String resource = null; // server will generate resource if not provided
 	
 	private volatile String user;
 		


### PR DESCRIPTION
According to RFC 6120 section 7.6.  Server-Generated Resource Identifier if the connecting client does not provide resource string, server will generate RANDOM one for it.
Smack API allows this by providing null resource in XMPPConnection#login(username, password, resource) call. See Smack's SASLAuthentication documentation.
