### PR TITLE
INT-2845: Gradle: check XSD-versions in the tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,26 @@ subprojects { subproject ->
 		from javadoc
 	}
 
+	task checkTestConfigs << {
+		def configFiles = []
+		sourceSets.test.java.srcDirs.each {
+			fileTree(it).include('**/*.xml').exclude('**/log4j.xml').each { configFile ->
+				def configXml = new XmlParser(false, false).parse(configFile)
+
+				if (configXml.@'xsi:schemaLocation' ==~ /.*spring-[a-z-]*\d\.\d\.xsd.*/) {
+					configFiles << configFile
+				}
+			}
+		}
+		if (configFiles) {
+			throw new InvalidUserDataException('Hardcoded XSD version in the config files:\n' +
+												configFiles.collect {relativePath(it)}.join('\n') +
+			'\nPlease, use versionless schemaLocations for Spring XSDs to avoid issues with builds on different versions of dependencies.')
+		}
+	}
+
+	test.dependsOn checkTestConfigs
+
 	artifacts {
 		archives sourcesJar
 		archives javadocJar

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/TransactionSynchronizationFactoryParserTests-config.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/TransactionSynchronizationFactoryParserTests-config.xml
@@ -3,15 +3,15 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.2.xsd">
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<int:transaction-synchronization-factory id="syncFactoryComplete">
 		<int:before-commit channel="beforeCommitChannel"/>
 		<int:after-commit expression="'afterCommit'"/>
 		<int:after-rollback channel="afterRollbackChannel" expression="'afterRollback'"/>
 	</int:transaction-synchronization-factory>
-	
+
 	<int:channel id="beforeCommitChannel"/>
 	<int:channel id="afterRollbackChannel"/>
-	
+
 </beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/TransactionSynchronizationFactoryParserTests-xsd.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/TransactionSynchronizationFactoryParserTests-xsd.xml
@@ -3,30 +3,30 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.2.xsd">
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<int:transaction-synchronization-factory id="a">
 		<int:before-commit channel="nullChannel"/>
 	</int:transaction-synchronization-factory>
-	
+
 	<int:transaction-synchronization-factory id="b">
 		<int:after-commit expression="'foo'"/>
 	</int:transaction-synchronization-factory>
-	
+
 	<int:transaction-synchronization-factory id="c">
 		<int:after-rollback expression="'f'"/>
 	</int:transaction-synchronization-factory>
-	
+
 	<int:transaction-synchronization-factory id="d">
 		<int:before-commit channel="nullChannel" expression="''"/>
 		<int:after-commit channel="nullChannel" expression="''"/>
 	</int:transaction-synchronization-factory>
-	
+
 	<int:transaction-synchronization-factory id="e">
 		<int:before-commit channel="nullChannel" expression="''"/>
 		<int:after-rollback channel="nullChannel" expression="''"/>
 	</int:transaction-synchronization-factory>
-	
+
 	<int:transaction-synchronization-factory id="f">
 		<int:after-commit expression="'f'"/>
 		<int:after-rollback channel="nullChannel"/>
@@ -37,5 +37,5 @@
 		<int:after-commit expression="'f'"/>
 		<int:after-rollback channel="nullChannel" expression="''"/>
 	</int:transaction-synchronization-factory>
-	
+
 </beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/broken-broker.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/broken-broker.xml
@@ -5,40 +5,40 @@
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
 	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
-		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway id="brkenBrokerGateway" default-request-channel="outGatewayInChannel"/>
-	
+
 	<int-jms:outbound-gateway id="jog" request-channel="outGatewayInChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="brokenBrokerRequestQueue"
 		correlation-key="JMSCorrelationID"
 		receive-timeout="1000"/>
-		
-	<int-jms:inbound-gateway request-channel="jmsInChannel" 
+
+	<int-jms:inbound-gateway request-channel="jmsInChannel"
 						     request-destination-name="brokenBrokerRequestQueue"
 							 connection-factory="connectionFactory"
 							 concurrent-consumers="10"
 							 reply-timeout="10000"/>
-							 
+
 	<int:channel id="jmsInChannel">
 		<int:dispatcher task-executor="executor"/>
 	</int:channel>
-							 		 
+
 	<int:service-activator input-channel="jmsInChannel" expression="payload"/>
-		
+
 	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
-				<property name="brokerURL" value="tcp://localhost:61623"/>		
+				<property name="brokerURL" value="tcp://localhost:61623"/>
 			</bean>
 		</property>
 		<property name="cacheProducers" value="true" />
 		<property name="cacheConsumers" value="true" />
 		<property name="sessionCacheSize" value="10" />
 	</bean>
-	
+
 	<task:executor id="executor" pool-size="20"/>
 </beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/explicit-correlation-key.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/explicit-correlation-key.xml
@@ -4,79 +4,79 @@
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd">
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd">
 
 	<int:gateway id="explicitCorrelationKeyGateway" default-request-channel="explicitCorrelationIn"/>
 
 	<int-jms:outbound-gateway request-channel="explicitCorrelationIn"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination="explicitCorrelationJmsOut"
 		correlation-key="bar"/>
-		
+
 	<bean id="explicitCorrelationJmsOut" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="explicitCorrelationJmsOut"/>
 	</bean>
-	
-	<int-jms:inbound-gateway request-channel="requestIn" 
+
+	<int-jms:inbound-gateway request-channel="requestIn"
 	    request-destination="explicitCorrelationJmsOut"
 	    correlation-key="bar"
 		connection-factory="connectionFactory"/>
-	
+
 	<int:transformer input-channel="requestIn" expression="payload"/>
-	
+
 	<!--  -->
-	
+
 	<int:gateway id="explicitCorrelationKeyGatewayB" default-request-channel="explicitCorrelationInB"/>
 
 	<int-jms:outbound-gateway request-channel="explicitCorrelationInB"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination="explicitCorrelationJmsOutB"
 		correlation-key="JMSCorrelationID"/>
-		
+
 	<bean id="explicitCorrelationJmsOutB" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="explicitCorrelationJmsOutB"/>
 	</bean>
-	
-	<int-jms:inbound-gateway request-channel="requestInB" 
+
+	<int-jms:inbound-gateway request-channel="requestInB"
 	    request-destination="explicitCorrelationJmsOutB"
 	    correlation-key="JMSCorrelationID"
 		connection-factory="connectionFactory"/>
-	
+
 	<int:transformer input-channel="requestInB" expression="payload"/>
-	
+
 	<!--  -->
-	
+
 	<int:gateway id="explicitCorrelationKeyGatewayC" default-request-channel="explicitCorrelationInC"/>
 
 	<int-jms:outbound-gateway id="outGateway" request-channel="explicitCorrelationInC"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination="explicitCorrelationJmsOutC"
 		reply-destination-name="explicitCorrelationJmsInC"
 		correlation-key="foo"
 		receive-timeout="100"/>
-		
+
 	<bean id="explicitCorrelationJmsOutC" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="explicitCorrelationJmsOutC"/>
 	</bean>
-	
-	<int-jms:inbound-gateway id="inGateway" request-channel="requestInC" 
+
+	<int-jms:inbound-gateway id="inGateway" request-channel="requestInC"
 	    request-destination="explicitCorrelationJmsOutC"
 	    correlation-key="foo"
 		connection-factory="connectionFactory"/>
-	
+
 	<int:transformer input-channel="requestInC">
 		<bean class="org.springframework.integration.jms.request_reply.RequestReplyScenariosWithCorrelationKeyProvidedTests.DelayedService"/>
 	</int:transformer>
-	
+
 	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
-				<property name="brokerURL" value="vm://localhost"/>		
+				<property name="brokerURL" value="vm://localhost"/>
 			</bean>
 		</property>
 		<property name="cacheProducers" value="true" />
 		<property name="cacheConsumers" value="true" />
 		<property name="sessionCacheSize" value="10" />
 	</bean>
-	
+
 </beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/honor-timeout.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/honor-timeout.xml
@@ -3,21 +3,17 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="in" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="in"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="honorTimeoutQueue"
 		receive-timeout="10000"/>
-	
+
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="honorTimeoutQueue"
 		connection-factory="connectionFactory"
@@ -31,7 +27,7 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<bean id="connectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/mult-producer-and-consumers-temp-reply.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/mult-producer-and-consumers-temp-reply.xml
@@ -5,45 +5,45 @@
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
 	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
-		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd
+		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway id="multiOutGateway" default-request-channel="outGatewayInChannel"/>
-	
+
 	<int:channel id="outGatewayInChannel">
 		<int:dispatcher task-executor="executor"/>
 	</int:channel>
-	
+
 	<int-jms:outbound-gateway request-channel="outGatewayInChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="multiOutGatewayTempQueue"
 		correlation-key="JMSCorrelationID"/>
-		
-	<int-jms:inbound-gateway request-channel="jmsInChannel" 
+
+	<int-jms:inbound-gateway request-channel="jmsInChannel"
 						     request-destination-name="multiOutGatewayTempQueue"
 							 connection-factory="connectionFactory"
 							 concurrent-consumers="10"
 							 reply-timeout="10000"/>
-							 
+
 	<int:channel id="jmsInChannel">
 		<int:dispatcher task-executor="executor"/>
 	</int:channel>
-							 
+
 	<int:service-activator input-channel="jmsInChannel">
 		<bean class="org.springframework.integration.jms.request_reply.RequestReplyScenariosWithTempReplyQueuesTests.MyRandomlySlowService"/>
 	</int:service-activator>
-		
+
 	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
-				<property name="brokerURL" value="vm://localhost"/>		
+				<property name="brokerURL" value="vm://localhost"/>
 			</bean>
 		</property>
 		<property name="cacheProducers" value="true" />
 		<property name="cacheConsumers" value="true" />
 		<property name="sessionCacheSize" value="10" />
 	</bean>
-	
+
 	<task:executor id="executor" pool-size="20"/>
 </beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-01.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-01.xml
@@ -3,18 +3,15 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline01" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline01"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline01-queue-01">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -32,9 +29,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline01-queue-02">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -44,7 +41,7 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-02.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-02.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline02" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline02"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline02-queue-01"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
@@ -33,9 +29,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline02-queue-02">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -45,7 +41,7 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-03.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-03.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline03" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline03"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline03-queue-01"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
@@ -33,9 +29,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline03-queue-02"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
@@ -46,7 +42,7 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-04.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-04.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline04" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline04"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline04-queue-01">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -32,9 +28,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline04-queue-02"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
@@ -45,7 +41,7 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-05.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-05.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline05" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline05"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline05-queue-01"
 		correlation-key="foo">
 		<int-jms:reply-listener />
@@ -34,9 +30,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline05-queue-02">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -46,7 +42,7 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-06.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-06.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline06" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline06"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline06-queue-01">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -32,9 +28,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline06-queue-02"
 		correlation-key="foo">
 		<int-jms:reply-listener />
@@ -46,7 +42,7 @@
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="foo"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-07.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-07.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline07" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline07"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline07-queue-01"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
@@ -33,9 +29,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline07-queue-02"
 		correlation-key="foo">
 		<int-jms:reply-listener />
@@ -47,7 +43,7 @@
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="foo"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-08.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-08.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline08" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline08"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline08-queue-01"
 		correlation-key="foo">
 		<int-jms:reply-listener />
@@ -34,9 +30,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline08-queue-02"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
@@ -47,7 +43,7 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-09.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-09.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline09" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline09"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline09-queue-01"
 		correlation-key="foo">
 		<int-jms:reply-listener />
@@ -34,9 +30,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="pipeline09-queue-02"
 		correlation-key="bar">
 		<int-jms:reply-listener />
@@ -48,7 +44,7 @@
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="bar"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-01.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-01.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline01" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline01"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline01-01"
 		request-destination-name="siOutQueue01-01">
 		<int-jms:reply-listener />
@@ -33,9 +29,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination-name="anotherGatewayQueue01-01">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -45,7 +41,7 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline02" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline02"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline02-01"
 	    correlation-key="corr02"
 		request-destination-name="siOutQueue02">
@@ -35,9 +31,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline02-02"
 	    correlation-key="corr02"
 		request-destination-name="anotherGatewayQueue02">
@@ -50,11 +46,11 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload" output-channel="toThird" />
 
 	<int-jms:outbound-gateway request-channel="toThird"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline02-03"
 		request-destination-name="thirdGatewayQueue02">
 		<int-jms:reply-listener />

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02a.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02a.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline02" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline02"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline02a-01"
 	    correlation-key="corr02a"
 		request-destination-name="siOutQueue02a">
@@ -35,9 +31,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline02a-01"
 	   	correlation-key="corr02a"
 		request-destination-name="anotherGatewayQueue02a">
@@ -50,11 +46,11 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload" output-channel="toThird" />
 
 	<int-jms:outbound-gateway request-channel="toThird"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline02a-01"
 		correlation-key="corr02a"
 		request-destination-name="thirdGatewayQueue02a">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline03" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline03"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline03-01"
 	    correlation-key="JMSCorrelationID"
 		request-destination-name="siOutQueue03">
@@ -34,9 +30,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline03-02"
 	    correlation-key="corr03"
 		request-destination-name="anotherGatewayQueue03">
@@ -49,11 +45,11 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload" output-channel="toThird" />
 
 	<int-jms:outbound-gateway request-channel="toThird"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline03-03"
 	    correlation-key="corr03"
 		request-destination-name="thirdGatewayQueue03">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03a.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03a.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline03" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline03"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline03a-01"
 	    correlation-key="JMSCorrelationID"
 		request-destination-name="siOutQueue03a">
@@ -34,9 +30,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline03a-01"
 	    correlation-key="corr03a"
 		request-destination-name="anotherGatewayQueue03a">
@@ -49,20 +45,20 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload" output-channel="toThird" />
 
 	<int-jms:outbound-gateway request-channel="toThird"
 		reply-channel="add10kOnTheWayBack"
 		correlation-key="corr03a"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline03a-01"
 		request-destination-name="thirdGatewayQueue03a">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
 
 	<int:transformer input-channel="add10kOnTheWayBack" expression="payload + 10000" />
-		
+
 	<int-jms:inbound-gateway request-channel="thirdIn"
 		request-destination-name="thirdGatewayQueue03a"
 		correlation-key="corr03a"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-04.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-04.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline04" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline04"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline04-01"
 	    correlation-key="foo"
 		request-destination-name="siOutQueue04">
@@ -35,9 +31,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline04-02"
 		request-destination-name="anotherGatewayQueue04">
 		<int-jms:reply-listener />
@@ -48,7 +44,7 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-05.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-05.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline05" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline05"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline05-01"
 	    correlation-key="foo"
 		request-destination-name="siOutQueue05">
@@ -35,9 +31,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline05-02"
 		request-destination-name="anotherGatewayQueue05"
 		correlation-key="JMSCorrelationID">
@@ -49,7 +45,7 @@
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-06.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-06.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline06" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline06"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline06-01"
 	    correlation-key="JMSCorrelationID"
 		request-destination-name="siOutQueue06">
@@ -35,9 +31,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline06-02"
 		request-destination-name="anotherGatewayQueue06"
 		correlation-key="foo">
@@ -50,7 +46,7 @@
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="foo"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-07.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-07.xml
@@ -3,18 +3,14 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.1.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:gateway default-request-channel="pipeline07" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline07"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline07-01"
 	    correlation-key="foo"
 		request-destination-name="siOutQueue07">
@@ -35,9 +31,9 @@
 		<int:delayer id="foo" default-delay="0" delay-header-name="delay"/>
 		<int:transformer expression="payload"/>
 	</int:chain>
-	
+
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 	    reply-destination-name="pipeline07-02"
 		request-destination-name="anotherGatewayQueue07"
 		correlation-key="bar">
@@ -50,7 +46,7 @@
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="bar"/>
-		
+
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
 	<bean id="connectionFactory"

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-cached-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-cached-consumers.xml
@@ -4,52 +4,52 @@
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd">
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd">
 
 	<int:gateway id="standardMessageIdCopyingConsumerWithOptimization" default-request-channel="jmsInOptimizedA"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInOptimizedA"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination="siOutQueueOptimizedA"
 		reply-destination="siInQueueOptimizedA"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
-	
-		
+
+
 	<bean id="siOutQueueOptimizedA" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siOutQueueOptimizedA"/>
 	</bean>
-	
+
 	<bean id="siInQueueOptimizedA" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siInQueueOptimizedA"/>
 	</bean>
-	
+
 	<!--  -->
-	
+
 	<int:gateway id="standardMessageIdCopyingConsumerWithoutOptimization" default-request-channel="jmsInNonOptimizedB"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedB"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination="siOutQueueNonOptimizedB"
 		reply-destination="siInQueueNonOptimizedB">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
-		
+
 	<bean id="siOutQueueNonOptimizedB" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siOutQueueNonOptimizedB"/>
 	</bean>
-	
+
 	<bean id="siInQueueNonOptimizedB" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siInQueueNonOptimizedB"/>
 	</bean>
-	
+
 	<!--  -->
-	
+
 	<int:gateway id="correlationPropagatingConsumerWithOptimization" default-request-channel="jmsInOptimizedC"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInOptimizedC"
-		connection-factory="connectionFactory" 
+		connection-factory="connectionFactory"
 		request-destination="siOutQueueOptimizedC"
 		reply-destination="siInQueueOptimizedC"
 		correlation-key="JMSCorrelationID">
@@ -69,7 +69,7 @@
 	<int:gateway id="correlationPropagatingConsumerWithoutOptimization" default-request-channel="jmsInNonOptimizedD"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedD"
-		connection-factory="connectionFactory" 
+		connection-factory="connectionFactory"
 		request-destination="siOutQueueNonOptimizedD"
 		reply-destination="siInQueueNonOptimizedD">
 		<int-jms:reply-listener />
@@ -88,7 +88,7 @@
 	<int:gateway id="correlationPropagatingConsumerWithOptimizationDelayFirstReply" default-request-channel="jmsInE"/>
 
 	<int-jms:outbound-gateway id="fastGateway" request-channel="jmsInE"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination="siOutQueueE"
 		reply-destination="siInQueueE"
 		receive-timeout="500"
@@ -107,7 +107,7 @@
 	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
-				<property name="brokerURL" value="vm://localhost?broker.persistent=false" />		
+				<property name="brokerURL" value="vm://localhost?broker.persistent=false" />
 			</bean>
 		</property>
 		<property name="cacheProducers" value="true" />

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-no-cached-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-no-cached-consumers.xml
@@ -4,12 +4,12 @@
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd">
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd">
 
 	<int:gateway id="optimized" default-request-channel="jmsInOptimized"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInOptimized"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination="siOutQueueA"
 		reply-destination="siInQueueA"
 		correlation-key="JMSCorrelationID">
@@ -19,17 +19,17 @@
 	<bean id="siOutQueueA" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siOutQueueA.not.cached"/>
 	</bean>
-	
+
 	<bean id="siInQueueA" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siInQueueA.not.cached"/>
 	</bean>
-	
+
 	<!--  -->
-	
+
 	<int:gateway id="nonoptimized" default-request-channel="jmsInNonOptimized"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInNonOptimized"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination="siOutQueueB"
 		reply-destination="siInQueueB">
 		<int-jms:reply-listener />
@@ -38,17 +38,17 @@
 	<bean id="siOutQueueB" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siOutQueueB.not.cached"/>
 	</bean>
-	
+
 	<bean id="siInQueueB" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siInQueueB.not.cached"/>
 	</bean>
-	
+
 	<!--  -->
-	
+
 	<int:gateway id="optimizedMessageId" default-request-channel="jmsInOptimizedC"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInOptimizedC"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination="siOutQueueC"
 		reply-destination="siInQueueC"
 		correlation-key="JMSCorrelationID">
@@ -58,17 +58,17 @@
 	<bean id="siOutQueueC" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siOutQueueC.not.cached"/>
 	</bean>
-	
+
 	<bean id="siInQueueC" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siInQueueC.not.cached"/>
 	</bean>
-	
+
 	<!--  -->
-	
+
 	<int:gateway id="nonoptimizedMessageId" default-request-channel="jmsInNonOptimizedD"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedD"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination="siOutQueueD"
 		reply-destination="siInQueueD">
 		<int-jms:reply-listener />
@@ -77,15 +77,15 @@
 	<bean id="siOutQueueD" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siOutQueueD.not.cached"/>
 	</bean>
-	
+
 	<bean id="siInQueueD" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siInQueueD.not.cached"/>
 	</bean>
-	 
+
 	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
-				<property name="brokerURL" value="vm://localhost"/>		
+				<property name="brokerURL" value="vm://localhost"/>
 			</bean>
 		</property>
 		<property name="cacheProducers" value="true" />

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-temp-reply-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-temp-reply-consumers.xml
@@ -4,29 +4,29 @@
 	xmlns:int-jms="http://www.springframework.org/schema/integration/jms"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd">
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd">
 
 	<int:gateway default-request-channel="jmsIn"/>
 
 	<int-jms:outbound-gateway request-channel="jmsIn"
-	    connection-factory="connectionFactory" 
+	    connection-factory="connectionFactory"
 		request-destination="siOutQueue">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
-		
+
 	<bean id="siOutQueue" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="siOutQueueA"/>
 	</bean>
-	 
+
 	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
-				<property name="brokerURL" value="vm://localhost"/>		
+				<property name="brokerURL" value="vm://localhost"/>
 			</bean>
 		</property>
 		<property name="cacheProducers" value="true" />
 		<property name="cacheConsumers" value="true" />
 		<property name="sessionCacheSize" value="10" />
 	</bean>
-	
+
 </beans>

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/imap-idle-mock-integration-config.xml
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/imap-idle-mock-integration-config.xml
@@ -1,16 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:int="http://www.springframework.org/schema/integration"
+	   xmlns:int-mail="http://www.springframework.org/schema/integration/mail"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.2.xsd
-		http://www.springframework.org/schema/integration/mail http://www.springframework.org/schema/integration/mail/spring-integration-mail-2.2.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:int="http://www.springframework.org/schema/integration"
-	xmlns:int-mail="http://www.springframework.org/schema/integration/mail"
-	xmlns:util="http://www.springframework.org/schema/util">
-	
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/mail http://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd">
+
 	<int-mail:imap-idle-channel-adapter id="customAdapter"
 					store-uri="imaps://foo.com:password@imap.foo.com/INBOX"
 					channel="nullChannel"
@@ -22,11 +18,11 @@
 	<int:transaction-synchronization-factory id="syncFactory">
 		<int:before-commit expression="@syncProcessor.process(payload)"/>
 	</int:transaction-synchronization-factory>
-	
+
 	<bean id="syncProcessor" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.integration.mail.config.ImapIdelIntegrationTests.PostTransactionProcessor"/>
 	</bean>
-	
+
 	<bean id="transactionManager" class="org.springframework.integration.transaction.PseudoTransactionManager"/>
-	
+
 </beans>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisStoreInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisStoreInboundChannelAdapterParserTests-context.xml
@@ -5,7 +5,7 @@
 	xmlns:int-redis="http://www.springframework.org/schema/integration/redis"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/integration/redis http://www.springframework.org/schema/integration/redis/spring-integration-redis-2.2.xsd">
+		http://www.springframework.org/schema/integration/redis http://www.springframework.org/schema/integration/redis/spring-integration-redis.xsd">
 
 	<int-redis:store-inbound-channel-adapter id="withStringTemplate"
 											connection-factory="redisConnectionFactory"
@@ -21,7 +21,7 @@
 		<property name="keySerializer" ref="keySerializer"/>
 		<property name="valueSerializer" ref="valueSerializer"/>
 		<property name="hashKeySerializer" ref="hashKeySerializer"/>
-		<property name="hashValueSerializer" ref="hashValueSerializer"/>						
+		<property name="hashValueSerializer" ref="hashValueSerializer"/>
 	</bean>
 
 	<int-redis:store-inbound-channel-adapter id="withExternalTemplate"
@@ -34,12 +34,12 @@
 	</int-redis:store-inbound-channel-adapter>
 
 	<int:channel id="redisChannel"/>
-		
+
 	<bean id="keySerializer" class="org.springframework.data.redis.serializer.StringRedisSerializer"/>
 	<bean id="valueSerializer" class="org.springframework.data.redis.serializer.JdkSerializationRedisSerializer"/>
 	<bean id="hashKeySerializer" class="org.springframework.data.redis.serializer.StringRedisSerializer"/>
 	<bean id="hashValueSerializer" class="org.springframework.data.redis.serializer.JdkSerializationRedisSerializer"/>
-	
+
 	<bean id="redisConnectionFactory" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.data.redis.connection.RedisConnectionFactory"/>
 	</bean>


### PR DESCRIPTION
In many cases our IDEs import into test configs Namespace-resources
with hardcoded versions of Spring & Spring Integration XSDs.

It may produce build issues on different Spring versions.

And it exactly causes an issue during the transition to the new Spring Integration version (e.g. 3.0).
- Add Gradle task 'checkTestConfigs' to check test configs for hardcoded resources' versions.
- Add to 'test' task dependency on new task 'checkTestConfigs'
- Fix hadrcoded versions in the test configs.

JIRA: https://jira.springsource.org/browse/INT-2845
