### PR TITLE
INT-2931 Fix concurrency problem in getRequiredConversionService()

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -129,9 +129,13 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 
 	protected final ConversionService getConversionService() {
 		if (this.conversionService == null && this.beanFactory != null) {
-			this.conversionService = IntegrationContextUtils.getConversionService(this.beanFactory);
-			if (this.conversionService == null && logger.isDebugEnabled()) {
-				logger.debug("Unable to attempt conversion of Message payload types. Component '" +
+			synchronized (this) {
+				if (this.conversionService == null) {
+					this.conversionService = IntegrationContextUtils.getConversionService(this.beanFactory);
+				}
+			}
+			if (this.conversionService == null && this.logger.isDebugEnabled()) {
+				this.logger.debug("Unable to attempt conversion of Message payload types. Component '" +
 						this.getComponentName() + "' has no explicit ConversionService reference, " +
 						"and there is no 'integrationConversionService' bean within the context.");
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageRouter.java
@@ -103,7 +103,11 @@ public abstract class AbstractMessageRouter extends AbstractMessageHandler {
 
 	protected ConversionService getRequiredConversionService() {
 		if (this.getConversionService() == null) {
-			this.setConversionService(new DefaultConversionService());
+			synchronized (this) {
+				if (this.getConversionService() == null) {
+					this.setConversionService(new DefaultConversionService());
+				}
+			}
 		}
 		return this.getConversionService();
 	}


### PR DESCRIPTION
AbstractMessageRouter.getRequiredConversionService() and
IntegrationObjectSupport.getConversionService() try to initialize the
conversion service and may be called from multiple threads. In case
of bad timing this could end up in an uninitialized conversion service
causing NPEs in subsequent method calls.
To solve this issue, the conversion service is initialized with
double-checked locking.

For further details see https://jira.springsource.org/browse/INT-2931
