### PR TITLE
INT-2838 Allow @bean Expressions in (S)FTP Out

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -192,6 +192,9 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 						"Failure during initialization of: " + this.getComponentType(), e);
 			}
 		}
+		if (this.getBeanFactory() != null) {
+			this.processor.setBeanFactory(this.getBeanFactory());
+		}
 	}
 
 	@Override

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/handler/FileTransferringMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/handler/FileTransferringMessageHandler.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.expression.Expression;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageDeliveryException;
@@ -64,6 +65,8 @@ public class FileTransferringMessageHandler<F> extends AbstractMessageHandler {
 	private volatile ExpressionEvaluatingMessageProcessor<String> temporaryDirectoryExpressionProcessor;
 
 	private volatile FileNameGenerator fileNameGenerator = new DefaultFileNameGenerator();
+
+	private volatile boolean fileNameGeneratorSet;
 
 	private volatile File temporaryDirectory = new File(System.getProperty("java.io.tmpdir"));
 
@@ -120,6 +123,7 @@ public class FileTransferringMessageHandler<F> extends AbstractMessageHandler {
 
 	public void setFileNameGenerator(FileNameGenerator fileNameGenerator) {
 		this.fileNameGenerator = (fileNameGenerator != null) ? fileNameGenerator : new DefaultFileNameGenerator();
+		this.fileNameGeneratorSet = fileNameGenerator != null;
 	}
 
 	public void setCharset(String charset) {
@@ -141,8 +145,8 @@ public class FileTransferringMessageHandler<F> extends AbstractMessageHandler {
 			if (this.temporaryDirectoryExpressionProcessor != null) {
 				this.temporaryDirectoryExpressionProcessor.setBeanFactory(beanFactory);
 			}
-			if (this.fileNameGenerator instanceof DefaultFileNameGenerator) {
-				((DefaultFileNameGenerator) this.fileNameGenerator).setBeanFactory(beanFactory);
+			if (!this.fileNameGeneratorSet && this.fileNameGenerator instanceof BeanFactoryAware) {
+				((BeanFactoryAware) this.fileNameGenerator).setBeanFactory(beanFactory);
 			}
 		}
 		if (this.autoCreateDirectory){

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/handler/FileTransferringMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/handler/FileTransferringMessageHandler.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.expression.Expression;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageDeliveryException;
@@ -134,6 +135,16 @@ public class FileTransferringMessageHandler<F> extends AbstractMessageHandler {
 	@Override
 	protected void onInit() throws Exception {
 		Assert.notNull(this.directoryExpressionProcessor, "remoteDirectoryExpression is required");
+		BeanFactory beanFactory = this.getBeanFactory();
+		if (beanFactory != null) {
+			this.directoryExpressionProcessor.setBeanFactory(beanFactory);
+			if (this.temporaryDirectoryExpressionProcessor != null) {
+				this.temporaryDirectoryExpressionProcessor.setBeanFactory(beanFactory);
+			}
+			if (this.fileNameGenerator instanceof DefaultFileNameGenerator) {
+				((DefaultFileNameGenerator) this.fileNameGenerator).setBeanFactory(beanFactory);
+			}
+		}
 		if (this.autoCreateDirectory){
 			Assert.hasText(this.remoteFileSeparator, "'remoteFileSeparator' must not be empty when 'autoCreateDirectory' is set to 'true'");
 		}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests-context.xml
@@ -76,4 +76,24 @@
 	<bean id="fileNameGenerator" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.integration.file.FileNameGenerator"/>
 	</bean>
+
+	<int-ftp:outbound-channel-adapter id="withBeanExpressions"
+		channel="ftpChannel"
+		remote-directory-expression="@fooBean"
+		temporary-remote-directory-expression="@barBean"
+		remote-filename-generator-expression="@bazBean"
+		session-factory="cachingSessionFactory" />
+
+	<bean id="fooBean" class="java.lang.String">
+		<constructor-arg value="foo" />
+	</bean>
+
+	<bean id="barBean" class="java.lang.String">
+		<constructor-arg value="bar" />
+	</bean>
+
+	<bean id="bazBean" class="java.lang.String">
+		<constructor-arg value="baz" />
+	</bean>
+
 </beans>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
@@ -47,6 +47,25 @@
 		</int-ftp:request-handler-advice-chain>
 	</int-ftp:outbound-gateway>
 
+	<int-ftp:outbound-gateway id="withBeanExpression"
+		local-directory="local-test-dir"
+		session-factory="sf"
+		request-channel="inbound3"
+		reply-channel="outbound"
+		auto-startup="false"
+		cache-sessions="false"
+		filename-pattern="*"
+		remote-file-separator="X"
+		command="ls"
+		command-options="-1 -f"
+		expression="@fooBean"
+		order="1"
+		/>
+
 	<int:channel id="outbound"/>
+
+	<bean id="fooBean" class="java.lang.String">
+		<constructor-arg value="foo" />
+	</bean>
 
 </beans>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
@@ -30,8 +30,10 @@ import org.springframework.integration.Message;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.file.remote.session.CachingSessionFactory;
 import org.springframework.integration.ftp.gateway.FtpOutboundGateway;
+import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -53,6 +55,9 @@ public class FtpOutboundGatewayParserTests {
 
 	@Autowired
 	AbstractEndpoint gateway2;
+
+	@Autowired
+	AbstractEndpoint withBeanExpression;
 
 	private static volatile int adviceCalled;
 
@@ -92,6 +97,16 @@ public class FtpOutboundGatewayParserTests {
 		assertTrue(options.contains("-P"));
 		gateway.handleMessage(new GenericMessage<String>("foo"));
 		assertEquals(1, adviceCalled);
+	}
+
+	@Test
+	public void testWithBeanExpression() {
+		FtpOutboundGateway gateway = TestUtils.getPropertyValue(withBeanExpression,
+				"handler", FtpOutboundGateway.class);
+		ExpressionEvaluatingMessageProcessor<?> processor = TestUtils.getPropertyValue(gateway, "processor",
+				ExpressionEvaluatingMessageProcessor.class);
+		assertNotNull(processor);
+		assertEquals("foo", processor.processMessage(MessageBuilder.withPayload("bar").build()));
 	}
 
 	public static class FooAdvice extends AbstractRequestHandlerAdvice {


### PR DESCRIPTION
The message processors previously did not have a bean
resolver.

Add the bean factory; add tests.
