### PR TITLE
INT-2821 Find Existing Mails When No RECENT Support 

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
@@ -110,6 +110,11 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 		if (imapFolder.hasNewMessages()) {
 			return;
 		}
+		else if (!folder.getPermanentFlags().contains(Flags.Flag.RECENT)) {
+			if (searchForNewMessages().length > 0) {
+				return;
+			}
+		}
 		imapFolder.addMessageCountListener(this.messageCountListener);
 		try {
 			imapFolder.idle();


### PR DESCRIPTION
Previously, if an IMAP server supports IDLE, but not
RECENT, no messages were retrieved for one IDLE cycle.

Add a boolean indicating that a new folder open has
occurred and, for the first time only, if the
server doesn't support RECENT, skip the call to
folder.idle() so that the adapter will immediately
call receive() which, in turn, searches for
messages.
