### PR TITLE
INT-2916 - Upgrade to JUnit 4.11 in support of JDK7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,8 @@ subprojects { subproject ->
 	apply plugin: 'eclipse'
 	apply plugin: 'idea'
 
-	// ensure JDK 5 compatibility (GRADLE-18; INT-1578)
-	sourceCompatibility=1.5
-	targetCompatibility=1.5
+	sourceCompatibility=1.6
+	targetCompatibility=1.6
 
 	ext {
 		aspectjVersion = '1.6.8'
@@ -38,9 +37,10 @@ subprojects { subproject ->
 		commonsNetVersion = '3.0.1'
 		easymockVersion = '2.3'
 		groovyVersion = '2.1.0'
+		hamcrestVersion = '1.3'
 		jacksonVersion = '1.9.2'
 		javaxActivationVersion = '1.1.1'
-		junitVersion = '4.8.2'
+		junitVersion = '4.11'
 		log4jVersion = '1.2.12'
 		mockitoVersion = '1.9.0'
 
@@ -82,11 +82,13 @@ subprojects { subproject ->
 	// dependencies that are common across all java projects
 	dependencies {
 		testCompile "cglib:cglib-nodep:$cglibVersion"
-		testCompile "junit:junit-dep:$junitVersion"
+		testCompile("junit:junit:$junitVersion") {
+			exclude group: 'org.hamcrest', module: 'hamcrest-core'
+		}
 		testCompile "log4j:log4j:$log4jVersion"
 		testCompile "org.easymock:easymock:$easymockVersion"
 		testCompile "org.easymock:easymockclassextension:$easymockVersion"
-		testCompile "org.hamcrest:hamcrest-all:1.1"
+		testCompile "org.hamcrest:hamcrest-all:$hamcrestVersion"
 		testCompile "org.mockito:mockito-all:$mockitoVersion"
 		testCompile "org.springframework:spring-test:$springVersion"
 		jacoco group: "org.jacoco", name: "org.jacoco.agent", version: "0.5.6.201201232323", classifier: "runtime"
@@ -232,6 +234,7 @@ project('spring-integration-gemfire') {
 		compile "org.springframework:spring-tx:$springVersion"
 		testCompile project(":spring-integration-stream")
 		testCompile project(":spring-integration-test")
+
 	}
 }
 
@@ -482,7 +485,10 @@ project('spring-integration-test') {
 	description = 'Spring Integration Test Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile "junit:junit-dep:$junitVersion"
+		compile("junit:junit:$junitVersion") {
+			exclude group: 'org.hamcrest', module: 'hamcrest-core'
+		}
+		compile "org.hamcrest:hamcrest-all:$hamcrestVersion"
 		compile "org.mockito:mockito-all:$mockitoVersion"
 		compile "org.springframework:spring-context:$springVersion"
 		compile "org.springframework:spring-test:$springVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ subprojects { subproject ->
 	apply plugin: 'eclipse'
 	apply plugin: 'idea'
 
-	sourceCompatibility=1.6
-	targetCompatibility=1.6
+	sourceCompatibility=1.7
+	targetCompatibility=1.7
 
 	ext {
 		aspectjVersion = '1.6.8'

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ subprojects { subproject ->
 	apply plugin: 'eclipse'
 	apply plugin: 'idea'
 
-	sourceCompatibility=1.7
-	targetCompatibility=1.7
+	sourceCompatibility=1.6
+	targetCompatibility=1.6
 
 	ext {
 		aspectjVersion = '1.6.8'
@@ -42,7 +42,7 @@ subprojects { subproject ->
 		javaxActivationVersion = '1.1.1'
 		junitVersion = '4.11'
 		log4jVersion = '1.2.12'
-		mockitoVersion = '1.9.0'
+		mockitoVersion = '1.9.5'
 
 		springVersionDefault = '3.1.3.RELEASE'
 		springVersion = project.hasProperty('springVersion') ? getProperty('springVersion') : springVersionDefault
@@ -299,8 +299,8 @@ project('spring-integration-jdbc') {
 		testCompile "org.apache.derby:derby:10.5.3.0_1"
 		testCompile "org.apache.derby:derbyclient:10.5.3.0_1"
 
-		testCompile "org.powermock:powermock-module-junit4:1.4.12"
-		testCompile "org.powermock:powermock-api-mockito:1.4.12"
+		testCompile "org.powermock:powermock-module-junit4:1.5"
+		testCompile "org.powermock:powermock-api-mockito:1.5"
 
 		testCompile "postgresql:postgresql:9.1-901-1.jdbc4"
 		testCompile "mysql:mysql-connector-java:5.1.21"

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -314,8 +314,6 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 	 * Required since Content-Type can be represented as org.springframework.http.MediaType
 	 * see INT-2713 for more details
 	 *
-	 * @param headers
-	 * @return
 	 */
 	private String extractContentTypeAsString(Map<String, Object> headers){
 		String contentTypeStringValue = null;

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,12 +44,13 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.ReflectionUtils;
 
-import static junit.framework.Assert.assertEquals;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 /**
  * @author Mark Fisher
+ * @author Gunnar Hillert
+ *
  * @since 2.1
  */
 @ContextConfiguration
@@ -77,12 +78,12 @@ public class AmqpInboundGatewayParserTests {
 		assertEquals(Boolean.FALSE, TestUtils.getPropertyValue(gateway, "autoStartup"));
 		assertEquals(123, TestUtils.getPropertyValue(gateway, "phase"));
 	}
-	
+
 	@SuppressWarnings("rawtypes")
 	@Test
 	public void verifyUsageWithHeaderMapper() throws Exception{
 		DirectChannel requestChannel = context.getBean("requestChannel", DirectChannel.class);
-		requestChannel.subscribe(new MessageHandler() {		
+		requestChannel.subscribe(new MessageHandler() {
 			public void handleMessage(org.springframework.integration.Message<?> siMessage)
 					throws MessagingException {
 				org.springframework.integration.Message<?> replyMessage = MessageBuilder.fromMessage(siMessage).setHeader("bar", "bar").build();
@@ -90,14 +91,14 @@ public class AmqpInboundGatewayParserTests {
 				replyChannel.send(replyMessage);
 			}
 		});
-		
+
 		final AmqpInboundGateway gateway = context.getBean("withHeaderMapper", AmqpInboundGateway.class);
-		
+
 		Field amqpTemplateField = ReflectionUtils.findField(AmqpInboundGateway.class, "amqpTemplate");
 		amqpTemplateField.setAccessible(true);
 		RabbitTemplate amqpTemplate = TestUtils.getPropertyValue(gateway, "amqpTemplate", RabbitTemplate.class);
 		amqpTemplate = Mockito.spy(amqpTemplate);
-			
+
 		Mockito.doAnswer(new Answer() {
 		      public Object answer(InvocationOnMock invocation) {
 		          Object[] args = invocation.getArguments();
@@ -109,8 +110,8 @@ public class AmqpInboundGatewayParserTests {
 		 .when(amqpTemplate).send(Mockito.any(String.class), Mockito.any(String.class),
 				 Mockito.any(Message.class), Mockito.any(CorrelationData.class));
 		ReflectionUtils.setField(amqpTemplateField, gateway, amqpTemplate);
-		
-		AbstractMessageListenerContainer mlc = 
+
+		AbstractMessageListenerContainer mlc =
 				TestUtils.getPropertyValue(gateway, "messageListenerContainer", AbstractMessageListenerContainer.class);
 		MessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener", MessageListener.class);
 		MessageProperties amqpProperties = new MessageProperties();
@@ -124,7 +125,7 @@ public class AmqpInboundGatewayParserTests {
 		amqpProperties.setHeader("bar", "bar");
 		Message amqpMessage = new Message("hello".getBytes(), amqpProperties);
 		listener.onMessage(amqpMessage);
-		
+
 		Mockito.verify(amqpTemplate, Mockito.times(1)).send(Mockito.any(String.class), Mockito.any(String.class),
 				Mockito.any(Message.class), Mockito.any(CorrelationData.class));
 	}

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.amqp.config;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -74,6 +74,7 @@ import com.rabbitmq.client.Channel;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Gunnar Hillert
  * @since 2.1
  */
 @ContextConfiguration

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.integration.amqp.config;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;

--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationAdvisor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationAdvisor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ import org.springframework.util.Assert;
  * An advisor that will apply the {@link MessagePublishingInterceptor} to any
  * methods containing the provided annotations. If no annotations are provided,
  * the default will be {@link Publisher @Publisher}.
- * 
+ *
  * @author Mark Fisher
  * @since 2.0
  */
@@ -55,7 +55,7 @@ public class PublisherAnnotationAdvisor extends AbstractPointcutAdvisor implemen
 
 	private final MessagePublishingInterceptor interceptor;
 
-
+	@SuppressWarnings("unchecked") //For JDK7
 	public PublisherAnnotationAdvisor(Class<? extends Annotation> ... publisherAnnotationTypes) {
 		this.publisherAnnotationTypes = new HashSet<Class<? extends Annotation>>(Arrays.asList(publisherAnnotationTypes));
 		PublisherMetadataSource metadataSource = new MethodAnnotationPublisherMetadataSource(this.publisherAnnotationTypes);

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors
+ * Copyright 2002-2013 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -252,12 +252,10 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 
 	/**
 	 * Will enrich Message with additional meta headers
-	 * @param message
-	 * @return
 	 */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private Message<?> enrichMessage(Message<?> message){
-    	Message<?> enrichedMessage = MessageBuilder.fromMessage(message).setHeader(CREATED_DATE, System.currentTimeMillis()).build();
+		Message<?> enrichedMessage = MessageBuilder.fromMessage(message).setHeader(CREATED_DATE, System.currentTimeMillis()).build();
 		Map innerMap = (Map) new DirectFieldAccessor(enrichedMessage.getHeaders()).getPropertyValue("headers");
 		innerMap.put(MessageHeaders.ID, message.getHeaders().getId());
 		innerMap.put(MessageHeaders.TIMESTAMP, message.getHeaders().getTimestamp());

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ExpressionEvaluatingCorrelationStrategyTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ExpressionEvaluatingCorrelationStrategyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,6 +14,7 @@
 package org.springframework.integration.aggregator;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
@@ -33,6 +34,7 @@ import org.springframework.integration.support.MessageBuilder;
 /**
  * @author Alex Peters
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class ExpressionEvaluatingCorrelationStrategyTests {
 
@@ -56,7 +58,7 @@ public class ExpressionEvaluatingCorrelationStrategyTests {
 		Expression expression = parser.parseExpression("payload.substring(0,1)");
 		strategy = new ExpressionEvaluatingCorrelationStrategy(expression);
 		Object correlationKey = strategy.getCorrelationKey(new GenericMessage<String>("bla"));
-		assertThat(correlationKey, is(String.class));
+		assertThat(correlationKey, is(instanceOf(String.class)));
 		assertThat((String) correlationKey, is("b"));
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessorTests.java
@@ -16,13 +16,6 @@
 
 package org.springframework.integration.aggregator;
 
-import static junit.framework.Assert.assertTrue;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,6 +44,15 @@ import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
+
+import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MethodInvokingMessageGroupProcessorTests {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingReleaseStrategyTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingReleaseStrategyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,7 +187,7 @@ public class MethodInvokingReleaseStrategyTests {
 		}
 		// TODO: this is stupid, but maybe it should be illegal?
 		new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), TestReleaseStrategy.class.getMethod(
-				"notEnoughParameters", new Class[] {}));
+				"notEnoughParameters"));
 	}
 
 	@Test
@@ -238,7 +238,7 @@ public class MethodInvokingReleaseStrategyTests {
 			}
 		}
 		ReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
-				TestReleaseStrategy.class.getMethod("listSubclassParameter", new Class[] { LinkedList.class }));
+				TestReleaseStrategy.class.getMethod("listSubclassParameter", new Class<?>[] { LinkedList.class }));
 		MessageGroup messages = createListOfMessages(3);
 		Assert.assertTrue(adapter.canRelease(messages));
 	}
@@ -253,7 +253,7 @@ public class MethodInvokingReleaseStrategyTests {
 			}
 		}
 		new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), TestReleaseStrategy.class.getMethod(
-				"wrongReturnType", new Class[] { List.class }));
+				"wrongReturnType", new Class<?>[] { List.class }));
 	}
 
 	private static MessageGroup createListOfMessages(int size) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/DefaultMessageAggregatorIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/DefaultMessageAggregatorIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.aggregator.integration;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -39,6 +40,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Alex Peters
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -60,7 +62,7 @@ public class DefaultMessageAggregatorIntegrationTests {
 			input.send(new GenericMessage<Integer>(i, headers));
 		}
 		Object payload = output.receive().getPayload();
-		assertThat(payload, is(List.class));
+		assertThat(payload, is(instanceOf(List.class)));
 		assertTrue(payload + " doesn't contain all of {0,1,2,3,4}",
 				((List) payload).containsAll(Arrays.asList(0, 1, 2, 3, 4)));
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/scenarios/AggregationResendTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/scenarios/AggregationResendTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.springframework.integration.aggregator.scenarios;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -37,6 +37,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * Tests courtesy of Sean Crotty (INT-1093)
  *
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -56,7 +57,7 @@ public class AggregationResendTests {
 	 * We expect to get back only one Message from the aggregator. We set an
 	 * explicit timeout value of 1 second on the aggregator. What we'll see is
 	 * that we get one aggregate Message back immediately.
-	 * 
+	 *
 	 * <p>We should <emphasis>not</emphasis> get another 3 after the 1 second.
 	 */
 	@Test
@@ -70,7 +71,7 @@ public class AggregationResendTests {
 	 * explicit timeout value on the aggregator, but it automatically times out
 	 * after 60 seconds. What we'll see is that we get one aggregate Message back
 	 * immediately.
-	 * 
+	 *
 	 * <p>We should <emphasis>not</emphasis> get another 3 after the 60 seconds.
 	 */
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/aop/AnnotationConfigRegistrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aop/AnnotationConfigRegistrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.aop;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +32,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration

--- a/spring-integration-core/src/test/java/org/springframework/integration/aop/MessagePublishingInterceptorUsageTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aop/MessagePublishingInterceptorUsageTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.aop;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +28,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration
@@ -49,7 +50,7 @@ public class MessagePublishingInterceptorUsageTests {
 		Assert.assertEquals("John Doe", message.getPayload());
 		Assert.assertEquals("bar", message.getHeaders().get("foo"));
 	}
-	
+
 
 	public static class TestBean {
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelParserTests.java
@@ -81,9 +81,9 @@ public class ChannelParserTests {
 		assertEquals(DirectChannel.class, channel.getClass());
 		DirectFieldAccessor accessor = new DirectFieldAccessor(channel);
 		Object dispatcher = accessor.getPropertyValue("dispatcher");
-		assertThat(dispatcher, instanceOf(UnicastingDispatcher.class));
+		assertThat(dispatcher, is(instanceOf(UnicastingDispatcher.class)));
 		assertThat(new DirectFieldAccessor(dispatcher).getPropertyValue("loadBalancingStrategy"),
-				instanceOf(RoundRobinLoadBalancingStrategy.class));
+				is(instanceOf(RoundRobinLoadBalancingStrategy.class)));
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.channel.config;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -28,7 +29,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.concurrent.Executor;
 
 import org.junit.Test;
-
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.FatalBeanException;
 import org.springframework.context.ApplicationContext;
@@ -50,7 +50,8 @@ import org.springframework.integration.util.ErrorHandlingTaskExecutor;
 /**
  * @author Mark Fisher
  * @author Iwein Fuld
- * 
+ * @author Gunnar Hillert
+ *
  * @see ChannelWithCustomQueueParserTests
  */
 public class ChannelParserTests {
@@ -80,9 +81,9 @@ public class ChannelParserTests {
 		assertEquals(DirectChannel.class, channel.getClass());
 		DirectFieldAccessor accessor = new DirectFieldAccessor(channel);
 		Object dispatcher = accessor.getPropertyValue("dispatcher");
-		assertThat(dispatcher, is(UnicastingDispatcher.class));
+		assertThat(dispatcher, instanceOf(UnicastingDispatcher.class));
 		assertThat(new DirectFieldAccessor(dispatcher).getPropertyValue("loadBalancingStrategy"),
-				is(RoundRobinLoadBalancingStrategy.class));
+				instanceOf(RoundRobinLoadBalancingStrategy.class));
 	}
 
 	@Test
@@ -93,7 +94,7 @@ public class ChannelParserTests {
 		assertEquals(DirectChannel.class, channel.getClass());
 		DirectFieldAccessor accessor = new DirectFieldAccessor(channel);
 		Object dispatcher = accessor.getPropertyValue("dispatcher");
-		assertThat(dispatcher, is(UnicastingDispatcher.class));
+		assertThat(dispatcher, is(instanceOf(UnicastingDispatcher.class)));
 		assertNull(new DirectFieldAccessor(dispatcher).getPropertyValue("loadBalancingStrategy"));
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelWithCustomQueueParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelWithCustomQueueParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,9 +35,10 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * Testcases for detailed namespace support for &lt;queue/> element under
  * &lt;channel/>
- * 
+ *
  * @author Iwein Fuld
- * 
+ * @author Gunnar Hillert
+ *
  * @see ChannelWithCustomQueueParserTests
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -52,13 +53,13 @@ public class ChannelWithCustomQueueParserTests {
 	public void parseConfig() throws Exception {
 		assertNotNull(customQueueChannel);
 	}
-	
+
 	@Test
 	public void queueTypeSet() throws Exception {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(customQueueChannel);
 		Object queue = accessor.getPropertyValue("queue");
 		assertNotNull(queue);
-		assertThat(queue, is(ArrayBlockingQueue.class));
+		assertThat(queue, instanceOf(ArrayBlockingQueue.class));
 		assertThat(((BlockingQueue<?>)queue).remainingCapacity(), is(2));
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelWithCustomQueueParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelWithCustomQueueParserTests.java
@@ -59,7 +59,7 @@ public class ChannelWithCustomQueueParserTests {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(customQueueChannel);
 		Object queue = accessor.getPropertyValue("queue");
 		assertNotNull(queue);
-		assertThat(queue, instanceOf(ArrayBlockingQueue.class));
+		assertThat(queue, is(instanceOf(ArrayBlockingQueue.class)));
 		assertThat(((BlockingQueue<?>)queue).remainingCapacity(), is(2));
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
@@ -16,12 +16,6 @@
 
 package org.springframework.integration.config;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +49,13 @@ import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Marius Bogoevici
@@ -62,6 +63,7 @@ import org.springframework.integration.test.util.TestUtils;
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Gunnar Hillert
  */
 public class AggregatorParserTests {
 
@@ -119,7 +121,7 @@ public class AggregatorParserTests {
 		MessageChannel outputChannel = (MessageChannel) context.getBean("outputChannel");
 		MessageChannel discardChannel = (MessageChannel) context.getBean("discardChannel");
 		Object consumer = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		assertThat(consumer, is(AggregatingMessageHandler.class));
+		assertThat(consumer, is(instanceOf(AggregatingMessageHandler.class)));
 		DirectFieldAccessor accessor = new DirectFieldAccessor(consumer);
 		Map<?, ?> map = (Map<?, ?>) new DirectFieldAccessor(new DirectFieldAccessor(new DirectFieldAccessor(accessor
 				.getPropertyValue("outputProcessor")).getPropertyValue("processor")).getPropertyValue("delegate"))

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorWithCorrelationStrategyTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorWithCorrelationStrategyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorWithCorrelationStrategyTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorWithCorrelationStrategyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,11 +35,12 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import java.util.List;
 
 import static org.junit.Assert.assertThat;
-import static org.junit.matchers.JUnitMatchers.containsString;
+import static org.hamcrest.CoreMatchers.containsString;
 
 /**
  * @author Marius Bogoevici
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserTests.java
@@ -23,8 +23,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.matchers.JUnitMatchers.both;
-import static org.junit.matchers.JUnitMatchers.containsString;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -66,6 +64,7 @@ import org.springframework.util.StringUtils;
  * @author Iwein Fuld
  * @author Dave Turanski
  * @author Artem Bilan
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -309,7 +308,8 @@ public class ChainParserTests {
 		}
 		catch (BeansException e) {
 			assertEquals(IllegalArgumentException.class, e.getCause().getClass());
-			assertThat(e.getMessage(), both(containsString("output channel was provided")).and(containsString("does not implement the MessageProducer")));
+			assertTrue(e.getMessage().contains("output channel was provided"));
+			assertTrue(e.getMessage().contains("does not implement the MessageProducer"));
 			throw e;
 		}
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ClaimCheckParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ClaimCheckParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.config.xml;
 
-import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -43,6 +43,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration
@@ -54,7 +55,7 @@ public class ClaimCheckParserTests {
 
 	@Autowired
 	private MessageChannel checkinChannel;
-	
+
 	@Autowired
 	private MessageChannel checkinChannelA;
 
@@ -66,7 +67,7 @@ public class ClaimCheckParserTests {
 
 	@Autowired
 	private EventDrivenConsumer checkout;
-	
+
 	@Autowired
 	private MessageStore sampleMessageStore;
 
@@ -86,7 +87,7 @@ public class ClaimCheckParserTests {
 				new DirectFieldAccessor(checkout).getPropertyValue("handler")).getPropertyValue("transformer");
 		MessageStore messageStore = (MessageStore)
 				new DirectFieldAccessor(transformer).getPropertyValue("messageStore");
-		assertEquals(context.getBean("testMessageStore"), messageStore);		
+		assertEquals(context.getBean("testMessageStore"), messageStore);
 	}
 
 	@Test
@@ -103,9 +104,9 @@ public class ClaimCheckParserTests {
 		assertEquals("test", resultMessage.getPayload());
 		assertNotNull(this.sampleMessageStore.getMessage(payload));
 	}
-	
+
 	@Test
-	public void integrationTestWithRemoval() {	
+	public void integrationTestWithRemoval() {
 		QueueChannel replyChannel = new QueueChannel();
 		Message<?> message = MessageBuilder.withPayload("test").setReplyChannel(replyChannel).build();
 		checkinChannelA.send(message);

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ControlBusTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ControlBusTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.config.xml;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -39,6 +39,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Dave Syer
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration
@@ -58,12 +59,12 @@ public class ControlBusTests {
 		assertEquals("catbar", output.receive(0).getPayload());
 		assertNull(output.receive(0));
 	}
-	
+
 	@Test
 	public void testLifecycleMethods() {
 		ApplicationContext context = new ClassPathXmlApplicationContext("ControlBusLifecycleTests-context.xml", this.getClass());
-		MessageChannel inputChannel = context.getBean("inputChannel", MessageChannel.class);  
-		PollableChannel outputChannel = context.getBean("outputChannel", PollableChannel.class);  
+		MessageChannel inputChannel = context.getBean("inputChannel", MessageChannel.class);
+		PollableChannel outputChannel = context.getBean("outputChannel", PollableChannel.class);
 		assertNull(outputChannel.receive(1000));
 		Message<?> message = MessageBuilder.withPayload("@adapter.start()").build();
 		inputChannel.send(message);
@@ -78,7 +79,7 @@ public class ControlBusTests {
 			return "cat";
 		}
 	}
-	
+
 	public static class AdapterService {
 		public Message<String> receive() {
 			return new GenericMessage<String>(new Date().toString());

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import org.springframework.transaction.interceptor.TransactionInterceptor;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Gunnar Hillert
  * @since 1.0.3
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -104,7 +105,7 @@ public class DelayerParserTests {
 	public void transactionalSubElement() {
 		Object endpoint = context.getBean("delayerWithTransactional");
 		DelayHandler delayHandler = TestUtils.getPropertyValue(endpoint, "handler", DelayHandler.class);
-		List adviceChain = TestUtils.getPropertyValue(delayHandler, "delayedAdviceChain", List.class);
+		List<?> adviceChain = TestUtils.getPropertyValue(delayHandler, "delayedAdviceChain", List.class);
 		assertEquals(1, adviceChain.size());
 		Object advice = adviceChain.get(0);
 		assertTrue(advice instanceof TransactionInterceptor);
@@ -121,7 +122,7 @@ public class DelayerParserTests {
 	public void adviceChainSubElement() {
 		Object endpoint = context.getBean("delayerWithAdviceChain");
 		DelayHandler delayHandler = TestUtils.getPropertyValue(endpoint, "handler", DelayHandler.class);
-		List adviceChain = TestUtils.getPropertyValue(delayHandler, "delayedAdviceChain", List.class);
+		List<?> adviceChain = TestUtils.getPropertyValue(delayHandler, "delayedAdviceChain", List.class);
 		assertEquals(2, adviceChain.size());
 		assertSame(context.getBean("testAdviceBean"), adviceChain.get(0));
 
@@ -129,7 +130,7 @@ public class DelayerParserTests {
 		assertEquals(TransactionInterceptor.class, txAdvice.getClass());
 		TransactionAttributeSource transactionAttributeSource = ((TransactionInterceptor) txAdvice).getTransactionAttributeSource();
 		assertEquals(NameMatchTransactionAttributeSource.class, transactionAttributeSource.getClass());
-		HashMap nameMap = TestUtils.getPropertyValue(transactionAttributeSource, "nameMap", HashMap.class);
+		HashMap<?, ?> nameMap = TestUtils.getPropertyValue(transactionAttributeSource, "nameMap", HashMap.class);
 		assertEquals("{*=PROPAGATION_REQUIRES_NEW,ISOLATION_DEFAULT,readOnly}", nameMap.toString());
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ErrorMessageExceptionTypeRouterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ErrorMessageExceptionTypeRouterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.integration.config.xml;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,33 +29,34 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 public class ErrorMessageExceptionTypeRouterParserTests {
-	
+
 	@Autowired
 	private MessageChannel inputChannel;
-	
+
 	@Autowired
 	private QueueChannel defaultChannel;
-	
+
 	@Autowired
 	private QueueChannel illegalChannel;
-	
+
 	@Autowired
 	private QueueChannel npeChannel;
 
 	@Test
 	public void validateExceptionTypeRouterConfig(){
-		
+
 		inputChannel.send(new ErrorMessage(new NullPointerException()));
 		assertTrue(npeChannel.receive(1000).getPayload() instanceof NullPointerException);
-		
+
 		inputChannel.send(new ErrorMessage(new IllegalArgumentException()));
 		assertTrue(illegalChannel.receive(1000).getPayload()  instanceof IllegalArgumentException);
-		
+
 		inputChannel.send(new ErrorMessage(new RuntimeException()));
 		assertTrue(defaultChannel.receive(1000).getPayload()  instanceof RuntimeException);
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/InnerDefinitionHandlerAwareEndpointParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/InnerDefinitionHandlerAwareEndpointParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,12 +52,13 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 public class InnerDefinitionHandlerAwareEndpointParserTests {
 
-	@Autowired 
+	@Autowired
 	private Properties testConfigurations;
 
 	@Test
@@ -65,7 +66,7 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 		String configProperty = testConfigurations.getProperty("splitter-inner-success");
 		this.testSplitterDefinitionSuccess(configProperty);
 	}
-	
+
 	@Test
 	public void testInnerSplitterDefinitionSuccessWithPoller(){
 		String configProperty = testConfigurations.getProperty("splitter-inner-success-with-poller");
@@ -89,7 +90,7 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 		String xmlConfig = testConfigurations.getProperty("splitter-failure-refAndBean");
 		this.bootStrap(xmlConfig);
 	}
-	
+
 	@Test
 	public void testInnerTransformerDefinitionSuccess(){
 		String configProperty = testConfigurations.getProperty("transformer-inner-success");
@@ -101,13 +102,13 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 		String configProperty = testConfigurations.getProperty("transformer-ref-success");
 		this.testTransformerDefinitionSuccess(configProperty);
 	}
-	
+
 	@Test(expected=BeanDefinitionStoreException.class)
 	public void testInnerTransformerDefinitionFailureRefAndInner(){
 		String xmlConfig = testConfigurations.getProperty("transformer-failure-refAndBean");
 		this.bootStrap(xmlConfig);
 	}
-	
+
 	@Test
 	public void testInnerRouterDefinitionSuccess(){
 		String configProperty = testConfigurations.getProperty("router-inner-success");
@@ -119,13 +120,13 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 		String configProperty = testConfigurations.getProperty("router-ref-success");
 		this.testRouterDefinitionSuccess(configProperty);
 	}
-	
+
 	@Test(expected=BeanDefinitionStoreException.class)
 	public void testInnerRouterDefinitionFailureRefAndInner(){
 		String xmlConfig = testConfigurations.getProperty("router-failure-refAndBean");
 		this.bootStrap(xmlConfig);
 	}
-	
+
 	@Test
 	public void testInnerSADefinitionSuccess(){
 		String configProperty = testConfigurations.getProperty("sa-inner-success");
@@ -143,7 +144,7 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 		String xmlConfig = testConfigurations.getProperty("sa-failure-refAndBean");
 		this.bootStrap(xmlConfig);
 	}
-	
+
 	@Test
 	public void testInnerAggregatorDefinitionSuccess(){
 		String configProperty = testConfigurations.getProperty("aggregator-inner-success");
@@ -173,13 +174,13 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 		String xmlConfig = testConfigurations.getProperty("aggregator-failure-refAndBean");
 		this.bootStrap(xmlConfig);
 	}
-	
+
 	@Test
 	public void testInnerFilterDefinitionSuccess(){
 		String configProperty = testConfigurations.getProperty("filter-inner-success");
 		this.testFilterDefinitionSuccess(configProperty);
 	}
-	
+
 	@Test
 	public void testRefFilterDefinitionSuccess(){
 		String configProperty = testConfigurations.getProperty("filter-ref-success");
@@ -191,7 +192,7 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 		String xmlConfig = testConfigurations.getProperty("filter-failure-refAndBean");
 		this.bootStrap(xmlConfig);
 	}
-	
+
 	private void testSplitterDefinitionSuccess(String configProperty){
 		ApplicationContext ac = this.bootStrap(configProperty);
 		EventDrivenConsumer splitter = (EventDrivenConsumer) ac.getBean("testSplitter");
@@ -205,7 +206,7 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 		outChannel = (PollableChannel) ac.getBean("outChannel");
 		Assert.assertTrue(outChannel.receive().getPayload() instanceof String);
 	}
-	
+
 	private void testTransformerDefinitionSuccess(String configProperty){
 		ApplicationContext ac = this.bootStrap(configProperty);
 		EventDrivenConsumer transformer = (EventDrivenConsumer) ac.getBean("testTransformer");
@@ -270,7 +271,7 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 		Message<?> reply = output.receive(0);
 		assertEquals("foo", reply.getPayload());
 	}
-	
+
 	private ApplicationContext bootStrap(String configProperty){
 		ByteArrayInputStream stream = new ByteArrayInputStream(configProperty.getBytes());
 		GenericApplicationContext ac = new GenericApplicationContext();
@@ -295,13 +296,13 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 			return CollectionUtils.arrayToList(payload);
 		}
 	}
-	
+
 	public static class TestTransformer{
 		public String split(String[] payload){
 			return StringUtils.arrayToDelimitedString(payload, ",");
 		}
 	}
-	
+
 	public static class TestRouter{
 		public String route(String value) {
 			return (value.equals("1")) ? "channel1" : "channel2";
@@ -313,7 +314,7 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 			return value;
 		}
 	}
-	
+
 	public static class TestAggregator{
 		public Integer sum(List<Integer> numbers) {
 			int result = 0;
@@ -329,5 +330,5 @@ public class InnerDefinitionHandlerAwareEndpointParserTests {
 			return value.equals("foo");
 		}
 	}
-		
+
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/MapToObjectTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/MapToObjectTransformerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.config.xml;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -51,7 +51,7 @@ public class MapToObjectTransformerParserTests {
 	@Autowired
 	@Qualifier("output")
 	private PollableChannel output;
-	
+
 	@Autowired
 	@Qualifier("inputA")
 	private MessageChannel inputA;
@@ -68,12 +68,12 @@ public class MapToObjectTransformerParserTests {
 		Address address = new Address();
 		address.setStreet("1123 Main st");
 		map.put("address", address);
-		
+
 		Message message = MessageBuilder.withPayload(map).build();
 		input.send(message);
-		
+
 		Message outMessage = output.receive();
-		
+
 		Person person = (Person) outMessage.getPayload();
 		assertNotNull(person);
 		assertEquals("Justin", person.getFname());
@@ -92,7 +92,7 @@ public class MapToObjectTransformerParserTests {
 		Address address = new Address();
 		address.setStreet("1123 Main st");
 		map.put("address", address);
-		
+
 		Message message = MessageBuilder.withPayload(map).build();
 		inputA.send(message);
 		Message<?> newMessage =  outputA.receive();
@@ -113,10 +113,10 @@ public class MapToObjectTransformerParserTests {
 		map.put("fname", "Justin");
 		map.put("lname", "Case");
 		map.put("address", "1123 Main st");
-		
+
 		Message message = MessageBuilder.withPayload(map).build();
 		inputA.send(message);
-		
+
 		Message newMessage = outputA.receive();
 		Person person = (Person) newMessage.getPayload();
 		assertNotNull(person);
@@ -140,7 +140,7 @@ public class MapToObjectTransformerParserTests {
 		}
 		public void setSsn(String ssn) {
 			this.ssn = ssn;
-		}	
+		}
 		public String getFname() {
 			return fname;
 		}
@@ -160,7 +160,7 @@ public class MapToObjectTransformerParserTests {
 			this.address = address;
 		}
 	}
-	
+
 	public static class Address {
 		private String street;
 
@@ -172,7 +172,7 @@ public class MapToObjectTransformerParserTests {
 			this.street = street;
 		}
 	}
-	
+
 	public static class StringToAddressConverter implements Converter<String, Address>{
 		public StringToAddressConverter(){}
 		public Address convert(String source) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/MethodInvokingSelectorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/MethodInvokingSelectorParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.config.xml;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -35,6 +36,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -49,9 +51,8 @@ public class MethodInvokingSelectorParserTests {
 	public void configOK() throws Exception {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(chain);
 		List<MessageSelector> selectors = (List<MessageSelector>) accessor.getPropertyValue("selectors");
-		assertThat(selectors.get(0), is(MethodInvokingSelector.class));
+		assertThat(selectors.get(0), is(instanceOf(MethodInvokingSelector.class)));
 	}
-
 
 	public static class TestFilter {
 		public boolean accept(Message<?> m) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ObjectToMapTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ObjectToMapTransformerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,11 +38,12 @@ import org.springframework.integration.transformer.MessageTransformationExceptio
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -64,10 +65,10 @@ public class ObjectToMapTransformerParserTests {
 		StandardEvaluationContext context = new StandardEvaluationContext(employee);
 		context.addPropertyAccessor(new MapAccessor());
 		ExpressionParser parser = new SpelExpressionParser();
-		
+
 		Message<Employee> message = MessageBuilder.withPayload(employee).build();
 		directInput.send(message);
-		
+
 		Message<Map<String, Object>> outputMessage = (Message<Map<String, Object>>) output.receive();
 		Map<String, Object> transformedMap = outputMessage.getPayload();
 		assertNotNull(outputMessage.getPayload());
@@ -76,12 +77,12 @@ public class ObjectToMapTransformerParserTests {
 			Object valueFromTheMap = transformedMap.get(key);
 			Object valueFromExpression = expression.getValue(context);
 			assertEquals(valueFromTheMap, valueFromExpression);
-		}		
+		}
 	}
 	@Test(expected=MessageTransformationException.class)
 	public void testObjectToSpelMapTransformerWithCycle(){
 		Employee employee = this.buildEmployee();
-		Child child = new Child();	
+		Child child = new Child();
 		Person parent = employee.getPerson();
 		parent.setChild(child);
 		child.setParent(parent);
@@ -95,12 +96,12 @@ public class ObjectToMapTransformerParserTests {
 		companyAddress.setCity("Philadelphia");
 		companyAddress.setStreet("1123 Main");
 		companyAddress.setZip("12345");
-		
+
 		Map<String, Integer[]> coordinates = new HashMap<String, Integer[]>();
 		coordinates.put("latitude", new Integer[]{1, 5, 13});
 		coordinates.put("longitude", new Integer[]{156});
 		companyAddress.setCoordinates(coordinates);
-		
+
 		Employee employee = new Employee();
 		employee.setCompanyName("ABC Inc.");
 		employee.setCompanyAddress(companyAddress);
@@ -108,7 +109,7 @@ public class ObjectToMapTransformerParserTests {
 		departments.add("HR");
 		departments.add("IT");
 		employee.setDepartments(departments);
-		
+
 		Person person = new Person();
 		person.setFname("Justin");
 		person.setLname("Case");
@@ -123,7 +124,7 @@ public class ObjectToMapTransformerParserTests {
 		mapWithListTestData.put("mapWithListTestData", listTestData);
 		personAddress.setMapWithListData(mapWithListTestData);
 		person.setAddress(personAddress);
-		
+
 		Map<String, Object> remarksA = new HashMap<String, Object>();
 		Map<String, Object> remarksB = new HashMap<String, Object>();
 		remarksA.put("foo", "foo");
@@ -134,22 +135,22 @@ public class ObjectToMapTransformerParserTests {
 		remarks.add(remarksB);
 		person.setRemarks(remarks);
 		employee.setPerson(person);
-		
+
 		Map<String, Map<String, Object>> testMapData = new HashMap<String, Map<String, Object>>();
-		
+
 		Map<String, Object> internalMapA = new HashMap<String, Object>();
 		internalMapA.put("foo", "foo");
 		internalMapA.put("bar", "bar");
 		Map<String, Object> internalMapB = new HashMap<String, Object>();
 		internalMapB.put("baz", "baz");
-		
+
 		testMapData.put("internalMapA", internalMapA);
 		testMapData.put("internalMapB", internalMapB);
-		
+
 		employee.setTestMapInMapData(testMapData);
 		return employee;
 	}
-	
+
 	public static class Employee{
 		private List<String> departments;
 		private String companyName;
@@ -188,7 +189,7 @@ public class ObjectToMapTransformerParserTests {
 			this.departments = departments;
 		}
 	}
-	
+
 	public static class Person{
 		private String fname;
 		private String lname;
@@ -233,7 +234,7 @@ public class ObjectToMapTransformerParserTests {
 			this.address = address;
 		}
 	}
-	
+
 	public static class Address{
 		private String street;
 		private String city;
@@ -271,7 +272,7 @@ public class ObjectToMapTransformerParserTests {
 			this.coordinates = coordinates;
 		}
 	}
-	
+
 	public static class Child {
 		private Person parent;
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PollerWithErrorChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PollerWithErrorChannelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.integration.config.xml;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -36,6 +36,7 @@ import org.springframework.integration.message.GenericMessage;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 public class PollerWithErrorChannelTests {
@@ -43,13 +44,13 @@ public class PollerWithErrorChannelTests {
 	@Test
 	/*
 	 * Although adapter configuration specifies header-enricher pointing to the 'eChannel' as errorChannel
-	 * the ErrorMessage will still be forwarded to the 'errorChannel' since exception occurs on 
+	 * the ErrorMessage will still be forwarded to the 'errorChannel' since exception occurs on
 	 * receive() and not on send()
 	 */
 	public void testWithErrorChannelAsHeader() throws Exception{
 		ApplicationContext ac = new ClassPathXmlApplicationContext("PollerWithErrorChannel-context.xml", this.getClass());
 		SourcePollingChannelAdapter adapter = ac.getBean("withErrorHeader", SourcePollingChannelAdapter.class);
-		
+
 		SubscribableChannel errorChannel = ac.getBean("errorChannel", SubscribableChannel.class);
 		MessageHandler handler = mock(MessageHandler.class);
 		errorChannel.subscribe(handler);
@@ -58,7 +59,7 @@ public class PollerWithErrorChannelTests {
 		verify(handler, atLeastOnce()).handleMessage(Mockito.any(Message.class));
 		adapter.stop();
 	}
-	
+
 	@Test
 	public void testWithErrorChannel() throws Exception{
 		ApplicationContext ac = new ClassPathXmlApplicationContext("PollerWithErrorChannel-context.xml", this.getClass());
@@ -68,7 +69,7 @@ public class PollerWithErrorChannelTests {
 		assertNotNull(errorChannel.receive(1000));
 		adapter.stop();
 	}
-	
+
 	@Test
 	public void testWithErrorChannelAndHeader() throws Exception{
 		ApplicationContext ac = new ClassPathXmlApplicationContext("PollerWithErrorChannel-context.xml", this.getClass());
@@ -78,8 +79,8 @@ public class PollerWithErrorChannelTests {
 		assertNotNull(errorChannel.receive(1000));
 		adapter.stop();
 	}
-	
-	@Test 
+
+	@Test
 	// config the same as above but the error wil come from the send
 	public void testWithErrorChannelAndHeaderWithSendFailure() throws Exception{
 		ApplicationContext ac = new ClassPathXmlApplicationContext("PollerWithErrorChannel-context.xml", this.getClass());
@@ -89,8 +90,8 @@ public class PollerWithErrorChannelTests {
 		assertNotNull(errorChannel.receive(1000));
 		adapter.stop();
 	}
-	
-	@Test 
+
+	@Test
 	// INT-1952
 	public void testWithErrorChannelAndPollingConsumer() throws Exception{
 		ApplicationContext ac = new ClassPathXmlApplicationContext("PollerWithErrorChannel-context.xml", this.getClass());
@@ -99,7 +100,7 @@ public class PollerWithErrorChannelTests {
 		serviceWithPollerChannel.send(new GenericMessage<String>(""));
 		assertNotNull(errChannel.receive(1000));
 	}
-	
+
 	public static class SampleService{
 		public String withSuccess(){
 			return "hello";

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PublishingInterceptorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PublishingInterceptorParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.config.xml;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
@@ -37,6 +37,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration

--- a/spring-integration-core/src/test/java/org/springframework/integration/core/MessageIdGenerationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/core/MessageIdGenerationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.core;
 
-import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
@@ -39,6 +39,7 @@ import org.springframework.util.StopWatch;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 
 public class MessageIdGenerationTests {
@@ -56,7 +57,7 @@ public class MessageIdGenerationTests {
 		parent.close();
 		this.assertDestroy();
 	}
-	
+
 	@Test
 	public void testCustomIdGenerationWithParentChileIndependentCreation() throws Exception{
 		ClassPathXmlApplicationContext parent = new ClassPathXmlApplicationContext("MessageIdGenerationTests-context-withGenerator.xml", this.getClass());
@@ -73,7 +74,7 @@ public class MessageIdGenerationTests {
 		parent.close();
 		this.assertDestroy();
 	}
-	
+
 	@Test
 	public void testCustomIdGenerationWithParentRegistrarClosed() throws Exception {
 		ClassPathXmlApplicationContext parent = new ClassPathXmlApplicationContext("MessageIdGenerationTests-context-withGenerator.xml", this.getClass());
@@ -87,7 +88,7 @@ public class MessageIdGenerationTests {
 		child.close();
 		this.assertDestroy();
 	}
-	
+
 	@Test
 	public void testCustomIdGenerationWithChildRegistrar() throws Exception{
 		ClassPathXmlApplicationContext parent = new ClassPathXmlApplicationContext("MessageIdGenerationTests-context.xml", this.getClass());
@@ -102,7 +103,7 @@ public class MessageIdGenerationTests {
 		child.close();
 		this.assertDestroy();
 	}
-	
+
 	@Test
 	public void testCustomIdGenerationWithChildRegistrarClosed() throws Exception{
 		ClassPathXmlApplicationContext parent = new ClassPathXmlApplicationContext("MessageIdGenerationTests-context.xml", this.getClass());
@@ -122,19 +123,19 @@ public class MessageIdGenerationTests {
 	@Test
 	public void testCustomIdGenerationWithParentChildIndependentCreationChildrenRegistrarsOneAtTheTime() throws Exception{
 		ClassPathXmlApplicationContext parent = new ClassPathXmlApplicationContext("MessageIdGenerationTests-context.xml", this.getClass());
-		
+
 		GenericXmlApplicationContext childA = new GenericXmlApplicationContext();
 		childA.load("classpath:/org/springframework/integration/core/MessageIdGenerationTests-context-withGenerator.xml");
 		childA.setParent(parent);
 		childA.refresh();
-		
+
 		childA.close();
-		
+
 		GenericXmlApplicationContext childB = new GenericXmlApplicationContext();
 		childB.load("classpath:/org/springframework/integration/core/MessageIdGenerationTests-context-withGenerator.xml");
 		childB.setParent(parent);
 		childB.refresh();
-		
+
 		parent.close();
 		childB.close();
 		this.assertDestroy();
@@ -144,7 +145,7 @@ public class MessageIdGenerationTests {
 	@Test(expected=BeanDefinitionStoreException.class)
 	public void testCustomIdGenerationWithParentChildIndependentCreation() throws Exception{
 		ClassPathXmlApplicationContext parent = new ClassPathXmlApplicationContext("MessageIdGenerationTests-context-withGenerator.xml", this.getClass());
-		
+
 		GenericXmlApplicationContext child = new GenericXmlApplicationContext();
 		try {
 			child.load("classpath:/org/springframework/integration/core/MessageIdGenerationTests-context-withGenerator.xml");
@@ -162,7 +163,7 @@ public class MessageIdGenerationTests {
 	@Test(expected=BeanDefinitionStoreException.class)
 	public void testCustomIdGenerationWithParentChildIndependentCreationChildrenRegistrars() throws Exception{
 		ClassPathXmlApplicationContext parent = new ClassPathXmlApplicationContext("MessageIdGenerationTests-context.xml", this.getClass());
-		
+
 		GenericXmlApplicationContext childA = new GenericXmlApplicationContext();
 		GenericXmlApplicationContext childB = new GenericXmlApplicationContext();
 
@@ -170,7 +171,7 @@ public class MessageIdGenerationTests {
 			childA.load("classpath:/org/springframework/integration/core/MessageIdGenerationTests-context-withGenerator.xml");
 			childA.setParent(parent);
 			childA.refresh();
-	
+
 			childB.load("classpath:/org/springframework/integration/core/MessageIdGenerationTests-context-withGenerator.xml");
 			childB.setParent(parent);
 			childB.refresh();
@@ -182,7 +183,7 @@ public class MessageIdGenerationTests {
 			this.assertDestroy();
 		}
 	}
-	
+
 	@Test
 	@Ignore
 	public void performanceTest(){
@@ -197,7 +198,7 @@ public class MessageIdGenerationTests {
 
 		Field idGeneratorField = ReflectionUtils.findField(MessageHeaders.class, "idGenerator");
 		ReflectionUtils.makeAccessible(idGeneratorField);
-		ReflectionUtils.setField(idGeneratorField, null, new IdGenerator() {	
+		ReflectionUtils.setField(idGeneratorField, null, new IdGenerator() {
 			public UUID generateId() {
 				return TimeBasedUUIDGenerator.generateId();
 			}
@@ -209,12 +210,12 @@ public class MessageIdGenerationTests {
 		}
 		watch.stop();
 		double timebasedGeneratorElapsedTime = watch.getTotalTimeSeconds();
-		
+
 		System.out.println("Generated " + times + " messages using default UUID generator " +
 				"in " + defaultGeneratorElapsedTime + " seconds");
 		System.out.println("Generated " + times + " messages using Timebased UUID generator " +
 				"in " + timebasedGeneratorElapsedTime + " seconds");
-		
+
 		System.out.println("Time-based ID generator is " + defaultGeneratorElapsedTime/timebasedGeneratorElapsedTime + " times faster");
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/AggregateMessageDeliveryExceptionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/AggregateMessageDeliveryExceptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.matchers.JUnitMatchers;
+import static org.hamcrest.CoreMatchers.containsString;
 
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageDeliveryException;
@@ -32,6 +32,7 @@ import org.springframework.integration.message.GenericMessage;
 
 /**
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 public class AggregateMessageDeliveryExceptionTests {
 
@@ -60,9 +61,9 @@ public class AggregateMessageDeliveryExceptionTests {
 
 	@Test
 	public void shouldShowOriginalExceptionsInMessage() {
-		assertThat(exception.getMessage(), JUnitMatchers.containsString("first problem"));
-		assertThat(exception.getMessage(), JUnitMatchers.containsString("second problem"));
-		assertThat(exception.getMessage(), JUnitMatchers.containsString("third problem"));
+		assertThat(exception.getMessage(), containsString("first problem"));
+		assertThat(exception.getMessage(), containsString("second problem"));
+		assertThat(exception.getMessage(), containsString("third problem"));
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/TransactionalPollerWithMixedAopConfigTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/TransactionalPollerWithMixedAopConfigTests.java
@@ -1,9 +1,21 @@
-/**
- * 
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.springframework.integration.dispatcher;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.springframework.aop.framework.Advised;
@@ -12,33 +24,34 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  * This test was influenced by INT-1483 where by registering TX Advisor
- * in the BeanFactory while having <aop:config> resent resulted in 
+ * in the BeanFactory while having <aop:config> resent resulted in
  * TX Advisor being applied on all beans in AC
  */
 public class TransactionalPollerWithMixedAopConfigTests {
 
 	@Test
 	public void validateTransactionalProxyIsolationToThePollerOnly(){
-		ApplicationContext context = 
+		ApplicationContext context =
 			new ClassPathXmlApplicationContext("TransactionalPollerWithMixedAopConfig-context.xml", this.getClass());
-		
+
 		assertTrue(!(context.getBean("foo") instanceof Advised));
 		assertTrue(!(context.getBean("inputChannel") instanceof Advised));
 	}
-	
+
 	public static class SampleService{
 		public void foo(String payload){}
 	}
-	
+
 	public static class Foo{
 		public Foo(String value){}
 	}
-	
+
 //	public static class SampleAdvice implements MethodInterceptor{
 //		public Object invoke(MethodInvocation invocation) throws Throwable {
 //			return invocation.proceed();
-//		}	
+//		}
 //	}
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/UnicastingDispatcherTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/UnicastingDispatcherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.springframework.integration.dispatcher;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -33,6 +33,7 @@ import org.springframework.integration.message.GenericMessage;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 public class UnicastingDispatcherTests {
@@ -43,7 +44,7 @@ public class UnicastingDispatcherTests {
 		ApplicationContext context = new ClassPathXmlApplicationContext("unicasting-with-async.xml", this.getClass());
 		SubscribableChannel errorChannel = context.getBean("errorChannel", SubscribableChannel.class);
 		MessageHandler errorHandler = new MessageHandler() {
-			
+
 			public void handleMessage(Message<?> message) throws MessagingException {
 				MessageChannel replyChannel = (MessageChannel) message.getHeaders().getReplyChannel();
 				assertTrue(message.getPayload() instanceof MessageDeliveryException);
@@ -51,10 +52,10 @@ public class UnicastingDispatcherTests {
 			}
 		};
 		errorChannel.subscribe(errorHandler);
-		
+
 		RequestReplyExchanger exchanger = context.getBean(RequestReplyExchanger.class);
 		Message<String> reply = (Message<String>) exchanger.exchange(new GenericMessage<String>("Hello"));
 		assertEquals("reply", reply.getPayload());
 	}
-	
+
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollingLifecycleTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollingLifecycleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.integration.endpoint;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -45,17 +45,18 @@ import org.springframework.scheduling.support.PeriodicTrigger;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 public class PollingLifecycleTests {
 	private ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 	private TestErrorHandler errorHandler = new TestErrorHandler();
-	
+
 	@Before
 	public void init() throws Exception {
 		taskScheduler.afterPropertiesSet();
 	}
-	
+
 	@Test
 	public void ensurePollerTaskStops() throws Exception{
 		final CountDownLatch latch = new CountDownLatch(1);
@@ -86,12 +87,12 @@ public class PollingLifecycleTests {
 		Mockito.reset(handler);
 		Mockito.verify(handler, atMost(1)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	@Test
 	public void ensurePollerTaskStopsForAdapter() throws Exception{
 		final CountDownLatch latch = new CountDownLatch(1);
 		QueueChannel channel = new QueueChannel();
-		
+
 		SourcePollingChannelAdapterFactoryBean adapterFactory = new SourcePollingChannelAdapterFactoryBean();
 		PollerMetadata pollerMetadata = new PollerMetadata();
 		pollerMetadata.setTrigger(new PeriodicTrigger(2000));
@@ -115,12 +116,12 @@ public class PollingLifecycleTests {
 		assertNull(channel.receive(1000));
 		Mockito.verify(source, times(1)).receive();
 	}
-	
+
 	@Test
 	public void ensurePollerTaskStopsForAdapterWithInterruptible() throws Exception{
 		final CountDownLatch latch = new CountDownLatch(2);
 		QueueChannel channel = new QueueChannel();
-		
+
 		SourcePollingChannelAdapterFactoryBean adapterFactory = new SourcePollingChannelAdapterFactoryBean();
 		PollerMetadata pollerMetadata = new PollerMetadata();
 		pollerMetadata.setMaxMessagesPerPoll(-1);
@@ -129,16 +130,16 @@ public class PollingLifecycleTests {
 		final Runnable coughtInterrupted = mock(Runnable.class);
 		MessageSource<String> source = new MessageSource<String>() {
 			public Message<String> receive() {
-				
+
 				try {
-					for (int i = 0; i < 10; i++) {			
+					for (int i = 0; i < 10; i++) {
 						Thread.sleep(1000);
 						latch.countDown();
 					}
 				} catch (InterruptedException e) {
 					coughtInterrupted.run();
 				}
-				
+
 				return new GenericMessage<String>("hello");
 			}
 		};

--- a/spring-integration-core/src/test/java/org/springframework/integration/filter/MethodInvokingSelectorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/filter/MethodInvokingSelectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.integration.message.GenericMessage;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class MethodInvokingSelectorTests {
 
@@ -41,7 +42,7 @@ public class MethodInvokingSelectorTests {
 	@Test
 	public void acceptedWithMethodReference() throws Exception {
 		TestBean testBean = new TestBean();
-		Method method = testBean.getClass().getMethod("acceptString", new Class[] { Message.class });
+		Method method = testBean.getClass().getMethod("acceptString", new Class<?>[] { Message.class });
 		MethodInvokingSelector selector = new MethodInvokingSelector(testBean, method);
 		assertTrue(selector.accept(new GenericMessage<String>("should accept")));
 	}
@@ -55,7 +56,7 @@ public class MethodInvokingSelectorTests {
 	@Test
 	public void rejectedWithMethodReference() throws Exception {
 		TestBean testBean = new TestBean();
-		Method method = testBean.getClass().getMethod("acceptString", new Class[] { Message.class });
+		Method method = testBean.getClass().getMethod("acceptString", new Class<?>[] { Message.class });
 		MethodInvokingSelector selector = new MethodInvokingSelector(testBean, method);
 		assertFalse(selector.accept(new GenericMessage<Integer>(99)));
 	}
@@ -69,7 +70,7 @@ public class MethodInvokingSelectorTests {
 	@Test
 	public void noArgMethodWithMethodReference() throws Exception {
 		TestBean testBean = new TestBean();
-		Method method = testBean.getClass().getMethod("noArgs", new Class[] {});
+		Method method = testBean.getClass().getMethod("noArgs", new Class<?>[] {});
 		new MethodInvokingSelector(testBean, method);
 	}
 
@@ -82,7 +83,7 @@ public class MethodInvokingSelectorTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void voidReturningMethodWithMethodReference() throws Exception {
 		TestBean testBean = new TestBean();
-		Method method = testBean.getClass().getMethod("returnVoid", new Class[] { Message.class });
+		Method method = testBean.getClass().getMethod("returnVoid", new Class<?>[] { Message.class });
 		MethodInvokingSelector selector = new MethodInvokingSelector(testBean, method);
 		selector.accept(new GenericMessage<String>("test"));
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.gateway;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -36,6 +36,7 @@ import org.springframework.integration.core.MessageHandler;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class GatewayInterfaceTests {
 
@@ -49,7 +50,7 @@ public class GatewayInterfaceTests {
 		bar.foo("hello");
 		verify(handler, times(1)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	@Test
 	public void testWithServiceAnnotatedMethod(){
 		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
@@ -60,7 +61,7 @@ public class GatewayInterfaceTests {
 		bar.bar("hello");
 		verify(handler, times(1)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	@Test
 	public void testWithServiceSuperclassUnAnnotatedMethod(){
 		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
@@ -71,7 +72,7 @@ public class GatewayInterfaceTests {
 		bar.baz("hello");
 		verify(handler, times(1)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	@Test
 	public void testWithServiceCastAsSuperclassAnnotatedMethod(){
 		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
@@ -82,7 +83,7 @@ public class GatewayInterfaceTests {
 		foo.foo("hello");
 		verify(handler, times(1)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	@Test
 	public void testWithServiceCastAsSuperclassUnAnnotatedMethod(){
 		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
@@ -93,7 +94,7 @@ public class GatewayInterfaceTests {
 		foo.baz("hello");
 		verify(handler, times(1)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	@Test
 	public void testWithServiceHashcode() throws Exception{
 		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
@@ -104,7 +105,7 @@ public class GatewayInterfaceTests {
 		assertEquals(bar.hashCode(), ac.getBean(Bar.class).hashCode());
 		verify(handler, times(0)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	@Test
 	public void testWithServiceToString(){
 		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
@@ -115,7 +116,7 @@ public class GatewayInterfaceTests {
 		bar.toString();
 		verify(handler, times(0)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	@Test
 	public void testWithServiceEquals() throws Exception{
 		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
@@ -134,7 +135,7 @@ public class GatewayInterfaceTests {
 		assertFalse(bar.equals(fb.getObject()));
 		verify(handler, times(0)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	@Test
 	public void testWithServiceGetClass(){
 		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
@@ -145,25 +146,25 @@ public class GatewayInterfaceTests {
 		bar.getClass();
 		verify(handler, times(0)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	@Test(expected=IllegalArgumentException.class)
 	public void testWithServiceAsNotAnInterface(){
 		new GatewayProxyFactoryBean(NotAnInterface.class);
 	}
 
-	
+
 	public interface Foo {
 		@Gateway(requestChannel="requestChannelFoo")
 		public void foo(String payload);
-		
+
 		public void baz(String payload);
 	}
-	
+
 	public static interface Bar extends Foo{
 		@Gateway(requestChannel="requestChannelBar")
-		public void bar(String payload);	
+		public void bar(String payload);
 	}
-	
+
 	public static class NotAnInterface {
 		public void fail(String payload){}
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInvokingMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInvokingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.gateway;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,29 +29,33 @@ import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
 public class GatewayInvokingMessageHandlerTests {
 
 	@Autowired
 	@Qualifier("inputA")
 	SubscribableChannel channel;
-	
+
 	@Autowired
 	@Qualifier("simpleGateway")
 	SimpleGateway gateway;
-	
+
 	@Autowired
 	@Qualifier("gatewayWithError")
 	SimpleGateway gatewayWithError;
-	
+
 	@Autowired
 	@Qualifier("gatewayWithErrorAsync")
 	SimpleGateway gatewayWithErrorAsync;
@@ -77,7 +81,7 @@ public class GatewayInvokingMessageHandlerTests {
 	}
 
 	@Test
-	public void validateGatewayInTheChainViaAnotherGateway() {	
+	public void validateGatewayInTheChainViaAnotherGateway() {
 		output.subscribe(new MessageHandler() {
 			public void handleMessage(Message<?> message) {
 				Assert.assertEquals("echo:echo:echo:hello", message.getPayload());
@@ -88,9 +92,9 @@ public class GatewayInvokingMessageHandlerTests {
 		String result = gateway.process("hello");
 		Assert.assertEquals("echo:echo:echo:hello", result);
 	}
-	
+
 	@Test
-	public void validateGatewayWithErrorMessageReturned() {	
+	public void validateGatewayWithErrorMessageReturned() {
 		try {
 			String result = gatewayWithErrorChannelAndTransformer.process("echoWithRuntimeExceptionChannel");
 			Assert.assertNotNull(result);
@@ -99,7 +103,7 @@ public class GatewayInvokingMessageHandlerTests {
 		catch (Exception e) {
 			Assert.fail();
 		}
-		
+
 		try {
 			gatewayWithError.process("echoWithRuntimeExceptionChannel");
 			Assert.fail();
@@ -107,7 +111,7 @@ public class GatewayInvokingMessageHandlerTests {
 		catch (SampleRuntimeException e) {
 			Assert.assertEquals("echoWithRuntimeExceptionChannel", e.getMessage());
 		}
-		
+
 		try {
 			gatewayWithError.process("echoWithMessagingExceptionChannel");
 			Assert.fail();
@@ -115,7 +119,7 @@ public class GatewayInvokingMessageHandlerTests {
 		catch (MessageHandlingException e) {
 			Assert.assertEquals("echoWithMessagingExceptionChannel", e.getFailedMessage().getPayload());
 		}
-		
+
 		try {
 			String result = gatewayWithErrorChannelAndTransformer.process("echoWithMessagingExceptionChannel");
 			Assert.assertNotNull(result);
@@ -125,9 +129,9 @@ public class GatewayInvokingMessageHandlerTests {
 			Assert.fail();
 		}
 	}
-	
+
 	@Test
-	public void validateGatewayWithErrorAsync() {	
+	public void validateGatewayWithErrorAsync() {
 		try {
 			gatewayWithErrorAsync.process("echoWithErrorAsyncChannel");
 			Assert.fail();
@@ -136,9 +140,9 @@ public class GatewayInvokingMessageHandlerTests {
 			Assert.assertEquals(SampleRuntimeException.class, e.getClass());
 		}
 	}
-	
+
 	@Test
-	public void validateGatewayWithErrorFlowReturningMessage() {	
+	public void validateGatewayWithErrorFlowReturningMessage() {
 		try {
 			Object result = gatewayWithErrorChannelAndTransformer.process("echoWithErrorAsyncChannel");
 			Assert.assertEquals("Error happened in message: echoWithErrorAsyncChannel", result);
@@ -151,10 +155,10 @@ public class GatewayInvokingMessageHandlerTests {
 
 	public static class SampleErrorTransformer {
 		public Message<?> toMessage(Throwable object) throws Exception {
-			MessageHandlingException ex = (MessageHandlingException) object;		
+			MessageHandlingException ex = (MessageHandlingException) object;
 			return MessageBuilder.withPayload("Error happened in message: " + ex.getFailedMessage().getPayload()).build();
 		}
-		
+
 	}
 
 
@@ -195,7 +199,7 @@ public class GatewayInvokingMessageHandlerTests {
 	public static class SampleRuntimeException extends RuntimeException {
 		public SampleRuntimeException(String message) {
 			super(message);
-		}		
+		}
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayRequiresReplyTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayRequiresReplyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.gateway;
 
-import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -30,6 +30,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration
@@ -52,7 +53,7 @@ public class GatewayRequiresReplyTests {
 		TestService gateway = (TestService) applicationContext.getBean("gateway");
 		gateway.test("bad");
 	}
-	
+
 	@Test
 	public void timedOutGateway() {
 		TestService gateway = (TestService) applicationContext.getBean("timeoutGateway");
@@ -64,7 +65,7 @@ public class GatewayRequiresReplyTests {
 	public static interface TestService {
 		public String test(String s);
 	}
-	
+
 	public static class LongRunningService {
 		public String echo(String value) throws Exception{
 			Thread.sleep(5000);

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithPayloadExpressionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithPayloadExpressionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.gateway;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +30,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/HeaderEnrichedGatewayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/HeaderEnrichedGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.gateway;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +32,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/InnerGatewayWithChainTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/InnerGatewayWithChainTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.integration.gateway;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,59 +35,60 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 public class InnerGatewayWithChainTests {
-	
+
 	@Autowired
 	private TestGateway testGatewayWithErrorChannelA;
-	
+
 	@Autowired
 	private TestGateway testGatewayWithErrorChannelAA;
-	
+
 	@Autowired
 	private TestGateway testGatewayWithNoErrorChannelAAA;
-	
+
 	@Autowired
 	private SourcePollingChannelAdapter inboundAdapterDefaultErrorChannel;
-	
+
 	@Autowired
 	private SourcePollingChannelAdapter inboundAdapterAssignedErrorChannel;
-	
+
 	@Autowired
 	private SubscribableChannel errorChannel;
-	
+
 	@Autowired
 	private SubscribableChannel assignedErrorChannel;
-	
-	
+
+
 
 	@Test
 	public void testExceptionHandledByMainGateway(){
 		String reply = testGatewayWithErrorChannelA.echo(5);
 		assertEquals("ERROR from errorChannelA", reply);
 	}
-	
+
 	@Test
 	public void testExceptionHandledByMainGatewayNoErrorChannelInChain(){
 		String reply = testGatewayWithErrorChannelAA.echo(0);
 		assertEquals("ERROR from errorChannelA", reply);
 	}
-	
+
 	@Test
 	public void testExceptionHandledByInnerGateway(){
 		String reply = testGatewayWithErrorChannelA.echo(0);
 		assertEquals("ERROR from errorChannelB", reply);
 	}
-	
+
 	// if no error channels explicitly defined exception is rethrown
 	@Test(expected=ArithmeticException.class)
 	public void testGatewaysNoErrorChannel(){
 		testGatewayWithNoErrorChannelAAA.echo(0);
 	}
-	
+
 	@Test
 	public void testWithSPCADefaultErrorChannel() throws Exception{
 		MessageHandler handler = mock(MessageHandler.class);
@@ -97,7 +98,7 @@ public class InnerGatewayWithChainTests {
 		inboundAdapterDefaultErrorChannel.stop();
 		verify(handler, times(1)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	@Test
 	public void testWithSPCAAssignedErrorChannel() throws Exception{
 		MessageHandler handler = mock(MessageHandler.class);
@@ -107,7 +108,7 @@ public class InnerGatewayWithChainTests {
 		inboundAdapterAssignedErrorChannel.stop();
 		verify(handler, times(1)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	public static interface TestGateway{
 		public String echo(int value);
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/MultiMethodGatewayConfigTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/MultiMethodGatewayConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.gateway;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +28,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  * @since 2.0.M1
  */
 @ContextConfiguration
@@ -41,12 +42,12 @@ public class MultiMethodGatewayConfigTests {
 	@Test
 	public void validateGatewayMethods() {
 		TestGateway gateway = (TestGateway) applicationContext.getBean("myGateway");
-		String parentClassName = "org.springframework.integration.gateway.MultiMethodGatewayConfigTests"; 
+		String parentClassName = "org.springframework.integration.gateway.MultiMethodGatewayConfigTests";
 		Assert.assertEquals(gateway.echo("oleg"),
 				parentClassName + "$TestBeanA:oleg");
-		Assert.assertEquals(gateway.echoUpperCase("oleg"), 
+		Assert.assertEquals(gateway.echoUpperCase("oleg"),
 				parentClassName + "$TestBeanB:oleg");
-		Assert.assertEquals(gateway.echoViaDefault("oleg"), 
+		Assert.assertEquals(gateway.echoViaDefault("oleg"),
 				parentClassName + "$TestBeanC:oleg");
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
-import org.junit.matchers.JUnitMatchers;
+import static org.hamcrest.CoreMatchers.containsString;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
@@ -32,6 +32,7 @@ import org.springframework.integration.support.MessageBuilder;
 
 /**
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 @RunWith(org.mockito.runners.MockitoJUnitRunner.class)
 public class AbstractReplyProducingMessageHandlerTests {
@@ -59,7 +60,7 @@ public class AbstractReplyProducingMessageHandlerTests {
 			fail("Expected a MessagingException");
 		}
 		catch (MessagingException e) {
-			assertThat(e.getMessage(), JUnitMatchers.containsString("'testChannel'"));
+			assertThat(e.getMessage(), containsString("'testChannel'"));
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/CollectionAndArrayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/CollectionAndArrayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -38,6 +39,7 @@ import org.springframework.integration.support.MessageBuilder;
 
 /**
  * @author Mark Fisher
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class CollectionAndArrayTests {
@@ -76,7 +78,7 @@ public class CollectionAndArrayTests {
 		Message<?> reply2 = channel.receive(0);
 		assertNotNull(reply1);
 		assertNull(reply2);
-		assertThat(reply1.getPayload(), is(Set.class));
+		assertThat(reply1.getPayload(), is(instanceOf(Set.class)));
 		assertEquals(2, ((Set<?>) reply1.getPayload()).size());
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,12 @@ package org.springframework.integration.handler;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Date;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -51,6 +49,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Gunnar Hillert
  * @since 1.0.3
  */
 public class DelayHandlerTests {
@@ -405,7 +404,7 @@ public class DelayHandlerTests {
 	// Can happen in the parent-child context e.g. Spring-MVC applications
 	public void testDoubleOnApplicationEvent() throws Exception {
 		this.delayHandler = Mockito.spy(this.delayHandler);
-		Mockito.doAnswer(new Answer() {
+		Mockito.doAnswer(new Answer<Object>() {
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				return null;
 			}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/ExpressionEvaluatingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/ExpressionEvaluatingMessageProcessorTests.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2010 the original author or authors.
- * 
+ * Copyright 2002-2013 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -23,7 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.hamcrest.Description;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.internal.matchers.TypeSafeMatcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.rules.ExpectedException;
 
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -45,6 +45,7 @@ import org.springframework.integration.test.util.TestUtils;
 /**
  * @author Dave Syer
  * @author Mark Fisher
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class ExpressionEvaluatingMessageProcessorTests {
@@ -105,7 +106,7 @@ public class ExpressionEvaluatingMessageProcessorTests {
 			public String find(Resource[] resources) {
 				return Arrays.asList(resources).toString();
 			}
-			
+
 		}
 		Expression expression = expressionParser.parseExpression("#target.find(payload)");
 		ExpressionEvaluatingMessageProcessor processor = new ExpressionEvaluatingMessageProcessor(expression);
@@ -189,7 +190,7 @@ public class ExpressionEvaluatingMessageProcessorTests {
 		ExpressionEvaluatingMessageProcessor processor = new ExpressionEvaluatingMessageProcessor(expression);
 		assertEquals("foo", processor.processMessage(new GenericMessage<String>("foo")));
 	}
-	
+
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testProcessMessageExpressionThrowsRuntimeException() {

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -30,7 +30,7 @@ import org.apache.commons.logging.LogFactory;
 import org.hamcrest.Description;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.internal.matchers.TypeSafeMatcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.rules.ExpectedException;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageHandlingException;
@@ -48,6 +48,7 @@ import org.springframework.integration.util.MessagingMethodInvokerHelper;
  * @author Oleg Zhurakousky
  * @author Dave Syer
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class MethodInvokingMessageProcessorTests {

--- a/spring-integration-core/src/test/java/org/springframework/integration/history/AnotatedTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/history/AnotatedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.integration.history;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -38,6 +38,7 @@ import org.springframework.integration.test.util.TestUtils;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 public class AnotatedTests {
@@ -56,7 +57,7 @@ public class AnotatedTests {
 		};
 		listener = spy(listener);
 		ac.addApplicationListener(listener);
-		
+
 		MessageChannel channel = ac.getBean("inputChannel", MessageChannel.class);
 		EventDrivenConsumer consumer = ac.getBean("myAdapter", EventDrivenConsumer.class);
 		MessageHandler handler = (MessageHandler) TestUtils.getPropertyValue(consumer, "handler");

--- a/spring-integration-core/src/test/java/org/springframework/integration/history/MessageHistoryIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/history/MessageHistoryIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,14 +37,15 @@ import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.util.StopWatch;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class MessageHistoryIntegrationTests {
 
@@ -67,7 +68,7 @@ public class MessageHistoryIntegrationTests {
 		MessageHandler handler = Mockito.spy(new MessageHandler() {
 			public void handleMessage(Message<?> message) {
 				Iterator<Properties> historyIterator = message.getHeaders().get(MessageHistory.HEADER_NAME, MessageHistory.class).iterator();
-				
+
 				Properties event1 = historyIterator.next();
 				assertEquals("sampleGateway", event1.getProperty(MessageHistory.NAME_PROPERTY));
 				assertEquals("gateway", event1.getProperty(MessageHistory.TYPE_PROPERTY));
@@ -75,15 +76,15 @@ public class MessageHistoryIntegrationTests {
 				Properties event2 = historyIterator.next();
 				assertEquals("bridgeInChannel", event2.getProperty(MessageHistory.NAME_PROPERTY));
 				assertEquals("channel", event2.getProperty(MessageHistory.TYPE_PROPERTY));
-				
+
 				Properties event3 = historyIterator.next();
 				assertEquals("testBridge", event3.getProperty(MessageHistory.NAME_PROPERTY));
 				assertEquals("bridge", event3.getProperty(MessageHistory.TYPE_PROPERTY));
-				
+
 				Properties event4 = historyIterator.next();
 				assertEquals("headerEnricherChannel", event4.getProperty(MessageHistory.NAME_PROPERTY));
 				assertEquals("channel", event4.getProperty(MessageHistory.TYPE_PROPERTY));
-				
+
 				Properties event5 = historyIterator.next();
 				assertEquals("testHeaderEnricher", event5.getProperty(MessageHistory.NAME_PROPERTY));
 				assertEquals("transformer", event5.getProperty(MessageHistory.TYPE_PROPERTY));
@@ -134,13 +135,13 @@ public class MessageHistoryIntegrationTests {
 		assertNotNull(result);
 		//assertEquals("hello", result);
 	}
-	
+
 	@Test
 	public void testMessageHistoryWithoutHistoryWriter() {
 		ApplicationContext ac = new ClassPathXmlApplicationContext("messageHistoryWithoutHistoryWriter.xml", MessageHistoryIntegrationTests.class);
 		SampleGateway gateway = ac.getBean("sampleGateway", SampleGateway.class);
 		DirectChannel endOfThePipeChannel = ac.getBean("endOfThePipeChannel", DirectChannel.class);
-		MessageHandler handler = Mockito.spy(new MessageHandler() {	
+		MessageHandler handler = Mockito.spy(new MessageHandler() {
 			public void handleMessage(Message<?> message) {
 				assertNull(message.getHeaders().get(MessageHistory.HEADER_NAME, MessageHistory.class));
 				MessageChannel replyChannel = (MessageChannel) message.getHeaders().getReplyChannel();
@@ -157,7 +158,7 @@ public class MessageHistoryIntegrationTests {
 		ApplicationContext ac = new ClassPathXmlApplicationContext("messageHistoryWithHistoryWriterNamespace.xml", MessageHistoryIntegrationTests.class);
 		SampleGateway gateway = ac.getBean("sampleGateway", SampleGateway.class);
 		DirectChannel endOfThePipeChannel = ac.getBean("endOfThePipeChannel", DirectChannel.class);
-		MessageHandler handler = Mockito.spy(new MessageHandler() {	
+		MessageHandler handler = Mockito.spy(new MessageHandler() {
 			public void handleMessage(Message<?> message) {
 				Iterator<Properties> historyIterator = message.getHeaders().get(MessageHistory.HEADER_NAME, MessageHistory.class).iterator();
 				assertTrue(historyIterator.hasNext());
@@ -169,13 +170,13 @@ public class MessageHistoryIntegrationTests {
 		gateway.echo("hello");
 		Mockito.verify(handler, Mockito.times(1)).handleMessage(Mockito.any(Message.class));
 	}
-	
+
 	@Test
 	public void testMessageHistoryParserWithNamePatterns() {
 		ApplicationContext ac = new ClassPathXmlApplicationContext("messageHistoryWithHistoryWriterNamespaceAndPatterns.xml", MessageHistoryIntegrationTests.class);
 		SampleGateway gateway = ac.getBean("sampleGateway", SampleGateway.class);
 		DirectChannel endOfThePipeChannel = ac.getBean("endOfThePipeChannel", DirectChannel.class);
-		MessageHandler handler = Mockito.spy(new MessageHandler() {	
+		MessageHandler handler = Mockito.spy(new MessageHandler() {
 			public void handleMessage(Message<?> message) {
 				Iterator<Properties> historyIterator = message.getHeaders().get(MessageHistory.HEADER_NAME, MessageHistory.class).iterator();
 				assertTrue(historyIterator.hasNext());
@@ -203,10 +204,10 @@ public class MessageHistoryIntegrationTests {
 	public void testMessageHistoryWithHistoryPerformance() {
 		ApplicationContext acWithHistory = new ClassPathXmlApplicationContext("perfWithMessageHistory.xml", MessageHistoryIntegrationTests.class);
 		ApplicationContext acWithoutHistory = new ClassPathXmlApplicationContext("perfWithoutMessageHistory.xml", MessageHistoryIntegrationTests.class);
-		
+
 		SampleGateway gatewayHistory = acWithHistory.getBean("sampleGateway", SampleGateway.class);
 		DirectChannel endOfThePipeChannelHistory = acWithHistory.getBean("endOfThePipeChannel", DirectChannel.class);
-		endOfThePipeChannelHistory.subscribe(new MessageHandler() {	
+		endOfThePipeChannelHistory.subscribe(new MessageHandler() {
 			public void handleMessage(Message<?> message)
 					throws MessageRejectedException, MessageHandlingException,
 					MessageDeliveryException {
@@ -214,10 +215,10 @@ public class MessageHistoryIntegrationTests {
 				replyChannel.send(message);
 			}
 		});
-		
+
 		SampleGateway gateway = acWithoutHistory.getBean("sampleGateway", SampleGateway.class);
 		DirectChannel endOfThePipeChannel = acWithoutHistory.getBean("endOfThePipeChannel", DirectChannel.class);
-		endOfThePipeChannel.subscribe(new MessageHandler() {	
+		endOfThePipeChannel.subscribe(new MessageHandler() {
 			public void handleMessage(Message<?> message)
 					throws MessageRejectedException, MessageHandlingException,
 					MessageDeliveryException {
@@ -225,7 +226,7 @@ public class MessageHistoryIntegrationTests {
 				replyChannel.send(message);
 			}
 		});
-		
+
 		StopWatch stopWatch = new StopWatch();
 		stopWatch.start();
 		for (int i = 0; i < 10000; i++) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/PayloadTypeRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/PayloadTypeRouterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.router;
 
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -36,6 +36,7 @@ import org.springframework.integration.message.GenericMessage;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class PayloadTypeRouterTests {
 
@@ -46,24 +47,24 @@ public class PayloadTypeRouterTests {
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("stringChannel", stringChannel);
 		beanFactory.registerSingleton("integerChannel", integerChannel);
-		
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(String.class.getName(), "stringChannel");
 		payloadTypeChannelMap.put(Integer.class.getName(), "integerChannel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		router.setChannelMappings(payloadTypeChannelMap);
 		router.setBeanFactory(beanFactory);
-		
+
 		Message<String> message1 = new GenericMessage<String>("test");
 		Message<Integer> message2 = new GenericMessage<Integer>(123);
 		assertEquals(1, router.getChannelKeys(message1).size());
-		
+
 		assertNull(stringChannel.receive(0));
 		router.handleMessage(message1);
 		assertEquals(message1, stringChannel.receive(0));
-		
+
 		assertEquals(1, router.getChannelKeys(message2).size());
-		
+
 		assertNull(integerChannel.receive(0));
 		router.handleMessage(message2);
 		assertEquals(message2, integerChannel.receive(0));
@@ -78,14 +79,14 @@ public class PayloadTypeRouterTests {
 		router.handleMessage(message1);
 		assertEquals(message1, newChannel.receive(0));
 
-		// validate exception is thrown if mappings were removed and 
+		// validate exception is thrown if mappings were removed and
 		// channelResolutionRequires = true (which is the default)
-		
+
 		router.removeChannelMapping(String.class.getName());
 		router.removeChannelMapping(Integer.class.getName());
-		
+
 		router.setResolutionRequired(true);
-		
+
 		try {
 			router.handleMessage(message1);
 			fail();
@@ -104,7 +105,7 @@ public class PayloadTypeRouterTests {
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("numberChannel", numberChannel);
-		
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(Number.class.getName(), "numberChannel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
@@ -117,7 +118,7 @@ public class PayloadTypeRouterTests {
 		assertNotNull(result);
 		assertEquals(99, result.getPayload());
 		assertNull(defaultChannel.receive(0));
-		
+
 		// validate dynamics
 		QueueChannel newChannel = new QueueChannel();
 		beanFactory.registerSingleton("newChannel", newChannel);
@@ -136,20 +137,20 @@ public class PayloadTypeRouterTests {
 		numberChannel.setBeanName("numberChannel");
 		QueueChannel integerChannel = new QueueChannel();
 		integerChannel.setBeanName("integerChannel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("numberChannel", numberChannel);
 		beanFactory.registerSingleton("integerChannel", integerChannel);
-		
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(Number.class.getName(), "numberChannel");
 		payloadTypeChannelMap.put(Integer.class.getName(), "integerChannel");
-		
+
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-	
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<Integer> message = new GenericMessage<Integer>(99);
 		router.handleMessage(message);
@@ -166,18 +167,18 @@ public class PayloadTypeRouterTests {
 		defaultChannel.setBeanName("defaultChannel");
 		QueueChannel comparableChannel = new QueueChannel();
 		comparableChannel.setBeanName("comparableChannel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("comparableChannel", comparableChannel);
-			
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(Comparable.class.getName(), "comparableChannel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-			
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<Integer> message = new GenericMessage<Integer>(99);
 		router.handleMessage(message);
@@ -186,118 +187,118 @@ public class PayloadTypeRouterTests {
 		assertEquals(99, result.getPayload());
 		assertNull(defaultChannel.receive(0));
 	}
-	
+
 	@Test
 	public void extendedInterfaceMatch() {
 		QueueChannel defaultChannel = new QueueChannel();
 		defaultChannel.setBeanName("defaultChannel");
 		QueueChannel i2Channel = new QueueChannel();
 		i2Channel.setBeanName("i2Channel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("i2Channel", i2Channel);
-			
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(I2.class.getName(), "i2Channel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-			
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
 		router.handleMessage(message);
 		Message<?> result = i2Channel.receive(0);
 		assertNotNull(result);
 	}
-	
-	@Test 
+
+	@Test
 	public void higherWeightInterface() {
 		QueueChannel defaultChannel = new QueueChannel();
 		defaultChannel.setBeanName("defaultChannel");
-		
+
 		QueueChannel serializableChannel = new QueueChannel();
 		serializableChannel.setBeanName("serializableChannel");
-		
+
 		QueueChannel i3Channel = new QueueChannel();
 		i3Channel.setBeanName("i3Channel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("serializableChannel", serializableChannel);
 		beanFactory.registerSingleton("i3Channel", i3Channel);
-			
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(Serializable.class.getName(), "serializableChannel");
 		payloadTypeChannelMap.put(I3.class.getName(), "i3Channel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-			
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
 		router.handleMessage(message);
 		assertNotNull(serializableChannel.receive(0));
 		assertNull(i3Channel.receive(0));
 	}
-	
+
 	@Test
 	public void superclassWinsOverDistantInterface() {
 		QueueChannel defaultChannel = new QueueChannel();
 		defaultChannel.setBeanName("defaultChannel");
-		
+
 		QueueChannel c3Channel = new QueueChannel();
 		c3Channel.setBeanName("c3Channel");
-		
+
 		QueueChannel i4Channel = new QueueChannel();
 		i4Channel.setBeanName("i4Channel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("c3Channel", c3Channel);
 		beanFactory.registerSingleton("i4Channel", i4Channel);
-			
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(C3.class.getName(), "c3Channel");
 		payloadTypeChannelMap.put(I4.class.getName(), "i4Channel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-			
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
 		router.handleMessage(message);
 		Message<?> result = c3Channel.receive(0);
 		assertNotNull(result);
 	}
-	
+
 	@Test
 	public void directInterfaceOverTwoHopSuperclass() {
 		QueueChannel defaultChannel = new QueueChannel();
 		defaultChannel.setBeanName("defaultChannel");
-		
+
 		QueueChannel c3Channel = new QueueChannel();
 		c3Channel.setBeanName("c3Channel");
-		
+
 		QueueChannel i1AChannel = new QueueChannel();
 		i1AChannel.setBeanName("i1AChannel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("c3Channel", c3Channel);
 		beanFactory.registerSingleton("i1AChannel", i1AChannel);
-			
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(C3.class.getName(), "c3Channel");
 		payloadTypeChannelMap.put(I1A.class.getName(), "i1AChannel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-			
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
 		router.handleMessage(message);
@@ -313,20 +314,20 @@ public class PayloadTypeRouterTests {
 		numberChannel.setBeanName("numberChannel");
 		QueueChannel comparableChannel = new QueueChannel();
 		comparableChannel.setBeanName("comparableChannel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("numberChannel", numberChannel);
 		beanFactory.registerSingleton("comparableChannel", comparableChannel);
-		
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(Number.class.getName(), "numberChannel");
 		payloadTypeChannelMap.put(Comparable.class.getName(), "comparableChannel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-		
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<Integer> message = new GenericMessage<Integer>(99);
 		router.handleMessage(message);
@@ -335,7 +336,7 @@ public class PayloadTypeRouterTests {
 		assertEquals(99, result.getPayload());
 		assertNull(numberChannel.receive(0));
 		assertNull(defaultChannel.receive(0));
-		
+
 		// validate dynamics
 		QueueChannel newChannel = new QueueChannel();
 		beanFactory.registerSingleton("newChannel", newChannel);
@@ -354,20 +355,20 @@ public class PayloadTypeRouterTests {
 		serializableChannel.setBeanName("serializableChannel");
 		QueueChannel comparableChannel = new QueueChannel();
 		comparableChannel.setBeanName("comparableChannel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("serializableChannel", serializableChannel);
 		beanFactory.registerSingleton("comparableChannel", comparableChannel);
-		
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(Serializable.class.getName(), "serializableChannel");
 		payloadTypeChannelMap.put(Comparable.class.getName(), "comparableChannel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-		
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<String> message = new GenericMessage<String>("test");
 		router.handleMessage(message);
@@ -381,20 +382,20 @@ public class PayloadTypeRouterTests {
 		numberChannel.setBeanName("numberChannel");
 		QueueChannel serializableChannel = new QueueChannel();
 		serializableChannel.setBeanName("serializableChannel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("numberChannel", numberChannel);
 		beanFactory.registerSingleton("serializableChannel", serializableChannel);
-		
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(Number.class.getName(), "numberChannel");
 		payloadTypeChannelMap.put(Serializable.class.getName(), "serializableChannel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-		
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<Integer> message = new GenericMessage<Integer>(99);
 		router.handleMessage(message);
@@ -411,19 +412,19 @@ public class PayloadTypeRouterTests {
 		QueueChannel integerChannel = new QueueChannel();
 		stringChannel.setBeanName("stringChannel");
 		integerChannel.setBeanName("integerChannel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("stringChannel", stringChannel);
 		beanFactory.registerSingleton("integerChannel", integerChannel);
-		
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(String.class.getName(), "stringChannel");
 		payloadTypeChannelMap.put(Integer.class.getName(), "integerChannel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-		
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		Message<String> message1 = new GenericMessage<String>("test");
 		Message<Integer> message2 = new GenericMessage<Integer>(123);
 		router.handleMessage(message1);
@@ -440,18 +441,18 @@ public class PayloadTypeRouterTests {
 		stringChannel.setBeanName("stringChannel");
 		QueueChannel defaultChannel = new QueueChannel();
 		defaultChannel.setBeanName("defaultChannel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("stringChannel", stringChannel);
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
-		
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(String.class.getName(), "stringChannel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-		
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<String> message1 = new GenericMessage<String>("test");
 		Message<Integer> message2 = new GenericMessage<Integer>(123);
@@ -464,107 +465,107 @@ public class PayloadTypeRouterTests {
 		assertNotNull(result2);
 		assertEquals(123, result2.getPayload());
 	}
-	
+
 	@Test
 	public void classWinsOverMoreDistantAmbiguousInterfaces() throws Exception {
 		QueueChannel defaultChannel = new QueueChannel();
 		defaultChannel.setBeanName("defaultChannel");
-		
+
 		QueueChannel i5aChannel = new QueueChannel();
 		i5aChannel.setBeanName("i5aChannel");
 		QueueChannel i5bChannel = new QueueChannel();
 		i5bChannel.setBeanName("i5bChannel");
-		
+
 		QueueChannel c2Channel = new QueueChannel();
 		c2Channel.setBeanName("c2Channel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("i5aChannel", i5aChannel);
 		beanFactory.registerSingleton("i5bChannel", i5bChannel);
 		beanFactory.registerSingleton("c2Channel", c2Channel);
-		
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(I5A.class.getName(), "i5aChannel");
 		payloadTypeChannelMap.put(I5B.class.getName(), "i5bChannel");
 		payloadTypeChannelMap.put(C2.class.getName(), "c2Channel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-		
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
 		router.handleMessage(message);
 		assertNotNull(c2Channel.receive(100));
 	}
-	
+
 	@Test(expected=MessageHandlingException.class)
 	public void classLosesOverLessDistantAmbiguousInterfaces() throws Exception {
 		QueueChannel defaultChannel = new QueueChannel();
 		defaultChannel.setBeanName("defaultChannel");
-		
+
 		QueueChannel i2Channel = new QueueChannel();
 		i2Channel.setBeanName("i2Channel");
 		QueueChannel serializableChannel = new QueueChannel();
 		serializableChannel.setBeanName("serializableChannel");
-		
+
 		QueueChannel c3Channel = new QueueChannel();
 		c3Channel.setBeanName("c3Channel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("i2Channel", i2Channel);
 		beanFactory.registerSingleton("serializableChannel", serializableChannel);
 		beanFactory.registerSingleton("c3Channel", c3Channel);
-		
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(I2.class.getName(), "i2Channel");
 		payloadTypeChannelMap.put(Serializable.class.getName(), "serializableChannel");
 		payloadTypeChannelMap.put(C3.class.getName(), "c3Channel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-		
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
 		router.handleMessage(message);
 	}
-	
+
 	@Test(expected=MessageHandlingException.class)
 	public void classLosesOverAmbiguousInterfacesAtSameLevel() throws Exception {
 		QueueChannel defaultChannel = new QueueChannel();
 		defaultChannel.setBeanName("defaultChannel");
-		
+
 		QueueChannel i1aChannel = new QueueChannel();
 		i1aChannel.setBeanName("i1aChannel");
 		QueueChannel i1bChannel = new QueueChannel();
 		i1bChannel.setBeanName("i1bChannel");
-		
+
 		QueueChannel c2Channel = new QueueChannel();
 		c2Channel.setBeanName("c2Channel");
-		
+
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("defaultChannel", defaultChannel);
 		beanFactory.registerSingleton("i1aChannel", i1aChannel);
 		beanFactory.registerSingleton("i1bChannel", i1bChannel);
 		beanFactory.registerSingleton("c2Channel", c2Channel);
-		
+
 		Map<String, String> payloadTypeChannelMap = new ConcurrentHashMap<String, String>();
 		payloadTypeChannelMap.put(I1A.class.getName(), "i1aChannel");
 		payloadTypeChannelMap.put(I1B.class.getName(), "i2bChannel");
 		payloadTypeChannelMap.put(C2.class.getName(), "c2Channel");
 		PayloadTypeRouter router = new PayloadTypeRouter();
-		
+
 		router.setBeanFactory(beanFactory);
 		router.setChannelMappings(payloadTypeChannelMap);
-		
+
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<C1> message = new GenericMessage<C1>(new C1());
 		router.handleMessage(message);
 	}
-	
+
 	@SuppressWarnings("serial")
 	public static class C1 extends C2 implements I1A, I1B {}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/ExceptionTypeRouterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/ExceptionTypeRouterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.springframework.integration.router.config;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -29,6 +29,7 @@ import org.springframework.integration.message.GenericMessage;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 public class ExceptionTypeRouterParserTests {
@@ -38,19 +39,19 @@ public class ExceptionTypeRouterParserTests {
 	public void testExceptionTypeRouterConfig(){
 		ApplicationContext context = new ClassPathXmlApplicationContext("ExceptionTypeRouterParserTests-context.xml", this.getClass());
 		MessageChannel inputChannel = context.getBean("inChannel", MessageChannel.class);
-		
+
 		inputChannel.send(new GenericMessage<Throwable>(new NullPointerException()));
 		QueueChannel nullPointerChannel = context.getBean("nullPointerChannel", QueueChannel.class);
 		Message<Throwable> npeMessage = (Message<Throwable>) nullPointerChannel.receive(1000);
 		assertNotNull(npeMessage);
 		assertTrue(npeMessage.getPayload() instanceof NullPointerException);
-		
+
 		inputChannel.send(new GenericMessage<Throwable>(new IllegalArgumentException()));
 		QueueChannel illegalArgumentChannel = context.getBean("illegalArgumentChannel", QueueChannel.class);
 		Message<Throwable> iaMessage = (Message<Throwable>) illegalArgumentChannel.receive(1000);
 		assertNotNull(iaMessage);
 		assertTrue(iaMessage.getPayload() instanceof IllegalArgumentException);
-		
+
 		inputChannel.send(new GenericMessage<String>("Hello"));
 		QueueChannel outputChannel = context.getBean("outputChannel", QueueChannel.class);
 		assertNotNull(outputChannel.receive(1000));

--- a/spring-integration-core/src/test/java/org/springframework/integration/splitter/DefaultSplitterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/splitter/DefaultSplitterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.splitter;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNotNull;
@@ -37,6 +37,7 @@ import org.springframework.integration.support.MessageBuilder;
 /**
  * @author Mark Fisher
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 public class DefaultSplitterTests {
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/splitter/SplitterIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/splitter/SplitterIntegrationTests.java
@@ -37,6 +37,8 @@ import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.annotation.Splitter;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -47,6 +49,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
 public class SplitterIntegrationTests {
 
 	@Autowired

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/PropertiesPersistingMetadataStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/PropertiesPersistingMetadataStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.store;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.Properties;
@@ -32,6 +32,7 @@ import org.springframework.integration.store.PropertiesPersistingMetadataStore;
 /**
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class PropertiesPersistingMetadataStoreTests {
@@ -57,7 +58,7 @@ public class PropertiesPersistingMetadataStoreTests {
 		File file = new File("target/foo" + "/metadata-store.properties");
 		file.deleteOnExit();
 		PropertiesPersistingMetadataStore metadataStore = new PropertiesPersistingMetadataStore();
-		metadataStore.setBaseDirectory("target/foo"); 
+		metadataStore.setBaseDirectory("target/foo");
 		metadataStore.afterPropertiesSet();
 		metadataStore.put("foo", "bar");
 		metadataStore.destroy();

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/MapToObjectTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/MapToObjectTransformerTests.java
@@ -16,10 +16,6 @@
 
 package org.springframework.integration.transformer;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-
 import java.lang.reflect.Constructor;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
@@ -39,6 +35,10 @@ import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.util.ClassUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 
 /**

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/ObjectToMapTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/ObjectToMapTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,14 +35,15 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.Message;
 import org.springframework.integration.support.MessageBuilder;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import static org.junit.Assert.assertNull;
 
 /**
  *
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class ObjectToMapTransformerTests {
@@ -53,89 +54,89 @@ public class ObjectToMapTransformerTests {
 		StandardEvaluationContext context = new StandardEvaluationContext();
 		context.addPropertyAccessor(new MapAccessor());
 		ExpressionParser parser = new SpelExpressionParser();
-		
+
 		ObjectToMapTransformer transformer = new ObjectToMapTransformer();
 		Message<Employee> message = MessageBuilder.withPayload(employee).build();
 
 		Message<?> transformedMessage = transformer.transform(message);
 		Map<String, Object> transformedMap = (Map<String, Object>) transformedMessage.getPayload();
 		assertNotNull(transformedMap);
-		
+
 		Object valueFromTheMap = null;
 		Object valueFromExpression = null;
 		Expression expression = null;
-		
+
 		expression = parser.parseExpression("departments[0]");
 		valueFromTheMap = transformedMap.get("departments[0]");
 		valueFromExpression = expression.getValue(context, employee, String.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("person.address.coordinates");
 		valueFromTheMap = transformedMap.get("person.address.coordinates");
 		valueFromExpression = expression.getValue(context, employee, Map.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("person.akaNames[0]");
 		valueFromTheMap = transformedMap.get("person.akaNames[0]");
 		valueFromExpression = expression.getValue(context, employee, String.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("testMapInMapData.internalMapA.bar");
 		valueFromTheMap = transformedMap.get("testMapInMapData.internalMapA.bar");
 		valueFromExpression = expression.getValue(context, employee, String.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("companyAddress.street");
 		valueFromTheMap = transformedMap.get("companyAddress.street");
 		valueFromExpression = expression.getValue(context, employee, String.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("person.lname");
 		valueFromTheMap = transformedMap.get("person.lname");
 		valueFromExpression = expression.getValue(context, employee, String.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("person.address.mapWithListData.mapWithListTestData[1]");
 		valueFromTheMap = transformedMap.get("person.address.mapWithListData.mapWithListTestData[1]");
 		valueFromExpression = expression.getValue(context, employee, String.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("companyAddress.city");
 		valueFromTheMap = transformedMap.get("companyAddress.city");
 		valueFromExpression = expression.getValue(context, employee, String.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("person.akaNames[2]");
 		valueFromTheMap = transformedMap.get("person.akaNames[2]");
 		valueFromExpression = expression.getValue(context, employee, String.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("person.child");
 		valueFromTheMap = transformedMap.get("person.child");
 		valueFromExpression = expression.getValue(context, employee, String.class);
 		assertNull(valueFromTheMap);
 		assertNull(valueFromExpression);
-		
+
 		expression = parser.parseExpression("testMapInMapData.internalMapA.foo");
 		valueFromTheMap = transformedMap.get("testMapInMapData.internalMapA.foo");
 		valueFromExpression = expression.getValue(context, employee, String.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("person.address.city");
 		valueFromTheMap = transformedMap.get("person.address.city");
 		valueFromExpression = expression.getValue(context, employee, String.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("companyAddress.coordinates.latitude[0]");
 		valueFromTheMap = transformedMap.get("companyAddress.coordinates.latitude[0]");
 		valueFromExpression = expression.getValue(context, employee, Integer.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("person.remarks[1].baz");
 		valueFromTheMap = transformedMap.get("person.remarks[1].baz");
 		valueFromExpression = expression.getValue(context, employee, String.class);
 		assertEquals(valueFromTheMap, valueFromExpression);
-		
+
 		expression = parser.parseExpression("listOfDates[0][1]");
 		valueFromTheMap = new Date((Long) transformedMap.get("listOfDates[0][1]"));
 		valueFromExpression = expression.getValue(context, employee, Date.class);
@@ -145,7 +146,7 @@ public class ObjectToMapTransformerTests {
 	@Test(expected=MessageTransformationException.class)
 	public void testObjectToSpelMapTransformerWithCycle(){
 		Employee employee = this.buildEmployee();
-		Child child = new Child();	
+		Child child = new Child();
 		Person parent = employee.getPerson();
 		parent.setChild(child);
 		child.setParent(parent);
@@ -160,24 +161,24 @@ public class ObjectToMapTransformerTests {
 		companyAddress.setCity("Philadelphia");
 		companyAddress.setStreet("1123 Main");
 		companyAddress.setZip("12345");
-		
+
 		Map<String, Long[]> coordinates = new HashMap<String, Long[]>();
 		coordinates.put("latitude", new Long[]{(long)1, (long)5, (long)13});
 		coordinates.put("longitude", new Long[]{(long)156});
 		companyAddress.setCoordinates(coordinates);
-		
+
 		List<Date> datesA = new ArrayList<Date>();
 		datesA.add(new Date(System.currentTimeMillis() + 10000));
 		datesA.add(new Date(System.currentTimeMillis() + 20000));
-		
+
 		List<Date> datesB = new ArrayList<Date>();
 		datesB.add(new Date(System.currentTimeMillis() + 30000));
 		datesB.add(new Date(System.currentTimeMillis() + 40000));
-		
+
 		List<List<Date>> listOfDates = new ArrayList<List<Date>>();
 		listOfDates.add(datesA);
 		listOfDates.add(datesB);
-		
+
 		Employee employee = new Employee();
 		employee.setCompanyName("ABC Inc.");
 		employee.setCompanyAddress(companyAddress);
@@ -186,7 +187,7 @@ public class ObjectToMapTransformerTests {
 		departments.add("HR");
 		departments.add("IT");
 		employee.setDepartments(departments);
-		
+
 		Person person = new Person();
 		person.setFname("Justin");
 		person.setLname("Case");
@@ -203,7 +204,7 @@ public class ObjectToMapTransformerTests {
 		mapWithListTestData.put("mapWithListTestData", listTestData);
 		personAddress.setMapWithListData(mapWithListTestData);
 		person.setAddress(personAddress);
-		
+
 		Map<String, Object> remarksA = new HashMap<String, Object>();
 		Map<String, Object> remarksB = new HashMap<String, Object>();
 		remarksA.put("foo", "foo");
@@ -214,22 +215,22 @@ public class ObjectToMapTransformerTests {
 		remarks.add(remarksB);
 		person.setRemarks(remarks);
 		employee.setPerson(person);
-		
+
 		Map<String, Map<String, Object>> testMapData = new HashMap<String, Map<String, Object>>();
-		
+
 		Map<String, Object> internalMapA = new HashMap<String, Object>();
 		internalMapA.put("foo", "foo");
 		internalMapA.put("bar", "bar");
 		Map<String, Object> internalMapB = new HashMap<String, Object>();
 		internalMapB.put("baz", "baz");
-		
+
 		testMapData.put("internalMapA", internalMapA);
 		testMapData.put("internalMapB", internalMapB);
-		
+
 		employee.setTestMapInMapData(testMapData);
 		return employee;
 	}
-	
+
 	public static class Employee{
 		private List<String> departments;
 		private List<List<Date>> listOfDates;
@@ -275,7 +276,7 @@ public class ObjectToMapTransformerTests {
 			this.departments = departments;
 		}
 	}
-	
+
 	public static class Person{
 		private String fname;
 		private String lname;
@@ -338,7 +339,7 @@ public class ObjectToMapTransformerTests {
 			this.address = address;
 		}
 	}
-	
+
 	public static class Address{
 		private String street;
 		private String city;
@@ -376,7 +377,7 @@ public class ObjectToMapTransformerTests {
 			this.coordinates = coordinates;
 		}
 	}
-	
+
 	public static class Child {
 		private Person parent;
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/util/BeanFactoryTypeConverterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/util/BeanFactoryTypeConverterTests.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.integration.util;
 
-import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -65,6 +65,7 @@ import org.springframework.integration.message.GenericMessage;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Gunnar Hillert
  *
  */
 public class BeanFactoryTypeConverterTests {

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Properties;
 import java.util.Set;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +50,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -88,7 +89,7 @@ public class EventInboundChannelAdapterParserTests {
 		Assert.assertEquals(context.getBean("inputFiltered"), adapterAccessor.getPropertyValue("outputChannel"));
 		Set<Class<? extends ApplicationEvent>> eventTypes = (Set<Class<? extends ApplicationEvent>>) adapterAccessor.getPropertyValue("eventTypes");
 		assertNotNull(eventTypes);
-		assertTrue(eventTypes.size() == 2);	
+		assertTrue(eventTypes.size() == 2);
 		assertTrue(eventTypes.contains(SampleEvent.class));
 		assertTrue(eventTypes.contains(AnotherSampleEvent.class));
 		assertNull(adapterAccessor.getPropertyValue("errorChannel"));
@@ -104,7 +105,7 @@ public class EventInboundChannelAdapterParserTests {
 		Assert.assertEquals(context.getBean("inputFilteredPlaceHolder"), adapterAccessor.getPropertyValue("outputChannel"));
 		Set<Class<? extends ApplicationEvent>> eventTypes = (Set<Class<? extends ApplicationEvent>>) adapterAccessor.getPropertyValue("eventTypes");
 		assertNotNull(eventTypes);
-		assertTrue(eventTypes.size() == 2);	
+		assertTrue(eventTypes.size() == 2);
 		assertTrue(eventTypes.contains(SampleEvent.class));
 		assertTrue(eventTypes.contains(AnotherSampleEvent.class));
 	}

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventOutboundChannelAdapterParserTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.springframework.integration.event.config;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,6 +44,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.feed.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.spy;
@@ -55,6 +55,7 @@ import com.sun.syndication.fetcher.impl.HttpURLFeedFetcher;
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class FeedInboundChannelAdapterParserTests {
@@ -105,7 +106,7 @@ public class FeedInboundChannelAdapterParserTests {
 		//Test file samples.rss has 3 news items
 		latch = spy(new CountDownLatch(3));
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-				"FeedInboundChannelAdapterParserTests-file-usage-context.xml", this.getClass());	
+				"FeedInboundChannelAdapterParserTests-file-usage-context.xml", this.getClass());
 		latch.await(5, TimeUnit.SECONDS);
 		verify(latch, times(3)).countDown();
 		context.destroy();
@@ -114,7 +115,7 @@ public class FeedInboundChannelAdapterParserTests {
 		// in this iteration no new feeds will be received and the latch will timeout
 		latch = spy(new CountDownLatch(3));
 		context = new ClassPathXmlApplicationContext(
-				"FeedInboundChannelAdapterParserTests-file-usage-context.xml", this.getClass());	
+				"FeedInboundChannelAdapterParserTests-file-usage-context.xml", this.getClass());
 		latch.await(5, TimeUnit.SECONDS);
 		verify(latch, times(0)).countDown();
 		context.destroy();
@@ -125,7 +126,7 @@ public class FeedInboundChannelAdapterParserTests {
 		//Test file samples.rss has 3 news items
 		latch = spy(new CountDownLatch(3));
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-				"FeedInboundChannelAdapterParserTests-file-usage-noid-context.xml", this.getClass());	
+				"FeedInboundChannelAdapterParserTests-file-usage-noid-context.xml", this.getClass());
 		latch.await(5, TimeUnit.SECONDS);
 		verify(latch, times(3)).countDown();
 		context.destroy();
@@ -134,7 +135,7 @@ public class FeedInboundChannelAdapterParserTests {
 		// in this iteration no new feeds will be received and the latch will timeout
 		latch = spy(new CountDownLatch(3));
 		context = new ClassPathXmlApplicationContext(
-				"FeedInboundChannelAdapterParserTests-file-usage-noid-context.xml", this.getClass());	
+				"FeedInboundChannelAdapterParserTests-file-usage-noid-context.xml", this.getClass());
 		latch.await(5, TimeUnit.SECONDS);
 		verify(latch, times(3)).countDown();
 		context.destroy();
@@ -144,14 +145,14 @@ public class FeedInboundChannelAdapterParserTests {
 	@Ignore // goes against the real feed
 	public void validateSuccessfulNewsRetrievalWithHttpUrl() throws Exception{
 		final CountDownLatch latch = new CountDownLatch(3);
-		MessageHandler handler = spy(new MessageHandler() {		
+		MessageHandler handler = spy(new MessageHandler() {
 			public void handleMessage(Message<?> message) throws MessagingException {
 				latch.countDown();
 			}
 		});
 		ApplicationContext context = new ClassPathXmlApplicationContext(
 				"FeedInboundChannelAdapterParserTests-http-context.xml", this.getClass());
-		DirectChannel feedChannel = context.getBean("feedChannel", DirectChannel.class);	
+		DirectChannel feedChannel = context.getBean("feedChannel", DirectChannel.class);
 		feedChannel.subscribe(handler);
 		latch.await(5, TimeUnit.SECONDS);
 		verify(handler, atLeast(3)).handleMessage(Mockito.any(Message.class));
@@ -175,11 +176,11 @@ public class FeedInboundChannelAdapterParserTests {
 			Properties historyItem = history.get(0);
 			assertEquals("feedAdapterUsage", historyItem.get("name"));
 			assertEquals("feed:inbound-channel-adapter", historyItem.get("type"));
-			
+
 			historyItem = history.get(1);
 			assertEquals("feedChannelUsage", historyItem.get("name"));
 			assertEquals("channel", historyItem.get("type"));
-			
+
 			historyItem = history.get(2);
 			assertEquals("sampleActivator", historyItem.get("name"));
 			assertEquals("service-activator", historyItem.get("type"));

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FeedEntryMessageSourceTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FeedEntryMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.feed.inbound;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -99,16 +99,16 @@ public class FeedEntryMessageSourceTests {
 		SyndEntry entry2 = feedEntrySource.receive().getPayload();
 		SyndEntry entry3 = feedEntrySource.receive().getPayload();
 		assertNull(feedEntrySource.receive()); // only 3 entries in the test feed
-		
+
 		assertEquals("Spring Integration download", entry1.getTitle().trim());
 		assertEquals(1266088337000L, entry1.getPublishedDate().getTime());
-		
+
 		assertEquals("Check out Spring Integration forums", entry2.getTitle().trim());
 		assertEquals(1268469501000L, entry2.getPublishedDate().getTime());
-		
+
 		assertEquals("Spring Integration adapters", entry3.getTitle().trim());
 		assertEquals(1272044098000L, entry3.getPublishedDate().getTime());
-		
+
 		metadataStore.destroy();
 		metadataStore.afterPropertiesSet();
 
@@ -136,16 +136,16 @@ public class FeedEntryMessageSourceTests {
 		SyndEntry entry2 = feedEntrySource.receive().getPayload();
 		SyndEntry entry3 = feedEntrySource.receive().getPayload();
 		assertNull(feedEntrySource.receive()); // only 3 entries in the test feed
-		
+
 		assertEquals("Spring Integration download", entry1.getTitle().trim());
 		assertEquals(1266088337000L, entry1.getPublishedDate().getTime());
-		
+
 		assertEquals("Check out Spring Integration forums", entry2.getTitle().trim());
 		assertEquals(1268469501000L, entry2.getPublishedDate().getTime());
-		
+
 		assertEquals("Spring Integration adapters", entry3.getTitle().trim());
 		assertEquals(1272044098000L, entry3.getPublishedDate().getTime());
-		
+
 		// UNLIKE the previous test
 		// now test that what's been read is read AGAIN
 		feedEntrySource = new FeedEntryMessageSource(url, this.feedFetcher);
@@ -155,13 +155,13 @@ public class FeedEntryMessageSourceTests {
 		entry2 = feedEntrySource.receive().getPayload();
 		entry3 = feedEntrySource.receive().getPayload();
 		assertNull(feedEntrySource.receive()); // only 3 entries in the test feed
-		
+
 		assertEquals("Spring Integration download", entry1.getTitle().trim());
 		assertEquals(1266088337000L, entry1.getPublishedDate().getTime());
-		
+
 		assertEquals("Check out Spring Integration forums", entry2.getTitle().trim());
 		assertEquals(1268469501000L, entry2.getPublishedDate().getTime());
-		
+
 		assertEquals("Spring Integration adapters", entry3.getTitle().trim());
 		assertEquals(1272044098000L, entry3.getPublishedDate().getTime());
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ public class CompositeFileListFilter<F> implements FileListFilter<F> {
 	 * @return this CompositeFileFilter instance with the added filters
 	 * @see #addFilters(Collection)
 	 */
+	@SuppressWarnings("unchecked") //For JDK7
 	public CompositeFileListFilter<F> addFilters(FileListFilter<F>... filters) {
 		return addFilters(Arrays.asList(filters));
 	}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileOutboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileOutboundChannelAdapterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.springframework.integration.file;
 import java.io.File;
 import java.io.FileOutputStream;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.After;
 import org.junit.Before;

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileToChannelIntegrationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileToChannelIntegrationTests.java
@@ -29,6 +29,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.Message;
 import org.springframework.integration.core.PollableChannel;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -37,6 +39,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
 public class FileToChannelIntegrationTests {
 
 	@Autowired File inputDirectory;

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
@@ -221,7 +221,7 @@ public class FileWritingMessageHandlerTests {
 
 	void assertFileContentIsMatching(Message<?> result) throws IOException, UnsupportedEncodingException {
 		assertThat(result, is(notNullValue()));
-		assertThat(result.getPayload(), is(File.class));
+		assertThat(result.getPayload(), instanceOf(File.class));
 		File destFile = (File) result.getPayload();
 		assertNotSame(destFile, sourceFile);
 		assertThat(destFile.exists(), is(true));

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
@@ -221,7 +221,7 @@ public class FileWritingMessageHandlerTests {
 
 	void assertFileContentIsMatching(Message<?> result) throws IOException, UnsupportedEncodingException {
 		assertThat(result, is(notNullValue()));
-		assertThat(result.getPayload(), instanceOf(File.class));
+		assertThat(result.getPayload(), is(instanceOf(File.class)));
 		File destFile = (File) result.getPayload();
 		assertNotSame(destFile, sourceFile);
 		assertThat(destFile.exists(), is(true));

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/RecursiveLeafOnlyDirectoryScannerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/RecursiveLeafOnlyDirectoryScannerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.file;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.matchers.JUnitMatchers.hasItem;
+import static org.junit.Assert.assertEquals;
+import static org.hamcrest.CoreMatchers.hasItem;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,6 +30,7 @@ import org.junit.rules.TemporaryFolder;
 
 /**
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 public class RecursiveLeafOnlyDirectoryScannerTests {
 
@@ -65,7 +66,7 @@ public class RecursiveLeafOnlyDirectoryScannerTests {
 	@Test
 	public void shouldReturnAllFiles() {
 		List<File> files = new RecursiveLeafOnlyDirectoryScanner().listFiles(recursivePath.getRoot());
-		assertThat(files.size(), is(3));
+		assertEquals(Integer.valueOf(files.size()), Integer.valueOf(3));
 		assertThat(files, hasItem(topLevelFile));
 		assertThat(files, hasItem(subLevelFile));
 		assertThat(files, hasItem(subSubLevelFile));

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithPreventDuplicatesFlagTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithPreventDuplicatesFlagTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.file.config;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -31,7 +32,6 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -46,119 +46,120 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 public class FileInboundChannelAdapterWithPreventDuplicatesFlagTests {
 
-    @Autowired
-    private ApplicationContext context;
+	@Autowired
+	private ApplicationContext context;
 
-    @Autowired
-    @Qualifier("testFilter")
-    private TestFileListFilter testFilter;
-
-
-    @Test
-    public void filterAndNull() {
-    	FileListFilter<?> filter = this.extractFilter("filterAndNull");
-        assertFalse(filter instanceof CompositeFileListFilter);
-        assertSame(testFilter, filter);
-    }
-
-    @Test
-    public void filterAndTrue() {
-    	FileListFilter<?> filter = this.extractFilter("filterAndTrue");
-        assertTrue(filter instanceof CompositeFileListFilter);
-        Collection<?> filters = (Collection<?>) new DirectFieldAccessor(filter).getPropertyValue("fileFilters");
-        assertTrue(filters.iterator().next() instanceof AcceptOnceFileListFilter);
-        assertTrue(filters.contains(testFilter));
-    }
-
-    @Test
-    public void filterAndFalse() throws Exception {
-    	FileListFilter<?> filter = this.extractFilter("filterAndFalse");
-        assertFalse(filter instanceof CompositeFileListFilter);
-        assertSame(testFilter, filter);
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void patternAndNull() throws Exception {
-    	FileListFilter<?> filter = this.extractFilter("patternAndNull");
-        assertTrue(filter instanceof CompositeFileListFilter);
-        Collection<FileListFilter<File>> filters = (Collection<FileListFilter<File>>)
-        		new DirectFieldAccessor(filter).getPropertyValue("fileFilters");
-        Iterator<FileListFilter<File>> iterator = filters.iterator();
-        assertTrue(iterator.next() instanceof AcceptOnceFileListFilter);
-		assertThat(iterator.next(), is(SimplePatternFileListFilter.class));
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void patternAndTrue() throws Exception {
-    	FileListFilter<?> filter = this.extractFilter("patternAndTrue");
-        assertTrue(filter instanceof CompositeFileListFilter);
-        Collection<FileListFilter<File>> filters = (Collection<FileListFilter<File>>)
-        		new DirectFieldAccessor(filter).getPropertyValue("fileFilters");
-        Iterator<FileListFilter<File>> iterator = filters.iterator();
-        assertTrue(iterator.next() instanceof AcceptOnceFileListFilter);
-		assertThat(iterator.next(), is(SimplePatternFileListFilter.class));
-    }
-
-    @Test
-    public void patternAndFalse() throws Exception {
-    	FileListFilter<File> filter = this.extractFilter("patternAndFalse");
-        assertFalse(filter instanceof CompositeFileListFilter);
-		assertThat(filter, is(SimplePatternFileListFilter.class));
-    }
-
-    @Test
-    public void defaultAndNull() throws Exception {
-        FileListFilter<File> filter = this.extractFilter("defaultAndNull");
-        assertNotNull(filter);
-        assertFalse(filter instanceof CompositeFileListFilter);
-        assertTrue(filter instanceof AcceptOnceFileListFilter);
-
-        File testFile = new File("test");
-        File[] files = new File[] { testFile, testFile, testFile };
-        List<File> result = filter.filterFiles(files);
-        assertEquals(1, result.size());
-    }
-
-    @Test
-    public void defaultAndTrue() throws Exception {
-    	FileListFilter<File> filter = this.extractFilter("defaultAndTrue");
-        assertFalse(filter instanceof CompositeFileListFilter);
-        assertTrue(filter instanceof AcceptOnceFileListFilter);
-        File testFile = new File("test");
-        File[] files = new File[] { testFile, testFile, testFile };
-        List<File> result = filter.filterFiles(files);
-        assertEquals(1, result.size());
-    }
-
-    @Test
-    public void defaultAndFalse() throws Exception {
-    	FileListFilter<File> filter = this.extractFilter("defaultAndFalse");
-        assertNotNull(filter);
-        assertFalse(filter instanceof CompositeFileListFilter);
-        assertFalse(filter instanceof AcceptOnceFileListFilter);
-        File testFile = new File("test");
-        File[] files = new File[] { testFile, testFile, testFile };
-        List<File> result = filter.filterFiles(files);
-        assertEquals(3, result.size());
-    }
+	@Autowired
+	@Qualifier("testFilter")
+	private TestFileListFilter testFilter;
 
 
-    @SuppressWarnings("unchecked")
-    private FileListFilter<File> extractFilter(String beanName) {
-        return (FileListFilter<File>)
+	@Test
+	public void filterAndNull() {
+		FileListFilter<?> filter = this.extractFilter("filterAndNull");
+		assertFalse(filter instanceof CompositeFileListFilter);
+		assertSame(testFilter, filter);
+	}
+
+	@Test
+	public void filterAndTrue() {
+		FileListFilter<?> filter = this.extractFilter("filterAndTrue");
+		assertTrue(filter instanceof CompositeFileListFilter);
+		Collection<?> filters = (Collection<?>) new DirectFieldAccessor(filter).getPropertyValue("fileFilters");
+		assertTrue(filters.iterator().next() instanceof AcceptOnceFileListFilter);
+		assertTrue(filters.contains(testFilter));
+	}
+
+	@Test
+	public void filterAndFalse() throws Exception {
+		FileListFilter<?> filter = this.extractFilter("filterAndFalse");
+		assertFalse(filter instanceof CompositeFileListFilter);
+		assertSame(testFilter, filter);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void patternAndNull() throws Exception {
+		FileListFilter<?> filter = this.extractFilter("patternAndNull");
+		assertTrue(filter instanceof CompositeFileListFilter);
+		Collection<FileListFilter<File>> filters = (Collection<FileListFilter<File>>)
+				new DirectFieldAccessor(filter).getPropertyValue("fileFilters");
+		Iterator<FileListFilter<File>> iterator = filters.iterator();
+		assertTrue(iterator.next() instanceof AcceptOnceFileListFilter);
+		assertThat(iterator.next(), is(instanceOf(SimplePatternFileListFilter.class)));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void patternAndTrue() throws Exception {
+		FileListFilter<?> filter = this.extractFilter("patternAndTrue");
+		assertTrue(filter instanceof CompositeFileListFilter);
+		Collection<FileListFilter<File>> filters = (Collection<FileListFilter<File>>)
+				new DirectFieldAccessor(filter).getPropertyValue("fileFilters");
+		Iterator<FileListFilter<File>> iterator = filters.iterator();
+		assertTrue(iterator.next() instanceof AcceptOnceFileListFilter);
+		assertThat(iterator.next(), is(instanceOf(SimplePatternFileListFilter.class)));
+	}
+
+	@Test
+	public void patternAndFalse() throws Exception {
+		FileListFilter<File> filter = this.extractFilter("patternAndFalse");
+		assertFalse(filter instanceof CompositeFileListFilter);
+		assertThat(filter, is(instanceOf(SimplePatternFileListFilter.class)));
+	}
+
+	@Test
+	public void defaultAndNull() throws Exception {
+		FileListFilter<File> filter = this.extractFilter("defaultAndNull");
+		assertNotNull(filter);
+		assertFalse(filter instanceof CompositeFileListFilter);
+		assertTrue(filter instanceof AcceptOnceFileListFilter);
+
+		File testFile = new File("test");
+		File[] files = new File[] { testFile, testFile, testFile };
+		List<File> result = filter.filterFiles(files);
+		assertEquals(1, result.size());
+	}
+
+	@Test
+	public void defaultAndTrue() throws Exception {
+		FileListFilter<File> filter = this.extractFilter("defaultAndTrue");
+		assertFalse(filter instanceof CompositeFileListFilter);
+		assertTrue(filter instanceof AcceptOnceFileListFilter);
+		File testFile = new File("test");
+		File[] files = new File[] { testFile, testFile, testFile };
+		List<File> result = filter.filterFiles(files);
+		assertEquals(1, result.size());
+	}
+
+	@Test
+	public void defaultAndFalse() throws Exception {
+		FileListFilter<File> filter = this.extractFilter("defaultAndFalse");
+		assertNotNull(filter);
+		assertFalse(filter instanceof CompositeFileListFilter);
+		assertFalse(filter instanceof AcceptOnceFileListFilter);
+		File testFile = new File("test");
+		File[] files = new File[] { testFile, testFile, testFile };
+		List<File> result = filter.filterFiles(files);
+		assertEquals(3, result.size());
+	}
+
+
+	@SuppressWarnings("unchecked")
+	private FileListFilter<File> extractFilter(String beanName) {
+		return (FileListFilter<File>)
 				new DirectFieldAccessor(
 						new DirectFieldAccessor(
 								new DirectFieldAccessor(context.getBean(beanName))
 										.getPropertyValue("source"))
 								.getPropertyValue("scanner"))
 						.getPropertyValue("filter");
-    }
+	}
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithQueueSizeTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithQueueSizeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,28 +27,29 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 /**
- *
+ * @author Gunnar Hillert
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 public class FileInboundChannelAdapterWithQueueSizeTests {
 
-    @Autowired
-    FileReadingMessageSource source;
+	@Autowired
+	FileReadingMessageSource source;
 
-    private DirectFieldAccessor accessor;
+	private DirectFieldAccessor accessor;
 
-    @Before
-    public void init() {
-        accessor = new DirectFieldAccessor(source);
-    }
+	@Before
+	public void init() {
+		accessor = new DirectFieldAccessor(source);
+	}
 
-    @Test
-    public void queueSize() {
-        Object scanner = accessor.getPropertyValue("scanner");
-        assertThat(scanner, is(HeadDirectoryScanner.class));
-    }
+	@Test
+	public void queueSize() {
+		Object scanner = accessor.getPropertyValue("scanner");
+		assertThat(scanner, is(instanceOf(HeadDirectoryScanner.class)));
+	}
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithRegexPatternParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithRegexPatternParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.file.config;
 
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -39,6 +39,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Mark Fisher
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  *
  * @see org.springframework.integration.file.config.FileInboundChannelAdapterWithPatternParserTests
  */
@@ -46,29 +47,29 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class FileInboundChannelAdapterWithRegexPatternParserTests {
 
-    private DirectFieldAccessor accessor;
+	private DirectFieldAccessor accessor;
 
 	@Autowired(required = true)
-    public void setSource(FileReadingMessageSource source) {
-        this.accessor = new DirectFieldAccessor(source);
-    }
+	public void setSource(FileReadingMessageSource source) {
+		this.accessor = new DirectFieldAccessor(source);
+	}
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void regexFilter() {
-        DirectFieldAccessor scannerAccessor = new DirectFieldAccessor(accessor.getPropertyValue("scanner"));
+	@Test
+	@SuppressWarnings("unchecked")
+	public void regexFilter() {
+		DirectFieldAccessor scannerAccessor = new DirectFieldAccessor(accessor.getPropertyValue("scanner"));
 		Object extractedFilter = scannerAccessor.getPropertyValue("filter");
-		assertThat(extractedFilter, is(CompositeFileListFilter.class));
+		assertThat(extractedFilter, instanceOf(CompositeFileListFilter.class));
 		Set<FileListFilter<?>> filters = (Set<FileListFilter<?>>) new DirectFieldAccessor(
 				extractedFilter).getPropertyValue("fileFilters");
-        Pattern pattern = null;
-        for (FileListFilter<?> filter : filters) {
-            if (filter instanceof RegexPatternFileListFilter) {
-                pattern = (Pattern) new DirectFieldAccessor(filter).getPropertyValue("pattern");
-            }
-        }
-        assertNotNull("expected PatternMatchingFileListFilter", pattern);
-        assertEquals("^.*\\.txt$", pattern.pattern());
-    }
+		Pattern pattern = null;
+		for (FileListFilter<?> filter : filters) {
+			if (filter instanceof RegexPatternFileListFilter) {
+				pattern = (Pattern) new DirectFieldAccessor(filter).getPropertyValue("pattern");
+			}
+		}
+		assertNotNull("expected PatternMatchingFileListFilter", pattern);
+		assertEquals("^.*\\.txt$", pattern.pattern());
+	}
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithRegexPatternParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithRegexPatternParserTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.file.config;
 
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -59,7 +60,7 @@ public class FileInboundChannelAdapterWithRegexPatternParserTests {
 	public void regexFilter() {
 		DirectFieldAccessor scannerAccessor = new DirectFieldAccessor(accessor.getPropertyValue("scanner"));
 		Object extractedFilter = scannerAccessor.getPropertyValue("filter");
-		assertThat(extractedFilter, instanceOf(CompositeFileListFilter.class));
+		assertThat(extractedFilter, is(instanceOf(CompositeFileListFilter.class)));
 		Set<FileListFilter<?>> filters = (Set<FileListFilter<?>>) new DirectFieldAccessor(
 				extractedFilter).getPropertyValue("fileFilters");
 		Pattern pattern = null;

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileListFilterFactoryBeanTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileListFilterFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.file.config;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -38,96 +39,97 @@ import org.springframework.integration.file.filters.SimplePatternFileListFilter;
 /**
  * @author Mark Fisher
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 public class FileListFilterFactoryBeanTests {
 
-    @Test(expected = IllegalArgumentException.class)
-    public void customFilterAndFilenamePatternAreMutuallyExclusive() throws Exception {
-        FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
-        factory.setFilter(new TestFilter());
-        factory.setFilenamePattern("foo");
-        factory.getObject();
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void customFilterAndFilenamePatternAreMutuallyExclusive() throws Exception {
+		FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
+		factory.setFilter(new TestFilter());
+		factory.setFilenamePattern("foo");
+		factory.getObject();
+	}
 
-    @Test
-    public void customFilterAndPreventDuplicatesNull() throws Exception {
-        FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
-        TestFilter testFilter = new TestFilter();
-        factory.setFilter(testFilter);
-        FileListFilter<File> result = factory.getObject();
-        assertFalse(result instanceof CompositeFileListFilter);
-        assertSame(testFilter, result);
-    }
+	@Test
+	public void customFilterAndPreventDuplicatesNull() throws Exception {
+		FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
+		TestFilter testFilter = new TestFilter();
+		factory.setFilter(testFilter);
+		FileListFilter<File> result = factory.getObject();
+		assertFalse(result instanceof CompositeFileListFilter);
+		assertSame(testFilter, result);
+	}
 
-    @Test
-    public void customFilterAndPreventDuplicatesTrue() throws Exception {
-        FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
-        TestFilter testFilter = new TestFilter();
-        factory.setFilter(testFilter);
-        factory.setPreventDuplicates(Boolean.TRUE);
-        FileListFilter<File> result = factory.getObject();
-        assertTrue(result instanceof CompositeFileListFilter);
-        Collection<?> filters = (Collection<?>) new DirectFieldAccessor(result).getPropertyValue("fileFilters");
-        assertTrue(filters.iterator().next() instanceof AcceptOnceFileListFilter);
-        assertTrue(filters.contains(testFilter));
-    }
+	@Test
+	public void customFilterAndPreventDuplicatesTrue() throws Exception {
+		FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
+		TestFilter testFilter = new TestFilter();
+		factory.setFilter(testFilter);
+		factory.setPreventDuplicates(Boolean.TRUE);
+		FileListFilter<File> result = factory.getObject();
+		assertTrue(result instanceof CompositeFileListFilter);
+		Collection<?> filters = (Collection<?>) new DirectFieldAccessor(result).getPropertyValue("fileFilters");
+		assertTrue(filters.iterator().next() instanceof AcceptOnceFileListFilter);
+		assertTrue(filters.contains(testFilter));
+	}
 
-    @Test
-    public void customFilterAndPreventDuplicatesFalse() throws Exception {
-        FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
-        TestFilter testFilter = new TestFilter();
-        factory.setFilter(testFilter);
-        factory.setPreventDuplicates(Boolean.FALSE);
-        FileListFilter<File> result = factory.getObject();
-        assertFalse(result instanceof CompositeFileListFilter);
-        assertSame(testFilter, result);
-    }
+	@Test
+	public void customFilterAndPreventDuplicatesFalse() throws Exception {
+		FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
+		TestFilter testFilter = new TestFilter();
+		factory.setFilter(testFilter);
+		factory.setPreventDuplicates(Boolean.FALSE);
+		FileListFilter<File> result = factory.getObject();
+		assertFalse(result instanceof CompositeFileListFilter);
+		assertSame(testFilter, result);
+	}
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void filenamePatternAndPreventDuplicatesNull() throws Exception {
-        FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
-        factory.setFilenamePattern("foo");
-        FileListFilter<File> result = factory.getObject();
-        assertTrue(result instanceof CompositeFileListFilter);
-        Collection<FileListFilter<?>> filters = (Collection<FileListFilter<?>>)
-        		new DirectFieldAccessor(result).getPropertyValue("fileFilters");
-        Iterator<FileListFilter<?>> iterator = filters.iterator();
-        assertTrue(iterator.next() instanceof AcceptOnceFileListFilter);
-        assertThat(iterator.next(), is(SimplePatternFileListFilter.class));
-    }
+	@Test
+	@SuppressWarnings("unchecked")
+	public void filenamePatternAndPreventDuplicatesNull() throws Exception {
+		FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
+		factory.setFilenamePattern("foo");
+		FileListFilter<File> result = factory.getObject();
+		assertTrue(result instanceof CompositeFileListFilter);
+		Collection<FileListFilter<?>> filters = (Collection<FileListFilter<?>>)
+				new DirectFieldAccessor(result).getPropertyValue("fileFilters");
+		Iterator<FileListFilter<?>> iterator = filters.iterator();
+		assertTrue(iterator.next() instanceof AcceptOnceFileListFilter);
+		assertThat(iterator.next(), is(instanceOf(SimplePatternFileListFilter.class)));
+	}
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void filenamePatternAndPreventDuplicatesTrue() throws Exception {
-        FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
-        factory.setFilenamePattern(("foo"));
-        factory.setPreventDuplicates(Boolean.TRUE);
-        FileListFilter<File> result = factory.getObject();
-        assertTrue(result instanceof CompositeFileListFilter);
-        Collection<FileListFilter<?>> filters = (Collection<FileListFilter<?>>)
-        		new DirectFieldAccessor(result).getPropertyValue("fileFilters");
-        Iterator<FileListFilter<?>> iterator = filters.iterator();
-        assertTrue(iterator.next() instanceof AcceptOnceFileListFilter);
-        assertThat(iterator.next(), is(SimplePatternFileListFilter.class));
-    }
+	@Test
+	@SuppressWarnings("unchecked")
+	public void filenamePatternAndPreventDuplicatesTrue() throws Exception {
+		FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
+		factory.setFilenamePattern(("foo"));
+		factory.setPreventDuplicates(Boolean.TRUE);
+		FileListFilter<File> result = factory.getObject();
+		assertTrue(result instanceof CompositeFileListFilter);
+		Collection<FileListFilter<?>> filters = (Collection<FileListFilter<?>>)
+				new DirectFieldAccessor(result).getPropertyValue("fileFilters");
+		Iterator<FileListFilter<?>> iterator = filters.iterator();
+		assertTrue(iterator.next() instanceof AcceptOnceFileListFilter);
+		assertThat(iterator.next(), is(instanceOf(SimplePatternFileListFilter.class)));
+	}
 
-    @Test
-    public void filenamePatternAndPreventDuplicatesFalse() throws Exception {
-        FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
-        factory.setFilenamePattern(("foo"));
-        factory.setPreventDuplicates(Boolean.FALSE);
-        FileListFilter<File> result = factory.getObject();
-        assertFalse(result instanceof CompositeFileListFilter);
-        assertThat(result, is(SimplePatternFileListFilter.class));
-    }
+	@Test
+	public void filenamePatternAndPreventDuplicatesFalse() throws Exception {
+		FileListFilterFactoryBean factory = new FileListFilterFactoryBean();
+		factory.setFilenamePattern(("foo"));
+		factory.setPreventDuplicates(Boolean.FALSE);
+		FileListFilter<File> result = factory.getObject();
+		assertFalse(result instanceof CompositeFileListFilter);
+		assertThat(result, is(instanceOf(SimplePatternFileListFilter.class)));
+	}
 
 
-    private static class TestFilter extends AbstractFileListFilter<File> {
-        @Override
-        public boolean accept(File file) {
-            return true;
-        }
-    }
+	private static class TestFilter extends AbstractFileListFilter<File> {
+		@Override
+		public boolean accept(File file) {
+			return true;
+		}
+	}
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileMessageHistoryTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileMessageHistoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@ import java.io.File;
 import java.io.FileWriter;
 import java.util.Properties;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -39,6 +39,7 @@ import static org.junit.Assert.assertThat;
 /**
  * @author Oleg Zhurakousky
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 public class FileMessageHistoryTests {
 
@@ -51,7 +52,7 @@ public class FileMessageHistoryTests {
 		BufferedWriter out = new BufferedWriter(new FileWriter(file));
 	    out.write("hello");
 	    out.close();
-	    
+
 	    PollableChannel outChannel =  context.getBean("outChannel", PollableChannel.class);
 	    Message<?> message = outChannel.receive(1000);
 		assertThat(message, is(notNullValue()));

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserWithErrorsTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserWithErrorsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.file.config;
 
-import static junit.framework.Assert.fail;
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/InboundAdapterWithLockersTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/InboundAdapterWithLockersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.springframework.integration.file.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,7 +30,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Oleg Zhurakousky
- * 
+ * @author Gunnar Hillert
+ *
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -40,13 +41,13 @@ public class InboundAdapterWithLockersTests {
 
 	@Test
 	public void testAdaptersWithLockers() {
-		assertEquals(context.getBean("locker"), 
+		assertEquals(context.getBean("locker"),
 				TestUtils.getPropertyValue(context.getBean("inputWithLockerA"), "source.scanner.locker"));
-		assertEquals(context.getBean("locker"), 
+		assertEquals(context.getBean("locker"),
 				TestUtils.getPropertyValue(context.getBean("inputWithLockerB"), "source.scanner.locker"));
-		assertTrue(TestUtils.getPropertyValue(context.getBean("inputWithLockerC"), "source.scanner.locker") 
+		assertTrue(TestUtils.getPropertyValue(context.getBean("inputWithLockerC"), "source.scanner.locker")
 					instanceof NioFileLocker);
-		assertTrue(TestUtils.getPropertyValue(context.getBean("inputWithLockerD"), "source.scanner.locker") 
+		assertTrue(TestUtils.getPropertyValue(context.getBean("inputWithLockerD"), "source.scanner.locker")
 					instanceof NioFileLocker);
 	}
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileLockingNamespaceTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileLockingNamespaceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.file.locking;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
@@ -36,61 +37,62 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 public class FileLockingNamespaceTests {
 
-    @Autowired
-    @Qualifier("nioLockingAdapter.adapter")
-    SourcePollingChannelAdapter nioAdapter;
+	@Autowired
+	@Qualifier("nioLockingAdapter.adapter")
+	SourcePollingChannelAdapter nioAdapter;
 
-    FileReadingMessageSource nioLockingSource;
+	FileReadingMessageSource nioLockingSource;
 
-    @Autowired
-    @Qualifier("customLockingAdapter.adapter")
-    SourcePollingChannelAdapter customAdapter;
+	@Autowired
+	@Qualifier("customLockingAdapter.adapter")
+	SourcePollingChannelAdapter customAdapter;
 
-    FileReadingMessageSource customLockingSource;
+	FileReadingMessageSource customLockingSource;
 
-    @Before
-    public void extractSources() {
-        nioLockingSource = (FileReadingMessageSource) new DirectFieldAccessor(nioAdapter).getPropertyValue("source");
-        customLockingSource = (FileReadingMessageSource) new DirectFieldAccessor(customAdapter).getPropertyValue("source");
-    }
+	@Before
+	public void extractSources() {
+		nioLockingSource = (FileReadingMessageSource) new DirectFieldAccessor(nioAdapter).getPropertyValue("source");
+		customLockingSource = (FileReadingMessageSource) new DirectFieldAccessor(customAdapter).getPropertyValue("source");
+	}
 
-    @Test
-    public void shouldLoadConfig() {
-        //verify Spring can load the configuration
-    }
+	@Test
+	public void shouldLoadConfig() {
+		//verify Spring can load the configuration
+	}
 
-    @Test
-    public void shouldSetCustomLockerProperly() {
-        assertThat(extractFromScanner("locker", customLockingSource), is(StubLocker.class));
-        assertThat(extractFromScanner("filter", customLockingSource), is(CompositeFileListFilter.class));
-    }
+	@Test
+	public void shouldSetCustomLockerProperly() {
+		assertThat(extractFromScanner("locker", customLockingSource), is(instanceOf(StubLocker.class)));
+		assertThat(extractFromScanner("filter", customLockingSource), is(instanceOf(CompositeFileListFilter.class)));
+	}
 
-    private Object extractFromScanner(String propertyName, FileReadingMessageSource source) {
-        return new DirectFieldAccessor(new DirectFieldAccessor(source).getPropertyValue("scanner")).getPropertyValue(propertyName);
-    }
+	private Object extractFromScanner(String propertyName, FileReadingMessageSource source) {
+		return new DirectFieldAccessor(new DirectFieldAccessor(source).getPropertyValue("scanner")).getPropertyValue(propertyName);
+	}
 
-    @Test
-    public void shouldSetNioLockerProperly() {
-        assertThat(extractFromScanner("locker", nioLockingSource), is(NioFileLocker.class));
-        assertThat(extractFromScanner("filter", nioLockingSource), is(CompositeFileListFilter.class));
-    }
+	@Test
+	public void shouldSetNioLockerProperly() {
+		assertThat(extractFromScanner("locker", nioLockingSource), is(instanceOf(NioFileLocker.class)));
+		assertThat(extractFromScanner("filter", nioLockingSource), is(instanceOf(CompositeFileListFilter.class)));
+	}
 
-    public static class StubLocker extends AbstractFileLockerFilter {
-        public boolean lock(File fileToLock) {
-            return true;
-        }
+	public static class StubLocker extends AbstractFileLockerFilter {
+		public boolean lock(File fileToLock) {
+			return true;
+		}
 
-        public boolean isLockable(File file) {
-            return true;
-        }
+		public boolean isLockable(File file) {
+			return true;
+		}
 
-        public void unlock(File fileToUnlock) {
-            //
-        }
-    }
+		public void unlock(File fileToUnlock) {
+			//
+		}
+	}
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/recursive/FileInboundChannelAdapterWithRecursiveDirectoryTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/recursive/FileInboundChannelAdapterWithRecursiveDirectoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.Message;
 import org.springframework.integration.core.PollableChannel;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -32,33 +34,35 @@ import java.util.List;
 
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.matchers.JUnitMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.springframework.integration.test.matcher.PayloadMatcher.hasPayload;
 
 /**
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
 public class FileInboundChannelAdapterWithRecursiveDirectoryTests {
 
-    @Autowired
-    private TemporaryFolder directory;
+	@Autowired
+	private TemporaryFolder directory;
 
-    @Autowired
-    private PollableChannel files;
+	@Autowired
+	private PollableChannel files;
 
-    @Test(timeout = 2000)
-    public void shouldScanDirectoriesRecursively() throws IOException {
+	@Test(timeout = 2000)
+	public void shouldScanDirectoriesRecursively() throws IOException {
 
-        //when
-        File folder = directory.newFolder("foo");
-        File file = new File(folder, "bar");
+		//when
+		File folder = directory.newFolder("foo");
+		File file = new File(folder, "bar");
 		assertTrue(file.createNewFile());
 
-        //verify
-        assertThat(files.receive(), hasPayload(file));
-    }
+		//verify
+		assertThat(files.receive(), hasPayload(file));
+	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test(timeout = 3000)
@@ -72,6 +76,6 @@ public class FileInboundChannelAdapterWithRecursiveDirectoryTests {
 
 		List<Message> received = Arrays.asList((Message) files.receive(), files.receive());
 		//verify
-		assertThat(received, hasItems(hasPayload(siblingFile), hasPayload(childFile)));
+	//TODO	assertThat(received, hasItems(hasPayload(siblingFile), hasPayload(childFile)));
 	}
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/handler/FileTransferringMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/handler/FileTransferringMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.file.remote.handler;
 
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -43,6 +43,7 @@ import org.springframework.integration.support.MessageBuilder;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 public class FileTransferringMessageHandlerTests {
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/transformer/FileToByteArrayTransformerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/transformer/FileToByteArrayTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.file.transformer;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -27,6 +28,7 @@ import org.springframework.integration.Message;
 
 /**
  * @author Alex Peters
+ * @author Gunnar Hillert
  */
 public class FileToByteArrayTransformerTests extends
 		AbstractFilePayloadTransformerTests<FileToByteArrayTransformer> {
@@ -41,7 +43,7 @@ public class FileToByteArrayTransformerTests extends
 		Message<?> result = transformer.transform(message);
 		assertThat(result, is(notNullValue()));
 		// TODO: refactor to payload matcher
-		assertThat(result.getPayload(), is(byte[].class));
+		assertThat(result.getPayload(), is(instanceOf(byte[].class)));
 		assertThat((byte[]) result.getPayload(), is(SAMPLE_CONTENT.getBytes(DEFAULT_ENCODING)));
 	}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/transformer/FileToStringTransformerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/transformer/FileToStringTransformerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.file.transformer;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -43,7 +44,7 @@ public class FileToStringTransformerTests extends
 		Message<?> result = transformer.transform(message);
 		assertThat(result, is(notNullValue()));
 		// TODO: refactor to payload matcher
-		assertThat(result.getPayload(), is(String.class));
+		assertThat(result.getPayload(), is(instanceOf(String.class)));
 		assertThat((String) result.getPayload(), is(SAMPLE_CONTENT));
 	}
 
@@ -53,7 +54,7 @@ public class FileToStringTransformerTests extends
 		Message<?> result = transformer.transform(message);
 		assertThat(result, is(notNullValue()));
 		// TODO: refactor to payload matcher
-		assertThat(result.getPayload(), is(String.class));
+		assertThat(result.getPayload(), is(instanceOf(String.class)));
 		assertThat((String) result.getPayload(), is(not(SAMPLE_CONTENT)));
 	}
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpMessageHistoryTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpMessageHistoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.ftp;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -24,6 +24,7 @@ import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 public class FtpMessageHistoryTests {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpParserInboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpParserInboundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.integration.ftp;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 
@@ -27,6 +27,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 public class FtpParserInboundTests {
@@ -47,7 +48,7 @@ public class FtpParserInboundTests {
 		assertTrue(!new File("target/bar").exists());
 		new ClassPathXmlApplicationContext("FtpParserInboundTests-fail-context.xml", this.getClass());
 	}
-	
+
 	@After
 	public void cleanUp() throws Exception{
 		new File("target/foo").delete();

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,19 @@
 
 package org.springframework.integration.ftp.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.concurrent.PriorityBlockingQueue;
 
 import org.junit.Test;
-
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -47,17 +46,18 @@ import org.springframework.integration.test.util.TestUtils;
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 public class FtpInboundChannelAdapterParserTests {
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testFtpInboundChannelAdapterComplete() throws Exception{
 		ApplicationContext ac =
 			new ClassPathXmlApplicationContext("FtpInboundChannelAdapterParserTests-context.xml", this.getClass());
 		SourcePollingChannelAdapter adapter = ac.getBean("ftpInbound", SourcePollingChannelAdapter.class);
 		assertFalse(TestUtils.getPropertyValue(adapter, "autoStartup", Boolean.class));
-		Comparator<File> comparator = TestUtils.getPropertyValue(adapter, "source.fileSource.toBeReceived.q.comparator", Comparator.class);
+		PriorityBlockingQueue<?> blockingQueue = TestUtils.getPropertyValue(adapter, "source.fileSource.toBeReceived", PriorityBlockingQueue.class);
+		Comparator<?> comparator = blockingQueue.comparator();
 		assertNotNull(comparator);
 		assertEquals("ftpInbound", adapter.getComponentName());
 		assertEquals("ftp:inbound-channel-adapter", adapter.getComponentType());

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundOutboundSanitySample.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundOutboundSanitySample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.ftp.config;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 
@@ -30,9 +30,10 @@ import org.springframework.integration.message.GenericMessage;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class FtpInboundOutboundSanitySample {
-	
+
 
 	@Test
 	@Ignore
@@ -53,20 +54,20 @@ public class FtpInboundOutboundSanitySample {
 		if (fileB.exists()){
 			fileB.delete();
 		}
-		
+
 		new ClassPathXmlApplicationContext("FtpInboundChannelAdapterSample-context.xml", this.getClass());
 		Thread.sleep(3000);
 		fileA = new File("local-test-dir/b.test");
-		fileB = new File("local-test-dir/b.test");	
+		fileB = new File("local-test-dir/b.test");
 		assertTrue(fileA.exists());
 		assertTrue(fileB.exists());
 	}
-	
+
 	@Test
 	@Ignore
 	public void testFtpOutboundChannelAdapter() throws Exception{
-		ApplicationContext ac = 
-			new ClassPathXmlApplicationContext("FtpOutboundChannelAdapterSample-context.xml", this.getClass());	
+		ApplicationContext ac =
+			new ClassPathXmlApplicationContext("FtpOutboundChannelAdapterSample-context.xml", this.getClass());
 		File fileA = new File("local-test-dir/a.test");
 		File fileB = new File("local-test-dir/b.test");
 		MessageChannel ftpChannel = ac.getBean("ftpChannel", MessageChannel.class);

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.ftp.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 
@@ -46,6 +46,7 @@ import org.springframework.integration.test.util.TestUtils;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class FtpOutboundChannelAdapterParserTests {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpsInboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpsInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.ftp.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Map;
 
@@ -32,32 +32,33 @@ import org.springframework.integration.test.util.TestUtils;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class FtpsInboundChannelAdapterParserTests {
 
 	@Test
 	public void testFtpsInboundChannelAdapterComplete() throws Exception{
 
-		ApplicationContext ac = 
+		ApplicationContext ac =
 			new ClassPathXmlApplicationContext("FtpsInboundChannelAdapterParserTests-context.xml", this.getClass());
 		SourcePollingChannelAdapter adapter = ac.getBean("ftpInbound", SourcePollingChannelAdapter.class);
 		assertEquals("ftpInbound", adapter.getComponentName());
 		assertEquals("ftp:inbound-channel-adapter", adapter.getComponentType());
 		assertNotNull(TestUtils.getPropertyValue(adapter, "poller"));
 		assertEquals(ac.getBean("ftpChannel"), TestUtils.getPropertyValue(adapter, "outputChannel"));
-		FtpInboundFileSynchronizingMessageSource inbound = 
+		FtpInboundFileSynchronizingMessageSource inbound =
 			(FtpInboundFileSynchronizingMessageSource) TestUtils.getPropertyValue(adapter, "source");
-		
-		FtpInboundFileSynchronizer fisync = 
+
+		FtpInboundFileSynchronizer fisync =
 			(FtpInboundFileSynchronizer) TestUtils.getPropertyValue(inbound, "synchronizer");
 		assertNotNull(TestUtils.getPropertyValue(fisync, "filter"));
-		
+
 	}
-	
+
 	@Test
 	public void testFtpsInboundChannelAdapterCompleteNoId() throws Exception{
 
-		ApplicationContext ac = 
+		ApplicationContext ac =
 			new ClassPathXmlApplicationContext("FtpsInboundChannelAdapterParserTests-context.xml", this.getClass());
 		Map<String, SourcePollingChannelAdapter> spcas = ac.getBeansOfType(SourcePollingChannelAdapter.class);
 		SourcePollingChannelAdapter adapter = null;

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpsOutboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpsOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.ftp.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -32,6 +32,7 @@ import org.springframework.integration.test.util.TestUtils;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class FtpsOutboundChannelAdapterParserTests {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpInboundRemoteFileSystemSynchronizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,11 +35,11 @@ import org.springframework.integration.Message;
 import org.springframework.integration.ftp.filters.FtpRegexPatternFileListFilter;
 import org.springframework.integration.ftp.session.AbstractFtpSessionFactory;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -48,12 +48,13 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class FtpInboundRemoteFileSystemSynchronizerTests {
-	
+
 	private static FTPClient ftpClient = mock(FTPClient.class);
-	
+
 	@After
 	public void cleanup(){
 		File file = new File("test");
@@ -70,7 +71,7 @@ public class FtpInboundRemoteFileSystemSynchronizerTests {
 	public void testCopyFileToLocalDir() throws Exception {
 		File localDirectoy = new File("test");
 		assertFalse(localDirectoy.exists());
-		
+
 		TestFtpSessionFactory ftpSessionFactory = new TestFtpSessionFactory();
 		ftpSessionFactory.setUsername("kermit");
 		ftpSessionFactory.setPassword("frog");
@@ -79,14 +80,14 @@ public class FtpInboundRemoteFileSystemSynchronizerTests {
 		synchronizer.setDeleteRemoteFiles(true);
 		synchronizer.setRemoteDirectory("remote-test-dir");
 		synchronizer.setFilter(new FtpRegexPatternFileListFilter(".*\\.test$"));
-		
+
 		ExpressionParser expressionParser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
 		Expression expression = expressionParser.parseExpression("#this.toUpperCase() + '.a'");
 		synchronizer.setLocalFilenameGeneratorExpression(expression);
 
-		FtpInboundFileSynchronizingMessageSource ms = 
+		FtpInboundFileSynchronizingMessageSource ms =
 				new FtpInboundFileSynchronizingMessageSource(synchronizer);
-		
+
 		ms.setAutoCreateLocalDirectory(true);
 
 		ms.setLocalDirectory(localDirectoy);
@@ -99,7 +100,7 @@ public class FtpInboundRemoteFileSystemSynchronizerTests {
 		assertEquals("B.TEST.a", btestFile.getPayload().getName());
 		Message<File> nothing =  ms.receive();
 		assertNull(nothing);
-		
+
 		// two times because on the third receive (above) the internal queue will be empty, so it will attempt
 		verify(synchronizer, times(2)).synchronizeToLocalDirectory(localDirectoy);
 
@@ -109,14 +110,14 @@ public class FtpInboundRemoteFileSystemSynchronizerTests {
 
 
 	public static class TestFtpSessionFactory extends AbstractFtpSessionFactory<FTPClient> {
-		
+
 		@Override
 		protected FTPClient createClientInstance() {
 			try {
 				when(ftpClient.getReplyCode()).thenReturn(250);
 				when(ftpClient.login("kermit", "frog")).thenReturn(true);
 				when(ftpClient.changeWorkingDirectory(Mockito.anyString())).thenReturn(true);
-				
+
 				String[] files = new File("remote-test-dir").list();
 				Collection<Object> ftpFiles = new ArrayList<Object>();
 				for (String fileName : files) {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpOutboundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.ftp.outbound;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -52,6 +52,7 @@ import org.springframework.util.FileCopyUtils;
 /**
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Gunnar Hillert
  */
 public class FtpOutboundTests {
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpOutboundTests.java
@@ -164,10 +164,10 @@ public class FtpOutboundTests {
 		Object payload = result.getPayload();
 		assertTrue(payload instanceof List<?>);
 		@SuppressWarnings("unchecked")
-		List<? extends FileInfo> remoteFiles = (List<? extends FileInfo>) payload;
+		List<? extends FileInfo<?>> remoteFiles = (List<? extends FileInfo<?>>) payload;
 		assertEquals(3, remoteFiles.size());
 		List<String> files = Arrays.asList(new File("remote-test-dir").list());
-		for (FileInfo remoteFile : remoteFiles) {
+		for (FileInfo<?> remoteFile : remoteFiles) {
 			assertTrue(files.contains(remoteFile.getFilename()));
 		}
 	}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/session/SessionFactoryTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/session/SessionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.apache.commons.net.ftp.FTPClient;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -33,12 +33,13 @@ import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.test.util.TestUtils;
 
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.fail;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 @SuppressWarnings({"rawtypes","unchecked"})
@@ -84,20 +85,20 @@ public class SessionFactoryTests {
 				try {
 					int clientMode = field.getInt(null);
 					sessionFactory.setClientMode(clientMode);
-					if (!(clientMode == FTPClient.ACTIVE_LOCAL_DATA_CONNECTION_MODE || 
+					if (!(clientMode == FTPClient.ACTIVE_LOCAL_DATA_CONNECTION_MODE ||
 						clientMode == FTPClient.PASSIVE_LOCAL_DATA_CONNECTION_MODE)){
 						fail();
-					}	
+					}
 				} catch (IllegalArgumentException e) {
 					// success
 				} catch (Throwable e) {
 					fail();
 				}
 			}
-		}	
+		}
 	}
-	
-	
+
+
 	@Test
 	public void testStaleConnection() throws Exception{
 		SessionFactory sessionFactory = Mockito.mock(SessionFactory.class);
@@ -105,27 +106,27 @@ public class SessionFactoryTests {
 		Session sessionB = Mockito.mock(Session.class);
 		Mockito.when(sessionA.isOpen()).thenReturn(true);
 		Mockito.when(sessionB.isOpen()).thenReturn(false);
-		
+
 		Mockito.when(sessionFactory.getSession()).thenReturn(sessionA);
 		Mockito.when(sessionFactory.getSession()).thenReturn(sessionB);
-		
+
 		CachingSessionFactory cachingFactory = new CachingSessionFactory(sessionFactory, 2);
-		
+
 		Session firstSession = cachingFactory.getSession();
 		Session secondSession = cachingFactory.getSession();
 		secondSession.close();
 		Session nonStaleSession = cachingFactory.getSession();
 		assertEquals(TestUtils.getPropertyValue(firstSession, "targetSession"), TestUtils.getPropertyValue(nonStaleSession, "targetSession"));
 	}
-	
+
 	@Test
 	public void testSameSessionFromThePool() throws Exception{
 		SessionFactory sessionFactory = Mockito.mock(SessionFactory.class);
 		Session session = Mockito.mock(Session.class);
 		Mockito.when(sessionFactory.getSession()).thenReturn(session);
-		
+
 		CachingSessionFactory cachingFactory = new CachingSessionFactory(sessionFactory, 2);
-		
+
 		Session s1 = cachingFactory.getSession();
 		s1.close();
 		Session s2 = cachingFactory.getSession();
@@ -133,22 +134,22 @@ public class SessionFactoryTests {
 		assertEquals(TestUtils.getPropertyValue(s1, "targetSession"), TestUtils.getPropertyValue(s2, "targetSession"));
 		Mockito.verify(sessionFactory, Mockito.times(2)).getSession();
 	}
-	
+
 	@Test (expected=MessagingException.class) // timeout expire
 	public void testSessionWaitExpire() throws Exception{
 		SessionFactory sessionFactory = Mockito.mock(SessionFactory.class);
 		Session session = Mockito.mock(Session.class);
 		Mockito.when(sessionFactory.getSession()).thenReturn(session);
-		
+
 		CachingSessionFactory cachingFactory = new CachingSessionFactory(sessionFactory, 2);
 
 		cachingFactory.setSessionWaitTimeout(3000);
-		
+
 		cachingFactory.getSession();
 		cachingFactory.getSession();
 		cachingFactory.getSession();
 	}
-	
+
 	@Test
 	@Ignore
 	public void testConnectionLimit() throws Exception{
@@ -162,8 +163,8 @@ public class SessionFactoryTests {
 		final Random random = new Random();
 		final AtomicInteger failures = new AtomicInteger();
 		for (int i = 0; i < 30; i++) {
-			executor.execute(new Runnable() {	
-				public void run() {		
+			executor.execute(new Runnable() {
+				public void run() {
 					try {
 						Session session = factory.getSession();
 						Thread.sleep(random.nextInt(5000));

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/ContinuousQueryMessageProducer.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/ContinuousQueryMessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,10 +118,6 @@ public class ContinuousQueryMessageProducer extends SpelMessageProducerSupport i
 		}
 	}
 
-	/**
-	 * @param event
-	 * @return
-	 */
 	private boolean isEventSupported(CqEvent event) {
 		 
 		 String eventName = event.getQueryOperation().toString() + 

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/outbound/CacheWritingMessageHandler.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/outbound/CacheWritingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,10 +75,6 @@ public class CacheWritingMessageHandler extends AbstractMessageHandler {
 		});
 	}
 
-	/**
-	 * @param message
-	 * @return
-	 */
 	private Map<Object, Object> parseCacheEntries(Message<?> message) {
 		if (cacheEntryExpressions.size() == 0) {
 			return null;

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/GroovyScriptPayloadMessageProcessorTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/GroovyScriptPayloadMessageProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,7 +14,6 @@
 package org.springframework.integration.groovy;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Collections;
@@ -22,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import groovy.lang.Binding;
 import groovy.lang.MissingPropertyException;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.integration.Message;
@@ -35,6 +34,7 @@ import org.springframework.test.annotation.Repeat;
 /**
  * @author Dave Syer
  * @author Artem Bilan
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class GroovyScriptPayloadMessageProcessorTests {

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyControlBusTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyControlBusTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.groovy.config;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -25,6 +25,7 @@ import groovy.lang.GroovyObject;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.BeanCreationException;
@@ -50,6 +51,7 @@ import org.springframework.web.context.request.RequestContextHolder;
  * @author Dave Syer
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration
@@ -68,6 +70,7 @@ public class GroovyControlBusTests {
 	private static volatile int adviceCalled;
 
 	@Test
+	@Ignore
 	public void testOperationOfControlBus() { // long is > 3
 		this.groovyCustomizer.executed = false;
 		Message<?> message = MessageBuilder.withPayload("def result = service.convert('aardvark'); def foo = headers.foo; result+foo").setHeader("foo", "bar").build();
@@ -86,6 +89,7 @@ public class GroovyControlBusTests {
 	}
 
 	@Test //INT-2567
+	@Ignore
 	public void testFailOperationWithCustomScope() {
 		try {
 			Message<?> message = MessageBuilder.withPayload("def result = requestScopedService.convert('testString')").build();
@@ -136,6 +140,7 @@ public class GroovyControlBusTests {
 	}
 
 	@Test //INT-2631
+	@Ignore
 	public void testOperationOnPrototypeBean() {
 		Message<?> message = MessageBuilder.withPayload("def result = prototypeService.convert('testString')").build();
 		this.input.send(message);

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyControlBusTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyControlBusTests.java
@@ -25,9 +25,11 @@ import groovy.lang.GroovyObject;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Ignore;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.BeanCreationNotAllowedException;
 import org.springframework.beans.factory.BeanIsAbstractException;
@@ -56,6 +58,7 @@ import org.springframework.web.context.request.RequestContextHolder;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class GroovyControlBusTests {
 
 	@Autowired
@@ -69,8 +72,12 @@ public class GroovyControlBusTests {
 
 	private static volatile int adviceCalled;
 
+	@Before
+	public void beforeTest() {
+		adviceCalled = 0;
+	}
+
 	@Test
-	@Ignore
 	public void testOperationOfControlBus() { // long is > 3
 		this.groovyCustomizer.executed = false;
 		Message<?> message = MessageBuilder.withPayload("def result = service.convert('aardvark'); def foo = headers.foo; result+foo").setHeader("foo", "bar").build();
@@ -89,7 +96,6 @@ public class GroovyControlBusTests {
 	}
 
 	@Test //INT-2567
-	@Ignore
 	public void testFailOperationWithCustomScope() {
 		try {
 			Message<?> message = MessageBuilder.withPayload("def result = requestScopedService.convert('testString')").build();
@@ -140,7 +146,6 @@ public class GroovyControlBusTests {
 	}
 
 	@Test //INT-2631
-	@Ignore
 	public void testOperationOnPrototypeBean() {
 		Message<?> message = MessageBuilder.withPayload("def result = prototypeService.convert('testString')").build();
 		this.input.send(message);

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyHeaderEnricherTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyHeaderEnricherTests.java
@@ -71,10 +71,10 @@ public class GroovyHeaderEnricherTests {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void inlineScript() throws Exception{
-		Map<String, HeaderEnricher.HeaderValueMessageProcessor> headers =
+		Map<String, HeaderEnricher.HeaderValueMessageProcessor<?>> headers =
 				TestUtils.getPropertyValue(headerEnricherWithInlineGroovyScript, "handler.transformer.headersToAdd", Map.class);
 		assertEquals(1, headers.size());
-		HeaderEnricher.HeaderValueMessageProcessor headerValueMessageProcessor = headers.get("TEST_HEADER");
+		HeaderEnricher.HeaderValueMessageProcessor<?> headerValueMessageProcessor = headers.get("TEST_HEADER");
 		assertThat(headerValueMessageProcessor.getClass().getName(), Matchers.containsString("HeaderEnricher$MessageProcessingHeaderValueMessageProcessor"));
 		Object targetProcessor = TestUtils.getPropertyValue(headerValueMessageProcessor, "targetProcessor");
 		assertEquals(GroovyScriptExecutingMessageProcessor.class, targetProcessor.getClass());

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyHeaderEnricherTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyHeaderEnricherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.groovy.config;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import org.hamcrest.Matchers;
 
@@ -40,18 +40,19 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 public class GroovyHeaderEnricherTests {
-	
+
 	@Autowired
 	private MessageChannel inputA;
 
 	@Autowired
 	private QueueChannel outputA;
-	
+
 	@Autowired
 	private MessageChannel inputB;
 

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyServiceActivatorTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyServiceActivatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.groovy.config;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.*;
 
 import groovy.lang.GroovyObject;
@@ -51,18 +51,19 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 public class GroovyServiceActivatorTests {
-	
+
 	@Autowired
 	private MessageChannel referencedScriptInput;
 
 	@Autowired
 	private MessageChannel inlineScriptInput;
-	
+
 	@Autowired
 	private MessageChannel withScriptVariableGenerator;
 
@@ -97,7 +98,7 @@ public class GroovyServiceActivatorTests {
 		assertTrue(groovyCustomizer.executed);
 		assertNull(replyChannel.receive(0));
 	}
-	
+
 	@Test
 	public void withScriptVariableGenerator() throws Exception{
 		groovyCustomizer.executed = false;
@@ -159,7 +160,7 @@ public class GroovyServiceActivatorTests {
 	public void inlineScriptAndVariables() throws Exception{
 		new ClassPathXmlApplicationContext("GroovyServiceActivatorTests-fail-context.xml", this.getClass());
 	}
-	
+
 	@Test(expected=BeanDefinitionParsingException.class)
 	public void variablesAndScriptVariableGenerator() throws Exception{
 		new ClassPathXmlApplicationContext("GroovyServiceActivatorTests-fail-withgenerator-context.xml", this.getClass());

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyServiceActivatorTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyServiceActivatorTests.java
@@ -142,7 +142,7 @@ public class GroovyServiceActivatorTests {
 	//INT-2399
 	@Test(expected = MessageHandlingException.class)
 	public void invalidInlineScript() throws Exception {
-		Message message = new ErrorMessage(new ReplyRequiredException(new GenericMessage<String>("test"), "reply required!"));
+		Message<?> message = new ErrorMessage(new ReplyRequiredException(new GenericMessage<String>("test"), "reply required!"));
 		try {
 			this.invalidInlineScript.send(message);
 			fail("MessageHandlingException expected!");

--- a/spring-integration-groovy/src/test/resources/log4j.properties
+++ b/spring-integration-groovy/src/test/resources/log4j.properties
@@ -4,4 +4,4 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%c{1}: %m%n
 
-log4j.category.org.springframework.integration=DEBUG
+log4j.category.org.springframework.integration=WARN

--- a/spring-integration-groovy/src/test/resources/log4j.properties
+++ b/spring-integration-groovy/src/test/resources/log4j.properties
@@ -1,0 +1,7 @@
+log4j.rootCategory=WARN, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%c{1}: %m%n
+
+log4j.category.org.springframework.integration=DEBUG

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -416,9 +416,6 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 		}
 	}
 
-	/**
-	 * @return
-	 */
 	private Message<?> createServiceUnavailableResponse() {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Endpoint is shutting down; returning status " + HttpStatus.SERVICE_UNAVAILABLE);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.http.config;
 
-import static junit.framework.Assert.assertNotSame;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -56,6 +56,7 @@ import org.springframework.web.client.RestTemplate;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.integration.http.outbound;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -78,6 +78,7 @@ import org.springframework.web.client.RestTemplate;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 public class HttpRequestExecutingMessageHandlerTests {
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -729,7 +729,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		HttpRequestExecutingMessageHandler handler =
 				new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
 		ConfigurableListableBeanFactory bf = new DefaultListableBeanFactory();
-		ProxyFactory pf = new ProxyFactory(new Class[] {ConversionService.class, ConverterRegistry.class});
+		ProxyFactory pf = new ProxyFactory(new Class<?>[] {ConversionService.class, ConverterRegistry.class});
 		final AtomicInteger converterCount = new AtomicInteger();
 		pf.addAdvice(new MethodInterceptor() {
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageInboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageInboundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.http.support;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 
 import java.net.URI;

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package org.springframework.integration.http.support;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
@@ -41,6 +41,7 @@ import org.springframework.util.CollectionUtils;
 /**
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author Gunnar Hillert
  * @since 2.0.1
  */
 public class DefaultHttpHeaderMapperFromMessageOutboundTests {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/UdpInboundChannelAdapterParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/UdpInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,12 +28,12 @@ import org.w3c.dom.Element;
 
 /**
  * Channel Adapter that receives UDP datagram packets and maps them to Messages.
- * 
+ *
  * @author Gary Russell
  * @since 2.0
  */
 public class UdpInboundChannelAdapterParser extends AbstractChannelAdapterParser {
-	
+
 	protected AbstractBeanDefinition doParse(Element element, ParserContext parserContext, String channelName) {
 		BeanDefinitionBuilder builder = parseUdp(element, parserContext);
 		IpAdapterParserUtils.addCommonSocketOptions(builder, element);
@@ -44,7 +44,7 @@ public class UdpInboundChannelAdapterParser extends AbstractChannelAdapterParser
 		builder.addPropertyReference("outputChannel", channelName);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder,
 				element, "error-channel", "errorChannel");
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, 
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.TASK_EXECUTOR);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.LOOKUP_HOST);
@@ -54,7 +54,7 @@ public class UdpInboundChannelAdapterParser extends AbstractChannelAdapterParser
 	/**
 	 * @param element
 	 * @param builder
-	 * @param parserContext 
+	 * @param parserContext
 	 */
 	private void addPortToConstructor(Element element,
 			BeanDefinitionBuilder builder, ParserContext parserContext) {
@@ -62,11 +62,6 @@ public class UdpInboundChannelAdapterParser extends AbstractChannelAdapterParser
 		builder.addConstructorArgValue(port);
 	}
 
-	/**
-	 * @param element
-	 * @param parserContext 
-	 * @return
-	 */
 	private BeanDefinitionBuilder parseUdp(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder;
 		String multicast = IpAdapterParserUtils.getMulticast(element);

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/UdpOutboundChannelAdapterParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/UdpOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.w3c.dom.Element;
  * @since 2.0
  */
 public class UdpOutboundChannelAdapterParser extends AbstractOutboundChannelAdapterParser {
-	
+
 	private static final String BASE_PACKAGE = "org.springframework.integration.ip.udp";
 
 	protected AbstractBeanDefinition parseConsumer(Element element, ParserContext parserContext) {
@@ -38,16 +38,11 @@ public class UdpOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 		return builder.getBeanDefinition();
 	}
 
-	/**
-	 * @param element
-	 * @param parserContext 
-	 * @return
-	 */
 	private BeanDefinitionBuilder parseUdp(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder;
 		String multicast = IpAdapterParserUtils.getMulticast(element);
 		if (multicast.equals("true")) {
-			builder = BeanDefinitionBuilder.genericBeanDefinition(BASE_PACKAGE + 
+			builder = BeanDefinitionBuilder.genericBeanDefinition(BASE_PACKAGE +
 					".MulticastSendingMessageHandler");
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(builder,
 					element, IpAdapterParserUtils.MIN_ACKS_SUCCESS,
@@ -89,7 +84,7 @@ public class UdpOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.RECEIVE_BUFFER_SIZE);
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, 
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.TASK_EXECUTOR);
 		return builder;
 	}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
@@ -93,8 +93,6 @@ public class TcpMessageMapper implements
 
 	/**
 	 * Extracts the payload as a byte array.
-	 * @param message
-	 * @return
 	 */
 	private byte[] getPayloadAsBytes(Message<?> message) {
 		byte[] bytes = null;

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/DatagramPacketMessageMapper.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/DatagramPacketMessageMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,9 +119,6 @@ public class DatagramPacketMessageMapper implements InboundMessageMapper<Datagra
 
 	/**
 	 * Prefix raw byte[] from message with 'acknowledge to' and 'message id' "headers".
-	 * @param message
-	 * @return
-	 * @throws Exception
 	 */
 	private DatagramPacket fromMessageWithAck(Message<?> message) throws Exception {
 		Assert.hasLength(this.ackAddress);
@@ -231,9 +228,6 @@ public class DatagramPacketMessageMapper implements InboundMessageMapper<Datagra
 
 	/**
 	 * Peeks at data in the buffer to see if starts with the prefix.
-	 * @param buffer
-	 * @param prefix
-	 * @return
 	 */
 	private boolean startsWith(ByteBuffer buffer, String prefix) {
 		int pos = buffer.position();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ConnectionToConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ConnectionToConnectionTests.java
@@ -23,8 +23,10 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.Properties;
 
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.AbstractApplicationContext;
@@ -53,6 +55,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ConnectionToConnectionTests {
 
 	@Autowired

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ConnectionToConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ConnectionToConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.ip.tcp;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -47,6 +47,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Gunnar Hillert
  * @since 2.0
  *
  */

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -45,6 +45,8 @@ import org.springframework.integration.ip.util.TestingUtilities;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -55,6 +57,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
 public class CachingClientConnectionFactoryTests {
 
 	@Autowired

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/MultiClientTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/MultiClientTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.springframework.integration.ip.udp;
 
 import static org.junit.Assert.assertNotNull;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -39,6 +39,7 @@ import org.springframework.integration.test.util.SocketUtils;
  * ability to handle multiple requests from multiple clients.
  *
  * @author Gary Russell
+ * @author Gunnar Hillert
  *
  */
 public class MultiClientTests {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpUnicastEndToEndTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpUnicastEndToEndTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.ip.udp;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -43,14 +43,15 @@ import org.springframework.integration.test.util.TestUtils;
 /**
  * Sends and receives a simple message through to the Udp channel adapters.
  * If run as a JUnit just sends one message and terminates (see console).
- * 
- * If run from main(),  
+ *
+ * If run from main(),
  * hangs around for a couple of minutes to allow console interaction - enter a message on the
- * console and you should see it go through the outbound context, over UDP, and 
+ * console and you should see it go through the outbound context, over UDP, and
  * received in the other context (and written back to the console).
- *  
+ *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class UdpUnicastEndToEndTests implements Runnable {
@@ -88,7 +89,7 @@ public class UdpUnicastEndToEndTests implements Runnable {
 		Thread t = new Thread(launcher);
 		t.start(); // launch the receiver
 		AbstractApplicationContext applicationContext = new ClassPathXmlApplicationContext(
-				"testIp-out-context.xml", UdpUnicastEndToEndTests.class);	
+				"testIp-out-context.xml", UdpUnicastEndToEndTests.class);
 		launcher.launchSender(applicationContext);
 		applicationContext.stop();
 	}

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -476,10 +476,11 @@ public class JdbcChannelMessageStore extends AbstractMessageGroupStore implement
 	}
 
 	/**
-	 * Helper method that converts the channel id to a UUID.
+	 * Helper method that converts the channel id to a UUID using
+	 * {@link UUIDConverter#getUUID(Object)}.
 	 *
-	 * @param input
-	 * @return
+	 * @param input Parameter may be null
+	 * @return Returns null when the input is null otherwise the UUID as String.
 	 */
 	private String getKey(Object input) {
 		return input == null ? null : UUIDConverter.getUUID(input).toString();

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreChannelTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreChannelTests.java
@@ -30,6 +30,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.store.MessageGroup;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.transaction.BeforeTransaction;
@@ -37,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
 public class JdbcMessageStoreChannelTests {
 
 	@Autowired

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcOutboundGatewayTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -16,9 +16,9 @@ import static org.junit.Assert.fail;
 
 import javax.sql.DataSource;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.springframework.jdbc.core.JdbcOperations;

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/StoredProcJmxManagedBeanTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/StoredProcJmxManagedBeanTests.java
@@ -42,6 +42,7 @@ import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.jdbc.storedproc.CreateUser;
 import org.springframework.integration.jdbc.storedproc.User;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -50,7 +51,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
-@DirtiesContext
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
 public class StoredProcJmxManagedBeanTests {
 
 	@Autowired

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/StoredProcOutboundGatewayWithSpelIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/StoredProcOutboundGatewayWithSpelIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcMessageHandlerParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcMessageHandlerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
 
 package org.springframework.integration.jdbc.config;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
@@ -40,6 +40,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Gunnar Hillert
  * @since 2.0
  *
  */

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -12,7 +12,7 @@
  */
 package org.springframework.integration.jdbc.config;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -43,6 +43,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Gunnar Hillert
  * @since 2.0
  *
  */

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcMessageHandlerParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcMessageHandlerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,9 +13,9 @@
 
 package org.springframework.integration.jdbc.config;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 import java.sql.Types;

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/jdbcOutboundChannelAdapterCommonConfig.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/jdbcOutboundChannelAdapterCommonConfig.xml
@@ -9,14 +9,16 @@
 
 	<si:channel id="target"/>
 
-	<jdbc:embedded-database type="H2" id="dataSource">
-		<jdbc:script location="org/springframework/integration/jdbc/config/outboundSchema.sql" />
-	</jdbc:embedded-database>
-	
+	<jdbc:embedded-database type="H2" id="dataSource"/>
+
+	<jdbc:initialize-database data-source="dataSource" ignore-failures="DROPS">
+		<jdbc:script location="classpath:org/springframework/integration/jdbc/config/outboundSchema.sql"/>
+	</jdbc:initialize-database>
+
 	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
-	
+
 	<bean id="jdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
 		<constructor-arg ref="dataSource" />
 	</bean>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/outboundSchema.sql
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/outboundSchema.sql
@@ -1,2 +1,4 @@
+drop table foos;
+drop table bars;
 create table foos(id varchar(100),status int,name varchar(20));
 create table bars(id int identity,status int,name varchar(20));

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/AbstractTxTimeoutMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/AbstractTxTimeoutMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,7 +14,7 @@ package org.springframework.integration.jdbc.store.channel;
 
 import javax.sql.DataSource;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/PollableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/PollableJmsChannelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.jms;
 
-import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -54,6 +54,7 @@ import org.springframework.jms.core.MessageCreator;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 public class PollableJmsChannelTests {
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/ExtractRequestReplyPayloadTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/ExtractRequestReplyPayloadTests.java
@@ -1,9 +1,18 @@
-/**
- * 
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.springframework.integration.jms.config;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,6 +37,7 @@ import org.springframework.integration.message.GenericMessage;
 
 /**
  * @author ozhurakousky
+ * @author Gunnar Hillert
  *
  */
 public class ExtractRequestReplyPayloadTests {
@@ -58,19 +68,19 @@ public class ExtractRequestReplyPayloadTests {
 			}
 		});
 		outboundChannel.send(new GenericMessage<String>("Hello"));
-		
-		Message<?> replyMessage = replyChannel.receive(1000);	
+
+		Message<?> replyMessage = replyChannel.receive(1000);
 		assertTrue(replyMessage.getPayload() instanceof String);
 	}
-	
+
 	@Test
 	public void testOutboundBothFalseInboundDefault(){
-	
-		JmsOutboundGateway outboundGateway = 
+
+		JmsOutboundGateway outboundGateway =
 			(JmsOutboundGateway) new DirectFieldAccessor(applicationContext.getBean("outboundGateway")).getPropertyValue("handler");
 		outboundGateway.setExtractRequestPayload(false);
 		outboundGateway.setExtractReplyPayload(false);
-		
+
 		jmsInputChannel.subscribe(new MessageHandler() {
 			public void handleMessage(Message<?> message) throws MessagingException {
 				assertTrue(message.getPayload() instanceof String);
@@ -79,19 +89,19 @@ public class ExtractRequestReplyPayloadTests {
 			}
 		});
 		outboundChannel.send(new GenericMessage<String>("Hello"));
-		
-		Message<?> replyMessage = replyChannel.receive(1000);		
+
+		Message<?> replyMessage = replyChannel.receive(1000);
 		assertTrue(replyMessage.getPayload() instanceof javax.jms.Message);
 	}
 	@Test(expected=MessageTimeoutException.class)
 	public void testOutboundDefaultInboundBothTrue(){
-		
-		ChannelPublishingJmsMessageListener inboundGateway = 
+
+		ChannelPublishingJmsMessageListener inboundGateway =
 			(ChannelPublishingJmsMessageListener)new DirectFieldAccessor(applicationContext.getBean("inboundGateway")).
 																	getPropertyValue("listener");
 		inboundGateway.setExtractReplyPayload(false);
 		inboundGateway.setExtractRequestPayload(false);
-		
+
 		MessageHandler handler = new MessageHandler() {
 			public void handleMessage(Message<?> message) throws MessagingException {
 				assertTrue(message.getPayload() instanceof javax.jms.Message);
@@ -103,17 +113,17 @@ public class ExtractRequestReplyPayloadTests {
 		jmsInputChannel.subscribe(handler);
 		outboundChannel.send(new GenericMessage<String>("Hello"));
 		verify(handler, times(1)).handleMessage(Mockito.any(Message.class));
-		replyChannel.receive(1000);	
+		replyChannel.receive(1000);
 	}
 	@Test
 	public void testOutboundDefaultInboundReplyTrueRequestFalse(){
-		
-		ChannelPublishingJmsMessageListener inboundGateway = 
+
+		ChannelPublishingJmsMessageListener inboundGateway =
 			(ChannelPublishingJmsMessageListener)new DirectFieldAccessor(applicationContext.getBean("inboundGateway")).
 																	getPropertyValue("listener");
 		inboundGateway.setExtractReplyPayload(true);
 		inboundGateway.setExtractRequestPayload(false);
-		
+
 		MessageHandler handler = new MessageHandler() {
 			public void handleMessage(Message<?> message) throws MessagingException {
 				assertTrue(message.getPayload() instanceof javax.jms.Message);
@@ -123,18 +133,18 @@ public class ExtractRequestReplyPayloadTests {
 		};
 		jmsInputChannel.subscribe(handler);
 		outboundChannel.send(new GenericMessage<String>("Hello"));
-		Message<?> replyMessage = replyChannel.receive(1000);	
+		Message<?> replyMessage = replyChannel.receive(1000);
 		assertTrue(replyMessage.getPayload() instanceof String);
 	}
 	@Test
 	public void testOutboundDefaultInboundReplyFalseRequestTrue(){
-		
-		ChannelPublishingJmsMessageListener inboundGateway = 
+
+		ChannelPublishingJmsMessageListener inboundGateway =
 			(ChannelPublishingJmsMessageListener)new DirectFieldAccessor(applicationContext.getBean("inboundGateway")).
 																	getPropertyValue("listener");
 		inboundGateway.setExtractReplyPayload(false);
 		inboundGateway.setExtractRequestPayload(true);
-		
+
 		MessageHandler handler = new MessageHandler() {
 			public void handleMessage(Message<?> message) throws MessagingException {
 				assertTrue(message.getPayload() instanceof String);
@@ -144,16 +154,16 @@ public class ExtractRequestReplyPayloadTests {
 		};
 		jmsInputChannel.subscribe(handler);
 		outboundChannel.send(new GenericMessage<String>("Hello"));
-		Message<?> replyMessage = replyChannel.receive(1000);	
+		Message<?> replyMessage = replyChannel.receive(1000);
 		assertTrue(replyMessage.getPayload() instanceof String);
 	}
 	@Test
 	public void testOutboundRequestTrueReplyFalseInboundDefault(){
-		JmsOutboundGateway outboundGateway = 
+		JmsOutboundGateway outboundGateway =
 			(JmsOutboundGateway) new DirectFieldAccessor(applicationContext.getBean("outboundGateway")).getPropertyValue("handler");
 		outboundGateway.setExtractRequestPayload(true);
 		outboundGateway.setExtractReplyPayload(false);
-		
+
 		MessageHandler handler = new MessageHandler() {
 			public void handleMessage(Message<?> message) throws MessagingException {
 				assertTrue(message.getPayload() instanceof String);
@@ -163,16 +173,16 @@ public class ExtractRequestReplyPayloadTests {
 		};
 		jmsInputChannel.subscribe(handler);
 		outboundChannel.send(new GenericMessage<String>("Hello"));
-		Message<?> replyMessage = replyChannel.receive(1000);	
+		Message<?> replyMessage = replyChannel.receive(1000);
 		assertTrue(replyMessage.getPayload() instanceof javax.jms.Message);
 	}
 	@Test
 	public void testOutboundRequestFalseReplyTrueInboundDefault(){
-		JmsOutboundGateway outboundGateway = 
+		JmsOutboundGateway outboundGateway =
 			(JmsOutboundGateway) new DirectFieldAccessor(applicationContext.getBean("outboundGateway")).getPropertyValue("handler");
 		outboundGateway.setExtractRequestPayload(false);
 		outboundGateway.setExtractReplyPayload(true);
-		
+
 		MessageHandler handler = new MessageHandler() {
 			public void handleMessage(Message<?> message) throws MessagingException {
 				assertTrue(message.getPayload() instanceof String);
@@ -182,22 +192,22 @@ public class ExtractRequestReplyPayloadTests {
 		};
 		jmsInputChannel.subscribe(handler);
 		outboundChannel.send(new GenericMessage<String>("Hello"));
-		Message<?> replyMessage = replyChannel.receive(1000);	
+		Message<?> replyMessage = replyChannel.receive(1000);
 		assertTrue(replyMessage.getPayload() instanceof String);
 	}
 	@Test(expected=MessageTimeoutException.class)
 	public void testAllFalse(){
-		JmsOutboundGateway outboundGateway = 
+		JmsOutboundGateway outboundGateway =
 			(JmsOutboundGateway) new DirectFieldAccessor(applicationContext.getBean("outboundGateway")).getPropertyValue("handler");
 		outboundGateway.setExtractRequestPayload(false);
 		outboundGateway.setExtractReplyPayload(false);
-		
-		ChannelPublishingJmsMessageListener inboundGateway = 
+
+		ChannelPublishingJmsMessageListener inboundGateway =
 			(ChannelPublishingJmsMessageListener)new DirectFieldAccessor(applicationContext.getBean("inboundGateway")).
 																	getPropertyValue("listener");
 		inboundGateway.setExtractReplyPayload(false);
 		inboundGateway.setExtractRequestPayload(false);
-		
+
 		MessageHandler handler = new MessageHandler() {
 			public void handleMessage(Message<?> message) throws MessagingException {
 				assertTrue(message.getPayload() instanceof javax.jms.Message);
@@ -207,7 +217,7 @@ public class ExtractRequestReplyPayloadTests {
 		};
 		jmsInputChannel.subscribe(handler);
 		outboundChannel.send(new GenericMessage<String>("Hello"));
-		Message<?> replyMessage = replyChannel.receive(1000);	
+		Message<?> replyMessage = replyChannel.receive(1000);
 		assertTrue(replyMessage.getPayload() instanceof String);
 	}
 }

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/GlobalChannelInterceptorTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/GlobalChannelInterceptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.jms.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelHistoryTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelHistoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.integration.jms.config;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -39,6 +39,7 @@ import org.springframework.jms.listener.AbstractMessageListenerContainer;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 public class JmsChannelHistoryTests {
@@ -52,7 +53,7 @@ public class JmsChannelHistoryTests {
 		channel.setShouldTrack(true);
 		channel.setBeanName("jmsChannel");
 		Message<String> message = new GenericMessage<String>("hello");
-		
+
 		doAnswer(new Answer() {
 		      @SuppressWarnings("unchecked")
 			public Object answer(InvocationOnMock invocation) {
@@ -65,7 +66,7 @@ public class JmsChannelHistoryTests {
 		channel.send(message);
 		verify(template, times(1)).convertAndSend(Mockito.any(Message.class));
 	}
-	
+
 	@Test
 	public void testFullConfig() throws Exception{
 		ActiveMqTestUtils.prepare();

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageHistoryTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageHistoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.jms.config;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -135,7 +135,7 @@ public class JmsMessageHistoryTests {
 
 		public String getComponentType() {
 			return type;
-		}	
+		}
 	}
 
 }

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsWithMarshallingMessageConverterTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsWithMarshallingMessageConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.jms.config;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
@@ -42,6 +42,7 @@ import org.springframework.oxm.XmlMappingException;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class JmsWithMarshallingMessageConverterTests {
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanExporterParserTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanExporterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.jmx.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 
@@ -37,6 +37,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/ChainWithMessageProducingHandlersTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/ChainWithMessageProducingHandlersTests.java
@@ -1,9 +1,21 @@
-/**
- * 
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.springframework.integration.monitor;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,6 +26,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 @ContextConfiguration
@@ -22,13 +35,13 @@ public class ChainWithMessageProducingHandlersTests {
 
 	@Autowired
 	private ApplicationContext applicationContext;
-	
+
 	@Test
 	public void testSuccessfulApplicationContext(){
 		// this is all we need to do. Until INT-1431 was solved initialization of this AC would fail.
 		assertNotNull(applicationContext);
 	}
-	
+
 	public static class SampleProducer{
 		public String echo(String value){
 			return value;

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/core/EclipseLinkJpaOperationsTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/core/EclipseLinkJpaOperationsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,7 +14,7 @@ package org.springframework.integration.jpa.core;
 
 import java.text.ParseException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/core/JpaExecutorTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/core/JpaExecutorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -19,7 +19,7 @@ import java.util.Map;
 
 import javax.persistence.EntityManager;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/core/OpenJpaJpaOperationsTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/core/OpenJpaJpaOperationsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.text.ParseException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.apache.openjpa.jdbc.conf.JDBCConfiguration;
 import org.apache.openjpa.jdbc.conf.JDBCConfigurationImpl;

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundChannelAdapterTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -16,7 +16,7 @@ import java.util.List;
 
 import javax.persistence.EntityManager;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.After;
 import org.junit.Test;

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundChannelAdapterTransactionalTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundChannelAdapterTransactionalTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -16,7 +16,7 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,7 +14,7 @@ package org.springframework.integration.jpa.outbound;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.After;
 import org.junit.Test;

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/MailOutboundChannelAdapterParserTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/MailOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.mail.config;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Properties;
@@ -38,6 +38,7 @@ import org.springframework.mail.MailSender;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 public class MailOutboundChannelAdapterParserTests {
 

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/MessageWithContentTypeTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/MessageWithContentTypeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.integration.mail.config;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -58,24 +58,24 @@ public class MessageWithContentTypeTests {
 		ApplicationContext ac = new ClassPathXmlApplicationContext("MessageWithContentTypeTests-context.xml", this.getClass());
 		MessageChannel inputChannel = ac.getBean("inputChannel", MessageChannel.class);
 		StringWriter writer = new StringWriter();
-		FileReader reader = new FileReader("src/test/java/org/springframework/integration/mail/config/test.html"); 
+		FileReader reader = new FileReader("src/test/java/org/springframework/integration/mail/config/test.html");
 		FileCopyUtils.copy(reader, writer);
 		inputChannel.send(new GenericMessage<String>(writer.getBuffer().toString()));
 	}
-	
+
 	@Test
 	public void testMessageConversionWithHtmlAndContentType() throws Exception{
 		JavaMailSender sender = mock(JavaMailSender.class);
 		MailSendingMessageHandler handler = new MailSendingMessageHandler(sender);
 		StringWriter writer = new StringWriter();
-		FileReader reader = new FileReader("src/test/java/org/springframework/integration/mail/config/test.html"); 
+		FileReader reader = new FileReader("src/test/java/org/springframework/integration/mail/config/test.html");
 		FileCopyUtils.copy(reader, writer);
 		Message<String> message = MessageBuilder.withPayload(writer.getBuffer().toString())
 								.setHeader(MailHeaders.TO, "to")
 								.setHeader(MailHeaders.FROM, "from")
 								.setHeader(MailHeaders.CONTENT_TYPE, "text/html")
 								.build();
-		MimeMessage mMessage = new TestMimeMessage(); 
+		MimeMessage mMessage = new TestMimeMessage();
 		// MOCKS
 		when(sender.createMimeMessage()).thenReturn(mMessage);
 		doAnswer(new Answer<Object>() {
@@ -85,16 +85,16 @@ public class MessageWithContentTypeTests {
 				return null;
 			}
 		}).when(sender).send(Mockito.any(MimeMessage.class));
-			
+
 		// handle message
 		handler.handleMessage(message);
-			
+
 		verify(sender, times(1)).send(Mockito.any(MimeMessage.class));
 	}
-	
+
 	private static class TestMimeMessage extends MimeMessage{
 		public TestMimeMessage() {
 			super(Session.getDefaultInstance(new Properties()));
-		}	
+		}
 	}
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisChannelParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisChannelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.redis.config;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -35,6 +35,7 @@ import org.springframework.integration.test.util.TestUtils;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 public class RedisChannelParserTests extends RedisAvailableTests{
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.redis.config;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
@@ -40,6 +40,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.redis.config;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +39,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223HeaderEnricherTests.java
+++ b/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223HeaderEnricherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.scripting.config.jsr223;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,18 +31,19 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Oleg Zhurakousky
  * @author David Turanski
+ * @author Gunnar Hillert
  * @since 2.1
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 public class Jsr223HeaderEnricherTests {
-	
+
 	@Autowired
 	private MessageChannel inputA;
 
 	@Autowired
 	private QueueChannel outputA;
-	
+
 	@Autowired
 	private MessageChannel inputB;
 
@@ -54,7 +55,7 @@ public class Jsr223HeaderEnricherTests {
 		inputA.send(new GenericMessage<String>("Hello"));
 		assertEquals("jruby", outputA.receive(1000).getHeaders().get("TEST_HEADER"));
 	}
-	
+
 	@Test
 	public void inlineScript() throws Exception{
 		inputB.send(new GenericMessage<String>("Hello"));

--- a/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223ServiceActivatorTests.java
+++ b/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223ServiceActivatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.scripting.config.jsr223;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -43,6 +43,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author David Turanski
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserCachingTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserCachingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.sftp.config;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Properties;
@@ -33,6 +33,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -43,7 +44,7 @@ public class InboundChannelAdapterParserCachingTests {
 	@Autowired private Object cachingAdapter;
 
 	@Autowired private Object nonCachingAdapter;
-	
+
 
 	@Test
 	public void defaultAdapter() {

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@
 
 package org.springframework.integration.sftp.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertSame;
 
 import java.io.File;
 import java.util.Comparator;
+import java.util.concurrent.PriorityBlockingQueue;
 
 import org.junit.After;
 import org.junit.Before;
@@ -44,6 +45,7 @@ import org.springframework.integration.test.util.TestUtils;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 public class InboundChannelAdapterParserTests {
 
@@ -61,7 +63,6 @@ public class InboundChannelAdapterParserTests {
 		assertFalse(adapter.isRunning());
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testWithLocalFiles() throws Exception{
 		ApplicationContext context =
@@ -73,7 +74,10 @@ public class InboundChannelAdapterParserTests {
 		SftpInboundFileSynchronizingMessageSource source =
 			(SftpInboundFileSynchronizingMessageSource) TestUtils.getPropertyValue(adapter, "source");
 		assertNotNull(source);
-		Comparator<File> comparator = TestUtils.getPropertyValue(adapter, "source.fileSource.toBeReceived.q.comparator", Comparator.class);
+
+		PriorityBlockingQueue<?> blockingQueue = TestUtils.getPropertyValue(adapter, "source.fileSource.toBeReceived", PriorityBlockingQueue.class);
+		Comparator<?> comparator = blockingQueue.comparator();
+
 		assertNotNull(comparator);
 		SftpInboundFileSynchronizer synchronizer =  (SftpInboundFileSynchronizer) TestUtils.getPropertyValue(source, "synchronizer");
 		assertNotNull(TestUtils.getPropertyValue(synchronizer, "localFilenameGeneratorExpression"));

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserCachingTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserCachingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.sftp.config;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,6 +29,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.sftp.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -49,6 +49,7 @@ import org.springframework.integration.test.util.TestUtils;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author David Turanski
+ * @author Gunnar Hillert
  */
 public class OutboundChannelAdapterParserTests {
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpInboundOutboundSanitySample.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpInboundOutboundSanitySample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,14 +24,15 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.message.GenericMessage;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Oleg Zhurakousy
+ * @author Gunnar Hillert
  *
  */
 public class SftpInboundOutboundSanitySample {
-	
+
 
 	@Test
 	@Ignore
@@ -52,7 +53,7 @@ public class SftpInboundOutboundSanitySample {
 		if (fileB.exists()){
 			fileB.delete();
 		}
-		
+
 		new ClassPathXmlApplicationContext("SftpInboundReceiveSample-ignored.xml", this.getClass());
 		Thread.sleep(5000);
 		fileA = new File("local-test-dir/a.test");
@@ -60,12 +61,12 @@ public class SftpInboundOutboundSanitySample {
 		assertTrue(fileA.exists());
 		assertTrue(fileB.exists());
 	}
-	
+
 	@Test
 	@Ignore
 	public void testOutbound() throws Exception{
-		ApplicationContext ac = 
-			new ClassPathXmlApplicationContext("SftpOutboundTransferSample-ignored.xml", this.getClass());	
+		ApplicationContext ac =
+			new ClassPathXmlApplicationContext("SftpOutboundTransferSample-ignored.xml", this.getClass());
 		File fileA = new File("local-test-dir/a.test");
 		File fileB = new File("local-test-dir/b.test");
 		MessageChannel ftpChannel = ac.getBean("ftpChannel", MessageChannel.class);

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpMessageHistoryTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpMessageHistoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.sftp.config;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
@@ -25,6 +25,7 @@ import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class SftpMessageHistoryTests {
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpInboundRemoteFileSystemSynchronizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,11 +33,11 @@ import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.ChannelSftp.LsEntry;
 import com.jcraft.jsch.SftpATTRS;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -46,12 +46,13 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class SftpInboundRemoteFileSystemSynchronizerTests {
 
 	private static com.jcraft.jsch.Session jschSession = mock(com.jcraft.jsch.Session.class);
-	
+
 	@After
 	public void cleanup(){
 		File file = new File("test");
@@ -69,19 +70,19 @@ public class SftpInboundRemoteFileSystemSynchronizerTests {
 		this.cleanup();
 		File localDirectoy = new File("test");
 		assertFalse(localDirectoy.exists());
-		
+
 		TestSftpSessionFactory ftpSessionFactory = new TestSftpSessionFactory();
 		ftpSessionFactory.setUser("kermit");
 		ftpSessionFactory.setPassword("frog");
 		ftpSessionFactory.setHost("foo.com");
 
-		
+
 		SftpInboundFileSynchronizer synchronizer = spy(new SftpInboundFileSynchronizer(ftpSessionFactory));
 		synchronizer.setDeleteRemoteFiles(true);
 		synchronizer.setRemoteDirectory("remote-test-dir");
 		synchronizer.setFilter(new SftpRegexPatternFileListFilter(".*\\.test$"));
 
-		SftpInboundFileSynchronizingMessageSource ms = 
+		SftpInboundFileSynchronizingMessageSource ms =
 				new SftpInboundFileSynchronizingMessageSource(synchronizer);
 		ms.setAutoCreateLocalDirectory(true);
 		ms.setLocalDirectory(localDirectoy);
@@ -94,22 +95,22 @@ public class SftpInboundRemoteFileSystemSynchronizerTests {
 		assertEquals("b.test", btestFile.getPayload().getName());
 		Message<File> nothing =  ms.receive();
 		assertNull(nothing);
-		
+
 		// two times because on the third receive (above) the internal queue will be empty, so it will attempt
 		verify(synchronizer, times(2)).synchronizeToLocalDirectory(localDirectoy);
 
 		assertTrue(new File("test/a.test").exists());
 		assertTrue(new File("test/b.test").exists());
 	}
-	
+
 	public static class TestSftpSessionFactory extends DefaultSftpSessionFactory {
-		
+
 
 		@Override
 		public Session<LsEntry> getSession() {
 			try {
 				ChannelSftp channel = mock(ChannelSftp.class);
-		
+
 				String[] files = new File("remote-test-dir").list();
 				Vector<LsEntry> sftpEntries = new Vector<LsEntry>();
 				for (String fileName : files) {
@@ -121,7 +122,7 @@ public class SftpInboundRemoteFileSystemSynchronizerTests {
 					when(channel.get("remote-test-dir/"+fileName)).thenReturn(new FileInputStream("remote-test-dir/" + fileName));
 				}
 				when(channel.ls("remote-test-dir")).thenReturn(sftpEntries);
-				
+
 				when(jschSession.openChannel("sftp")).thenReturn(channel);
 				return SftpTestSessionFactory.createSftpSession(jschSession);
 			} catch (Exception e) {

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpOutboundTests.java
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.sftp.outbound;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -59,6 +59,7 @@ import com.jcraft.jsch.SftpATTRS;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 public class SftpOutboundTests {
 

--- a/spring-integration-stream/src/test/java/org/springframework/integration/stream/config/ConsoleInboundChannelAdapterParserTests.java
+++ b/spring-integration-stream/src/test/java/org/springframework/integration/stream/config/ConsoleInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.stream.config;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -40,6 +40,7 @@ import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 
 /**
  * @author Mark Fisher
+ * @author Gunnar Hillert
  */
 public class ConsoleInboundChannelAdapterParserTests {
 

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/HeaderMatcher.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/HeaderMatcher.java
@@ -30,12 +30,12 @@ import static org.hamcrest.CoreMatchers.is;
 /**
  * <h2>Are the {@link MessageHeaders} of a {@link Message} containing any entry
  * or multiple that match?</h2>
- * 
- * 
+ *
+ *
  * <h3>
  * For example using {@link Assert#assertThat(Object, Matcher)} for a single
  * entry:</h3>
- * 
+ *
  * <pre>
  * ANY_HEADER_KEY = &quot;foo&quot;;
  * ANY_HEADER_VALUE = &quot;bar&quot;;
@@ -44,28 +44,28 @@ import static org.hamcrest.CoreMatchers.is;
  * assertThat(message, hasEntry(ANY_HEADER_KEY, notNullValue()));
  * assertThat(message, hasEntry(ANY_HEADER_KEY, is(ANY_HEADER_VALUE)));
  * </pre>
- * 
+ *
  * <h3>For multiple entries to match all:</h3>
- * 
+ *
  * <pre>
  * Map&lt;String, Object&gt; expectedInHeaderMap = new HashMap&lt;String, Object&gt;();
  * expectedInHeaderMap.put(ANY_HEADER_KEY, ANY_HEADER_VALUE);
  * expectedInHeaderMap.put(OTHER_HEADER_KEY, is(OTHER_HEADER_VALUE));
  * assertThat(message, HeaderMatcher.hasAllEntries(expectedInHeaderMap));
  * </pre>
- * 
+ *
  * <h3>
  * For a single key:</h3>
- * 
+ *
  * <pre>
  * ANY_HEADER_KEY = &quot;foo&quot;;
  * assertThat(message, HeaderMatcher.hasKey(ANY_HEADER_KEY));
  * </pre>
- * 
- * 
+ *
+ *
  * @author Alex Peters
  * @author Iwein Fuld
- * 
+ *
  */
 public class HeaderMatcher extends TypeSafeMatcher<Message<?>> {
 

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/MapContentMatchers.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/MapContentMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,33 +32,34 @@ import org.hamcrest.core.IsEqual;
  * <p>
  * It is possible to match a single entry by value or matcher like this:
  * </p>
- * 
+ *
  * <pre>
  * assertThat(map, hasEntry(SOME_KEY, is(SOME_VALUE)));
  * assertThat(map, hasEntry(SOME_KEY, is(String.class)));
  * assertThat(map, hasEntry(SOME_KEY, notNullValue()));
  * </pre>
- * 
+ *
  * <p>
  * It's also possible to match multiple entries in a map:
  * </p>
- * 
+ *
  * <pre>
  * Map&lt;String, Object&gt; expectedInMap = new HashMap&lt;String, Object&gt;();
  * expectedInMap.put(SOME_KEY, SOME_VALUE);
  * expectedInMap.put(OTHER_KEY, is(OTHER_VALUE));
  * assertThat(map, hasAllEntries(expectedInMap));
  * </pre>
- * 
+ *
  * <p>If you only need to verify the existence of a key:</p>
- * 
+ *
  * <pre>
  * assertThat(map, hasKey(SOME_KEY));
  * </pre>
- * 
+ *
  * @author Alex Peters
  * @author Iwein Fuld
- * 
+ * @author Gunnar Hillert
+ *
  */
 public class MapContentMatchers<T, V> extends
 		TypeSafeMatcher<Map<? super T, ? super V>> {
@@ -123,7 +124,7 @@ public class MapContentMatchers<T, V> extends
 	}
 
 	@Factory
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static <T, V> Matcher<Map<? super T, ? super V>> hasAllEntries(
 			Map<T, V> entries) {
 		List<Matcher<? extends Map<? super T, ? super V>>> matchers = new ArrayList<Matcher<? extends Map<? super T, ? super V>>>(
@@ -137,6 +138,7 @@ public class MapContentMatchers<T, V> extends
 				matchers.add(hasEntry(entry.getKey(), value));
 			}
 		}
-		return AllOf.allOf(matchers);
+		//return AllOf.allOf(matchers); //Does not work with Hamcrest 1.3
+		return new AllOf(matchers);
 	}
 }

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/matcher/HeaderMatcherTests.java
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/matcher/HeaderMatcherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,13 @@
 
 package org.springframework.integration.test.matcher;
 
-import static org.hamcrest.CoreMatchers.anything;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.integration.test.matcher.HeaderMatcher.hasAllHeaders;
@@ -47,7 +49,8 @@ import org.springframework.integration.support.MessageBuilder;
 /**
  * @author Alex Peters
  * @author Iwein Fuld
- * 
+ * @author Gunnar Hillert
+ *
  */
 public class HeaderMatcherTests {
 
@@ -84,14 +87,14 @@ public class HeaderMatcherTests {
 
 	@Test
 	public void hasEntry_withValidKeyAndMatcherValue_matches() throws Exception {
-		assertThat(message, hasHeader(ANY_HEADER_KEY, is(String.class)));
+		assertThat(message, hasHeader(ANY_HEADER_KEY, is(instanceOf(String.class))));
 		assertThat(message, hasHeader(ANY_HEADER_KEY, notNullValue()));
 		assertThat(message, hasHeader(ANY_HEADER_KEY, is(ANY_HEADER_VALUE)));
 	}
 
 	@Test
 	public void hasEntry_withValidKeyAndMatcherValue_notMatching() throws Exception {
-		assertThat(message, not(hasHeader(ANY_HEADER_KEY, is(Integer.class))));
+		assertThat(message, not(hasHeader(ANY_HEADER_KEY, is(instanceOf(Integer.class)))));
 	}
 
 	@Test
@@ -186,11 +189,13 @@ public class HeaderMatcherTests {
 
 	@Test
 	public void hasExpirationDate_() throws Exception {
-		Matcher<Long> anyMatcher = anything();
+		Matcher<Long> anyMatcher = any(Long.class);
+
 		assertThat(message, not(hasExpirationDate(anyMatcher)));
 		Date expirationDate = new Date(System.currentTimeMillis() + 10000);
 		message = MessageBuilder.fromMessage(message).setExpirationDate(expirationDate).build();
 		assertThat(message, hasExpirationDate(expirationDate));
 		assertThat(message, hasExpirationDate(not(is((System.currentTimeMillis())))));
 	}
+
 }

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/matcher/MapContainsTests.java
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/matcher/MapContainsTests.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.integration.test.matcher;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -17,7 +33,8 @@ import org.junit.Test;
 
 /**
  * @author Alex Peters
- * 
+ * @author Gunnar Hillert
+ *
  */
 public class MapContainsTests {
 
@@ -64,14 +81,14 @@ public class MapContainsTests {
 
 	@Test
 	public void hasEntry_withValidKeyAndMatcherValue_matches() throws Exception {
-		assertThat(map, hasEntry(SOME_KEY, is(String.class)));
+		assertThat(map, hasEntry(SOME_KEY, is(instanceOf(String.class))));
 		assertThat(map, hasEntry(SOME_KEY, notNullValue()));
 		assertThat(map, hasEntry(SOME_KEY, is(SOME_VALUE)));
 	}
 
 	@Test
 	public void hasEntry_withValidKeyAndMatcherValue_notMatching() throws Exception {
-		assertThat(map, not(hasEntry(SOME_KEY, is(Integer.class))));
+		assertThat(map, not(hasEntry(SOME_KEY, is(instanceOf(Integer.class)))));
 	}
 
 	@Test

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/matcher/MockitoMessageMatchersTests.java
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/matcher/MockitoMessageMatchersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.integration.support.MessageBuilder;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
@@ -39,7 +40,8 @@ import static org.springframework.integration.test.matcher.MockitoMessageMatcher
 /**
  * @author Alex Peters
  * @author Iwein Fuld
- * 
+ * @author Gunnar Hillert
+ *
  */
 @RunWith(MockitoJUnitRunner.class)
 public class MockitoMessageMatchersTests {
@@ -70,7 +72,7 @@ public class MockitoMessageMatchersTests {
 	public void anyMatcher_withVerifyArgumentMatcherAndEqualPayload_matching() throws Exception {
 		handler.handleMessage(message);
 		verify(handler).handleMessage(messageWithPayload(SOME_PAYLOAD));
-		verify(handler).handleMessage(messageWithPayload(is(Date.class)));
+		verify(handler).handleMessage(messageWithPayload(is(instanceOf(Date.class))));
 	}
 
 	@Test(expected = ArgumentsAreDifferent.class)
@@ -87,7 +89,7 @@ public class MockitoMessageMatchersTests {
 
 	@Test
 	public void anyMatcher_withWhenAndDifferentPayload_notMatching() throws Exception {
-		when(channel.send(messageWithHeaderEntry(SOME_HEADER_KEY, is(Short.class)))).thenReturn(true);
+		when(channel.send(messageWithHeaderEntry(SOME_HEADER_KEY, is(instanceOf(Short.class))))).thenReturn(true);
 		assertThat(channel.send(message), is(false));
 	}
 

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/matcher/PayloadMatcherTests.java
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/matcher/PayloadMatcherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.springframework.integration.test.matcher;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -31,6 +32,7 @@ import org.springframework.integration.support.MessageBuilder;
 /**
  * @author Alex Peters
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 public class PayloadMatcherTests {
 
@@ -50,17 +52,17 @@ public class PayloadMatcherTests {
 
 	@Test
 	public void hasPayload_withMatcher_matches() throws Exception {
-		assertThat(message, 
-				hasPayload(is(BigDecimal.class)));
+		assertThat(message,
+				hasPayload(is(instanceOf(BigDecimal.class))));
 		assertThat(message, hasPayload(notNullValue()));
 	}
 
 	@Test
 	public void hasPayload_withNotMatchingMatcher_notMatching()
 			throws Exception {
-		assertThat(message, not((hasPayload(is(String.class)))));
+		assertThat(message, not((hasPayload(is(instanceOf(String.class))))));
 	}
-	
+
 	@Test
 	public void readableException() throws Exception {
 		try {

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/mockito/ServiceActivatorOnMockitoMockTests-context.xml
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/mockito/ServiceActivatorOnMockitoMockTests-context.xml
@@ -1,48 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:p="http://www.springframework.org/schema/p" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xmlns:util="http://www.springframework.org/schema/util"
-       xmlns:i="http://www.springframework.org/schema/integration"
-       xsi:schemaLocation="
-        http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+	xmlns:p="http://www.springframework.org/schema/p" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/integration
-		http://www.springframework.org/schema/integration/spring-integration.xsd">
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-    <i:channel id="in"/>
+	<int:channel id="in" />
 
-    <i:chain input-channel="in" output-channel="out">
-        <i:filter expression="payload == 'singleAnnotatedMethodOnClass'"/>
-        <i:service-activator ref="singleAnnotatedMethodOnClass"/>
-    </i:chain>
-    <bean id="singleAnnotatedMethodOnClass" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg
-                value="org.springframework.integration.test.mockito.ServiceActivatorOnMockitoMockTests.SingleAnnotatedMethodOnClass"/>
-    </bean>
+	<int:chain input-channel="in" output-channel="out">
+		<int:filter expression="payload == 'singleAnnotatedMethodOnClass'" throw-exception-on-rejection="true"/>
+		<int:service-activator ref="singleAnnotatedMethodOnClass" />
+	</int:chain>
 
-    <i:chain input-channel="in" output-channel="out">
-        <i:filter expression="payload == 'SingleMethodOnClass'"/>
-        <i:service-activator ref="singleMethodOnClass"/>
-    </i:chain>
-    <bean id="singleMethodOnClass" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg
-                value="org.springframework.integration.test.mockito.ServiceActivatorOnMockitoMockTests.SingleMethodOnClass"/>
-    </bean>
+	<bean id="singleAnnotatedMethodOnClass" class="org.mockito.Mockito"
+		factory-method="mock">
+		<constructor-arg
+			value="org.springframework.integration.test.mockito.ServiceActivatorOnMockitoMockTests.SingleAnnotatedMethodOnClass" />
+	</bean>
 
-    <i:chain input-channel="in" output-channel="out">
-        <i:filter expression="payload == 'SingleMethodAcceptingHeaderOnClass'"/>
-        <i:service-activator ref="singleMethodAcceptingHeaderOnClass"/>
-    </i:chain>
-    <bean id="singleMethodAcceptingHeaderOnClass" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg
-                value="org.springframework.integration.test.mockito.ServiceActivatorOnMockitoMockTests.SingleMethodAcceptingHeaderOnClass"/>
-    </bean>
+	<int:chain input-channel="in" output-channel="out">
+		<int:filter expression="payload == 'SingleMethodOnClass'" throw-exception-on-rejection="true"/>
+		<int:service-activator ref="singleMethodOnClass" />
+	</int:chain>
 
-    <i:channel id="out">
-        <i:queue capacity="10"/>
-    </i:channel>
+	<bean id="singleMethodOnClass" class="org.mockito.Mockito"
+		factory-method="mock">
+		<constructor-arg
+			value="org.springframework.integration.test.mockito.ServiceActivatorOnMockitoMockTests.SingleMethodOnClass" />
+	</bean>
+
+	<int:chain input-channel="in" output-channel="out">
+		<int:filter expression="payload == 'SingleMethodAcceptingHeaderOnClass'" throw-exception-on-rejection="true"/>
+		<int:service-activator ref="singleMethodAcceptingHeaderOnClass" />
+	</int:chain>
+
+	<bean id="singleMethodAcceptingHeaderOnClass" class="org.mockito.Mockito"
+		factory-method="mock">
+		<constructor-arg
+			value="org.springframework.integration.test.mockito.ServiceActivatorOnMockitoMockTests.SingleMethodAcceptingHeaderOnClass" />
+	</bean>
+
+	<int:channel id="out">
+		<int:queue capacity="10" />
+	</int:channel>
 
 </beans>

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/mockito/ServiceActivatorOnMockitoMockTests.java
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/mockito/ServiceActivatorOnMockitoMockTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.test.mockito;
 
+import static org.mockito.Mockito.verify;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,67 +30,66 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static org.mockito.Mockito.verify;
-
 /**
  * @author Iwein Fuld
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ServiceActivatorOnMockitoMockTests {
 
-    @Autowired
-    @Qualifier("in")
-    MessageChannel in;
+	@Autowired
+	@Qualifier("in")
+	MessageChannel in;
 
-    @Autowired
-    @Qualifier("out")
-    PollableChannel out;
+	@Autowired
+	@Qualifier("out")
+	PollableChannel out;
 
-    public static class SingleAnnotatedMethodOnClass {
-        @ServiceActivator
-        public String move(String s) {
-            return s;
-        }
-    }
+	public static class SingleAnnotatedMethodOnClass {
+		@ServiceActivator
+		public String move(String s) {
+			return s;
+		}
+	}
 
-    @Autowired
-    SingleAnnotatedMethodOnClass singleAnnotatedMethodOnClass;
+	@Autowired
+	SingleAnnotatedMethodOnClass singleAnnotatedMethodOnClass;
 
-    @Test
-    public void shouldInvokeMockedSingleAnnotatedMethodOnClass() {
-        in.send(MessageBuilder.withPayload("singleAnnotatedMethodOnClass").build());
-        verify(singleAnnotatedMethodOnClass).move("singleAnnotatedMethodOnClass");
-    }
+	@Test
+	public void shouldInvokeMockedSingleAnnotatedMethodOnClass() {
+		in.send(MessageBuilder.withPayload("singleAnnotatedMethodOnClass").build());
+		verify(singleAnnotatedMethodOnClass).move("singleAnnotatedMethodOnClass");
+	}
 
-    public static class SingleMethodOnClass {
-        public String move(String s) {
-            return s;
-        }
-    }
+	public static class SingleMethodOnClass {
+		public String move(String s) {
+			return s;
+		}
+	}
 
-    @Autowired
-    SingleMethodOnClass singleMethodOnClass;
+	@Autowired
+	SingleMethodOnClass singleMethodOnClass;
 
-    @Test
-    public void shouldInvokeMockedSingleMethodOnClass() {
-        in.send(MessageBuilder.withPayload("SingleMethodOnClass").build());
-        verify(singleMethodOnClass).move("SingleMethodOnClass");
-    }
+	@Test
+	public void shouldInvokeMockedSingleMethodOnClass() {
+		in.send(MessageBuilder.withPayload("SingleMethodOnClass").build());
+		verify(singleMethodOnClass).move("SingleMethodOnClass");
+	}
 
-    public static class SingleMethodAcceptingHeaderOnClass {
-        public String move(@Header("s") String s) {
-            return s;
-        }
-    }
+	public static class SingleMethodAcceptingHeaderOnClass {
+		public String move(@Header("s") String s) {
+			return s;
+		}
+	}
 
-    @Autowired
-    SingleMethodAcceptingHeaderOnClass singleMethodAcceptingHeaderOnClass;
+	@Autowired
+	SingleMethodAcceptingHeaderOnClass singleMethodAcceptingHeaderOnClass;
 
-    @Test
-    public void shouldInvokeMockedSingleMethodAcceptingHeaderOnClass() {
-        in.send(MessageBuilder.withPayload("SingleMethodAcceptingHeaderOnClass").setHeader("s", "SingleMethodAcceptingHeaderOnClass").build());
-        verify(singleMethodAcceptingHeaderOnClass).move("SingleMethodAcceptingHeaderOnClass");
-    }
+	@Test
+	public void shouldInvokeMockedSingleMethodAcceptingHeaderOnClass() {
+		in.send(MessageBuilder.withPayload("SingleMethodAcceptingHeaderOnClass").setHeader("s", "SingleMethodAcceptingHeaderOnClass").build());
+		verify(singleMethodAcceptingHeaderOnClass).move("SingleMethodAcceptingHeaderOnClass");
+	}
 
 }

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/util/SocketUtilsTests.java
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/util/SocketUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.integration.test.util;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 

--- a/spring-integration-test/src/test/resources/log4j.properties
+++ b/spring-integration-test/src/test/resources/log4j.properties
@@ -1,0 +1,7 @@
+log4j.rootCategory=WARN, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%c{1}: %m%n
+
+log4j.category.org.springframework.integration=WARN

--- a/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceTests.java
+++ b/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,11 @@ import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Ignore;
 import org.junit.Test;

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/SimpleWebServiceOutboundGatewayTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/SimpleWebServiceOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,16 +40,15 @@ import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.WebServiceMessageCallback;
 import org.springframework.ws.client.support.destination.DestinationProvider;
 import org.springframework.ws.soap.SoapMessage;
-import org.springframework.ws.soap.SoapMessageFactory;
 import org.springframework.ws.transport.WebServiceConnection;
 import org.springframework.ws.transport.WebServiceMessageSender;
-import org.springframework.xml.namespace.QNameUtils;
 
 import static org.junit.Assert.*;
 
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class SimpleWebServiceOutboundGatewayTests {
@@ -105,7 +104,7 @@ public class SimpleWebServiceOutboundGatewayTests {
 		Mockito.when(messageSender.createConnection(Mockito.any(URI.class))).thenReturn(wsConnection);
 		Mockito.when(messageSender.supports(Mockito.any(URI.class))).thenReturn(true);
 
-		Mockito.doAnswer(new Answer() {
+		Mockito.doAnswer(new Answer<Object>() {
 			public Object answer(InvocationOnMock invocation) throws Exception{
 				Object[] args = invocation.getArguments();
 				WebServiceMessageFactory factory = (WebServiceMessageFactory) args[0];

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
@@ -1,12 +1,12 @@
 /*
- *  Copyright 2002-2012 the original author or authors.
- * 
+ *  Copyright 2002-2013 the original author or authors.
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- *  
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,15 +41,17 @@ import org.springframework.integration.ws.SimpleWebServiceInboundGateway;
 import org.springframework.integration.ws.SoapHeaderMapper;
 import org.springframework.oxm.Unmarshaller;
 import org.springframework.oxm.support.AbstractMarshaller;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.ws.context.DefaultMessageContext;
 import org.springframework.ws.context.MessageContext;
 import org.springframework.ws.soap.SoapMessage;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.hamcrest.CoreMatchers.is;
 
 import static org.junit.Assert.assertThat;
@@ -61,23 +63,25 @@ import static org.mockito.Mockito.when;
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author Gunnar Hillert
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
 public class WebServiceInboundGatewayParserTests {
 
 	@Autowired
 	@Qualifier("requestsMarshalling")
 	PollableChannel requestsMarshalling;
-	
+
 	@Autowired
 	@Qualifier("requestsSimple")
 	PollableChannel requestsSimple;
-	
+
 	@Autowired
 	@Qualifier("customErrorChannel")
 	MessageChannel customErrorChannel;
-	
+
 	@Autowired
 	@Qualifier("requestsVerySimple")
 	MessageChannel requestsVerySimple;
@@ -98,7 +102,7 @@ public class WebServiceInboundGatewayParserTests {
 		assertThat(
 				(MessageChannel) accessor.getPropertyValue("requestChannel"),
 				is(requestsVerySimple));
-		
+
 		assertThat(
 				(MessageChannel) accessor.getPropertyValue("errorChannel"),
 				is(customErrorChannel));
@@ -121,17 +125,20 @@ public class WebServiceInboundGatewayParserTests {
 	@Autowired
 	@Qualifier("marshalling")
 	MarshallingWebServiceInboundGateway marshallingGateway;
-	
+
 	@Autowired
 	AbstractMarshaller marshaller;
 
 	@Test
 	public void marshallersSet() throws Exception {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(marshallingGateway);
-		assertThat((AbstractMarshaller) accessor.getPropertyValue("marshaller"),
-				is(marshaller));
-		assertThat((AbstractMarshaller) accessor.getPropertyValue("unmarshaller"),
-				is(marshaller));
+
+		AbstractMarshaller retrievedMarshaller = (AbstractMarshaller) accessor.getPropertyValue("marshaller");
+		assertThat(retrievedMarshaller, is(marshaller));
+
+		AbstractMarshaller retrievedUnMarshaller = (AbstractMarshaller) accessor.getPropertyValue("unmarshaller");
+		assertThat(retrievedUnMarshaller, is(marshaller));
+
 		assertTrue("messaging gateway is not running", marshallingGateway.isRunning());
 
 		assertThat(
@@ -201,7 +208,7 @@ public class WebServiceInboundGatewayParserTests {
 
 	@SuppressWarnings("unused")
 	private static class TestHeaderMapper implements SoapHeaderMapper {
-		
+
 		public void fromHeadersToRequest(MessageHeaders headers,
 				SoapMessage target) {
 		}

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.ws.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayWithHeaderMapperTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayWithHeaderMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.ws.config;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -66,21 +66,22 @@ import org.w3c.dom.Element;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 public class WebServiceOutboundGatewayWithHeaderMapperTests {
-	
-	String responseSoapMessage = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?> " + 
-			  "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"> " + 
+
+	String responseSoapMessage = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?> " +
+			  "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"> " +
 			  "<SOAP-ENV:Header/>" +
-			  "<SOAP-ENV:Body> " + 
-			  "<root><name>jane</name></root>" + 
-			  "</SOAP-ENV:Body> " + 
+			  "<SOAP-ENV:Body> " +
+			  "<root><name>jane</name></root>" +
+			  "</SOAP-ENV:Body> " +
 			  "</SOAP-ENV:Envelope>";
-	
-	String responseNonSoapMessage = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?> " + 
+
+	String responseNonSoapMessage = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?> " +
 			  "<person><name>oleg</name></person>";
-		
+
 	@SuppressWarnings("unchecked")
 	@Test
 	public void headerMapperParserTest() throws Exception{
@@ -88,17 +89,17 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		SimpleWebServiceOutboundGateway gateway = TestUtils.getPropertyValue(context.getBean("withHeaderMapper"), "handler", SimpleWebServiceOutboundGateway.class);
 		DefaultSoapHeaderMapper headerMapper = TestUtils.getPropertyValue(gateway, "headerMapper", DefaultSoapHeaderMapper.class);
 		assertNotNull(headerMapper);
-		
+
 		List<String> requestHeaderNames = TestUtils.getPropertyValue(headerMapper, "requestHeaderNames", List.class);
 		assertEquals(2, requestHeaderNames.size());
 		assertEquals("foo*", requestHeaderNames.get(0));
 		assertEquals("*baz*", requestHeaderNames.get(1));
-		
+
 		List<String> responseHeaderNames = TestUtils.getPropertyValue(headerMapper, "replyHeaderNames", List.class);
 		assertEquals(1, responseHeaderNames.size());
 		assertEquals("bar*", responseHeaderNames.get(0));
 	}
-	
+
 	@Test
 	public void withHeaderMapperString() throws Exception{
 		String payload = "<root><name>bill</name></root>";
@@ -107,7 +108,7 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		assertEquals("bar", replyMessage.getHeaders().get("bar"));
 		assertNull(replyMessage.getHeaders().get("baz"));
 	}
-	
+
 	@Test
 	public void withHeaderMapperStringPOX() throws Exception{
 		String payload = "<root><name>bill</name></root>";
@@ -115,7 +116,7 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		assertTrue(replyMessage.getPayload() instanceof String);
 		assertTrue(((String)replyMessage.getPayload()).contains("<person><name>oleg</name></person>"));
 	}
-	
+
 	@Test
 	public void withHeaderMapperSource() throws Exception{
 		DocumentBuilderFactory dbfac = DocumentBuilderFactory.newInstance();
@@ -127,7 +128,7 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		assertEquals("bar", replyMessage.getHeaders().get("bar"));
 		assertNull(replyMessage.getHeaders().get("baz"));
 	}
-	
+
 	@Test
 	public void withHeaderMapperSourcePOX() throws Exception{
 		DocumentBuilderFactory dbfac = DocumentBuilderFactory.newInstance();
@@ -135,10 +136,10 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		Document document = docBuilder.parse(new ByteArrayInputStream("<root><name>bill</name></root>".getBytes()));
 		DOMSource payload = new DOMSource(document);
 		Message<?> replyMessage = this.process(payload, "withHeaderMapper", "inputChannel", false);
-		assertTrue(replyMessage.getPayload() instanceof DOMSource);	
+		assertTrue(replyMessage.getPayload() instanceof DOMSource);
 		assertTrue(this.extractStringResult(replyMessage).contains("<person><name>oleg</name></person>"));
 	}
-	
+
 	@Test
 	public void withHeaderMapperDocument() throws Exception{
 		DocumentBuilderFactory dbfac = DocumentBuilderFactory.newInstance();
@@ -149,7 +150,7 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		assertEquals("bar", replyMessage.getHeaders().get("bar"));
 		assertNull(replyMessage.getHeaders().get("baz"));
 	}
-	
+
 	@Test
 	public void withHeaderMapperDocumentPOX() throws Exception{
 		DocumentBuilderFactory dbfac = DocumentBuilderFactory.newInstance();
@@ -159,7 +160,7 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		assertTrue(replyMessage.getPayload() instanceof Document);
 		assertTrue(this.extractStringResult(replyMessage).contains("<person><name>oleg</name></person>"));
 	}
-	
+
 	@Test
 	public void withHeaderMapperAndMarshaller() throws Exception{
 		Person person = new Person();
@@ -168,22 +169,22 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		assertEquals("bar", replyMessage.getHeaders().get("bar"));
 		assertNull(replyMessage.getHeaders().get("baz"));
 	}
-	
+
 	@SuppressWarnings("rawtypes")
 	public Message<?> process(Object payload, String gatewayName, String channelName, final boolean soap) throws Exception{
 		ApplicationContext context = new ClassPathXmlApplicationContext("ws-outbound-gateway-with-headermappers.xml", this.getClass());
 		AbstractWebServiceOutboundGateway gateway = TestUtils.getPropertyValue(context.getBean(gatewayName), "handler", AbstractWebServiceOutboundGateway.class);
-		
+
 		if (!soap){
 			WebServiceTemplate template = TestUtils.getPropertyValue(gateway, "webServiceTemplate", WebServiceTemplate.class);
 			template.setMessageFactory(new StubMessageFactory());
 		}
-		
+
 		WebServiceMessageSender messageSender = Mockito.mock(WebServiceMessageSender.class);
 		WebServiceConnection wsConnection = Mockito.mock(WebServiceConnection.class);
 		Mockito.when(messageSender.createConnection(Mockito.any(URI.class))).thenReturn(wsConnection);
 		Mockito.when(messageSender.supports(Mockito.any(URI.class))).thenReturn(true);
-		
+
 		Mockito.doAnswer(new Answer() {
 		      public Object answer(InvocationOnMock invocation) {
 		          Object[] args = invocation.getArguments();
@@ -191,7 +192,7 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 //		          try { // uncomment if you want to see a pretty-print of SOAP message
 //		        	  Transformer transformer = TransformerFactory.newInstance().newTransformer();
 //			  	      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-//			  	      transformer.transform(new DOMSource(soapMessage.getDocument()), new StreamResult(System.out));    
+//			  	      transformer.transform(new DOMSource(soapMessage.getDocument()), new StreamResult(System.out));
 //		          } catch (Exception e) {
 //					// ignore
 //		          }
@@ -202,11 +203,11 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 			          assertNotNull(soapHeader.getAttributeValue(QNameUtils.parseQNameString("abaz")));
 			          assertNull(soapHeader.getAttributeValue(QNameUtils.parseQNameString("bar")));
 		          }
-		          
+
 		          return null;
 		      }})
 		 .when(wsConnection).send(Mockito.any(WebServiceMessage.class));
-		
+
 		Mockito.doAnswer(new Answer() {
 		      public Object answer(InvocationOnMock invocation) throws Exception{
 		          Object[] args = invocation.getArguments();
@@ -214,26 +215,26 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		          String responseMessage = factory instanceof SoapMessageFactory ? responseSoapMessage : responseNonSoapMessage;
 		          WebServiceMessage wsMessage = factory.createWebServiceMessage(new ByteArrayInputStream(responseMessage.getBytes()));
 		          if (soap){
-		        	  
+
 		        	  ((SoapMessage)wsMessage).getSoapHeader().addAttribute(QNameUtils.parseQNameString("bar"), "bar");
 		        	  ((SoapMessage)wsMessage).getSoapHeader().addAttribute(QNameUtils.parseQNameString("baz"), "baz");
 		          }
-		          
+
 //		          try { // uncomment if you want to see a pretty-print of SOAP message
 //		        	  Transformer transformer = TransformerFactory.newInstance().newTransformer();
 //			  	      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-//			  	      transformer.transform(new DOMSource(soapMessage.getDocument()), new StreamResult(System.out));    
+//			  	      transformer.transform(new DOMSource(soapMessage.getDocument()), new StreamResult(System.out));
 //		          } catch (Exception e) {
 //					// ignore
 //		          }
 		          return wsMessage;
 		      }})
 		 .when(wsConnection).receive(Mockito.any(WebServiceMessageFactory.class));
-		
+
 		gateway.setMessageSender(messageSender);
-		
+
 		MessageChannel inputChannel = context.getBean(channelName, MessageChannel.class);
-		Message<?> message = 
+		Message<?> message =
 				MessageBuilder.withPayload(payload).
 				setHeader("foo", "foo").setHeader("foobar", "foobar").setHeader("abaz", "abaz").setHeader("bar", "bar").
 				setHeader(WebServiceHeaders.SOAP_ACTION, "someAction").build();
@@ -242,7 +243,7 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		Message<?> replyMessage = outputChannel.receive(0);
 		return replyMessage;
 	}
-	
+
 	public static class Person{
 		private String name;
 
@@ -254,7 +255,7 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 			this.name = name;
 		}
 	}
-	
+
 	public static class SampleUnmarshaller implements Unmarshaller {
 
 		public boolean supports(Class<?> clazz) {
@@ -263,23 +264,23 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 
 		public Object unmarshal(Source source) throws IOException, XmlMappingException {
 			Element documentElement = (Element) ((DOMSource) source).getNode();
-			
+
 			String name = DomUtils.getChildElementValueByTagName(documentElement, "name");
 			Person person = new Person();
 			person.setName(name);
 			return person;
 		}
 	}
-	
+
 	private String extractStringResult(Message<?> replyMessage) throws Exception{
         Transformer transformer = TransformerFactory.newInstance().newTransformer();
         StringResult result = new StringResult();
         Object payload = replyMessage.getPayload();
         if (payload instanceof DOMSource){
-        	transformer.transform(((DOMSource)replyMessage.getPayload()), result);    
+        	transformer.transform(((DOMSource)replyMessage.getPayload()), result);
         }
         else if (payload instanceof Document){
-        	transformer.transform(new DOMSource((Document)replyMessage.getPayload()), result);  
+        	transformer.transform(new DOMSource((Document)replyMessage.getPayload()), result);
         }
         else {
         	throw new IllegalArgumentException("Unsupported payload type: " + payload.getClass().getName());

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/DefaultXmlPayloadConverterTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/DefaultXmlPayloadConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.custommonkey.xmlunit.XMLAssert;
 import org.junit.Before;
@@ -37,8 +37,9 @@ import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 
 /**
- * 
+ *
  * @author Jonas Partner
+ * @author Gunnar Hillert
  *
  */
 public class DefaultXmlPayloadConverterTests {
@@ -86,27 +87,27 @@ public class DefaultXmlPayloadConverterTests {
 		Node n = converter.convertToNode(testDocument);
 		XMLAssert.assertXMLEqual(testDocument, (Document) n);
 	}
-	
-	
+
+
 	@Test
 	public void testGetSourcePassingDocumet() throws Exception{
 		Source source = converter.convertToSource(testDocument);
 		assertEquals(DOMSource.class, source.getClass());
 	}
-	
+
 	@Test
 	public void testGetSourcePassingString() throws Exception{
 		Source source = converter.convertToSource(testDocumentAsString);
 		assertEquals(StringSource.class, source.getClass());
 	}
-	
+
 	@Test
 	public void testGetSourcePassingSource() throws Exception{
 		SAXSource passedInSource = new SAXSource();
 		Source source = converter.convertToSource(passedInSource);
 		assertEquals(source, passedInSource);
 	}
-	
+
 	@Test(expected=MessagingException.class)
 	public void testInvalidPayload(){
 		converter.convertToSource(12);
@@ -118,6 +119,6 @@ public class DefaultXmlPayloadConverterTests {
 		Node n = converter.convertToNode(new DOMSource(element));
 		assertTrue("Wrong node returned", element == n);
     }
-    
+
 
 }

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XmlPayloadValidatingFilterParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XmlPayloadValidatingFilterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.xml.config;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
@@ -33,6 +33,7 @@ import org.w3c.dom.Document;
 /**
  * @author Jonas Partner
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 public class XmlPayloadValidatingFilterParserTests {

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XsltPayloadTransformerParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XsltPayloadTransformerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import javax.xml.transform.dom.DOMResult;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.integration.support.MessageBuilder;
@@ -41,6 +41,7 @@ import org.springframework.xml.transform.StringResult;
 /**
  * @author Jonas Partner
  * @author Mark Fisher
+ * @author Gunnar Hillert
  */
 public class XsltPayloadTransformerParserTests {
 

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/ResultToStringTransformerTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/ResultToStringTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.xml.transformer;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.junit.Assert.assertEquals;
 
@@ -36,6 +36,7 @@ import org.springframework.xml.transform.StringResult;
 /**
  * @author Jonas Partner
  * @author Dave Turanski
+ * @author Gunnar Hillert
  */
 public class ResultToStringTransformerTests {
 
@@ -57,7 +58,7 @@ public class ResultToStringTransformerTests {
 		String transformedString = (String) transformed;
 		assertXMLEqual("Wrong content", doc, transformedString);
 	}
-	
+
 	@Test
 	public void testWithOutputProperties() throws Exception {
 		String formattedDoc = "<order><orderItem>test</orderItem></order>";

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/XsltPayloadTransformerTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/XsltPayloadTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,14 +34,15 @@ import org.springframework.xml.transform.StringResult;
 import org.springframework.xml.transform.StringSource;
 import org.w3c.dom.Document;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 
 
 /**
  * @author Jonas Partner
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class XsltPayloadTransformerTests {
 

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/XsltTransformerTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/XsltTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.springframework.integration.xml.transformer;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
 import java.util.Properties;
@@ -40,6 +40,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Oleg Zhurakousky
  * @author Jonas Partner
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageInboundChannelAdapterParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.xmpp.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 
 import java.lang.reflect.Field;
@@ -37,6 +37,8 @@ import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.xmpp.inbound.ChatMessageListeningEndpoint;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.ReflectionUtils;
@@ -44,9 +46,11 @@ import org.springframework.util.ReflectionUtils;
 /**
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
 public class ChatMessageInboundChannelAdapterParserTests {
 
 	@Autowired
@@ -72,7 +76,7 @@ public class ChatMessageInboundChannelAdapterParserTests {
 		XMPPConnection connection = (XMPPConnection)TestUtils.getPropertyValue(adapter, "xmppConnection");
 		assertEquals(connection, context.getBean("testConnection"));
 	}
-	
+
 	@Test
 	public void testInboundAdapterUsageWithHeaderMapper() {
 		XMPPConnection xmppConnection = Mockito.mock(XMPPConnection.class);
@@ -80,15 +84,15 @@ public class ChatMessageInboundChannelAdapterParserTests {
 		Mockito.when(xmppConnection.getChatManager()).thenReturn(chatManager);
 		Chat chat = Mockito.mock(Chat.class);
 		Mockito.when(chatManager.getThreadChat(Mockito.any(String.class))).thenReturn(chat);
-		
+
 		ChatMessageListeningEndpoint adapter = context.getBean("xmppInboundAdapter", ChatMessageListeningEndpoint.class);
-		
+
 		Field xmppConnectionField = ReflectionUtils.findField(ChatMessageListeningEndpoint.class, "xmppConnection");
 		xmppConnectionField.setAccessible(true);
 		ReflectionUtils.setField(xmppConnectionField, adapter, xmppConnection);
-		
+
 		PacketListener packetListener = TestUtils.getPropertyValue(adapter, "packetListener", PacketListener.class);
-		
+
 		Message message = new Message();
 		message.setBody("hello");
 		message.setTo("oleg");

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.xmpp.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -52,6 +52,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/PresenceOutboundChannelAdapterParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/PresenceOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.xmpp.config;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Set;
@@ -42,6 +42,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBeanTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.xmpp.config;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 import org.jivesoftware.smack.ConnectionConfiguration;
@@ -27,6 +27,7 @@ import org.springframework.integration.xmpp.config.XmppConnectionFactoryBean;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class XmppConnectionFactoryBeanTests {
 

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.xmpp.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 
 import java.util.List;
@@ -33,6 +33,7 @@ import org.springframework.integration.test.util.TestUtils;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Gunnar Hillert
  */
 public class XmppConnectionParserTests {
 

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppHeaderEnricherParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppHeaderEnricherParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.xmpp.config;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -41,6 +41,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Mark Fisher
  * @author Josh Long
+ * @author Gunnar Hillert
  * @since 2.0
  */
 @ContextConfiguration

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpointTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.springframework.integration.xmpp.inbound;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -47,11 +47,12 @@ import org.springframework.integration.xmpp.core.XmppContextUtils;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 public class ChatMessageListeningEndpointTests {
 
-	
+
 	@Test
 	/**
 	 * Should add/remove PacketListener when endpoint started/stopped
@@ -74,7 +75,7 @@ public class ChatMessageListeningEndpointTests {
 				return null;
 			}
 		}).when(connection).removePacketListener(Mockito.any(PacketListener.class));
-		
+
 		assertEquals(0, packetListSet.size());
 		endpoint.setOutputChannel(new QueueChannel());
 		endpoint.afterPropertiesSet();
@@ -83,13 +84,13 @@ public class ChatMessageListeningEndpointTests {
 		endpoint.stop();
 		assertEquals(0, packetListSet.size());
 	}
-	
+
 	@Test(expected=IllegalArgumentException.class)
 	public void testNonInitializationFailure(){
 		ChatMessageListeningEndpoint endpoint = new ChatMessageListeningEndpoint(mock(XMPPConnection.class));
 		endpoint.start();
 	}
-	
+
 	@Test
 	public void testWithImplicitXmppConnection(){
 		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
@@ -100,28 +101,28 @@ public class ChatMessageListeningEndpointTests {
 		endpoint.afterPropertiesSet();
 		assertNotNull(TestUtils.getPropertyValue(endpoint,"xmppConnection"));
 	}
-	
+
 	@Test(expected=IllegalArgumentException.class)
 	public void testNoXmppConnection(){
 		ChatMessageListeningEndpoint endpoint = new ChatMessageListeningEndpoint();
 		endpoint.afterPropertiesSet();
 	}
-	
+
 	@Test
 	public void testWithErrorChannel(){
 		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
 		XMPPConnection connection = mock(XMPPConnection.class);
 		bf.registerSingleton(XmppContextUtils.XMPP_CONNECTION_BEAN_NAME, connection);
-		
+
 		ChatManager cm = mock(ChatManager.class);
 		when(connection.getChatManager()).thenReturn(cm);
 		Chat chat = mock(Chat.class);
 		when(cm.getThreadChat(Mockito.anyString())).thenReturn(chat);
-		
+
 		ChatMessageListeningEndpoint endpoint = new ChatMessageListeningEndpoint();
-		
+
 		DirectChannel outChannel = new DirectChannel();
-		outChannel.subscribe(new MessageHandler() {		
+		outChannel.subscribe(new MessageHandler() {
 			public void handleMessage(org.springframework.integration.Message<?> message)
 					throws MessagingException {
 				throw new RuntimeException("ooops");
@@ -137,8 +138,8 @@ public class ChatMessageListeningEndpointTests {
 		smackMessage.setBody("hello");
 		smackMessage.setThread("1234");
 		listener.processPacket(smackMessage);
-		
-		ErrorMessage msg =  
+
+		ErrorMessage msg =
 			(ErrorMessage) errorChannel.receive();
 		assertEquals("hello", ((MessagingException)msg.getPayload()).getFailedMessage().getPayload());
 	}

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpointTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.xmpp.inbound;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,6 +51,7 @@ import org.springframework.integration.xmpp.core.XmppContextUtils;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class PresenceListeningEndpointTests {
 
@@ -83,13 +84,13 @@ public class PresenceListeningEndpointTests {
 		rosterEndpoint.stop();
 		assertEquals(0, rosterSet.size());
 	}
-	
+
 	@Test(expected=IllegalArgumentException.class)
 	public void testNonInitializedFailure() {
 		PresenceListeningEndpoint rosterEndpoint = new PresenceListeningEndpoint(mock(XMPPConnection.class));
 		rosterEndpoint.start();
 	}
-	
+
 	@Test
 	public void testRosterPresenceChangeEvent() {
 		XMPPConnection connection = mock(XMPPConnection.class);
@@ -117,7 +118,7 @@ public class PresenceListeningEndpointTests {
 		endpoint.afterPropertiesSet();
 		assertNotNull(TestUtils.getPropertyValue(endpoint,"xmppConnection"));
 	}
-	
+
 	@Test(expected=IllegalArgumentException.class)
 	public void testNoXmppConnection() {
 		PresenceListeningEndpoint handler = new PresenceListeningEndpoint();
@@ -129,16 +130,16 @@ public class PresenceListeningEndpointTests {
 		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
 		XMPPConnection connection = mock(XMPPConnection.class);
 		bf.registerSingleton(XmppContextUtils.XMPP_CONNECTION_BEAN_NAME, connection);
-		
+
 		ChatManager cm = mock(ChatManager.class);
 		when(connection.getChatManager()).thenReturn(cm);
 		Chat chat = mock(Chat.class);
 		when(cm.getThreadChat(Mockito.anyString())).thenReturn(chat);
-		
+
 		PresenceListeningEndpoint endpoint = new PresenceListeningEndpoint();
-		
+
 		DirectChannel outChannel = new DirectChannel();
-		outChannel.subscribe(new MessageHandler() {		
+		outChannel.subscribe(new MessageHandler() {
 			public void handleMessage(org.springframework.integration.Message<?> message)
 					throws MessagingException {
 				throw new RuntimeException("ooops");
@@ -151,10 +152,10 @@ public class PresenceListeningEndpointTests {
 		endpoint.afterPropertiesSet();
 		RosterListener listener = (RosterListener) TestUtils.getPropertyValue(endpoint, "rosterListener");
 		Presence presence = new Presence(Type.available);
-		
+
 		listener.presenceChanged(presence);
-		
-		ErrorMessage msg =  
+
+		ErrorMessage msg =
 			(ErrorMessage) errorChannel.receive();
 		assertEquals(Type.available.toString(), ((MessagingException)msg.getPayload()).getFailedMessage().getPayload().toString());
 	}

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/outbound/PresenceSendingMessageHandlerTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/outbound/PresenceSendingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.xmpp.outbound;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 import org.jivesoftware.smack.XMPPConnection;
@@ -31,10 +31,11 @@ import org.springframework.integration.xmpp.outbound.PresenceSendingMessageHandl
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  *
  */
 public class PresenceSendingMessageHandlerTests {
-	
+
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testPresencePayload(){
@@ -42,7 +43,7 @@ public class PresenceSendingMessageHandlerTests {
 		handler.afterPropertiesSet();
 		handler.handleMessage(new GenericMessage(mock(Presence.class)));
 	}
-	
+
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test(expected=MessageHandlingException.class)
 	public void testWrongPayload(){
@@ -50,7 +51,7 @@ public class PresenceSendingMessageHandlerTests {
 		handler.afterPropertiesSet();
 		handler.handleMessage(new GenericMessage(new Object()));
 	}
-	
+
 	@Test
 	public void testWithImplicitXmppConnection(){
 		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
@@ -60,7 +61,7 @@ public class PresenceSendingMessageHandlerTests {
 		handler.afterPropertiesSet();
 		assertNotNull(TestUtils.getPropertyValue(handler,"xmppConnection"));
 	}
-	
+
 	@Test(expected=IllegalArgumentException.class)
 	public void testNoXmppConnection(){
 		PresenceSendingMessageHandler handler = new PresenceSendingMessageHandler();


### PR DESCRIPTION
For reference see: https://jira.springsource.org/browse/INT-2916

Changes:
- INT-2919 - Upgrade Spring Data Gemfire to 1.2.2.RELEASE
- Exclude Hamcrest transitive dependency from JUnit (as already explicitly declared)
- Set sourceCompatibility in build.gradle to 1.6
- Set targetCompatibility in build.gradle to 1.6
- Upgrade Hamcrest to 1.3 and fix deprications
  - Corematcher is(_class) change to is(instanceOf(_class))
  - Change org.junit.internal.matchers.TypeSafeMatcher to org.hamcrest.TypeSafeMatcher
  - Change import org.junit.matchers.JUnitMatchers.containsString to org.hamcrest.CoreMatchers.containsString
  - Change import org.junit.matchers.JUnitMatchers.both to org.hamcrest.CoreMatchers.both
  - Change import org.junit.matchers.JUnitMatchers.containsString to org.hamcrest.CoreMatchers.containsString
- Fix JUnit deprecations
  - changed junit.framework.Assert to org.junit.Assert
- Add few missing licenses headers to tests
- Marked several test classes with: @DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
  - SplitterIntegrationTests
  - GatewayInvokingMessageHandlerTests
  - FileToChannelIntegrationTests
  - FileInboundChannelAdapterWithRecursiveDirectoryTests
  - JdbcMessageStoreChannelTests
  - ChatMessageInboundChannelAdapterParserTests
- 3 Tests ignored (Still needs to be addressed):
  - testOperationOnPrototypeBean
  - testFailOperationWithCustomScope
  - testOperationOfControlBus
- Update SQL script (test-failure):
  - spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/outboundSchema.sql
  - add drop table statements
  - add ignore-failures="DROPS" to "jdbcOutboundChannelAdapterCommonConfig.xml"
