### PR TITLE
INT-2880 fix System.out concurrent race condition

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserTests-context.xml
@@ -100,7 +100,7 @@
 		<outbound-channel-adapter ref="testConsumer"/>
 	</chain>
 
-	<chain input-channel="loggingChannelAdapterChannel">
+	<chain id="logChain" input-channel="loggingChannelAdapterChannel">
 		<transformer expression="payload.toUpperCase()"/>
 		<logging-channel-adapter level="WARN"/>
 	</chain>


### PR DESCRIPTION
Gradle may run tests via multi-threaded way.
Using shared resources (e.g. `System.out`) may produce concurrency issues.
- Add first `synchronized (System.out)` to ensure that current Thread waits lock on resource
- Add second `synchronized (System.out)` to ensure that current Thread takes lock from other Threads on replaced resource

JIRA: https://jira.springsource.org/browse/INT-2880
