### PR TITLE
INT-2874 Fix JSON/JMS Incompatibility

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/json/ObjectToJsonTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/ObjectToJsonTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,13 @@ package org.springframework.integration.json;
 import java.io.StringWriter;
 
 import org.codehaus.jackson.map.ObjectMapper;
-
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.transformer.AbstractTransformer;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedCaseInsensitiveMap;
+import org.springframework.util.StringUtils;
 
 /**
  * Transformer implementation that converts a payload instance into a JSON string representation.
@@ -32,6 +32,7 @@ import org.springframework.util.LinkedCaseInsensitiveMap;
  * @author Mark Fisher
  * @author James Carr
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.0
  */
 public class ObjectToJsonTransformer extends AbstractTransformer {
@@ -61,7 +62,7 @@ public class ObjectToJsonTransformer extends AbstractTransformer {
 		// only null assertion is needed since "" is a valid value
 		Assert.notNull(contentType, "'contentType' must not be null");
 		this.contentTypeExplicitlySet = true;
-		this.contentType = contentType;
+		this.contentType = contentType.trim();
 	}
 
 	private String transformPayload(Object payload) throws Exception {
@@ -81,10 +82,15 @@ public class ObjectToJsonTransformer extends AbstractTransformer {
 		if (headers.containsKey(MessageHeaders.CONTENT_TYPE)) {
 			if (this.contentTypeExplicitlySet){
 				// override
-				headers.put(MessageHeaders.CONTENT_TYPE, this.contentType);
+				if (StringUtils.hasLength(this.contentType)) {
+					headers.put(MessageHeaders.CONTENT_TYPE, this.contentType);
+				}
+				else {
+					headers.remove(MessageHeaders.CONTENT_TYPE);
+				}
 			}
 		}
-		else {
+		else if (StringUtils.hasLength(this.contentType)) {
 			headers.put(MessageHeaders.CONTENT_TYPE, this.contentType);
 		}
 		messageBuilder.copyHeaders(headers);

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/ObjectToJsonTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/ObjectToJsonTransformer.java
@@ -81,12 +81,9 @@ public class ObjectToJsonTransformer extends AbstractTransformer {
 
 		if (headers.containsKey(MessageHeaders.CONTENT_TYPE)) {
 			if (this.contentTypeExplicitlySet){
-				// override
+				// override, unless empty
 				if (StringUtils.hasLength(this.contentType)) {
 					headers.put(MessageHeaders.CONTENT_TYPE, this.contentType);
-				}
-				else {
-					headers.remove(MessageHeaders.CONTENT_TYPE);
 				}
 			}
 		}

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -2107,9 +2107,12 @@
 		<xsd:attribute name="content-type" use="optional">
 			<xsd:annotation>
 				<xsd:documentation>
-					Allows you to set 'content-type' Message header. In the case that a content-type header is already present,
-					we will only override that value IF this attribute is explicitely set with
-					content-type value (e.g., content-type="text/xml")
+					Allows you to set the 'content-type' Message header. When a 'content-type' header is already present
+					on the input message, the transformer will only override that value IF this attribute is explicitly set
+					(e.g., content-type="text/x-json"). Setting the attribute to an empty string ("")
+					will suppress setting the header, including removal of the header, if present on the input message.
+					If this attribute is omitted, the transformer will set the 'content-type' header to "application/json",
+					when there is no existing 'content-type' header on the input message.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -2106,14 +2106,17 @@
 		</xsd:choice>
 		<xsd:attribute name="content-type" use="optional">
 			<xsd:annotation>
-				<xsd:documentation>
+				<xsd:documentation><![CDATA[
 					Allows you to set the 'content-type' Message header. When a 'content-type' header is already present
 					on the input message, the transformer will only override that value IF this attribute is explicitly set
-					(e.g., content-type="text/x-json"). Setting the attribute to an empty string ("")
-					will suppress setting the header, including removal of the header, if present on the input message.
+					(e.g., content-type="text/x-json").
 					If this attribute is omitted, the transformer will set the 'content-type' header to "application/json",
 					when there is no existing 'content-type' header on the input message.
-				</xsd:documentation>
+					Setting the attribute to an empty string ("")
+					will suppress setting the header to the default value,
+					but will not remove the header, if present on the input message. If you wish to remove an existing
+					header, use a <header-filter/> before or after the transformer.
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="object-mapper" use="optional">

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.json;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -31,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
+import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
@@ -40,12 +42,13 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.0
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ObjectToJsonTransformerParserTests {
-	
+
 	@Autowired
 	private volatile ApplicationContext context;
 
@@ -56,10 +59,14 @@ public class ObjectToJsonTransformerParserTests {
 	private volatile MessageChannel customObjectMapperInput;
 
 	@Test
-	public void testContextType(){
-		ObjectToJsonTransformer transformer = 
+	public void testContentType(){
+		ObjectToJsonTransformer transformer =
 				TestUtils.getPropertyValue(context.getBean("defaultTransformer"), "handler.transformer", ObjectToJsonTransformer.class);
 		assertEquals("application/json", TestUtils.getPropertyValue(transformer, "contentType"));
+
+		Message<?> transformed = transformer.transform(MessageBuilder.withPayload("foo").build());
+		assertTrue(transformed.getHeaders().containsKey(MessageHeaders.CONTENT_TYPE));
+		assertEquals("application/json", transformed.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 
 		transformer =
 				TestUtils.getPropertyValue(context.getBean("customTransformer"), "handler.transformer", ObjectToJsonTransformer.class);
@@ -68,6 +75,12 @@ public class ObjectToJsonTransformerParserTests {
 		transformer =
 				TestUtils.getPropertyValue(context.getBean("emptyContentTypeTransformer"), "handler.transformer", ObjectToJsonTransformer.class);
 		assertEquals("", TestUtils.getPropertyValue(transformer, "contentType"));
+
+		transformed = transformer.transform(MessageBuilder.withPayload("foo").build());
+		assertFalse(transformed.getHeaders().containsKey(MessageHeaders.CONTENT_TYPE));
+
+		transformed = transformer.transform(MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "foo").build());
+		assertFalse(transformed.getHeaders().containsKey(MessageHeaders.CONTENT_TYPE));
 
 		transformer =
 				TestUtils.getPropertyValue(context.getBean("overridenContentTypeTransformer"), "handler.transformer", ObjectToJsonTransformer.class);

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests.java
@@ -80,7 +80,8 @@ public class ObjectToJsonTransformerParserTests {
 		assertFalse(transformed.getHeaders().containsKey(MessageHeaders.CONTENT_TYPE));
 
 		transformed = transformer.transform(MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "foo").build());
-		assertFalse(transformed.getHeaders().containsKey(MessageHeaders.CONTENT_TYPE));
+		assertNotNull(transformed.getHeaders().get(MessageHeaders.CONTENT_TYPE));
+		assertEquals("foo", transformed.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 
 		transformer =
 				TestUtils.getPropertyValue(context.getBean("overridenContentTypeTransformer"), "handler.transformer", ObjectToJsonTransformer.class);

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.json;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.regex.Matcher;
@@ -76,7 +75,7 @@ public class ObjectToJsonTransformerTests {
 		transformer.setContentType("");
 		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "text/xml").build();
 		Message<?> result = transformer.transform(message);
-		assertNull(result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
+		assertEquals("text/xml", result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test(expected=IllegalArgumentException.class)

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,25 @@
 
 package org.springframework.integration.json;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.codehaus.jackson.JsonGenerator.Feature;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
-
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.0
  */
 public class ObjectToJsonTransformerTests {
@@ -75,9 +76,9 @@ public class ObjectToJsonTransformerTests {
 		transformer.setContentType("");
 		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "text/xml").build();
 		Message<?> result = transformer.transform(message);
-		assertEquals("", result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
+		assertNull(result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 	}
-	
+
 	@Test(expected=IllegalArgumentException.class)
 	public void withProvidedContentTypeAsNull() throws Exception {
 		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
@@ -55,8 +55,6 @@ public class DefaultJmsHeaderMapper implements JmsHeaderMapper {
 	private static List<Class<?>> SUPPORTED_PROPERTY_TYPES = Arrays.asList(new Class<?>[] {
 			Boolean.class, Byte.class, Double.class, Float.class, Integer.class, Long.class, Short.class, String.class });
 
-	private static final String JMS_COMPATIBLE_CONTENT_TYPE_PROPERTY = "content_type";
-
 
 	private final Log logger = LogFactory.getLog(this.getClass());
 
@@ -238,7 +236,7 @@ public class DefaultJmsHeaderMapper implements JmsHeaderMapper {
 			propertyName = this.outboundPrefix + headerName;
 		}
 		else if (MessageHeaders.CONTENT_TYPE.equals(headerName)) {
-			propertyName = JMS_COMPATIBLE_CONTENT_TYPE_PROPERTY;
+			propertyName = CONTENT_TYPE_PROPERTY;
 		}
 		return propertyName;
 	}
@@ -252,7 +250,7 @@ public class DefaultJmsHeaderMapper implements JmsHeaderMapper {
 		if (StringUtils.hasText(this.inboundPrefix) && !headerName.startsWith(this.inboundPrefix)) {
 			headerName = this.inboundPrefix + propertyName;
 		}
-		else if (JMS_COMPATIBLE_CONTENT_TYPE_PROPERTY.equals(propertyName)) {
+		else if (CONTENT_TYPE_PROPERTY.equals(propertyName)) {
 			headerName = MessageHeaders.CONTENT_TYPE;
 		}
 		return headerName;

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsHeaderMapper.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,14 @@ import org.springframework.integration.mapping.HeaderMapper;
  * Strategy interface for mapping integration Message headers to an outbound
  * JMS Message (e.g. to configure JMS properties) or extracting integration
  * header values from an inbound JMS Message.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
-public interface JmsHeaderMapper extends HeaderMapper<Message> {}
+public interface JmsHeaderMapper extends HeaderMapper<Message> {
+
+	static final String CONTENT_TYPE_PROPERTY = "content_type";
+
+}
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/DefaultJmsHeaderMapperTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/DefaultJmsHeaderMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,14 +28,13 @@ import javax.jms.Destination;
 import javax.jms.JMSException;
 
 import org.junit.Test;
-
 import org.springframework.integration.Message;
-import org.springframework.integration.jms.DefaultJmsHeaderMapper;
-import org.springframework.integration.jms.JmsHeaders;
+import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.support.MessageBuilder;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public class DefaultJmsHeaderMapperTests {
 
@@ -113,6 +112,19 @@ public class DefaultJmsHeaderMapperTests {
 		javax.jms.Message jmsMessage = new StubTextMessage();
 		mapper.fromHeaders(message.getHeaders(), jmsMessage);
 		assertNull(jmsMessage.getJMSType());
+	}
+
+	@Test
+	public void testContentTypePropertyMappedFromHeader() throws JMSException {
+		Message<String> message = MessageBuilder.withPayload("test")
+				.setHeader(MessageHeaders.CONTENT_TYPE, "foo")
+				.build();
+		DefaultJmsHeaderMapper mapper = new DefaultJmsHeaderMapper();
+		javax.jms.Message jmsMessage = new StubTextMessage();
+		mapper.fromHeaders(message.getHeaders(), jmsMessage);
+		Object value = jmsMessage.getObjectProperty("content_type");
+		assertNotNull(value);
+		assertEquals("foo", value);
 	}
 
 	@Test
@@ -215,6 +227,17 @@ public class DefaultJmsHeaderMapperTests {
 		Object attrib = headers.get(JmsHeaders.TIMESTAMP);
 		assertNotNull(attrib);
 		assertEquals(timestamp, attrib);
+	}
+
+	@Test
+	public void testContentTypePropertyMappedToHeader() throws JMSException {
+		javax.jms.Message jmsMessage = new StubTextMessage();
+		jmsMessage.setStringProperty("content_type", "foo");
+		DefaultJmsHeaderMapper mapper = new DefaultJmsHeaderMapper();
+		Map<String, Object> headers = mapper.toHeaders(jmsMessage);
+		Object attrib = headers.get(MessageHeaders.CONTENT_TYPE);
+		assertNotNull(attrib);
+		assertEquals("foo", attrib);
 	}
 
 	@Test

--- a/src/reference/docbook/transformer.xml
+++ b/src/reference/docbook/transformer.xml
@@ -230,8 +230,18 @@ public class Kid {
     <important>
      <para>
       Beginning with version 2.2, the <code>object-to-json-transformer</code> sets the <emphasis>content-type</emphasis>
-      header to <emphasis>application/json</emphasis>, by default. It can be overridden using the <code>content-type</code>
-      attribute. The default behavior has a side affect - causing applications with the following
+      header to <code>application/json</code>, by default, if the input message does not already have that header
+      present.
+     </para>
+     <para>
+      It you wish to set the <emphasis>content type</emphasis> header to some other value, or explicitly overwrite any existing header
+      with some value (including <code>application/json</code>), use the <code>content-type</code>
+      attribute. If you wish to completely suppress the setting of the header, set the <code>content-type</code>
+      attribute to an empty string (<code>""</code>). This will result in a message with no <code>content-type</code>
+      header, even if such a header was present on the input message.
+     </para>
+     <para>
+      The behavior of adding the default header has a side affect - causing applications with the following
       sequence to fail:
      </para>
      <para>

--- a/src/reference/docbook/transformer.xml
+++ b/src/reference/docbook/transformer.xml
@@ -236,9 +236,9 @@ public class Kid {
      <para>
       It you wish to set the <emphasis>content type</emphasis> header to some other value, or explicitly overwrite any existing header
       with some value (including <code>application/json</code>), use the <code>content-type</code>
-      attribute. If you wish to completely suppress the setting of the header, set the <code>content-type</code>
+      attribute. If you wish to suppress the setting of the header, set the <code>content-type</code>
       attribute to an empty string (<code>""</code>). This will result in a message with no <code>content-type</code>
-      header, even if such a header was present on the input message.
+      header, unless such a header was present on the input message.
      </para>
      <para>
       The behavior of adding the default header has a side affect - causing applications with the following


### PR DESCRIPTION
https://jira.springsource.org/browse/INT-2874

2.2.0 changed ObjectToJsonTransformer to add content-type to
simplify AMQP applications.

However, in a JMS environment, the DefaultJmsHeaderMapper attempted
to map (and failed) to map the header, emitting a warning log entry.

JMS does not allow '-' in property names.

Add code such that:
1. If the ObjectToJsonTransformer is configured to use a
   content-type of an empty String (after trimming), suppress the
   addition of the header to the output message. For consistency, if
   the inbound message already has a content type header, and the transformer
   is configured with an empty String, remove the header.
2. Change the DefaultJmsHeaderMapper to map the MessageHeaders.CONTENT_TYPE
   header (content-type) to/from a JMS compliant property name (content_type).
