### PR TITLE
INT-2839 Fix TCP Caching Connections with Gateways

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests-context.xml
@@ -22,6 +22,12 @@
 		<int:queue/>
 	</int:channel>
 
+	<int-ip:tcp-outbound-channel-adapter
+		connection-factory="scf"
+		channel="replies" />
+
+	<int:channel id="replies" />
+
 	<int-ip:tcp-connection-factory
 		id="ccf"
 		type="client"
@@ -43,4 +49,29 @@
 
 	<int:channel id="outbound" />
 
+	<int-ip:tcp-connection-factory
+		id="gateway.ccf"
+		type="client"
+		host="localhost"
+		port="9876"
+		so-timeout="60000"
+	/>
+
+	<bean id="gateway.caching.ccf" class="org.springframework.integration.ip.tcp.connection.CachingClientConnectionFactory">
+		<constructor-arg ref="gateway.ccf" />
+		<constructor-arg value="10" />
+		<property name="connectionWaitTimeout" value="10000"/>
+	</bean>
+
+	<int-ip:tcp-outbound-gateway
+		id="ob.gw"
+		connection-factory="gateway.caching.ccf"
+		request-channel="toGateway"
+		reply-channel="fromGateway" />
+
+	<int:channel id="toGateway" />
+
+	<int:channel id="fromGateway">
+		<int:queue/>
+	</int:channel>
 </beans>


### PR DESCRIPTION
Using the CachingClientConnectionFactory with a gateway
doesn't work. The Listener (gateway) was not being set up
properly by the wrapper. Instead, the actualListener in the
wrapped connection was set to null. This caused the connection
to "close" itself (return to the pool) immediately after the send.

In addition, even with the actualListener set up to properly
reference the gateway, it still wouldn't work because the
gateway can't correlate the reply (the cached connectionId is
prefixed with "cached:" so the gateway can't find the reply.

Further, when onMessage() returned, it caused the reader loop
to end.

Fixes:
1. Properly set up the cached connection with the real listener
   so that ultimately the underlying connection sees there is an
   actualListener and so doesn't close itself after the send.
2. Override getListener() on the cached connection to return the
   real listener.
3. Override onMessage() in order to fix up the connection id in
   the message, and return true (intercepted) so the connection doesn't
   close itself (terminate the reader thread).
4. close() (return to the pool) after invoking the gateway's
   onMessage().
5. Add test cases to verify proper operation including an assertion
   that the pooled connection is reused.

This is made a little more complex by the tangle between
connections and connection interceptors; mainly because single-use
connections close themselves after use. This will be addressed in
3.0 (INT-2829) making connection interceptors simpler.
