### PR TITLE
INT-2863 - allow the configuration of release strategies on resequencers

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
@@ -12,14 +12,13 @@
  */
 package org.springframework.integration.config.xml;
 
-import org.w3c.dom.Element;
-
 import org.springframework.beans.BeanMetadataElement;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.aggregator.AbstractCorrelatingMessageHandler;
 import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
 
 /**
  * Base class for parsers that create an instance of {@link AbstractCorrelatingMessageHandler}
@@ -38,6 +37,14 @@ public abstract class AbstractCorrelatingMessageHandlerParser extends AbstractCo
 
 	private static final String CORRELATION_STRATEGY_PROPERTY = "correlationStrategy";
 
+	private static final String RELEASE_STRATEGY_REF_ATTRIBUTE = "release-strategy";
+
+  private static final String RELEASE_STRATEGY_METHOD_ATTRIBUTE = "release-strategy-method";
+
+  private static final String RELEASE_STRATEGY_EXPRESSION_ATTRIBUTE = "release-strategy-expression";
+
+  private static final String RELEASE_STRATEGY_PROPERTY = "releaseStrategy";
+
 	private static final String MESSAGE_STORE_ATTRIBUTE = "message-store";
 
 	private static final String DISCARD_CHANNEL_ATTRIBUTE = "discard-channel";
@@ -50,6 +57,10 @@ public abstract class AbstractCorrelatingMessageHandlerParser extends AbstractCo
 		this.injectPropertyWithAdapter(CORRELATION_STRATEGY_REF_ATTRIBUTE, CORRELATION_STRATEGY_METHOD_ATTRIBUTE,
 				CORRELATION_STRATEGY_EXPRESSION_ATTRIBUTE, CORRELATION_STRATEGY_PROPERTY, "CorrelationStrategy",
 				element, builder, processor, parserContext);
+		this.injectPropertyWithAdapter(RELEASE_STRATEGY_REF_ATTRIBUTE, RELEASE_STRATEGY_METHOD_ATTRIBUTE,
+        RELEASE_STRATEGY_EXPRESSION_ATTRIBUTE, RELEASE_STRATEGY_PROPERTY, "ReleaseStrategy",
+        element, builder, processor, parserContext);
+
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, MESSAGE_STORE_ATTRIBUTE);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, DISCARD_CHANNEL_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, SEND_TIMEOUT_ATTRIBUTE);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AggregatorParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AggregatorParser.java
@@ -31,22 +31,14 @@ import org.w3c.dom.Element;
 /**
  * Parser for the <em>aggregator</em> element of the integration namespace. Registers the annotation-driven
  * post-processors.
- * 
+ *
  * @author Marius Bogoevici
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Dave Syer
  */
 public class AggregatorParser extends AbstractCorrelatingMessageHandlerParser {
-	
-	private static final String RELEASE_STRATEGY_REF_ATTRIBUTE = "release-strategy";
 
-	private static final String RELEASE_STRATEGY_METHOD_ATTRIBUTE = "release-strategy-method";
-
-	private static final String RELEASE_STRATEGY_EXPRESSION_ATTRIBUTE = "release-strategy-expression";
-	
-	private static final String RELEASE_STRATEGY_PROPERTY = "releaseStrategy";
-	
 	private static final String EXPIRE_GROUPS_UPON_COMPLETION = "expire-groups-upon-completion";
 
 	@Override
@@ -89,14 +81,10 @@ public class AggregatorParser extends AbstractCorrelatingMessageHandlerParser {
 			processorBuilder.getRawBeanDefinition().getConstructorArgumentValues().addGenericArgumentValue(method,
 					"java.lang.String");
 		}
-		
+
 		this.doParse(builder, element, processor, parserContext);
-		
+
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, EXPIRE_GROUPS_UPON_COMPLETION);
-		
-		this.injectPropertyWithAdapter(RELEASE_STRATEGY_REF_ATTRIBUTE, RELEASE_STRATEGY_METHOD_ATTRIBUTE,
-				RELEASE_STRATEGY_EXPRESSION_ATTRIBUTE, RELEASE_STRATEGY_PROPERTY, "ReleaseStrategy", element, builder,
-				processor, parserContext);
 
 		return builder;
 	}

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -3146,38 +3146,6 @@ is provided, the return value is expected to match a channel name exactly.
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
-				<xsd:attribute name="release-strategy" type="xsd:string">
-					<xsd:annotation>
-						<xsd:appinfo>
-							<tool:annotation kind="ref">
-								<tool:expected-type type="java.lang.Object" />
-							</tool:annotation>
-						</xsd:appinfo>
-						<xsd:documentation>
-							A reference to a bean that implements the release strategy.
-							The bean can be an implementation of the
-							ReleaseStrategy interface or a POJO
-						</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-				<xsd:attribute name="release-strategy-method" type="xsd:string">
-					<xsd:annotation>
-						<xsd:appinfo>
-							<tool:annotation>
-								<tool:expected-method type-ref="@release-strategy" />
-							</tool:annotation>
-						</xsd:appinfo>
-						<xsd:documentation>
-							A method defined on the bean referenced by release-strategy, that implements the completion
-							decision algorithm.
-						</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-				<xsd:attribute name="release-strategy-expression" type="xsd:string">
-					<xsd:annotation>
-						<xsd:documentation>A SpEL expression to evaluate against a root object that is the Collection of messages within the message group (e.g, size() > 6)</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
@@ -3219,6 +3187,38 @@ is provided, the return value is expected to match a channel name exactly.
 						 based on the 'id' of the 'person' attribute of the message payload object)</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
+                <xsd:attribute name="release-strategy" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo>
+                            <tool:annotation kind="ref">
+                                <tool:expected-type type="java.lang.Object" />
+                            </tool:annotation>
+                        </xsd:appinfo>
+                        <xsd:documentation>
+                            A reference to a bean that implements the release strategy.
+                            The bean can be an implementation of the
+                            ReleaseStrategy interface or a POJO
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="release-strategy-method" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo>
+                            <tool:annotation>
+                                <tool:expected-method type-ref="@release-strategy" />
+                            </tool:annotation>
+                        </xsd:appinfo>
+                        <xsd:documentation>
+                            A method defined on the bean referenced by release-strategy, that implements the completion
+                            decision algorithm.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="release-strategy-expression" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation>A SpEL expression to evaluate against a root object that is the Collection of messages within the message group (e.g, size() > 6)</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
 				<xsd:attribute name="discard-channel" type="xsd:string">
 					<xsd:annotation>
 						<xsd:appinfo>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/resequencerParserTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/resequencerParserTests.xml
@@ -45,6 +45,15 @@
 		input-channel="inputChannel4"
 		correlation-strategy="testCorrelationStrategyPojo"
 		correlation-strategy-method="foo"/>
+    
+    <resequencer id="resequencerWithReleaseStrategyRefOnly"
+        input-channel="inputChannel5"
+        release-strategy="testReleaseStrategy"/>
+        
+    <resequencer id="resequencerWithReleaseStrategyRefAndMethod"
+        input-channel="inputChannel6"
+        release-strategy="testReleaseStrategyPojo"
+        release-strategy-method="bar"/>
 
 	<beans:bean id="testCorrelationStrategy"
 		class="org.springframework.integration.config.ResequencerParserTests$TestCorrelationStrategy"/>
@@ -52,4 +61,9 @@
 	<beans:bean id="testCorrelationStrategyPojo"
 		class="org.springframework.integration.config.ResequencerParserTests$TestCorrelationStrategyPojo"/>
 
+    <beans:bean id="testReleaseStrategy"
+        class="org.springframework.integration.config.ResequencerParserTests$TestReleaseStrategy" />
+        
+    <beans:bean id="testReleaseStrategyPojo"
+        class="org.springframework.integration.config.ResequencerParserTests$TestReleaseStrategyPojo" />
 </beans:beans>


### PR DESCRIPTION
- adjust the xsd to allow the definition of a release strategy
- move release strategy parsing to AbstractCorrelatingMessageHandlerParser
- add unit tests

For reference see: https://jira.springsource.org/browse/INT-2863
