### PR TITLE
INT-2915 JMS Remove Deprecated Attributes

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
@@ -145,7 +145,6 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler imp
 	 * specified as a boolean value ("true" or "false"). This will set the delivery
 	 * mode accordingly to either "PERSISTENT" (1) or "NON_PERSISTENT" (2).
 	 * <p>The default is "true", i.e. delivery mode "PERSISTENT".
-	 * @see #setDeliveryMode(int)
 	 * @see javax.jms.DeliveryMode#PERSISTENT
 	 * @see javax.jms.DeliveryMode#NON_PERSISTENT
 	 */
@@ -260,7 +259,13 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler imp
 
 	/**
 	 * Specify the JMS DeliveryMode to use when sending request Messages.
+	 * @deprecated use {@link #setDeliveryPersistent(boolean)}
+	 * This should have been deprecated in 2.0 when the attribute was
+	 * deprecated in the schema. As of 3.0, the attribute has been
+	 * removed but this remains to allow users of the API to migrate.
+	 * TODO: Remove in 3.1/4.0
 	 */
+	@Deprecated
 	public void setDeliveryMode(int deliveryMode) {
 		this.deliveryMode = deliveryMode;
 	}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
@@ -65,19 +65,8 @@ public class JmsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "priority");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "explicit-qos-enabled");
 
-		String deliveryMode = element.getAttribute("delivery-mode");
 		String deliveryPersistent = element.getAttribute("delivery-persistent");
-		if (StringUtils.hasText(deliveryMode) && StringUtils.hasText(deliveryPersistent)) {
-			parserContext.getReaderContext().error(
-					"The 'delivery-mode' and 'delivery-persistent' attributes are mutually exclusive.", element);
-			return null;
-		}
-		if (StringUtils.hasText(deliveryMode)) {
-			parserContext.getReaderContext().warning(
-					"The 'delivery-mode' attribute is deprecated. Use 'delivery-persistent' instead.", element);
-			builder.addPropertyValue("deliveryMode", deliveryMode);
-		}
-		else if (StringUtils.hasText(deliveryPersistent)) {
+		if (StringUtils.hasText(deliveryPersistent)) {
 			builder.addPropertyValue("deliveryPersistent", deliveryPersistent);
 		}
 		Element container = DomUtils.getChildElementByTagName(element, "reply-listener");

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-3.0.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-3.0.xsd
@@ -924,6 +924,11 @@
 			</xsd:attribute>
 			<xsd:attribute name="destination-resolver" type="xsd:string">
 				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	A reference to the DestinationResolver strategy for resolving Destination names
+	to Destination objects. Used when a reqest/reply destination name is provided, or
+	an expression that resolves to a name. Default is a DynamicDestinationResolver.
+				]]></xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
 							<tool:expected-type type="org.springframework.jms.support.destination.DestinationResolver"/>
@@ -933,6 +938,9 @@
 			</xsd:attribute>
 			<xsd:attribute name="connection-factory" type="xsd:string" default="connectionFactory">
 				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	The name of a ConnectionFactory bean. Default is 'connectionFactory'.
+				]]></xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
 							<tool:expected-type type="javax.jms.ConnectionFactory"/>
@@ -960,20 +968,31 @@
 							<tool:expected-type type="org.springframework.integration.jms.JmsHeaderMapper"/>
 						</tool:annotation>
 						<xsd:documentation>
-						Allows to specify custom implementation of JmsHeaderMapper to map Message Headers to JMS Message.
+	A reference to an implementation of JmsHeaderMapper to map Message Headers to JMS Message. Default
+	is a 'DefaultJmsHeaderMapper'.
 						</xsd:documentation>
 					</xsd:appinfo>
 				</xsd:annotation>
 			</xsd:attribute>
-			<xsd:attribute name="extract-request-payload" type="xsd:string" default="true"/>
-			<xsd:attribute name="extract-reply-payload" type="xsd:string" default="true"/>
-			<xsd:attribute name="delivery-mode" type="xsd:string">
+			<xsd:attribute name="extract-request-payload" type="xsd:string" default="true">
 				<xsd:annotation>
-					<xsd:documentation><![CDATA[
-	[DEPRECATED - use delivery-persistent attribute instead]
-	A reference to the MessageConverter strategy for converting between JMS Messages
-	and the Spring Integration Message payloads. Default is a SimpleMessageConverter.
-					]]></xsd:documentation>
+					<xsd:documentation>
+	When 'true' (default), this attribute indicates that the JMS Message body will be created
+	(by the MessageConverter) from the Spring Integration Message's payload.
+	When 'false', the entire Spring Integration Message will be converted to the JMS Message body.
+	In both cases, the message headers will be mapped to JMS headers/properties by the HeaderMapper.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="extract-reply-payload" type="xsd:string" default="true">
+				<xsd:annotation>
+					<xsd:documentation>
+	When 'true' (default), this attribute indicates that the payload of the Spring Integration
+	reply message will be created from the 'JMS Message' body (by the MessageConverter).
+	When 'false', the Spring Integration Message payload will be the entire JMS Message.
+	In both cases, the JMS Message headers/properties will be mapped to message headers
+	by the HeaderMapper.
+					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="delivery-persistent" type="xsd:string">


### PR DESCRIPTION
delivery-mode was deprecated (in favor of delivery-persistent)
in 2.0. Remove attribute from schema and parser.

Unfortunately, the setter on the gateway was never deprecated
so there is a possibility someone is using it programmatically,
with no knowledge that it is going away.

Deprecated the setter.

Also, added schema documentation for several attributes where
no documentation was provided.
