### PR TITLE
INT-2861/INT-2862 TCP Outbound Gateway Fixes

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
@@ -51,11 +51,11 @@ import org.springframework.util.Assert;
  */
 public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler implements TcpSender, TcpListener, SmartLifecycle {
 
-	private volatile AbstractConnectionFactory connectionFactory;
+	private volatile AbstractClientConnectionFactory connectionFactory;
 
-	private Map<String, AsyncReply> pendingReplies = new ConcurrentHashMap<String, AsyncReply>();
+	private final Map<String, AsyncReply> pendingReplies = new ConcurrentHashMap<String, AsyncReply>();
 
-	private Semaphore semaphore = new Semaphore(1, true);
+	private final Semaphore semaphore = new Semaphore(1, true);
 
 	private volatile long remoteTimeout = 10000L;
 
@@ -100,6 +100,7 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler imp
 		Assert.notNull(connectionFactory, this.getClass().getName() +
 				" requires a client connection factory");
 		boolean haveSemaphore = false;
+		String connectionId = null;
 		try {
 			boolean singleUseConnection = this.connectionFactory.isSingleUse();
 			if (!singleUseConnection) {
@@ -114,13 +115,19 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler imp
 			}
 			TcpConnection connection = this.connectionFactory.getConnection();
 			AsyncReply reply = new AsyncReply();
-			pendingReplies.put(connection.getConnectionId(), reply);
+			connectionId = connection.getConnectionId();
+			pendingReplies.put(connectionId, reply);
 			if (logger.isDebugEnabled()) {
 				logger.debug("Added " + connection.getConnectionId());
 			}
 			connection.send(requestMessage);
 			Message<?> replyMessage = reply.getReply();
 			if (replyMessage == null) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Remote Timeout on " + connection.getConnectionId());
+				}
+				// The connection is dirty - force it closed.
+				this.connectionFactory.forceClose(connection);
 				throw new MessageTimeoutException(requestMessage, "Timed out waiting for response");
 			}
 			if (logger.isDebugEnabled()) {
@@ -136,6 +143,9 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler imp
 			throw new MessagingException("Failed to send or receive", e);
 		}
 		finally {
+			if (connectionId != null) {
+				pendingReplies.remove(connectionId);
+			}
 			if (haveSemaphore) {
 				this.semaphore.release();
 				if (logger.isDebugEnabled()) {
@@ -161,9 +171,10 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler imp
 	}
 
 	public void setConnectionFactory(AbstractConnectionFactory connectionFactory) {
+		// TODO: In 3.0 Change parameter type to AbstractClientConnectionFactory
 		Assert.isTrue(connectionFactory instanceof AbstractClientConnectionFactory,
 				this.getClass().getName() + " requires a client connection factory");
-		this.connectionFactory = connectionFactory;
+		this.connectionFactory = (AbstractClientConnectionFactory) connectionFactory;
 		connectionFactory.registerListener(this);
 		connectionFactory.registerSender(this);
 	}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
@@ -96,4 +96,16 @@ public abstract class AbstractClientConnectionFactory extends AbstractConnection
 		return theConnection;
 	}
 
+	/**
+	 * Force close the connection and null the field if it's
+	 * a shared connection.
+	 * @param connection
+	 */
+	public void forceClose(TcpConnection connection) {
+		if (this.theConnection == connection) {
+			this.theConnection = null;
+		}
+		connection.close();
+	}
+
 }


### PR DESCRIPTION
**INT-2861**

Close connection after 'remoteTimeout' because the
socket is dirty (may contain an in-flight reply).

Add test that demonstrates the problem and that it
is resolved.

**INT-2862**

Remove entries from pendingReplies (map of async responses
for which we are waiting).

Add an assertion to the above test to ensure cleanup.

**cherry-pick to 2.1.x required**
