### PR TITLE
INT-2873 Create 3.0 Schemas

### DIFF
--- a/spring-integration-amqp/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-amqp/src/main/resources/META-INF/spring.schemas
@@ -1,3 +1,4 @@
 http\://www.springframework.org/schema/integration/amqp/spring-integration-amqp-2.1.xsd=org/springframework/integration/amqp/config/spring-integration-amqp-2.1.xsd
 http\://www.springframework.org/schema/integration/amqp/spring-integration-amqp-2.2.xsd=org/springframework/integration/amqp/config/spring-integration-amqp-2.2.xsd
-http\://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd=org/springframework/integration/amqp/config/spring-integration-amqp-2.2.xsd
+http\://www.springframework.org/schema/integration/amqp/spring-integration-amqp-3.0.xsd=org/springframework/integration/amqp/config/spring-integration-amqp-3.0.xsd
+http\://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd=org/springframework/integration/amqp/config/spring-integration-amqp-3.0.xsd

--- a/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-3.0.xsd
+++ b/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-3.0.xsd
@@ -1,0 +1,787 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/amqp"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration"
+	targetNamespace="http://www.springframework.org/schema/integration/amqp"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+			schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Configures an endpoint that will publish an AMQP Message to the provided Exchange.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="outboundType">
+					<xsd:attribute name="id" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+			Unique ID for this adapter.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+			Message Channel to which Messages should be sent in order to have them converted and published to an AMQP Exchange.
+			If this attribute is not provided, the ID will be used to create a new DirectChannel, and then instead of using that
+			ID as the bean name of the EventDrivenConsumer instance that hosts the MessageHandler responsible for publishing the
+			AMQP Messages, that EventDrivenConsumer's bean name will be the ID plus the added suffix: ".adapter"
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="confirm-correlation-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+			Expression for correlating publisher confirms to sent messages. The Rabbit API only correlates confirms
+			to a channel; this is used to further correlate a confirm to a message. An example is
+			"headers['amqp_confirmCorrelationData']", assuming that header contains the data.
+			Messages that do not have correlation data do not generate publisher confirm messages.
+			Requires a CachingConnectionFactory with the 'publisherConfirms' property set to TRUE.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="confirm-ack-channel" type="xsd:string" default="nullChannel">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+			Channel to which positive publisher confirms will be sent; the payload will be the correlation data from
+			the sent message. The message will also contain a header 'amqp_publishConfirm' with a value true.
+			Requires a connection factory that is configured to request publisher confirms. Default
+			is nullChannel in case an adapter doesn't want to use publisher confirms, but is using a
+			connection factory that is configured to request them.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="confirm-nack-channel" type="xsd:string" default="nullChannel">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+			Channel to which negative publisher confirms will be sent; the payload will be the correlation data from
+			the sent message. The message will also contain a header 'amqp_publishConfirm' with a value false.
+			Requires a connection factory that is configured to request publisher confirms. Default
+			is nullChannel in case an adapter doesn't want to use publisher confirms, but is using a
+			connection factory that is configured to request them.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Configures an endpoint that will receive AMQP Messages sent to a given queue and then forward those messages to a Message Channel.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="inboundType">
+					<xsd:attribute name="channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Message Channel to which converted Messages should be sent. If this attribute is not provided, the ID will
+	be used to create a new DirectChannel, and then instead of using that ID as the bean name of the Channel Adapter
+	instance, the bean name will be the ID plus the added suffix: ".adapter"
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-gateway">
+		<xsd:annotation>
+			<xsd:documentation>
+	Configures a gateway that will publish an AMQP Message to the provided Exchange
+	and expect a reply Message.
+            </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="outboundType">
+					<xsd:attribute name="id" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+			Unique ID for this gateway.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+			Message Channel to which Messages should be sent in order to have them converted and published to an AMQP Exchange.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+			Message Channel to which replies should be sent after being received from an AQMP Queue and converted.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+									Allows you to specify how long this gateway will wait for
+									the reply message to be sent successfully to the reply channel
+									before throwing an exception. This attribute only applies when the
+									channel might block, for example when using a bounded queue channel that
+									is currently full.
+
+									Also, keep in mind that when sending to a DirectChannel, the
+									invocation will occur in the sender's thread. Therefore,
+									the failing of the send operation may be caused by other
+									components further downstream.
+
+									The "reply-timeout" attribute maps to the "sendTimeout" property of the
+									underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+									The attribute will default, if not specified, to '-1', meaning that
+									by default, the Gateway will wait indefinitely. The value is
+									specified in milliseconds.
+								]]></xsd:documentation>
+							</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="mapped-reply-headers" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+			Comma-separated list of names of MessageHeaders to be mapped into the AMQP Message Properties of the AMQP reply message.
+			All standard Headers (e.g., contentType) will be mapped to AMQP Message Properties while user-defined headers will be mapped to 'headers' property
+			which itself is a Map.
+			This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+			this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+								]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="inbound-gateway">
+		<xsd:annotation>
+			<xsd:documentation>
+	Configures a gateway that will receive AMQP Messages sent to a given queue and then forward those messages to a Message Channel.
+	If a reply Message is returned, it will also send that to the 'replyTo' provide by the AMQP request Message.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="inboundType">
+					<xsd:attribute name="request-channel" use="required" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Message Channel to which converted Messages should be sent.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-channel" use="optional" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Message Channel where reply Messages will be expected.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="mapped-reply-headers" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Comma-separated list of names of MessageHeaders to be mapped into the AMQP Message Properties of the AMQP reply message.
+	All standard Headers (e.g., contentType) will be mapped to AMQP Message Properties while user-defined headers will be mapped to 'headers' property
+	which itself is a Map.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="channel">
+		<xsd:annotation>
+			<xsd:documentation>
+	Creates a point-to-point channel that is backed by an AMQP Queue.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="channelType">
+					<xsd:attribute name="message-driven" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Indicate whether this channel should be message-driven (subscribable) or not (pollable).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="queue-name" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Provide an explicitly configured queue name. If this is not provided, then a Queue will be created
+	implicitly with the same name as the channel itself (the "id" of this element). If this channel is
+	not message-driven, the implicit creation will require that either an AmqpAdmin instance has been
+	provided via the "amqp-admin" attribute or that the configured AmqpTemplate is an instance of RabbitTemplate.
+	If the channel is message-driven, the AmqpAdmin will be created using the underlying listener container's
+	ConnectionFactory.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="amqp-admin" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	An AmqpAdmin instance to use when declaring a Queue implicitly. This is only needed if an explicit
+	"queue-name" is not provided and the channel is not message-driven. Even then, if the referenced
+	AmqpTemplate is an instance of RabbitTemplate, the AmqpAdmin can be constructed from that template's
+	ConnectionFactory.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.amqp.core.AmqpAdmin"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="publish-subscribe-channel">
+		<xsd:annotation>
+			<xsd:documentation>
+	Creates a publish-subscribe-channel that is backed by an AMQP FanoutExchange.
+	Always message-driven (subscribable).
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="channelType">
+					<xsd:attribute name="exchange" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Reference to a FanoutExchange instance to which this channel should send Messages. If not provided,
+	a FanoutExchange will be declared with this channel's name prefixed by "si.fanout.".
+	A Queue will be declared automatically and bound to that exchange to handle the consumer role
+	of this channel.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.amqp.core.FanoutExchange"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="channelType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Base type for 'channel' and 'publish-subscribe-channel'.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="interceptors" type="integration:channelInterceptorsType" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A list of ChannelInterceptor instances to be applied to this channel.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+	Unique ID for this Message Channel.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Flag to indicate whether this Message Channel should start automatically.
+	This only applies to a message-driven channel. Default is true.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="containerAndTemplateAttributes"/>
+		<xsd:attributeGroup ref="integration:subscribersAttributeGroup" />
+	</xsd:complexType>
+
+	<xsd:complexType name="outboundType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Base type for the 'outbound-channel-adapter' and 'outbound-gateway' elements.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="exchange-name" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+The fixed name of the AMQP Exchange to which Messages should be sent. If not provided, Messages will be sent to the default, no-name Exchange.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="exchange-name-expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+The exchange name to use when sending Messages evaluated as an expression on the message (e.g. 'headers.exchange'). By default, this will be an emtpy String.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="routing-key" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+The fixed routing-key to use when sending Messages. By default, this will be an empty String.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="routing-key-expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+The routing-key to use when sending Messages evaluated as an expression on the message (e.g. 'payload.key'). By default, this will be an empty String.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="amqp-template" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.amqp.core.AmqpTemplate" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="order" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+The order for this consumer when multiple consumers are registered thereby enabling load-balancing and/or failover.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="header-mapper" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="mapped-request-headers" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Comma-separated list of names of AMQP Headers to be mapped from the AMQP request into the MessageHeaders.
+This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+						]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="return-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Channel to which returned messages will be sent. Requires a RabbitTemplate with the 'mandatory' or
+'immediate' properties set to TRUE; requires a CachingConnectionFactory with the 'publisherReturns'
+property set to TRUE.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="inboundType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Base type for the 'inbound-channel-adapter' and 'inbound-gateway' elements.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="id" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Unique ID for this adapter.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="containerAttributes"/>
+		<xsd:attribute name="error-channel" use="optional" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Message Channel to which error Messages should be sent.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="header-mapper" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="mapped-request-headers" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Comma-separated list of names of AMQP Headers to be mapped from the AMQP request into the MessageHeaders.
+This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+						]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="message-converter" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	MessageConverter to use when receiving AMQP Messages.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.amqp.support.converter.MessageConverter"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="listener-container" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Reference to the MessageListener container to use for receiving AMQP Messages. If this attribute is provided,
+	then no other attribute related to the listener container configuration should be provided. In other words, by
+	setting this reference, you must take full responsibility of the listener container configuration. The only
+	exception is the MessageListener itself. Since that is actually the core responsibility of this Channel Adapter
+	implementation, the referenced listener container must NOT already have its own MessageListener configured.
+	Note that this means that the external listener container must be configured using standard Spring <bean/>
+	(or @Bean) syntax. You cannot use the <rabbit:listener-container/> XML namespace support because it requires
+	attributes such as queue names to be specified on a child <listener/> element and, as stated above, the
+	container must not have a MessageListener defined.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="queue-names" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Names of the AMQP Queues from which Messages should be consumed (comma-separated list).
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Boolean value indicating whether this endpoint should start automatically.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:attributeGroup name="containerAttributes">
+		<xsd:attributeGroup ref="containerOnlyAttributes"/>
+		<xsd:attributeGroup ref="containerAndTemplateSharedAttributes"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="templateAttributes">
+		<xsd:attributeGroup ref="templateOnlyAttributes"/>
+		<xsd:attributeGroup ref="containerAndTemplateSharedAttributes"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="containerAndTemplateAttributes">
+		<xsd:attributeGroup ref="containerOnlyAttributes"/>
+		<xsd:attributeGroup ref="templateOnlyAttributes"/>
+		<xsd:attributeGroup ref="containerAndTemplateSharedAttributes"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="containerAndTemplateSharedAttributes">
+		<xsd:attribute name="channel-transacted" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Flag to indicate that channels created by this component will be transactional.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="connection-factory" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Reference to the Rabbit ConnectionFactory to be used by this component.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.amqp.rabbit.connection.ConnectionFactory"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="message-properties-converter" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	MessagePropertiesConverter to use when receiving AMQP Messages.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.amqp.rabbit.support.MessagePropertiesConverter"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="templateOnlyAttributes">
+		<xsd:annotation>
+			<xsd:documentation>
+	Attributes for a RabbitTemplate. This does not include the exchange, queue, or routingKey properties
+	since those may or may not be exposed for configuration depending on what type of component uses this
+	attribute group. This group also does not include any of the properties that are shared with the
+	SimpleMessageListenerContainer, such as channelTransacted, connectionFactory, and messagePropertiesConverter.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="encoding" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	The encoding to use when converting between byte arrays and Strings in message properties.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="message-converter" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Reference to a MessageConverter to be used by this RabbitTemplate.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.amqp.support.converter.MessageConverter"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="containerOnlyAttributes">
+		<xsd:annotation>
+			<xsd:documentation>
+	Attributes for a SimpleMesssageListenerContainer's properties other than queues, queueNames, messageListener, and
+	autoStartup which may or may not be exposed for configuration depending on what type of component uses this attribute group.
+	This group also does not include any of the properties that are shared with RabbitTemplate, such as channelTransacted,
+	connectionFactory, and messsagePropertiesConverter.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="acknowledge-mode">
+			<xsd:annotation>
+				<xsd:documentation>
+	Acknowledge Mode for the MessageListenerContainer.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="AUTO"/>
+					<xsd:enumeration value="MANUAL"/>
+					<xsd:enumeration value="NONE"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="advice-chain" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="java.util.Collection" />
+					</tool:annotation>
+					<xsd:documentation>
+	Array of AOP Advice instances to be applied to the MessageListener.
+					</xsd:documentation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="concurrent-consumers" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Specify the number of concurrent consumers to create. Default is 1.
+	Raising the number of concurrent consumers is recommended in order to scale the consumption of messages coming in
+	from a queue. However, note that any ordering guarantees are lost once multiple consumers are registered. In
+	general, stick with 1 consumer for low-volume queues.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="error-handler" use="optional" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	ErrorHandler to be configured on the underlying MessageListener container.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.util.ErrorHandler"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expose-listener-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<xsd:documentation>
+	Set whether to expose the listener Rabbit Channel to a registered ChannelAwareMessageListener as well as
+	to RabbitTemplate calls.
+					</xsd:documentation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="phase" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<xsd:documentation>
+	The lifeycle phase determining the start/stop order of the underlying listener container.
+					</xsd:documentation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="prefetch-count" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<xsd:documentation>
+	Specifies how many messages to send to each consumer in a single request. Often this can be set quite high
+	to improve throughput. It should be greater than or equal to the tx-size value.
+					</xsd:documentation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="receive-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<xsd:documentation>
+	The timeout for each attempt by a consumer to receive the next message.
+					</xsd:documentation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="recovery-interval" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<xsd:documentation>
+	The interval between recovery attempts, in milliseconds. The default is 5000 ms, that is, 5 seconds.
+					</xsd:documentation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="shutdown-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<xsd:documentation>
+	The time to wait for workers in milliseconds after the container is stopped, and before the connection is forced closed.
+					</xsd:documentation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="task-executor" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<xsd:documentation>
+	Reference to the Executor to be used for running Consumer threads.
+					</xsd:documentation>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="java.util.concurrent.Executor"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="transaction-attribute" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<xsd:documentation>
+	The TransactionAttribute to use when the Consumer receives the AMQP Message and the Listener is invoked
+	within a transaction. This is only applicable when a TransactionManager has been configured.
+					</xsd:documentation>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.transaction.interceptor.TransactionAttribute"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="transaction-manager" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<xsd:documentation>
+	The PlatformTransactionManager to use when the Consumer receives the AMQP Message and the Listener is invoked.
+					</xsd:documentation>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.transaction.PlatformTransactionManager"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="tx-size" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<xsd:documentation>
+	How many messages to process in a single transaction (if the channel is transactional). For best results it should be
+	less than or equal to the prefetch count.
+					</xsd:documentation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+</xsd:schema>

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractIntegrationNamespaceHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractIntegrationNamespaceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,6 @@
 
 package org.springframework.integration.config.xml;
 
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
@@ -32,17 +29,20 @@ import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.ChannelInitializer.AutoCreateCandidatesCollector;
 import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 /**
  * Base class for NamespaceHandlers that registers a BeanFactoryPostProcessor
  * for configuring default bean definitions.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
 public abstract class AbstractIntegrationNamespaceHandler implements NamespaceHandler {
 
-	private static final String VERSION = "2.2";
+	private static final String VERSION = "3.0";
 
 	public static final String CHANNEL_INITIALIZER_BEAN_NAME = "channelInitializer";
 

--- a/spring-integration-core/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-core/src/main/resources/META-INF/spring.schemas
@@ -2,4 +2,5 @@ http\://www.springframework.org/schema/integration/spring-integration-1.0.xsd=or
 http\://www.springframework.org/schema/integration/spring-integration-2.0.xsd=org/springframework/integration/config/xml/spring-integration-2.0.xsd
 http\://www.springframework.org/schema/integration/spring-integration-2.1.xsd=org/springframework/integration/config/xml/spring-integration-2.1.xsd
 http\://www.springframework.org/schema/integration/spring-integration-2.2.xsd=org/springframework/integration/config/xml/spring-integration-2.2.xsd
-http\://www.springframework.org/schema/integration/spring-integration.xsd=org/springframework/integration/config/xml/spring-integration-2.2.xsd
+http\://www.springframework.org/schema/integration/spring-integration-3.0.xsd=org/springframework/integration/config/xml/spring-integration-3.0.xsd
+http\://www.springframework.org/schema/integration/spring-integration.xsd=org/springframework/integration/config/xml/spring-integration-3.0.xsd

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -1,0 +1,3919 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:tool="http://www.springframework.org/schema/tool"
+	targetNamespace="http://www.springframework.org/schema/integration" elementFormDefault="qualified"
+	attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+	Defines the core configuration elements for Spring Integration.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="annotation-config">
+		<xsd:annotation>
+			<xsd:documentation>
+				Enables annotation support for Message Endpoints.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="default-publisher-channel" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						Default output channel for the @Publisher annotation support.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="transaction-synchronization-factory">
+		<xsd:annotation>
+			<xsd:documentation>
+				Allows you to configure org.springframework.integration.transaction.DefaultTransactionSynchronizationFactory
+				This implementation of org.springframework.integration.transaction.TransactionSynchronizationFactory
+				allows you to configure SpEL expressions, with their execution being coordinated (synchronized) with a
+				transaction - see {TransactionSynchronization}. Expressions for before-commit, after.-commit, and after-rollback
+				are supported, together with a channel for each where the evaluation result  (if any) will be sent.
+				For each sub-element you can specify 'expression' and/or 'channel' attributes.
+				If only the 'channel' attribute is present the received Message will be sent there as part of a particular synchronization scenario.
+				If only the 'expression' attribute is present and the result of an expression is a non-Null value, a Message with the
+				result as the payload will be generated and sent to a default channel (NullChannel) and will appear in the logs.
+				If you want the evaluation result to go to a specific channel add a 'channel' attribute. If the result of an expression is null
+				or void, no Message will be generated.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+					<xsd:element name="before-commit" minOccurs="0" maxOccurs="1">
+						<xsd:complexType>
+							<xsd:attributeGroup ref="synchronizationAttributeGroup"/>
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="after-commit" minOccurs="0" maxOccurs="1">
+						<xsd:complexType>
+							<xsd:attributeGroup ref="synchronizationAttributeGroup"/>
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="after-rollback" minOccurs="0" maxOccurs="1">
+						<xsd:complexType>
+							<xsd:attributeGroup ref="synchronizationAttributeGroup"/>
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="required"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:attributeGroup name="synchronizationAttributeGroup">
+		<xsd:attribute name="expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+				SpEL expression to be executed as part of Transaction synchronization
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation><![CDATA[
+				Reference to a MessageChannel where the result or an expression or received Message wil be sent.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:element name="application-event-multicaster">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+					Defines the ApplicationEventMulticaster to use for this
+					ApplicationContext.
+					The "task-executor"
+					reference is optional. If not provided, an
+					instance of
+					ThreadPoolTaskExecutor will be created by default.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:attribute name="task-executor" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Provides the reference to a bean that implements
+						org.springframework.core.task.TaskExecutor which is used
+						when dispatching Messages to this channel's subscribers.
+						Also, when using a TaskExecutor, keep in mind that any
+						transaction active for the sender will NOT propagate to
+						the handler invocation since the TaskExecutor dispatches
+						to the handler on a separate Thread. Usually configured
+						using the 'task' namespace support provided by Spring
+						(e.g., <task:executor/>).
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.core.task.TaskExecutor" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="channel">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Point-to-Point MessageChannel.
+			</xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.springframework.integration.MessageChannel" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="channelType">
+					<xsd:sequence>
+						<xsd:choice minOccurs="0" maxOccurs="1">
+							<xsd:element name="queue" type="queueType">
+								<xsd:annotation>
+									<xsd:documentation>
+										Identifies this channel as a Queue style
+										channel
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="priority-queue" type="priorityQueueType">
+								<xsd:annotation>
+									<xsd:documentation>
+										Identifies this channel as a Queue style
+										channel where messages could be prioritized
+										based on custom logic
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element name="rendezvous-queue" type="rendezvousQueueType" />
+							<xsd:element name="dispatcher" type="dispatcherType" >
+								<xsd:annotation>
+									<xsd:documentation>Provides MessageDispatcher configuration
+									(i.e., failover, load-balancing, task-executor)</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:choice>
+						<xsd:element name="interceptors" type="channelInterceptorsType" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+	A list of ChannelInterceptor instances whose preSend and postSend methods
+	will be applied to this channel. Note that the preReceive and postReceive
+	methods have no effect for a SubscribableChannel instance.
+								]]></xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+					</xsd:sequence>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="queueType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a queue for messages. If 'capacity' is specified, it will be a
+				bounded queue.
+				A custom Queue
+				implementation can be injected using the 'ref'
+				attribute.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="capacity" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Capacity for this queue. Default capacity is 0 which means
+					this queue will accumulate as many
+					messages as available resources allow.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="message-store" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to a MessageGroupStore that can be used to buffer the messages. If a message store is
+					specified then it will store messages for this channel with a correlation key equal to the
+					channel name. If you need
+					more control over the correlation key (e.g. two channels in the same
+					application share a name), then you need to
+					look to the queue implementation itself and provide an
+					explicit instance via the "ref" attribute, or else maybe the
+					message store has a way to specify a region or similar additional
+					tag for messages. This attribute is
+					mutually
+					exclusive with the "ref" attribute (only one can be specified).
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.store.MessageGroupStore" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ref" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to a BlockingQueue that can be used to buffer the messages. This attribute is
+					mutually
+					exclusive with the "message-store" attribute (only one can be specified).
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="java.util.concurrent.BlockingQueue" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="priorityQueueType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a queue with priority-ordering for message reception.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="capacity" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Capacity for this queue. Default capacity is 0 which means
+					this queue will accumulate as many
+					messages as available resources allow.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="comparator" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					<![CDATA[
+	Allows you to specify the reference to the bean which implements java.util.Comparator&lt;Message&lt;?&gt;&gt;
+	interface and provides logic based on which Messages will be prioritized.
+					]]>
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="rendezvousQueueType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a rendezvous queue where a sender will block until the receiver
+				arrives or vice-versa.
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:complexType>
+
+	<xsd:complexType name="dispatcherType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines the dispatching configuration for a non-buffering channel
+				(i.e. one without a queue).
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="load-balancer">
+			<xsd:annotation>
+				<xsd:documentation>
+					Defines a load-balancing strategy for the channel's dispatcher.
+					The default is a round-robin load
+					balancer.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="round-robin">
+						<xsd:annotation>
+							<xsd:documentation>
+								[DEFAULT] Defines a Round Robin dispatching strategy which allows
+								load balancing of messages
+								between multiple Message Handlers. Which
+								message
+								handler receives the message first is determined by the 'order'
+								attribute
+								of such Message Handler.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:enumeration>
+					<xsd:enumeration value="none">
+						<xsd:annotation>
+							<xsd:documentation>
+								No LoadBalancingStrategy will be used.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:enumeration>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="failover" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specifies whether this dispatcher has failover enabled. By default,
+					failover will be enabled. Set
+					this to 'false' to disable it.
+					When enabled and message delivery to the primary Message Handler fails,
+					an attempt
+					will be made to deliver the message to the next handler
+					and so on...
+					Primary, secondary etc... is determined by the
+					load-balancing strategy in
+					use
+					(e.g. round-robin). If no load-balancer strategy is configured, the
+					order will
+					be fixed
+					in a sequence determined by the 'order' attribute on the
+					Message Handlers
+					(or the @Ordered annotation on adapted
+					methods).
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="task-executor" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Provides the reference to a bean that implements
+					org.springframework.core.task.TaskExecutor which is used
+					when dispatching Messages to this channel's subscribers.
+					Also, when using a TaskExecutor, keep in mind that any
+					transaction active for the sender will NOT propagate to
+					the handler invocation since the TaskExecutor dispatches
+					to the handler on a separate Thread. Usually configured
+					using the 'task' namespace support provided by Spring
+					(e.g., <task:executor/>).
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.core.task.TaskExecutor" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="subscribersAttributeGroup" />
+	</xsd:complexType>
+
+	<xsd:element name="publish-subscribe-channel">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Publish-Subscribe channel that broadcasts messages to its
+				subscribers.
+			</xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.springframework.integration.MessageChannel" />
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="channelType">
+					<xsd:sequence>
+						<xsd:element name="interceptors" type="channelInterceptorsType" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+	A list of ChannelInterceptor instances whose preSend and postSend methods
+	will be applied to this channel. Note that the preReceive and postReceive
+	methods have no effect for a SubscribableChannel instance.
+								]]></xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+					</xsd:sequence>
+					<xsd:attribute name="task-executor" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Provides the reference to a bean that implements
+								org.springframework.core.task.TaskExecutor which is used
+								when dispatching Messages to this channel's subscribers.
+								Also, when using a TaskExecutor, keep in mind that any
+								transaction active for the sender will NOT propagate to
+								the handler invocation since the TaskExecutor dispatches
+								to the handler on a separate Thread. Usually configured
+								using the 'task' namespace support provided by Spring
+								(e.g., <task:executor/>).
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.core.task.TaskExecutor" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="error-handler" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+							<![CDATA[
+								Provides reference to a bean that implements
+								org.springframework.util.ErrorHandler and
+								provides a strategy for handling errors.
+								This is especially useful for handling errors
+								that occur during asynchronous execution of tasks
+								that have been submitted to a TaskScheduler, where
+								it may not be possible to throw the error to the
+								original caller.
+							]]>
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.util.ErrorHandler" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="ignore-failures" type="xsd:string" default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether Exceptions thrown by any subscribed handler should be
+								ignored (only logged).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="apply-sequence" type="xsd:string" default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether the sequence size, sequence number, and correlation id
+								headers should be set on
+								Messages that are sent through this channel.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="subscribersAttributeGroup" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="channelType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a message channel.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="id" type="xsd:string" use="required" />
+		<xsd:attribute name="scope" type="xsd:string" />
+		<xsd:attribute name="datatype" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					<![CDATA[
+						Allows you to identify this channel as a Datatype channel
+						and specify the type of the Message payload this channel
+						accepts (e.g., datatype="java.lang.String"). A Datatype
+						channel is a channel that accepts messages containing
+						payloads of a certain type.
+					]]>
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="dispatcher">
+			<xsd:annotation>
+					<xsd:documentation>
+						This attribute is DEPRECATED. Please use the dispatcher sub-element
+						instead.
+					</xsd:documentation>
+				</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="failover">
+						<xsd:annotation>
+							<xsd:documentation>
+								Enables failover, but disables load-balancing.
+								See the dispatcher sub-element for more
+								information.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:enumeration>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="gateway">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Messaging Gateway.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="method" minOccurs="0" maxOccurs="unbounded">
+					<xsd:annotation>
+						<xsd:documentation>
+							<![CDATA[
+	Provides mechanism to define method per channel mappings for this gateway
+							]]>
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:sequence>
+							<xsd:element name="header" minOccurs="0" maxOccurs="unbounded" type="headerSubElementType">
+								<xsd:annotation>
+									<xsd:documentation>
+										<![CDATA[
+				Provides mechanism to enrich content of the message with custom message headers. When this method is going to be invoked
+				the generated message will be enriched with these headers.
+										]]>
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:sequence>
+						<xsd:attribute name="name" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation>
+									<![CDATA[
+										The name of the method
+									]]>
+								</xsd:documentation>
+								<xsd:appinfo>
+									<tool:annotation>
+										<tool:expected-method type="../@service-interface" />
+									</tool:annotation>
+								</xsd:appinfo>
+							</xsd:annotation>
+						</xsd:attribute>
+						<xsd:attribute name="payload-expression" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation>
+									<![CDATA[
+										Expression that should be evaluated to generate the payload.
+									]]>
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:attribute>
+						<xsd:attribute name="request-channel" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation>
+									<![CDATA[
+										Identifies channel the message will be sent to upon invocation of this method
+									]]>
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:attribute>
+						<xsd:attribute name="reply-channel" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation>
+										<![CDATA[
+								Identifies channel this gateway will subscribe to to receive reply Message.
+								The reply Message which will then be converted to the return type of the method signature.
+										]]>
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:attribute>
+						<xsd:attribute name="request-timeout" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation>
+										<![CDATA[
+								Provides the amount of time dispatcher would wait to send a message.
+								This timeout would only apply if there is a potential to block in the send call.
+								For example if this gateway is hooked up to a Queue channel. 
+								Value is specified in milliseconds.
+										]]>
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:attribute>
+						<xsd:attribute name="reply-timeout" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation>
+										<![CDATA[
+								Allows you to specify how long this gateway will wait for the reply message
+								before throwing an exception. By default it will wait indefinitely.
+								Value is specified in milliseconds
+										]]>
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:attribute>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="optional" />
+			<xsd:attribute name="service-interface" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+							The name of the interface which will be exposed by this gateway.
+						]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="direct">
+							<tool:expected-type type="java.lang.Class" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="default-request-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+										<![CDATA[
+								Identifies default channel the messages will be sent to upon invocation of methods of this gateway
+										]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="default-reply-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+										<![CDATA[
+								Identifies default channel this gateway will subscribe to to receive reply Messages, which will then be
+								converted to the return type of the method signature.
+										]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="error-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Identifies channel that error messages will be sent to if a failure occurs in this
+						gateway's invocation. If no "error-channel" reference is provided, this gateway will
+						propagate Exceptions to the caller. To completely suppress Exceptions, provide a
+						reference to the "nullChannel" here.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="default-request-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+							<![CDATA[
+					Provides the amount of time dispatcher would wait to send a message.
+					This timeout would only apply if there is a potential to block in the send call.
+					For example if this gateway is hooked up to a Queue channel. 
+					Value is specified in milliseconds.
+							]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="default-reply-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+							<![CDATA[
+					Allows you to specify how long this gateway will wait for the reply message
+					before throwing an exception. By default it will wait indefinitely.
+					Value is specified in milliseconds.
+							]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="async-executor" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+							<![CDATA[
+					Provide a reference to an implementation of java.util.concurrent.Executor
+					to use for any of the interface methods that have a Future return type.
+					This Executor will only be used for those async methods; the sync methods
+					will be invoked in the caller's thread.
+							]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="headerSubElementType">
+		<xsd:annotation>
+			<xsd:documentation>	<![CDATA[
+				Provides mechanism to enrich content of the message with custom message headers. When this method is going to be invoked
+				the generated message will be enriched with these headers.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="name" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The name of the header
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="value" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The value of the header. Either this or 'expression' must be provided.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Expression to be evaluated to produce a value for the header.
+					Either this or 'value' must be provided.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="innerGatewayType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Messaging Gateway to be used within a chain.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="request-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+						<![CDATA[
+				Identifies channel the message will be sent to upon invocation of methods of this gateway
+						]]>
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="request-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+							<![CDATA[
+					Provides the amount of time dispatcher would wait to send a message.
+					This timeout would only apply if there is a potential to block in the send call.
+					For example if this gateway is hooked up to a Queue channel. 
+					Value is specified in milliseconds.
+							]]>
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="error-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Identifies channel that error messages will be sent to if a failure occurs in this
+					adapter's invocation. To completely suppress Exceptions, provide a
+					reference to the "nullChannel" here.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Channel Adapter that receives from a MessageSource and sends to a
+				MessageChannel.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:choice minOccurs="0" maxOccurs="1" >
+					<xsd:sequence>
+						<xsd:element name="poller" type="basePollerType" />
+						<xsd:element ref="beans:bean" minOccurs="0" maxOccurs="1" />
+					</xsd:sequence>
+					<xsd:sequence>
+						<xsd:element ref="beans:bean" />
+						<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1" />
+					</xsd:sequence>
+				</xsd:choice>
+				<xsd:element name="header" type="headerSubElementType" minOccurs="0" maxOccurs="unbounded" />
+			</xsd:sequence>
+			<xsd:attributeGroup ref="methodInvokingOrExpressionEvaluatingAttributes" />
+			<xsd:attributeGroup ref="channelAdapterAttributes" />
+			<xsd:attribute name="send-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+		Maximum amount of time in milliseconds to wait when sending a message to the channel if such channel may block.
+		For example, a Queue Channel can block until space is available if its maximum capacity has been reached.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="resource-inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Channel Adapter that receives Resource(s) and sends them to a
+				MessageChannel identified via 'channel' attribute.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:sequence>
+						<xsd:element name="poller" type="basePollerType" />
+				</xsd:sequence>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Component identifier
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Channel where Message will be sent to
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="filter" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to the implementation of org.springframework.integration.util.CollectionFilter.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.util.CollectionFilter" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-startup" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Lifecycle attribute signaling if this component should be started during Application Context startup.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="pattern" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Location pattern expression (e.g., "/**/*.txt")
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+
+			<xsd:attribute name="pattern-resolver" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to a org.springframework.core.io.support.ResourcePatternResolver.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="send-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+		Maximum amount of time in milliseconds to wait when sending a message to the channel if such channel may block.
+		For example, a Queue Channel can block until space is available if its maximum capacity has been reached.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-channel-adapter" type="methodInvokingChannelAdapterType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Channel Adapter that receives from a MessageChannel and passes to
+				a method-invoking
+				MessageHandler.
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:element name="logging-channel-adapter">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="outboundChannelAdapterType">
+					<xsd:attributeGroup ref="loggingChannelAdapterAttributes"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="loggingChannelAdapterTypeChain">
+		<xsd:complexContent>
+			<xsd:extension base="outboundChannelAdapterTypeChain">
+				<xsd:attributeGroup ref="loggingChannelAdapterAttributes"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:attributeGroup name="loggingChannelAdapterAttributes">
+		<xsd:attribute name="level" default="INFO">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Specify the log level.
+							]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="FATAL" />
+					<xsd:enumeration value="ERROR" />
+					<xsd:enumeration value="WARN" />
+					<xsd:enumeration value="INFO" />
+					<xsd:enumeration value="DEBUG" />
+					<xsd:enumeration value="TRACE" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="logger-name" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Provide a name for the logger. This is useful when there are multiple logging Channel Adapters configured,
+					and you would like to differentiate them within the actual log. By default the logger name will be the
+					fully qualified class name of the LoggingHandler implementation.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expression">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Provide a SpEL expression to be evaluated against the Message as the root object. For example,
+	the default behavior is equivalent to an expression of "payload", or an expression may evaluate
+	against the payload itself ("payload.address.city") or headers ("headers.foo"). This attribute and
+	the 'log-full-message' attribute are mutually exclusive. See the documentation on the
+	'log-full-message' attribute for more information.
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="log-full-message">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Specify whether to log the full message. This attribute and the 'expression' attribute are
+	mutually exclusive. Setting this to true is equivalent to setting an expression value of "#root"
+	since the Message is the root object against which the expression will be evaluated. If no
+	'expression' is provided, and this value is false (the default), only the payload will be logged.
+							]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="methodInvokingOrExpressionEvaluatingAttributes">
+		<xsd:attribute name="ref" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="java.lang.Object" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+				A reference to a bean defined in the application context.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="method" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation>
+						<tool:expected-method type-ref="@ref" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+					A method defined on the bean referenced by 'ref' attribute
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					SpEL expression to be evaluated for each triggered execution.
+					The result of the evaluation will be
+					passed as the payload of
+					the Message that is sent to the MessageChannel.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="channelAdapterAttributes">
+		<xsd:attribute name="id" type="xsd:string" />
+		<xsd:attribute name="channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+					Identifies channel attached to this adapter. Depending on the type of the adapter
+					this channel could be the receiving channel (e.g., outbound-channel-adapter) or channel where
+					messages will be sent to by this adapter (e.g., inbound-channel-adapter).
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string" default="true">
+			<xsd:annotation>
+				<xsd:documentation>
+					Lifecycle attribute signaling if this component should be started during Application Context startup.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:complexType name="methodInvokingChannelAdapterType">
+		<xsd:complexContent>
+			<xsd:extension base="outboundChannelAdapterType">
+				<xsd:attributeGroup ref="methodInvokingOrExpressionEvaluatingAttributes" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="methodInvokingChannelAdapterTypeChain">
+		<xsd:complexContent>
+			<xsd:extension base="outboundChannelAdapterTypeChain">
+				<xsd:attributeGroup ref="methodInvokingOrExpressionEvaluatingAttributes" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="outboundChannelAdapterType">
+		<xsd:all>
+			<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1" />
+			<xsd:element ref="beans:bean" minOccurs="0" maxOccurs="1" />
+		</xsd:all>
+		<xsd:attributeGroup ref="channelAdapterAttributes" />
+		<xsd:attribute name="order">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specifies the order for invocation when this endpoint is connected as a
+					subscriber to a channel. This is particularly relevant when that channel
+					is using a "failover" dispatching strategy. It has no effect when this
+					endpoint itself is a Polling Consumer for a channel with a queue.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="outboundChannelAdapterTypeChain">
+		<xsd:all>
+			<xsd:element ref="beans:bean" minOccurs="0" maxOccurs="1" />
+		</xsd:all>
+	</xsd:complexType>
+
+	<xsd:element name="service-activator">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an endpoint for exposing any bean reference as a service that
+				receives request Messages
+				from an 'input-channel' and may send reply
+				Messages to an 'output-channel'. The 'ref' may point to an instance
+				that
+				has either a single public method or a method with the
+				@ServiceActivator annotation. Otherwise, the 'method'
+				attribute
+				should be provided along with 'ref'.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="expressionOrInnerEndpointDefinitionAware">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+					<xsd:attribute name="requires-reply" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether the service method must return a non-null value. This value will be
+								FALSE by
+								default, but if set to TRUE, a MessageHandlingException will be thrown when
+								the underlying service method (or
+								expression) returns a NULL value.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="handlerEndpointType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Base type for Message-handling endpoints.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="ref" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="java.lang.Object" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+				A reference to a bean that implements the handler.
+				The bean can be an implementation of the MessageHandler interface or a POJO
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="method" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation>
+						<tool:expected-method type-ref="@ref" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+				A method defined on the bean referenced by 'ref' attribute
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="handlerType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Base type for Message Handlers.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="beans:identifiedType">
+				<xsd:attribute name="ref" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="java.lang.Object" />
+							</tool:annotation>
+						</xsd:appinfo>
+						<xsd:documentation>
+						A reference to a bean that implements the handler.
+						The bean can be an implementation of the MessageHandler interface or a POJO
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="method" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation>
+								<tool:expected-method type-ref="@ref" />
+							</tool:annotation>
+						</xsd:appinfo>
+						<xsd:documentation>
+						A method defined on the bean referenced by 'ref' attribute
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="enricher">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an endpoint that passes a Message to its request-channel
+				and then expects a reply Message. The reply Message then becomes
+				the root object for evaluation of expressions to enrich the
+				target payload.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="enricher-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="enricher-type">
+		<xsd:sequence>
+			<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="property" type="propertySubElementType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>
+						Each property sub-element provides the name of a property (via the required 'name' attribute).
+						That property should be settable on the target payload instance. Exactly one of the 'value'
+						or 'expression' attributes must be provided as well. The former for a literal value to set,
+						and the latter for a SpEL expression to be evaluated. The root object of the evaluation
+						context is the Message that was returned from the flow initiated by this enricher.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="request-handler-advice-chain" type="adviceChainType" minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="request-channel" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Channel to which a Message will be sent to get the data to use
+					for enrichment. This attribute is optional. Not specifying a
+					'request-channel' is useful in situations, where only static
+					values shall be used for enrichment using the 'property'
+					sub-element.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="reply-channel" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Channel where a reply Message is expected. This is optional; typically the auto-generated
+					temporary reply channel is sufficient.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+        <xsd:attribute name="request-timeout" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[
+                    Set the timeout value for sending request messages in milliseconds.
+                    If not explicitly configured, the default is one second.
+                    ]]>
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="reply-timeout" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[
+                    Set the timeout value for receiving reply messages in milliseconds.
+                    If not explicitly configured, the default is one second.
+                    ]]>
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="requires-reply" use="optional" default="true">
+        <xsd:annotation>
+            <xsd:documentation><![CDATA[
+                If you specify a 'request-channel' you can optionally set the
+                'requires-reply' attribute as well. If you set this attribute to
+                'true', a reply must return a non-null value.
+
+                For example, you dispatch a message to the request-channel
+                (backed by a 'QueueChannel'). If the reply does not return within
+                the specified 'replyTimeout', then the reply message will end up
+                being Null.
+
+                By setting 'requires-reply' to 'true', a 'ReplyRequiredException'
+                will be raised for null reply messages. If 'requires-reply' is set
+                to false, those messages are silently dropped.
+
+                This attribute defaults to 'true', if not specified.]]>
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+                <xsd:union memberTypes="xsd:boolean xsd:string" />
+            </xsd:simpleType>
+        </xsd:attribute>
+		<xsd:attribute name="should-clone-payload">
+			<xsd:annotation>
+				<xsd:documentation>
+					Boolean value indicating whether any payload that implements Cloneable should be cloned
+					prior to sending the Message to the request chanenl for acquiring the enriching data.
+					The cloned version would be used as the target payload for the ultimate reply.
+
+					If the payload does NOT implement 'Cloneable', then setting this
+					attribute to 'true' has NO effect.
+
+					Default is false.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+        <xsd:attribute name="request-payload-expression" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[
+                    By default the original message's payload will be used as payload
+                    that will be send to the request-channel. By specifying a SpEL expression
+                    as value for the 'request-payload-expression' attribute, a
+                    subset of the original payload, a header value or any other
+                    resolvable SpEL expression can be used as the basis for the payload,
+                    that will be sent to the request-channel.
+
+                    For the Expression evaluation the full message is available
+                    as the 'root object'.
+
+                    For instance the following SpEL expressions (among others)
+                    are possible:
+
+                    - payload.foo
+                    - headers.foobar
+                    - new java.util.Date()
+                    - 'foo' + 'bar'
+
+                    If more sophisticated logic is required (e.g. changing the
+                    message headers etc.) please use additional downstream transformers.
+                ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="propertySubElementType">
+		<xsd:annotation>
+			<xsd:documentation>	<![CDATA[
+				Sub-element type for the 'enricher' element.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="name" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The name of the property on the target payload. Please be aware
+					that this value is a SpEL expression, also. For example, if
+					your payload is represented by a 'java.util.Map', you can add new
+					Map entries using the 'name' attribute, e.g. name='foo' would add a new
+					Map entry with key 'foo'.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="value" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The value of the property. Either this or 'expression' must be provided.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Expression to be evaluated to produce a value for the property.
+					Either this or 'value' must be provided.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="delayer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an endpoint that passes a Message to the output-channel after a
+				delay. The delay may
+				be
+				retrieved from a Message header or else fallback to the
+				'default-delay' of this endpoint.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="delayer-type">
+					<xsd:sequence minOccurs="0" maxOccurs="1">
+						<xsd:element name="poller" type="basePollerType" />
+					</xsd:sequence>
+					<xsd:attributeGroup ref="inputOutputChannelGroup"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="delayer-type">
+		<xsd:choice>
+			<xsd:annotation>
+				<xsd:documentation>
+					'transactional' and 'advice-chain' elements specify the configuration List of AOP Advice
+					to proxy DelayHandler's 'release Message task'.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:element name="transactional" type="transactionalType" minOccurs="0" maxOccurs="1" />
+			<xsd:element name="advice-chain" type="adviceChainType" minOccurs="0" maxOccurs="1" />
+		</xsd:choice>
+		<xsd:attribute name="id" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+					'id' value is used:
+					- as the 'AbstractEndpoint' bean 'id' if this tag is defined as root element.
+					- as the DelayHandler bean alias together with suffix '.handler'
+					- as the 'messageGroupId' property of DelayHandler together with suffix '.messageGroupId'
+					  in the operations of the MessageGroupStore for scheduling delayed messages.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="default-delay" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specify the default delay in milliseconds. This value can be set to 0
+					if the only Messages
+					that
+					should be delayed are those with a particular header (in that
+					case, be sure to provide
+					a value for the
+					'delay-header-name' attribute).
+					</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="delay-header-name" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specify the name of the header that should contain the delay value.
+					This value can either
+					represent the number of milliseconds to delay counting from the current
+					time or it can be an
+					absolute Date until
+					which the Message should be delayed.
+					</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="scheduler" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Provide a reference to the TaskScheduler instance to which
+					this endpoint should
+					delegate when scheduling the sending of delayed Messages. If not
+					provided, the default scheduler
+					registered in the ApplicationContext {ThreadPoolTaskScheduler} will be
+					used.
+					</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.scheduling.TaskScheduler" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="message-store" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Provide a reference to the MessageStore instance that should be used
+					to store Messages while
+					awaiting the delay.
+					</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.store.MessageStore" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="bridge">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an endpoint that passes a Message to the
+				output-channel without
+				modifying it.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:choice minOccurs="1" maxOccurs="unbounded">
+				<xsd:any processContents="strict" namespace="##other" minOccurs="0" maxOccurs="unbounded" />
+				<xsd:element ref="poller" />
+			</xsd:choice>
+			<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="chain">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an endpoint composed of a chain of Message
+				Handlers.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:choice maxOccurs="unbounded">
+				<xsd:element name="poller" type="basePollerType" minOccurs="0"/>
+				<xsd:group ref="chain-elements-group" maxOccurs="unbounded"/>
+			</xsd:choice>
+			<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+			<xsd:attribute name="phase" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<xsd:documentation>
+							The Lifecycle attribute determining the start/stop order
+							of the underlying MessageHandlerChain.
+						</xsd:documentation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:group name="chain-elements-group">
+			<xsd:sequence>
+				<xsd:choice minOccurs="0" maxOccurs="unbounded">
+					<xsd:any processContents="strict" namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+
+					<xsd:element name="service-activator" type="expressionOrInnerEndpointDefinitionAware"/>
+					<xsd:element name="splitter" type="splitter-type"/>
+					<xsd:element name="transformer" type="expressionOrInnerEndpointDefinitionAware"/>
+					<xsd:element name="header-enricher" type="header-enricher-type"/>
+					<xsd:element name="header-filter" type="header-filter-type"/>
+					<xsd:element name="enricher" type="enricher-type"/>
+					<xsd:element name="filter" type="filter-type"/>
+					<xsd:element name="aggregator" type="aggregator-type"/>
+					<xsd:element name="resequencer" type="resequencer-type"/>
+					<xsd:element name="router" type="routerTypeChain"/>
+					<xsd:element name="payload-type-router" type="payloadTypeRouterTypeChain"/>
+					<xsd:element name="recipient-list-router" type="recipientListRouterTypeChain"/>
+					<xsd:element name="exception-type-router" type="exceptionTypeRouterTypeChain"/>
+					<xsd:element name="header-value-router" type="headerValueRouterTypeChain"/>
+					<xsd:element name="delayer" type="delayer-type"/>
+					<xsd:element name="gateway" type="innerGatewayType"/>
+					<xsd:element name="payload-serializing-transformer" type="payload-serializing-transformer-type"/>
+					<xsd:element name="payload-deserializing-transformer"
+								 type="payload-deserializing-transformer-type"/>
+					<xsd:element name="object-to-string-transformer" type="specialized-transformer-type"/>
+					<xsd:element name="object-to-map-transformer" type="specialized-transformer-type"/>
+					<xsd:element name="map-to-object-transformer" type="map-to-object-transformer-type"/>
+					<xsd:element name="object-to-json-transformer" type="object-to-json-transformer-type"/>
+					<xsd:element name="json-to-object-transformer" type="json-to-object-transformer-type"/>
+					<xsd:element name="claim-check-in" type="claimCheckInTypeChain"/>
+					<xsd:element name="claim-check-out" type="claimCheckOutTypeChain"/>
+					<xsd:element name="control-bus" type="control-bus-type"/>
+					<xsd:element name="chain">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:group ref="chain-elements-group"/>
+							</xsd:sequence>
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+				<xsd:choice minOccurs="0">
+					<xsd:element name="outbound-channel-adapter" type="methodInvokingChannelAdapterTypeChain"/>
+					<xsd:element name="logging-channel-adapter" type="loggingChannelAdapterTypeChain"/>
+				</xsd:choice>
+			</xsd:sequence>
+	</xsd:group>
+
+	<xsd:element name="poller">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a top-level poller.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="basePollerType">
+					<xsd:attribute name="id" type="xsd:string" />
+					<xsd:attribute name="default" type="xsd:boolean" default="false" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="basePollerType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines the configuration metadata for a poller.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:element name="transactional" type="transactionalType" minOccurs="0" maxOccurs="1" />
+				<xsd:element name="advice-chain" type="adviceChainType" minOccurs="0" maxOccurs="1" />
+			</xsd:choice>
+		</xsd:sequence>
+		<xsd:attribute name="fixed-delay" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>Fixed delay trigger (in milliseconds).</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ref" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Allows this poller to reference another instance of a top-level poller.
+					[IMPORTANT] - This attribute is only allowed on inner poller definitions.
+					Defining this attribute on a top-level poller definition will result in a configuration exception.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="fixed-rate" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>Fixed rate trigger (in milliseconds).</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="time-unit">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The java.util.concurrent.TimeUnit enum value. This can ONLY be used in combination
+	with the 'fixed-delay' or 'fixed-rate' attributes. If combined with either 'cron'
+	or a 'trigger' reference attribute, it will cause a failure. The minimal supported
+	granularity for a PeriodicTrigger is MILLISEONDS. Therefore, the only available options
+	are MILLISECONDS and SECONDS. If this value is not provided, then any 'fixed-delay' or
+	'fixed-rate' value will be interpreted as MILLISECONDS by default. Basically this enum
+	provides a convenience for SECONDS-based interval trigger values. For hourly, daily,
+	and monthly settings, consider using a 'cron' trigger instead.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="MILLISECONDS" />
+					<xsd:enumeration value="SECONDS" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="cron" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>Cron trigger.</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="trigger" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.scheduling.Trigger" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="receive-timeout" type="xsd:string" />
+		<xsd:attribute name="max-messages-per-poll" type="xsd:string" />
+		<xsd:attribute name="task-executor" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.core.task.TaskExecutor" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="error-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Identifies channel that error messages will be sent to if a failure occurs in this
+					poller's invocation. To completely suppress Exceptions, provide a
+					reference to the "nullChannel" here.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="selector-chain">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+					Defines a MessageSelector chain.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:element name="selector" type="selectorType" />
+				<xsd:element ref="selector-chain" />
+			</xsd:choice>
+			<xsd:attribute name="id" type="xsd:string" />
+			<xsd:attribute name="voting-strategy" default="ALL">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Enumeration with values that match the MessageSelectorChain.VotingStrategy enum.
+					]]></xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:enumeration value="ALL" />
+						<xsd:enumeration value="ANY" />
+						<xsd:enumeration value="MAJORITY" />
+						<xsd:enumeration value="MAJORITY_OR_TIE" />
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="selector">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="selectorType">
+					<xsd:attribute name="id" type="xsd:string" use="required" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="selectorType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Provides a MessageSelector reference. If a method attribute is set the
+				referred bean doesn't need
+				to implement the MessageSelector
+				interface.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="ref" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="java.lang.Object" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="method" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation>
+						<tool:expected-method type-ref="@ref" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="header-enricher">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a HeaderEnricher endpoint for values defined in the MessageHeader.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="header-enricher-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="header-enricher-type">
+		<xsd:choice minOccurs="1" maxOccurs="unbounded">
+			<xsd:element name="reply-channel" type="referenceOrValueHeaderType">
+				<xsd:annotation>
+					<xsd:documentation>
+					Shortcut to specify value for 'replyChannel' header.
+					Can be a 'ref' to the MessageChannel, a 'value' as name of the MessageChannel,
+					or some valid SpEL 'expression' which returns the MessageChannel reference or name of the MessageChannel.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="error-channel" type="referenceOrValueHeaderType">
+				<xsd:annotation>
+					<xsd:documentation>
+					Shortcut to specify value for 'errorChannel' header.
+					Can be a 'ref' to the MessageChannel, a 'value' as name of the MessageChannel,
+					or some valid SpEL 'expression' which returns the MessageChannel reference or name of the MessageChannel.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="correlation-id" type="referenceOrValueHeaderType">
+				<xsd:annotation>
+					<xsd:documentation>
+					Shortcut to specify value for 'correlationId' header
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="expiration-date" type="referenceOrValueHeaderType">
+				<xsd:annotation>
+					<xsd:documentation>
+					Shortcut to specify value for 'expirationDate' header (java.lang.Long)
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="priority">
+				<xsd:annotation>
+					<xsd:documentation>
+						Shortcut to specify value for 'priority' header when using PriorityChannel
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:attribute name="value">
+						<xsd:annotation>
+							<xsd:documentation>
+								Integer value identifying the value of the 'priority' header.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="overwrite">
+						<xsd:annotation>
+							<xsd:documentation>
+								Boolean value to indicate whether this header value should overwrite
+								an existing header
+								value
+								for the same name.
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="xsd:boolean xsd:string" />
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="header" type="userDefinedHeaderType">
+				<xsd:annotation>
+					<xsd:documentation>
+						Element that accepts any user-defined header name/value pair.
+						</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1" >
+				<xsd:annotation>
+					<xsd:documentation>
+						Allows you to configure Message Poller if this endpoint is a Polling Consumer
+						</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:choice>
+		<xsd:attribute name="default-overwrite">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specify the default boolean value for whether to overwrite existing
+					header values. This will
+					only
+					take effect for
+					sub-elements that do not provide their own 'overwrite' attribute. If the
+					'default-overwrite'
+					attribute is not
+					provided, then the specified header values will NOT overwrite any
+					existing ones with the same
+					header
+					names.
+					</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="should-skip-nulls">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specify whether null values, such as might be returned from an expression evaluation,
+					should be
+					skipped. The default value is true. Set this to false if a null value should
+					trigger removal of the corresponding
+					header instead.
+					</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="ref" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to an Object to be invoked for header values.
+					The 'method' attribute is required
+					along
+					with this.
+					</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref" />
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="method" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Method to be invoked on the referenced Object as specified by the
+					'ref' attribute. The method
+					should return a Map with String-typed keys.
+					</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation>
+						<tool:expected-method type-ref="@ref"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="userDefinedHeaderType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Message Header with a literal value or object reference.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="referenceOrValueHeaderType">
+				<xsd:attribute name="name" use="required" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							Name of the header to be added.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="referenceOrValueHeaderType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Provides a header value for the given header name. Requires
+				exactly one of the 'ref', 'value', or
+				'expression' attributes.
+				The 'type' attribute allows for the specification of the expected
+				type when using a 'value'
+				or 'expression', but it is optional.
+				Also for a header value one of 'bean', 'script' or
+				'expression' sub-elements can be defined, but they are mutually exclusive
+				with the attributes defined above.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="referenceHeaderType">
+				<xsd:choice minOccurs="0" maxOccurs="1">
+					<xsd:any processContents="strict" namespace="##other"/>
+					<xsd:element name="expression" type="innerExpressionType" />
+				</xsd:choice>
+				<xsd:attribute name="value" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							Literal value to be associated with the given header name.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="expression" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							Expression to be evaluated at runtime to determine the header value.
+							The EvaluationContext will
+							include variables for 'payload' and
+							'headers'.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="type" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation source="java:java.lang.Class"><![CDATA[
+	The fully qualified class name of the header value's expected type.
+						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="referenceHeaderType">
+		<xsd:attribute name="ref" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to be associated with the given header name.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref" />
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="method" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Name of a method to be invoked on the referenced target object.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation>
+						<tool:expected-method type-ref="@ref" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="overwrite">
+			<xsd:annotation>
+				<xsd:documentation>
+					Boolean value to indicate whether this header value should overwrite an
+					existing header value for
+					the same name.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="header-filter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a HeaderFilter endpoint to remove values defined in the MessageHeaders.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="header-filter-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="header-filter-type">
+		<xsd:attribute name="header-names" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specify one or more header names (as a comma separated list) to
+					be removed from the
+					MessageHeaders
+					of the Message being handled.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="pattern-match" type="xsd:boolean" default="true">
+			<xsd:annotation>
+				<xsd:documentation>
+					Boolean flag that specifies whether values provided in 'header-names' should be treated as
+					match patterns or literal values. For example header-names='foo*' would mean remove all
+					headers that begin with 'foo' including the header named 'foo*'. However if you want to
+					treat '*' as literal value setting this flag to FALSE will not perform pattern match and
+					the only header that will be removed is the one that is an exact match.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Transformer.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="expressionOrInnerEndpointDefinitionAware">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="object-to-string-transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Transformer that converts any Object payload to a String by
+				invoking its toString()
+				method.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="specialized-transformer-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="object-to-map-transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Transformer that converts any Object payload to a SpEL Map.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="specialized-transformer-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="map-to-object-transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Transformer that converts SpEL-based Map to an object.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="map-to-object-transformer-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="map-to-object-transformer-type">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="poller" />
+		</xsd:choice>
+		<xsd:attribute name="type" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation source="java:java.lang.Class"><![CDATA[
+					Fully qulified name of the java type to be created by this transformer (e.g. foo.bar.Foo)
+					NOTE: This attribute is mutually-exclusive with 'ref'.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ref" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The name of the bean to be produced by this transformer. The bean MUST BE of scope 'prototype'.
+					NOTE: This attribute is mutually-exclusive with 'type'.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="java.lang.Object" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="object-to-json-transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Transformer that converts any Object payload to a JSON String.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="object-to-json-transformer-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="object-to-json-transformer-type">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="poller" />
+		</xsd:choice>
+		<xsd:attribute name="content-type" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Allows you to set the 'content-type' Message header. When a 'content-type' header is already present
+					on the input message, the transformer will only override that value IF this attribute is explicitly set
+					(e.g., content-type="text/x-json").
+					If this attribute is omitted, the transformer will set the 'content-type' header to "application/json",
+					when there is no existing 'content-type' header on the input message.
+					Setting the attribute to an empty string ("")
+					will suppress setting the header to the default value,
+					but will not remove the header, if present on the input message. If you wish to remove an existing
+					header, use a <header-filter/> before or after the transformer.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="object-mapper" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to a Jackson ObjectMapper instance to be provided optionally
+					if the default ObjectMapper
+					configuration is not desirable.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.codehaus.jackson.map.ObjectMapper" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="json-to-object-transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Transformer that converts a JSON String to an object.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="json-to-object-transformer-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="json-to-object-transformer-type">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="poller" />
+		</xsd:choice>
+		<xsd:attribute name="type" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation source="java:java.lang.Class"><![CDATA[
+					Fully qulified name of the java type to be created by this transformer (e.g. foo.bar.Foo)
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="object-mapper" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to a Jackson ObjectMapper instance to be provided optionally
+					if the default ObjectMapper
+					configuration is not desirable.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.codehaus.jackson.map.ObjectMapper" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="payload-serializing-transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Transformer that converts an object payload to a byte array.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="payload-serializing-transformer-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="payload-serializing-transformer-type">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="poller" />
+		</xsd:choice>
+		<xsd:attribute name="serializer" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to a Serializer instance to convert from an object to a byte array.
+					This is optional.
+					The default will use standard Java serialization.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.core.serializer.Serializer" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="payload-deserializing-transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Transformer that converts a byte array to an object.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="payload-deserializing-transformer-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="payload-deserializing-transformer-type">
+		<xsd:choice minOccurs="0" maxOccurs="unbounded">
+			<xsd:element ref="poller" />
+		</xsd:choice>
+		<xsd:attribute name="deserializer" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to a Deserializer instance to convert from a byte array to an object.
+					This is optional.
+					The default will use standard Java deserialization.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.core.serializer.Deserializer" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="syslog-to-map-transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Transformer that converts an RFC5424 packet to a Map.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+		</xsd:complexType>
+	</xsd:element>
+
+    <!-- Claim Check -->
+
+	<xsd:element name="claim-check-in" type="claimCheckInType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Transformer that stores a Message and returns a new
+				Message, whose payload is the id of the stored Message.
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+    <xsd:complexType name="claimCheckInType">
+        <xsd:complexContent>
+            <xsd:extension base="commonClaimCheckType">
+                <xsd:sequence minOccurs="0" maxOccurs="1">
+                    <xsd:element ref="poller" />
+                </xsd:sequence>
+                <xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="claimCheckInTypeChain">
+        <xsd:complexContent>
+            <xsd:extension base="commonClaimCheckType">
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+	<xsd:element name="claim-check-out" type="claimCheckOutType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Transformer that accepts a Message whose payload is a
+				UUID and retrieves the Message associated with that id from a
+				MessageStore if available (else null).
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+    <xsd:complexType name="claimCheckOutType">
+        <xsd:complexContent>
+			<xsd:extension base="commonClaimCheckOutType">
+                <xsd:sequence minOccurs="0" maxOccurs="1">
+                    <xsd:element ref="poller" />
+                </xsd:sequence>
+                <xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+			</xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="claimCheckOutTypeChain">
+        <xsd:complexContent>
+            <xsd:extension base="commonClaimCheckOutType">
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="commonClaimCheckOutType">
+        <xsd:complexContent>
+            <xsd:extension base="commonClaimCheckType">
+				<xsd:attribute name="remove-message" default="false">
+				    <xsd:annotation>
+				        <xsd:documentation>
+				            If set to 'true' the Message will be removed
+				            from the MessageStore by this transformer.
+				            Useful when Message can be 'claimed' only
+				            once. DEFAULT is 'false'.
+				        </xsd:documentation>
+				    </xsd:annotation>
+				    <xsd:simpleType>
+				        <xsd:union memberTypes="xsd:boolean xsd:string" />
+				    </xsd:simpleType>
+				</xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+	<xsd:complexType name="commonClaimCheckType">
+		<xsd:attribute name="message-store" default="messageStore">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to the MessageStore to be used by this Claim Check
+					transformer. If not specified, the default reference will be
+					to a bean named 'messageStore'.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.store.MessageStore" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="specialized-transformer-type">
+		<xsd:choice minOccurs="1" maxOccurs="unbounded">
+			<xsd:any processContents="strict" namespace="##other" minOccurs="0" maxOccurs="unbounded" />
+			<xsd:element ref="poller" />
+		</xsd:choice>
+	</xsd:complexType>
+
+	<xsd:element name="filter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Message Filters that is used to decide whether a Message should be passed
+				along or dropped based on some criteria
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="filter-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="filter-type">
+		<xsd:complexContent>
+			<xsd:extension base="expressionOrInnerEndpointDefinitionAware">
+				<xsd:attribute name="discard-channel" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.integration.MessageChannel" />
+							</tool:annotation>
+						</xsd:appinfo>
+						<xsd:documentation>
+						The channel where the filter will send the messages that were dropped
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="throw-exception-on-rejection" type="xsd:string" default="false" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+    <!--
+        Router Element Definitions
+    -->
+
+    <xsd:element name="header-value-router" type="headerValueRouterType">
+        <xsd:annotation>
+            <xsd:documentation><![CDATA[
+            Defines a Header Value Router. The 'header-name' attribute specifies which
+            header value to lookup. That header value can then provide the name of a
+            channel to be resolved. Alternatively, 1 or more 'mapping' sub-elements
+            may be provided with expected header values mapped to channels.
+            ]]></xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:element name="recipient-list-router" type="recipientListRouterType">
+        <xsd:annotation>
+            <xsd:documentation><![CDATA[
+                Defines a Recipient List Router. A RecipientListRouter will send
+                each received Message to a statically defined list of Message Channels.
+
+                Another convenient option when configuring a RecipientListRouter
+                is to define the 'selector-expression' for the 'mapping' sub elements.
+                The 'selector-expression' uses Spring Expression Language (SpEL)
+                and can be used as selectors for individual recipient channels.
+
+                This is similar to using a Filter at the beginning of 'chain' to
+                act as a "Selective Consumer". However, in this case, it's all
+                combined rather concisely into the router's configuration.
+            ]]></xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:element name="payload-type-router" type="payloadTypeRouterType">
+        <xsd:annotation>
+            <xsd:documentation><![CDATA[
+            Defines a Payload Type Router. The 'mapping' sub-elements specify the
+            associations between Java types and target channels.
+            ]]></xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:element name="exception-type-router" type="exceptionTypeRouterType">
+        <xsd:annotation>
+            <xsd:documentation><![CDATA[
+            Defines a Exception Type Router which resolves the target MessageChannel for
+            messages whose payload is an Exception. The channel resolution is based upon
+            the most specific cause of the error for which a channel mapping exists.
+            ]]></xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:element name="router" type="routerType">
+        <xsd:annotation>
+            <xsd:documentation><![CDATA[
+            Defines a Router that serves as an adapter for invoking a method on any
+            Spring-managed object as specified by the "ref" and "method" attributes.
+            ]]></xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+
+    <!--
+
+        Router Types
+
+    -->
+
+    <!-- Type definitions used by the generic Router -->
+
+    <xsd:complexType name="commonRouterType" abstract="true">
+        <xsd:complexContent>
+            <xsd:extension base="abstractRouterType">
+                <xsd:attribute name="ref" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            The "ref" attribute references the bean name of a custom
+                            Router implementation. Typically that implementation will
+                            be a simple POJO, but it may extend AbstractMessageRouter.
+
+                            Provide the "method" attribute as well to clarify which
+                            method should be invoked, Alternatively, the "ref" attribute
+                            may point to an instance that contains the @Router annotation
+                            on one of its methods.
+
+                            Instead of using the "ref" attribute you may also provide
+                            the custom Router implementation as an inner bean
+                            definition.
+
+                            However, keep in mind that using both the "ref" attribute
+                            and an inner handler definition in the same Router
+                            configuration is not allowed, as it creates an
+                            ambiguous condition, and an Exception will be thrown.
+
+							Additionally, instead of using "ref" and "method" at all,
+                            you can use the "expression" attribute (see description below).
+                        </xsd:documentation>
+                        <xsd:appinfo>
+                            <tool:annotation kind="ref">
+                                <tool:expected-type type="java.lang.Object" />
+                            </tool:annotation>
+                        </xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="method" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            When implementing a custom Router using a plain POJO
+                            the "ref" attribute may be combined with an explicit
+                            method name using the "method" attribute.
+
+                            The referenced method may return either a MessageChannel
+                            or a String type. Additionally, the method may return
+                            either a single value or a collection. If a collection
+                            is returned, the reply message will be sent to
+                            multiple channels.
+
+                            Specifying a "method" attribute applies the same behavior
+                            as when using the @Router annotation on a single method
+                            within the object pointed to by the "ref".
+                        </xsd:documentation>
+                        <xsd:appinfo>
+                            <tool:annotation>
+                                <tool:expected-method type-ref="@ref" />
+                            </tool:annotation>
+                        </xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:attribute>
+                <xsd:attribute name="expression" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation>
+                            SpEL Expression to be evaluated at runtime. Allows you
+                            to implement simple computations without implementing
+                            a custom POJO router. Generally, the SpEL expression is
+                            evaluated and the result is mapped to a channel using
+                            "mapping" sub-elements.
+
+                            However, if no "mapping" sub-element is present, the
+                            SpEL Expression will evaluate to a channel name directly.
+
+                            A SpEL expression may also return a Collection. Whenever
+                            the expression returns multiple channel values the
+                            Message will be forwarded to each channel.
+
+                            Note that SpEL supports bean-references within expressions
+                            using the @ sign. This enables more sophisticated mapping
+                            of Message content to method arguments, e.g.:
+                            expression="@someBean.someMethod(payload.foo, headers.bar)"
+                        </xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="routerType">
+        <xsd:complexContent>
+            <xsd:extension base="commonRouterType">
+                <xsd:sequence>
+                    <xsd:element ref="poller"                                        minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="expression" type="innerExpressionType"        minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                            <![CDATA[
+                           You can use SpEL Expressions to implement simple
+                           computations. Generally a SpEL expression is evaluated
+                           and the result is either a channel name or
+                           alternatively the result can be mapped to a channel using the
+                           'mapping' sub-element.
+
+                           The SpEL expression can return a Collection,
+                           effectively making this Router a Dynamic Recipient List
+                           Router. Whenever the expression returns multiple
+                           channel values the Message will be forwarded to
+                           each channel.
+                            ]]></xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="mapping"    type="mappingValueChannelType" minOccurs="0" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                            <![CDATA[
+                            Defines mapping rules for this router
+                            (e.g., mapping value='foo' channel='myChannel')
+                            ]]></xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:any namespace="##other" processContents="strict"            minOccurs="0" maxOccurs="1" />
+                </xsd:sequence>
+                <xsd:attributeGroup ref="topLevelRouterAttributeGroup"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="routerTypeChain">
+        <xsd:complexContent>
+            <xsd:extension base="commonRouterType">
+                <xsd:sequence>
+                    <xsd:element name="expression" type="innerExpressionType"        minOccurs="0" maxOccurs="1" />
+                    <xsd:element name="mapping" type="mappingValueChannelType"    minOccurs="0" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                            <![CDATA[
+                            Defines mapping rules for this router
+                            (e.g., mapping value='foo' channel='myChannel')
+                            ]]></xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Type definitions used by the Header Value Router -->
+
+    <xsd:complexType name="commonHeaderValueRouterType" abstract="true">
+        <xsd:complexContent>
+            <xsd:extension base="abstractRouterType">
+                <xsd:attribute name="header-name" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation><![CDATA[
+                            Name of the header whose value will be used to
+                            route messages.
+                        ]]></xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="headerValueRouterType">
+        <xsd:complexContent>
+            <xsd:extension base="commonHeaderValueRouterType">
+                <xsd:sequence>
+                    <xsd:element ref="poller" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="mapping" type="mappingValueChannelType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>
+							<![CDATA[
+							Defines mapping rules for this router
+							(e.g., mapping value='foo' channel='myChannel')
+							]]></xsd:documentation>
+						</xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+                <xsd:attributeGroup ref="topLevelRouterAttributeGroup"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="headerValueRouterTypeChain">
+        <xsd:complexContent>
+            <xsd:extension base="commonHeaderValueRouterType">
+                <xsd:sequence>
+                    <xsd:element name="mapping" type="mappingValueChannelType" minOccurs="0" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                            <![CDATA[
+                            Defines mapping rules for this router
+                            (e.g., mapping value='foo' channel='myChannel')
+                            ]]></xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Type definitions used by the Recipient List Router -->
+
+    <xsd:complexType name="commonRecipientListRouterType" abstract="true">
+        <xsd:complexContent>
+            <xsd:extension base="abstractRouterType">
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="recipientListRouterType">
+        <xsd:complexContent>
+            <xsd:extension base="commonRecipientListRouterType">
+                <xsd:sequence>
+                    <xsd:element ref="poller" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="recipient" type="recipientSelectorExpressionChannelType" minOccurs="1" maxOccurs="unbounded">
+						<xsd:annotation>
+						    <xsd:documentation>
+						        An expression to be evaluated to determine if this recipient
+						        should be included in the recipient list for a given input
+						        Message. The evaluation result of the expression must be a boolean.
+						        If this attribute is not defined, the channel will always be
+						        among the list of recipients.
+						    </xsd:documentation>
+						</xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+                <xsd:attributeGroup ref="topLevelRouterAttributeGroup"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="recipientListRouterTypeChain">
+        <xsd:complexContent>
+            <xsd:extension base="commonRecipientListRouterType">
+                <xsd:sequence>
+                    <xsd:element name="recipient" type="recipientSelectorExpressionChannelType" minOccurs="1" maxOccurs="unbounded">
+                        <xsd:annotation>
+						    <xsd:documentation>
+						        An expression to be evaluated to determine if this recipient
+						        should be included in the recipient list for a given input
+						        Message. The evaluation result of the expression must be a boolean.
+						        If this attribute is not defined, the channel will always be
+						        among the list of recipients.
+						    </xsd:documentation>
+						</xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Type definitions used by the Payload Type Router -->
+
+    <xsd:complexType name="commonPayloadTypeRouterType" abstract="true">
+        <xsd:complexContent>
+            <xsd:extension base="abstractRouterType">
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="payloadTypeRouterType">
+        <xsd:complexContent>
+            <xsd:extension base="commonPayloadTypeRouterType">
+                <xsd:sequence>
+                    <xsd:element ref="poller" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="mapping" type="mappingTypeChannelType" minOccurs="1" maxOccurs="unbounded">
+                        <xsd:annotation>
+							<xsd:documentation><![CDATA[Element defines the rules
+							for this router to map the type of a payload to the
+							corresponding channel (e.g.
+							<int:mapping value='java.lang.String' channel='stringChannel'/>).
+							]]></xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+                <xsd:attributeGroup ref="topLevelRouterAttributeGroup"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="payloadTypeRouterTypeChain">
+        <xsd:complexContent>
+            <xsd:extension base="commonPayloadTypeRouterType">
+                <xsd:sequence>
+                    <xsd:element name="mapping" type="mappingTypeChannelType" minOccurs="1" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                            <![CDATA[
+                            Element defines the rules for this router to map the type
+                            of a payload to the corresponding channel.
+                            (e.g., <int:mapping value='java.lang.String' channel='stringChannel'/>)
+                            ]]></xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Type definitions used by the Exception Type Router -->
+
+    <xsd:complexType name="commonExceptionTypeRouterType" abstract="true">
+        <xsd:complexContent>
+            <xsd:extension base="abstractRouterType">
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="exceptionTypeRouterType">
+        <xsd:complexContent>
+            <xsd:extension base="commonExceptionTypeRouterType">
+                <xsd:sequence>
+                    <xsd:element ref="poller" minOccurs="0" maxOccurs="1"/>
+                    <xsd:element name="mapping" type="mappingExceptionTypeChannelType" minOccurs="1" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                            <![CDATA[
+                            Element defines the rules for this router to map the
+                            exception type of the payload to the corresponding channel.
+                            (e.g. <int:mapping exception-type='java.lang.NullPointerException' channel='npeChannel'/>)
+
+                            The most specific matching exception type is determined
+                            by navigating the hierarchy of 'exception causes'
+                            (e.g., payload.getCause()).
+                            ]]></xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+                <xsd:attributeGroup ref="topLevelRouterAttributeGroup"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="exceptionTypeRouterTypeChain">
+        <xsd:complexContent>
+            <xsd:extension base="commonExceptionTypeRouterType">
+                <xsd:sequence>
+                    <xsd:element name="mapping" type="mappingExceptionTypeChannelType" minOccurs="1" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                            <![CDATA[
+                            Element defines the rules for this router to map the
+                            exception type of the payload to the corresponding channel.
+                            (e.g. <int:mapping exception-type='java.lang.NullPointerException' channel='npeChannel'/>)
+
+                            The most specific matching exception type is determined
+                            by navigating the hierarchy of 'exception causes'
+                            (e.g., payload.getCause()).
+                            ]]></xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!--
+    The following complex types define the attributes used for the Router
+    sub-elements - "mapping" and "recipient"
+     -->
+
+    <xsd:complexType name="mappingExceptionTypeChannelType">
+        <xsd:attribute name="exception-type" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[The exception type of the payload
+                that this mapping will match, e.g. 'java.lang.IllegalArgumentException']]>
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="channel" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[The channel the matching message will be
+                send to.]]>
+                </xsd:documentation>
+                <xsd:appinfo>
+                    <tool:annotation kind="ref">
+                        <tool:expected-type type="org.springframework.integration.MessageChannel" />
+                    </tool:annotation>
+                </xsd:appinfo>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="mappingValueChannelType">
+        <xsd:attribute name="value" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation>
+                A value of the evaluation token that will be mapped to a channel reference
+                (e.g., mapping value='foo' channel='myChannel')
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="channel" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation>
+                    A reference to a bean that defines a Message Channel
+                    (e.g., mapping value='foo' channel='myChannel')
+                </xsd:documentation>
+                <xsd:appinfo>
+                    <tool:annotation kind="ref">
+                        <tool:expected-type type="org.springframework.integration.MessageChannel" />
+                    </tool:annotation>
+                </xsd:appinfo>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="mappingTypeChannelType">
+        <xsd:attribute name="type" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[The type of the payload that this mapping
+				will match, e.g. 'java.lang.String' or 'java.lang.Integer']]>
+				</xsd:documentation>
+			</xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[The channel the matching message will be
+				send to.]]>
+				</xsd:documentation>
+                <xsd:appinfo>
+                    <tool:annotation kind="ref">
+                        <tool:expected-type type="org.springframework.integration.MessageChannel" />
+                    </tool:annotation>
+                </xsd:appinfo>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="recipientSelectorExpressionChannelType">
+        <xsd:attribute name="selector-expression" type="xsd:string" use="optional">
+            <xsd:annotation>
+                <xsd:documentation>
+                    An expression to be evaluated to determine if this recipient
+                    should be included in the recipient list for a given input
+                    Message. The evaluation result of the expression must be a boolean.
+                    If this attribute is not defined, the channel will always be
+                    among the list of recipients.
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="channel" type="xsd:string" use="required">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[The channel (recepient) that the
+                    message will be send to.]]>
+                </xsd:documentation>
+                <xsd:appinfo>
+                    <tool:annotation kind="ref">
+                        <tool:expected-type type="org.springframework.integration.MessageChannel" />
+                    </tool:annotation>
+                </xsd:appinfo>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <!--
+     The top level router attribute group contains all all attributes that are commonly
+     used for all Top-Level-Routers (Defined outside of Chains).
+    -->
+
+    <xsd:attributeGroup name="topLevelRouterAttributeGroup">
+        <xsd:attribute name="id" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[Identifies the underlying Spring bean
+				      definition which in case of Routers is an instance of
+				      EventDrivenConsumer or PollingConsumer depending on whether
+				      the Router's "input-channel" is a "SubscribableChannel" or
+                      "PollableChannel", respectively. This is an "optional" attribute.
+				    ]]></xsd:documentation>
+			</xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="auto-startup" default="true">
+            <xsd:annotation>
+                <xsd:documentation>
+                    Lifecycle attribute signaling if this component should be
+                    started during Application Context startup. Defaults to true.
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+                <xsd:union memberTypes="xsd:boolean xsd:string" />
+            </xsd:simpleType>
+        </xsd:attribute>
+        <xsd:attribute name="input-channel" type="xsd:string">
+            <xsd:annotation>
+                <xsd:appinfo>
+                    <tool:annotation kind="ref">
+                        <tool:expected-type type="org.springframework.integration.MessageChannel" />
+                    </tool:annotation>
+                </xsd:appinfo>
+                <xsd:documentation>
+                    The receiving Message channel of this endpoint
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="order" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[
+                    Specifies the order for invocation when this endpoint is connected as a
+                    subscriber to a channel. This is particularly relevant when that channel
+                    is using a "failover" dispatching strategy. It has no effect when this
+                    endpoint itself is a Polling Consumer for a channel with a queue.
+                    ]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:attributeGroup>
+
+    <!--
+     The base router type definition contains all attributes that are used across
+     all routers AND are applicable to BOTH Top-Level-Elements and Routers defined
+     in Chains.
+    -->
+
+	<xsd:complexType name="abstractRouterType" abstract="true">
+        <xsd:attribute name="default-output-channel" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation>
+                    Reference to the channel where Messages should be sent if
+                    channel resolution fails to return any channels. If no
+                    default output channel is provided, the router will throw an
+                    Exception.
+
+                    If you would like to silently drop those messages instead,
+                    add the "nullChannel" as the default output channel attribute
+                    value.
+                </xsd:documentation>
+                <xsd:appinfo>
+                    <tool:annotation kind="ref">
+                        <tool:expected-type type="org.springframework.integration.MessageChannel" />
+                    </tool:annotation>
+                </xsd:appinfo>
+            </xsd:annotation>
+        </xsd:attribute>
+		<xsd:attribute name="timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specify the maximum amount of time in milliseconds to wait
+					when sending Messages to the target MessageChannels. By
+					default the send will block indefinitely.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="channel-resolver" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+[DEPRECATED]Provides a reference to a ChannelResolver that resolves the return value
+to the name of a MessageChannel within the application context. If none
+is provided, the return value is expected to match a channel name exactly.
+						]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.support.channel.ChannelResolver" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ignore-send-failures" default="false">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					If set to "true", failures to send to a message channel will
+					be ignored. If set to "false", a MessageDeliveryException will be
+					thrown instead, and if the router resolves more than one channel,
+					any subsequent channels will not receive the message.
+
+					Please be aware that when using direct channels (single threaded),
+					send-failures can be caused by exceptions thrown by components
+					much further down-stream.
+
+					This attribute defaults to false.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+                <xsd:union memberTypes="xsd:boolean xsd:string" />
+            </xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="apply-sequence" default="false">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specify whether sequence number and size headers should be added to each
+					Message. Defaults to false.
+				</xsd:documentation>
+			</xsd:annotation>
+            <xsd:simpleType>
+                <xsd:union memberTypes="xsd:boolean xsd:string" />
+            </xsd:simpleType>
+		</xsd:attribute>
+        <xsd:attribute name="resolution-required" default="true">
+            <xsd:annotation>
+                <xsd:documentation>
+                    Specify whether channel names must always be successfully resolved
+                    to existing channel instances.
+
+                    If set to 'true', a MessagingException will be raised in case
+                    the channel cannot be resolved. Setting this attribute to 'false',
+                    will cause any unresovable channels to be ignored.
+
+                    If not explicitly set, 'resolution-required' will
+                    default to 'true'.
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+                <xsd:union memberTypes="xsd:boolean xsd:string" />
+            </xsd:simpleType>
+        </xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="splitter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Splitter.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="splitter-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="splitter-type">
+		<xsd:complexContent>
+			<xsd:extension base="expressionOrInnerEndpointDefinitionAware">
+				<xsd:attribute name="requires-reply" type="xsd:string" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							Specify whether the splitter method must return a non-null value. This value will be
+							FALSE by default, but if set to TRUE, a MessageHandlingException will be thrown when
+							the underlying service method (or expression) returns a NULL value.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="apply-sequence" type="xsd:string" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							Set this flag to false to prevent adding sequence related headers in this splitter.
+							This can be convenient in cases where the set sequence numbers conflict with downstream
+							custom aggregations.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="delimiters" type="xsd:string" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							Provide one or more delimiters (as a single String value, e.g. delimiters=",;:") for
+							tokenizing String-typed payload values. This attribute is only allowed if no 'ref' or
+							'expression' have been provided since that is when the DefaultMessageSplitter would
+							be used, and it's the implementation that contains the "delimiters" property.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="aggregator">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an aggregating message endpoint.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="aggregator-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="aggregator-type">
+		<xsd:complexContent>
+			<xsd:extension base="correlating-message-handler-type">
+				<xsd:attribute name="expression" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							A SpEL expression to be evaluated against the input message list as its root object.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="expire-groups-upon-completion" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							Boolean flag specifying if MessageGroup should be removed once completed. Useful for
+							handling late arrival use cases where messages arriving with the correlationKey that
+							is the same as the completed MessageGroup will be discarded. Default is 'false'
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="correlating-message-handler-type">
+		<xsd:complexContent>
+			<xsd:extension base="innerEndpointDefinitionAware">
+				<xsd:attribute name="correlation-strategy" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="java.lang.Object" />
+							</tool:annotation>
+						</xsd:appinfo>
+						<xsd:documentation>
+							A reference to a bean that implements the decision algorithm as to whether a given
+							message group is complete. The bean can be an implementation of the
+							CorrelationStrategy interface or a POJO.
+							</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="correlation-strategy-method" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation>
+								<tool:expected-method type-ref="@correlation-strategy" />
+							</tool:annotation>
+						</xsd:appinfo>
+						<xsd:documentation>
+						A method defined on the bean referenced by correlation-strategy, that implements the
+						correlation decision algorithm
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="correlation-strategy-expression" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>A SpEL expression which implements correlation decision
+						algorithm to apply to the Message (e.g., payload.getPerson().getId() - correlate
+						 based on the 'id' of the 'person' attribute of the message payload object)</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="release-strategy" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="java.lang.Object" />
+							</tool:annotation>
+						</xsd:appinfo>
+						<xsd:documentation>
+							A reference to a bean that implements the release strategy.
+							The bean can be an implementation of the
+							ReleaseStrategy interface or a POJO
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="release-strategy-method" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation>
+								<tool:expected-method type-ref="@release-strategy" />
+							</tool:annotation>
+						</xsd:appinfo>
+						<xsd:documentation>
+							A method defined on the bean referenced by release-strategy, that implements the completion
+							decision algorithm.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="release-strategy-expression" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>A SpEL expression to evaluate against a root object that is the Collection of messages within the message group (e.g, size() > 6)</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="discard-channel" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.integration.MessageChannel" />
+							</tool:annotation>
+						</xsd:appinfo>
+						<xsd:documentation>
+						The channel where the aggregator will send the messages that timed out (if send-partial-results-
+						on-expiry is 'false').
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="message-store" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							Reference to a MessageGroupStore for holding
+							state in between message processing. The default
+							is to use a volatile in-memory store, which means that unprocessed messages
+							will be lost if the JVM exits. To customize
+							the expiry of incomplete message groups configure the message store.
+							</xsd:documentation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.integration.store.MessageGroupStore" />
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="send-partial-result-on-expiry" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+						Specifies whether messages that expired should be aggregated and sent to the 'output-channel' or 'replyChannel'.
+						Messages are expired when their containing MessageGroup expires. One of the ways of expiring MessageGroups is by
+						configuring a MessageGroupStoreReaper. However MessageGroups can alternatively be expired by simply calling
+						MessageGroupStore.expireMessageGroup(groupId). That could be accomplished via a ControlBus operation
+						or by simply invoking that method if you have a reference to the MessageGroupStore instance.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="resequencer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a resequencing message endpoint.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="resequencer-type">
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="resequencer-type">
+		<xsd:complexContent>
+			<xsd:extension base="correlating-message-handler-type">
+				<xsd:attribute name="comparator" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							Comparator for messages used to sort the sequence when released. Defaults to comparing
+							the
+							sequence number header.
+						</xsd:documentation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="java.util.Comparator" />
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="release-partial-sequences" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							Flag to say that partial sequences can be released (e.g. 1-4 of 10).
+							Defaults to true, so the
+							sequence has to be complete before any messages
+							are released.
+							This is mutually exclusive with the release-strategy
+							attribute (either or none can be specified , but not both).
+							</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="channelInterceptorsType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a list of interceptors. Each element may be a ChannelInterceptor,
+				ref, or inner-bean.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:element name="ref" minOccurs="0" maxOccurs="unbounded">
+					<xsd:annotation>
+						<xsd:documentation>
+							Reference to a bean in this Application Context that implements ChannelInterceptor
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:attribute name="bean" use="required">
+							<xsd:annotation>
+								<xsd:appinfo>
+									<tool:annotation kind="ref">
+										<tool:expected-type type="org.springframework.integration.channel.ChannelInterceptor" />
+									</tool:annotation>
+								</xsd:appinfo>
+								<xsd:documentation>
+							Reference to a bean in this Application Context that implements ChannelInterceptor
+						</xsd:documentation>
+							</xsd:annotation>
+						</xsd:attribute>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="wire-tap" type="wireTapType" minOccurs="0" maxOccurs="unbounded">
+					<xsd:annotation>
+						<xsd:documentation>
+						Alows you to configure a Wire Tap interceptor that will send a copy of the message to a
+						channel identified by 'channel' attribute.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:any namespace="##other" processContents="strict" minOccurs="0" maxOccurs="unbounded" />
+			</xsd:choice>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:complexType name="wireTapType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Wire Tap Channel Interceptor.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="id" type="xsd:string" use="optional" />
+		<xsd:attribute name="channel" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="selector" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				A reference to a bean in the Application Context
+				which implements  MessageSelector that must accept a message for it to be
+				sent to the intercepting channel
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				The timeout for sending the message to the intercepting channel
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="transactionalType">
+		<xsd:attribute name="transaction-manager" type="xsd:string" default="transactionManager">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The bean name of the PlatformTransactionManager to use.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.transaction.PlatformTransactionManager" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="propagation" default="REQUIRED">
+			<xsd:annotation>
+				<xsd:documentation source="java:org.springframework.transaction.annotation.Propagation"><![CDATA[
+	The transaction propagation behavior.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="REQUIRED" />
+					<xsd:enumeration value="SUPPORTS" />
+					<xsd:enumeration value="MANDATORY" />
+					<xsd:enumeration value="REQUIRES_NEW" />
+					<xsd:enumeration value="NOT_SUPPORTED" />
+					<xsd:enumeration value="NEVER" />
+					<xsd:enumeration value="NESTED" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="isolation" default="DEFAULT">
+			<xsd:annotation>
+				<xsd:documentation source="java:org.springframework.transaction.annotation.Isolation"><![CDATA[
+	The transaction isolation level.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="DEFAULT" />
+					<xsd:enumeration value="READ_UNCOMMITTED" />
+					<xsd:enumeration value="READ_COMMITTED" />
+					<xsd:enumeration value="REPEATABLE_READ" />
+					<xsd:enumeration value="SERIALIZABLE" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="timeout" type="xsd:string" default="-1">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The transaction timeout value (in seconds).
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="read-only" type="xsd:string" default="false">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Is this transaction read-only?
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="synchronization-factory" type="xsd:string" >
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Reference to an instance of org.springframework.integration.transaction.TransactionSynchronizationFactory
+	which will return an instance of org.springframework.transaction.support.TransactionSynchronization via its create(..) method.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.transaction.TransactionSynchronizationFactory" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="pseudoTransactionalType">
+		<xsd:attributeGroup ref="transactionSyncAttributeGroup" />
+	</xsd:complexType>
+
+	<xsd:complexType name="adviceChainType">
+		<xsd:sequence>
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:element name="ref" minOccurs="0" maxOccurs="unbounded">
+					<xsd:complexType>
+						<xsd:attribute name="bean" type="xsd:string" use="required">
+							<xsd:annotation>
+								<xsd:appinfo>
+									<tool:annotation kind="ref">
+										<tool:expected-type type="java.lang.Object" />
+									</tool:annotation>
+								</xsd:appinfo>
+							</xsd:annotation>
+						</xsd:attribute>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:any namespace="##other" processContents="strict" minOccurs="0" maxOccurs="unbounded" />
+			</xsd:choice>
+		</xsd:sequence>
+		<xsd:attribute name="synchronization-factory" type="xsd:string" >
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Reference to an instance of org.springframework.integration.transaction.TransactionSynchronizationFactory
+	which will return an instance of org.springframework.transaction.support.TransactionSynchronization via its create(..) method.
+	Setting of this attribute will only have an affect if a Transaction advice is present in the chain.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.transaction.TransactionSynchronizationFactory" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="expressionOrInnerEndpointDefinitionAware">
+		<xsd:complexContent>
+			<xsd:extension base="handlerEndpointType">
+				<xsd:choice minOccurs="0" maxOccurs="3">
+					<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1" />
+					<xsd:element name="expression" type="innerExpressionType" minOccurs="0" maxOccurs="1" />
+					<xsd:element name="request-handler-advice-chain" type="adviceChainType" minOccurs="0" maxOccurs="1" />
+					<xsd:any namespace="##other" processContents="strict" minOccurs="0" maxOccurs="1" />
+				</xsd:choice>
+				<xsd:attribute name="expression" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							A SpEL expression to be evaluated against the input Message as its root object.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="innerExpressionType">
+		<xsd:attribute name="key" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+					The key for retrieving the expression from an ExpressionSource.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="source" type="xsd:string" default="expressionSource">
+			<xsd:annotation>
+				<xsd:documentation>
+					The reference to an ExpressionSource.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.expression.ExpressionSource" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="innerEndpointDefinitionAware">
+		<xsd:complexContent>
+			<xsd:extension base="handlerEndpointType">
+				<xsd:choice minOccurs="0" maxOccurs="2">
+					<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1" />
+					<xsd:any namespace="##other" processContents="strict" minOccurs="0" maxOccurs="1" />
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="publishing-interceptor">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a MessagePublishingInterceptor which allows you to generate messages
+				as a by-product of
+				method invocations on Spring configured components.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="method" minOccurs="0" maxOccurs="unbounded">
+					<xsd:complexType>
+						<xsd:sequence minOccurs="0" maxOccurs="unbounded">
+							<xsd:element name="header">
+								<xsd:complexType>
+									<xsd:attribute name="name" type="xsd:string" use="required" />
+									<xsd:attribute name="value" type="xsd:string" />
+									<xsd:attribute name="expression" type="xsd:string" />
+								</xsd:complexType>
+							</xsd:element>
+						</xsd:sequence>
+						<xsd:attribute name="pattern" type="xsd:string" />
+						<xsd:attribute name="payload" type="xsd:string" />
+						<xsd:attribute name="channel" type="xsd:string">
+							<xsd:annotation>
+								<xsd:appinfo>
+									<tool:annotation kind="ref">
+										<tool:expected-type type="org.springframework.integration.MessageChannel" />
+									</tool:annotation>
+								</xsd:appinfo>
+							</xsd:annotation>
+						</xsd:attribute>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="required" />
+			<xsd:attribute name="default-channel" type="xsd:string" default="nullChannel">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Specifies default-channel to publish messages
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+    <xsd:element name="wire-tap">
+      <xsd:complexType>
+        <xsd:complexContent>
+           <xsd:extension base="wireTapType">
+              <xsd:attribute name="pattern" type="xsd:string" use="optional">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        [REQUIRED] Channel name(s) or patterns. To specify more than one channel use
+                        ',' 
+                        (e.g.,
+                        channel-name-pattern="input*, foo, bar")
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="order" type="xsd:integer" use="optional">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        [OPTIONAL] Specifies the order in which this interceptor will be
+                        added to the existing channel
+                        interceptors (if any).
+                        Negative value (e.g., -2) will signify BEFORE existing interceptors (if any). Positive
+                        value (e.g., 2)
+                        will signify AFTER existing interceptors (if any)
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+           </xsd:extension>
+        </xsd:complexContent>
+      </xsd:complexType>
+    </xsd:element>
+
+	<xsd:element name="channel-interceptor">
+		<xsd:annotation>
+			<xsd:documentation>
+				Allows you to define channel interceptors to be applied globally.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:any namespace="##any" processContents="strict" minOccurs="0" maxOccurs="1" />
+			</xsd:sequence>
+			<xsd:attribute name="pattern" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						[REQUIRED] Channel name(s) or patterns. To specify more than one channel use
+						',' 
+						(e.g.,
+						channel-name-pattern="input*, foo, bar")
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="order" type="xsd:integer" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						[OPTIONAL] Specifies the order in which this interceptor will be
+						added to the existing channel
+						interceptors (if any).
+						Negative value (e.g., -2) will signify BEFORE existing iinterceptors (if any). Positive
+						value (e.g., 2)
+						will signify AFTER existing interceptors (if any)
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="ref" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+	[OPTIONAL] points to a bean reference which implements this interceptor. Could also be defined as inner &lt;bean&gt; element.
+				]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="converter">
+		<xsd:annotation>
+			<xsd:documentation>
+			Allows you to register Converters (implementation of the Converter interface) that will
+be automatically registered with the ConversionService. ConversionService itself does not have to be
+explicitly defined since the default ConversionService will be registered under the name 'integrationConversionService'
+unless bean with this name is already registered.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:all minOccurs="0" maxOccurs="1">
+				<xsd:element ref="beans:bean" />
+			</xsd:all>
+			<xsd:attribute name="ref" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="java.lang.Object" />
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						<![CDATA[
+	[OPTIONAL] points to a bean reference which implements this Converter. Could also be defined as inner &lt;bean&gt; element.
+						]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="message-history">
+		<xsd:annotation>
+			<xsd:documentation>
+				<![CDATA[
+Will register a Message History writer which will track the message history. There can
+only be one Message History writer per ApplicationContext hierarchy.
+					]]>
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="tracked-components" type="xsd:string" default="*">
+				<xsd:annotation>
+					<xsd:documentation>
+				<![CDATA[
+The list of component name patterns you want to track (e.g.,  tracked-components="inputChannel, out*, *Channel, *Service")
+					]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="control-bus">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="control-bus-type">
+					<xsd:all minOccurs="0" maxOccurs="1">
+						<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1" />
+					</xsd:all>
+					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="control-bus-type">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Control bus that accepts messages in the form of SpEL expressions. The expressions should be provided
+				either as Expression or String payloads (that can be parsed into valid Expressions) in incoming messages.
+				The expressions can refer to beans in the context using the standard @beanName convention. The methods
+				that will be available include:
+				   1) any that are annotated with @ManagedAttribute or @ManagedOperation
+				   2) Lifecycle methods
+				   3) get/set or shutdown methods on configurable TaskExecutors or TaskSchedulers
+			]]></xsd:documentation>
+		</xsd:annotation>
+	</xsd:complexType>
+
+	<xsd:attributeGroup name="inputOutputChannelGroup">
+		<xsd:attribute name="output-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+				Identifies the Message channel where Message will be sent after it's being processed by this endpoint
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="send-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specify the maximum amount of time in milliseconds to wait when sending a reply
+					Message to the
+					output channel. By default the send will block for one second.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="input-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+				The receiving Message channel of this endpoint
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="order" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Specifies the order for invocation when this endpoint is connected as a
+subscriber to a channel. This is particularly relevant when that channel
+is using a "failover" dispatching strategy. It has no effect when this
+endpoint itself is a Polling Consumer for a channel with a queue.
+					]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+        <xsd:attribute name="auto-startup" default="true">
+            <xsd:annotation>
+                <xsd:documentation>
+                    Lifecycle attribute signaling if this component should be
+                    started during Application Context startup. Defaults to true.
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+                <xsd:union memberTypes="xsd:boolean xsd:string" />
+            </xsd:simpleType>
+        </xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="inputOutputChannelGroupWithId">
+		<xsd:attribute name="id" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					'id' value:
+					- Identifies the underlying Spring bean definition (AbstractEndpoint)
+					- as MessageHandler bean alias together with suffix '.handler'
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="inputOutputChannelGroup"/>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="subscribersAttributeGroup">
+		<xsd:attribute name="max-subscribers" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Specifies the maximum subscribers allowed on this channel; defaults to
+					Integer.MAX_VALUE, unless a 'channelInitializer' bean has previously been
+					declared, with a different default.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="transactionSyncAttributeGroup">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Attributes provided in either a <transactional/> or <psedo-transactional/> poller
+				sub element.
+				Used to take action after the transaction completes (<transactional/>) or after
+				the channel.send() is complete (<pseudo-transactional/>).
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="on-success-expression">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Expression to be evaluated when no exception is thrown (<pseudo-transactional/>),
+					or after the transaction commits (<transactional/>). The #root variable of the
+					expression evaluation is the original message; a BeanResolver is also available.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="on-success-result-channel">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Channel where the result (if any) from the evaluation of the on-success-expression is sent.
+					The message sent is the original message, enhanced with a 'dispositionResult' header
+					containing the result, or an Exception, if the evaluation failed. Default:
+					nullChannel.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="on-failure-expression">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Expression to be evaluated when an exception is thrown (<pseudo-transactional/>),
+					or after the transaction rolls back (<transactional/>). The #root variable of the
+					expression evaluation is the original message; a BeanResolver is also available.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="on-failure-result-channel">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Channel where the result (if any) from the evaluation of the on-failure-expression is sent.
+					The message sent is the original message, enhanced with a 'dispositionResult' header
+					containing the result, or an Exception, if the evaluation failed. Default:
+					nullChannel.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="send-timeout">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					A timout used when sending expression evaluation results to the success or
+					failure channels. Only applies if the channel can block on a send, such as
+					a limited-capacity QueueChannel that is currently full.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+</xsd:schema>

--- a/spring-integration-event/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-event/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
 http\://www.springframework.org/schema/integration/event/spring-integration-event-2.0.xsd=org/springframework/integration/event/config/spring-integration-event-2.0.xsd
 http\://www.springframework.org/schema/integration/event/spring-integration-event-2.1.xsd=org/springframework/integration/event/config/spring-integration-event-2.1.xsd
 http\://www.springframework.org/schema/integration/event/spring-integration-event-2.2.xsd=org/springframework/integration/event/config/spring-integration-event-2.2.xsd
-http\://www.springframework.org/schema/integration/event/spring-integration-event.xsd=org/springframework/integration/event/config/spring-integration-event-2.2.xsd
+http\://www.springframework.org/schema/integration/event/spring-integration-event-3.0.xsd=org/springframework/integration/event/config/spring-integration-event-3.0.xsd
+http\://www.springframework.org/schema/integration/event/spring-integration-event.xsd=org/springframework/integration/event/config/spring-integration-event-3.0.xsd

--- a/spring-integration-event/src/main/resources/org/springframework/integration/event/config/spring-integration-event-3.0.xsd
+++ b/spring-integration-event/src/main/resources/org/springframework/integration/event/config/spring-integration-event-3.0.xsd
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/event"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration"
+	targetNamespace="http://www.springframework.org/schema/integration/event"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+			Defines the configuration elements for Spring Integration Event Adapters.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an inbound Channel Adapter which listens for Application Context
+				events, converts them to Messages and sends them to a Message Channel.
+            </xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" use="optional" />
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						The channel to which Messages generated from Application Context events will be sent.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="error-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						If a (synchronous) downstream exception is thrown and an error-channel is specified,
+						the MessagingException will be sent to this channel. Otherwise, any such exception
+						will be propagated to the caller.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="event-types" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						Comma delimited list of event types (classes that extend ApplicationEvent) that this adapter
+						should send to the message channel. By default, all event types will be sent [OPTIONAL]
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="payload-expression">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						SpEL expression to be evaluated against the ApplicationEvent to create the payload instance.
+						If not provided, the ApplicationEvent itself will be the payload.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-startup" type="xsd:string" default="true" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Channel Adapter that receives Messages from a MessageChannel and then publishes
+				MessagingEvents containing those Messages.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:choice minOccurs="0" maxOccurs="2">
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
+				<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+			</xsd:choice>
+			<xsd:attribute name="id" type="xsd:string" />
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+						<xsd:documentation>
+							The Message Channel from which this adapter receives Messages.
+						</xsd:documentation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="order">
+				<xsd:annotation>
+					<xsd:documentation>
+						Specifies the order for invocation when this endpoint is connected as a
+						subscriber to a SubscribableChannel.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-startup" type="xsd:string" default="true" />
+		</xsd:complexType>
+	</xsd:element>
+
+</xsd:schema>

--- a/spring-integration-feed/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-feed/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
 http\://www.springframework.org/schema/integration/feed/spring-integration-feed-2.0.xsd=org/springframework/integration/feed/config/spring-integration-feed-2.0.xsd
 http\://www.springframework.org/schema/integration/feed/spring-integration-feed-2.1.xsd=org/springframework/integration/feed/config/spring-integration-feed-2.1.xsd
 http\://www.springframework.org/schema/integration/feed/spring-integration-feed-2.2.xsd=org/springframework/integration/feed/config/spring-integration-feed-2.2.xsd
-http\://www.springframework.org/schema/integration/feed/spring-integration-feed.xsd=org/springframework/integration/feed/config/spring-integration-feed-2.2.xsd
+http\://www.springframework.org/schema/integration/feed/spring-integration-feed-3.0.xsd=org/springframework/integration/feed/config/spring-integration-feed-3.0.xsd
+http\://www.springframework.org/schema/integration/feed/spring-integration-feed.xsd=org/springframework/integration/feed/config/spring-integration-feed-3.0.xsd

--- a/spring-integration-feed/src/main/resources/org/springframework/integration/feed/config/spring-integration-feed-3.0.xsd
+++ b/spring-integration-feed/src/main/resources/org/springframework/integration/feed/config/spring-integration-feed-3.0.xsd
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/feed"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration"
+	targetNamespace="http://www.springframework.org/schema/integration/feed"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				This adapter takes a feed URL (either RSS or ATOM) and responds to updates.
+				Each Message will be sent to the provided channel with a feed entry as its payload.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" />
+			<xsd:attribute name="url" type="xsd:string" use="required">
+				<xsd:annotation>
+					<xsd:documentation>
+						The URL for an RSS or ATOM feed.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						Identifies channel attached to this adapter. Depending on the type of the adapter
+						this channel could be the receiving channel (e.g., outbound-channel-adapter) or channel where
+						messages will be sent to by this adapter (e.g., inbound-channel-adapter).
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="feed-fetcher" use="optional" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to a FeedFetcher instance for retrieveing Feeds from the provided URL.
+						By default, the HTTP protocol is supported. For any other protocols or general
+						customizations, provide a reference to a different implementation.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="com.sun.syndication.fetcher.FeedFetcher" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="metadata-store" use="optional" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to a MetadataStore instance for storing metadata associated with
+						the retrieved feeds. If the implementation is persistent, it can help to
+						prevent duplicates between restarts. If shared, it can help coordinate multiple
+						instances of an adapter across different processes.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.store.MetadataStore" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-startup" type="xsd:string" default="true">
+				<xsd:annotation>
+					<xsd:documentation>
+					Lifecycle attribute signaling if this component should be started during Application Context startup.
+					Default is 'true'
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+</xsd:schema>

--- a/spring-integration-file/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-file/src/main/resources/META-INF/spring.schemas
@@ -2,4 +2,5 @@ http\://www.springframework.org/schema/integration/file/spring-integration-file-
 http\://www.springframework.org/schema/integration/file/spring-integration-file-2.0.xsd=org/springframework/integration/file/config/spring-integration-file-2.0.xsd
 http\://www.springframework.org/schema/integration/file/spring-integration-file-2.1.xsd=org/springframework/integration/file/config/spring-integration-file-2.1.xsd
 http\://www.springframework.org/schema/integration/file/spring-integration-file-2.2.xsd=org/springframework/integration/file/config/spring-integration-file-2.2.xsd
-http\://www.springframework.org/schema/integration/file/spring-integration-file.xsd=org/springframework/integration/file/config/spring-integration-file-2.2.xsd
+http\://www.springframework.org/schema/integration/file/spring-integration-file-3.0.xsd=org/springframework/integration/file/config/spring-integration-file-3.0.xsd
+http\://www.springframework.org/schema/integration/file/spring-integration-file.xsd=org/springframework/integration/file/config/spring-integration-file-3.0.xsd

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-3.0.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-3.0.xsd
@@ -1,0 +1,565 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/file"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:beans="http://www.springframework.org/schema/beans"
+            xmlns:tool="http://www.springframework.org/schema/tool"
+            xmlns:integration="http://www.springframework.org/schema/integration"
+            targetNamespace="http://www.springframework.org/schema/integration/file"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+
+    <xsd:import namespace="http://www.springframework.org/schema/beans"/>
+    <xsd:import namespace="http://www.springframework.org/schema/integration"
+                schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+
+    <xsd:annotation>
+        <xsd:documentation><![CDATA[
+	Defines the configuration elements for Spring Integration File Adapters.
+		]]></xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:element name="inbound-channel-adapter">
+        <xsd:annotation>
+            <xsd:documentation>
+                Configures an inbound Channel Adapter that polls a directory and sends Messages whose payloads are
+                instances of java.io.File.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+				<xsd:choice minOccurs="0" maxOccurs="1" >
+					<xsd:sequence>
+						<xsd:element ref="integration:poller" />
+					    <xsd:choice minOccurs="0" maxOccurs="1">
+							<xsd:element ref="locker"/>
+							<xsd:element ref="nio-locker"/>
+						</xsd:choice>
+					</xsd:sequence>
+					<xsd:sequence>
+						<xsd:choice>
+							<xsd:element ref="locker"/>
+							<xsd:element ref="nio-locker"/>
+						</xsd:choice>
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+					</xsd:sequence>
+				</xsd:choice>
+            </xsd:sequence>
+            <xsd:attribute name="id" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[Identifies the underlying Spring bean definition (SourcePollingChannelAdapter)
+
+                        Keep in mind that if no "channel" attribute is defined, then the "id" attribute is required.
+                        In that case the "id" attribute's value will be used as the channel name and ".adapter" will be
+                        appended to the "id" value of the underlying bean definition.
+                        ]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="channel" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[Defines the message channel to which the payload shall be forwarded to.
+
+                        Keep in mind that any Channel Adapter can be created without a "channel" reference in which case
+                        it will implicitly create an instance of DirectChannel. The created channel's name will match
+                        the "id" attribute of the <inbound-channel-adapter/> element. Therefore, if the "channel" attribute
+                        is not provided, then the "id" attribute is required.
+                        ]]></xsd:documentation>
+                    <xsd:appinfo>
+                        <tool:annotation kind="ref">
+                            <tool:expected-type type="org.springframework.integration.MessageChannel"/>
+                        </tool:annotation>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="directory" type="xsd:string" use="required">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[Specifies the input directory (The directory to poll from) e.g.:
+                    directory="file:/absolute/input" or directory="file:relative/input"]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="comparator" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[
+	Specify a Comparator to be used when ordering Files. If none is provided, the
+	order will be determined by the java.io.File implementation of Comparable.  MUTUALLY EXCLUSIVE with queue-size.
+					]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="filter" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[
+						Specify a FileListFilter to be used. By default, an AcceptOnceFileListFilter is used,
+						which ensures files are picked up only once from the directory.
+
+						You can also apply multiple filters by referencing a CompositeFileListFilter.
+					]]></xsd:documentation>
+                    <xsd:appinfo>
+                        <tool:annotation kind="ref">
+                            <tool:expected-type type="org.springframework.integration.file.filters.FileListFilter"/>
+                        </tool:annotation>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="filename-pattern" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[
+Only files matching this ant style path will be picked up by this adapter. Note that
+in Spring Integration 1.0 this attribute accepted a regular expression, but from 2.0
+filename-regex should be used for that purpose instead.
+                            ]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="filename-regex" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[
+Only files matching this regular expression will be picked up by this adapter.
+                            ]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="scanner" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[Reference to a custom DirectoryScanner implementation.]]></xsd:documentation>
+                    <xsd:appinfo>
+                        <tool:annotation kind="ref">
+                            <tool:expected-type
+                                    type="org.springframework.integration.file.DirectoryScanner"/>
+                        </tool:annotation>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="prevent-duplicates" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[
+	A boolean flag indicating whether duplicates should be prevented. If a 'filter' reference is
+	provided, duplicate prevention will not be enabled by default (the assumption is that the
+	provided filter is sufficient), but setting this to true will enable it. If a 'filename-pattern'
+	is provided, duplicate prevention will be enabled by default (preceding the pattern matching),
+	but setting this to false will disable it. If neither 'filter' or 'filename-pattern' is provided,
+	duplicate prevention is enabled by default, but setting this to false will disable it. For more
+	detail on the actual duplicate prevention, see the javadoc for AcceptOnceFileListFilter.
+					]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="auto-startup" type="xsd:string" default="true">
+                <xsd:annotation>
+				    <xsd:documentation>
+				        Lifecycle attribute signaling if this component should be started during Application Context startup.
+				    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="auto-create-directory" type="xsd:string" default="true">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Specify whether to automatically create the source directory if it does not yet exist when this
+                        adapter is being initialized. The default value is 'true'. If set to 'false' and the directory
+                        does not exist upon initialization, an Exception will be thrown.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="queue-size" type="xsd:integer">
+                <xsd:annotation>
+                  <xsd:documentation>
+                    Specify the maximum number of files stored in memory by the underlying FileReadingMessageSource.
+                    This is useful to limit the memory footprint of this endpoint. Using a stateful filter would counter
+                    this benefit, so AcceptOnceFileListFilter is not used when this attribute is specified.
+                    MUTUALLY EXCLUSIVE with comparator, if comparator is set this attribute will be ignored.
+                    MUTUALLY EXCLUSIVE with stateful filtering.
+                  </xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:element name="outbound-channel-adapter">
+        <xsd:annotation>
+            <xsd:documentation>
+                Configures an outbound Channel Adapter that writes Message payloads to a File.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="outboundFileBaseType">
+                    <xsd:attribute name="channel" type="xsd:string">
+                        <xsd:annotation>
+                            <xsd:documentation>The channel through which outgoing messages will arrive.</xsd:documentation>
+                            <xsd:appinfo>
+                                <tool:annotation kind="ref">
+                                    <tool:expected-type type="org.springframework.integration.MessageChannel"/>
+                                </tool:annotation>
+                            </xsd:appinfo>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:element name="outbound-gateway">
+        <xsd:annotation>
+            <xsd:documentation>
+                Configures an outbound Gateway that writes request Message payloads to a File and then generates a
+                reply Message containing the newly written File as its payload.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="outboundFileBaseType">
+                    <xsd:attribute name="request-channel" type="xsd:string">
+                        <xsd:annotation>
+                            <xsd:documentation>The channel through which outgoing messages will arrive.</xsd:documentation>
+                            <xsd:appinfo>
+                                <tool:annotation kind="ref">
+                                    <tool:expected-type type="org.springframework.integration.MessageChannel"/>
+                                </tool:annotation>
+                            </xsd:appinfo>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="reply-channel" type="xsd:string">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[After writing the File, it will be sent to the specified reply channel as the payload of a Message.
+                                         Another way of providing the 'reply-channel' is by setting the MessageHeaders.REPLY_CHANNEL Message Header]]>
+                            </xsd:documentation>
+                            <xsd:appinfo>
+                                <tool:annotation kind="ref">
+                                    <tool:expected-type type="org.springframework.integration.MessageChannel"/>
+                                </tool:annotation>
+                            </xsd:appinfo>
+                        </xsd:annotation>
+                    </xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Allows you to specify how long this gateway will wait for
+								the reply message to be sent successfully to the reply channel
+								before throwing an exception. This attribute only applies when the
+								channel might block, for example when using a bounded queue channel that
+								is currently full.
+
+								Also, keep in mind that when sending to a DirectChannel, the
+								invocation will occur in the sender's thread. Therefore,
+								the failing of the send operation may be caused by other
+								components further downstream.
+
+								The "reply-timeout" attribute maps to the "sendTimeout" property of the
+								underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+								The attribute will default, if not specified, to '-1', meaning that
+								by default, the Gateway will wait indefinitely. The value is
+								specified in milliseconds.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:complexType name="outboundFileBaseType">
+        <xsd:choice minOccurs="0" maxOccurs="2">
+            <xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+        </xsd:choice>
+        <xsd:attribute name="id" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[Identifies the underlying Spring bean definition (EventDrivenConsumer)]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+		<xsd:attribute name="directory" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					<![CDATA[Specifies the output directory, e.g.:
+					directory="file:/absolute/output" or directory="file:relative/output"
+					Either this attribute or 'directory-expression' must be provided.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="directory-expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					<![CDATA[Specifies the output directory using a SpEL expression.
+					This allows you to dynamically specify the output directory
+					on a per message basis. For example a message header or payload
+					property can be used for specifying the destination directory
+					at runtime.]]>
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+        <xsd:attribute name="filename-generator" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation>
+                    <![CDATA[Allows you to provide a reference to the FileNameGenerator strategy
+                    to use when generating the destination file's name. If not specified the
+                    DefaultFileNameGenerator is used.]]>
+                </xsd:documentation>
+                <xsd:appinfo>
+                    <tool:annotation kind="ref">
+                        <tool:expected-type type="org.springframework.integration.file.FileNameGenerator"/>
+                    </tool:annotation>
+                </xsd:appinfo>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="filename-generator-expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				Allows you to provide a SpEL expression which will compute the file name of
+				the target file (e.g., assuming payload is java.io.File "payload.name + '.transferred'");
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+        <xsd:attribute name="temporary-file-suffix" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+					Extension used when uploading files. We change it after we know it's uploaded.
+					This attribute is mutualy exclusive with 'append' since the append is done to the
+					actual file and not its temporary counterpart. The default value of this attribute (i.e., .writing)
+					is ignored when 'append' is set to true.
+					</xsd:documentation>
+				</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="mode">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					This attribute defaults to 'REPLACE' if not set explicitly.
+
+					The following options are available:
+
+					APPEND:
+
+					If append is specified, the data will be appended
+					to the existing file if such file exists, otherwise the
+					new file will be created as usual but once created the
+					subsequent data will be appended to it. This attribute
+					is mutualy exclusive with the 'temporary-file-suffix'
+					since append is done to the actual file and not its
+					temporary counterpart.
+
+					If set to APPEND, the component will also create a real
+					instance of the LockRegistry to ensure that there are no
+					collisions when multiple threads are writing to the same
+					file.
+
+					FAIL:
+
+					If the target file exists, a MessageHandlingException
+					is thrown.
+
+					IGNORE:
+
+					If the target file exists, the message payload is silently
+					ignored.
+
+					REPLACE:
+
+					This is the default behavior when writing files. If the
+					target file already exists, it will be overwritten.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="mode xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+        <xsd:attribute name="delete-source-files" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[
+	Specify whether to delete source files after writing to the destination directory.
+	This will take effect if the Message payload is the actual source File instance
+	or if the original File instance (or its path) is available in the header value
+	associated with the FileHeaders.ORIGINAL_FILE constant. The default value is false.
+				]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="order" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[
+	Specifies the order for invocation when this endpoint is connected as a
+	subscriber to a SubscribableChannel.
+				]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="auto-create-directory" type="xsd:string" default="true">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[Specify whether to automatically create the destination directory if it does not yet exist when this
+                    adapter is being initialized. The default value is 'true'. If set to 'false' and the directory does
+                    not exist upon initialization, an Exception will be thrown.]]>
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="auto-startup" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation>
+                    <![CDATA[Lifecycle attribute signaling if this component should be started during Application Context startup.]]>
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="charset" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation>
+                    <![CDATA[Set the charset name to use when writing a File from a String-based
+                    Message payload, e.g. charset="UTF-8". If not set, the default charset of this
+                    Java virtual machine is used.
+                    ]]>
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:element name="file-to-string-transformer">
+        <xsd:annotation>
+            <xsd:documentation>
+                Creates a Transformer that converts a File payload to a String.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="transformerType">
+                    <xsd:attribute name="charset" type="xsd:string">
+						<xsd:annotation>
+						    <xsd:documentation>
+						        <![CDATA[Set the charset name to use when converting a File
+						        payload to a String, e.g. charset="UTF-8". If not set, the default charset of this
+						        Java virtual machine is used.]]>
+						    </xsd:documentation>
+						</xsd:annotation>
+                    </xsd:attribute>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:element name="file-to-bytes-transformer">
+        <xsd:annotation>
+            <xsd:documentation>
+                Creates a Transformer that converts a File payload to an array of bytes.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="transformerType"/>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:complexType name="transformerType">
+        <xsd:attribute name="id" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation><![CDATA[Identifies the underlying Spring bean definition (EventDrivenConsumer)]]></xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="input-channel" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation>
+                    <![CDATA[The input channel of the transformer.]]>
+                </xsd:documentation>
+                <xsd:appinfo>
+                    <tool:annotation kind="ref">
+                        <tool:expected-type type="org.springframework.integration.MessageChannel"/>
+                    </tool:annotation>
+                </xsd:appinfo>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="output-channel" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation>
+                    <![CDATA[The channel to which the transformer will send the transformed message.
+                    Optional, because incoming messages can specify a reply channel using the 'replyChannel'
+                    message header value themselves.]]>
+                </xsd:documentation>
+                <xsd:appinfo>
+                    <tool:annotation kind="ref">
+                        <tool:expected-type type="org.springframework.integration.MessageChannel"/>
+                    </tool:annotation>
+                </xsd:appinfo>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="delete-files" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation>
+                    <![CDATA[The delete-files option signals to the transformer that it should delete the
+                    inbound File after the transformation is complete.]]>
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:element name="locker">
+        <xsd:annotation>
+			<xsd:documentation>
+				<![CDATA[When multiple processes are reading from the same
+				directory it can be desirable to lock files to prevent them
+				from being picked up concurrently. To do this you can specify a reference to a FileLocker.]]>
+			</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:attribute name="ref" type="xsd:string">
+                <xsd:annotation>
+				    <xsd:documentation>
+				        <![CDATA[The reference to the FileLocker.]]>
+				    </xsd:documentation>
+                    <xsd:appinfo>
+                        <tool:annotation kind="ref">
+                            <tool:expected-type type="org.springframework.integration.file.FileLocker"/>
+                        </tool:annotation>
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:attribute>
+        </xsd:complexType>
+    </xsd:element>
+
+	<xsd:element name="nio-locker">
+		<xsd:annotation>
+			<xsd:documentation>
+           <![CDATA[When multiple processes are reading from the same directory
+           it can be desirable to lock files to prevent them from being picked up
+           concurrently. This is a java.nio based implementation available out of the box.]]>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:simpleType name="mode">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="REPLACE">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						This is the default behavior when writing files. If the
+						target file already exists, it will be overwritten.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="APPEND">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						If append is specified, the data will be appended
+						to the existing file if such file exists, otherwise the
+						new file will be created as usual but once created the
+						subsequent data will be appended to it. This attribute
+						is mutualy exclusive with the 'temporary-file-suffix'
+						since append is done to the actual file and not its
+						temporary counterpart.
+
+						If set to APPEND, the component will also create a real
+						instance of the LockRegistry to ensure that there are no
+						collisions when multiple threads are writing to the same
+						file.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="FAIL">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						If the target file exists, a MessageHandlingException
+						is thrown.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="IGNORE">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						If the target file exists, the message payload is silently
+						ignored.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/spring-integration-ftp/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-ftp/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
 http\://www.springframework.org/schema/integration/ftp/spring-integration-ftp-2.0.xsd=org/springframework/integration/ftp/config/spring-integration-ftp-2.0.xsd
 http\://www.springframework.org/schema/integration/ftp/spring-integration-ftp-2.1.xsd=org/springframework/integration/ftp/config/spring-integration-ftp-2.1.xsd
 http\://www.springframework.org/schema/integration/ftp/spring-integration-ftp-2.2.xsd=org/springframework/integration/ftp/config/spring-integration-ftp-2.2.xsd
-http\://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd=org/springframework/integration/ftp/config/spring-integration-ftp-2.2.xsd
+http\://www.springframework.org/schema/integration/ftp/spring-integration-ftp-3.0.xsd=org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
+http\://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd=org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
@@ -1,0 +1,511 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/ftp"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration"
+	targetNamespace="http://www.springframework.org/schema/integration/ftp"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+                Builds an outbound-channel-adapter that writes files to a remote FTP endpoint.
+            ]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="base-ftp-adapter-type">
+					<xsd:all>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:all>
+					<xsd:attribute name="remote-directory-expression"
+						type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide a SpEL expression which
+								will compute the directory
+								path where the files will be transferred to
+								(e.g., "headers.['remote_dir'] +
+								'/myTransfers'");
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="temporary-remote-directory-expression"
+						type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide a SpEL expression which
+								will compute the temporary directory
+								path where files will be transferred to before they are moved to the remote-directory
+								(e.g., "headers.['remote_dir'] +
+								'/temp/myTransfers'");
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="auto-create-directory" type="xsd:string"
+						default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether to automatically create the
+								remote target directory if
+								it doesn't exist.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="remote-filename-generator" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to specify a reference to
+								[org.springframework.integration.file.FileNameGenerator] bean.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.file.FileNameGenerator" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="remote-filename-generator-expression"
+						type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide SpEL expression which
+								will compute file name of
+								the remote file (e.g., assuming payload
+								is java.io.File
+								"payload.getName() + '.transfered'");
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="use-temporary-file-name" type="xsd:string" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to suppress using a temporary file name while writing the file.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the order for invocation when this
+								endpoint is connected as a
+								subscriber to a channel. This is
+								particularly relevant when that channel
+								is using a "failover"
+								dispatching strategy, or when a failure in
+								the delivery to one
+								subscriber should signal that
+								the message should not be sent to
+								subscribers with a higher 'order'
+								attribute. It has no effect
+								when this
+								endpoint itself is a Polling Consumer for a channel
+								with a queue.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+                    Builds an inbound-channel-adapter that synchronizes a local directory with the contents of a remote FTP endpoint.
+            ]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="base-ftp-adapter-type">
+					<xsd:sequence>
+						<xsd:element ref="integration:poller" minOccurs="0"
+							maxOccurs="1" />
+					</xsd:sequence>
+					<xsd:attribute name="filename-pattern" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide a file name pattern to
+								determine the file names
+								that need to be scanned.
+								This is based on
+								simple pattern matching (e.g., "*.txt, fo*.txt"
+								etc.)
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="local-filename-generator-expression"
+						type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide a SpEL expression to
+								generate the file name of
+								the local (transferred) file. The root
+								object of the SpEL
+								evaluation is the name of the original
+								file.
+								For example, a valid expression would be "#this.toUpperCase() +
+								'.a'" where #this represents the
+								original name of the remote
+								file.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="filename-regex" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide a Regular Expression to
+								determine the file names
+								that need to be scanned.
+								(e.g.,
+								"f[o]+\.txt" etc.)
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="comparator" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+			Specify a Comparator to be used when ordering Files. If none is provided, the
+			order will be determined by the java.io.File implementation of Comparable.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="filter" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.file.filters.FileListFilter" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Allows you to specify a reference to a
+								[org.springframework.integration.file.filters.FileListFilter]
+								bean.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="local-directory" type="xsd:string"
+						use="required">
+						<xsd:annotation>
+							<xsd:documentation>
+								Identifies the directory path (e.g.,
+								"/local/mytransfers") where files
+								will be transferred TO.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="auto-create-local-directory"
+						type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Tells this adapter if the local directory must
+								be auto-created if it
+								doesn't exist. Default is TRUE.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="delete-remote-files" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether to delete the remote source
+								file after copying.
+								By default, the remote files will NOT be
+								deleted.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-gateway">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+                Builds an outbound gateway used to issue FTP commands.
+            ]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="base-adapter-type">
+					<xsd:all>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:all>
+					<xsd:attribute name="command" use="required" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								FTP command - ls, get or rm
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="command-options" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								FTP command options; for ls, -1 means just
+								return the file names
+								(otherwise file
+								metadata is returned, -dirs
+								means include directories (not included by
+								default),
+								-links means
+								include links (not included by default); for get, -P means
+								preserve
+								timestamp from remote file.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="expression" use="required" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								SpEL expression representing the path in the
+								command (e.g. ls path to
+								list the files in directory path).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Identifies the request channel attached to
+								this
+								gateway.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Identifies the reply channel attached to this
+								gateway.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Allows you to specify how long this gateway will wait for
+								the reply message to be sent successfully to the reply channel
+								before throwing an exception. This attribute only applies when the
+								channel might block, for example when using a bounded queue channel that
+								is currently full.
+
+								Also, keep in mind that when sending to a DirectChannel, the
+								invocation will occur in the sender's thread. Therefore,
+								the failing of the send operation may be caused by other
+								components further downstream.
+
+								The "reply-timeout" attribute maps to the "sendTimeout" property of the
+								underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+								The attribute will default, if not specified, to '-1', meaning that
+								by default, the Gateway will wait indefinitely. The value is
+								specified in milliseconds.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="filter" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.file.filters.FileListFilter" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Allows you to specify a reference to
+								[org.springframework.integration.file.filters.FileListFilter]
+								bean.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="filename-pattern" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide file name pattern to
+								determine the file names retrieved by the ls command
+								and is based
+								on simple pattern matching algorithm (e.g., "*.txt, fo*.txt"
+								etc.)
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="filename-regex" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide Regular Expression to
+								determine the file names retrieved by the ls command.
+								(e.g.,
+								"f[o]+\.txt" etc.)
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="local-directory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Identifies directory path (e.g.,
+								"/local/mytransfers") where file will be
+								transferred TO.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="auto-create-local-directory"
+						type="xsd:boolean">
+						<xsd:annotation>
+							<xsd:documentation>
+								Tells this adapter if local directory must be
+								auto-created if it
+								doesn''t exist. Default is TRUE.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the order for invocation when this
+								endpoint is connected as a
+								subscriber to a channel. This is
+								particularly relevant when that channel
+								is using a "failover"
+								dispatching strategy, or when a failure in the
+								delivery to one
+								subscriber should signal that
+								the message should not be sent to
+								subscribers with a higher 'order'
+								attribute. It has no effect
+								when
+								this
+								endpoint itself is a Polling Consumer for a channel with
+								a
+								queue.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="base-ftp-adapter-type">
+		<xsd:complexContent>
+			<xsd:extension base="base-adapter-type">
+				<xsd:attribute name="remote-directory" type="xsd:string"
+					use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							Identifies the remote directory path (e.g., "/remote/mytransfers")
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="temporary-remote-directory" type="xsd:string"
+					use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							Identifies the remote temporary directory path (e.g., "/remote/temp/mytransfers")
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="channel" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+							</tool:annotation>
+						</xsd:appinfo>
+						<xsd:documentation>
+							Identifies channel attached to this adapter. Depending on the type of the adapter
+							this channel could be the receiving channel (e.g., outbound-channel-adapter) or channel where
+							messages will be sent to by this adapter (e.g., inbound-channel-adapter).
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="charset" type="xsd:string" default="UTF-8">
+					<xsd:annotation>
+						<xsd:documentation>
+							Allows you to specify Charset (e.g., US-ASCII, ISO-8859-1, UTF-8). [UTF-8] is default
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+        </xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="base-adapter-type">
+		<xsd:attribute name="id" type="xsd:string" />
+		<xsd:attribute name="session-factory" type="xsd:string"
+			use="required">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type
+							type="org.springframework.integration.ftp.session.DefaultFtpSessionFactory" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation><![CDATA[
+                Reference to a [org.springframework.integration.ftp.session.DefaultFtpSessionFactory] bean.
+            ]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="temporary-file-suffix" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Extension used when downloading files. We
+					change
+					it right after we know it's
+					downloaded.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+
+		<xsd:attribute name="remote-file-separator" type="xsd:string"
+			default="/">
+			<xsd:annotation>
+				<xsd:documentation>
+					Allows you to provide remote file/directory
+					separator character. DEFAULT:
+					'/'
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="cache-sessions" type="xsd:string"
+			default="true">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+		[DEPRECATED] Consider wrapping your SessionFactory in an instance of org.springframework.integration.file.remote.session.CachingSessionFactory.
+		]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string"
+			default="true">
+			<xsd:annotation>
+				<xsd:documentation>
+					Lifecycle attribute signaling if this component
+					should be started during
+					Application Context startup.
+					Default is
+					'true'
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+
+</xsd:schema>

--- a/spring-integration-gemfire/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-gemfire/src/main/resources/META-INF/spring.schemas
@@ -1,3 +1,4 @@
 http\://www.springframework.org/schema/integration/gemfire/spring-integration-gemfire-2.1.xsd=org/springframework/integration/gemfire/config/xml/spring-integration-gemfire-2.1.xsd
 http\://www.springframework.org/schema/integration/gemfire/spring-integration-gemfire-2.2.xsd=org/springframework/integration/gemfire/config/xml/spring-integration-gemfire-2.2.xsd
-http\://www.springframework.org/schema/integration/gemfire/spring-integration-gemfire.xsd=org/springframework/integration/gemfire/config/xml/spring-integration-gemfire-2.2.xsd
+http\://www.springframework.org/schema/integration/gemfire/spring-integration-gemfire-3.0.xsd=org/springframework/integration/gemfire/config/xml/spring-integration-gemfire-3.0.xsd
+http\://www.springframework.org/schema/integration/gemfire/spring-integration-gemfire.xsd=org/springframework/integration/gemfire/config/xml/spring-integration-gemfire-3.0.xsd

--- a/spring-integration-gemfire/src/main/resources/org/springframework/integration/gemfire/config/xml/spring-integration-gemfire-3.0.xsd
+++ b/spring-integration-gemfire/src/main/resources/org/springframework/integration/gemfire/config/xml/spring-integration-gemfire-3.0.xsd
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/gemfire"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration"
+	targetNamespace="http://www.springframework.org/schema/integration/gemfire"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"
+		schemaLocation="http://www.springframework.org/schema/beans/spring-beans-3.1.xsd" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+	Defines the core configuration elements for Spring Integration GemFire Support.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an inbound Channel Adapter backed by a
+				GemFire CacheListener
+			</xsd:documentation>
+		</xsd:annotation>
+
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="InboundChannelAdapterType">
+
+					<xsd:attribute name="region" type="xsd:string" use="required">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="com.gemstone.gemfire.cache.Region" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+
+					<xsd:attribute name="cache-events" type="xsd:string"
+						use="optional" default="CREATED,UPDATED">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+						Enabled cache entry event types
+				]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="value">
+									<tool:expected-type
+										type="org.springframework.integration.gemfire.inbound.EventType" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="cq-inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an inbound Channel Adapter backed by a
+				Spring Gemfire QueryListener
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="InboundChannelAdapterType">
+					<xsd:attribute name="cq-listener-container" use="required">
+					<xsd:annotation>
+							<xsd:documentation><![CDATA[
+						Reference to a ContinuousQueryListenerContainer
+				]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="value">
+									<tool:expected-type
+										type="org.springframework.data.gemfire.listener.ContinuousQueryListenerContainer" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="query-events" type="xsd:string"
+						use="optional" default="CREATED,UPDATED">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+						Enabled continuous query event types
+				]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="value">
+									<tool:expected-type
+										type="org.springframework.integration.gemfire.inbound.CqEventType" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="query" use="required" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+						The query string
+				]]></xsd:documentation>
+				</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="query-name" use="optional" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+						The query name
+				]]></xsd:documentation>
+				</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="durable" use="optional" type="xsd:boolean" default="false">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+							Indicates if the query is a durable subscription
+							]]></xsd:documentation>
+							</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+		</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+					Configures an outbound Channel Adapter that
+					writes Message to a Gemfire cache
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:choice minOccurs="0" maxOccurs="2">
+				<xsd:element name="cache-entries" type="beans:mapType"
+					minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation>
+							A map of SpEL expressions used to create cache entries. If not
+							provided, payload must be a Map
+					</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+			</xsd:choice>
+			<xsd:attribute name="id" type="xsd:string" use="optional" />
+
+
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+
+			<xsd:attribute name="region" type="xsd:string" use="required">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="com.gemstone.gemfire.cache.Region" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+
+			<xsd:attribute name="order" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					Specifies the order for invocation when this endpoint is connected as a
+					subscriber to a SubscribableChannel.
+				]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="InboundChannelAdapterType">
+		<xsd:attribute name="id" type="xsd:string" use="optional" />
+		<xsd:attribute name="channel" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type
+							type="org.springframework.integration.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+
+		<xsd:attribute name="error-channel" type="xsd:string"
+			use="optional">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<xsd:documentation><![CDATA[
+							Identifies the channel to which error messages will be sent if a failure occurs in this
+							component's invocation. If no "error-channel" reference is provided, this component will
+							propagate Exceptions to the caller. To completely suppress Exceptions, provide a
+							reference to the "nullChannel" here.
+						]]></xsd:documentation>
+						<tool:expected-type
+							type="org.springframework.integration.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+
+		<xsd:attribute name="expression" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Expression to be evaluated to produce a value for the payload.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+
+	</xsd:complexType>
+</xsd:schema>

--- a/spring-integration-groovy/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-groovy/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
 http\://www.springframework.org/schema/integration/groovy/spring-integration-groovy-2.0.xsd=org/springframework/integration/groovy/config/spring-integration-groovy-2.0.xsd
 http\://www.springframework.org/schema/integration/groovy/spring-integration-groovy-2.1.xsd=org/springframework/integration/groovy/config/spring-integration-groovy-2.1.xsd
 http\://www.springframework.org/schema/integration/groovy/spring-integration-groovy-2.2.xsd=org/springframework/integration/groovy/config/spring-integration-groovy-2.2.xsd
-http\://www.springframework.org/schema/integration/groovy/spring-integration-groovy.xsd=org/springframework/integration/groovy/config/spring-integration-groovy-2.2.xsd
+http\://www.springframework.org/schema/integration/groovy/spring-integration-groovy-3.0.xsd=org/springframework/integration/groovy/config/spring-integration-groovy-3.0.xsd
+http\://www.springframework.org/schema/integration/groovy/spring-integration-groovy.xsd=org/springframework/integration/groovy/config/spring-integration-groovy-3.0.xsd

--- a/spring-integration-groovy/src/main/resources/org/springframework/integration/groovy/config/spring-integration-groovy-3.0.xsd
+++ b/spring-integration-groovy/src/main/resources/org/springframework/integration/groovy/config/spring-integration-groovy-3.0.xsd
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/groovy"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration"
+	targetNamespace="http://www.springframework.org/schema/integration/groovy"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:include
+		schemaLocation="http://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core-3.0.xsd"
+		/>
+
+	<xsd:import namespace="http://www.springframework.org/schema/integration" schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+
+	<xsd:element name="script" type="GroovyScript">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an inner bean that will generate a
+				Groovy Script.
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="GroovyScript">
+		<xsd:complexContent>
+			<xsd:extension base="ScriptType">
+				<xsd:attribute name="customizer" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							Reference to a GroovyObjectCustomizer bean to be applied to this script.
+						</xsd:documentation>
+						<xsd:appinfo>
+							<tool:expected-type
+								type="org.springframework.scripting.groovy.GroovyObjectCustomizer" />
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
+	<xsd:element name="control-bus">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Control bus that accepts messages in the form of Groovy scripts. The scripts should be provided as
+				String payload in incoming messages. The variable bindings will include any @ManagedResource, Lifecycle,
+				or CustomizableThreadCreator instances from within the ApplicationContext.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:choice minOccurs="0" maxOccurs="2">
+				<xsd:element ref="integration:poller" minOccurs="0"
+					maxOccurs="1" />
+				<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+			</xsd:choice>
+			<xsd:attributeGroup ref="integration:inputOutputChannelGroupWithId" />
+			<xsd:attribute name="customizer" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to a GroovyObjectCustomizer bean to be
+						applied to each script payload.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:expected-type
+							type="org.springframework.scripting.groovy.GroovyObjectCustomizer" />
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+</xsd:schema>

--- a/spring-integration-http/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-http/src/main/resources/META-INF/spring.schemas
@@ -2,4 +2,5 @@ http\://www.springframework.org/schema/integration/http/spring-integration-http-
 http\://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd=org/springframework/integration/http/config/spring-integration-http-2.0.xsd
 http\://www.springframework.org/schema/integration/http/spring-integration-http-2.1.xsd=org/springframework/integration/http/config/spring-integration-http-2.1.xsd
 http\://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd=org/springframework/integration/http/config/spring-integration-http-2.2.xsd
-http\://www.springframework.org/schema/integration/http/spring-integration-http.xsd=org/springframework/integration/http/config/spring-integration-http-2.2.xsd
+http\://www.springframework.org/schema/integration/http/spring-integration-http-3.0.xsd=org/springframework/integration/http/config/spring-integration-http-3.0.xsd
+http\://www.springframework.org/schema/integration/http/spring-integration-http.xsd=org/springframework/integration/http/config/spring-integration-http-3.0.xsd

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-3.0.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-3.0.xsd
@@ -1,0 +1,800 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/http" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration"
+	targetNamespace="http://www.springframework.org/schema/integration/http" elementFormDefault="qualified"
+	attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration" schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+	Defines the configuration elements for Spring Integration's HTTP adapters.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+					Defines an inbound HTTP-based Channel Adapter.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:sequence>
+				<xsd:element name="header" type="headerType" minOccurs="0" maxOccurs="unbounded" />
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" />
+			<xsd:attribute name="name" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						[DEPRECATED since v2.1] Use the 'path' attribute if you want
+						to specify the path or the 'id' attribute if you simply want
+						to identify this component.
+
+						When using the 'path' attribute, please ensure to also
+						declare a handler mapping bean of type
+						'org.springframework.integration.http.inbound.UriPathHandlerMapping'.
+
+						This bean is used by the Spring MVC DispatcherServlet
+						to evaluate which URL maps to which inbound endpoint.
+						For more information please see the chapter on
+						'Handler mappings' in the Spring Framework Reference
+						Documentation.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="request-payload-type" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Target type for payload that is the conversion result of the request.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="send-timeout" type="xsd:string" />
+			<xsd:attribute name="supported-methods" type="xsd:string" />
+			<xsd:attribute name="view-name" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						View name to be resolved when rendering a response.
+						This attribute is not allowed if there is a 'view-expression' attribute.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="view-expression" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						SpEL expression that resolves to a view to be resolved when rendering a response.
+						The expression can resolve to a view name or View object.
+						However, because there is no reply message, the
+						'evaluationContext' for this expression is rather lightweight; it has a
+						'BeanResolver' but no variables,
+						so the usage of this attribute is somewhat limited.
+						An example might be to resolve, at runtime, some scoped Bean that returns a
+						view name or View object.
+						This attribute is not allowed if there is a 'view-name' attribute.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="errors-key" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						In the case that a view-name is specified this attribute can be used to
+						override the default key of the Errors (if the request cannot be handled).
+						Defaults to "errors" (similar to normal MVC
+						usage).
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="payload-expression" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Allows you to specify SpEL expression to construct a Message payload
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="path" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Allows you to specify the URI path (e.g., /orderId/{order})
+
+						When using the 'path' attribute, please ensure to also
+						declare a handler mapping bean of type
+						'org.springframework.integration.http.inbound.UriPathHandlerMapping'.
+
+						This bean is used by the Spring MVC DispatcherServlet to
+						evaluate which URL maps to which inbound endpoint. For
+						more information please see the chapter on 'Handler mappings'
+						in the Spring Framework Reference Documentation.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="error-code" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						In the case that a view-name is specified this attribute can be used to
+						override the default error code under which the handling exception is exposed.
+						Defaults to
+						"spring.integration.http.handler.error" and is supplied with 3
+						parameters: the exception itself, its message and
+						its stack trace as a String.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="message-converters" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						List of HttpMessageConverters for this Channel Adapter.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="header-mapper" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-request-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Comma-separated list of names of HttpHeaders to be mapped from the HTTP request into the MessageHeaders..
+This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Request headers.
+						]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="error-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="inbound-gateway">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+					Defines an inbound HTTP-based Messaging Gateway.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:complexContent>
+				<xsd:extension base="gatewayType">
+					<xsd:sequence>
+						<xsd:element name="header" type="headerType" minOccurs="0" maxOccurs="unbounded" />
+					</xsd:sequence>
+					<xsd:attribute name="request-channel" type="xsd:string" use="required">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="name" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								[DEPRECATED since v2.1] Use the 'path' attribute if you want
+								to specify the path or the 'id' attribute if you simply want
+								to identify this component.
+
+								When using the 'path' attribute, please ensure to also
+								declare a handler mapping bean of type
+								'org.springframework.integration.http.inbound.UriPathHandlerMapping'.
+
+								This bean is used by the Spring MVC DispatcherServlet
+								to evaluate which URL maps to which inbound endpoint.
+								For more information please see the chapter on
+								'Handler mappings' in the Spring Framework Reference
+								Documentation.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="extract-reply-payload" type="xsd:string" default="true" />
+					<xsd:attribute name="supported-methods" type="xsd:string" />
+					<xsd:attribute name="view-name" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								View name to be resolved when rendering a response.
+								This attribute is not allowed if there is a 'view-expression' attribute.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="view-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								SpEL expression that resolves to a view to be resolved when rendering a response.
+								The expression can resolve to a view name or View object.
+								The root object of the evaluation context is the reply message.
+								This attribute is not allowed if there is a 'view-name' attribute.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="errors-key" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								In the case that a view-name is specified this attribute can be used to
+								override the default key of the Errors (if the request cannot be handled).
+								Defaults to "errors" (similar to normal MVC usage).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="payload-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to specify SpEL expression to construct a Message payload
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="path" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to specify the URI path (e.g., /orderId/{order})
+
+								When using the 'path' attribute, please ensure to also
+								declare a handler mapping bean of type
+								'org.springframework.integration.http.inbound.UriPathHandlerMapping'.
+
+								This bean is used by the Spring MVC DispatcherServlet
+								to evaluate which URL maps to which inbound endpoint.
+								For more information please see the chapter on
+								'Handler mappings' in the Spring Framework Reference
+								Documentation.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="error-code" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								In the case that a view-name is specified this attribute can be used to
+								override the default error code under which the handling exception is exposed.
+								Defaults to "spring.integration.http.handler.error" and is supplied with 3
+								parameters: the exception itself, its message and its stack trace as a String.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="convert-exceptions" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								In the case that a view-name is not specified this attribute can be used to
+								override the default behaviour when there is a message handling exception (which
+								is to rethrow).  If this flag is true then the normal conversion process will be
+								applied to the exception and written out to the response body.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-payload-type" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Target type for payload that is the conversion result of the request.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="message-converters" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								List of HttpMessageConverters for this Gateway.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="header-mapper" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="error-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="mapped-request-headers" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Comma-separated list of names of HttpHeaders to be mapped from the HTTP request into the MessageHeaders.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+	The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Request headers.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="mapped-response-headers" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Comma-separated list of names of MessageHeaders to be mapped into the HttpHeaders of the HTTP response.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+	The String "HTTP_RESPONSE_HEADERS" will match against any of the standard HTTP Response headers.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-key" type="xsd:string" />
+					<xsd:attribute name="request-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Used to set the sendTimeout on the underlying MessagingTemplate instance
+	(org.springframework.integration.core.MessagingTemplate) for sending messages
+	to the request channel. If not specified this propery will default to "1000"
+	(1 second).
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-timeout"   type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Used to set the revceiveTimeout on the underlying MessagingTemplate instance
+	(org.springframework.integration.core.MessagingTemplate) for receiving messages
+	from the reply channel. If not specified this propery will default to "1000"
+	(1 second).
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+					Defines an outbound HTTP-based Channel Adapter.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:choice minOccurs="0" maxOccurs="2">
+				<xsd:element name="uri-variable" type="uriVariableType" minOccurs="0" maxOccurs="unbounded" />
+				<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+			</xsd:choice>
+			<xsd:attribute name="id" type="xsd:string" />
+			<xsd:attribute name="url" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+	URL to which the requests should be sent. It may include {placeholders} for
+	evaluation against uri-variables.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="url-expression" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+	SpEL Expression resolving to a URL to which the requests should be sent. The resolved
+	value may include {placeholders} for further evaluation against uri-variables.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="http-method">
+				<xsd:annotation>
+					<xsd:documentation>
+						The HTTP method to use when executing requests with this adapter Default is POST.
+						This attribute cannot be provided if http-method-expression has a value.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="httpMethodEnumeration xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="http-method-expression" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						The SpEL expression to determine HTTP method, use when executing requests with this adapter,
+						dynamically. This attribute cannot be provided if http-method has a value.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="rest-template" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.web.client.RestTemplate" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="charset" type="xsd:string" />
+			<xsd:attribute name="extract-payload" type="xsd:string" />
+			<xsd:attribute name="expected-response-type" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						The expected type to which the response body should be converted.
+						Default is 'org.springframework.http.ResponseEntity'.
+						This attribute cannot be provided if expected-response-type-expression has a value
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="direct">
+							<tool:expected-type type="java.lang.Class" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="expected-response-type-expression" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						SpEL expression to determine the type for the expected response to which the response body should be converted
+				        The returned value of the expression could be an instance of java.lang.Class or
+				        java.lang.String representing a fully qualified class name.
+						This attribute cannot be provided if expected-response-type has a value
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="message-converters" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Provide a reference to a list of HttpMessageConverter instances. If specified, these converters will replace
+						all of the default converters that would normally be present on the underlying RestTemplate.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="header-mapper" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-request-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Comma-separated list of names of MessageHeaders to be mapped into the HttpHeaders of the HTTP request.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+	The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Request headers.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="request-factory" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to a ClientHttpRequestFactory to be used by the underlying RestTemplate.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.http.client.ClientHttpRequestFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="error-handler" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Reference to a ResponseErrorHandler to be used by the underlying RestTemplate.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.web.client.ResponseErrorHandler" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="order" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Specifies the order for invocation when this adapter is connected as a subscriber to a SubscribableChannel.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-startup" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Specifies whether this adapter should start automatically.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-gateway">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+					Defines an outbound HTTP-based Messaging Gateway.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:complexContent>
+				<xsd:extension base="gatewayType">
+					<xsd:choice minOccurs="0" maxOccurs="2">
+						<xsd:element name="uri-variable" type="uriVariableType" minOccurs="0" maxOccurs="unbounded" />
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:choice>
+					<xsd:attribute name="request-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="url" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>
+			URL to which the requests should be sent. It may include {placeholders} for
+			evaluation against uri-variables.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="url-expression" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>
+								<![CDATA[
+			SpEL Expression resolving to a URL to which the requests should be sent. The resolved
+			value may include {placeholders} for further evaluation against uri-variables.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="http-method">
+						<xsd:annotation>
+							<xsd:documentation>
+								The HTTP method to use when executing requests with this adapter. Default is POST.
+								This attribute cannot be provided if http-method-expression has a value.
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="httpMethodEnumeration xsd:string" />
+						</xsd:simpleType>
+					</xsd:attribute>
+					<xsd:attribute name="http-method-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								The SpEL expression to determine HTTP method, use when executing requests with this gateway,
+								dynamically. This attribute cannot be provided if http-method has a value.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="message-converters" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Provide a reference to a list of HttpMessageConverter instances. If specified, these converters will replace
+								all of the default converters that would normally be present on the underlying RestTemplate.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="header-mapper" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="rest-template" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.web.client.RestTemplate" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="mapped-request-headers" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Comma-separated list of names of MessageHeaders to be mapped into the HttpHeaders of the HTTP request.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+	The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Request headers.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="mapped-response-headers" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Comma-separated list of names of HttpHeaders to be mapped from the HTTP response into the MessageHeaders.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+	The String "HTTP_RESPONSE_HEADERS" will match against any of the standard HTTP Response headers.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="extract-request-payload" type="xsd:string" />
+					<xsd:attribute name="expected-response-type" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								The expected type to which the response body should be converted.
+								Default is 'org.springframework.http.ResponseEntity'.
+								This attribute cannot be provided if expected-response-type-expression has a value
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="direct">
+									<tool:expected-type type="java.lang.Class" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="expected-response-type-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								SpEL expression to determine the type for the expected response to which the response body should be converted
+				                The returned value of the expression could be an instance of java.lang.Class or
+				                java.lang.String representing a fully qualified class name.
+								This attribute cannot be provided if expected-response-type has a value
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="charset" type="xsd:string" />
+					<xsd:attribute name="request-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Reference to a ClientHttpRequestFactory to be used by the underlying RestTemplate.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.http.client.ClientHttpRequestFactory" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="error-handler" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Reference to a ResponseErrorHandler to be used by the underlying RestTemplate.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.web.client.ResponseErrorHandler" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Specifies the order for invocation when this gateway is connected as a subscriber to a SubscribableChannel.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="auto-startup" type="xsd:string" />
+					<xsd:attribute name="transfer-cookies" type="xsd:string" default="false">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	When set to "true", if a response contains a 'Set-Cookie' header, it will be mapped to a 'Cookie' header. This enables simple
+	cookie handling where subsequent HTTP interactions in the same message flow can use a cookie
+	supplied by the server. Default is "false".
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Allows you to specify how long this gateway will wait for
+								the reply message to be sent successfully to the reply channel
+								before throwing an exception. This attribute only applies when the
+								channel might block, for example when using a bounded queue channel that
+								is currently full.
+
+								Also, keep in mind that when sending to a DirectChannel, the
+								invocation will occur in the sender's thread. Therefore,
+								the failing of the send operation may be caused by other
+								components further downstream.
+
+								The "reply-timeout" attribute maps to the "sendTimeout" property of the
+								underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+								The attribute will default, if not specified, to '-1', meaning that
+								by default, the Gateway will wait indefinitely. The value is
+								specified in milliseconds.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="uriVariableType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Expression to be evaluated against the Message to replace a URI {placeholder} with the evaluation result.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="name" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Name of the placeholder to be replaced.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expression" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Expression to be evaluated to determine the replacement value.
+					The Message is the root object of the expression, therefore
+					the 'payload' and 'headers' are available directly. Any bean
+					may be resolved if the bean name is preceded with '@'.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="headerType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Expression to be evaluated against the ServletRequest(makes BODY and Headers available) as well as URI Variables (e.g., foo/bar/{id}).
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="name" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Name of the Message Header
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expression" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Expression to be evaluated to determine the value of the header.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:simpleType name="httpMethodEnumeration">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="GET" />
+			<xsd:enumeration value="POST" />
+			<xsd:enumeration value="HEAD" />
+			<xsd:enumeration value="OPTIONS" />
+			<xsd:enumeration value="PUT" />
+			<xsd:enumeration value="DELETE" />
+			<xsd:enumeration value="TRACE" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:complexType name="gatewayType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines common configuration for gateway adapters.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="id" type="xsd:string" />
+		<xsd:attribute name="reply-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/spring-integration-ip/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-ip/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
 http\://www.springframework.org/schema/integration/ip/spring-integration-ip-2.0.xsd=org/springframework/integration/ip/config/spring-integration-ip-2.0.xsd
 http\://www.springframework.org/schema/integration/ip/spring-integration-ip-2.1.xsd=org/springframework/integration/ip/config/spring-integration-ip-2.1.xsd
 http\://www.springframework.org/schema/integration/ip/spring-integration-ip-2.2.xsd=org/springframework/integration/ip/config/spring-integration-ip-2.2.xsd
-http\://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd=org/springframework/integration/ip/config/spring-integration-ip-2.2.xsd
+http\://www.springframework.org/schema/integration/ip/spring-integration-ip-3.0.xsd=org/springframework/integration/ip/config/spring-integration-ip-3.0.xsd
+http\://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd=org/springframework/integration/ip/config/spring-integration-ip-3.0.xsd

--- a/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-3.0.xsd
+++ b/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-3.0.xsd
@@ -1,0 +1,699 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/ip"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:beans="http://www.springframework.org/schema/beans"
+		xmlns:tool="http://www.springframework.org/schema/tool"
+		xmlns:integration="http://www.springframework.org/schema/integration"
+		targetNamespace="http://www.springframework.org/schema/integration/ip"
+		elementFormDefault="qualified"
+		attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+			schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+	Defines the configuration elements for Spring Integration's IP adapters.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="udp-inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines a udp inbound Channel Adapter for receiving incoming udp packets.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="udpAdapterType">
+					<xsd:attribute name="pool-size" type="xsd:string" >
+						<xsd:annotation>
+							<xsd:documentation>
+The number of threads that will be used for socket/channel handling. Only applies
+if an external task-executor is NOT being used. When using an external task executor,
+its configuration specifies the number of threads.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="receive-buffer-size" type="xsd:string" />
+					<xsd:attribute name="multicast-address" type="xsd:string" />
+					<xsd:attribute name="task-executor" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specifies a specific Executor to be used for socket handling. If not supplied, an internal
+	pooled executor will be used (See pool-size). Needed on some platforms that require the use of specific
+	task executors such as a WorkManagerTaskExecutor.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="error-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								If a (synchronous) downstream exception is thrown and an "error-channel" is specified,
+								the MessagingException will be sent to this channel. Otherwise, any such exception
+								will simply be logged by the channel adapter.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="lookup-host" type="xsd:string" >
+						<xsd:annotation>
+							<xsd:documentation>
+Whether or not to do a DNS reverse-lookup on the remote ip address to insert the host name into the
+message headers (ip_hostName). Default "true".
+							</xsd:documentation>
+						</xsd:annotation>
+			</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="udp-outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an outbound UDP packet-sending Channel Adapter.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="udpAdapterType">
+					<xsd:all>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:all>
+					<xsd:attribute name="host" type="xsd:string" />
+					<xsd:attribute name="acknowledge" type="xsd:string" />
+					<xsd:attribute name="ack-host" type="xsd:string" />
+					<xsd:attribute name="ack-port" type="xsd:string" />
+					<xsd:attribute name="ack-timeout" type="xsd:string" />
+					<xsd:attribute name="min-acks-for-success" type="xsd:string" />
+					<xsd:attribute name="time-to-live" type="xsd:string" />
+					<xsd:attribute name="task-executor" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+Specifies a specific Executor to be used for handling acknowledgments in the UDP adapter. If not supplied, an internal
+pooled executor will be used. Needed on some platforms that require the use of specific
+task executors such as a WorkManagerTaskExecutor.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the order for invocation when this endpoint is connected as a
+								subscriber to a SubscribableChannel.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="tcp-inbound-channel-adapter">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="smartLifeCycleType">
+					<xsd:attribute name="id" type="xsd:string"/>
+					<xsd:attribute name="connection-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.ip.tcp.connection.ConnectionFactory"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+		A connection factory is needed by an inbound adapter. If the connection factory has a type 'server',
+		the factory is 'owned' by this adapter. If it has a type 'client', it is owned by an outbound channel
+		adapter and this adapter will receive any incoming messages on the connection created by the outbound
+		adapter.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="error-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								If a (synchronous) downstream exception is thrown and an "error-channel" is specified,
+								the MessagingException will be sent to this channel. Otherwise, any such exception
+								will simply be logged by the channel adapter.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="client-mode" type="xsd:string" use="optional" default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+							 If set to true, causes the adapter to act as a client with respect to
+							 establishing the connection, rather than listening for incoming connections.
+							 Requires a type="client" connection factory, with single-use set to false.
+							 Defaults to false.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="clientModeAttributeGroup" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="tcp-outbound-channel-adapter">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="smartLifeCycleType">
+					<xsd:all>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:all>
+					<xsd:attribute name="id" type="xsd:string"/>
+					<xsd:attribute name="connection-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.ip.tcp.connection.ConnectionFactory"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+		A connection factory is needed by an outbound adapter. If the connection factory has a type 'client',
+		the factory is 'owned' by this adapter. If it has a type 'server', it is owned by an inbound channel
+		adapter and this adapter will attempt to correlate messages to the connection on which an original
+		inbound message was received.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the order for invocation when this endpoint is connected as a
+								subscriber to a SubscribableChannel.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="client-mode" type="xsd:string" use="optional" default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+							 If set to true, causes the adapter to establish a connection when started,
+							 rather than when the first message is sent.
+							 Requires a type="client" connection factory, with single-use set to false.
+							 Defaults to false.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="clientModeAttributeGroup" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="tcp-inbound-gateway">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="smartLifeCycleType">
+					<xsd:attribute name="id" type="xsd:string"/>
+					<xsd:attribute name="connection-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+		A connection factory is needed by an inbound adapter. The connection factory must be of type 'server'.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-channel" type="xsd:string" use="required">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string"/>
+					<xsd:attribute name="error-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								If a (synchronous) downstream exception is thrown and an "error-channel" is specified,
+								the MessagingException will be sent to this channel and the ultimate response
+								of the error flow will be returned as a response by the gateway. If no
+								"error-channel" is specified, any such exception
+								will simply be logged by the gateway. In such a situation, no response is sent
+								to the client.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="client-mode" type="xsd:string" use="optional" default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+							 If set to true, causes the gateway to act as a client with respect to
+							 establishing the connection, rather than listening for incoming connections.
+							 Requires a type="client" connection factory, with single-use set to false.
+							 Defaults to false.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attributeGroup ref="clientModeAttributeGroup" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="tcp-outbound-gateway">
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="smartLifeCycleType">
+					<xsd:all>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:all>
+					<xsd:attribute name="id" type="xsd:string"/>
+					<xsd:attribute name="connection-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.ip.tcp.connection.ConnectionFactory"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+		A connection factory is needed by an outbound adapter. The connection factory must be of 'client'.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								When using a shared socket, specifies the time the gateway will wait
+								to get access to the socket to send the request.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Allows you to specify how long this gateway will wait for
+								the reply message to be sent successfully to the reply channel
+								before throwing an exception. This attribute only applies when the
+								channel might block, for example when using a bounded queue channel that
+								is currently full.
+
+								Also, keep in mind that when sending to a DirectChannel, the
+								invocation will occur in the sender's thread. Therefore,
+								the failing of the send operation may be caused by other
+								components further downstream.
+
+								The "reply-timeout" attribute maps to the "sendTimeout" property of the
+								underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+								The attribute will default, if not specified, to '-1', meaning that
+								by default, the Gateway will wait indefinitely. The value is
+								specified in milliseconds.
+
+								Prior to 2.2, this attribute served the function of
+								the remote-timeout attribute; it has been changed
+								to make it consistent with other endpoints.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="remote-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the time the gateway will wait for a reply
+								from the remote system. Prior to 2.2, this was specified
+								with the reply-timeout attribute. To provide easier migration,
+								this attribute defaults to the same value of the reply-timeout,
+								if supplied, or 10 seconds otherwise.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the order for invocation when this endpoint is connected as a
+								subscriber to a SubscribableChannel.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="tcp-connection-factory">
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string"/>
+			<xsd:attribute name="type">
+				<xsd:annotation>
+					<xsd:documentation>
+Connection factories can be 'client' or 'server'. Client factories
+open a connection to a server using a host and port. Server factories
+listen on a port and create a separate connection for each incoming
+connection request.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="client" />
+						<xsd:enumeration value="server" />
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="host" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+The host to which a client connection factory will connect.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="port" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+For client factories, the port to which a client connection factory will connect.
+For server factories, the port on which the factory will listen for incoming
+connections.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="using-nio" type="xsd:string" default="false">
+				<xsd:annotation>
+					<xsd:documentation>
+If true, the factory will use java.nio.channel.SocketChannel for communication;
+for a large number of connections on the server side, this can provide better
+performance and may use fewer threads.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="so-keep-alive" type="xsd:string" />
+			<xsd:attribute name="so-linger" type="xsd:string" />
+			<xsd:attribute name="so-receive-buffer-size" type="xsd:string" />
+			<xsd:attribute name="so-send-buffer-size" type="xsd:string" />
+			<xsd:attribute name="so-tcp-no-delay" type="xsd:string" />
+			<xsd:attribute name="so-timeout" type="xsd:string" />
+			<xsd:attribute name="so-traffic-class" type="xsd:string" />
+			<xsd:attribute name="using-direct-buffers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+If true, instructs the factory to use direct buffers if possible; only applies if
+using-nio is true. Refer to ByteBuffer javadocs for more information.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="single-use" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+If true, a new connection will be created for each use. For inbound adapters
+where there is no outbound adapter sharing the factory, the connection will
+be closed after a message is received. For outbound adapters where there is
+no inbound adapter sharing the factory, or for inbound adapters where an
+outbound adapter shares the factory, the connection will be closed after
+so-timeout milliseconds. For outbound adapters where an inbound adapter shares
+the factory, the connection will be closed after a response is received.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="serializer" type="xsd:string" >
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.core.serializer.Serializer"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+A Serializer that converts message payloads to/from output streams/input streams
+associated with the connection. Default is ByteArrayCrLfSerializer. Serializer and Deserializer
+would normally be the same but this is not required.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="deserializer" type="xsd:string" >
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.core.serializer.Deserializer"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+A Deserializer that converts message payloads to/from output streams/input streams
+associated with the connection. Default is ByteArrayCrLfSerializer. Serializer and Deserializer
+would normally be the same but this is not required.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="local-address" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+On a multi-homed system, specifies the ip address of the network interface used to communicate.
+For inbound adapters and gateways, specifies the interface used to listen for incoming connections.
+If omitted, the endpoint will listen on all available adapters. For the UDP multicast outbound adapter
+specifies the interface to which multicast packets will be sent. For UDP unicast and multicast
+adapters, specifies which interface to which the acknowledgment socket will be bound. Does not
+apply to TCP outbound adapters and gateways.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="task-executor" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+A task executor for managing connections; if not specified a
+cached thread pool task executor is used.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="pool-size" type="xsd:string" >
+				<xsd:annotation>
+					<xsd:documentation>
+Deprecated since 2.2; previously it specified the thread pool size if
+an external task executor was not provided; it was also used to set
+the connection backlog for server factories. That setting is now
+specified by the backlog attribute.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="backlog" type="xsd:string" >
+				<xsd:annotation>
+					<xsd:documentation>
+Specifies the connection backlog for server sockets. Does not
+apply to client factories.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="lookup-host" type="xsd:string" >
+				<xsd:annotation>
+					<xsd:documentation>
+Whether or not to do a DNS reverse-lookup on the remote ip address to insert the host name into the
+message headers (ip_connectionId, ip_hostName). Default "true".
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="interceptor-factory-chain" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.ip.tcp.connection.TcpConnectionInterceptorFactoryChain"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="apply-sequence" type="xsd:string" default="false">
+				<xsd:annotation>
+					<xsd:documentation>
+When set to "true", adds sequenceNumber and correlationId headers to messages originating from
+connections created by this factory. Facilitates resequencing if necessary. Default "false".
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="ssl-context-support" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+A reference to a TcpSSLContextSupport strategy implementation. Providing this reference
+enables SSL on connections created by this factory. A DefaultTcpSSLContextSupport implementation
+is provided that takes keystore and trustore names and passwords. The SSLContext created by
+this implementation is used to obtain socket factories (when using-nio="false") or SSLEngine
+instances (when using-nio="true"). When this attribute is omitted, normal plain text
+sockets are used.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.ip.tcp.connection.support.TcpSSLContextSupport"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="socket-support" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+A reference to a TcpSocketSupport strategy implementation. Allows post-processing Socket
+and ServerSocket instances after creation and after configured attributes are applied.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.ip.tcp.connection.support.TcpSocketSupport"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="socket-factory-support" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+A reference to a TcpSocketFactorySupport strategy implementation. Allows customization
+of the factories used to create sockets. The default implementation returns default.
+ServerSocketFactory and SocketFactory instances, unless an 'ssl-context-support'
+attribute has been supplied, in which case the SSLContext obtained therefrom is
+used to create SSLServerSocketFactory and SSLSocketFactory instances.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.ip.tcp.connection.support.TcpSocketFactorySupport"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="udpAdapterType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Common configuration for UDP-based adapters.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="common-attributes">
+				<xsd:attribute name="channel" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="check-length" type="xsd:string" />
+				<xsd:attribute name="multicast" type="xsd:string" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="common-attributes">
+		<xsd:attribute name="id" type="xsd:string"/>
+		<xsd:attribute name="port" type="xsd:string" />
+		<xsd:attribute name="so-receive-buffer-size" type="xsd:string" />
+		<xsd:attribute name="so-send-buffer-size" type="xsd:string" />
+		<xsd:attribute name="so-timeout" type="xsd:string" />
+		<xsd:attribute name="local-address" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+On a multi-homed system, specifies the ip address of the network interface used to communicate.
+For inbound adapters and gateways, specifies the interface used to listen for incoming connections.
+If omitted, the endpoint will listen on all available adapters. For the UDP multicast outbound adapter
+specifies the interface to which multicast packets will be sent. For UDP unicast and multicast
+adapters, specifies which interface to which the acknowledgment socket will be bound. Does not
+apply to TCP outbound adapters and gateways.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="smartLifeCycleType">
+		<xsd:attribute name="auto-startup" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+Boolean value indicating whether this endpoint should start automatically.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="phase" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The lifecycle phase within which this endpoint should start and stop.
+The lower the value the earlier this endpoint will start and the later it will stop. The
+default is 0. Values can be negative. See SmartLifeCycle.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:attributeGroup name="clientModeAttributeGroup">
+		<xsd:attribute name="retry-interval" type="xsd:string" use="optional" default="60000">
+			<xsd:annotation>
+				<xsd:documentation>
+				 When in client mode, specifies the retry interval, in milliseconds, if a connection
+				 cannot be established. Defaults to 60000.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="scheduler" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					When in client mode,
+					provide a reference to the TaskScheduler instance to
+					be used for establishing connections. If not provided, the default
+					will use a thread pool of size 1.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.scheduling.TaskScheduler" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+</xsd:schema>

--- a/spring-integration-jdbc/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-jdbc/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
 http\://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc-2.0.xsd=org/springframework/integration/jdbc/config/spring-integration-jdbc-2.0.xsd
 http\://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc-2.1.xsd=org/springframework/integration/jdbc/config/spring-integration-jdbc-2.1.xsd
 http\://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc-2.2.xsd=org/springframework/integration/jdbc/config/spring-integration-jdbc-2.2.xsd
-http\://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd=org/springframework/integration/jdbc/config/spring-integration-jdbc-2.2.xsd
+http\://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc-3.0.xsd=org/springframework/integration/jdbc/config/spring-integration-jdbc-3.0.xsd
+http\://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd=org/springframework/integration/jdbc/config/spring-integration-jdbc-3.0.xsd

--- a/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-3.0.xsd
+++ b/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-3.0.xsd
@@ -1,0 +1,1346 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/jdbc" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration" targetNamespace="http://www.springframework.org/schema/integration/jdbc"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration" schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+	Defines the configuration elements for Spring Integration's JDBC components.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="message-store">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a MessageStore (and MessageGroupStore)
+				backed by a database.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="beans:identifiedType">
+					<xsd:attribute name="data-source" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Reference to a data source to use to access
+								the database. Either this or the jdbc-operations
+								must be
+								specified (but not both).
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="javax.sql.DataSource" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="jdbc-operations" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Reference to a JdbcOperations. Either
+									this or
+									the data-source must be
+									specified (but not both).
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.jdbc.core.JdbcOperations" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="region" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Unique string to use as a partition for the
+								data in this store, so that
+								multiple instances can
+								share the same
+								database tables. The default
+								is "DEFAULT".
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="table-prefix" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Prefix for the table names in the database
+								(e.g. so that a schema can be specified, or to avoid
+								a clash
+								with
+								other tables). The default is "INT_".
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="lob-handler" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+							Reference to a lob handler (optional).  Only override if using Oracle and
+							the database type is not being detected for some reason.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.jdbc.support.lob.LobHandler" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="serializer" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+							Reference to an OutputStreamingConverter. Defaults to
+							using java.io native serialization.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.core.serializer.Serializer" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="deserializer" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+							Reference to an InputStreamingConverter.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.core.serializer.Deserializer" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an inbound Channel Adapter for polling a database.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="selectType">
+					<xsd:sequence>
+						<xsd:element name="update" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:appinfo>
+									<xsd:documentation>
+										An update query to execute when a message is
+										polled. If the poll is in a transaction then the
+										update will roll back if the transaction
+										does.
+									</xsd:documentation>
+								</xsd:appinfo>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
+					</xsd:sequence>
+					<xsd:attribute name="id" type="xsd:string" use="optional"/>
+					<xsd:attribute name="update" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									An update query to execute when a message is
+									polled. If the poll is in a transaction then the
+									update will roll back if the transaction does.
+									The update can also be specified as a nested element.
+								</xsd:documentation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="update-per-row" type="xsd:boolean" default="false">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Flag to indicate whether the update query
+									should be executed per message, or per row (in the
+									case that a message contains multiple rows).
+								</xsd:documentation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="max-rows-per-poll" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Limits the number of rows extracted per query (otherwise all rows
+								are extracted into the
+								outgoing message).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Channel to which polled messages will be sent.
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="auto-startup" type="xsd:string" default="true">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Flag to indicate that the poller should start automatically on startup (default true).
+								</xsd:documentation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="update-sql-parameter-source-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Reference to a SqlParameterSourceFactory. The input is the result of the
+									query. The
+									default factory creates a parameter source that treats a List in a special
+									way: the parameter name is used as an expression and projected onto the list,
+									so for instance "update foos set status=1 where id in (:id)" will generate
+									an in clause from the properties "id" of the input list elements.
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.jdbc.SqlParameterSourceFactory" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="select-sql-parameter-source" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Reference to a static SqlParameterSource for the SELECT query used for polling. If
+									that query has
+									placeholders (e.g. "SELECT * from FOO where KEY=:key") they
+									will be bound from this source by name.
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.jdbc.core.namedparam.SqlParameterSource" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an outbound Channel Adapter for updating a
+				database.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="queryType">
+					<xsd:choice minOccurs="0" maxOccurs="2">
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:choice>
+					<xsd:attribute name="sql-parameter-source-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Reference to a SqlParameterSourceFactory. The input is the whole
+									outgoing message. The
+									default factory creates a bean
+									property parameter source so the query can specify named
+									parameters like :payload and :headers[foo].
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.jdbc.SqlParameterSourceFactory" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="id" type="xsd:string" use="optional"/>
+					<xsd:attribute name="channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Channel from which messages will be output.
+									When a message is sent to this channel it will
+									cause the query
+									to be executed.
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="keys-generated" type="xsd:boolean">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Flag to indicate whether primary keys are generated by the query.
+								</xsd:documentation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="auto-startup" type="xsd:string" default="true">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Flag to indicate that the poller should start automatically on startup (default true).
+								</xsd:documentation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the order for invocation when this endpoint is connected as a
+								subscriber to a SubscribableChannel.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-gateway">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an outbound Channel Gateway for updating a
+				database in response to a message on the request channel, and/or
+				for retrieving data from the database using the input message as
+				a source of parameters for the specified SQL select query.
+
+				The database response will be used to create the response Message
+				on the reply channel.
+
+				The response can be created from a query
+				supplied here, or (if keys-generated="true") can be the
+				primary keys generated from an auto-increment, or else just a
+				count of the number of rows affected by the update.  The response
+				is in general a case insensitive Map (or list of maps if multi-valued), unless
+				a select query and a row-mapper is provided.  If the update count is
+				returned then the map key is "UPDATE".
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="selectType">
+					<xsd:choice minOccurs="0" maxOccurs="3">
+						<xsd:element name="update" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:appinfo>
+									<xsd:documentation>
+										An update query to be executed when a message is
+										received. If this is in a transaction then the
+										update will roll back when the transaction does.
+
+										The update can also be specified using the
+										"update" attribute.
+
+										Since Spring Integration 2.2 specifying an
+										update query is optional, if at least the
+										select query is specified.
+
+										If you specify both, update- and select
+										query, then the update is executed first.
+									</xsd:documentation>
+								</xsd:appinfo>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:choice>
+					<xsd:attribute name="id" type="xsd:string" use="optional"/>
+					<xsd:attribute name="update" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									An update query to execute when a message is
+									received. If this is in a transaction then the
+									update will roll back when the transaction does.
+
+									The update can also be specified as a nested element.
+
+									Since Spring Integration 2.2 specifying an
+									update query is optional, if at least the
+									select query is specified.
+
+									If you specify both, update- and select
+									query, then the update is executed first.
+								</xsd:documentation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="max-rows-per-poll" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								When using a select query, you can set a
+								custom limit regarding the number of rows
+								extracted. Otherwise by default only the first
+								row will be extracted into the outgoing message.
+
+								If set to '0' all rows are extracted.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-sql-parameter-source-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Reference to a SqlParameterSourceFactory. The input is the whole
+									outgoing message. The
+									default factory creates a bean
+									property parameter source so the query can specify named
+									parameters like :payload and :headers[foo].
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.jdbc.SqlParameterSourceFactory" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-sql-parameter-source-factory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Reference to a SqlParameterSourceFactory. The input is the whole
+									outgoing message. The
+									default factory creates a bean
+									property parameter source so the query can specify named
+									parameters like :payload and :headers[foo].
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.jdbc.SqlParameterSourceFactory" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-channel" type="xsd:string">
+						<xsd:annotation>
+								<xsd:documentation>
+									The receiving Message Channel of this endpoint.
+								</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-channel" type="xsd:string">
+						<xsd:annotation>
+								<xsd:documentation>
+									Message Channel to which replies should be sent,
+									after receiving the database response.
+								</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+									Allows you to specify how long this gateway will wait for
+									the reply message to be sent successfully to the reply channel
+									before throwing an exception. This attribute only applies when the
+									channel might block, for example when using a bounded queue channel that
+									is currently full.
+
+									Also, keep in mind that when sending to a DirectChannel, the
+									invocation will occur in the sender's thread. Therefore,
+									the failing of the send operation may be caused by other
+									components further downstream.
+
+									The "reply-timeout" attribute maps to the "sendTimeout" property of the
+									underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+									The attribute will default, if not specified, to '-1', meaning that
+									by default, the Gateway will wait indefinitely. The value is
+									specified in milliseconds.
+								]]></xsd:documentation>
+							</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="keys-generated" type="xsd:boolean">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Flag to indicate whether primary keys are generated by the query.  If they are then
+									they can be used as a reply payload instead of providing a select query.  A single
+									valued result is extracted before returning (the usual case), so the payload of the reply message
+									can be a Map (column name to value) or a list of maps.
+								</xsd:documentation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="auto-startup" type="xsd:string" default="true">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									Flag to indicate that the poller should start automatically on startup (default true).
+								</xsd:documentation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the order for invocation when this endpoint is connected as a
+								subscriber to a SubscribableChannel.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="jdbcType">
+		<xsd:attribute name="data-source" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to a data source to use to access the database.
+					Either this or the simple-jdbc-operations must be specified
+					(but not both).
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="javax.sql.DataSource" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="jdbc-operations" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<xsd:documentation>
+						Reference to a JdbcOperations. Either this or the
+						data-source must be specified (but not both).
+					</xsd:documentation>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.jdbc.core.JdbcOperations" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="queryType">
+		<xsd:complexContent>
+			<xsd:extension base="jdbcType">
+				<xsd:sequence>
+					<xsd:element name="query" minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									A select query to execute when a message is
+									polled. In general the query can return multiple
+									rows, because the result will be a List (of
+									type determined by the row mapper).
+								</xsd:documentation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+				<xsd:attribute name="query" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<xsd:documentation>
+								A select query to execute when a message is
+								polled. In general the query can return multiple
+								rows, because
+								the result will be a List (of type determined by the row
+								mapper). The query can also be specified as
+								a nested element.
+							</xsd:documentation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="selectType">
+		<xsd:complexContent>
+			<xsd:extension base="queryType">
+				<xsd:attribute name="row-mapper" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<xsd:documentation>
+								Reference to a row mapper to use to convert
+								JDBC result set rows to message payloads. Optional
+								with default that maps result set row to a map
+								(column name to column value).
+								Other simple use cases can be handled with
+								out-of-the box implementations from Spring JDBC.
+								Others require a custom row mapper.
+							</xsd:documentation>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.jdbc.core.RowMapper" />
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="stored-proc-outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an outbound Channel Adapter for updating a
+				database using stored procedures.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
+				<xsd:element name="sql-parameter-definition" minOccurs="0"
+					maxOccurs="unbounded" type="sqlParameterDefinitionType">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+							If you are using a database that is fully supported,
+							you typically don't have to specify the Stored Procedure
+							parameter definitions using the 'sql-parameter-definition'
+							attribute.
+
+							Instead, those parameters can be automatically derived
+							from the JDBC Meta-data. However, if you are using
+							databases that are not fully supported or if you like
+							to provide customized parameter definitions, you can
+							set those parameters explicitly. See also the
+							'ignore-column-meta-data' attribute.
+
+							Fully Supported Databases (Stored Procedures):
+
+								* Apache Derby
+								* DB2
+								* MySQL
+								* Microsoft SQL Server
+								* Oracle
+								* PostgreSQL
+								* Sybase
+
+							Fully Supported Databases (Functions)
+
+								* MySQL
+								* Microsoft SQL Server
+								* Oracle
+								* PostgreSQL
+							]]>
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="parameter" minOccurs="0" maxOccurs="unbounded"
+					type="parameterSubElementType">
+					<xsd:annotation>
+						<xsd:documentation>
+							<![CDATA[
+								Provides a mechanism to provide stored procedure
+								parameters.
+							]]>
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+			</xsd:sequence>
+			<xsd:attributeGroup ref="coreStoredProcComponentAttributes"/>
+			<xsd:attribute name="use-payload-as-parameter-source">
+				<xsd:annotation>
+					<xsd:documentation>
+					<![CDATA[
+					If set to 'true', the payload of the Message will be used
+					as a source for providing parameters. If false the entire
+					Message will be available as a source for parameters.
+
+					If no Procedure Parameters are passed in, this property
+					will default to 'true'. This means that using a default
+					BeanPropertySqlParameterSourceFactory the bean properties
+					of the payload will be used as a source for parameter
+					values for the to-be-executed Stored Procedure or Function.
+
+					However, if Procedure Parameters are passed in, then this
+					property will by default evaluate to 'false'. ProcedureParameter
+					allow for SpEL Expressions to be provided and therefore
+					it is highly beneficial to have access to the entire Message.
+					]]>
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="sql-parameter-source-factory"
+				type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<xsd:documentation>
+							Reference to a SqlParameterSourceFactory.
+						</xsd:documentation>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.jdbc.SqlParameterSourceFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<xsd:documentation>
+							Channel from which messages will be output.
+							When a message is sent to this channel it will
+							cause the query
+							to be executed.
+						</xsd:documentation>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="order">
+				<xsd:annotation>
+					<xsd:documentation>
+						Specifies the order for invocation when this endpoint is connected as a
+						subscriber to a SubscribableChannel.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="stored-proc-outbound-gateway">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an Outbound Channel Gateway for updating a database using
+				a stored procedure. The response of the stored procedure is used
+				to populate the Message for the reply channel.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:sequence>
+					<xsd:element name="sql-parameter-definition" minOccurs="0"
+							maxOccurs="unbounded" type="sqlParameterDefinitionType">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								If you are using a database that is fully supported,
+								you typically don't have to specify the Stored Procedure
+								parameter definitions using the 'sql-parameter-definition'
+								attribute.
+
+								Instead, those parameters can be automatically derived
+								from the JDBC Meta-data. However, if you are using
+								databases that are not fully supported or if you like
+								to provide customized parameter definitions, you can
+								set those parameters explicitly. See also the
+								'ignore-column-meta-data' attribute.
+
+								Fully Supported Databases (Stored Procedures):
+
+									* Apache Derby
+									* DB2
+									* MySQL
+									* Microsoft SQL Server
+									* Oracle
+									* PostgreSQL
+									* Sybase
+
+								Fully Supported Databases (Functions)
+
+									* MySQL
+									* Microsoft SQL Server
+									* Oracle
+									* PostgreSQL
+								]]>
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="parameter" minOccurs="0" maxOccurs="unbounded"
+						type="parameterSubElementType">
+						<xsd:annotation>
+							<xsd:documentation>
+								<![CDATA[
+									Provides a mechanism to provide stored procedure
+									parameters. Parameters can be either static
+									or provided using a SpEL Expression.
+								]]>
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="returning-resultset" minOccurs="0"
+						maxOccurs="unbounded" type="returningResultSetRowMappersType">
+						<xsd:annotation>
+							<xsd:documentation>
+								<![CDATA[
+									Stored procedures may return multiple resultsets.
+								]]>
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+				</xsd:sequence>
+			</xsd:sequence>
+			<xsd:attributeGroup ref="coreStoredProcComponentAttributes"/>
+			<xsd:attribute name="use-payload-as-parameter-source">
+				<xsd:annotation>
+					<xsd:documentation>
+						<![CDATA[
+						If set to 'true', the payload of the Message will be used
+						as a source for providing parameters. If false the entire
+						Message will be available as a source for parameters.
+
+						If no Procedure Parameters are passed in, this property
+						will default to 'true'. This means that using a default
+						BeanPropertySqlParameterSourceFactory the bean properties
+						of the payload will be used as a source for parameter
+						values for the to-be-executed Stored Procedure or Function.
+
+						However, if Procedure Parameters are passed in, then this
+						property will by default evaluate to 'false'. ProcedureParameter
+						allow for SpEL Expressions to be provided and therefore
+						it is highly beneficial to have access to the entire Message.
+						]]>
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="sql-parameter-source-factory" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<xsd:documentation>
+							Reference to a SqlParameterSourceFactory. The input is the whole
+							outgoing message. The
+							default factory creates a bean
+							property parameter source so the query can specify named
+							parameters like :payload and :headers[foo].
+						</xsd:documentation>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.jdbc.SqlParameterSourceFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="is-function" default="false">
+				<xsd:annotation>
+					<xsd:documentation>
+						If "true", a SQL Function is called. In that case
+						the "stored-procedure-name" attribute defines
+						the name of the called function.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="skip-undeclared-results" default="true">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+							If this attribute is set to 'true', then all results from
+							a stored procedure call that don't have a corresponding
+							'SqlOutParameter' declaration will be bypassed.
+
+							E.g. Stored Procedures may return an update count value,
+							even though your Stored Procedure only declared a single
+							result parameter. The exact behavior depends on the used
+							database.
+
+							The value is set on the underlying 'JdbcTemplate'.
+
+							Only few developers will probably ever like to process
+							update counts, thus the value defaults to 'true'.]]>
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:union memberTypes="xsd:boolean xsd:string" />
+					</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="expect-single-result" default="false">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						This parameter indicates that only one result object shall be returned from
+						the Stored Procedure/Function Call. If set to true and the result map
+						from the Stored Procedure/Function Call contains only 1 element,
+						then that 1 element is extracted and returned as payload.
+
+						If the result map contains more than 1 element and
+						expect-single-result is true, then a MessagingException
+						is thrown.
+
+						Otherwise the complete result map is returned as the
+						payload.
+
+						Important Note: Several databases such as H2 are not
+						fully supported for Stored Procedure and/oir Function calls.
+
+						The H2 database, for example, does not fully support the CallableStatement
+						semantics and when executing function calls against H2, a result list is
+						returned, rather than a single value.
+
+						Therefore, even if you set expect-single-result = true,
+						you may end up with a collection being returned.
+						]]>
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="request-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						The receiving Message Channel of this endpoint.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Message Channel to which replies should be sent,
+						after receiving the database response.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Allows you to specify how long this gateway will wait for
+						the reply message to be sent successfully to the reply channel
+						before throwing an exception. This attribute only applies when the
+						channel might block, for example when using a bounded queue channel that
+						is currently full.
+
+						Also, keep in mind that when sending to a DirectChannel, the
+						invocation will occur in the sender's thread. Therefore,
+						the failing of the send operation may be caused by other
+						components further downstream.
+
+						The "reply-timeout" attribute maps to the "sendTimeout" property of the
+						underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+						The attribute will default, if not specified, to '-1', meaning that
+						by default, the Gateway will wait indefinitely. The value is
+						specified in milliseconds.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="order">
+				<xsd:annotation>
+					<xsd:documentation>
+						Specifies the order for invocation when this endpoint is connected as a
+						subscriber to a SubscribableChannel.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="return-value-required" default="false">
+				<xsd:annotation>
+					<xsd:documentation>
+						Indicates the procedure's return value should be included
+						in the results returned.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="stored-proc-inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an inbound Channel Adapter for polling a
+				database using a stored procedure or function.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
+				<xsd:element name="sql-parameter-definition" minOccurs="0"
+						maxOccurs="unbounded" type="sqlParameterDefinitionType">
+					<xsd:annotation>
+						<xsd:documentation>
+							<![CDATA[
+							For fully supported database these parameters
+							need not be declared as for those database the
+							type information can be retrieved from the
+							JDBC Metadata.
+
+							Fully Supported Databases (Stored Procedures):
+
+							* Apache Derby
+							* DB2
+							* MySQL
+							* Microsoft SQL Server
+							* Oracle
+							* PostgreSQL
+							* Sybase
+
+							Fully Supported Databases (Functions)
+
+							* MySQL
+							* Microsoft SQL Server
+							* Oracle
+							* PostgreSQL
+
+							If you use a database not listed above, you
+							MUST provide Sql Parameter Definitions.
+							]]>
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="parameter" minOccurs="0" maxOccurs="unbounded"
+					type="parameterSubElementType">
+					<xsd:annotation>
+						<xsd:documentation>
+							<![CDATA[
+							Provides a mechanism to provide stored procedure
+							parameters.
+							]]>
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="returning-resultset" minOccurs="0"
+					maxOccurs="unbounded" type="returningResultSetRowMappersType">
+					<xsd:annotation>
+						<xsd:documentation>
+							<![CDATA[
+							Storeed procedured may return multiple resultsets.
+							]]>
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:sequence>
+			<xsd:attributeGroup ref="coreStoredProcComponentAttributes"/>
+			<xsd:attribute name="is-function" default="false">
+				<xsd:annotation>
+					<xsd:documentation>
+						If "true", a SQL Function is called. In that case
+						the "stored-procedure-name" attribute defines
+						the name of the called function.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="skip-undeclared-results" default="true">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						If this attribute is set to 'true', then all results from
+						a stored procedure call that don't have a corresponding
+						'SqlOutParameter' declaration will be bypassed.
+
+						E.g. Stored Procedures may return an update count value,
+						even though your Stored Procedure only declared a single
+						result parameter. The exact behavior depends on the used
+						database.
+
+						The value is set on the underlying 'JdbcTemplate'.
+
+						Only few developers will probably ever like to process
+						update counts, thus the value defaults to 'true'.]]>
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="expect-single-result" default="false">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+					This parameter indicates that only one result object shall be returned from
+					the Stored Procedure/Function Call. If set to true and the result map
+					from the Stored Procedure/Function Call contains only 1 element,
+					then that 1 element is extracted and returned as payload.
+
+					If the result map contains more than 1 element and
+					expect-single-result is true, then a MessagingException
+					is thrown.
+
+					Otherwise the complete result map is returned as the
+					payload.
+
+					Important Note: Several databases such as H2 are not
+					fully supported for Stored Procedure and/oir Function calls.
+
+					The H2 database, for example, does not fully support the CallableStatement
+					semantics and when executing function calls against H2, a result list is
+					returned, rather than a single value.
+
+					Therefore, even if you set expect-single-result = true,
+					you may end up with a collection being returned.
+					]]>
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Channel to which polled messages will be send. If the stored
+						procedure or function does not return any data, the payload
+						of the Message will be Null.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:attributeGroup name="coreStoredProcComponentAttributes">
+		<xsd:attribute name="id" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Identifies the underlying Spring bean definition, which is an
+					instance of either 'EventDrivenConsumer' or 'PollingConsumer',
+					depending on whether the component's input channel is a
+					'SubscribableChannel' or 'PollableChannel'.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="stored-procedure-name" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The name of the stored procedure. If the "is-function"
+					attribute is "true", this attributes specifies the
+					function name.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="stored-procedure-name-expression" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					The name of the stored procedure provided as a SpEL expression.
+					Components that use a Message as source of parameters have
+					full access to the message and its headers, in order to
+					derive a stored procedure name.
+
+					The expression must resolve to a String.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="jdbc-call-operations-cache-size" default="10" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Defines the maximum number of cached SimpleJdbcCallOperations
+					instances. Basically, for each Stored Procedure Name a new
+					SimpleJdbcCallOperations instance is created that in return
+					is being cached. The default cache size is '10'. A value of
+					'0' disables caching. Negative values are not permitted.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:integer" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="data-source" type="xsd:string" use="required" >
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to a data source to use to access
+					the database.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="javax.sql.DataSource" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string" default="true" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Flag to indicate that the poller should start automatically
+					on startup (default true).
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ignore-column-meta-data" default="false" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					If true, the JDBC parameter definitions for the stored procedure
+					are not automatically derived from the underlying JDBC connection. In
+					that case you must specify all Sql parameter definitions explicitly
+					using the 'sql-parameter-definition' sub-element.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:complexType name="parameterSubElementType">
+		<xsd:attribute name="name" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The name of stored procedure or function parameter.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="value" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The value of the parameter. Either this or the 'expression'
+					attribute must be provided.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="type" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The type of the value used. If nothing is provided this attribute
+					will default to java.lang.String. This attribute is not used
+					when the 'expression' attribute is used instead.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Expression to be evaluated to produce a value for the header.
+					Either this or the 'value' attribute must be provided.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="returningResultSetRowMappersType">
+		<xsd:attribute name="name"      type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The name of the under which the resultset will be returned.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		 <xsd:attribute name="row-mapper" type="xsd:string" use="required">
+			 <xsd:annotation>
+				 <xsd:documentation source="java:java.lang.Class"><![CDATA[
+					The fully qualified class name of the row mapper.
+				]]></xsd:documentation>
+			 </xsd:annotation>
+		 </xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="sqlParameterDefinitionType">
+		<xsd:attribute name="name"      type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The name of the Sql parameter.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="direction" use="optional" default="IN">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Specifies the direction of the Sql parameter definition. Defaults
+					to 'IN'. If your procedure is returning ResultSets, please
+					use the 'returning-resultset' element.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="sqlTypeDirection xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="type">
+			 <xsd:annotation>
+				 <xsd:documentation><![CDATA[
+					The Sql type used for this Sql parameter defintion. Will translate
+					into the integer value as defined by java.sql.Types. Alternatively
+					you can provide the integer value as well. If this attribute is
+					not explicitly set, then it will default to 'VARCHAR'.
+				 ]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="sqlType xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+			<xsd:attribute name="scale" type="xsd:integer" use="optional">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						The scale of the Sql parameter. Only used for numeric and decimal
+						parameters.
+					]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:simpleType name="sqlType">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="VARCHAR"/>
+			<xsd:enumeration value="ARRAY"/>
+			<xsd:enumeration value="BIGINT"/>
+			<xsd:enumeration value="BINARY"/>
+			<xsd:enumeration value="BIT"/>
+			<xsd:enumeration value="BLOB"/>
+			<xsd:enumeration value="BOOLEAN"/>
+			<xsd:enumeration value="CHAR"/>
+			<xsd:enumeration value="CLOB"/>
+			<xsd:enumeration value="DATALINK"/>
+			<xsd:enumeration value="DATE"/>
+			<xsd:enumeration value="DECIMAL"/>
+			<xsd:enumeration value="DISTINCT"/>
+			<xsd:enumeration value="DOUBLE"/>
+			<xsd:enumeration value="FLOAT"/>
+			<xsd:enumeration value="INTEGER"/>
+			<xsd:enumeration value="JAVA_OBJECT"/>
+			<xsd:enumeration value="LONGVARBINARY"/>
+			<xsd:enumeration value="LONGNVARCHAR"/>
+			<xsd:enumeration value="LONGVARCHAR"/>
+			<xsd:enumeration value="NCHAR"/>
+			<xsd:enumeration value="NCLOB"/>
+			<xsd:enumeration value="NULL"/>
+			<xsd:enumeration value="NUMERIC"/>
+			<xsd:enumeration value="NVARCHAR"/>
+			<xsd:enumeration value="OTHER"/>
+			<xsd:enumeration value="REAL"/>
+			<xsd:enumeration value="REF"/>
+			<xsd:enumeration value="ROWID"/>
+			<xsd:enumeration value="SMALLINT"/>
+			<xsd:enumeration value="SQLXML"/>
+			<xsd:enumeration value="STRUCT"/>
+			<xsd:enumeration value="TIME"/>
+			<xsd:enumeration value="TIMESTAMP"/>
+			<xsd:enumeration value="TINYINT"/>
+			<xsd:enumeration value="VARBINARY"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="sqlTypeDirection">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="IN"/>
+			<xsd:enumeration value="OUT"/>
+			<xsd:enumeration value="INOUT"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+</xsd:schema>

--- a/spring-integration-jms/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-jms/src/main/resources/META-INF/spring.schemas
@@ -2,4 +2,5 @@ http\://www.springframework.org/schema/integration/jms/spring-integration-jms-1.
 http\://www.springframework.org/schema/integration/jms/spring-integration-jms-2.0.xsd=org/springframework/integration/jms/config/spring-integration-jms-2.0.xsd
 http\://www.springframework.org/schema/integration/jms/spring-integration-jms-2.1.xsd=org/springframework/integration/jms/config/spring-integration-jms-2.1.xsd
 http\://www.springframework.org/schema/integration/jms/spring-integration-jms-2.2.xsd=org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
-http\://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd=org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
+http\://www.springframework.org/schema/integration/jms/spring-integration-jms-3.0.xsd=org/springframework/integration/jms/config/spring-integration-jms-3.0.xsd
+http\://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd=org/springframework/integration/jms/config/spring-integration-jms-3.0.xsd

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-3.0.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-3.0.xsd
@@ -1,0 +1,1391 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/jms"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:beans="http://www.springframework.org/schema/beans"
+		xmlns:tool="http://www.springframework.org/schema/tool"
+		xmlns:integration="http://www.springframework.org/schema/integration"
+		targetNamespace="http://www.springframework.org/schema/integration/jms"
+		elementFormDefault="qualified"
+		attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+			schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+	Defines the configuration elements for Spring Integration's JMS adapters.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="channel">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines a Message Channel that is backed by a JMS Queue.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="channelType">
+					<xsd:attribute name="queue" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Reference to a JMS Queue. Either this attribute or the 'queue-name'
+	must be provided, but only one.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="message-driven" type="xsd:boolean" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specifies whether this channel should be Message-Driven. The value is "true" by default.
+	Set to "false" if this channel should be pollable.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="queue-name" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Name of a JMS Queue to be resolved by this channel's DestinationResolver.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="publish-subscribe-channel">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines a Message Channel that is backed by a JMS Topic.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="channelType">
+					<xsd:attribute name="topic" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Reference to a JMS Topic. Either this attribute or the 'topic-name'
+	must be provided, but only one.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="topic-name" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Name of a JMS Topic to be resolved by this channel's DestinationResolver.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="durable" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Boolean value indicating whether the Topic subscription is durable.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="client-id" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	The JMS client id. Should be specified when using durable subscriptions.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="subscription" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	The name for the durable subscription, if any.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="channelType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Base type for JMS Destination backed Message Channels (either 'channel' for a
+	Queue-backed channel or 'publish-subscribe-channel' for a Topic-backed channel).
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.springframework.integration.jms.AbstractJmsChannel"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="interceptors" type="integration:channelInterceptorsType" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A list of ChannelInterceptor instances to be applied to this channel.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+	ID for this channel. Required.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="connection-factory" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Reference to a JMS ConnectionFactory. If none is provided, the default
+	bean name for the reference will be "connectionFactory".
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="javax.jms.ConnectionFactory"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="destination-resolver" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to the DestinationResolver strategy for resolving destination names.
+	Default is a DynamicDestinationResolver, using the JMS provider's queue/topic
+	name resolution. Alternatively, specify a reference to a JndiDestinationResolver
+	(typically in a J2EE environment).
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.jms.support.destination.DestinationResolver"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="container-type" default="default">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The type of this listener container: "default" or "simple", choosing
+	between DefaultMessageListenerContainer and SimpleMessageListenerContainer.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="default"/>
+					<xsd:enumeration value="simple"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="container-class" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A custom listener container implementation class as fully qualified class name.
+	Default is Spring's standard DefaultMessageListenerContainer or
+	SimpleMessageListenerContainer, according to the "container-type" attribute.
+	Note that a custom container class will typically be a subclass of either of
+	those two Spring-provided standard container classes: Make sure that the
+	"container-type" attribute matches the actual base type that the custom class
+	derives from ("default" will usually be fine anyway, since most custom classes
+	will derive from DefaultMessageListenerContainer).
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation>
+						<tool:expected-type type="java.lang.Class"/>
+						<tool:assignable-to type="org.springframework.jms.listener.AbstractMessageListenerContainer"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="receive-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Timeout for the container's consumers if messsage-driven is TRUE, or
+	timeout for receive calls on the template if message-driven is FALSE.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="task-executor" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to a Spring TaskExecutor (or standard JDK 1.5+ Executor) for executing
+	JMS listener invokers. Default is a SimpleAsyncTaskExecutor in case of a
+	DefaultMessageListenerContainer, using internally managed threads. For a
+	SimpleMessageListenerContainer, listeners will always get invoked within the
+	JMS provider's receive thread by default.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="java.util.concurrent.Executor"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="message-converter" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to the MessageConverter strategy for converting between JMS Messages
+	and the Spring Integration Message payloads. Default is a SimpleMessageConverter.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.jms.support.converter.MessageConverter"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="error-handler" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to an ErrorHandler strategy for handling any uncaught Exceptions
+	that may occur during the execution of the underlying MessageListener.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.util.ErrorHandler"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="selector" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The JMS message selector for this channel's underlying MessageListener.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="cache" default="auto">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The cache level for JMS resources: "none", "connection", "session", "consumer"
+	or "auto". By default ("auto"), the cache level will effectively be "consumer",
+	unless an external transaction manager has been specified - in which case the
+	effective default will be "none" (assuming J2EE-style transaction management
+	where the given ConnectionFactory is an XA-aware pool).
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="none"/>
+					<xsd:enumeration value="connection"/>
+					<xsd:enumeration value="session"/>
+					<xsd:enumeration value="consumer"/>
+					<xsd:enumeration value="auto"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="acknowledge" default="transacted">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The native JMS acknowledge mode: "auto", "client", "dups-ok" or "transacted".
+	A value of "transacted" effectively activates a locally transacted Session;
+	alternatively, specify an external "transaction-manager" via the corresponding
+	attribute. Default is "transacted".
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:NMTOKEN">
+					<xsd:enumeration value="auto"/>
+					<xsd:enumeration value="client"/>
+					<xsd:enumeration value="dups-ok"/>
+					<xsd:enumeration value="transacted"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="transaction-manager" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to an external PlatformTransactionManager (typically an
+	XA-based transaction coordinator, e.g. Spring's JtaTransactionManager).
+	If not specified, native acknowledging will be used (see "acknowledge" attribute).
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.transaction.PlatformTransactionManager"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="concurrency" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The number of concurrent sessions/consumers to start for each listener.
+	Can either be a simple number indicating the maximum number (e.g. "5")
+	or a range indicating the lower as well as the upper limit (e.g. "3-5").
+	Note that a specified minimum is just a hint and might be ignored at runtime.
+	Default is 1; keep concurrency limited to 1 in case of a topic listener
+	or if message ordering is important; consider raising it for general queues.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="prefetch" type="xsd:int">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The maximum number of messages to load into a single session.
+	Note that raising this number might lead to starvation of concurrent consumers!
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Boolean value indicating whether this channel's listener container should start automatically.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="phase" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The lifecycle phase within which this channel's listener container should start and stop.
+	The lower the value the earlier this container will start and the later it will stop. The
+	default is Integer.MAX_VALUE meaning the container will start as late as possible
+	and stop as soon as possible.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="delivery-persistent" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Specify a boolean value indicating whether the delivery mode should be
+	DeliveryMode.PERSISTENT (true) or DeliveryMode.NON_PERSISTENT (false).
+	This setting will only take effect if 'explicit-qos-enabled' is true.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="time-to-live" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Specify the message time to live.
+	This setting will only take effect if 'explicit-qos-enabled' is true.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="priority" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Specify the default priority of the message. Overridden by the message priority
+	header, if present; range 0-9.
+	This setting will only take effect if 'explicit-qos-enabled' is true.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="explicit-qos-enabled" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Setting this attribute to true enables the use of quality of service attributes - message
+	priority, delivery mode, time to live.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="integration:subscribersAttributeGroup" />
+	</xsd:complexType>
+
+	<xsd:element name="message-driven-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines a JMS Message-Driven inbound Channel Adapter.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="jmsMessageDrivenInboundAdapterType">
+					<xsd:attribute name="destination" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	A reference to a javax.jms.Destination by bean name. As an alternative to a bean
+	reference, use 'destination-name' and 'pub-sub-domain' which will rely upon the
+	DestinationResolver strategy (DynamicDestinationResolver by default).
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="javax.jms.Destination"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="destination-name" type="xsd:string"/>
+					<xsd:attribute name="pub-sub-domain" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	The boolean property used to configure the JmsTemplate with knowledge of what JMS domain is being used. By default the value of this property is 'false'',
+	indicating that the point-to-point domain, Queues, will be used. This property used by JmsTemplate determines the behavior of dynamic destination resolution
+	via implementations of the DestinationResolver interface.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="subscription-durable" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Boolean property indicating whether to make the subscription durable. The durable subscription name to be used can be specified
+	through the "durableSubscriptionName" property. Default is "false". Set this to "true" to register a durable subscription,
+	typically in combination with a "durableSubscriptionName" value (unless your message listener class name is good enough as
+	subscription name). Only makes sense when listening to a topic (pub-sub domain).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="durable-subscription-name" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	The name of a durable subscription to create. To be applied in case of a topic (pub-sub domain) with subscription durability
+	activated. The durable subscription name needs to be unique within this client's JMS client id. Default is the class name of the
+	specified message listener. Note: Only 1 concurrent consumer (which is the default of this message listener container) is allowed
+	for each durable subscription.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="client-id" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	The JMS client id for a shared Connection created and used by this container. Note that client ids need to be unique among all
+	active Connections of the underlying JMS provider. Furthermore, a client id can only be assigned if the original ConnectionFactory
+	hasn't already assigned one.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="header-mapper" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.jms.JmsHeaderMapper"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="extract-payload" type="xsd:string" default="true"/>
+					<xsd:attribute name="send-timeout" type="xsd:string"/>
+					<xsd:attribute name="error-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								If a (synchronous) downstream exception is thrown and an error-channel is specified,
+								the MessagingException will be sent to this channel. Otherwise, any such exception
+								will be propagated to the listener container and any JMS transaction will be
+								rolled back. Any synchronous downstream exceptions in the error flow will
+								also cause any JMS transaction to be rolled back.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="transaction-manager" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.transaction.PlatformTransactionManager"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+
+					<xsd:attribute name="receive-timeout" type="xsd:string"/>
+
+					<xsd:attributeGroup ref="dmlcAttributeGroup"/>
+
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an inbound Channel Adapter for polling a JMS Destination.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="jmsInboundAdapterType">
+					<xsd:sequence>
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+					</xsd:sequence>
+					<xsd:attribute name="destination" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	A reference to a javax.jms.Destination by bean name. As an alternative to a bean
+	reference, use 'destination-name' and 'pub-sub-domain' which will rely upon the
+	DestinationResolver strategy (DynamicDestinationResolver by default).
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="javax.jms.Destination"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="destination-name" type="xsd:string"/>
+					<xsd:attribute name="pub-sub-domain" type="xsd:string"/>
+					<xsd:attribute name="channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="header-mapper" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.jms.JmsHeaderMapper"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="extract-payload" type="xsd:string" default="true"/>
+					<xsd:attribute name="receive-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Timeout for receive calls on the template.
+	NOTE: for JmsTemplate, 0 means indefinite while -1 means no-wait.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="jms-template" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.jms.core.JmsTemplate"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="inbound-gateway">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an inbound JMS-based Messaging Gateway.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="jmsMessageDrivenInboundAdapterType">
+					<xsd:attribute name="request-destination" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	A reference to a javax.jms.Destination by bean name. As an alternative to a bean
+	reference, use 'request-destination-name' and 'request-pub-sub-domain' which will rely
+	upon the DestinationResolver strategy (DynamicDestinationResolver by default).
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="javax.jms.Destination"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-destination-name" type="xsd:string"/>
+					<xsd:attribute name="request-pub-sub-domain" type="xsd:string"/>
+					<xsd:attribute name="default-reply-destination" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	A reference to a javax.jms.Destination by bean name. As an alternative to a bean
+	reference, use either 'default-reply-queue-name' or 'default-reply-topic-name'  which
+	will rely upon the DestinationResolver strategy (DynamicDestinationResolver by default).
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="javax.jms.Destination"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="default-reply-queue-name" type="xsd:string"/>
+					<xsd:attribute name="default-reply-topic-name" type="xsd:string"/>
+					<xsd:attribute name="correlation-key" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Provide the name of a JMS property that should be copied from the request
+								Message to the reply Message. If NO value is provided for this attribute then the
+								JMSMessageID from the request will be copied into the JMSCorrelationID of the reply
+								unless there is already a value in the JMSCorrelationID property of the newly created
+								reply Message in which case nothing will be copied. If the JMSCorrelationID of the
+								request Message should be copied into the JMSCorrelationID of the reply Message
+								instead, then this value should be set to "JMSCorrelationID".
+								Any other value will be treated as a JMS String Property to be copied as-is
+								from the request Message into the reply Message with the same property name.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="header-mapper" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.jms.JmsHeaderMapper"/>
+								</tool:annotation>
+								<xsd:documentation>
+								Allows to specify custom implementation of JmsHeaderMapper to map Message Headers to JMS Message.
+								</xsd:documentation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="extract-request-payload" type="xsd:string" default="true"/>
+					<xsd:attribute name="extract-reply-payload" type="xsd:string" default="true"/>
+					<xsd:attribute name="request-channel" type="xsd:string" use="required">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-timeout" type="xsd:string"/>
+					<xsd:attribute name="reply-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string"/>
+					<xsd:attribute name="error-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								If a (synchronous) downstream exception is thrown and an "error-channel" is specified,
+								the MessagingException will be sent to this channel; any response from
+								which will be returned as a reply by the gateway. If an "error-channel" is not
+								supplied, any such exception
+								will be propagated to the listener container and any JMS transaction will be
+								rolled back. Any synchronous downstream exceptions in the error flow will
+								also cause any JMS transaction to be rolled back.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="transaction-manager" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.transaction.PlatformTransactionManager"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="subscription-durable" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Boolean property indicating whether to make the subscription durable. The durable subscription name to be used can be specified
+	through the "durableSubscriptionName" property. Default is "false". Set this to "true" to register a durable subscription,
+	typically in combination with a "durableSubscriptionName" value (unless your message listener class name is good enough as
+	subscription name). Only makes sense when listening to a topic (pub-sub domain).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="durable-subscription-name" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	The name of a durable subscription to create. To be applied in case of a topic (pub-sub domain) with subscription durability
+	activated. The durable subscription name needs to be unique within this client's JMS client id. Default is the class name of the
+	specified message listener. Note: Only 1 concurrent consumer (which is the default of this message listener container) is allowed
+	for each durable subscription.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="client-id" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	The JMS client id for a shared Connection created and used by this container. Note that client ids need to be unique among all
+	active Connections of the underlying JMS provider. Furthermore, a client id can only be assigned if the original ConnectionFactory
+	hasn't already assigned one.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="receive-timeout" type="xsd:string"/>
+
+					<xsd:attributeGroup ref="dmlcAttributeGroup"/>
+
+					<xsd:attribute name="reply-time-to-live" type="xsd:string"/>
+					<xsd:attribute name="reply-priority" type="xsd:string"/>
+					<xsd:attribute name="reply-delivery-persistent" type="xsd:string"/>
+					<xsd:attribute name="explicit-qos-enabled-for-replies" type="xsd:string"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-gateway">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an outbound JMS-based Messaging Gateway.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:choice minOccurs="0" maxOccurs="3">
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
+				<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+				<xsd:element name="reply-listener" minOccurs="0" maxOccurs="1">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+	Configures the gateway to use an asynchronous listener container to receive reply
+	messages.
+						]]></xsd:documentation>
+					</xsd:annotation>
+					<xsd:complexType>
+						<xsd:attribute name="acknowledge">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+			The native JMS acknowledge mode: "auto", "client", "dups-ok" or "transacted".
+			The latter effectively activates a locally transacted Session.
+								]]></xsd:documentation>
+							</xsd:annotation>
+							<xsd:simpleType>
+								<xsd:restriction base="xsd:NMTOKEN">
+									<xsd:enumeration value="auto"/>
+									<xsd:enumeration value="client"/>
+									<xsd:enumeration value="dups-ok"/>
+									<xsd:enumeration value="transacted"/>
+								</xsd:restriction>
+							</xsd:simpleType>
+						</xsd:attribute>
+						<xsd:attributeGroup ref="dmlcAttributeGroup" />
+						<xsd:attribute name="receive-timeout" type="xsd:string"/>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:choice>
+			<xsd:attribute name="id" type="xsd:string"/>
+			<xsd:attribute name="request-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="receive-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Timeout for the JMS MessageConsumer to receive the JMS reply Message. Default is 5 seconds.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Allows you to specify how long this gateway will wait for
+						the reply message to be sent successfully to the reply channel
+						before throwing an exception. This attribute only applies when the
+						channel might block, for example when using a bounded queue channel that
+						is currently full.
+
+						Also, keep in mind that when sending to a DirectChannel, the
+						invocation will occur in the sender's thread. Therefore,
+						the failing of the send operation may be caused by other
+						components further downstream.
+
+						The "reply-timeout" attribute maps to the "sendTimeout" property of the
+						underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+						The attribute will default, if not specified, to '-1', meaning that
+						by default, the Gateway will wait indefinitely. The value is
+						specified in milliseconds.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="request-destination" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	A reference to a javax.jms.Destination by bean name. As an alternative to a bean
+	reference, use 'request-destination-name' and 'request-pub-sub-domain' which will rely
+	upon the DestinationResolver strategy (DynamicDestinationResolver by default). This
+	attribute is mutually exclusive with 'request-destination-name' and
+	'request-destination-expression'.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="javax.jms.Destination"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="request-destination-name" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Name of a destination to which request messages will be sent. This name will be handled
+	by this gateway's DestinationResolver. This attribute is mutually exclusive with
+	'request-destination' and 'request-destination-expression'.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="request-destination-expression" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	A SpEL expression to be evaluated at runtime against each Spring Integration request Message as
+	the root object. The result should be either a Destination instance or a String representing
+	the destination name. In the latter case, it will be passed to this adapter's DestinationResolver.
+	This attribute is mutually exclusive with 'request-destination' and 'request-destination-name'.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="request-pub-sub-domain" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	When resolving a request destination name (rather than having a 'request-destination' reference),
+	a true value here specifies that the DestinationResolver should resolve Topics rather than Queues.
+	Default is false.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-destination" type="xsd:string">
+				<xsd:annotation>
+							<xsd:documentation>
+	A reference to a javax.jms.Destination by bean name. As an alternative to a bean
+	reference, use 'reply-destination-name' and 'reply-pub-sub-domain' which will rely
+	upon the DestinationResolver strategy (DynamicDestinationResolver by default).
+							</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="javax.jms.Destination"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-destination-name" type="xsd:string"/>
+			<xsd:attribute name="reply-pub-sub-domain" type="xsd:string"/>
+			<xsd:attribute name="correlation-key" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Provide the name of a JMS property that should hold a generated UUID that
+						the receiver of the JMS Message would expect to represent the CorrelationID.
+						When waiting for the reply Message, a MessageSelector will be configured
+						to match this property name and the UUID value that was sent in the request.
+						If NO value is provided for this attribute, then the reply consumer's
+						MessageSelector will be expecting the JMSCorrelationID to equal the Message ID
+						of the request. If you want to store the outbound correlation UUID value in the
+						actual "JMSCorrelationID" property, then set this value to "JMSCorrelationID".
+						However, any other value will be treated as a JMS String Property.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="destination-resolver" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.jms.support.destination.DestinationResolver"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="connection-factory" type="xsd:string" default="connectionFactory">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="javax.jms.ConnectionFactory"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="message-converter" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A reference to the MessageConverter strategy for converting between JMS Messages
+	and the Spring Integration Message payloads. Default is a SimpleMessageConverter.
+				]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.jms.support.converter.MessageConverter"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="header-mapper" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.jms.JmsHeaderMapper"/>
+						</tool:annotation>
+						<xsd:documentation>
+						Allows to specify custom implementation of JmsHeaderMapper to map Message Headers to JMS Message.
+						</xsd:documentation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="extract-request-payload" type="xsd:string" default="true"/>
+			<xsd:attribute name="extract-reply-payload" type="xsd:string" default="true"/>
+			<xsd:attribute name="delivery-mode" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	[DEPRECATED - use delivery-persistent attribute instead]
+	A reference to the MessageConverter strategy for converting between JMS Messages
+	and the Spring Integration Message payloads. Default is a SimpleMessageConverter.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="delivery-persistent" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Specify a boolean value indicating whether the delivery mode should be
+	DeliveryMode.PERSISTENT (true) or DeliveryMode.NON_PERSISTENT (false).
+	This setting will only take effect if 'explicit-qos-enabled' is true.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="time-to-live" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Specify the message time to live.
+	This setting will only take effect if 'explicit-qos-enabled' is true.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="priority" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Specify the default priority of the message. Overridden by the message priority
+	header, if present; range 0-9
+	This setting will only take effect if 'explicit-qos-enabled' is true.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="explicit-qos-enabled" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Setting this attribute to true enables the use of quality of service attributes - message
+	priority, delivery mode, time to live.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-startup" type="xsd:string" default="true"/>
+			<xsd:attribute name="order" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Specifies the order for invocation when this gateway is connected as a
+	subscriber to a SubscribableChannel.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an outbound JMS Message-sending Channel Adapter.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="jmsAdapterType">
+					<xsd:choice minOccurs="0" maxOccurs="2">
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:choice>
+					<xsd:attribute name="destination" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	A reference to a javax.jms.Destination by bean name. As an alternative to a bean
+	reference, use 'destination-name' and 'pub-sub-domain' which will rely upon the
+	DestinationResolver strategy (DynamicDestinationResolver by default). This attribute
+	is mutually exclusive with 'destination-name' and 'destination-expression'.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="javax.jms.Destination"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="destination-name" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Name of the destination to which JMS Messages will be sent. This will be passed to the
+	adapter's DestinationResolver. This attribute is mutually exclusive with 'destination'
+	and 'destination-expression'.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="destination-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	A SpEL expression to be evaluated at runtime against each Spring Integration Message as
+	the root object. The result should be either a Destination instance or a String representing
+	the destination name. In the latter case, it will be passed to this adapter's DestinationResolver.
+	If the evaluation result is null, messages will be sent to the default destination of the
+	underlying JmsTemplate. This attribute is mutually exclusive with 'destination' and 'destination-name'.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="pub-sub-domain" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	If true, specifies that destination names should resolve to Topics rather than Queues. Default is false.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="header-mapper" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.jms.JmsHeaderMapper"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="extract-payload" type="xsd:string" default="true"/>
+					<xsd:attribute name="jms-template" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.jms.core.JmsTemplate"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="delivery-persistent" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specify a boolean value indicating whether the delivery mode should be
+	DeliveryMode.PERSISTENT (true) or DeliveryMode.NON_PERSISTENT (false).
+	This setting will only take effect if 'explicit-qos-enabled' is true.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="time-to-live" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specify the message time to live.
+	This setting will only take effect if 'explicit-qos-enabled' is true.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="priority" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specify the default priority of the message. Overridden by the message priority
+	header, if present; range 0-9.
+	This setting will only take effect if 'explicit-qos-enabled' is true.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="explicit-qos-enabled" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Setting this attribute to true enables the use of quality of service attributes - message
+	priority, delivery mode, time to live.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Specifies the order for invocation when this adapter is connected as a
+	subscriber to a SubscribableChannel.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="jmsMessageDrivenInboundAdapterType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Common configuration for message-driven inbound JMS-based adapters.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="jmsInboundAdapterType">
+				<xsd:attribute name="container" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.jms.listener.AbstractMessageListenerContainer"/>
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="jmsInboundAdapterType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Common configuration for inbound JMS-based adapters.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="jmsAdapterType">
+				<xsd:attribute name="acknowledge">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+	The native JMS acknowledge mode: "auto", "client", "dups-ok" or "transacted".
+	The latter effectively activates a locally transacted Session.
+						]]></xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:restriction base="xsd:NMTOKEN">
+							<xsd:enumeration value="auto"/>
+							<xsd:enumeration value="client"/>
+							<xsd:enumeration value="dups-ok"/>
+							<xsd:enumeration value="transacted"/>
+						</xsd:restriction>
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="selector" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+	A JMS Message Selector expression.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="header-enricher">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+	Defines a Transformer for adding statically configured JMS Headers.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:complexContent>
+				<xsd:extension base="transformerType">
+					<xsd:choice minOccurs="1" maxOccurs="unbounded">
+						<xsd:element name="reply-to" type="refOnlyHeaderType">
+							<xsd:annotation>
+								<xsd:documentation>
+	The ReplyTo Destination for the JMS Message.
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="correlation-id" type="refOrValueHeaderType">
+							<xsd:annotation>
+								<xsd:documentation>
+	The Correlation ID for the JMS Message.
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+					</xsd:choice>
+					<xsd:attribute name="default-overwrite">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specify the default boolean value for whether to overwrite existing header values. This will only take effect for
+	sub-elements that do not provide their own 'overwrite' attribute. If the 'default-overwrite' attribute is not
+	provided, then the specified header values will NOT overwrite any existing ones with the same header names.
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="xsd:boolean xsd:string"/>
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="refOrValueHeaderType">
+		<xsd:complexContent>
+			<xsd:extension base="refOnlyHeaderType">
+				<xsd:attribute name="value" type="xsd:string" />
+				<xsd:attribute name="expression" type="xsd:string" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="refOnlyHeaderType">
+		<xsd:attribute name="ref" type="xsd:string" />
+		<xsd:attribute name="overwrite">
+			<xsd:annotation>
+				<xsd:documentation>
+	Boolean value to indicate whether this header value should overwrite an existing header value for the same name.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="jmsAdapterType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Common configuration for JMS-based adapters.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="id" type="xsd:string"/>
+		<xsd:attribute name="connection-factory" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="javax.jms.ConnectionFactory"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="destination-resolver" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.jms.support.destination.DestinationResolver"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="message-converter" type="xsd:string">
+			<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	A reference to the MessageConverter strategy for converting between JMS Messages
+	and the Spring Integration Message payloads. Default is a SimpleMessageConverter.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.jms.support.converter.MessageConverter"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string" default="true"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="transformerType">
+		<xsd:attribute name="id" type="xsd:string"/>
+		<xsd:attribute name="input-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="output-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:attributeGroup name="dmlcAttributeGroup">
+		<xsd:attribute name="concurrent-consumers" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specify the number of concurrent consumers to create. Default is 1.
+						Specifying a higher value for this setting will increase the standard
+						level of scheduled concurrent consumers at runtime: This is effectively
+						the minimum number of concurrent consumers which will be scheduled
+						at any given time. This is a static setting; for dynamic scaling,
+						consider specifying the "maxConcurrentConsumers" setting instead.
+						Raising the number of concurrent consumers is recommendable in order
+						to scale the consumption of messages coming in from a queue. However,
+						note that any ordering guarantees are lost once multiple consumers are
+						registered
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-concurrent-consumers" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					 Specify the maximum number of concurrent consumers to create. Default is 1.
+						 If this setting is higher than "concurrentConsumers", the listener container
+						 will dynamically schedule new consumers at runtime, provided that enough
+						 incoming messages are encountered. Once the load goes down again, the number of
+						 consumers will be reduced to the standard level ("concurrentConsumers") again.
+						 Raising the number of concurrent consumers is recommendable in order
+						to scale the consumption of messages coming in from a queue. However,
+						note that any ordering guarantees are lost once multiple consumers are
+						registered.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="cache-level" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					 Specify the level of caching that this listener container is allowed to apply:
+					 CACHE_NONE = 0
+					 CACHE_CONNECTION = 1
+					 CACHE_SESSION = 2
+					 CACHE_CONSUMER = 3
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-messages-per-task" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				Specify the maximum number of messages to process in one task.
+					More concretely, this limits the number of message reception attempts
+					per task, which includes receive iterations that did not actually
+					pick up a message until they hit their timeout
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+
+		<xsd:attribute name="recovery-interval" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				Interval in miliseconds between the recovery attempts
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="idle-consumer-limit" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				Specify the limit for the number of consumers that are allowed to be idle at any given time.
+				This limit is used to determine if a new invoker should be created. Increasing the limit causes
+				invokers to be created more aggressively. This can be useful to ramp up the
+					number of invokers faster.
+					The default is 1, only scheduling a new invoker (which is likely to
+					be idle initially) if none of the existing invokers is currently idle.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="idle-task-execution-limit" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				Specify the limit for idle executions of a consumer task, not having
+					received any message within its execution. If this limit is reached,
+					the task will shut down and leave receiving to other executing tasks.
+					The default is 1, closing idle resources early once a task didn't
+					receive a message.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+
+	</xsd:attributeGroup>
+
+</xsd:schema>

--- a/spring-integration-jmx/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-jmx/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
 http\://www.springframework.org/schema/integration/jmx/spring-integration-jmx-2.0.xsd=org/springframework/integration/jmx/config/spring-integration-jmx-2.0.xsd
 http\://www.springframework.org/schema/integration/jmx/spring-integration-jmx-2.1.xsd=org/springframework/integration/jmx/config/spring-integration-jmx-2.1.xsd
 http\://www.springframework.org/schema/integration/jmx/spring-integration-jmx-2.2.xsd=org/springframework/integration/jmx/config/spring-integration-jmx-2.2.xsd
-http\://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd=org/springframework/integration/jmx/config/spring-integration-jmx-2.2.xsd
+http\://www.springframework.org/schema/integration/jmx/spring-integration-jmx-3.0.xsd=org/springframework/integration/jmx/config/spring-integration-jmx-3.0.xsd
+http\://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd=org/springframework/integration/jmx/config/spring-integration-jmx-3.0.xsd

--- a/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-3.0.xsd
+++ b/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-3.0.xsd
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/jmx" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration" targetNamespace="http://www.springframework.org/schema/integration/jmx"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration" schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+	Defines the configuration elements for Spring Integration's JMX adapters.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="attribute-polling-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an inbound Channel Adapter that polls for JMX attribute values.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="adapterType">
+					<xsd:sequence minOccurs="0" maxOccurs="1">
+						<xsd:element ref="integration:poller" />
+					</xsd:sequence>
+					<xsd:attribute name="attribute-name" type="xsd:string" use="required" />
+					<xsd:attribute name="auto-startup" type="xsd:string" default="true" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+	<xsd:element name="operation-invoking-outbound-gateway">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an outbound Gateway which allows for Message-driven invocation of managed operations that
+				return values
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="operationInvokingType">
+					<xsd:all>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:all>
+					<xsd:attribute name="request-channel" type="xsd:string" />
+					<xsd:attribute name="reply-channel" type="xsd:string" use="optional" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="operation-invoking-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an outbound Channel Adapter for invoking JMX operations.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="operationInvokingType">
+					<xsd:all>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:all>
+					<xsd:attribute name="channel" type="xsd:string" use="optional" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="notification-listening-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Defines an inbound Channel Adapter that listens for JMX notifications. The 'object-name'
+				attribute on this endpoint can contain an ObjectName pattern and the MBeanServer will
+				be queried for MBeans with ObjectNames matching the pattern. In addition, it can contain
+				a SpEL expression that references a <util:list/> of ObjectNames or ObjectName patterns.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="adapterType">
+					<xsd:attribute name="notification-filter" type="xsd:string" use="optional" />
+					<xsd:attribute name="handback" type="xsd:string" use="optional" />
+					<xsd:attribute name="send-timeout" type="xsd:string" use="optional" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="notification-publishing-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an outbound Channel Adapter that publishes JMX notifications.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="adapterType">
+					<xsd:all>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:all>
+					<xsd:attribute name="default-notification-type" type="xsd:string" use="optional" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="mbean-export">
+		<xsd:annotation>
+			<xsd:documentation>
+				Exports Message Channels and Endpoints as MBeans.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="mbeanServerIdentifyerType">
+					<xsd:attribute name="default-domain" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>
+								The domain name for the MBeans exported by this Exporter.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="object-name-static-properties" use="optional">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="java.util.Properties" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Static object properties to be used for this domain.  These properties are appended to
+								the ObjectName of all MBeans registered by this component.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="managed-components" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>
+								Comma separated list of simple patterns for component names to register (defaults to '*').
+								The pattern is applied to all components before they are registered, looking for a match on
+								the 'name' property of the ObjectName.  A MessageChannel and a MessageHandler (for instance)
+								can share a name because they have a different type, so in that case they would either both
+								be included or both excluded.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="shutdown-executor" use="optional">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="java.util.concurrent.Executor" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								An Executor used when shutting down the application using the 'stopActiveComponents()'
+								method. Only required when invoking the operation on a Spring-managed thread, such as
+								via a <control-bus/> from, say, an error flow. Using this executor avoids the
+								problem where the shutdown will wait for the current thread to terminate, time out,
+								and then force-close other components. When a dedicated executor is supplied,
+								the method will not wait on its threads to complete, and will terminate normally.
+								It is recommended that the executor used here is dedicated for this purpose and
+								not used elsewhere.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="adapterType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines inbound operation invoking type
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="mbeanServerIdentifyerType">
+				<xsd:attribute name="channel" type="xsd:string" />
+				<xsd:attribute name="object-name" type="xsd:string" use="required" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="operationInvokingType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines outbound operation invoking type
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="mbeanServerIdentifyerType">
+				<xsd:attribute name="object-name" type="xsd:string" use="required" />
+				<xsd:attribute name="operation-name" type="xsd:string" use="required" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="mbeanServerIdentifyerType">
+		<xsd:attribute name="id" type="xsd:string" use="optional" />
+		<xsd:attribute name="server" type="xsd:string" default="mbeanServer">
+			<xsd:annotation>
+				<xsd:documentation>
+					Defines the name of the MBeanServer bean to connect to.
+					</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/spring-integration-jpa/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-jpa/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,3 @@
 http\://www.springframework.org/schema/integration/jpa/spring-integration-jpa-2.2.xsd=org/springframework/integration/jpa/config/xml/spring-integration-jpa-2.2.xsd
-http\://www.springframework.org/schema/integration/jpa/spring-integration-jpa.xsd=org/springframework/integration/jpa/config/xml/spring-integration-jpa-2.2.xsd
+http\://www.springframework.org/schema/integration/jpa/spring-integration-jpa-3.0.xsd=org/springframework/integration/jpa/config/xml/spring-integration-jpa-3.0.xsd
+http\://www.springframework.org/schema/integration/jpa/spring-integration-jpa.xsd=org/springframework/integration/jpa/config/xml/spring-integration-jpa-3.0.xsd

--- a/spring-integration-jpa/src/main/resources/org/springframework/integration/jpa/config/xml/spring-integration-jpa-3.0.xsd
+++ b/spring-integration-jpa/src/main/resources/org/springframework/integration/jpa/config/xml/spring-integration-jpa-3.0.xsd
@@ -1,0 +1,579 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/jpa"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration"
+	targetNamespace="http://www.springframework.org/schema/integration/jpa"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+			Defines the configuration elements for Spring Integration's JPA Adapter.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				The definition for the Spring Integration JPA Inbound Channel Adapter.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+			</xsd:sequence>
+			<xsd:attributeGroup ref="coreJpaComponentAttributes"/>
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.core.MessageChannel" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="parameter-source" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.jpa.core.JpaQLParameterSource" />
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						specifies the parameter source that would be used to
+						provide additional parameters.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attributeGroup ref="commonRetrievingJpaAttributes" />
+			<xsd:attribute name="send-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Allows you to specify how long this inbound-channel-adapter
+						will wait for the message (containing the retrieved entities)
+						to be sent successfully to the message channel, before throwing
+						an exception.
+
+						Keep in mind that when sending to a DirectChannel, the
+						invocation will occur in the sender's thread so the failing
+						of the send operation may be caused by other components
+						further downstream. By default the Inbound Channel Adapter
+						will wait indefinitely. The value is specified in milliseconds.
+					]]>
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-channel-adapter">
+			<xsd:annotation>
+					<xsd:documentation>
+							Defines an outbound Channel Adapter for updating a
+							database using the Java Persistence API (JPA).
+					</xsd:documentation>
+			</xsd:annotation>
+			<xsd:complexType>
+				<xsd:sequence>
+					<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
+					<xsd:element name="transactional" type="integration:transactionalType" minOccurs="0" maxOccurs="1" />
+					<xsd:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="parameterSubElementType">
+						<xsd:annotation>
+							<xsd:documentation>
+								<![CDATA[
+								Provides a mechanism to provide
+								parameters for the queries that are either based
+								on the Java Persistence Query Language (JPQL) or
+								native SQL queries.
+
+								Parameters can also be provided for Named Queries.
+								]]>
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+				</xsd:sequence>
+				<xsd:attributeGroup ref="coreJpaComponentAttributes"/>
+				<xsd:attributeGroup ref="commonUpdatingJpaAttributes"/>
+				<xsd:attribute name="use-payload-as-parameter-source">
+					<xsd:annotation>
+						<xsd:documentation>
+						<![CDATA[
+						If set to 'true', the payload of the Message will be used
+						as a source for providing parameters. If false the entire
+						Message will be available as a source for parameters.
+
+						If no JPA Parameters are passed in, this property
+						will default to 'true'. This means that using a default
+						BeanPropertyParameterSourceFactory, the bean properties
+						of the payload will be used as a source for parameter
+						values for the to-be-executed JPA query.
+
+						However, if JPA Parameters are passed in, then this
+						property will by default evaluate to 'false'. JPA Parameters
+						allow for SpEL Expressions to be provided and therefore
+						it is highly beneficial to have access to the entire Message.
+						]]>
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:union memberTypes="xsd:boolean xsd:string" />
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="parameter-source-factory"
+						type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<xsd:documentation>
+								Reference to a ParameterSourceFactory.
+							</xsd:documentation>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.integration.jpa.support.parametersource.ParameterSourceFactory" />
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="channel" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<xsd:documentation>
+								Channel from which messages will be output.
+								When a message is sent to this channel it will
+								cause the query
+								to be executed.
+							</xsd:documentation>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.integration.MessageChannel" />
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="order">
+					<xsd:annotation>
+						<xsd:documentation>
+							Specifies the order for invocation when this endpoint is connected as a
+							subscriber to a SubscribableChannel.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="updating-outbound-gateway">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines the Spring Integration JPA Outbound Gateway
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
+				<xsd:element name="transactional" type="integration:transactionalType" minOccurs="0" maxOccurs="1" />
+				<xsd:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="parameterSubElementType">
+					<xsd:annotation>
+						<xsd:documentation>
+							<![CDATA[
+							Provides a mechanism to provide
+							parameters for the queries that are either based
+							on the Java Persistence Query Language (JPQL) or
+							native SQL queries.
+
+							Parameters can also be provided for Named Queries.
+							]]>
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+			</xsd:sequence>
+			<xsd:attributeGroup ref="coreJpaComponentAttributes" />
+			<xsd:attributeGroup ref="commonUpdatingJpaAttributes"/>
+			<xsd:attributeGroup ref="commonJpaOutboundGatewayAttributes"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="retrieving-outbound-gateway">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines a Spring Integration JPA Outbound Gateway
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
+				<xsd:element name="transactional" type="integration:transactionalType" minOccurs="0" maxOccurs="1" />
+				<xsd:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="parameterSubElementType">
+					<xsd:annotation>
+						<xsd:documentation>
+							<![CDATA[
+							Provides a mechanism to provide
+							parameters for the queries that are either based
+							on the Java Persistence Query Language (JPQL) or
+							native SQL queries.
+
+							Parameters can also be provided for Named Queries.
+							]]>
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+			</xsd:sequence>
+			<xsd:attributeGroup ref="coreJpaComponentAttributes" />
+			<xsd:attributeGroup ref="commonJpaOutboundGatewayAttributes"/>
+			<xsd:attributeGroup ref="commonRetrievingJpaAttributes" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="parameterSubElementType">
+		<xsd:attribute name="name" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The name of Jpa parameter. This parameter can also be used for
+					native SQL query parameters. The name attribute is optional.
+					If the name is not provided, this parameter will act as a positional
+					parameters, in which case the order of the parameter sub-element
+					matters.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="value" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The value of the parameter. Either this or the 'expression'
+					attribute must be provided.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="type" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					The type of the value used. If nothing is provided this attribute
+					will default to java.lang.String. This attribute is not used
+					when the 'expression' attribute is used instead.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Expression to be evaluated to produce a parameter value.
+					Either this or the 'value' attribute must be provided.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:attributeGroup name="commonJpaOutboundGatewayAttributes">
+		<xsd:attribute name="use-payload-as-parameter-source">
+			<xsd:annotation>
+				<xsd:documentation>
+				<![CDATA[
+				If set to 'true', the payload of the Message will be used
+				as a source for providing parameters. If false the entire
+				Message will be available as a source for parameters.
+
+				If no JPA Parameters are passed in, this property
+				will default to 'true'. This means that using a default
+				BeanPropertyParameterSourceFactory, the bean properties
+				of the payload will be used as a source for parameter
+				values for the to-be-executed JPA query.
+
+				However, if JPA Parameters are passed in, then this
+				property will by default evaluate to 'false'. JPA Parameters
+				allow for SpEL Expressions to be provided and therefore
+				it is highly beneficial to have access to the entire Message.
+				]]>
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="request-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					The receiving Message Channel of this endpoint.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.core.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="reply-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Message Channel to which replies should be
+					sent, after receiving the database response.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.core.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="reply-timeout" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Allows you to specify how long this gateway will wait for
+					the reply message to be sent successfully to the reply channel
+					before throwing an exception. This attribute only applies when the
+					channel might block, for example when using a bounded queue channel that
+					is currently full.
+
+					Also, keep in mind that when sending to a DirectChannel, the
+					invocation will occur in the sender's thread. Therefore,
+					the failing of the send operation may be caused by other
+					components further downstream.
+
+					The "reply-timeout" attribute maps to the "sendTimeout" property of the
+					underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+					The attribute will default, if not specified, to '-1', meaning that
+					by default, the Gateway will wait indefinitely. The value is
+					specified in milliseconds.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="parameter-source-factory" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.jpa.JPAQLParameterSourceFactory" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+					The parameter source factory that would be used for evaluating the
+					parameters of the response JPA QL that would be evaluated
+					JPA outbound gateway
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="order">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specifies the order for invocation when this endpoint is connected as a
+					subscriber to a SubscribableChannel.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="commonUpdatingJpaAttributes">
+		<xsd:attribute name="persist-mode" use="optional" default="MERGE">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Defines the persistence mode which is used when soley using
+					the entity-class. This attribute instructs to either Merge
+					entities, to Persist them. Furthermore and entity can also
+					be deleted. By Default 'MERGE' is used.
+				]]></xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="persistMode xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="commonRetrievingJpaAttributes">
+		<xsd:attribute name="max-number-of-results">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specifies the maximum number of entities that shall be returned
+					by a JPA Operation. Using this attribute you basically set
+					the 'maxResults' property of the JPA Query object.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expect-single-result" default="false">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					This parameter indicates that only one result object shall be
+					returned as a result from the executed JPA operation.
+
+					If set to 'true' and the result list from the JPA operations
+					contains only 1 element, then that 1 element is extracted
+					and returned as payload.
+
+					If the result map contains more than 1 element and
+					'expect-single-result' is true, then a 'MessagingException'
+					is thrown.
+
+					If set to 'false', the complete result list is returned
+					as the payload.
+					]]>
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="delete-after-poll" default="false" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Once entities have been retrieved from the database, shall
+					they be removed from the database?
+
+					If instead of deleting the retrieved entities, you would
+					rather like to updated them, e.g. setting a flag in a
+					column marking the record as retrieved, please consider
+					using a subsequent Outbound Gateway (coupled with a payload enricher).
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="delete-in-batch" default="false" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					If you want to automatically remove retrieved entities from
+					the database you can also specify using the 'delete-in-batch'
+					attribute, whether the list of retrieved objects shall be
+					deleted on a 'per-object-basis (false) or whether the objects
+					shall be removed using a batch operation (true). The
+					attribute defaults to 'false'.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="coreJpaComponentAttributes">
+		<xsd:attribute name="id" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Identifies the underlying Spring bean definition, which is an
+					instance of either 'EventDrivenConsumer' or 'PollingConsumer',
+					depending on whether the component's input channel is a
+					'SubscribableChannel' or 'PollableChannel'.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="entity-manager-factory" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					<![CDATA[
+					The reference to the JPA Entity Manager Factory
+					that will be used by the adapter to create the EntityManager.
+					Either this attribute or the 'enity-manager' attribute or the
+					'jpa-operations' attribute must be provided.
+					]]>
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="javax.persistence.EntityManagerFactory" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="entity-manager"  type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				<![CDATA[
+					The reference to the JPA Entity Manager that will be used by
+					the adapter. Either this attribute or the 'enity-manager-factory'
+					attribute or the 'jpa-operations' attribute must be provided.
+					]]>
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="javax.persistence.EntityManager" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="jpa-operations"  type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					<![CDATA[
+					Reference to a bean implementing the JpaOperations interface.
+
+					In rare cases it might be advisable to provide your own implementation
+					of the JpaOperations interface, instead of relying on the
+					default implementation. As JpaOperations wraps the necessay
+					datasource; the JPA Entity Manager or JPA Entity Manager Factory
+					must not be provided if the 'jpa-operations' attribute is used.
+					]]>
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.jpa.core.JpaOperations" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="entity-class">
+			<xsd:annotation>
+				<xsd:documentation>
+					<![CDATA[
+					The reference to the JPA Persistence Entity. If not specified the
+					entity class will be retrieved from the Message's payload (for
+					operation that involve an enityClass).
+					]]>
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="value">
+						<tool:expected-type type="java.lang.Class" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="jpa-query" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					<![CDATA[
+					Defines the JPA query (Java Persistence Query Language) to be used.
+					]]>
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="native-query" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Defines the native SQL query to be used.
+					]]>
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="named-query" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					<![CDATA[
+					This attribute refers to a named query. A named query can be
+					either be defined in Native SQL or JPAQL but the underlying JPA
+					persistence provider handles that distinction internally.
+					]]>
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" default="true" use="optional">
+			<xsd:annotation>
+				<xsd:documentation>
+					Flag to indicate that the component should start automatically
+					on startup (default true).
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:simpleType name="persistMode">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="DELETE"/>
+			<xsd:enumeration value="MERGE"/>
+			<xsd:enumeration value="PERSIST"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/spring-integration-mail/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-mail/src/main/resources/META-INF/spring.schemas
@@ -2,4 +2,5 @@ http\://www.springframework.org/schema/integration/mail/spring-integration-mail-
 http\://www.springframework.org/schema/integration/mail/spring-integration-mail-2.0.xsd=org/springframework/integration/mail/config/spring-integration-mail-2.0.xsd
 http\://www.springframework.org/schema/integration/mail/spring-integration-mail-2.1.xsd=org/springframework/integration/mail/config/spring-integration-mail-2.1.xsd
 http\://www.springframework.org/schema/integration/mail/spring-integration-mail-2.2.xsd=org/springframework/integration/mail/config/spring-integration-mail-2.2.xsd
-http\://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd=org/springframework/integration/mail/config/spring-integration-mail-2.2.xsd
+http\://www.springframework.org/schema/integration/mail/spring-integration-mail-3.0.xsd=org/springframework/integration/mail/config/spring-integration-mail-3.0.xsd
+http\://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd=org/springframework/integration/mail/config/spring-integration-mail-3.0.xsd

--- a/spring-integration-mail/src/main/resources/org/springframework/integration/mail/config/spring-integration-mail-3.0.xsd
+++ b/spring-integration-mail/src/main/resources/org/springframework/integration/mail/config/spring-integration-mail-3.0.xsd
@@ -1,0 +1,383 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/mail"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:beans="http://www.springframework.org/schema/beans"
+		xmlns:tool="http://www.springframework.org/schema/tool"
+		xmlns:integration="http://www.springframework.org/schema/integration"
+		targetNamespace="http://www.springframework.org/schema/integration/mail"
+		elementFormDefault="qualified"
+		attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+			schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+	Defines the configuration elements for Spring Integration's Mail Channel Adapters.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+	Defines an outbound mail-sending Channel Adapter.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:choice minOccurs="0" maxOccurs="2">
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+				<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+			</xsd:choice>
+			<xsd:attribute name="id" type="xsd:string"/>
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mail-sender" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.mail.MailSender"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="host" type="xsd:string"/>
+			<xsd:attribute name="port" type="xsd:string"/>
+			<xsd:attribute name="username" type="xsd:string"/>
+			<xsd:attribute name="password" type="xsd:string"/>
+			<xsd:attribute name="java-mail-properties" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="java.util.Properties"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-startup" type="xsd:string" default="true"/>
+			<xsd:attribute name="order">
+				<xsd:annotation>
+					<xsd:documentation>
+						Specifies the order for invocation when this endpoint is connected as a
+						subscriber to a SubscribableChannel.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an inbound Channel Adapter that polls a mailbox for mail messages.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="inboundMailAdapterType">
+					<xsd:sequence>
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+					</xsd:sequence>
+					<xsd:attribute name="protocol" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	The protocol to use (e.g. "pop3" or "imap"). Typically, either this or the 'store-uri' would be
+	provided, but not both. However, at least one of them is required.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="search-term-strategy" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.mail.SearchTermStrategy" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Reference to a custom implementation of org.springframework.integration.mail.SearchTermStrategy
+								to use when retrieving email. Only permitted with 'imap' protocol or an 'imap' uri.
+								By default, the ImapMailReceiver will search for Messages based on the default SearchTerm
+								which is "All mails that are RECENT (if supported), that are NOT ANSWERED, that are NOT DELETED, that are NOT SEEN and have not
+								been processed by this mail receiver (enabled by the use of the custom USER flag or simply NOT FLAGGED if not supported)".
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="imap-idle-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an IMAP IDLE channel adapter.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="inboundMailAdapterType">
+				<xsd:choice minOccurs="0" maxOccurs="2">
+					<xsd:element name="transactional" type="integration:transactionalType" minOccurs="0" maxOccurs="1" />
+				</xsd:choice>
+					<xsd:attribute name="error-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								If a (synchronous) downstream exception is thrown and an error-channel is specified,
+								the MessagingException will be sent to this channel. Otherwise, any such exception
+								will simply be logged as a warning by the channel adapter.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="search-term-strategy" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.mail.SearchTermStrategy" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Reference to a custom implementation of org.springframework.integration.mail.SearchTermStrategy
+								to use when retrieving email.
+								By default, the ImapMailReceiver will search for Messages based on the default SearchTerm
+								which is "All mails that are RECENT (if supported), that are NOT ANSWERED, that are NOT DELETED, that are NOT SEEN and have not
+								been processed by this mail receiver (enabled by the use of the custom USER flag or simply NOT FLAGGED if not supported)".
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="task-executor" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Reference to a bean that implements
+								org.springframework.core.task.TaskExecutor which is used
+								to send Messages received by this adapter.
+								If not provided, the adapter uses a single-threaded executor.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.core.task.TaskExecutor" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="inboundMailAdapterType">
+		<xsd:attribute name="id" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	A unique identifier for this Channel Adapter.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Reference for the MessageChannel to which this adapter will send Messages.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="store-uri" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	The URI for the Mail Store. Typically of the form: [pop3|imap]://user:password@host:port/INBOX
+	If this is not provided, then the store will be retrieved via the no-arg Session.getStore()
+	instead of the Session.getStore(url) method.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="mail-filter-expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Allows you to provide a SpEL expression which defines a fine grained filtering criteria for the mail messages to be processed by this adapter.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="session" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Specify the javax.mail.Session reference.
+	NOTE: if this is provided, then 'java-mail-properties' should not be.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="javax.mail.Session"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="java-mail-properties" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Reference to a 'java.util.Properties' instance with settings for the JavaMail Session.
+	NOTE: if this is provided, then 'session' should not be.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="java.util.Properties"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="authenticator" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Specify the javax.mail.Authenticator.
+	NOTE: if this is provided, then 'session' should not be.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="javax.mail.Authenticator"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="max-fetch-size" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Specify the maximum number of Mail Messages to fetch per receive call.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="should-delete-messages" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Specify whether mail messages should be deleted after retrieval. Messages are deleted after
+	retrieval but before they are processed. If you wish to delete a message after completion
+	of message processing, use transaction synchronization instead.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="should-mark-messages-as-read" type="xsd:string" use="optional" default="true">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	Specify whether mail messages should be marked as read after being retrieved (Not supported in POP3).
+	Messages are marked after
+	retrieval but before they are processed. If you wish to mark a message after completion
+	of message processing, use transaction synchronization instead.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string" default="true">
+			<xsd:annotation>
+				<xsd:documentation>
+	Specify whether this endpoint should be started automatically. The default is TRUE.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="mail-to-string-transformer">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+	Defines a Transformer that converts a javax.mail.Message payload to a String.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:complexContent>
+				<xsd:extension base="transformerType">
+					<xsd:attribute name="charset" type="xsd:string"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="header-enricher">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+	Defines a Transformer for adding statically configured Mail Headers.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:complexContent>
+				<xsd:extension base="transformerType">
+					<xsd:choice minOccurs="1" maxOccurs="unbounded">
+						<xsd:element name="subject" type="headerType"/>
+						<xsd:element name="to" type="headerType"/>
+						<xsd:element name="cc" type="headerType"/>
+						<xsd:element name="bcc" type="headerType"/>
+						<xsd:element name="from" type="headerType"/>
+						<xsd:element name="reply-to" type="headerType"/>
+						<xsd:element name="content-type" type="headerType"/>
+						<xsd:element name="attachment-filename" type="headerType"/>
+						<xsd:element name="multipart-mode" type="headerType"/>
+					</xsd:choice>
+					<xsd:attribute name="default-overwrite">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specify the default boolean value for whether to overwrite existing header values. This will only take effect for
+	sub-elements that do not provide their own 'overwrite' attribute. If the 'default-overwrite' attribute is not
+	provided, then the specified header values will NOT overwrite any existing ones with the same header names.
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="xsd:boolean xsd:string"/>
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="headerType">
+		<xsd:attribute name="value" type="xsd:string" />
+		<xsd:attribute name="ref" type="xsd:string" />
+		<xsd:attribute name="expression" type="xsd:string" />
+		<xsd:attribute name="overwrite">
+			<xsd:annotation>
+				<xsd:documentation>
+	Boolean value to indicate whether this header value should overwrite an existing header value for the same name.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="transformerType">
+		<xsd:attribute name="id" type="xsd:string"/>
+		<xsd:attribute name="input-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="output-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/spring-integration-mongodb/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-mongodb/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,3 @@
 http\://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb-2.2.xsd=org/springframework/integration/mongodb/config/spring-integration-mongodb-2.2.xsd
-http\://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb.xsd=org/springframework/integration/mongodb/config/spring-integration-mongodb-2.2.xsd
+http\://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb-3.0.xsd=org/springframework/integration/mongodb/config/spring-integration-mongodb-3.0.xsd
+http\://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb.xsd=org/springframework/integration/mongodb/config/spring-integration-mongodb-3.0.xsd

--- a/spring-integration-mongodb/src/main/resources/org/springframework/integration/mongodb/config/spring-integration-mongodb-3.0.xsd
+++ b/spring-integration-mongodb/src/main/resources/org/springframework/integration/mongodb/config/spring-integration-mongodb-3.0.xsd
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/mongodb"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration"
+	targetNamespace="http://www.springframework.org/schema/integration/mongodb"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+			Defines the configuration elements for Spring Integration mongodb Adapters.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines mongodb inbound channel adapter that
+				creates
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="mongodbAdapterType">
+					<xsd:sequence>
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
+					</xsd:sequence>
+					<xsd:attribute name="query" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								String representation of MongoDb Query (e.g.,
+								query="{'name' : 'Bob'}").
+								Please refer to MongoDb documentation for more query samples
+								http://www.mongodb.org/display/DOCS/Querying
+								This attribute is
+								mutually exclusive with 'query-expression' attribute.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="query-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								SpEL expression which should resolve to a
+								String value identifying the
+								MongoDb Query. Also see 'query' attribute
+								This attribute is mutually exclusive with 'query' attribute.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="entity-class" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+									The fully qualified name of the entity class to be passed to
+									find(..) or findOne(..) method MongoTemplate.
+									If this attribute is not provided the default value is com.mongodb.DBObject
+								</xsd:documentation>
+								<tool:annotation kind="direct">
+									<tool:expected-type type="java.lang.Class" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="expect-single-result" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to manage find* method of MongoTemplate is used to query MongoDb. Default value for this
+								attribute is 'false'. This means that we'll use find(..) method thus resulting in a Message with
+								payload of type List of entities identified by 'entity-class' attribute. If you want/expect a single
+								value set this attribute to 'true' which will result in invocation of findOne(..) method resulting in
+								the payload of type identified by 'entity-class' attribute (default com.mongodb.DBObject)
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines mongodb outbound channel adapter that
+				writes the contents of the
+				Message into
+				org.springframework.data.mongodb.support.collections.mongodbStore
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="mongodbAdapterType" />
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="mongodbAdapterType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Common configuration for mongodb adapters.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="id" type="xsd:string" />
+		<xsd:attribute name="channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to a Message Channel that will be used
+					by this adapter to
+					'receiveFrom' or 'sendTo' Messages depending on the adapter type (e.g.,
+					inbound/outbound)
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="mongodb-factory" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<xsd:documentation>
+							Reference to an instance of
+							org.springframework.data.mongodb.MongoDbFactory
+						</xsd:documentation>
+						<tool:expected-type
+							type="org.springframework.data.mongodb.MongoDbFactory" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="mongo-template" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<xsd:documentation>
+							Reference to an instance of
+							org.springframework.data.mongodb.core.MongoTemplate
+						</xsd:documentation>
+						<tool:expected-type
+							type="org.springframework.data.mongodb.core.MongoTemplate" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="collection-name" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Identifies the name of the MongoDb collection to
+					use.
+					This attribute is mutually exclusive with
+					'collection-name-expression'
+					attribute.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="collection-name-expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					SpEL expression which should resolve to a String
+					value identifying the
+					name of the MongoDb collection to use.
+					This
+					attribute is mutually exclusive with 'collection-name' attribute.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="mongo-converter" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type
+							type="org.springframework.data.mongodb.core.convert.MongoConverter" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+					Reference to an instance of
+					org.springframework.data.mongodb.core.convert.MongoConverter
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string"
+			default="true" />
+	</xsd:complexType>
+</xsd:schema>

--- a/spring-integration-redis/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-redis/src/main/resources/META-INF/spring.schemas
@@ -1,3 +1,4 @@
 http\://www.springframework.org/schema/integration/redis/spring-integration-redis-2.1.xsd=org/springframework/integration/redis/config/spring-integration-redis-2.1.xsd
 http\://www.springframework.org/schema/integration/redis/spring-integration-redis-2.2.xsd=org/springframework/integration/redis/config/spring-integration-redis-2.2.xsd
-http\://www.springframework.org/schema/integration/redis/spring-integration-redis.xsd=org/springframework/integration/redis/config/spring-integration-redis-2.2.xsd
+http\://www.springframework.org/schema/integration/redis/spring-integration-redis-3.0.xsd=org/springframework/integration/redis/config/spring-integration-redis-3.0.xsd
+http\://www.springframework.org/schema/integration/redis/spring-integration-redis.xsd=org/springframework/integration/redis/config/spring-integration-redis-3.0.xsd

--- a/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-3.0.xsd
+++ b/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-3.0.xsd
@@ -1,0 +1,575 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/redis"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration"
+	targetNamespace="http://www.springframework.org/schema/integration/redis"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+			Defines the configuration elements for Spring Integration Redis Adapters and Channels.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="publish-subscribe-channel">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines a publish-subscribe Message Channel that is backed by a Redis topic.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="channelType">
+					<xsd:attribute name="topic-name" type="xsd:string" use="required">
+						<xsd:annotation>
+							<xsd:documentation>
+	Name of the Redis topic that backs this channel.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="channelType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+	Base type for Redis backed Message Channels (either 'channel' for a
+	list-backed channel or 'publish-subscribe-channel' for a topic-backed channel).
+			]]></xsd:documentation>
+			<xsd:appinfo>
+				<tool:annotation>
+					<tool:exports type="org.springframework.integration.channel.AbstractMessageChannel"/>
+				</tool:annotation>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="interceptors" type="integration:channelInterceptorsType" minOccurs="0" maxOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A list of ChannelInterceptor instances to be applied to this channel.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+	ID for this channel. Required.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="connection-factory" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+	Reference to a RedisConnectionFactory. If none is provided, the default
+	bean name for the reference will be "redisConnectionFactory".
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.data.redis.connection.RedisConnectionFactory"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="task-executor" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to a Spring TaskExecutor (or standard JDK 1.5+ Executor) for executing
+	JMS listener invokers. Default is a SimpleAsyncTaskExecutor in case of a
+	DefaultMessageListenerContainer, using internally managed threads. For a
+	SimpleMessageListenerContainer, listeners will always get invoked within the
+	JMS provider's receive thread by default.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="java.util.concurrent.Executor"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="message-converter" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to the MessageConverter strategy for converting between Redis Messages
+	and the Spring Integration Message payloads. Default is a SimpleMessageConverter.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.support.converter.MessageConverter"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="serializer" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to the RedisSerializer strategy
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attributeGroup ref="integration:subscribersAttributeGroup" />
+	</xsd:complexType>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an inbound Channel Adapter for subscribing to a Redis topic.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	The ID for this Channel Adapter.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="connection-factory" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Reference to a RedisConnectionFactory. If none is provided, the default
+	bean name for the reference will be "redisConnectionFactory".
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.data.redis.connection.RedisConnectionFactory"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="topics" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Redis topic names as a comma-delimited list of Strings.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Channel to which Messages will be sent.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="message-converter" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A reference to the MessageConverter strategy for converting between Redis Messages
+	and the Spring Integration Message payloads. Default is a SimpleMessageConverter.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.support.converter.MessageConverter"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="error-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Identifies channel that error messages will be sent to if a failure occurs in this
+						gateway's invocation. If no "error-channel" reference is provided, this gateway will
+						propagate Exceptions to the caller. To completely suppress Exceptions, provide a
+						reference to the "nullChannel" here.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="serializer" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<xsd:documentation>
+						Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer
+						</xsd:documentation>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an outbound Redis Message-sending Channel Adapter.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="redisAdapterType">
+					<xsd:sequence>
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+					</xsd:sequence>
+					<xsd:attribute name="topic" type="xsd:string"/>
+					<xsd:attribute name="message-converter" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	A reference to the MessageConverter strategy for converting between Redis Messages
+	and the Spring Integration Message payloads. Default is a SimpleMessageConverter.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.support.converter.MessageConverter"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Specifies the order for invocation when this adapter is connected as a
+	subscriber to a SubscribableChannel.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="serializer" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="store-inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines Redis inbound channel adapter that creates a Message which contains
+	a view into a redis store. THe view could be one of the subclasses of
+	org.springframework.data.redis.support.collections.RedisStore
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="redisCollectionInboundAdapterType">
+					<xsd:attribute name="collection-type">
+						<xsd:annotation>
+							<xsd:documentation>
+								Collection type supported by this adapter
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:string">
+								<xsd:enumeration value="LIST">
+									<xsd:annotation>
+										<xsd:documentation>
+											[DEFAULT] Redis List
+										</xsd:documentation>
+									</xsd:annotation>
+								</xsd:enumeration>
+								<xsd:enumeration value="SET">
+									<xsd:annotation>
+										<xsd:documentation>
+											Redis Set
+										</xsd:documentation>
+									</xsd:annotation>
+								</xsd:enumeration>
+								<xsd:enumeration value="ZSET">
+									<xsd:annotation>
+										<xsd:documentation>
+											Redis Sorted Set
+										</xsd:documentation>
+									</xsd:annotation>
+								</xsd:enumeration>
+								<xsd:enumeration value="MAP">
+									<xsd:annotation>
+										<xsd:documentation>
+											Redis Map
+										</xsd:documentation>
+									</xsd:annotation>
+								</xsd:enumeration>
+								<xsd:enumeration value="PROPERTIES">
+									<xsd:annotation>
+										<xsd:documentation>
+											Redis Properties
+										</xsd:documentation>
+									</xsd:annotation>
+								</xsd:enumeration>
+							</xsd:restriction>
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="store-outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines Redis outbound channel adapter that writes the contents of the Message into
+	org.springframework.data.redis.support.collections.RedisStore
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="redisAdapterType">
+					<xsd:attributeGroup ref="storeAdapterAttributeGroup"/>
+					<xsd:attribute name="redis-template" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+							RedisTemplate to be used with this adapter
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.data.redis.core.RedisTemplate"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="redisAdapterType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Common configuration for Redis adapters.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="id" type="xsd:string"/>
+		<xsd:attribute name="connection-factory" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.data.redis.connection.RedisConnectionFactory"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string" default="true"/>
+		<xsd:attribute name="channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				Channel to which Messages will be sent.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="redisCollectionInboundAdapterType">
+		<xsd:complexContent>
+				<xsd:extension base="redisAdapterType">
+					<xsd:sequence>
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+					</xsd:sequence>
+					<xsd:attribute name="redis-template" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+							RedisTemplate to be used with this adapter
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.data.redis.core.RedisTemplate"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="key-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+			SpEL expression that returns the name of the key for the collection being used. If you want to provide a
+			constant key, use the 'key' attribute.
+			This attribute is mutually exclusive with the 'key' attribute.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="key" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+			The name of the key for the collection being used. If you require a key to be dynamically
+			determined per each poll use 'key-expression' attribute.
+			This attribute is mutually exclusive with the 'key-expression' attribute.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="key-serializer" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer
+								to serialize the 'key' value for this collection. Please refer to the JavaDoc of the RedisTemplate
+								for more detail.
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="value-serializer" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer
+								to serialize the 'value' entered into the collection. Please refer to the JavaDoc of the RedisTemplate
+								for more detail.
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="hash-key-serializer" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer
+								to be used when serializing hash keys (only relevant for hash-typed collections).
+								Please refer to the JavaDoc of the RedisTemplate for more detail.
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="hash-value-serializer" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+								Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer
+								to be used when serializing hash values (only relevant for hash-typed collections).
+								Please refer to the JavaDoc of the RedisTemplate for more detail.
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="error-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<xsd:documentation>
+			Channel to which Error Messages will be sent.
+								</xsd:documentation>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:attributeGroup name="storeAdapterAttributeGroup">
+		<xsd:attribute name="key" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Provide the name of the key for the collection being used. If you require a key that
+					is determined dynamically for each message, use the 'key-expression' attribute.
+					The default key is dynamically determined from the 'redis_key' header.
+					This attribute is mutually exclusive with the 'key-expression' attribute.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="key-expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					SpEL expression that returns the name of the key for the collection being used. If you want to provide a
+					constant key, use the 'key' attribute. Default is the 'redis_key' message header.
+					This attribute is mutually exclusive with the 'key' attribute.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="map-key-expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					SpEL expression that returns the name of the key for entry being stored. Only applies
+					if the 'collection-type' is MAP or PROPERTIES and 'extract-payload-elements' is false.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="extract-payload-elements" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				If set to 'true' (Default) and the payload is an instance of a "multi-value" object (i.e., Collection or Map)
+				it will be stored using addAll/putAll semantics. Otherwise, if set to 'false' the payload will be stored
+				as single entry regardless of its type.
+				If the payload is not an instance of a "multi-value" object, the value of this attribute is ignored and
+				the payload will always be stored as a single entry.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="collection-type">
+			<xsd:annotation>
+				<xsd:documentation>
+					Collection type supported by this adapter
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="LIST">
+						<xsd:annotation>
+							<xsd:documentation>
+								[DEFAULT] Redis List
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:enumeration>
+					<xsd:enumeration value="SET">
+						<xsd:annotation>
+							<xsd:documentation>
+								Redis Set
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:enumeration>
+					<xsd:enumeration value="ZSET">
+						<xsd:annotation>
+							<xsd:documentation>
+								Redis Sorted Set
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:enumeration>
+					<xsd:enumeration value="MAP">
+						<xsd:annotation>
+							<xsd:documentation>
+								Redis Map
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:enumeration>
+					<xsd:enumeration value="PROPERTIES">
+						<xsd:annotation>
+							<xsd:documentation>
+								Redis Properties
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:enumeration>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+</xsd:schema>

--- a/spring-integration-rmi/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-rmi/src/main/resources/META-INF/spring.schemas
@@ -2,4 +2,5 @@ http\://www.springframework.org/schema/integration/rmi/spring-integration-rmi-1.
 http\://www.springframework.org/schema/integration/rmi/spring-integration-rmi-2.0.xsd=org/springframework/integration/rmi/config/spring-integration-rmi-2.0.xsd
 http\://www.springframework.org/schema/integration/rmi/spring-integration-rmi-2.1.xsd=org/springframework/integration/rmi/config/spring-integration-rmi-2.1.xsd
 http\://www.springframework.org/schema/integration/rmi/spring-integration-rmi-2.2.xsd=org/springframework/integration/rmi/config/spring-integration-rmi-2.2.xsd
-http\://www.springframework.org/schema/integration/rmi/spring-integration-rmi.xsd=org/springframework/integration/rmi/config/spring-integration-rmi-2.2.xsd
+http\://www.springframework.org/schema/integration/rmi/spring-integration-rmi-3.0.xsd=org/springframework/integration/rmi/config/spring-integration-rmi-3.0.xsd
+http\://www.springframework.org/schema/integration/rmi/spring-integration-rmi.xsd=org/springframework/integration/rmi/config/spring-integration-rmi-3.0.xsd

--- a/spring-integration-rmi/src/main/resources/org/springframework/integration/rmi/config/spring-integration-rmi-3.0.xsd
+++ b/spring-integration-rmi/src/main/resources/org/springframework/integration/rmi/config/spring-integration-rmi-3.0.xsd
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/rmi"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:beans="http://www.springframework.org/schema/beans"
+		xmlns:tool="http://www.springframework.org/schema/tool"
+		xmlns:integration="http://www.springframework.org/schema/integration"
+		targetNamespace="http://www.springframework.org/schema/integration/rmi"
+		elementFormDefault="qualified"
+		attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+			schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+	Defines the configuration elements for Spring Integration's RMI adapters.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="inbound-gateway">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+	Defines an RMI-based inbound MessagingGateway.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:complexContent>
+				<xsd:extension base="gatewayType">
+					<xsd:attribute name="request-channel" type="xsd:string" use="required">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="expect-reply" type="xsd:string" default="true"/>
+					<xsd:attribute name="registry-host" type="xsd:string"/>
+					<xsd:attribute name="registry-port" type="xsd:string"/>
+					<xsd:attribute name="remote-invocation-executor" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.remoting.support.RemoteInvocationExecutor"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-gateway">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+	Defines an RMI-based outbound Messaging Gateway.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:complexContent>
+				<xsd:extension base="gatewayType">
+					<xsd:choice minOccurs="0" maxOccurs="2">
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:choice>
+					<xsd:attribute name="request-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="host" type="xsd:string" use="required"/>
+					<xsd:attribute name="port" type="xsd:string"/>
+					<xsd:attribute name="remote-channel" type="xsd:string" use="required"/>
+					<xsd:attribute name="order">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the order for invocation when this endpoint is connected as a
+								subscriber to a SubscribableChannel.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="gatewayType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines common configuration for gateway adapters.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="id" type="xsd:string"/>
+		<xsd:attribute name="name" type="xsd:string"/>
+		<xsd:attribute name="reply-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="request-timeout" type="xsd:string"/>
+		<xsd:attribute name="reply-timeout" type="xsd:string"/>
+		<xsd:attribute name="auto-startup" type="xsd:string" default="true"/>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/spring-integration-scripting/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-scripting/src/main/resources/META-INF/spring.schemas
@@ -1,6 +1,8 @@
 http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-2.1.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-2.1.xsd
 http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-2.2.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-2.2.xsd
-http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-2.2.xsd
+http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-3.0.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-3.0.xsd
+http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-3.0.xsd
 http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core-2.1.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-core-2.1.xsd
 http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core-2.2.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-core-2.2.xsd
-http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-core-2.2.xsd
+http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core-3.0.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-core-3.0.xsd
+http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-core-3.0.xsd

--- a/spring-integration-scripting/src/main/resources/org/springframework/integration/scripting/config/spring-integration-scripting-3.0.xsd
+++ b/spring-integration-scripting/src/main/resources/org/springframework/integration/scripting/config/spring-integration-scripting-3.0.xsd
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/scripting"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://www.springframework.org/schema/integration/scripting"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:include
+		schemaLocation="http://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core-3.0.xsd" />
+
+	<xsd:element name="script">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an inner bean that will generate a
+				JSR 223 compliant script.
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="Jsr223Script">
+		<xsd:complexContent>
+			<xsd:extension base="ScriptType">
+				<xsd:attribute name="lang" use="required">
+					<xsd:annotation>
+						<xsd:documentation>
+							The script language or JSR 223 scripting engine name
+					</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="return" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							The script variable to return as a result of the evaluation (Optional).
+					</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
+</xsd:schema>

--- a/spring-integration-scripting/src/main/resources/org/springframework/integration/scripting/config/spring-integration-scripting-core-3.0.xsd
+++ b/spring-integration-scripting/src/main/resources/org/springframework/integration/scripting/config/spring-integration-scripting-core-3.0.xsd
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+	xmlns="http://www.springframework.org/schema/integration/scripting"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+
+
+	<xsd:complexType name="ScriptType" mixed="true" abstract="true">
+		<xsd:sequence>
+			<xsd:element name="variable" minOccurs="0" maxOccurs="unbounded">
+				<xsd:complexType>
+					<xsd:annotation>
+						<xsd:documentation>
+							Allows you to define custom script variable bindings. The use of this
+							sub-element is mutually
+							exclusive with the 'script-variable-generator' attribute.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:attribute name="name" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Name of the script variable.
+								</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="value" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Value of the script variable as a literal.
+								</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="ref" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Value of the script variable as a bean reference.
+								</xsd:documentation>
+							<xsd:appinfo>
+								<tool:expected-type type="java.lang.Object" />
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="location">
+			<xsd:annotation>
+				<xsd:documentation>
+					Resource location path for the Script. Either this or an inline script
+					as body text should be provided, but not both.
+					</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="script-variable-generator" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to the ScriptVariableGenerator bean. This attribute is mutually
+					exclusive with any 'variable' sub-elements.
+					</xsd:documentation>
+				<xsd:appinfo>
+					<tool:expected-type
+						type="org.springframework.integration.scripting.ScriptVariableGenerator" />
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+
+		<xsd:attribute name="refresh-check-delay">
+			<xsd:annotation>
+				<xsd:documentation>
+					Refresh delay for the script contents if specified as a resource
+					location (defaults to -1, never refresh).
+					</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/spring-integration-security/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-security/src/main/resources/META-INF/spring.schemas
@@ -2,4 +2,5 @@ http\://www.springframework.org/schema/integration/security/spring-integration-s
 http\://www.springframework.org/schema/integration/security/spring-integration-security-2.0.xsd=org/springframework/integration/security/config/spring-integration-security-2.0.xsd
 http\://www.springframework.org/schema/integration/security/spring-integration-security-2.1.xsd=org/springframework/integration/security/config/spring-integration-security-2.1.xsd
 http\://www.springframework.org/schema/integration/security/spring-integration-security-2.2.xsd=org/springframework/integration/security/config/spring-integration-security-2.2.xsd
-http\://www.springframework.org/schema/integration/security/spring-integration-security.xsd=org/springframework/integration/security/config/spring-integration-security-2.2.xsd
+http\://www.springframework.org/schema/integration/security/spring-integration-security-3.0.xsd=org/springframework/integration/security/config/spring-integration-security-3.0.xsd
+http\://www.springframework.org/schema/integration/security/spring-integration-security.xsd=org/springframework/integration/security/config/spring-integration-security-3.0.xsd

--- a/spring-integration-security/src/main/resources/org/springframework/integration/security/config/spring-integration-security-3.0.xsd
+++ b/spring-integration-security/src/main/resources/org/springframework/integration/security/config/spring-integration-security-3.0.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/security"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tool="http://www.springframework.org/schema/tool"
+	targetNamespace="http://www.springframework.org/schema/integration/security"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+
+	<xsd:element name="secured-channels">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+	Defines security requirements for one or more Message Channels.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:sequence>
+				<xsd:element name="access-policy" type="accessPolicyType" minOccurs="1" maxOccurs="unbounded"/>
+			</xsd:sequence>
+			<xsd:attribute name="authentication-manager" type="xsd:string" default="authenticationManager">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.security.authentication.AuthenticationManager"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="access-decision-manager" type="xsd:string" default="accessDecisionManager">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.security.access.AccessDecisionManager"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="accessPolicyType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines the security access policy for send and/or receive invocations based on a Message Channel name pattern.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="pattern" type="xsd:string" use="required"/>
+		<xsd:attribute name="send-access" type="xsd:string"/>
+		<xsd:attribute name="receive-access" type="xsd:string"/>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/spring-integration-sftp/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-sftp/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
 http\://www.springframework.org/schema/integration/sftp/spring-integration-sftp-2.0.xsd=org/springframework/integration/sftp/config/spring-integration-sftp-2.0.xsd
 http\://www.springframework.org/schema/integration/sftp/spring-integration-sftp-2.1.xsd=org/springframework/integration/sftp/config/spring-integration-sftp-2.1.xsd
 http\://www.springframework.org/schema/integration/sftp/spring-integration-sftp-2.2.xsd=org/springframework/integration/sftp/config/spring-integration-sftp-2.2.xsd
-http\://www.springframework.org/schema/integration/sftp/spring-integration-sftp.xsd=org/springframework/integration/sftp/config/spring-integration-sftp-2.2.xsd
+http\://www.springframework.org/schema/integration/sftp/spring-integration-sftp-3.0.xsd=org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
+http\://www.springframework.org/schema/integration/sftp/spring-integration-sftp.xsd=org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
@@ -1,0 +1,517 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/sftp"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:tool="http://www.springframework.org/schema/tool"
+	xmlns:integration="http://www.springframework.org/schema/integration"
+	targetNamespace="http://www.springframework.org/schema/integration/sftp"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+                Builds an outbound-channel-adapter that writes files to a remote SFTP endpoint.
+            ]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="base-sftp-adapter-type">
+					<xsd:all>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:all>
+					<xsd:attribute name="remote-directory-expression"
+						type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide a SpEL expression which
+								will compute the directory
+								path
+								where files will be transferred to
+								(e.g., "headers.['remote_dir'] +
+								'/myTransfers'");
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="temporary-remote-directory-expression"
+						type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide a SpEL expression which
+								will compute the temporary directory
+								path where files will be transferred to before they are moved to the remote-directory
+								(e.g., "headers.['remote_dir'] +
+								'/temp/myTransfers'");
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="auto-create-directory" type="xsd:string"
+						default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether to automatically create the
+								remote target directory if
+								it doesn't exist.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="remote-filename-generator" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to specify a reference to
+								[org.springframework.integration.file.FileNameGenerator] bean.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.file.FileNameGenerator" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="remote-filename-generator-expression"
+						type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide SpEL expression which
+								will compute file name of
+								the remote file (e.g., assuming payload
+								is java.io.File
+								"payload.getName() + '.transfered'");
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="use-temporary-file-name" type="xsd:string" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to suppress using a temporary file name while writing the file.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the order for invocation when this
+								endpoint is connected as a
+								subscriber to a channel. This is
+								particularly relevant when that channel
+								is using a "failover"
+								dispatching strategy, or when a failure in
+								the delivery to one
+								subscriber should signal that
+								the message should not be sent to
+								subscribers with a higher 'order'
+								attribute. It has no effect
+								when this
+								endpoint itself is a Polling Consumer for a channel
+								with a queue.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+                Builds an inbound-channel-adapter that synchronizes with a remote SFTP endpoint.
+            ]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="base-sftp-adapter-type">
+					<xsd:sequence>
+						<xsd:element ref="integration:poller" minOccurs="0"
+							maxOccurs="1" />
+					</xsd:sequence>
+					<xsd:attribute name="comparator" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+	Specify a Comparator to be used when ordering Files. If none is provided, the
+	order will be determined by the java.io.File implementation of Comparable.
+					]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="filter" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.file.filters.FileListFilter" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Allows you to specify a reference to a
+								[org.springframework.integration.file.filters.FileListFilter]
+								bean.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="filename-pattern" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide a file name pattern to
+								determine the file names
+								that need to be scanned.
+								This is based on
+								simple pattern matching (e.g., "*.txt, fo*.txt"
+								etc.)
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="local-filename-generator-expression"
+						type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide a SpEL expression to
+								generate the file name of
+								the local (transferred) file. The root
+								object of the SpEL
+								evaluation is the name of the original
+								file.
+								For example, a valid expression would be "#this.toUpperCase() +
+								'.a'" where #this represents the
+								original name of the remote
+								file.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="filename-regex" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide a Regular Expression to
+								determine the file names
+								that need to be scanned.
+								(e.g.,
+								"f[o]+\.txt" etc.)
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="local-directory" type="xsd:string"
+						use="required">
+						<xsd:annotation>
+							<xsd:documentation>
+								Identifies the directory path (e.g.,
+								"/local/mytransfers") where files
+								will be transferred TO.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="auto-create-local-directory"
+						type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Tells this adapter if the local directory must
+								be auto-created if it
+								doesn't exist. Default is TRUE.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="delete-remote-files" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether to delete the remote source
+								file after copying.
+								By default, the remote files will NOT be
+								deleted.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-gateway">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Builds an outbound gateway used to issue sftp commands.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="base-adapter-type">
+					<xsd:all>
+						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+					</xsd:all>
+					<xsd:attribute name="command" use="required" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								sftp command - ls, get or rm
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="command-options" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								sftp command options; for ls, -1 means just
+								return the file names
+								(otherwise file
+								metadata is returned, -dirs
+								means include directories (not included by
+								default),
+								-links means
+								include links (not included by default); for get, -P means
+								preserve
+								timestamp from remote file.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="expression" use="required" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								SpEL expression representing the path in the
+								command (e.g. ls path to
+								list the files in directory path).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="request-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Identifies the request channel attached to this
+								gateway.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-channel" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.MessageChannel" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Identifies the reply channel attached to this
+								gateway.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-timeout" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Allows you to specify how long this gateway will wait for
+								the reply message to be sent successfully to the reply channel
+								before throwing an exception. This attribute only applies when the
+								channel might block, for example when using a bounded queue channel that
+								is currently full.
+
+								Also, keep in mind that when sending to a DirectChannel, the
+								invocation will occur in the sender's thread. Therefore,
+								the failing of the send operation may be caused by other
+								components further downstream.
+
+								The "reply-timeout" attribute maps to the "sendTimeout" property of the
+								underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+								The attribute will default, if not specified, to '-1', meaning that
+								by default, the Gateway will wait indefinitely. The value is
+								specified in milliseconds.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="filter" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+										type="org.springframework.integration.file.filters.FileListFilter" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Allows you to specify a reference to
+								[org.springframework.integration.file.filters.FileListFilter]
+								bean.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="filename-pattern" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide file name pattern to
+								determine the file names retrieved by the ls command
+								and is based
+								on simple pattern matching algorithm (e.g., "*.txt, fo*.txt" etc.)
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="filename-regex" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide Regular Expression to
+								determine the file names retrieved by the ls command.
+								(e.g.,
+								"f[o]+\.txt" etc.)
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="local-directory" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Identifies directory path (e.g.,
+								"/local/mytransfers") where file will be
+								transferred TO.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="auto-create-local-directory"
+						type="xsd:boolean">
+						<xsd:annotation>
+							<xsd:documentation>
+								Tells this adapter if local directory must be
+								auto-created if it
+								doesn''t exist. Default is TRUE.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="order" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies the order for invocation when this
+								endpoint is connected as a
+								subscriber to a channel. This is
+								particularly relevant when that channel
+								is using a "failover"
+								dispatching strategy, or when a failure in the
+								delivery to one
+								subscriber should signal that
+								the message should not be sent to
+								subscribers with a higher 'order'
+								attribute. It has no effect when
+								this
+								endpoint itself is a Polling Consumer for a channel with a
+								queue.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="base-sftp-adapter-type">
+		<xsd:complexContent>
+			<xsd:extension base="base-adapter-type">
+				<xsd:attribute name="remote-directory" type="xsd:string"
+					use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							Identifies the directory path (e.g.,
+							"/temp/mytransfers")
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="temporary-remote-directory" type="xsd:string"
+					use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							Identifies the remote temporary directory path (e.g., "/remote/temp/mytransfers")
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="channel" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type
+									type="org.springframework.integration.MessageChannel" />
+							</tool:annotation>
+						</xsd:appinfo>
+						<xsd:documentation>
+							Identifies channel attached to this adapter.
+							Depending on the type of the
+							adapter
+							this channel could be the
+							receiving channel (e.g.,
+							outbound-channel-adapter) or channel
+							where
+							messages will be sent to by this adapter (e.g.,
+							inbound-channel-adapter).
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="charset" type="xsd:string"
+					default="UTF-8">
+					<xsd:annotation>
+						<xsd:documentation>
+							Allows you to specify Charset (e.g., US-ASCII,
+							ISO-8859-1, UTF-8). [UTF-8] is default
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="base-adapter-type">
+		<xsd:attribute name="id" type="xsd:string" />
+		<xsd:attribute name="session-factory" type="xsd:string"
+			use="required">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type
+							type="org.springframework.integration.sftp.session.DefaultSftpSessionFactory" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation><![CDATA[
+                Reference to a [org.springframework.integration.sftp.session.DefaultSftpSessionFactory] bean.
+            ]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="temporary-file-suffix" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Extension used when downloading files. We
+					change
+					it right after we know it's
+					downloaded.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="remote-file-separator" type="xsd:string"
+			default="/">
+			<xsd:annotation>
+				<xsd:documentation>
+					Allows you to provide remote file/directory
+					separator character. DEFAULT:
+					'/'
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="cache-sessions" type="xsd:string"
+			default="true">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+		[DEPRECATED] Consider wrapping your SessionFactory in an instance of org.springframework.integration.file.remote.session.CachingSessionFactory.
+		]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string"
+			default="true">
+			<xsd:annotation>
+				<xsd:documentation>
+					Lifecycle attribute signaling if this component
+					should be started during
+					Application Context startup.
+					Default is
+					'true'
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/spring-integration-stream/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-stream/src/main/resources/META-INF/spring.schemas
@@ -2,4 +2,5 @@ http\://www.springframework.org/schema/integration/stream/spring-integration-str
 http\://www.springframework.org/schema/integration/stream/spring-integration-stream-2.0.xsd=org/springframework/integration/stream/config/spring-integration-stream-2.0.xsd
 http\://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd=org/springframework/integration/stream/config/spring-integration-stream-2.1.xsd
 http\://www.springframework.org/schema/integration/stream/spring-integration-stream-2.2.xsd=org/springframework/integration/stream/config/spring-integration-stream-2.2.xsd
-http\://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd=org/springframework/integration/stream/config/spring-integration-stream-2.2.xsd
+http\://www.springframework.org/schema/integration/stream/spring-integration-stream-3.0.xsd=org/springframework/integration/stream/config/spring-integration-stream-3.0.xsd
+http\://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd=org/springframework/integration/stream/config/spring-integration-stream-3.0.xsd

--- a/spring-integration-stream/src/main/resources/org/springframework/integration/stream/config/spring-integration-stream-3.0.xsd
+++ b/spring-integration-stream/src/main/resources/org/springframework/integration/stream/config/spring-integration-stream-3.0.xsd
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/stream"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:beans="http://www.springframework.org/schema/beans"
+		xmlns:tool="http://www.springframework.org/schema/tool"
+		xmlns:integration="http://www.springframework.org/schema/integration"
+		targetNamespace="http://www.springframework.org/schema/integration/stream"
+		elementFormDefault="qualified"
+		attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+			schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+	Defines the configuration elements for Spring Integration Stream-based Channel Adapters.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="stdin-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Configures a source that reads from stdin (System.in).
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string"/>
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="charset" type="xsd:string"/>
+			<xsd:attribute name="auto-startup" type="xsd:string" default="true"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="stdout-channel-adapter" type="consoleOutboundChannelAdapterType"/>
+
+	<xsd:element name="stderr-channel-adapter" type="consoleOutboundChannelAdapterType"/>
+
+	<xsd:complexType name="consoleOutboundChannelAdapterType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Configures an outbound Channel Adapter that writes to stdout (System.out)
+	or to stderr (System.err) depending on the element name.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="id" type="xsd:string"/>
+		<xsd:attribute name="channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="charset" type="xsd:string"/>
+		<xsd:attribute name="append-newline" type="xsd:string" default="false"/>
+		<xsd:attribute name="auto-startup" type="xsd:string" default="true"/>
+		<xsd:attribute name="order">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specifies the order for invocation when this endpoint is connected as a
+					subscriber to a SubscribableChannel.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/spring-integration-twitter/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-twitter/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
 http\://www.springframework.org/schema/integration/twitter/spring-integration-twitter-2.0.xsd=org/springframework/integration/twitter/config/spring-integration-twitter-2.0.xsd
 http\://www.springframework.org/schema/integration/twitter/spring-integration-twitter-2.1.xsd=org/springframework/integration/twitter/config/spring-integration-twitter-2.1.xsd
 http\://www.springframework.org/schema/integration/twitter/spring-integration-twitter-2.2.xsd=org/springframework/integration/twitter/config/spring-integration-twitter-2.2.xsd
-http\://www.springframework.org/schema/integration/twitter/spring-integration-twitter.xsd=org/springframework/integration/twitter/config/spring-integration-twitter-2.2.xsd
+http\://www.springframework.org/schema/integration/twitter/spring-integration-twitter-3.0.xsd=org/springframework/integration/twitter/config/spring-integration-twitter-3.0.xsd
+http\://www.springframework.org/schema/integration/twitter/spring-integration-twitter.xsd=org/springframework/integration/twitter/config/spring-integration-twitter-3.0.xsd

--- a/spring-integration-twitter/src/main/resources/org/springframework/integration/twitter/config/spring-integration-twitter-3.0.xsd
+++ b/spring-integration-twitter/src/main/resources/org/springframework/integration/twitter/config/spring-integration-twitter-3.0.xsd
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/twitter"
+			xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:beans="http://www.springframework.org/schema/beans"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns:integration="http://www.springframework.org/schema/integration"
+			targetNamespace="http://www.springframework.org/schema/integration/twitter"
+			elementFormDefault="qualified"
+			attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+				schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+
+	<!--
+		INBOUND
+	-->
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an inbound channel adapter that consumes your friends' timeline updates
+				from Twitter and sends Messages whose payloads are Tweet objects.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType >
+			<xsd:complexContent>
+				<xsd:extension base="inbound-twitter-type"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="mentions-inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an inbound channel adapter that consumes mentions of your handle
+				from Twitter and sends Messages whose payloads are Tweet objects.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="inbound-twitter-type"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+
+	<xsd:element name="search-inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an inbound channel adapter that consumes search results for a given query
+				from Twitter and sends Messages whose payloads are Tweet objects.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="inbound-twitter-type">
+					<xsd:attribute name="query" type="xsd:string" use="required">
+						<xsd:annotation>
+							<xsd:documentation>
+							Twitter search query (e.g, #springintegration).
+							For more info on Twitter queries please refer to this site: http://search.twitter.com/operators)
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="dm-inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an inbound channel adapter that consumes direct messages from Twitter
+				and sends Messages whose payloads are DirectMessage objects.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="inbound-twitter-type"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<!--
+		OUTBOUND
+	-->
+
+	<xsd:element name="dm-outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an outbound channel adapter that sends Direct Messages to a Twitter user as
+				specified in the header whose name is defined by the TwitterHeaders.DM_TARGET_USER_ID constant.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="outbound-twitter-type"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an outbound channel adapter that posts a status update to the authorized user's timeline.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="outbound-twitter-type"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<!--
+		BASE TYPES
+	-->
+
+	<xsd:complexType name="inbound-twitter-type">
+		<xsd:sequence>
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:string"/>
+		<xsd:attribute name="twitter-template"  type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.social.twitter.api.Twitter"/>
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+					Reference to a TwitterTemplate bean provided by the Spring Social project.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="auto-startup" type="xsd:string" default="true">
+			<xsd:annotation>
+					<xsd:documentation>
+					Lifecycle attribute signaling whether this component should be started during Application Context startup.
+					Default is 'true'.
+					</xsd:documentation>
+				</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+					Message Channel to which messages will be sent by this adapter.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="outbound-twitter-type">
+		<xsd:all>
+			<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+		</xsd:all>
+		<xsd:attribute name="id" type="xsd:string"/>
+			<xsd:attribute name="twitter-template" use="required" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.social.twitter.api.Twitter"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						Reference to a TwitterTemplate bean provided by the Spring Social project.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						Message Channel where this adapter receives messages to be handled by performing Twitter operations.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="order">
+				<xsd:annotation>
+					<xsd:documentation>
+						Specifies the order for invocation when this endpoint is connected as a
+						subscriber to a SubscribableChannel.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+	</xsd:complexType>
+</xsd:schema>

--- a/spring-integration-ws/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-ws/src/main/resources/META-INF/spring.schemas
@@ -2,4 +2,5 @@ http\://www.springframework.org/schema/integration/ws/spring-integration-ws-1.0.
 http\://www.springframework.org/schema/integration/ws/spring-integration-ws-2.0.xsd=org/springframework/integration/ws/config/spring-integration-ws-2.0.xsd
 http\://www.springframework.org/schema/integration/ws/spring-integration-ws-2.1.xsd=org/springframework/integration/ws/config/spring-integration-ws-2.1.xsd
 http\://www.springframework.org/schema/integration/ws/spring-integration-ws-2.2.xsd=org/springframework/integration/ws/config/spring-integration-ws-2.2.xsd
-http\://www.springframework.org/schema/integration/ws/spring-integration-ws.xsd=org/springframework/integration/ws/config/spring-integration-ws-2.2.xsd
+http\://www.springframework.org/schema/integration/ws/spring-integration-ws-3.0.xsd=org/springframework/integration/ws/config/spring-integration-ws-3.0.xsd
+http\://www.springframework.org/schema/integration/ws/spring-integration-ws.xsd=org/springframework/integration/ws/config/spring-integration-ws-3.0.xsd

--- a/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws-3.0.xsd
+++ b/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws-3.0.xsd
@@ -1,0 +1,459 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/ws"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:beans="http://www.springframework.org/schema/beans"
+		xmlns:tool="http://www.springframework.org/schema/tool"
+		xmlns:integration="http://www.springframework.org/schema/integration"
+		targetNamespace="http://www.springframework.org/schema/integration/ws"
+		elementFormDefault="qualified"
+		attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+			schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+
+	<xsd:annotation>
+		<xsd:documentation><![CDATA[
+	Defines the configuration elements for Spring Integration's Web Service adapters.
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="outbound-gateway">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+	Defines a Web Service based outbound Messaging Gateway.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:sequence>
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+				<xsd:element name="uri-variable" type="uriVariableType" minOccurs="0" maxOccurs="unbounded" />
+				<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	A unique identifier for this Gateway.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="request-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	The channel where Messages should be sent to invoke the Web Service.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	The channel where Messages created from the Web Service responses will be sent.
+	This is optional. However, if non-empty responses are expected and this is not set,
+	then the request Messages must contain a REPLY_CHANNEL header.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Allows you to specify how long this gateway will wait for
+						the reply message to be sent successfully to the reply channel
+						before throwing an exception. This attribute only applies when the
+						channel might block, for example when using a bounded queue channel that
+						is currently full.
+
+						Also, keep in mind that when sending to a DirectChannel, the
+						invocation will occur in the sender's thread. Therefore,
+						the failing of the send operation may be caused by other
+						components further downstream.
+
+						The "reply-timeout" attribute maps to the "sendTimeout" property of the
+						underlying 'MessagingTemplate' instance (org.springframework.integration.core.MessagingTemplate).
+
+						The attribute will default, if not specified, to '-1', meaning that
+						by default, the Gateway will wait indefinitely. The value is
+						specified in milliseconds.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="uri" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	The Destination URI for this Web Service Gateway. If the URI should be determined at runtime
+	(e.g. registry lookup), then configure a 'destination-provider' reference instead. Aternatively,
+	this URI may include {placeholders} whose values are determined by evaluating SpEL expressions
+	provided via 'uri-variable' sub-elements. The root object for those evaluations is the actual
+	request Message at runtime, i.e. you can access its payload or headers in the expression.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+            <xsd:attribute name="destination-provider" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Reference to a DestinationProvider implementation. Either provide this or a 'uri', never both.
+	See org.springframework.ws.client.support.destination.DestinationProvider for more detail.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.ws.client.support.destination.DestinationProvider"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="marshaller" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Reference to a Spring OXM Mashaller. If the Marshaller instance also implements
+	the Unmarshaller interface, then the 'unmarshaller' attribute is not required.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.oxm.Marshaller"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="unmarshaller" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Reference to a Spring OXM Unmarshaller.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.oxm.Unmarshaller"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="ignore-empty-responses" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Indicates whether empty String response payloads should be ignored. The default is TRUE.
+	Set this to FALSE if you want to send empty String responses in reply Messages.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="source-extractor" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Reference to a Spring Web Services SourceExtractor.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.ws.client.core.SourceExtractor"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="request-callback" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Reference to a Spring Web Services WebServiceMessageCallback. This enables changing
+	the Web Service request message after the payload has been written to it but prior
+	to invocation of the actual Web Service.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.ws.client.core.WebServiceMessageCallback"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="message-factory" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.ws.WebServiceMessageFactory"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="fault-message-resolver" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.ws.client.core.FaultMessageResolver"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="message-sender" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to the bean definition of a WebServiceMessageSender.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.ws.transport.WebServiceMessageSender"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="message-senders" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to the bean definition for a list or array of WebServiceMessageSenders.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="interceptor" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to the bean definition of a ClientInterceptor.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.ws.client.support.interceptor.ClientInterceptor"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="interceptors" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to the bean definition for a list or array of ClientInterceptors.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="order" type="xsd:string"/>
+			<xsd:attribute name="auto-startup" type="xsd:string" default="true"/>
+			<xsd:attribute name="header-mapper">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to a HeaderMapper&lt;SoapHeader&gt; implementation
+						that this gateway will use to map between Spring Integration
+						MessageHeaders and the SoapHeader.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-request-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Comma-separated list of names of SOAP Headers to be mapped from the SOAP request into the MessageHeaders.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-reply-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Comma-separated list of names of MessageHeaders to be mapped into the SOAP Headers of the SOAP reply.
+This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+						]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="uriVariableType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Expression to be evaluated against the Message to replace a URI {placeholder} with the evaluation result.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="name" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Name of the placeholder to be replaced.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expression" use="required">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					Expression to be evaluated to determine the replacement value.
+					The Message is the root object of the expression, therefore
+					the 'payload' and 'headers' are available directly. Any bean
+					may be resolved if the bean name is preceded with '@'.
+				]]></xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:element name="inbound-gateway">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+	Defines a Web Service based inbound Messaging Gateway.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:attribute name="id" type="xsd:string"/>
+			<xsd:attribute name="request-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="reply-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+	Maximum time in milliseconds to wait for a reply from the downstream message flow initiated by this gateway.
+	This attribute is only relevant if at least some part of the downstream flow is asynchronous.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="error-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						If a (synchronous) downstream exception is thrown and an error-channel is specified,
+						the MessagingException will be sent to this channel.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="marshaller" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.oxm.Marshaller"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="unmarshaller" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.oxm.Unmarshaller"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="extract-payload" type="xsd:string"/>
+			<xsd:attribute name="header-mapper">
+				<xsd:annotation>
+					<xsd:documentation>
+						Reference to a HeaderMapper&lt;SoapHeader&gt; implementation
+						that this gateway will use to map between Spring Integration
+						MessageHeaders and the SoapHeader.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-request-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Comma-separated list of names of SOAP Headers to be mapped from the SOAP request into the MessageHeaders.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-reply-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+Comma-separated list of names of MessageHeaders to be mapped into the SOAP Headers of the SOAP reply.
+This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+						]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="header-enricher">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+	Defines a Transformer for adding a SOAP Action value.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:complexContent>
+				<xsd:extension base="transformerType">
+					<xsd:choice minOccurs="1" maxOccurs="1">
+						<xsd:element name="soap-action" type="headerType"/>
+					</xsd:choice>
+					<xsd:attribute name="default-overwrite">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specify the default boolean value for whether to overwrite existing header values. This will only take effect for
+	sub-elements that do not provide their own 'overwrite' attribute. If the 'default-overwrite' attribute is not
+	provided, then the specified header values will NOT overwrite any existing ones with the same header names.
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="xsd:boolean xsd:string"/>
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="headerType">
+		<xsd:attribute name="value" type="xsd:string" />
+		<xsd:attribute name="ref" type="xsd:string" />
+		<xsd:attribute name="expression" type="xsd:string" />
+		<xsd:attribute name="overwrite">
+			<xsd:annotation>
+				<xsd:documentation>
+	Boolean value to indicate whether this header value should overwrite an existing header value for the same name.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="transformerType">
+		<xsd:attribute name="id" type="xsd:string"/>
+		<xsd:attribute name="input-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="output-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/spring-integration-xml/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-xml/src/main/resources/META-INF/spring.schemas
@@ -2,4 +2,5 @@ http\://www.springframework.org/schema/integration/xml/spring-integration-xml-1.
 http\://www.springframework.org/schema/integration/xml/spring-integration-xml-2.0.xsd=org/springframework/integration/xml/config/spring-integration-xml-2.0.xsd
 http\://www.springframework.org/schema/integration/xml/spring-integration-xml-2.1.xsd=org/springframework/integration/xml/config/spring-integration-xml-2.1.xsd
 http\://www.springframework.org/schema/integration/xml/spring-integration-xml-2.2.xsd=org/springframework/integration/xml/config/spring-integration-xml-2.2.xsd
-http\://www.springframework.org/schema/integration/xml/spring-integration-xml.xsd=org/springframework/integration/xml/config/spring-integration-xml-2.2.xsd
+http\://www.springframework.org/schema/integration/xml/spring-integration-xml-3.0.xsd=org/springframework/integration/xml/config/spring-integration-xml-3.0.xsd
+http\://www.springframework.org/schema/integration/xml/spring-integration-xml.xsd=org/springframework/integration/xml/config/spring-integration-xml-3.0.xsd

--- a/spring-integration-xml/src/main/resources/org/springframework/integration/xml/config/spring-integration-xml-3.0.xsd
+++ b/spring-integration-xml/src/main/resources/org/springframework/integration/xml/config/spring-integration-xml-3.0.xsd
@@ -1,0 +1,874 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/xml"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		xmlns:beans="http://www.springframework.org/schema/beans"
+		xmlns:tool="http://www.springframework.org/schema/tool"
+		xmlns:integration="http://www.springframework.org/schema/integration"
+		targetNamespace="http://www.springframework.org/schema/integration/xml"
+		elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans" />
+	<xsd:import namespace="http://www.springframework.org/schema/tool" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+			schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+
+	<xsd:annotation>
+		<xsd:documentation>
+	Defines the configuration elements for Spring Integration's XML support.
+		</xsd:documentation>
+	</xsd:annotation>
+
+	<xsd:element name="marshalling-transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an XML marshalling transformer.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType >
+			<xsd:complexContent>
+				<xsd:extension base="inputOutputEndpoint">
+					<xsd:attribute name="marshaller" type="xsd:string" use="required">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.oxm.Marshaller"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="result-type" use="optional">
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:string">
+								<xsd:enumeration value="DOMResult"/>
+								<xsd:enumeration value="StringResult"/>
+							</xsd:restriction>
+						</xsd:simpleType>
+					</xsd:attribute>
+					<xsd:attribute name="result-factory" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.xml.result.ResultFactory"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="result-transformer" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.xml.transformer.ResultTransformer"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="extract-payload" type="xsd:string" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specify whether to extract the payload before passing to the Marshaller. By default, this
+	value is "true". To have the full Message passed instead, set this to "false".
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="unmarshalling-transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an XML unmarshalling transformer.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="inputOutputEndpoint">
+					<xsd:attribute name="unmarshaller" type="xsd:string" use="required">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.oxm.Unmarshaller"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="xslt-transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an XSLT transformer.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="inputOutputEndpoint">
+					<xsd:sequence>
+						<xsd:element name="xslt-param" type="paramType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Allows to configure individual Xslt parameters.
+								There the 'expression' and 'value' attribute are
+								available. The expression attribute should be
+								any valid SpEL expression with the message being
+								the root object of the expression evaluation
+								context.
+
+								The value attribute, just like any value in Spring
+								beans, allows you to specify simple static values.
+
+								You can also use property placeholders (e.g.,
+								${some.value}).
+							]]></xsd:documentation>
+						</xsd:annotation>
+						</xsd:element>
+					</xsd:sequence>
+					<xsd:attribute name="xslt-param-headers" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								If message header names match 1:1 to parameter
+								names, you can use this attribute to make
+								the parameters available.
+
+								The use of wildcards for simple pattern
+								matching is also possible. It supports the
+								following simple pattern styles: 'xxx*', '*xxx',
+								'*xxx*' and 'xxx*yyy'.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="xsl-resource" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Allows you to specify a org.springframework.core.io.Resource,
+								which will be used to create the javax.xml.transform.Templates
+								instance.
+
+								Either this attribute or the 'xsl-templates'
+								attribute MUST be specified.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="xsl-templates" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Reference to a Templates instance.
+
+								Either this attribute or the 'xsl-resource'
+								attribute MUST be specified.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="javax.xml.transform.Templates"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="source-factory" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Reference to a 'SourceFactory' instance. Allows
+								for the custom conversion to a javax.xml.transform.Source
+								If not set, this property will internally default
+								to 'DomSourceFactory'.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.xml.source.SourceFactory"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="result-factory" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Reference to a custom implementation of 'ResultFactory'.
+								If this attribute is provided, you must not specify
+								the 'result-type' attribute.
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.xml.result.ResultFactory"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="result-type" use="optional">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								This attribute can be used to control the type
+								of result created.
+
+								If this attribute is provided, you must not specify
+								the 'result-factory' attribute.
+
+								If neither this property nor the 'result-factory'
+								attribute are provided, 'DomResult' will be used.
+							]]></xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:string">
+								<xsd:enumeration value="DOMResult"/>
+								<xsd:enumeration value="StringResult"/>
+							</xsd:restriction>
+						</xsd:simpleType>
+					</xsd:attribute>
+					<xsd:attribute name="result-transformer" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								If the XSLT transformation returns a 'Result' object,
+								than you have the option to specify a reference
+								to a 'ResultTransformer' instance. This allows
+								you to transform the 'Result' into another format.
+
+								By default 2 implementations are available:
+
+								- 'ResultToDocumentTransformer' and
+								- 'ResultToStringTransformer'
+							]]></xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.xml.transformer.ResultTransformer"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="xpath-transformer">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an XPath transformer.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="inputOutputEndpoint">
+					<xsd:attribute name="xpath-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	The XPath expression string to be evaluated against the input Message's payload.
+	Either this or 'xpath-expression-ref' must be provided, but not both.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="xpath-expression-ref" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+	Reference to the XPathExpression instance to be evaluated against the input Message's payload.
+	Either this or 'xpath-expression' must be provided, but not both.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.xml.xpath.XPathExpression"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="evaluation-type" default="STRING_RESULT">
+						<xsd:annotation>
+							<xsd:documentation>
+	The result type expected from the XPath evaluation. This will be the payload type of the output Message.
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:string">
+								<xsd:enumeration value="BOOLEAN_RESULT"/>
+								<xsd:enumeration value="STRING_RESULT"/>
+								<xsd:enumeration value="NUMBER_RESULT"/>
+								<xsd:enumeration value="NODE_RESULT"/>
+								<xsd:enumeration value="NODE_LIST_RESULT"/>
+							</xsd:restriction>
+						</xsd:simpleType>
+					</xsd:attribute>
+					<xsd:attribute name="node-mapper">
+						<xsd:annotation>
+							<xsd:documentation>
+	Reference to a NodeMapper. If this is provided, the 'evaluation-type' will be ignored. Instead, the
+	org.springframework.xml.xpath.XPathExpression's evaluateAsObject(Node node, NodeMapper nodeMapper)
+	method will be invoked.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.xml.xpath.NodeMapper"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="converter">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specify the XmlPayloadConverter to use when converting a Message payload prior to XPath evaluation.
+	The DefaultXmlPayloadConverter is used if this reference is not provided, and it
+	should be sufficient in most cases since it can convert from Node, Document, Source,
+	File, and String typed payloads. If you need to extend beyond the capabilities of
+	that default implementation, then an upstream Transformer is probably a better option
+	than providing a reference to a custom implementation of this strategy here.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.xml.XmlPayloadConverter"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="xpath-header-enricher">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines a Header Enricher Message Transformer that evaluates XPath expressions against the
+	message payload and inserts the result of the evaluation into a message header.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="inputOutputEndpoint">
+					<xsd:sequence minOccurs="1" maxOccurs="unbounded">
+						<xsd:element type="xpathHeaderType" name="header"/>
+					</xsd:sequence>
+					<xsd:attribute name="default-overwrite">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specify the default boolean value for whether to overwrite existing header values. This will
+	only take effect for sub-elements that do not provide their own 'overwrite' attribute. If the
+	'default-overwrite' attribute is not provided, then the specified header values will NOT
+	overwrite any existing ones with the same header names.
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="xsd:boolean xsd:string" />
+						</xsd:simpleType>
+					</xsd:attribute>
+					<xsd:attribute name="should-skip-nulls">
+						<xsd:annotation>
+							<xsd:documentation>
+	Specify whether null values, such as might be returned from an expression evaluation, should be
+	skipped. The default value is true. Set this to false if a null value should trigger removal of
+	the corresponding header instead.
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="xsd:boolean xsd:string" />
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="xpathHeaderType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an XPath expression to be configured within an &lt;xpath-header-enricher/&gt; element.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="name" type="xsd:string" use="required">
+			<xsd:annotation>
+				<xsd:documentation>
+	The name of the header to be enriched.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="xpath-expression">
+			<xsd:annotation>
+				<xsd:documentation>
+	The XPath Expression as a String. Either this or 'xpath-expression-ref' must be provided, but not both.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="xpath-expression-ref">
+			<xsd:annotation>
+				<xsd:documentation>
+	The XPath Expression reference. Either this or 'xpath-expression' must be provided, but not both.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.xml.xpath.XPathExpression"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="evaluation-type" default="STRING_RESULT">
+			<xsd:annotation>
+				<xsd:documentation>
+	The result type expected from the XPath evaluation. This will be the type of the header value.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:string">
+					<xsd:enumeration value="BOOLEAN_RESULT"/>
+					<xsd:enumeration value="STRING_RESULT"/>
+					<xsd:enumeration value="NUMBER_RESULT"/>
+					<xsd:enumeration value="NODE_RESULT"/>
+					<xsd:enumeration value="NODE_LIST_RESULT"/>
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="overwrite">
+			<xsd:annotation>
+				<xsd:documentation>
+	Boolean value to indicate whether this header value should overwrite an existing header value
+	for the same name if already present on the input Message.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<!-- XPath Router definition -->
+
+	<xsd:complexType name="commonXPathRouterType" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="integration:abstractRouterType">
+			<xsd:attribute name="evaluate-as-string" default="false">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						By default XPath expressions are evaluated as NODESET type and then converted
+						to a List of channel names, thus handling single channel scenarios as well as multiple.
+						However certain XPath expressions may evaluate to String type results from the very
+						beginning (e.g., 'name(./node())' - which will return the name of the root node) thus resulting in
+						an exception if the default evaluation type (NODESET) is used.
+
+						This flag will allow you to manage the
+						evaluation type. It is 'false' by default, however if
+						set to 'true', then the String evaluation type will be used.
+					]]></xsd:documentation>
+				</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:union memberTypes="xsd:boolean xsd:string" />
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="xpath-expression-ref" type="xsd:string" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							Reference to the XPathExpression instance to be
+							evaluated against the input Message's payload. Either
+							this or 'xpath-expression' must be provided, but not
+							both.
+						</xsd:documentation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.xml.xpath.XPathExpression"/>
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="XPathRouterType">
+		<xsd:complexContent>
+			<xsd:extension base="commonXPathRouterType">
+				<xsd:sequence>
+					<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="xpath-expression"   minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Internally XPath expressions will be evaluated as
+								NODESET type and converted to a List<String>
+								representing channel names. Typically such a list
+								will contain a single channel name. However,
+								based on the results of an XPath Expression, the
+								XPath router can also take on the characteristics
+								of a Recipient List Router if the XPath Expression
+								returns more then one value. In that case, the
+								List<String> will contain more then one channel
+								name and consequently Messages will be sent to
+								all channels in the list.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="mapping" type="integration:mappingValueChannelType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								If the values returned by the XPath Expression
+								do not represent the channel names themselves, additional
+								mappings can be specified using the "mapping" sub-element.
+
+								For example if the '/request/responders' expression
+								results in two values: 'responderA' and 'responderB',
+								but you don't want to couple the responder names
+								to channel names you may provide additional mappings
+								such as:
+
+								<int-xml:mapping value="responderA" channel="channelA"/>
+								<int-xml:mapping value="responderB" channel="channelB"/>
+								]]>
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					</xsd:sequence>
+					<xsd:attributeGroup ref="integration:topLevelRouterAttributeGroup"/>
+					<xsd:attribute name="converter" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							Specify the Converter to use when converting payloads prior to XPath evaluation.
+							The DefaultXmlPayloadConverter is used if this reference is not provided, and it
+							should be sufficient in most cases since it can convert from Node, Document, Source,
+							File, and String typed payloads. If you need to extend beyond the capabilities of
+							that default implementation, then an upstream Transformer is probably a better option
+							than providing a reference to a custom implementation of this strategy here.
+						</xsd:documentation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.integration.xml.XmlPayloadConverter"/>
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="XPathRouterTypeChain">
+		<xsd:complexContent>
+			<xsd:extension base="commonXPathRouterType">
+				<xsd:sequence>
+					<xsd:element ref="xpath-expression"                                    minOccurs="0" maxOccurs="1">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Internally XPath expressions will be evaluated as
+								NODESET type and converted to a List<String>
+								representing channel names. Typically such a list
+								will contain a single channel name. However,
+								based on the results of an XPath Expression, the
+								XPath router can also take on the characteristics
+								of a Recipient List Router if the XPath Expression
+								returns more then one value. In that case, the
+								List<String> will contain more then one channel
+								name and consequently Messages will be sent to
+								all channels in the list.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="mapping" type="integration:mappingValueChannelType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								If the values returned by the XPath Expression
+								do not represent the channel names themselves, additional
+								mappings can be specified using the "mapping" sub-element.
+
+								For example if the '/request/responders' expression
+								results in two values: 'responderA' and 'responderB',
+								but you don't want to couple the responder names
+								to channel names you may provide additional mappings
+								such as:
+
+								<int-xml:mapping value="responderA" channel="channelA"/>
+								<int-xml:mapping value="responderB" channel="channelB"/>
+								]]>
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="xpath-router" type="XPathRouterType">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Defines an XPath Router which allows for the routing of messages
+				using XPath expressions. This Message Endpoint has no output
+				channel. Instead, one or more output channels are determined
+				dynamically using the provided XPath Expression.
+			]]></xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:element name="xpath-filter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an XPath-based Message Filter. If the XPath expression will evaluate to a boolean,
+	no configuration attributes are required. If the XPath expression will evaluate to a String,
+	a "match-value" should be provided against which the evaluation result will be matched.
+	There are three options for the "match-type": exact, case-insensitive, and regex. These
+	correspond to the equals, equals-ignore-case, and matches operations on java.lang.String,
+	respectively. When providing a 'match-type' value of 'regex', the value provided in
+	'match-value' must be a valid Regular Expression.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="baseFilterType">
+					<xsd:sequence>
+						<xsd:element ref="xpath-expression" minOccurs="0" maxOccurs="1">
+							<xsd:annotation>
+								<xsd:documentation>
+									The XPath expression to evaluate.
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+					</xsd:sequence>
+					<xsd:attribute name="xpath-expression-ref" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:documentation>
+								Reference to an XPath expression instance to evaluate.
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.xml.xpath.XPathExpression"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="match-value" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								String value to be matched against the XPath evaluation result. If this is not provided,
+								then the XPath evaluation MUST produce a boolean result directly.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="match-type" default="exact">
+						<xsd:annotation>
+							<xsd:documentation>
+								Type of match to apply between the XPath evaluation result and the 'match-value'.
+								Default is "exact".
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="matchTypeEnumeration xsd:string" />
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:simpleType name="matchTypeEnumeration">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="exact"/>
+			<xsd:enumeration value="case-insensitive"/>
+			<xsd:enumeration value="regex"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:element name="xpath-selector">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an XPath selector.
+				NOTE: this element is deprecated as of 2.1. Please use &lt;xpath-filter&gt; instead.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="xpath-expression" minOccurs="0" maxOccurs="1"/>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string"/>
+			<xsd:attribute name="xpath-expression-ref" type="xsd:string" use="optional">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.xml.xpath.XPathExpression"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="evaluation-result-type" use="required">
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:string">
+						<xsd:enumeration value="boolean"/>
+						<xsd:enumeration value="string"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="string-test-value" type="xsd:string" use="optional"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="xpath-expression">
+		<xsd:annotation>
+			<xsd:documentation><![CDATA[
+				Defines an XPath expression.
+
+				Internally XPath expressions will be evaluated as
+				NODESET type and converted to a List<String>
+				representing channel names. Typically such a list
+				will contain a single channel name. However, based
+				on the result of an XPath Expression the XPath router
+				can also take on the characteristics of the
+				Recipient List Router if the XPath Expression
+				returns more than one value, thus resulting in
+				the List<String> containing more than one channel
+				name.
+
+				In that case the Message will be sent to all channels
+				in the list.
+			]]></xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element ref="beans:map" minOccurs="0" maxOccurs="1"/>
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="optional"/>
+			<xsd:attribute name="expression" type="xsd:string" use="required"/>
+			<xsd:attribute name="ns-prefix" type="xsd:string" use="optional"/>
+			<xsd:attribute name="ns-uri" type="xsd:string" use="optional"/>
+			<xsd:attribute name="namespace-map" type="xsd:string" use="optional"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="xpath-splitter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an XPath splitter.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="inputOutputEndpoint">
+					<xsd:sequence>
+						<xsd:element ref="xpath-expression" minOccurs="0" maxOccurs="1"/>
+					</xsd:sequence>
+					<xsd:attribute name="xpath-expression-ref" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.xml.xpath.XPathExpression"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="doc-builder-factory" type="xsd:string" use="optional">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="javax.xml.parsers.DocumentBuilderFactory"/>
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="create-documents" type="xsd:string" use="optional"/>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="validating-filter">
+		<xsd:annotation>
+			<xsd:documentation>
+	Defines an XML validating filter.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="baseFilterType">
+					<xsd:attribute name="xml-validator" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Reference to a custom 'org.springframework.xml.validation.XmlValidator' strategy
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.xml.validation.XmlValidator" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="schema-location"/>
+					<xsd:attribute name="schema-type" default="xml-schema">
+						<xsd:simpleType>
+							<xsd:restriction base="xsd:string">
+								<xsd:enumeration value="xml-schema"/>
+								<xsd:enumeration value="relax-ng"/>
+							</xsd:restriction>
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="baseFilterType">
+		<xsd:annotation>
+			<xsd:documentation>
+	Base type for XML filters.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:string"/>
+		<xsd:attribute name="input-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="output-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Message Channel where you want accepted messages to be sent.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="discard-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Message Channel where you want rejected messages to be sent.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="throw-exception-on-rejection" type="xsd:boolean" default="false"/>
+	</xsd:complexType>
+
+	<xsd:complexType name="inputOutputEndpoint">
+		<xsd:sequence>
+			<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:string"/>
+		<xsd:attribute name="input-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="output-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="paramType">
+			<xsd:attribute name="name" type="xsd:string" use="required"/>
+			<xsd:attribute name="expression" type="xsd:string" use="optional"/>
+			<xsd:attribute name="value" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/spring-integration-xmpp/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-xmpp/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
 http\://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp-2.0.xsd=org/springframework/integration/xmpp/config/spring-integration-xmpp-2.0.xsd
 http\://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp-2.1.xsd=org/springframework/integration/xmpp/config/spring-integration-xmpp-2.1.xsd
 http\://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp-2.2.xsd=org/springframework/integration/xmpp/config/spring-integration-xmpp-2.2.xsd
-http\://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd=org/springframework/integration/xmpp/config/spring-integration-xmpp-2.2.xsd
+http\://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp-3.0.xsd=org/springframework/integration/xmpp/config/spring-integration-xmpp-3.0.xsd
+http\://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd=org/springframework/integration/xmpp/config/spring-integration-xmpp-3.0.xsd

--- a/spring-integration-xmpp/src/main/resources/org/springframework/integration/xmpp/config/spring-integration-xmpp-3.0.xsd
+++ b/spring-integration-xmpp/src/main/resources/org/springframework/integration/xmpp/config/spring-integration-xmpp-3.0.xsd
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.springframework.org/schema/integration/xmpp"
+			xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:beans="http://www.springframework.org/schema/beans"
+			xmlns:tool="http://www.springframework.org/schema/tool"
+			xmlns:integration="http://www.springframework.org/schema/integration"
+			targetNamespace="http://www.springframework.org/schema/integration/xmpp"
+			elementFormDefault="qualified"
+			attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
+	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
+	<xsd:import namespace="http://www.springframework.org/schema/integration"
+				schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+
+	<xsd:element name="xmpp-connection">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an XMPP connection that can in turn be referenced by other components
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:attribute name="id" type="xsd:string" default="xmppConnection"/>
+			<xsd:attribute name="user" type="xsd:string" use="required">
+				<xsd:annotation>
+					<xsd:documentation>
+						The user name (e.g., someuser@gmail.com) that will be used by this connection object
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="auto-startup" type="xsd:string" default="true">
+				<xsd:annotation>
+					<xsd:documentation>
+						Lifecycle attribute signaling if this component should be started during Application Context startup.
+						Default is TRUE
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="password" type="xsd:string" use="required">
+				<xsd:annotation>
+					<xsd:documentation>
+						The user's password
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="host" type="xsd:string" use="required">
+				<xsd:annotation>
+					<xsd:documentation>
+						The host name to connect TO
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="service-name" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						The XMPP service name for this connection
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="resource" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+					The resource field specifies the XMPP resource you are using. The use of unique resources allows
+					you to connect to your XMPP server from multiple locations simultaneously. Resources might
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="port" type="xsd:string" default="5222">
+				<xsd:annotation>
+					<xsd:documentation>
+						The port on which the host is running
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="subscription-mode" default="accept_all">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+    The subscription mode for the XMPP connection. Dictates the policy for handling inbound messages from entries not already on the roster.
+    Values can be "accept_all," "manual," or "reject_all."
+				]]></xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:restriction base="xsd:NMTOKEN">
+						<xsd:enumeration value="accept_all"/>
+						<xsd:enumeration value="manual"/>
+						<xsd:enumeration value="reject_all"/>
+					</xsd:restriction>
+				</xsd:simpleType>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an endpoint that will receive chat messages sent to a given account and then forward those messages to a MessageChannel.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="xmppInboundAdapterType">
+					<xsd:attribute name="extract-payload" type="xsd:string" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+							Specifies if generated Message payload should consist of only
+							the text of the XMPP message or the entire XMPP (Smack API specific) message. Default is true.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Outbound Channel Adapter that sends chat messages.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="xmppOutboundAdapterType"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="presence-inbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an endpoint that will forward Presence state changes to a MessageChannel.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="xmppInboundAdapterType"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="presence-outbound-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Configures an endpoint that will publish an updated {@link org.jivesoftware.smack.packet.Presence} state on your {@link XMPPConnection } object.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="xmppOutboundAdapterType"/>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+
+	<xsd:complexType name="xmppInboundAdapterType">
+			<xsd:attribute name="id" type="xsd:string"/>
+			<xsd:attribute name="auto-startup" type="xsd:string" default="true">
+				<xsd:annotation>
+					<xsd:documentation>
+						Lifecycle attribute signaling if this component should be started during Application Context startup.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+					Identifies channel attached to this adapter. Depending on the type of the adapter
+					this channel could be the receiving channel (e.g., outbound-channel-adapter) or channel where
+					messages will be sent to by this adapter (e.g., inbound-channel-adapter).
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="error-channel" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						Identifies channel that error messages will be sent to if a failure occurs in this
+						adapter's invocation.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="xmpp-connection" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.jivesoftware.smack.XMPPConnection"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						Reference to XMPP connection bean
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="header-mapper">
+				<xsd:annotation>
+					<xsd:documentation>
+						Allows you to reference custom implementation of HeaderMapper.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-request-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Comma-separated list of names of MessageHeaders to be mapped into the XMPP Headers of the request.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="xmppOutboundAdapterType">
+			<xsd:choice minOccurs="0" maxOccurs="2">
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
+				<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
+			</xsd:choice>
+			<xsd:attribute name="id" type="xsd:string"/>
+			<xsd:attribute name="channel"  type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+					Identifies channel attached to this adapter. Depending on the type of the adapter
+					this channel could be the receiving channel (e.g., outbound-channel-adapter) or channel where
+					messages will be sent to by this adapter (e.g., inbound-channel-adapter).
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="xmpp-connection" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.jivesoftware.smack.XMPPConnection"/>
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						Reference to XMPP connection bean
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="order">
+				<xsd:annotation>
+					<xsd:documentation>
+						Specifies the order for invocation when this endpoint is connected as a
+						subscriber to a SubscribableChannel.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="header-mapper">
+				<xsd:annotation>
+					<xsd:documentation>
+						Allows you to reference custom implementation of HeaderMapper.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="mapped-request-headers" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	Comma-separated list of names of MessageHeaders to be mapped into the XMPP Headers of the request.
+	This can only be provided if the 'header-mapper' reference is not being set directly. The values in
+	this list can also be simple patterns to be matched against the header names (e.g. "foo*" or "*foo").
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+
+	<xsd:element name="header-enricher">
+		<xsd:complexType>
+			<xsd:annotation>
+				<xsd:documentation>
+					Defines a Transformer for adding XMPP headers.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:complexContent>
+				<xsd:extension base="transformerType">
+					<xsd:choice minOccurs="1" maxOccurs="unbounded">
+						<xsd:element name="chat-to" type="headerType">
+							<xsd:annotation>
+								<xsd:documentation>
+								The id of the user you sending a message to (e.g., user@gmail.com)
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+						<xsd:element name="chat-thread-id" type="headerType">
+							<xsd:annotation>
+								<xsd:documentation>
+									The conversation thread id used to corelate XMPP packets as
+									belonging to a particular conversation
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
+					</xsd:choice>
+					<xsd:attribute name="default-overwrite">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify the default boolean value for whether to overwrite existing header values. This will only take effect for
+								sub-elements that do not provide their own 'overwrite' attribute. If the 'default-overwrite' attribute is not
+								provided, then the specified header values will NOT overwrite any existing ones with the same header names.
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="xsd:boolean xsd:string"/>
+						</xsd:simpleType>
+					</xsd:attribute>
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:complexType name="headerType">
+		<xsd:attribute name="value" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Value of this header inside of a Message
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="ref" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Reference to a bean that contains a method that will compute the header value
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+				SpEL expression that will compute the header value
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="overwrite">
+			<xsd:annotation>
+				<xsd:documentation>
+					Boolean value to indicate whether this header value should overwrite an existing header value for the same name.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:complexType>
+
+	<xsd:complexType name="transformerType">
+		<xsd:attribute name="id" type="xsd:string"/>
+		<xsd:attribute name="input-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+				The receiving Message channel of this endpoint
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="output-channel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+				Identifies the Message channel where Message will be sent after it's being processed by this endpoint
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
Copy schemas, cleanup whitespace, update `spring.schemas` files,
update version in AbstractIntegrationNamespaceHandler.

For each schema, compared the 2.2 version with the 3.0 version
(diff -w), ensuring the only difference is the import of
3.0 schemas (where appropriate) instead of 2.2.
