### PR TITLE
INT-2820 Shutdown Default Idle Executor

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
@@ -19,6 +19,7 @@ package org.springframework.integration.mail;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 
@@ -58,6 +59,8 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport implements Be
 	private final IdleTask idleTask = new IdleTask();
 
 	private volatile Executor sendingTaskExecutor = Executors.newFixedThreadPool(1);
+
+	private volatile boolean sendingTaskExecutorSet;
 
 	private volatile boolean shouldReconnectAutomatically = true;
 
@@ -102,6 +105,7 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport implements Be
 	public void setSendingTaskExecutor(Executor sendingTaskExecutor) {
 		Assert.notNull(sendingTaskExecutor, "'sendingTaskExecutor' must not be null");
 		this.sendingTaskExecutor = sendingTaskExecutor;
+		this.sendingTaskExecutorSet = true;
 	}
 
 	/**
@@ -145,6 +149,12 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport implements Be
 		catch (Exception e) {
 			throw new IllegalStateException(
 					"Failure during the destruction of Mail receiver: " + mailReceiver, e);
+		}
+		/*
+		 * If we're running with the default executor, shut it down.
+		 */
+		if (!sendingTaskExecutorSet) {
+			((ExecutorService) sendingTaskExecutor).shutdown();
 		}
 	}
 

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
@@ -134,6 +134,10 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport implements Be
 	protected void doStart() {
 		final TaskScheduler scheduler =  this.getTaskScheduler();
 		Assert.notNull(scheduler, "'taskScheduler' must not be null" );
+		if (this.sendingTaskExecutor == null) {
+			// we must have previously been stopped; create a new executor
+			this.sendingTaskExecutor = Executors.newFixedThreadPool(1);
+		}
 		this.receivingTask = scheduler.schedule(new ReceivingTask(), this.receivingTaskTrigger);
 		this.pingTask = scheduler.scheduleAtFixedRate(new PingTask(), this.connectionPingInterval);
 	}
@@ -155,6 +159,7 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport implements Be
 		 */
 		if (!sendingTaskExecutorSet) {
 			((ExecutorService) sendingTaskExecutor).shutdown();
+			this.sendingTaskExecutor = null;
 		}
 	}
 

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
@@ -522,5 +522,7 @@ public class ImapMailReceiverTests {
 		adapter.start();
 		exec = TestUtils.getPropertyValue(adapter, "sendingTaskExecutor", ExecutorService.class);
 		adapter.stop();
-		assertTrue(exec.isShutdown());	}
+		assertTrue(exec.isShutdown());
+	}
+
 }

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
@@ -18,6 +18,7 @@ package org.springframework.integration.mail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -29,6 +30,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.util.Properties;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -59,6 +61,7 @@ import org.springframework.integration.handler.AbstractReplyProducingMessageHand
 import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.mail.config.ImapIdleChannelAdapterParserTests;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.FileCopyUtils;
 
 import com.sun.mail.imap.IMAPFolder;
@@ -504,5 +507,17 @@ public class ImapMailReceiverTests {
 		assertEquals("bar\n", ((Multipart) content).getBodyPart(0).getContent());
 
 		assertSame(folder, messages[0].getFolder());
+	}
+
+	@Test
+	public void testExecShutdown() {
+		ImapIdleChannelAdapter adapter = new ImapIdleChannelAdapter(new ImapMailReceiver());
+		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+		taskScheduler.initialize();
+		adapter.setTaskScheduler(taskScheduler);
+		adapter.start();
+		adapter.stop();
+		ExecutorService exec = TestUtils.getPropertyValue(adapter, "sendingTaskExecutor", ExecutorService.class);
+		assertTrue(exec.isShutdown());
 	}
 }

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
@@ -516,8 +516,11 @@ public class ImapMailReceiverTests {
 		taskScheduler.initialize();
 		adapter.setTaskScheduler(taskScheduler);
 		adapter.start();
-		adapter.stop();
 		ExecutorService exec = TestUtils.getPropertyValue(adapter, "sendingTaskExecutor", ExecutorService.class);
+		adapter.stop();
 		assertTrue(exec.isShutdown());
-	}
+		adapter.start();
+		exec = TestUtils.getPropertyValue(adapter, "sendingTaskExecutor", ExecutorService.class);
+		adapter.stop();
+		assertTrue(exec.isShutdown());	}
 }


### PR DESCRIPTION
The default executor for sending messages from the IMAP IDLE
channel adapter is a single threaded thread pool.

If the default executor is used (no executor injected), shut
it down when the adapter is stopped.
