### PR TITLE
INT-2894 Do Not Leak ThrowableHolderException

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
@@ -111,7 +111,37 @@ public abstract class AbstractRequestHandlerAdvice extends IntegrationObjectSupp
 	protected abstract Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) throws Exception;
 
 	/**
-	 * Called by subclasses in doInvoke() to proceed() the invocation.
+	 * Unwrap the cause of a {@link ThrowableHolderException}.
+	 * @param e The exception.
+	 * @return The cause, or e, if not a {@link ThrowableHolderException}
+	 */
+	protected Exception unwrapExceptionIfNecessary(Exception e) {
+		Exception actualException = e;
+		if (e instanceof ThrowableHolderException) {
+			if (e.getCause() instanceof Exception) {
+				actualException = (Exception) e.getCause();
+			}
+		}
+		return actualException;
+	}
+
+	/**
+	 * Unwrap the cause of a {@link ThrowableHolderException}.
+	 * @param e The exception.
+	 * @return The cause, or e, if not a {@link ThrowableHolderException}
+	 */
+	protected Throwable unwrapThrowableIfNecessary(Exception e) {
+		Throwable actualThrowable = e;
+		if (e instanceof ThrowableHolderException) {
+			actualThrowable = e.getCause();
+		}
+		return actualThrowable;
+	}
+
+	/**
+	 * Called by subclasses in doInvoke() to proceed() the invocation. Callers
+	 * unwrap {@link ThrowableHolderException}s and use the cause for evaluation and re-throwing purposes.
+	 * See {@link AbstractRequestHandlerAdvice#unwrapExceptionIfNecessary(Exception)}.
 	 *
 	 */
 	protected interface ExecutionCallback {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ExpressionEvaluatingRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ExpressionEvaluatingRequestHandlerAdvice.java
@@ -120,14 +120,15 @@ public class ExpressionEvaluatingRequestHandlerAdvice extends AbstractRequestHan
 			return result;
 		}
 		catch (Exception e) {
+			Exception actualException = this.unwrapExceptionIfNecessary(e);
 			if (this.onFailureExpression != null) {
-				Object evalResult = this.evaluateFailureExpression(message, e);
+				Object evalResult = this.evaluateFailureExpression(message, actualException);
 				if (this.returnFailureExpressionResult) {
 					return evalResult;
 				}
 			}
 			if (!this.trapException) {
-				throw e;
+				throw actualException;
 			}
 			return null;
 		}
@@ -163,7 +164,7 @@ public class ExpressionEvaluatingRequestHandlerAdvice extends AbstractRequestHan
 		}
 		if (evalResult != null && this.failureChannel != null) {
 			MessagingException messagingException = new MessageHandlingExpressionEvaluatingAdviceException(message,
-					"Handler Failed", exception, evalResult);
+					"Handler Failed", this.unwrapThrowableIfNecessary(exception), evalResult);
 			ErrorMessage resultMessage = new ErrorMessage(messagingException);
 			this.messagingTemplate.send(this.failureChannel, resultMessage);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerCircuitBreakerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerCircuitBreakerAdvice.java
@@ -68,7 +68,7 @@ public class RequestHandlerCircuitBreakerAdvice extends AbstractRequestHandlerAd
 		catch (Exception e) {
 			metadata.getFailures().incrementAndGet();
 			metadata.setLastFailure(System.currentTimeMillis());
-			throw e;
+			throw this.unwrapExceptionIfNecessary(e);
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
@@ -93,7 +93,8 @@ public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice
 						throw e;
 					}
 					catch (Exception e) {
-						throw new MessagingException(message, "Failed to invoke handler", e);
+						throw new MessagingException(message, "Failed to invoke handler",
+								unwrapExceptionIfNecessary(e));
 					}
 				}
 			}, this.recoveryCallback, retryState);


### PR DESCRIPTION
The AbstractRequestHandlerAdvice uses an internal wrapper for
Throwable, in a similar fashion to the TransactionInterceptor.

Exceptions are unwrapped properly when exiting the invoke method so
callers are unaware of the wrapping.

The technique is used to avoid user errors (for example catching OOM
Errors and not propagating). User code (subclasses) only catch
Exceptions.

However, in the case of the ExpressionEvaluatingRequestHandlerAdvice,
the exception is included in any ErrorMessage sent to a failureChannel.

User code should not have to navigate these internal exceptions within
the cause tree.

Add a method to the abstract class unwrapExceptionIfNecessary, which
will unwrap the root cause exception if possible.

Add a method to the abstract class unwrapThrowableIfNecessary, which
will unwrap the root cause Throwable if possible.

Update tests to reduce the cause() traversals to refelect the
ThrowableHolderExceptions are no longer in the tree.

Add a test to verify a Throwable (such as an OOM) is properly
propagated.

Add a test to verify that when the root cause is a Throwable (and not
an Exception), the ErrorMessage sent to the failureChannel does not include
the ThrowableHolderException.
