### PR TITLE
INT-2800 Add search-term-strategy to IMAP Adapter

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/MailInboundChannelAdapterParser.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/MailInboundChannelAdapterParser.java
@@ -51,6 +51,7 @@ public class MailInboundChannelAdapterParser extends AbstractPollingInboundChann
 		Object source = parserContext.extractSource(element);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(receiverBuilder, element, "store-uri");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(receiverBuilder, element, "protocol");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(receiverBuilder, element, "search-term-strategy");
 		String session = element.getAttribute("session");
 		if (StringUtils.hasText(session)) {
 			if (element.hasAttribute("java-mail-properties") || element.hasAttribute("authenticator")) {
@@ -73,9 +74,6 @@ public class MailInboundChannelAdapterParser extends AbstractPollingInboundChann
 				String mmpp = pollerElement.getAttribute("max-messages-per-poll");
 				if (StringUtils.hasText(mmpp)) {
 					receiverBuilder.addPropertyValue("maxFetchSize", mmpp);
-				}
-				if (StringUtils.hasText(pollerElement.getAttribute("synchronized"))) {
-					receiverBuilder.addPropertyValue("synchronized", true);
 				}
 			}
 		}

--- a/spring-integration-mail/src/main/resources/org/springframework/integration/mail/config/spring-integration-mail-2.2.xsd
+++ b/spring-integration-mail/src/main/resources/org/springframework/integration/mail/config/spring-integration-mail-2.2.xsd
@@ -94,6 +94,23 @@
 							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="search-term-strategy" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.mail.SearchTermStrategy" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Reference to a custom implementation of org.springframework.integration.mail.SearchTermStrategy
+								to use when retrieving email. Only permitted with 'imap' protocol or an 'imap' uri.
+								By default, the ImapMailReceiver will search for Messages based in the default SearchTerm 
+								which is "All mails that are RECENT (if supported), that are NOT ANSWERED, that are NOT DELETED, that are NOT SEEN and have not 
+								been processed by this mail receiver (enabled by the use of the custom USER flag or simply NOT FLAGGED if not supported)". 							
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -137,9 +154,9 @@
 							<xsd:documentation>
 								Reference to a custom implementation of org.springframework.integration.mail.SearchTermStrategy
 								to use when retrieving email.
-								By default ImapMailReceiver will search for Messages based in the default SearchTerm 
-                                which is "All mails that are RECENT (if supported), that are NOT ANSWERED, that are NOT DELETED, that are NOT SEEN and have not 
-                                been processed by this mail receiver (enabled by the use of the custom USER flag or simply NOT FLAGGED if not supported)". 							
+								By default, the ImapMailReceiver will search for Messages based in the default SearchTerm 
+								which is "All mails that are RECENT (if supported), that are NOT ANSWERED, that are NOT DELETED, that are NOT SEEN and have not 
+								been processed by this mail receiver (enabled by the use of the custom USER flag or simply NOT FLAGGED if not supported)". 							
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests-context.xml
@@ -104,6 +104,15 @@
 
 	<si:bridge input-channel="autoChannel" output-channel="nullChannel"/>
 
+	<!--  INT-2800 -->
+
+	<mail:inbound-channel-adapter id="imapWithSearch" channel="testChannel" protocol="imap" should-delete-messages="false" auto-startup="false"
+		search-term-strategy="searchTermStrategy"/>
+
+	<bean id="searchTermStrategy" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.integration.mail.SearchTermStrategy"/>
+	</bean>
+
 	<!-- COMMON CONFIGURATION -->
 
 	<si:channel id="testChannel"/>

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests-pop3Search-context.xml
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests-pop3Search-context.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:mail="http://www.springframework.org/schema/integration/mail"
+	xmlns:si="http://www.springframework.org/schema/integration"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/mail http://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+	<!--  INT-2800 -->
+
+	<mail:inbound-channel-adapter id="imapWithSearch" channel="testChannel" protocol="pop3" should-delete-messages="false" auto-startup="false"
+		search-term-strategy="searchTermStrategy"/>
+
+	<bean id="searchTermStrategy" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.integration.mail.SearchTermStrategy"/>
+	</bean>
+
+	<!-- COMMON CONFIGURATION -->
+
+	<si:channel id="testChannel"/>
+
+	<si:poller default="true" max-messages-per-poll="1" fixed-rate="60000"/>
+
+</beans>


### PR DESCRIPTION
Previously, the ability to customize the search term
strategy was added to the IMAP Idle adapter; it should
also be available to the polled IMAP adapter.

Add the attribute.

Remove some obsolete code from the parser.
