### PR TITLE
INT-2791 Add JsonAwareInboundMessageConverter

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AbstractAmqpInboundAdapterParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AbstractAmqpInboundAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +32,10 @@ import org.w3c.dom.Element;
 
 /**
  * Base class for inbound adapter parsers for the AMQP namespace.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.1
  */
 abstract class AbstractAmqpInboundAdapterParser extends AbstractSingleBeanDefinitionParser {
@@ -100,12 +101,16 @@ abstract class AbstractAmqpInboundAdapterParser extends AbstractSingleBeanDefini
 			builder.addConstructorArgValue(listenerContainerBeanDef);
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
-		
+
 		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultAmqpHeaderMapper.class, null);
-		
+
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-startup");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "phase");
+		if (element.hasAttribute("message-converter") && element.hasAttribute("request-payload-type")) {
+			parserContext.getReaderContext().error("Only one of 'message-converter' and 'request-payload-type' is allowed", element);
+		}
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "request-payload-type");
 		this.configureChannels(element, parserContext, builder);
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AbstractAmqpInboundAdapterParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AbstractAmqpInboundAdapterParser.java
@@ -108,7 +108,7 @@ abstract class AbstractAmqpInboundAdapterParser extends AbstractSingleBeanDefini
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-startup");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "phase");
 		if (element.hasAttribute("message-converter") && element.hasAttribute("request-payload-type")) {
-			parserContext.getReaderContext().error("Only one of 'message-converter' and 'request-payload-type' is allowed", element);
+			parserContext.getReaderContext().error("Only one of 'message-converter' or 'request-payload-type' is allowed", element);
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "request-payload-type");
 		this.configureChannels(element, parserContext, builder);

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -25,6 +25,7 @@ import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
+import org.springframework.integration.amqp.support.JsonAwareInboundMessageConverter;
 import org.springframework.integration.context.OrderlyShutdownCapable;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.support.MessageBuilder;
@@ -45,6 +46,8 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 
 	private volatile MessageConverter messageConverter = new SimpleMessageConverter();
 
+	private volatile boolean messageConverterSet;
+
 	private volatile AmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
 
 
@@ -60,11 +63,18 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 	public void setMessageConverter(MessageConverter messageConverter) {
 		Assert.notNull(messageConverter, "messageConverter must not be null");
 		this.messageConverter = messageConverter;
+		this.messageConverterSet = true;
 	}
 
 	public void setHeaderMapper(AmqpHeaderMapper headerMapper) {
 		Assert.notNull(headerMapper, "headerMapper must not be null");
 		this.headerMapper = headerMapper;
+	}
+
+	public void setRequestPayloadType(Class<?> type) {
+		Assert.notNull(type, "requestPayloadType must not be null");
+		Assert.isTrue(!this.messageConverterSet, "Cannot set requestPayloadType if a MessageConverter has been provided");
+		this.messageConverter = new JsonAwareInboundMessageConverter(type);
 	}
 
 	@Override

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
+import org.springframework.integration.amqp.support.JsonAwareInboundMessageConverter;
 import org.springframework.integration.gateway.MessagingGatewaySupport;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.util.Assert;
@@ -40,8 +41,9 @@ import org.springframework.util.StringUtils;
  * Spring Integration Messages, and sends the results to a Message Channel.
  * If a reply Message is received, it will be converted and sent back to
  * the AMQP 'replyTo'.
- * 
+ *
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.1
  */
 public class AmqpInboundGateway extends MessagingGatewaySupport {
@@ -49,6 +51,8 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 	private final AbstractMessageListenerContainer messageListenerContainer;
 
 	private volatile MessageConverter amqpMessageConverter = new SimpleMessageConverter();
+
+	private volatile boolean messageConverterSet;
 
 	private volatile AmqpHeaderMapper headerMapper = new DefaultAmqpHeaderMapper();
 
@@ -69,11 +73,18 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 		Assert.notNull(messageConverter, "MessageConverter must not be null");
 		this.amqpMessageConverter = messageConverter;
 		this.amqpTemplate.setMessageConverter(messageConverter);
+		this.messageConverterSet = true;
 	}
 
 	public void setHeaderMapper(AmqpHeaderMapper headerMapper) {
 		Assert.notNull(headerMapper, "headerMapper must not be null");
 		this.headerMapper = headerMapper;
+	}
+
+	public void setRequestPayloadType(Class<?> type) {
+		Assert.notNull(type, "requestPayloadType must not be null");
+		Assert.isTrue(!this.messageConverterSet, "Cannot set requestPayloadType if a MessageConverter has been provided");
+		this.amqpMessageConverter = new JsonAwareInboundMessageConverter(type);
 	}
 
 	@Override

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/JsonAwareInboundMessageConverter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/JsonAwareInboundMessageConverter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.amqp.support;
+
+import java.io.UnsupportedEncodingException;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.support.converter.ClassMapper;
+import org.springframework.amqp.support.converter.JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConversionException;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+/**
+ * MessageConverter used on inbound endpoints that delegates either to a SimpleMessageConverter,
+ * or a JsonMessageConverter, with a custom {@link ClassMapper} that uses a configured class name
+ * rather than looking for the type information in the message headers.
+ * <p/>
+ * To provide backwards compatibility,
+ * if the contentType property contains json (but does not start with text), we delegate to
+ * the JsonMessageConverter. Otherwise we delegate to the SimpleMessageConverter.
+ * <p/>
+ * If the className property is set to <code>java.lang.String</code> the message
+ * body is returned as a String.
+ *
+ * @author Gary Russell
+ * @author Artem Bilan
+ * @since 2.2
+ */
+public class JsonAwareInboundMessageConverter extends SimpleMessageConverter {
+
+	private final JsonMessageConverter jsonMessageConverter = new JsonMessageConverter();
+
+	private volatile String charset = DEFAULT_CHARSET;
+
+	private final Class<?> clazz;
+
+	public JsonAwareInboundMessageConverter(Class<?> aClass) {
+		Assert.notNull(aClass, "'className' cannot be null");
+		this.clazz = aClass;
+
+		jsonMessageConverter.setClassMapper(new ClassMapper() {
+
+			public void fromClass(Class<?> clazz, MessageProperties properties) {
+				throw new UnsupportedOperationException("This converter can only be used to map inbound requests");
+			}
+
+			public Class<?> toClass(MessageProperties properties) {
+				return clazz;
+			}
+		});
+	}
+
+	public void setDefaultCharset(String charset) {
+		Assert.notNull(charset, "'charset' cannot be null");
+		this.charset = charset;
+		super.setDefaultCharset(charset);
+		this.jsonMessageConverter.setDefaultCharset(charset);
+	}
+
+	public Object fromMessage(Message message) throws MessageConversionException {
+		MessageProperties properties = message.getMessageProperties();
+		if (properties != null) {
+			String contentType = properties.getContentType();
+			if (contentType != null && contentType.contains("json") && !(contentType.startsWith("text"))) {
+				if (clazz == String.class) {
+					String encoding = properties.getContentEncoding();
+					if (encoding == null) {
+						encoding = this.charset;
+					}
+					try {
+						return new String(message.getBody(), encoding);
+					}
+					catch (UnsupportedEncodingException e) {
+						throw new MessageConversionException("Failed to convert byte[] to String", e);
+					}
+				}
+				else {
+					return this.jsonMessageConverter.fromMessage(message);
+				}
+			}
+		}
+
+		return super.fromMessage(message);
+	}
+
+}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/JsonAwareInboundMessageConverter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/JsonAwareInboundMessageConverter.java
@@ -28,11 +28,11 @@ import org.springframework.util.Assert;
 /**
  * MessageConverter used on inbound endpoints that delegates either to a SimpleMessageConverter,
  * or a JsonMessageConverter, with a custom {@link ClassMapper} that uses a configured class name
- * rather than looking for the type information in the message headers.
+ * rather than looking for the type information in the {@link MessageProperties}.
  * <p/>
  * To provide backwards compatibility,
  * if the contentType property contains json (but does not start with text), we delegate to
- * the JsonMessageConverter. Otherwise we delegate to the SimpleMessageConverter.
+ * the JsonMessageConverter. Otherwise we invoke the super class (SimpleMessageConverter).
  * <p/>
  * If the className property is set to <code>java.lang.String</code> the message
  * body is returned as a String.

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/JsonAwareInboundMessageConverter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/JsonAwareInboundMessageConverter.java
@@ -22,10 +22,8 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.support.converter.ClassMapper;
 import org.springframework.amqp.support.converter.JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConversionException;
-import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 
 /**
  * MessageConverter used on inbound endpoints that delegates either to a SimpleMessageConverter,
@@ -52,7 +50,7 @@ public class JsonAwareInboundMessageConverter extends SimpleMessageConverter {
 	private final Class<?> clazz;
 
 	public JsonAwareInboundMessageConverter(Class<?> aClass) {
-		Assert.notNull(aClass, "'className' cannot be null");
+		Assert.notNull(aClass, "'class' cannot be null");
 		this.clazz = aClass;
 
 		jsonMessageConverter.setClassMapper(new ClassMapper() {
@@ -67,6 +65,7 @@ public class JsonAwareInboundMessageConverter extends SimpleMessageConverter {
 		});
 	}
 
+	@Override
 	public void setDefaultCharset(String charset) {
 		Assert.notNull(charset, "'charset' cannot be null");
 		this.charset = charset;
@@ -74,6 +73,7 @@ public class JsonAwareInboundMessageConverter extends SimpleMessageConverter {
 		this.jsonMessageConverter.setDefaultCharset(charset);
 	}
 
+	@Override
 	public Object fromMessage(Message message) throws MessageConversionException {
 		MessageProperties properties = message.getMessageProperties();
 		if (properties != null) {

--- a/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-2.2.xsd
+++ b/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-2.2.xsd
@@ -537,6 +537,21 @@ this list can also be simple patterns to be matched against the header names (e.
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="request-payload-type" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Target type for payload that is the conversion result of the request. If the content-type
+					property contains "json", the endpoint will configure a "JsonMessageConverter" to attempt
+					to convert the payload if the message contentType property is 'application/json'.
+					If the 'request-payload-type' is 'java.lang.String' the payload
+					will contain the JSON as a String. Otherwise it will be converted to the type, if
+					possible. This will override the default 'JsonMessageConverter' behavior of getting
+					type information from the message properties. For more control over the conversion,
+					provide a 'message-converter' instead. This attribute is not allowed if a
+					'message-converter' is supplied.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:attributeGroup name="containerAttributes">

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests-context-fail.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests-context-fail.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:amqp="http://www.springframework.org/schema/integration/amqp"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<amqp:inbound-channel-adapter id="rabbitInbound" queue-names="inboundchanneladapter.test.1"
+		request-payload-type="java.lang.String" message-converter="foo"/>
+
+	<bean id="foo" class="org.springframework.amqp.support.converter.SimpleMessageConverter" />
+
+	<int:channel id="requestChannel">
+		<int:queue/>
+	</int:channel>
+
+	<bean id="rabbitConnectionFactory" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.amqp.rabbit.connection.ConnectionFactory"/>
+	</bean>
+		
+</beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests-context.xml
@@ -13,22 +13,29 @@
 
 	<amqp:inbound-channel-adapter id="autoStartFalse" queue-names="inboundchanneladapter.test.2"
 		auto-startup="false" phase="123"/>
-		
+
 	<amqp:inbound-channel-adapter id="withHeaderMapperStandardAndCustomHeaders" channel="requestChannel" queue-names="inboundchanneladapter.test.2"
 		auto-startup="false" phase="123"
 		mapped-request-headers="foo*, STANDARD_REQUEST_HEADERS"/>
-		
+
 	<amqp:inbound-channel-adapter id="withHeaderMapperOnlyCustomHeaders" channel="requestChannel" queue-names="inboundchanneladapter.test.2"
 		auto-startup="false" phase="123"
 		mapped-request-headers="foo*"/>
-		
+
 	<amqp:inbound-channel-adapter id="withHeaderMapperNothingToMap" channel="requestChannel" queue-names="inboundchanneladapter.test.2"
 		auto-startup="false" phase="123"
 		mapped-request-headers=""/>
-		
+
 	<amqp:inbound-channel-adapter id="withHeaderMapperDefaultMapping" channel="requestChannel" queue-names="inboundchanneladapter.test.2"
 		auto-startup="false" phase="123"/>
-		
+
+	<amqp:inbound-channel-adapter id="withRequestPayloadTypeString" channel="requestChannel" queue-names="inboundchanneladapter.test.2"
+		auto-startup="false" phase="123" request-payload-type="java.lang.String" />
+
+	<amqp:inbound-channel-adapter id="withRequestPayloadTypeFoo" channel="requestChannel" queue-names="inboundchanneladapter.test.2"
+		auto-startup="false" phase="123"
+		request-payload-type="org.springframework.integration.amqp.config.AmqpInboundChannelAdapterParserTests$Foo" />
+
 	<int:channel id="requestChannel">
 		<int:queue/>
 	</int:channel>
@@ -36,5 +43,5 @@
 	<bean id="rabbitConnectionFactory" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.amqp.rabbit.connection.ConnectionFactory"/>
 	</bean>
-		
+
 </beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests-context.xml
@@ -34,7 +34,7 @@
 
 	<amqp:inbound-channel-adapter id="withRequestPayloadTypeFoo" channel="requestChannel" queue-names="inboundchanneladapter.test.2"
 		auto-startup="false" phase="123"
-		request-payload-type="org.springframework.integration.amqp.config.AmqpInboundChannelAdapterParserTests$Foo" />
+		request-payload-type="org.springframework.integration.amqp.support.JsonAwareInboundMessageConverterTests$Foo" />
 
 	<int:channel id="requestChannel">
 		<int:queue/>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests.java
@@ -35,6 +35,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.amqp.AmqpHeaders;
 import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter;
 import org.springframework.integration.amqp.support.JsonAwareInboundMessageConverter;
+import org.springframework.integration.amqp.support.JsonAwareInboundMessageConverterTests;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.test.util.TestUtils;
@@ -233,8 +234,8 @@ public class AmqpInboundChannelAdapterParserTests {
 		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.APP_ID));
 		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE));
 		assertTrue(TestUtils.getPropertyValue(adapter, "messageConverter") instanceof JsonAwareInboundMessageConverter);
-		assertEquals(Foo.class, TestUtils.getPropertyValue(adapter, "messageConverter.clazz"));
-		assertEquals(new Foo("bar"), siMessage.getPayload());
+		assertEquals(JsonAwareInboundMessageConverterTests.Foo.class, TestUtils.getPropertyValue(adapter, "messageConverter.clazz"));
+		assertEquals(new JsonAwareInboundMessageConverterTests.Foo("bar"), siMessage.getPayload());
 
 	}
 
@@ -245,51 +246,6 @@ public class AmqpInboundChannelAdapterParserTests {
 		}
 		catch (BeanDefinitionParsingException e) {
 			assertTrue(e.getMessage().contains("Only one of 'message-converter' and 'request-payload-type' is allowed"));
-		}
-	}
-
-	public static class Foo {
-		private String foo;
-
-		public Foo() {
-		}
-
-		public Foo(String string) {
-			this.foo = string;
-		}
-
-		public String getFoo() {
-			return foo;
-		}
-
-		public void setFoo(String foo) {
-			this.foo = foo;
-		}
-
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + ((foo == null) ? 0 : foo.hashCode());
-			return result;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			Foo other = (Foo) obj;
-			if (foo == null) {
-				if (other.foo != null)
-					return false;
-			}
-			else if (!foo.equals(other.foo))
-				return false;
-			return true;
 		}
 	}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests-context.xml
@@ -23,12 +23,16 @@
 	<si-amqp:inbound-gateway id="autoStartFalseGateway" request-channel="requests" queue-names="test"
 			connection-factory="rabbitConnectionFactory" message-converter="testConverter"
 			auto-startup="false" phase="123"/>
-			
+
 	<si-amqp:inbound-gateway id="withHeaderMapper" request-channel="requestChannel" queue-names="inboundchanneladapter.test.2"
 		auto-startup="false" phase="123"
 		mapped-request-headers="foo*, STANDARD_REQUEST_HEADERS"
 		mapped-reply-headers="bar*"/>
-		
+
+	<si-amqp:inbound-gateway id="withPayloadType" request-channel="requestChannel" queue-names="inboundchanneladapter.test.2"
+		auto-startup="false" phase="123"
+		request-payload-type="java.lang.String"/>
+
 	<int:channel id="requestChannel"/>
-		
+
 </beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,10 @@
  */
 
 package org.springframework.integration.amqp.config;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
 
@@ -36,6 +40,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessagingException;
 import org.springframework.integration.amqp.inbound.AmqpInboundGateway;
+import org.springframework.integration.amqp.support.JsonAwareInboundMessageConverter;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.support.MessageBuilder;
@@ -44,12 +49,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.ReflectionUtils;
 
-import static junit.framework.Assert.assertEquals;
-
-import static org.junit.Assert.assertSame;
-
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.1
  */
 @ContextConfiguration
@@ -77,12 +79,12 @@ public class AmqpInboundGatewayParserTests {
 		assertEquals(Boolean.FALSE, TestUtils.getPropertyValue(gateway, "autoStartup"));
 		assertEquals(123, TestUtils.getPropertyValue(gateway, "phase"));
 	}
-	
+
 	@SuppressWarnings("rawtypes")
 	@Test
 	public void verifyUsageWithHeaderMapper() throws Exception{
 		DirectChannel requestChannel = context.getBean("requestChannel", DirectChannel.class);
-		requestChannel.subscribe(new MessageHandler() {		
+		requestChannel.subscribe(new MessageHandler() {
 			public void handleMessage(org.springframework.integration.Message<?> siMessage)
 					throws MessagingException {
 				org.springframework.integration.Message<?> replyMessage = MessageBuilder.fromMessage(siMessage).setHeader("bar", "bar").build();
@@ -90,14 +92,15 @@ public class AmqpInboundGatewayParserTests {
 				replyChannel.send(replyMessage);
 			}
 		});
-		
+
 		final AmqpInboundGateway gateway = context.getBean("withHeaderMapper", AmqpInboundGateway.class);
-		
+		assertTrue(TestUtils.getPropertyValue(gateway, "amqpMessageConverter") instanceof SimpleMessageConverter);
+
 		Field amqpTemplateField = ReflectionUtils.findField(AmqpInboundGateway.class, "amqpTemplate");
 		amqpTemplateField.setAccessible(true);
 		RabbitTemplate amqpTemplate = TestUtils.getPropertyValue(gateway, "amqpTemplate", RabbitTemplate.class);
 		amqpTemplate = Mockito.spy(amqpTemplate);
-			
+
 		Mockito.doAnswer(new Answer() {
 		      public Object answer(InvocationOnMock invocation) {
 		          Object[] args = invocation.getArguments();
@@ -109,8 +112,8 @@ public class AmqpInboundGatewayParserTests {
 		 .when(amqpTemplate).send(Mockito.any(String.class), Mockito.any(String.class),
 				 Mockito.any(Message.class), Mockito.any(CorrelationData.class));
 		ReflectionUtils.setField(amqpTemplateField, gateway, amqpTemplate);
-		
-		AbstractMessageListenerContainer mlc = 
+
+		AbstractMessageListenerContainer mlc =
 				TestUtils.getPropertyValue(gateway, "messageListenerContainer", AbstractMessageListenerContainer.class);
 		MessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener", MessageListener.class);
 		MessageProperties amqpProperties = new MessageProperties();
@@ -124,9 +127,17 @@ public class AmqpInboundGatewayParserTests {
 		amqpProperties.setHeader("bar", "bar");
 		Message amqpMessage = new Message("hello".getBytes(), amqpProperties);
 		listener.onMessage(amqpMessage);
-		
+
 		Mockito.verify(amqpTemplate, Mockito.times(1)).send(Mockito.any(String.class), Mockito.any(String.class),
 				Mockito.any(Message.class), Mockito.any(CorrelationData.class));
+	}
+
+	@Test
+	public void testWithPayloadType() {
+		AmqpInboundGateway gateway = context.getBean("withPayloadType", AmqpInboundGateway.class);
+		assertTrue(TestUtils.getPropertyValue(gateway, "amqpMessageConverter") instanceof JsonAwareInboundMessageConverter);
+		assertEquals(String.class, TestUtils.getPropertyValue(gateway, "amqpMessageConverter.clazz"));
+
 	}
 
 	private static class TestConverter extends SimpleMessageConverter {}

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/JsonAwareInboundMessageConverterTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/JsonAwareInboundMessageConverterTests.java
@@ -40,24 +40,21 @@ public class JsonAwareInboundMessageConverterTests {
 	@Test
 	public void testJsonTextToString() {
 		Message amqpMessage = buildMessage("text/json");
-		JsonAwareInboundMessageConverter converter = new JsonAwareInboundMessageConverter(
-				org.springframework.integration.amqp.support.JsonAwareInboundMessageConverterTests.Foo.class);
+		JsonAwareInboundMessageConverter converter = new JsonAwareInboundMessageConverter(Foo.class);
 		assertEquals(foobar, converter.fromMessage(amqpMessage));
 	}
 
 	@Test
 	public void testPlainTextToString() {
 		Message amqpMessage = buildMessage("text/plain");
-		JsonAwareInboundMessageConverter converter = new JsonAwareInboundMessageConverter(
-				org.springframework.integration.amqp.support.JsonAwareInboundMessageConverterTests.Foo.class);
+		JsonAwareInboundMessageConverter converter = new JsonAwareInboundMessageConverter(Foo.class);
 		assertEquals(foobar, converter.fromMessage(amqpMessage));
 	}
 
 	@Test
 	public void testJsonToObject() throws Exception {
 		Message amqpMessage = buildMessage("application/json");
-		JsonAwareInboundMessageConverter converter = new JsonAwareInboundMessageConverter(
-				org.springframework.integration.amqp.support.JsonAwareInboundMessageConverterTests.Foo.class);
+		JsonAwareInboundMessageConverter converter = new JsonAwareInboundMessageConverter(Foo.class);
 		assertEquals(new Foo("bar"), converter.fromMessage(amqpMessage));
 	}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/JsonAwareInboundMessageConverterTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/JsonAwareInboundMessageConverterTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.amqp.support;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+
+/**
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+public class JsonAwareInboundMessageConverterTests {
+
+	private String foobar = "{\"foo\":\"bar\"}";
+
+	@Test
+	public void testJsonToString() {
+		Message amqpMessage = buildMessage("application/json");
+		JsonAwareInboundMessageConverter converter = new JsonAwareInboundMessageConverter(java.lang.String.class);
+		assertEquals(foobar, converter.fromMessage(amqpMessage));
+	}
+
+	@Test
+	public void testJsonTextToString() {
+		Message amqpMessage = buildMessage("text/json");
+		JsonAwareInboundMessageConverter converter = new JsonAwareInboundMessageConverter(
+				org.springframework.integration.amqp.support.JsonAwareInboundMessageConverterTests.Foo.class);
+		assertEquals(foobar, converter.fromMessage(amqpMessage));
+	}
+
+	@Test
+	public void testPlainTextToString() {
+		Message amqpMessage = buildMessage("text/plain");
+		JsonAwareInboundMessageConverter converter = new JsonAwareInboundMessageConverter(
+				org.springframework.integration.amqp.support.JsonAwareInboundMessageConverterTests.Foo.class);
+		assertEquals(foobar, converter.fromMessage(amqpMessage));
+	}
+
+	@Test
+	public void testJsonToObject() throws Exception {
+		Message amqpMessage = buildMessage("application/json");
+		JsonAwareInboundMessageConverter converter = new JsonAwareInboundMessageConverter(
+				org.springframework.integration.amqp.support.JsonAwareInboundMessageConverterTests.Foo.class);
+		assertEquals(new Foo("bar"), converter.fromMessage(amqpMessage));
+	}
+
+	private Message buildMessage(String contentType) {
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType(contentType);
+		byte[] body = foobar.getBytes();
+		Message amqpMessage = new Message(body, messageProperties);
+		return amqpMessage;
+	}
+
+	public static class Foo {
+		private String foo;
+
+		public Foo() {
+		}
+
+		public Foo(String string) {
+			this.foo = string;
+		}
+
+		public String getFoo() {
+			return foo;
+		}
+
+		public void setFoo(String foo) {
+			this.foo = foo;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((foo == null) ? 0 : foo.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			Foo other = (Foo) obj;
+			if (foo == null) {
+				if (other.foo != null)
+					return false;
+			}
+			else if (!foo.equals(other.foo))
+				return false;
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
The recent change to make the object-to-json-transformer
insert a content-type header 'application/json' broke the
common pattern

->object-to-json-transformer->amqp-out->amqp-in->json-to-object-transformer

because the amqp-in now creates a byte[] instead of a String. This is
because the default SimpleMessageConverter doesn't understand this
contentType.

Introduce a new attribute 'request-payload-type' on the amqp inbound
endpoints. When set, the endpoints now configure a JsonAwareInboundMessageConverter
that can delegate to either a JsonMessageConverter (with a custom class mapper)
or invoke the superclass (SimpleMessageConverter) methods.

This provides backward compatibility; users with the above pattern can
simply set 'request-payload-type' to 'java.lang.String' and everything will
work as before.

Or, set the 'request-payload-type' to the type in the json-to-object-transformer,
and eliminate that transformer.

**Add note to migration guide**

INT-2797: polishing (artembilan)

Replaces PR #659 which was from the wrong branch.
