### PR TITLE
INT-2890 Remove Hard-Coded Port from HTTP Tests

### DIFF
--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context-fail.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context-fail.xml
@@ -7,8 +7,9 @@
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http.xsd">
 
+	<bean id="portBean" class="org.springframework.integration.http.config.OutboundResponseTypeTests$Port" />
 
-	<int-http:outbound-gateway url="http://localhost:51235/testApps/outboundResponse"
+	<int-http:outbound-gateway url="http://localhost:#{portBean.port}/testApps/outboundResponse"
 							   request-channel="resTypeSetChannel"
 							   reply-channel="replyChannel"
 							   expected-response-type="java.lang.String"

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context.xml
@@ -9,27 +9,28 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+	<bean id="portBean" class="org.springframework.integration.http.config.OutboundResponseTypeTests$Port" />
 
-	<int-http:outbound-gateway url="http://localhost:51235/testApps/outboundResponse"
+	<int-http:outbound-gateway url="http://localhost:#{portBean.port}/testApps/outboundResponse"
 							   request-channel="requestChannel"
 							   reply-channel="replyChannel"/>
 
-	<int-http:outbound-gateway url="http://localhost:51235/testApps/outboundResponse"
+	<int-http:outbound-gateway url="http://localhost:#{portBean.port}/testApps/outboundResponse"
 							   request-channel="resTypeSetChannel"
 							   reply-channel="replyChannel"
 							   expected-response-type="java.lang.String"/>
 
-	<int-http:outbound-gateway url="http://localhost:51235/testApps/outboundResponse"
+	<int-http:outbound-gateway url="http://localhost:#{portBean.port}/testApps/outboundResponse"
 							   request-channel="resPrimitiveStringPresentationChannel"
 							   reply-channel="replyChannel"
 							   expected-response-type="[B"/>
 
-	<int-http:outbound-gateway url="http://localhost:51235/testApps/outboundResponse"
+	<int-http:outbound-gateway url="http://localhost:#{portBean.port}/testApps/outboundResponse"
 							   request-channel="resTypeExpressionSetChannel"
 							   reply-channel="replyChannel"
 							   expected-response-type-expression="payload"/>
 
-	<int-http:outbound-gateway url="http://localhost:51235/testApps/outboundResponse"
+	<int-http:outbound-gateway url="http://localhost:#{portBean.port}/testApps/outboundResponse"
 							   request-channel="resTypeExpressionSetSerializationChannel"
 							   reply-channel="replyChannel"
 							   message-converters="stringAndSerializingConverters"

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.util.SocketUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -79,10 +80,12 @@ public class OutboundResponseTypeTests {
 	@Autowired
 	private MessageChannel resTypeExpressionSetSerializationChannel;
 
+	private static int port = SocketUtils.findAvailableServerSocket();
+
 	@BeforeClass
 	public static void createServer() throws Exception {
 		httpHandler = new MyHandler();
-		server = HttpServer.create(new InetSocketAddress(51235), 0);
+		server = HttpServer.create(new InetSocketAddress(port), 0);
 		server.createContext("/testApps/outboundResponse", httpHandler);
 		server.start();
 	}
@@ -178,4 +181,13 @@ public class OutboundResponseTypeTests {
 			os.close();
 		}
 	}
+
+	public static class Port {
+
+		public String getPort() {
+			return Integer.toString(port);
+		}
+
+	}
+
 }


### PR DESCRIPTION
Conflicts with other ports on build server.

Use SocketUtils to find an available port.
