### PR TITLE
INT-2728 - Stored Proc - Add 'return-value-required' attribute

### DIFF
--- a/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-3.0.xsd
+++ b/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-3.0.xsd
@@ -1101,6 +1101,17 @@
 					<xsd:union memberTypes="xsd:boolean xsd:string" />
 				</xsd:simpleType>
 			</xsd:attribute>
+			<xsd:attribute name="return-value-required" default="false">
+				<xsd:annotation>
+					<xsd:documentation>
+						Indicates the procedure's return value should be included
+						in the results returned.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string" />
+				</xsd:simpleType>
+			</xsd:attribute>
 			<xsd:attribute name="channel" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcOutboundGatewayParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcOutboundGatewayParserTests.java
@@ -89,7 +89,6 @@ public class StoredProcOutboundGatewayParserTests {
 
 	}
 
-
 	@Test
 	public void testSkipUndeclaredResultsAttributeSet() throws Exception {
 		setUp("storedProcOutboundGatewayParserTest.xml", getClass());
@@ -101,6 +100,19 @@ public class StoredProcOutboundGatewayParserTests {
 		accessor = new DirectFieldAccessor(source);
 		boolean  skipUndeclaredResults = (Boolean) accessor.getPropertyValue("skipUndeclaredResults");
 		assertFalse(skipUndeclaredResults);
+	}
+
+	@Test
+	public void testReturnValueRequiredAttributeSet() throws Exception {
+		setUp("storedProcOutboundGatewayParserTest.xml", getClass());
+
+		DirectFieldAccessor accessor = new DirectFieldAccessor(this.outboundGateway);
+		Object source = accessor.getPropertyValue("handler");
+		accessor = new DirectFieldAccessor(source);
+		source = accessor.getPropertyValue("executor");
+		accessor = new DirectFieldAccessor(source);
+		boolean returnValueRequired = (Boolean) accessor.getPropertyValue("returnValueRequired");
+		assertTrue(returnValueRequired);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcPollingChannelAdapterParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcPollingChannelAdapterParserTests.java
@@ -118,6 +118,19 @@ public class StoredProcPollingChannelAdapterParserTests {
 		assertTrue("skipUndeclaredResults was not set and should default to 'true'", skipUndeclaredResults);
 	}
 
+	@Test
+	public void testReturnValueRequiredAttributeSet() throws Exception {
+		setUp("storedProcPollingChannelAdapterParserTest.xml", getClass());
+
+		DirectFieldAccessor accessor = new DirectFieldAccessor(this.pollingAdapter);
+		Object source = accessor.getPropertyValue("source");
+		accessor = new DirectFieldAccessor(source);
+		source = accessor.getPropertyValue("executor");
+		accessor = new DirectFieldAccessor(source);
+		boolean returnValueRequired = (Boolean) accessor.getPropertyValue("returnValueRequired");
+		assertTrue(returnValueRequired);
+	}
+
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testProcedurepParametersAreSet() throws Exception {

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/storedProcOutboundGatewayParserTest.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/storedProcOutboundGatewayParserTest.xml
@@ -18,7 +18,7 @@
 		data-source="datasource" auto-startup="true" id="storedProcedureOutboundGateway"
 		ignore-column-meta-data="false" is-function="false"
 		skip-undeclared-results="false" order="2" reply-channel="replyChannel"
-		reply-timeout="555" return-value-required="false">
+		reply-timeout="555" return-value-required="true">
 
 		<int-jdbc:sql-parameter-definition name="username" direction="IN" type="VARCHAR" />
 		<int-jdbc:sql-parameter-definition name="password" direction="OUT" />

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/storedProcPollingChannelAdapterParserTest.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/storedProcPollingChannelAdapterParserTest.xml
@@ -15,6 +15,7 @@
 	<int-jdbc:stored-proc-inbound-channel-adapter id="storedProcedurePollingChannelAdapter"
 				data-source="dataSource" channel="target"
 				stored-procedure-name="GET_PRIME_NUMBERS"
+				return-value-required="true"
 				is-function="false">
 			<int-jdbc:sql-parameter-definition name="username" direction="IN"    type="VARCHAR"/>
 			<int-jdbc:sql-parameter-definition name="password" direction="OUT" />

--- a/src/reference/docbook/jdbc.xml
+++ b/src/reference/docbook/jdbc.xml
@@ -906,6 +906,7 @@
                                    is-function="false"
                                    max-rows-per-poll=""                         ]]><co id="sp-inbound-xml02-co" linkends="sp-inbound-xml02" /><![CDATA[
                                    skip-undeclared-results=""                   ]]><co id="sp-inbound-xml03-co" linkends="sp-inbound-xml03" /><![CDATA[
+                                   return-value-required="false"                ]]><co id="sp-inbound-xml04-co" linkends="sp-inbound-xml04" /><![CDATA[
     <int:poller/>
     <int-jdbc:sql-parameter-definition name="" direction="IN"
                                                type="STRING"
@@ -951,6 +952,13 @@
                              <emphasis>Optional</emphasis>.
                          </para>
                     </callout>
+					<callout arearefs="sp-inbound-xml04-co" id="sp-inbound-xml04">
+						<para>
+							Indicates whether this procedure's return value
+							should be included. Since <emphasis>Spring Integration 3.0.</emphasis>
+							<emphasis>Optional</emphasis>.
+						</para>
+					</callout>
               </calloutlist></para>
 			<note>
 				When you declare a Poller, you may notice the Poller's
@@ -972,7 +980,6 @@
                                                id=""
                                                ignore-column-meta-data="false"
                                                order=""                         ]]><co id="sp-outbound-xml02-co" linkends="sp-outbound-xml02" /><![CDATA[
-                                               return-value-required="false"    ]]><co id="sp-outbound-xml03-co" linkends="sp-outbound-xml03" /><![CDATA[
                                                sql-parameter-source-factory=""
                                                use-payload-as-parameter-source="">
     <int:poller fixed-rate=""/>
@@ -996,13 +1003,6 @@
                              <emphasis>failover</emphasis> dispatching strategy.
                              It has no effect when this endpoint itself is a
                              Polling Consumer for a channel with a queue.
-                            <emphasis>Optional</emphasis>.
-                        </para>
-                    </callout>
-                    <callout arearefs="sp-outbound-xml03-co" id="sp-outbound-xml03">
-                        <para>
-                            Indicates whether this procedure's return value
-                            should be included.
                             <emphasis>Optional</emphasis>.
                         </para>
                     </callout>


### PR DESCRIPTION
- For Stored Procedure Inbound Channel Adapter: Add 'return-value-required' attribute
- Add tests

For reference: https://jira.springsource.org/browse/INT-2728
