### PR TITLE
INT-2899: fix aggregator overhead on startup

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2011 the original author or authors.
- * 
+ * Copyright 2002-2013 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -14,58 +14,69 @@
 package org.springframework.integration.aggregator;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.Iterator;
 
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.integration.Message;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 
 /**
- * Aggregator specific implementation of {@link AbstractCorrelatingMessageHandler}. 
- * Will remove {@link MessageGroup}s only if 'expireGroupsUponCompletion' flag is set to 'true'.
+ * Aggregator specific implementation of {@link AbstractCorrelatingMessageHandler}.
+ * Will remove {@link MessageGroup}s only if {@linkplain #expireGroupsUponCompletion} flag is set to <code>true</code>.
  *
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  * @since 2.1
  */
-public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler {
+public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler
+		implements ApplicationListener<ContextRefreshedEvent> {
+
+	private volatile boolean initialized = false;
 
 	private volatile boolean expireGroupsUponCompletion = false;
 
 	public AggregatingMessageHandler(MessageGroupProcessor processor, MessageGroupStore store,
-			CorrelationStrategy correlationStrategy, ReleaseStrategy releaseStrategy) {
+									 CorrelationStrategy correlationStrategy, ReleaseStrategy releaseStrategy) {
 		super(processor, store, correlationStrategy, releaseStrategy);
 	}
 
 	public AggregatingMessageHandler(MessageGroupProcessor processor, MessageGroupStore store) {
 		super(processor, store);
 	}
-	
+
 	public AggregatingMessageHandler(MessageGroupProcessor processor) {
 		super(processor);
 	}
 
 	/**
-	 * Will set the 'expireGroupsUponCompletion' flag and if it is 
-	 * set to 'true' it will also remove all 'complete' {@link MessageGroup}s
+	 * Will set the {@linkplain #expireGroupsUponCompletion} flag and if it is
+	 * set to <code>true</code> and if {@linkplain #initialized} is set to <code>true</code> too,
+	 * it will also remove all 'complete' {@link MessageGroup}s
+	 *
 	 * @param expireGroupsUponCompletion
+	 *
+	 * @see #removeCompleteMessageGroups
 	 */
 	public void setExpireGroupsUponCompletion(boolean expireGroupsUponCompletion) {
 		this.expireGroupsUponCompletion = expireGroupsUponCompletion;
-		if (expireGroupsUponCompletion) {
-			Iterator<MessageGroup> messageGroups = this.messageStore.iterator();
-			while (messageGroups.hasNext()) {
-				MessageGroup messageGroup = messageGroups.next();
-				if (messageGroup.isComplete()) {
-					remove(messageGroup);
-				}
-			}
+		if (expireGroupsUponCompletion && this.initialized) {
+			this.removeCompleteMessageGroups();
 		}
+	}
+
+	@Override
+	protected void onInit() throws Exception {
+		super.onInit();
+		this.initialized = true;
 	}
 
 	@Override
 	protected void afterRelease(MessageGroup messageGroup, Collection<Message<?>> completedMessages) {
 		this.messageStore.completeGroup(messageGroup.getGroupId());
-		
+
 		if (this.expireGroupsUponCompletion) {
 			remove(messageGroup);
 		}
@@ -73,7 +84,44 @@ public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler
 			for (Message<?> message : messageGroup.getMessages()) {
 				this.messageStore.removeMessageFromGroup(messageGroup.getGroupId(), message);
 			}
-		}	
+		}
+	}
+
+	private void removeCompleteMessageGroups() {
+		Iterator<MessageGroup> messageGroups = this.messageStore.iterator();
+		while (messageGroups.hasNext()) {
+			MessageGroup messageGroup = messageGroups.next();
+			if (messageGroup.isComplete()) {
+				this.remove(messageGroup);
+			}
+		}
+
+	}
+
+	/**
+	 * Handles {@link ContextRefreshedEvent} to schedules the task for {@linkplain #removeCompleteMessageGroups}
+	 * as late as possible after application context startup.
+	 * Also it checks equality of event's <code>applicationContext</code> and
+	 * provided <code>beanFactory</code> to ignore other {@link ContextRefreshedEvent}s
+	 * which may be published in the 'parent-child' contexts, e.g. in the Spring-MVC applications.
+	 * This behavior is dictated by the avoidance of invocation thread overload,
+	 * especially when the provided {@link MessageGroupStore} is persistent.
+	 *
+	 * @param event - {@link ContextRefreshedEvent} which occurs
+	 *              after Application context is completely initialized.
+	 *
+	 * @see #removeCompleteMessageGroups
+	 */
+	public void onApplicationEvent(ContextRefreshedEvent event) {
+		if (event.getApplicationContext().equals(this.getBeanFactory())) {
+			if (this.expireGroupsUponCompletion) {
+				this.getTaskScheduler().schedule(new Runnable() {
+					public void run() {
+						AggregatingMessageHandler.this.removeCompleteMessageGroups();
+					}
+				}, new Date());
+			}
+		}
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -23,7 +23,6 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.integration.Message;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
-import org.springframework.util.StopWatch;
 
 /**
  * Aggregator specific implementation of {@link AbstractCorrelatingMessageHandler}.

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorSupportedUseCasesTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorSupportedUseCasesTests.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2011 the original author or authors.
- * 
+ * Copyright 2002-2013 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -13,9 +13,23 @@
 
 package org.springframework.integration.aggregator.integration;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.integration.aggregator.AggregatingMessageHandler;
 import org.springframework.integration.aggregator.DefaultAggregatingMessageGroupProcessor;
 import org.springframework.integration.aggregator.ReleaseStrategy;
@@ -24,22 +38,24 @@ import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.integration.support.MessageBuilder;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import org.springframework.integration.test.util.TestUtils;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  *
  */
 public class AggregatorSupportedUseCasesTests {
-	
+
 	private MessageGroupStore store = new SimpleMessageStore(100);
-	
+
 	private DefaultAggregatingMessageGroupProcessor processor = new DefaultAggregatingMessageGroupProcessor();
-	
+
 	private AggregatingMessageHandler defaultHandler = new AggregatingMessageHandler(processor, store);
+
+	{
+		defaultHandler.afterPropertiesSet();
+	}
 
 	@Test
 	public void waitForAllDefaultReleaseStrategyWithLateArrivals(){
@@ -47,25 +63,25 @@ public class AggregatorSupportedUseCasesTests {
 		QueueChannel discardChannel = new QueueChannel();
 		defaultHandler.setOutputChannel(outputChannel);
 		defaultHandler.setDiscardChannel(discardChannel);
-		
+
 		for (int i = 0; i < 5; i++) {
 			defaultHandler.handleMessage(MessageBuilder.withPayload(i).setSequenceSize(5).setCorrelationId("A").setSequenceNumber(i).build());
 		}
 		assertEquals(5, ((List<?>)outputChannel.receive(0).getPayload()).size());
 		assertNull(discardChannel.receive(0));
 		assertEquals(0, store.getMessageGroup("A").getMessages().size());
-		
+
 		// send another message with the same correlation id and see it in the discard channel
 		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setSequenceSize(5).setCorrelationId("A").setSequenceNumber(3).build());
 		assertNotNull(discardChannel.receive(0));
-		
+
 		// set 'expireGroupsUponCompletion' to 'true' and the messages should start accumulating again
 		defaultHandler.setExpireGroupsUponCompletion(true);
 		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setSequenceSize(5).setCorrelationId("A").setSequenceNumber(3).build());
 		assertNull(discardChannel.receive(0));
 		assertEquals(1, store.getMessageGroup("A").getMessages().size());
 	}
-	
+
 	@Test
 	public void waitForAllCustomReleaseStrategyWithLateArrivals(){
 		QueueChannel outputChannel = new QueueChannel();
@@ -73,25 +89,25 @@ public class AggregatorSupportedUseCasesTests {
 		defaultHandler.setOutputChannel(outputChannel);
 		defaultHandler.setDiscardChannel(discardChannel);
 		defaultHandler.setReleaseStrategy(new SampleSizeReleaseStrategy());
-		
+
 		for (int i = 0; i < 5; i++) {
 			defaultHandler.handleMessage(MessageBuilder.withPayload(i).setCorrelationId("A").build());
 		}
 		assertEquals(5, ((List<?>)outputChannel.receive(0).getPayload()).size());
 		assertNull(discardChannel.receive(0));
 		assertEquals(0, store.getMessageGroup("A").getMessages().size());
-		
+
 		// send another message with the same correlation id and see it in the discard channel
 		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setCorrelationId("A").build());
 		assertNotNull(discardChannel.receive(0));
-		
+
 		// set 'expireGroupsUponCompletion' to 'true' and the messages should start accumulating again
 		defaultHandler.setExpireGroupsUponCompletion(true);
 		defaultHandler.handleMessage(MessageBuilder.withPayload("foo").setCorrelationId("A").build());
 		assertNull(discardChannel.receive(0));
 		assertEquals(1, store.getMessageGroup("A").getMessages().size());
 	}
-	
+
 	@Test
 	public void firstBest(){
 		QueueChannel outputChannel = new QueueChannel();
@@ -99,7 +115,7 @@ public class AggregatorSupportedUseCasesTests {
 		defaultHandler.setOutputChannel(outputChannel);
 		defaultHandler.setDiscardChannel(discardChannel);
 		defaultHandler.setReleaseStrategy(new FirstBestReleaseStrategy());
-		
+
 		for (int i = 0; i < 5; i++) {
 			defaultHandler.handleMessage(MessageBuilder.withPayload(i).setCorrelationId("A").build());
 		}
@@ -109,7 +125,7 @@ public class AggregatorSupportedUseCasesTests {
 		assertNotNull(discardChannel.receive(0));
 		assertNotNull(discardChannel.receive(0));
 	}
-	
+
 	@Test
 	public void batchingWithoutLeftovers(){
 		QueueChannel outputChannel = new QueueChannel();
@@ -118,7 +134,7 @@ public class AggregatorSupportedUseCasesTests {
 		defaultHandler.setDiscardChannel(discardChannel);
 		defaultHandler.setReleaseStrategy(new SampleSizeReleaseStrategy());
 		defaultHandler.setExpireGroupsUponCompletion(true);
-		
+
 		for (int i = 0; i < 10; i++) {
 			defaultHandler.handleMessage(MessageBuilder.withPayload(i).setCorrelationId("A").build());
 		}
@@ -126,7 +142,7 @@ public class AggregatorSupportedUseCasesTests {
 		assertEquals(5, ((List<?>)outputChannel.receive(0).getPayload()).size());
 		assertNull(discardChannel.receive(0));
 	}
-	
+
 	@Test
 	public void batchingWithLeftovers(){
 		QueueChannel outputChannel = new QueueChannel();
@@ -135,7 +151,7 @@ public class AggregatorSupportedUseCasesTests {
 		defaultHandler.setDiscardChannel(discardChannel);
 		defaultHandler.setReleaseStrategy(new SampleSizeReleaseStrategy());
 		defaultHandler.setExpireGroupsUponCompletion(true);
-		
+
 		for (int i = 0; i < 12; i++) {
 			defaultHandler.handleMessage(MessageBuilder.withPayload(i).setCorrelationId("A").build());
 		}
@@ -144,21 +160,45 @@ public class AggregatorSupportedUseCasesTests {
 		assertNull(discardChannel.receive(0));
 		assertEquals(2, store.getMessageGroup("A").getMessages().size());
 	}
-	
+
+	@Test
+	public void testInt2899VerifyMessageStoreCalls() throws InterruptedException {
+		MessageGroupStore store = Mockito.spy(this.store);
+		AggregatingMessageHandler aggregator = new AggregatingMessageHandler(processor, store);
+		ApplicationContext applicationContext = TestUtils.createTestApplicationContext();
+		DirectFieldAccessor directFieldAccessor = new DirectFieldAccessor(aggregator);
+		directFieldAccessor.setPropertyValue("beanFactory", applicationContext);
+
+		final CountDownLatch latchForScheduledTask = new CountDownLatch(1);
+		Mockito.doAnswer(new Answer() {
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				latchForScheduledTask.countDown();
+				return invocation.callRealMethod();
+			}
+		}).when(store).iterator();
+
+		aggregator.setExpireGroupsUponCompletion(true);
+		Mockito.verify(store, Mockito.never()).iterator();
+
+		aggregator.onApplicationEvent(new ContextRefreshedEvent(applicationContext));
+		assertTrue(latchForScheduledTask.await(2, TimeUnit.SECONDS));
+		Mockito.verify(store, Mockito.times(1)).iterator();
+	}
+
 	private class SampleSizeReleaseStrategy implements ReleaseStrategy {
 
 		public boolean canRelease(MessageGroup group) {
 			return group.getMessages().size() == 5;
 		}
-		
+
 	}
-	
+
 	private class FirstBestReleaseStrategy implements ReleaseStrategy {
 
 		public boolean canRelease(MessageGroup group) {
 			return true;
 		}
-		
+
 	}
-	
+
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorSupportedUseCasesTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorSupportedUseCasesTests.java
@@ -16,17 +16,12 @@ package org.springframework.integration.aggregator.integration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;


### PR DESCRIPTION
If <aggregator> is configured with expire-groups-upon-completion="true"
 and message-store="persistentMessageStore", it causes blocking of the main deploy Thread,
if there are a lot of Messages in the persistent MessageStore.
- Add to `AggregatingMessageHandler` implementation of `ApplicationListener<ContextRefreshedEvent>`
  to handle iteration over MessageStore as late as possible.
- Wrap 'iteration over MessageStore' to scheduled task to avoid overhead of the main Thread
- allow call 'iteration over MessageStore' from `setExpireGroupsUponCompletion` only when `AggregatingMessageHandler#initialized = true`,
  who is switched on on the `onInit()`
- Add verification test `AggregatorSupportedUseCasesTests#testInt2899VerifyMessageStoreCalls`

JIRA: https://jira.springsource.org/browse/INT-2899
