### PR TITLE
INT-2782 Fix spring-retry Import-Package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,9 +186,10 @@ project('spring-integration-core') {
 	bundlor {
 		bundleSymbolicName = 'org.springframework.integration'
 		importTemplate += [
+			'org.springframework.retry.*;version="[1.0.2, 2.0.0)"',
+			'org.springframework.classify.*;version="[1.0.2, 2.0.0)"', // package is in spring-retry
 			'org.springframework.*;version="[3.0.7, 4.0.0)"',
 			'org.springframework.transaction;version="[3.0.7, 4.0.0)";resolution:=optional',
-			'org.springframework.retry;version="[1.0.2, 2.0.0)"',
 			'org.apache.commons.logging;version="[1.1.1, 2.0.0)"',
 			'org.aopalliance.*;version="[1.0.0, 2.0.0)"',
 			'org.codehaus.jackson.*;version="[1.0.0, 2.0.0)";resolution:=optional',


### PR DESCRIPTION
Bundlor: move retry packages above catch-all org.springframework.*
in the import template.
