### PR TITLE
INT-2899: remove redundant logic from Aggregator

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2011 the original author or authors.
- * 
+ * Copyright 2002-2013 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -14,17 +14,18 @@
 package org.springframework.integration.aggregator;
 
 import java.util.Collection;
-import java.util.Iterator;
 
 import org.springframework.integration.Message;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 
 /**
- * Aggregator specific implementation of {@link AbstractCorrelatingMessageHandler}. 
- * Will remove {@link MessageGroup}s only if 'expireGroupsUponCompletion' flag is set to 'true'.
+ * Aggregator specific implementation of {@link AbstractCorrelatingMessageHandler}.
+ * Will remove {@link MessageGroup}s in the {@linkplain #afterRelease}
+ * only if 'expireGroupsUponCompletion' flag is set to 'true'.
  *
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  * @since 2.1
  */
 public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler {
@@ -39,33 +40,24 @@ public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler
 	public AggregatingMessageHandler(MessageGroupProcessor processor, MessageGroupStore store) {
 		super(processor, store);
 	}
-	
+
 	public AggregatingMessageHandler(MessageGroupProcessor processor) {
 		super(processor);
 	}
 
 	/**
-	 * Will set the 'expireGroupsUponCompletion' flag and if it is 
-	 * set to 'true' it will also remove all 'complete' {@link MessageGroup}s
-	 * @param expireGroupsUponCompletion
+	 * Will set the 'expireGroupsUponCompletion' flag
+	 *
+	 * @see #afterRelease
 	 */
 	public void setExpireGroupsUponCompletion(boolean expireGroupsUponCompletion) {
 		this.expireGroupsUponCompletion = expireGroupsUponCompletion;
-		if (expireGroupsUponCompletion) {
-			Iterator<MessageGroup> messageGroups = this.messageStore.iterator();
-			while (messageGroups.hasNext()) {
-				MessageGroup messageGroup = messageGroups.next();
-				if (messageGroup.isComplete()) {
-					remove(messageGroup);
-				}
-			}
-		}
 	}
 
 	@Override
 	protected void afterRelease(MessageGroup messageGroup, Collection<Message<?>> completedMessages) {
 		this.messageStore.completeGroup(messageGroup.getGroupId());
-		
+
 		if (this.expireGroupsUponCompletion) {
 			remove(messageGroup);
 		}
@@ -73,7 +65,7 @@ public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler
 			for (Message<?> message : messageGroup.getMessages()) {
 				this.messageStore.removeMessageFromGroup(messageGroup.getGroupId(), message);
 			}
-		}	
+		}
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
@@ -25,6 +25,7 @@ import org.w3c.dom.Element;
  *
  * @author Oleg Zhurakousky
  * @author Stefan Ferstl
+ * @author Artem Bilan
  * @since 2.1
  *
  */
@@ -66,6 +67,7 @@ public abstract class AbstractCorrelatingMessageHandlerParser extends AbstractCo
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, DISCARD_CHANNEL_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, SEND_TIMEOUT_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, SEND_PARTIAL_RESULT_ON_EXPIRY_ATTRIBUTE);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "empty-group-time-to-live-on-expiry", "minimumTimeoutForEmptyGroups");
 	}
 
 	protected void injectPropertyWithAdapter(String beanRefAttribute, String methodRefAttribute,
@@ -86,7 +88,7 @@ public abstract class AbstractCorrelatingMessageHandlerParser extends AbstractCo
 
 		BeanMetadataElement adapter = null;
 		if (hasBeanRef) {
-			adapter = this.createAdapter(new RuntimeBeanReference(beanRef), beanMethod, adapterClass, parserContext);
+			adapter = this.createAdapter(new RuntimeBeanReference(beanRef), beanMethod, adapterClass);
 		}
 		else if (hasExpression) {
 			BeanDefinitionBuilder adapterBuilder = BeanDefinitionBuilder
@@ -96,16 +98,15 @@ public abstract class AbstractCorrelatingMessageHandlerParser extends AbstractCo
 			adapter = adapterBuilder.getBeanDefinition();
 		}
 		else if (processor != null) {
-			adapter = this.createAdapter(processor, beanMethod, adapterClass, parserContext);
+			adapter = this.createAdapter(processor, beanMethod, adapterClass);
 		}
 		else {
-			adapter = this.createAdapter(null, beanMethod, adapterClass, parserContext);
+			adapter = this.createAdapter(null, beanMethod, adapterClass);
 		}
 		builder.addPropertyValue(beanProperty, adapter);
 	}
 
-	private BeanMetadataElement createAdapter(BeanMetadataElement ref, String method, String unqualifiedClassName,
-			ParserContext parserContext) {
+	private BeanMetadataElement createAdapter(BeanMetadataElement ref, String method, String unqualifiedClassName) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder
 				.genericBeanDefinition(IntegrationNamespaceUtils.BASE_PACKAGE + ".config." + unqualifiedClassName
 						+ "FactoryBean");

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
@@ -67,7 +67,7 @@ public abstract class AbstractCorrelatingMessageHandlerParser extends AbstractCo
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, DISCARD_CHANNEL_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, SEND_TIMEOUT_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, SEND_PARTIAL_RESULT_ON_EXPIRY_ATTRIBUTE);
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "empty-group-time-to-live-on-expiry", "minimumTimeoutForEmptyGroups");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "empty-group-min-timeout", "minimumTimeoutForEmptyGroups");
 	}
 
 	protected void injectPropertyWithAdapter(String beanRefAttribute, String methodRefAttribute,

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -3262,6 +3262,19 @@ is provided, the return value is expected to match a channel name exactly.
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
+				<xsd:attribute name="empty-group-time-to-live-on-expiry" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							By default, when a MessageGroupStoreReaper is configured to expire partial
+							groups, empty groups are also removed. Empty groups exist after a group
+							is released normally. This is to enable the detection and discarding of
+							late-arriving messages. If you wish to run empty group deletion on a longer
+							schedule than expiring partial groups, set this property. Empty groups will
+							then not be removed from the MessageStore until they have not been modified
+							for at least this number of milliseconds.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -3262,9 +3262,11 @@ is provided, the return value is expected to match a channel name exactly.
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
-				<xsd:attribute name="empty-group-time-to-live-on-expiry" type="xsd:string">
+				<xsd:attribute name="empty-group-min-timeout" type="xsd:string">
 					<xsd:annotation>
 						<xsd:documentation>
+							Makes sense only if MessageGroupStoreReaper is configured for MessageStore
+							of this Correlation Endpoint.
 							By default, when a MessageGroupStoreReaper is configured to expire partial
 							groups, empty groups are also removed. Empty groups exist after a group
 							is released normally. This is to enable the detection and discarding of

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,12 @@
  */
 
 package org.springframework.integration.config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,18 +55,13 @@ import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 
-import static org.hamcrest.CoreMatchers.is;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Marius Bogoevici
  * @author Mark Fisher
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  */
 public class AggregatorParserTests {
 
@@ -192,7 +193,7 @@ public class AggregatorParserTests {
 		Assert.assertNotNull(reply);
 		assertEquals(11l, reply.getPayload());
 	}
-	
+
 	@Test // see INT-2011
 	public void testAggregatorWithPojoReleaseStrategyAsCollection() {
 		MessageChannel input = (MessageChannel) context.getBean("aggregatorWithPojoReleaseStrategyInputAsCollection");
@@ -232,9 +233,11 @@ public class AggregatorParserTests {
 		assertSame(context.getBean("aggregatorBean"), messageGroupProcessorTargetObject);
 		ReleaseStrategy releaseStrategy = (ReleaseStrategy) TestUtils.getPropertyValue(aggregatingMessageHandler, "releaseStrategy");
 		CorrelationStrategy correlationStrategy = (CorrelationStrategy) TestUtils.getPropertyValue(aggregatingMessageHandler, "correlationStrategy");
+		Long minimumTimeoutForEmptyGroups = TestUtils.getPropertyValue(aggregatingMessageHandler, "minimumTimeoutForEmptyGroups", Long.class);
 
 		assertTrue(ExpressionEvaluatingReleaseStrategy.class.equals(releaseStrategy.getClass()));
 		assertTrue(ExpressionEvaluatingCorrelationStrategy.class.equals(correlationStrategy.getClass()));
+		assertEquals(60000L, minimumTimeoutForEmptyGroups.longValue());
 	}
 
 	@Test(expected=BeanDefinitionParsingException.class)

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ResequencerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ResequencerParserTests.java
@@ -44,6 +44,7 @@ import org.springframework.integration.test.util.TestUtils;
  * @author Dave Syer
  * @author Oleg Zhurakousky
  * @author Stefan Ferstl
+ * @author Artem Bilan
  */
 public class ResequencerParserTests {
 
@@ -88,6 +89,7 @@ public class ResequencerParserTests {
 				true, getPropertyValue(resequencer, "sendPartialResultOnExpiry"));
 		assertEquals("The ResequencerEndpoint is not configured with the appropriate 'release partial sequences' flag",
 				true, getPropertyValue(getPropertyValue(resequencer, "releaseStrategy"), "releasePartialSequences"));
+		assertEquals(60000L, getPropertyValue(resequencer, "minimumTimeoutForEmptyGroups", Long.class).longValue());
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/aggregatorParserTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/aggregatorParserTests.xml
@@ -68,7 +68,8 @@
 		input-channel="aggregatorWithExpressionsAndPojoAggregatorInput"
 		ref="aggregatorBean"
 		release-strategy-expression="size() == 2"
-        correlation-strategy-expression="headers['foo']"/>
+        correlation-strategy-expression="headers['foo']"
+		empty-group-time-to-live-on-expiry="60000"/>
 
 	<beans:bean id="aggregatorBean"
 		class="org.springframework.integration.config.TestAggregatorBean" />

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/aggregatorParserTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/aggregatorParserTests.xml
@@ -69,7 +69,7 @@
 		ref="aggregatorBean"
 		release-strategy-expression="size() == 2"
         correlation-strategy-expression="headers['foo']"
-		empty-group-time-to-live-on-expiry="60000"/>
+		empty-group-min-timeout="60000"/>
 
 	<beans:bean id="aggregatorBean"
 		class="org.springframework.integration.config.TestAggregatorBean" />

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/resequencerParserTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/resequencerParserTests.xml
@@ -29,12 +29,13 @@
 
 	<channel id="inputChannel6"/>
 
-	<resequencer id="completelyDefinedResequencer" 
+	<resequencer id="completelyDefinedResequencer"
 		input-channel="inputChannel2"
-		output-channel="outputChannel" 
+		output-channel="outputChannel"
 		discard-channel="discardChannel"
-		send-timeout="86420000" 
+		send-timeout="86420000"
 		send-partial-result-on-expiry="true"
+		empty-group-time-to-live-on-expiry="60000"
 		release-partial-sequences="true"/>
 
 	<resequencer id="resequencerWithCorrelationStrategyRefOnly"

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/resequencerParserTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/resequencerParserTests.xml
@@ -35,7 +35,7 @@
 		discard-channel="discardChannel"
 		send-timeout="86420000"
 		send-partial-result-on-expiry="true"
-		empty-group-time-to-live-on-expiry="60000"
+		empty-group-min-timeout="60000"
 		release-partial-sequences="true"/>
 
 	<resequencer id="resequencerWithCorrelationStrategyRefOnly"

--- a/src/reference/docbook/aggregator.xml
+++ b/src/reference/docbook/aggregator.xml
@@ -25,7 +25,7 @@
     Aggregator will create a single message by processing the whole group, and
     will send the aggregated message as output.</para>
 
-    <para>Implementing an Aggregator requires providing the logic 
+    <para>Implementing an Aggregator requires providing the logic
     to perform the aggregation (i.e., the creation of a single message
     from many). Two related concepts are correlation and
     release.</para>
@@ -34,13 +34,13 @@
     In Spring Integration correlation is done by default based on the
     <code>MessageHeaders.CORRELATION_ID</code> message
     header. Messages with the same <code>MessageHeaders.CORRELATION_ID</code> will be grouped
-    together. However, the correlation strategy may be customized to allow 
+    together. However, the correlation strategy may be customized to allow
     other ways of specifying how the messages should be grouped together by
     implementing a <interfacename>CorrelationStrategy</interfacename> (see below).</para>
 
     <para>To determine the point at which a group of messages is ready to be processed, a
-    <interfacename>ReleaseStrategy</interfacename> is consulted. 
-    The default release strategy for the Aggregator will release a group when all 
+    <interfacename>ReleaseStrategy</interfacename> is consulted.
+    The default release strategy for the Aggregator will release a group when all
     messages included in a sequence are present, based on the
     <code>MessageHeaders.SEQUENCE_SIZE</code> header.
     This default strategy may be overridden by providing a reference to a
@@ -121,14 +121,14 @@
 
 }]]></programlisting>
 
-       The <interfacename>CorrelationStrategy</interfacename> is owned by the 
+       The <interfacename>CorrelationStrategy</interfacename> is owned by the
 
       <classname>AbstractCorrelatingMessageHandler</classname>
 
        and it has a default value based on the <code>MessageHeaders.CORRELATION_ID</code> message header:
 
       <programlisting language="java"><![CDATA[
-    public CorrelatingMessageHandler(MessageGroupProcessor processor, MessageGroupStore store,
+    public AbstractCorrelatingMessageHandler(MessageGroupProcessor processor, MessageGroupStore store,
                    CorrelationStrategy correlationStrategy, ReleaseStrategy releaseStrategy) {
      ...
       this.correlationStrategy = correlationStrategy == null ?
@@ -158,13 +158,13 @@
       <para>When implementing a specific aggregator strategy for an application,
       a developer can extend
       <classname>AbstractAggregatingMessageGroupProcessor</classname> and implement the
-      <code>aggregatePayloads</code> method. However, there are better solutions, less 
+      <code>aggregatePayloads</code> method. However, there are better solutions, less
       coupled to the API, for implementing the aggregation logic which can be configured easily
       either through XML or through annotations.</para>
- 
+
       <para>In general, any POJO can implement the
       aggregation algorithm if it provides a method that
-      accepts a single <interfacename>java.util.List</interfacename> as an argument 
+      accepts a single <interfacename>java.util.List</interfacename> as an argument
       (parameterized lists are supported as well). This method will be invoked for aggregating
       messages as follows:</para>
 
@@ -194,7 +194,7 @@
         implementing the aggregation logic is through a POJO, and using the
         XML or annotation support for configuring it in the application.</para>
       </note>
-       
+
     </section>
 
     <section>
@@ -234,18 +234,18 @@
           aggregation, and false otherwise.</para>
         </listitem>
       </itemizedlist>
-      
+
       For example:
-      
+
       <programlisting language="java"><![CDATA[public class MyReleaseStrategy {
 
-    @ReleaseStrategy 
+    @ReleaseStrategy
     public boolean canMessagesBeReleased(List<Message<?>>) {...}
 }]]></programlisting>
 
 <programlisting language="java"><![CDATA[public class MyReleaseStrategy {
 
-    @ReleaseStrategy 
+    @ReleaseStrategy
     public boolean canMessagesBeReleased(List<String>) {...}
 }]]></programlisting>
 
@@ -328,7 +328,7 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
       <title>Configuring an Aggregator with XML</title>
 
       <para>Spring Integration supports the configuration of an aggregator via
-      XML through the &lt;aggregator/&gt; element. Below you can see an example
+      XML through the <code>&lt;aggregator/&gt;</code> element. Below you can see an example
       of an aggregator.</para>
 
     <programlisting lang="xml"><![CDATA[<channel id="inputChannel"/>
@@ -355,7 +355,8 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 		release-strategy-method="release" ]]><co id="aggxml16" /><![CDATA[
 		release-strategy-expression="size() == 5" ]]><co id="aggxml17" /><![CDATA[
 
-		expire-groups-upon-completion="false"/> ]]><co id="aggxml18" /><![CDATA[
+		expire-groups-upon-completion="false" ]]><co id="aggxml18" /><![CDATA[
+		empty-group-min-timeout="60000" /> ]]><co id="aggxml19" /><![CDATA[
 
 
 <int:channel id="outputChannel"/>
@@ -382,7 +383,7 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
         <para>Lifecycle attribute signaling if aggregator should be started during Application Context startup.
         <emphasis>Optional (default is 'true')</emphasis>.</para>
       </callout>
-      
+
       <callout arearefs="aggxml03">
         <para>The channel from which where aggregator will receive messages.
         <emphasis>Required</emphasis>.</para>
@@ -406,16 +407,16 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
         complete. <emphasis>Optional</emphasis>, by default a volatile
         in-memory store.</para>
       </callout>
-      
+
        <callout arearefs="aggxml07">
         <para>Order of this aggregator when more than one handle is subscribed to the same DirectChannel
-        (use for load balancing purposes). 
+        (use for load balancing purposes).
         <emphasis>Optional</emphasis>.</para>
       </callout>
-      
+
       <callout arearefs="aggxml08">
         <para>
-        Indicates that expired messages should be aggregated and sent to the 'output-channel' or 'replyChannel' 
+        Indicates that expired messages should be aggregated and sent to the 'output-channel' or 'replyChannel'
 		once their containing <classname>MessageGroup</classname> is expired (see <code>MessageGroupStore.expireMessageGroups(long)</code>).
 		One way of expiring <classname>MessageGroup</classname>s is by configuring a <classname>MessageGroupStoreReaper</classname>.
 		However <classname>MessageGroup</classname>s can alternatively be expired by simply calling
@@ -426,20 +427,20 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
         <emphasis>Optional</emphasis>.</para>
         <para><emphasis>Default - 'false'</emphasis>.</para>
       </callout>
-      
+
        <callout arearefs="aggxml09">
         <para>The timeout interval for sending the aggregated messages to the output or
         reply channel. <emphasis>Optional</emphasis>.</para>
       </callout>
-     
+
        <callout arearefs="aggxml10">
-        <para>A reference to a bean that implements the message correlation (grouping) 
-        algorithm. The bean can be an implementation of the <interfacename>CorrelationStrategy</interfacename> 
+        <para>A reference to a bean that implements the message correlation (grouping)
+        algorithm. The bean can be an implementation of the <interfacename>CorrelationStrategy</interfacename>
         interface or a POJO. In the latter case the correlation-strategy-method attribute must be defined
         as well. <emphasis>Optional (by default, the aggregator will use
         the <code>MessageHeaders.CORRELATION_ID</code> header) </emphasis>.</para>
       </callout>
-      
+
       <callout arearefs="aggxml11">
         <para>A method defined on the bean referenced by
         <code>correlation-strategy</code>, that implements the
@@ -457,7 +458,7 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 
       <callout arearefs="aggxml13">
         <para>A reference to a bean defined in the application context. The bean must implement the aggregation logic
-    as described above. <emphasis>Optional (by default the list of aggregated Messages will become a 
+    as described above. <emphasis>Optional (by default the list of aggregated Messages will become a
     payload of the output message).</emphasis></para>
       </callout>
       <callout arearefs="aggxml14">
@@ -465,7 +466,7 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
         that implements the message aggregation
         algorithm. <emphasis>Optional, depends on <code>ref</code> attribute being defined.</emphasis></para>
       </callout>
-      
+
       <callout arearefs="aggxml15">
         <para>A reference to a bean that implements the release strategy.
         The bean can be an implementation of the <interfacename>ReleaseStrategy</interfacename> interface
@@ -496,6 +497,18 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
         the same correlation to form a new group. The default behavior
         is to send messages with the same correlation as a completed
         group to the <emphasis>discard-channel</emphasis>.</para>
+      </callout>
+
+      <callout arearefs="aggxml19">
+        <para>Makes sense only if <classname>MessageGroupStoreReaper</classname> is configured for the <classname>MessageStore</classname>
+        of the <code>&lt;aggregator&gt;</code>.
+        By default, when a <classname>MessageGroupStoreReaper</classname> is configured to expire partial
+        groups, empty groups are also removed. Empty groups exist after a group
+        is released normally. This is to enable the detection and discarding of
+        late-arriving messages. If you wish to run empty group deletion on a longer
+        schedule than expiring partial groups, set this property. Empty groups will
+        then not be removed from the <classname>MessageStore</classname> until they have not been modified
+        for at least this number of milliseconds.</para>
       </callout>
 
     </calloutlist>
@@ -570,16 +583,16 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
       strategy method and the aggregator method can be combined in a single
       bean (all of them or any two).</para>
     </note>
-    
+
     <para>
     	<emphasis>Aggregators and Spring Expression Language (SpEL)</emphasis>
     </para>
-    
+
     <para>
-    Since Spring Integration 2.0, the various strategies (correlation, release, and aggregation) may be handled with 
-    <ulink url="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/expressions.html">SpEL</ulink> 
+    Since Spring Integration 2.0, the various strategies (correlation, release, and aggregation) may be handled with
+    <ulink url="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/expressions.html">SpEL</ulink>
     which is recommended if the logic behind such <emphasis>release strategy</emphasis> is relatively simple.
-    Let's say you have a legacy component that was designed to receive an array of objects. We know that the default release 
+    Let's say you have a legacy component that was designed to receive an array of objects. We know that the default release
     strategy will assemble all aggregated messages in the List. So now we have two problems. First we need to extract
     individual messages from the list, and then we need to extract the payload of each message and assemble
     the array of objects (see code below).
@@ -595,22 +608,22 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 	However, with SpEL such a requirement could actually be handled relatively easily with a
 	one-line expression, thus sparing you from writing a custom class and configuring it as a bean.
 
-	<programlisting language="xml"><![CDATA[<int:aggregator input-channel="aggChannel" 
-	output-channel="replyChannel" 
+	<programlisting language="xml"><![CDATA[<int:aggregator input-channel="aggChannel"
+	output-channel="replyChannel"
 	expression="#this.![payload].toArray()"/>]]></programlisting>
 
-	In the above configuration we are using a <ulink 
-	url="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/expressions.html#d0e12113">Collection Projection</ulink> expression 
-	to assemble a new collection from the payloads of all messages in the list and then transforming it to an Array, thus 
+	In the above configuration we are using a <ulink
+	url="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/expressions.html#d0e12113">Collection Projection</ulink> expression
+	to assemble a new collection from the payloads of all messages in the list and then transforming it to an Array, thus
 	achieving the same result as the java code above.
     </para>
-    
+
     <para>
-    The same expression-based approach can be applied when dealing with custom <emphasis>Release</emphasis> and 
+    The same expression-based approach can be applied when dealing with custom <emphasis>Release</emphasis> and
     <emphasis>Correlation</emphasis> strategies.
     </para>
     <para>
-	Instead of defining a bean for a custom <classname>CorrelationStrategy</classname> via 
+	Instead of defining a bean for a custom <classname>CorrelationStrategy</classname> via
     the <code>correlation-strategy</code> attribute, you can implement your simple correlation logic
     via a SpEL expression and configure it via the <code>correlation-strategy-expression</code> attribute.
 	</para>
@@ -618,13 +631,13 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 	For example:
 
 	<programlisting language="xml"><![CDATA[correlation-strategy-expression="payload.person.id"]]></programlisting>
-	
-	In the above example it is assumed that the payload has an attribute <code>person</code> with an <code>id</code> 
+
+	In the above example it is assumed that the payload has an attribute <code>person</code> with an <code>id</code>
 	which is going to be used to correlate messages.
 	</para>
 	<para>
-    Likewise, for the <interfacename>ReleaseStrategy</interfacename> you can implement your release logic as 
-    a SpEL expression and configure it via the <code>release-strategy-expression</code> attribute. 
+    Likewise, for the <interfacename>ReleaseStrategy</interfacename> you can implement your release logic as
+    a SpEL expression and configure it via the <code>release-strategy-expression</code> attribute.
     The only difference is that since ReleaseStrategy is passed the List of Messages, the root object in the SpEL
     evaluation context is the List itself. That List can be referenced as <code>#this</code> within the expression.
 	</para>
@@ -632,9 +645,9 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 	For example:
 
 	<programlisting language="xml"><![CDATA[release-strategy-expression="#this.size() gt 5"]]></programlisting>
-	
+
 	In this example the root object of the SpEL Evaluation Context is the
-    <interfacename>MessageGroup</interfacename> itself, and you are simply stating 
+    <interfacename>MessageGroup</interfacename> itself, and you are simply stating
     that as soon as there are more than 5 messages in this group, it should be released.
     </para>
   </section>
@@ -645,9 +658,9 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
     <para>An aggregator configured using annotations would look like this.</para>
 
     <programlisting language="java"><![CDATA[public class Waiter {
-  ... 
+  ...
 
-  @Aggregator ]]><co id="aggann" /><![CDATA[ 
+  @Aggregator ]]><co id="aggann" /><![CDATA[
   public Delivery aggregatingMethod(List<OrderItem> items) {
     ...
   }
@@ -693,7 +706,7 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
     the @MessageEndpoint is defined on the class, detected automatically
     through classpath scanning.</para>
   </section>
-		
+
 	</section>
 
   <section id="reaper">
@@ -709,8 +722,8 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
     All state is carried by the <interfacename>MessageGroup</interfacename> and its
     management is delegated to the
     <interfacename>MessageGroupStore</interfacename>.
-    
-    
+
+
     <programlisting><![CDATA[public interface MessageGroupStore {
    int getMessageCountForAllMessageGroups();
 
@@ -734,11 +747,11 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 
    int expireMessageGroups(long timeout);
 }]]></programlisting>
-    
+
     For more information please refer to the
     <ulink url="http://static.springsource.org/spring-integration/api/org/springframework/integration/store/MessageGroupStore.html">JavaDoc</ulink>.
     </para>
-    
+
     <para>The <interfacename>MessageGroupStore</interfacename> accumulates state
     information in <interfacename>MessageGroups</interfacename> while waiting for
     a release strategy to be triggered, and that event might not ever happen.
@@ -777,32 +790,43 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
   <property name="timeout" value="30000"/>
 </bean>
 
-<task:scheduled-tasks scheduler="scheduler">	
+<task:scheduled-tasks scheduler="scheduler">
   <task:scheduled ref="reaper" method="run" fixed-rate="10000"/>
 </task:scheduled-tasks>]]></programlisting>
 
     <para>The reaper is a <interfacename>Runnable</interfacename>, and all that is happening
     in the example above is that the message group store's expire method is being called
     once every 10 seconds. The timeout itself is 30 seconds.</para>
-    
+
     <note>
-    It is important to understand that the 'timeout' property of the <classname>MessageGroupStoreReaper</classname> is an 
-    approximate value and is impacted by the  the rate of the task scheduler since this property will 
-    only be checked on the next scheduled execution of the <classname>MessageGroupStoreReaper</classname> task. For example if 
-    the timeout is set for 10 min, but the <classname>MessageGroupStoreReaper</classname> task is scheduled to run every 60 min 
-    and the last execution of the <classname>MessageGroupStoreReaper</classname> task happened 1 min before the timeout, the 
+    It is important to understand that the 'timeout' property of the <classname>MessageGroupStoreReaper</classname> is an
+    approximate value and is impacted by the  the rate of the task scheduler since this property will
+    only be checked on the next scheduled execution of the <classname>MessageGroupStoreReaper</classname> task. For example if
+    the timeout is set for 10 min, but the <classname>MessageGroupStoreReaper</classname> task is scheduled to run every 60 min
+    and the last execution of the <classname>MessageGroupStoreReaper</classname> task happened 1 min before the timeout, the
     <classname>MessageGroup</classname>  will not expire for the next 59 min. So it is recommended to set the rate at least equal to the value of the timeout or shorter.
     </note>
 
     <para>In addition to the reaper, the expiry callbacks are invoked when the application
-    shuts down via a lifecycle callback in the <classname>CorrelatingMessageHandler</classname>.
+    shuts down via a lifecycle callback in the <classname>AbstractCorrelatingMessageHandler</classname>.
     </para>
 
-    <para>The <classname>CorrelatingMessageHandler</classname> registers its
+    <para>The <classname>AbstractCorrelatingMessageHandler</classname> registers its
     own expiry callback, and this is the link with the boolean flag
     <code>send-partial-result-on-expiry</code> in the XML configuration of the
     aggregator. If the flag is set to true, then when the expiry callback is
     invoked, any unmarked messages in groups that are not yet released can
     be sent on to the output channel.</para>
+
+    <important>
+      <para>Keep in mind <interfacename>MessageGroupStore</interfacename> iterates over all registered <interfacename>MessageGroupCallback</interfacename>s.
+      So if you configure the same <interfacename>MessageGroupStore</interfacename> for different Correlation Endpoints, the invoke of
+      <classname>MessageGroupStoreReaper</classname> may expire groups in some endpoint when groups are really from other endpoint
+      who is not interested in expiring.</para>
+      <para>To achieve robustness and to divide the level of responsibility it is recommended to have separate <interfacename>MessageGroupStore</interfacename>s
+      for different Correlation Endpoints. E.g. for <classname>JdbcMessageStore</classname> there is a <code>region</code> property,
+      for <classname>MongoDbMessageStore</classname> - <code>collectionName</code> property and so forth.</para>
+      <para>For more information about <interfacename>MessageStore</interfacename> and its implementations, please read <xref linkend="message-store"/>.</para>
+    </important>
   </section>
 </section>

--- a/src/reference/docbook/resequencer.xml
+++ b/src/reference/docbook/resequencer.xml
@@ -52,7 +52,8 @@
 
   release-strategy="releaseStrategyBean" ]]><co id="resxml14-co" linkends="resxml14" /><![CDATA[
   release-strategy-method="release" ]]><co id="resxml15-co" linkends="resxml15" /><![CDATA[
-  release-strategy-expression="size() == 10" />]]><co id="resxml16-co" linkends="resxml16" /></programlisting>
+  release-strategy-expression="size() == 10" ]]><co id="resxml16-co" linkends="resxml16" /><![CDATA[
+  empty-group-min-timeout="60000" />]]><co id="resxml17-co" linkends="resxml17" /></programlisting>
 
     <para><calloutlist>
         <callout arearefs="resxml1-co" id="resxml1">
@@ -170,6 +171,19 @@
           <code>release-strategy</code>
           or <code>release-strategy-expression</code> is allowed.</para>
         </callout>
+
+        <callout arearefs="resxml17-co" id="resxml17">
+          <para>Makes sense only if <classname>MessageGroupStoreReaper</classname> is configured for the <classname>MessageStore</classname>
+          of the <code>&lt;resequencer&gt;</code>.
+          By default, when a <classname>MessageGroupStoreReaper</classname> is configured to expire partial
+          groups, empty groups are also removed. Empty groups exist after a group
+          is released normally. This is to enable the detection and discarding of
+          late-arriving messages. If you wish to run empty group deletion on a longer
+          schedule than expiring partial groups, set this property. Empty groups will
+          then not be removed from the <classname>MessageStore</classname> until they have not been modified
+          for at least this number of milliseconds.</para>
+        </callout>
+
       </calloutlist></para>
 
     <note>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -10,4 +10,22 @@
 		were resolved as part of the 3.0 development process.
 	</para>
 
+    <section id="2.2-new-components">
+       <title>New Components</title>
+    </section>
+
+    <section id="2.2-general">
+       <title>General Changes</title>
+
+       <section id="2.2-corr-endpoint-empty-groups">
+          <title>Aggregator 'empty-group-min-timeout' property</title>
+       	  <para><classname>AbstractCorrelatingMessageHandler</classname> provides new property <code>empty-group-min-timeout</code>
+       		to allow run empty group deletion on a longer schedule than expiring partial groups. Empty groups will
+       		then not be removed from the <interfacename>MessageStore</interfacename> until they have not been modified
+       		for at least this number of milliseconds. For more information see <xref linkend="aggregator-config"/>.
+       	  </para>
+       </section>
+
+    </section>
+
 </chapter>


### PR DESCRIPTION
Before `AggregatingMessageHandler#setExpireGroupsUponCompletion` had additional logic
for removing complete MessageGroups. It could produce some overhead on application start-up with big persistent `MessageStore`.
This logic played a role to clean `MessageStore` from empty groups.
Since `AbstractCorrelatingMessageHandler#forceComplete` had had an ability to remove empty groups too,
Mentioned logic became redundant.
So, if we're going to clean `MessageStore` from empty complete groups it's enough to use `MessageGroupStoreReaper` on it.
From other side: if some MessageGroup is complete and not empty, how it became into such state?..
Nor `<aggregator>`, neither `<resequencer>` don't have similar logic.
- Remove logic about iteration over `MessageStore` from `AggregatingMessageHandler#setExpireGroupsUponCompletion`
- Polishing `AggregatorSupportedUseCasesTests` to use `store.expireMessageGroups(0)`
- Introduce `empty-group-time-to-live-on-expiry` xml-attribute based on `AbstractCorrelatingMessageHandler#minimumTimeoutForEmptyGroups`
- Add parser's tests for `empty-group-time-to-live-on-expiry` attribute

JIRA: https://jira.springsource.org/browse/INT-2899
