### PR TITLE
INT-2889 Fix Concurrency Problem in Type Converter

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/BeanFactoryTypeConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/BeanFactoryTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,8 +118,11 @@ public class BeanFactoryTypeConverter implements TypeConverter, BeanFactoryAware
 				editor = delegate.getDefaultEditor(sourceType.getType());
 			}
 			if (editor != null) { // INT-1441
-				editor.setValue(value);
-				String text = editor.getAsText();
+				String text = null;
+				synchronized (editor) {
+					editor.setValue(value);
+					text = editor.getAsText();
+				}
 				if (String.class.isAssignableFrom(targetType.getClass())) {
 					return text;
 				}


### PR DESCRIPTION
In the BeanFactoryTypeConverter, when falling
back to a PropertyEditor (when the source is non-
String and the target is String), the setValue() and getAsText()
methods are used.

This is not thread-safe and one thread might get another's
converted value.

Synchronize the use of the PropertyEditor.

Add test, that reliably reproduces the problem, to verify the
fix.

**cherry-pick to 2.1.x**
