### PR TITLE
INT-2858: fix for repeatable invocation.proceed()

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,10 +59,18 @@ public abstract class AbstractRequestHandlerAdvice extends IntegrationObjectSupp
 
 					public Object execute() throws Exception {
 						try {
+							return invocation.proceed();
+						}
+						catch (Throwable e) {
+							throw new ThrowableHolderException(e);
+						}
+					}
+
+					public Object cloneAndExecute() throws Exception {
+						try {
 							/*
 				 			* If we don't copy the invocation carefully it won't keep a reference to the other
-				 			* interceptors in the chain. We don't have a choice here but to specialise to
-				 			* ReflectiveMethodInvocation (but how often would another implementation come along?).
+				 			* interceptors in the chain.
 				 			*/
 							if (invocation instanceof ProxyMethodInvocation) {
 								return ((ProxyMethodInvocation) invocation).invocableClone().proceed();
@@ -105,6 +113,8 @@ public abstract class AbstractRequestHandlerAdvice extends IntegrationObjectSupp
 	protected interface ExecutionCallback {
 
 		Object execute() throws Exception;
+
+		Object cloneAndExecute() throws Exception;
 
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,12 +32,13 @@ import org.springframework.util.Assert;
  * exception is thrown but state is maintained to support
  * the retry policies. Stateful retry requires a
  * {@link RetryStateGenerator}.
- * @author Gary Russell
- * @since 2.2
  *
+ * @author Gary Russell
+ * @author Artem Bilan
+ * @since 2.2
  */
 public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice
-	implements RetryListener {
+		implements RetryListener {
 
 	private volatile RetryTemplate retryTemplate = new RetryTemplate();
 
@@ -80,10 +81,10 @@ public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice
 		messageHolder.set(message);
 
 		try {
-			return retryTemplate.execute(new RetryCallback<Object>(){
+			return retryTemplate.execute(new RetryCallback<Object>() {
 				public Object doWithRetry(RetryContext context) throws Exception {
 					try {
-						return callback.execute();
+						return callback.cloneAndExecute();
 					}
 					catch (MessagingException e) {
 						if (e.getFailedMessage() == null) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -28,6 +28,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.aopalliance.aop.Advice;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
 import org.junit.Test;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageHandlingException;
@@ -47,8 +49,8 @@ import org.springframework.retry.support.RetryTemplate;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.2
- *
  */
 public class AdvisedMessageHandlerTests {
 
@@ -359,7 +361,7 @@ public class AdvisedMessageHandlerTests {
 	}
 
 	@Test
-	public void defaultRetrySucceedonThirdTry() {
+	public void defaultRetrySucceedOnThirdTry() {
 		final AtomicInteger counter = new AtomicInteger(2);
 		AbstractReplyProducingMessageHandler handler = new AbstractReplyProducingMessageHandler() {
 
@@ -390,7 +392,7 @@ public class AdvisedMessageHandlerTests {
 	}
 
 	@Test
-	public void defaultStatefulRetrySucceedonThirdTry() {
+	public void defaultStatefulRetrySucceedOnThirdTry() {
 		final AtomicInteger counter = new AtomicInteger(2);
 		AbstractReplyProducingMessageHandler handler = new AbstractReplyProducingMessageHandler() {
 
@@ -484,7 +486,7 @@ public class AdvisedMessageHandlerTests {
 	}
 
 	private void defaultStatefulRetryRecoverAfterThirdTryGuts(final AtomicInteger counter,
-			AbstractReplyProducingMessageHandler handler, QueueChannel replies, RequestHandlerRetryAdvice advice) {
+															  AbstractReplyProducingMessageHandler handler, QueueChannel replies, RequestHandlerRetryAdvice advice) {
 		advice.setRecoveryCallback(new RecoveryCallback<Object>() {
 
 			public Object recover(RetryContext context) throws Exception {
@@ -574,6 +576,124 @@ public class AdvisedMessageHandlerTests {
 		assertTrue(error.getPayload() instanceof ErrorMessageSendingRecoverer.RetryExceptionNotAvailableException);
 		assertNotNull(((MessagingException) error.getPayload()).getFailedMessage());
 		assertSame(message, ((MessagingException) error.getPayload()).getFailedMessage());
+	}
+
+	@Test
+	public void testINT2858RetryAdviceAsFirstInAdviceChain() {
+		final AtomicInteger counter = new AtomicInteger(3);
+
+		AbstractReplyProducingMessageHandler handler = new AbstractReplyProducingMessageHandler() {
+			protected Object handleRequestMessage(Message<?> requestMessage) {
+				return "foo";
+			}
+		};
+
+		List<Advice> adviceChain = new ArrayList<Advice>();
+
+		adviceChain.add(new RequestHandlerRetryAdvice());
+		adviceChain.add(new MethodInterceptor() {
+			public Object invoke(MethodInvocation invocation) throws Throwable {
+				counter.getAndDecrement();
+				throw new RuntimeException("intentional");
+			}
+		});
+
+		handler.setAdviceChain(adviceChain);
+		handler.afterPropertiesSet();
+
+		try {
+			handler.handleMessage(new GenericMessage<String>("test"));
+		}
+		catch (Exception e) {
+			Throwable cause = e.getCause();
+			assertEquals("ThrowableHolderException", cause.getClass().getSimpleName());
+			assertEquals("intentional", cause.getCause().getMessage());
+		}
+
+		assertTrue(counter.get() == 0);
+	}
+
+	@Test
+	public void testINT2858RetryAdviceAsNestedInAdviceChain() {
+		final AtomicInteger counter = new AtomicInteger(0);
+
+		AbstractReplyProducingMessageHandler handler = new AbstractReplyProducingMessageHandler() {
+			protected Object handleRequestMessage(Message<?> requestMessage) {
+				return "foo";
+			}
+		};
+
+		QueueChannel replies = new QueueChannel();
+		handler.setOutputChannel(replies);
+
+		List<Advice> adviceChain = new ArrayList<Advice>();
+
+		ExpressionEvaluatingRequestHandlerAdvice expressionAdvice = new ExpressionEvaluatingRequestHandlerAdvice();
+//		ThrowableHolderException / MessagingException / ThrowableHolderException / RuntimeException
+		expressionAdvice.setOnFailureExpression("#exception.cause.cause.cause.message");
+		expressionAdvice.setReturnFailureExpressionResult(true);
+		adviceChain.add(expressionAdvice);
+		adviceChain.add(new RequestHandlerRetryAdvice());
+		adviceChain.add(new MethodInterceptor() {
+			public Object invoke(MethodInvocation invocation) throws Throwable {
+				throw new RuntimeException("intentional: " + counter.incrementAndGet());
+			}
+		});
+
+		handler.setAdviceChain(adviceChain);
+		handler.afterPropertiesSet();
+
+		handler.handleMessage(new GenericMessage<String>("test"));
+		Message<?> receive = replies.receive(1000);
+		assertNotNull(receive);
+		assertEquals("intentional: 3", receive.getPayload());
+	}
+
+
+	@Test
+	public void testINT2858ExpressionAdviceWithSendFailureOnEachRetry() {
+		final AtomicInteger counter = new AtomicInteger(0);
+
+		AbstractReplyProducingMessageHandler handler = new AbstractReplyProducingMessageHandler() {
+			protected Object handleRequestMessage(Message<?> requestMessage) {
+				return "foo";
+			}
+		};
+
+		QueueChannel errors = new QueueChannel();
+
+		List<Advice> adviceChain = new ArrayList<Advice>();
+
+		ExpressionEvaluatingRequestHandlerAdvice expressionAdvice = new ExpressionEvaluatingRequestHandlerAdvice();
+		expressionAdvice.setOnFailureExpression("#exception.cause.message");
+		expressionAdvice.setFailureChannel(errors);
+
+		adviceChain.add(new RequestHandlerRetryAdvice());
+		adviceChain.add(expressionAdvice);
+		adviceChain.add(new MethodInterceptor() {
+			public Object invoke(MethodInvocation invocation) throws Throwable {
+				throw new RuntimeException("intentional: " + counter.incrementAndGet());
+			}
+		});
+
+		handler.setAdviceChain(adviceChain);
+		handler.afterPropertiesSet();
+
+		try {
+			handler.handleMessage(new GenericMessage<String>("test"));
+		}
+		catch (Exception e) {
+			assertEquals("intentional: 3", e.getCause().getCause().getMessage());
+		}
+
+		for (int i = 1; i <= 3; i++) {
+			Message<?> receive = errors.receive(1000);
+			assertNotNull(receive);
+			assertEquals("intentional: " + i, ((MessageHandlingExpressionEvaluatingAdviceException) receive.getPayload()).getEvaluationResult());
+		}
+
+		assertNull(errors.receive(1));
+
 	}
 
 

--- a/src/reference/docbook/handler-advice.xml
+++ b/src/reference/docbook/handler-advice.xml
@@ -148,7 +148,7 @@ DEBUG [task-scheduler-2]Retry failed last attempt: count=3]]></programlisting></
 				<para><emphasis>Simple Stateless Retry with Recovery</emphasis></para>
 				<para>
 					This example adds a <classname>RecoveryCallback</classname> to the
-					above example; it uses a <classname></classname>
+					above example; it uses a <classname>ErrorMessageSendingRecoverer</classname>
 					to send an <emphasis>ErrorMessage</emphasis> to a channel.
 				</para>
 				<para><programlisting><![CDATA[<int:service-activator input-channel="input" ref="failer" method="service">
@@ -448,5 +448,20 @@ Caused by: java.lang.RuntimeException: foo
 		return result;
 	}
 }]]></programlisting></para>
+		<para>
+			Custom <classname>AbstractRequestHandlerAdvice</classname> may have a repeatable logic
+			in the <classname>doInvoke()</classname> method, when its implementation invokes <classname>callback</classname>
+			several times or provides it to other cyclic contexts. In this case the state of current
+			<classname>org.aopalliance.intercept.MethodInvocation</classname> will be kept. From other side typical provided Spring AOP
+			implementation <classname>org.springframework.aop.framework.ReflectiveMethodInvocation</classname> has its own state
+			in the <classname>currentInterceptorIndex</classname>, which is increased in the recursive <classname>proceed()</classname> method
+			to move to other nested <classname>org.aopalliance.intercept.MethodInterceptor</classname>s. To avoid the loss of
+			<classname>currentInterceptorIndex</classname> in the repeatable context <classname>ExecutionCallback</classname>
+			provides <classname>cloneAndExecute()</classname> method, which try to do <classname>invocableClone()</classname> of
+			<classname>MethodInvocation</classname>. See the JavaDocs of:
+			<ulink url="http://static.springsource.org/spring-framework/docs/current/javadoc-api/org/springframework/aop/framework/ReflectiveMethodInvocation.html">
+				ReflectiveMethodInvocation</ulink>. By the way <classname>RequestHandlerRetryAdvice</classname> uses this method,
+			because it provides <classname>ExecutionCallback</classname> to the <classname>RetryTemplate</classname>.
+		</para>
 	</section>
 </section>


### PR DESCRIPTION
Heretofore there wasn't ability to make some scenario like this, when we want to make failure notification on each retry:

``` xml
<service-activator>
  <request-handler-advice-chain>
      <bean class="org.springframework.integration.handler.advice.RequestHandlerRetryAdvice"/>
      <bean class="org.springframework.integration.handler.advice.ExpressionEvaluatingRequestHandlerAdvice"
        p:onFailureExpression="#exception" p:failureChannel-ref="errorOnEachRetryChannel"/>
  </request-handler-advice-chain>
</service-activator>
```

The second Advice was invoked only once. It happens because `ProxyMethodInvocation` keeps index of current interceptor
on each `invocation.proceed()`, which is recursive by design.

So, change `AbstractRequestHandlerAdvice` to do `((ProxyMethodInvocation) invocation).invocableClone().proceed();`
fix the problem, because we get fresh `MethodInvocation` for current `Advice` with nested desired advices.

JIRA: https://jira.springsource.org/browse/INT-2858
