### PR TITLE
INT-2844 Fix Http Test If Building With Spring 3.0

### DIFF
--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
@@ -771,7 +772,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		}
 		assertTrue(requestHeaders.getAccept() != null);
 		assertTrue(requestHeaders.getAccept().size() > 0);
-		assertEquals("404 null", exception.getCause().getMessage());
+		assertEquals("404 Not Found", exception.getCause().getMessage());
 		List<MediaType> accept = requestHeaders.getAccept();
 		assertTrue(accept != null && accept.size() > 0);
 		assertEquals("application", accept.get(0).getType());
@@ -805,7 +806,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		}
 		assertTrue(requestHeaders.getAccept() != null);
 		assertTrue(requestHeaders.getAccept().size() > 0);
-		assertEquals("404 null", exception.getCause().getMessage());
+		assertEquals("404 Not Found", exception.getCause().getMessage());
 		List<MediaType> accept = requestHeaders.getAccept();
 		assertTrue(accept != null && accept.size() > 0);
 		assertEquals("application", accept.get(0).getType());
@@ -825,6 +826,8 @@ public class HttpRequestExecutingMessageHandlerTests {
 
 		ClientHttpResponse response = mock(ClientHttpResponse.class);
 		when(response.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND);
+		when(response.getStatusText()).thenReturn("Not Found");
+		when(response.getBody()).thenReturn(new ByteArrayInputStream(new byte[0]));
 
 		HttpHeaders responseHeaders = new HttpHeaders();
 		when(response.getHeaders()).thenReturn(responseHeaders);


### PR DESCRIPTION
In Spring 3.1, DefaultResponseErrorHandler.getResponseBody() is
tolerant of a null InputStream on the response. With Spring 3.0
a null response causes an assertion exception.

The mock in the tests was not set up to return an InputStream
and so the test failed when building with Spring 3.0.

Configure the mock to return an empty InputStream.

Also added a text response to response.getStatusText().

Tested with Spring 3.0 and 3.1.
