### PR TITLE
INT-2934 IntegrationObjectSupport Initialization of ConversionService

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -94,6 +94,15 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 	}
 
 	public final void afterPropertiesSet() {
+		if (this.conversionService == null && this.beanFactory != null) {
+			this.conversionService = IntegrationContextUtils.getConversionService(this.beanFactory);
+			if (this.conversionService == null && this.logger != null && this.logger.isDebugEnabled()) {
+				this.logger.debug("Unable to attempt conversion of Message payload types. Component '" +
+						this.getComponentName() + "' has no explicit ConversionService reference, " +
+						"and there is no 'integrationConversionService' bean within the context.");
+			}
+		}
+		
 		try {
 			this.onInit();
 		}
@@ -128,18 +137,6 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 	}
 
 	protected final ConversionService getConversionService() {
-		if (this.conversionService == null && this.beanFactory != null) {
-			synchronized (this) {
-				if (this.conversionService == null) {
-					this.conversionService = IntegrationContextUtils.getConversionService(this.beanFactory);
-				}
-			}
-			if (this.conversionService == null && this.logger.isDebugEnabled()) {
-				this.logger.debug("Unable to attempt conversion of Message payload types. Component '" +
-						this.getComponentName() + "' has no explicit ConversionService reference, " +
-						"and there is no 'integrationConversionService' bean within the context.");
-			}
-		}
 		return this.conversionService;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
@@ -131,7 +131,8 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 	}
 
 	@Override
-	public void onInit() {
+	public void onInit() throws Exception {
+		super.onInit();
 		BeanFactory beanFactory = this.getBeanFactory();
 		if (this.channelResolver == null && beanFactory != null) {
 			this.channelResolver = new BeanFactoryChannelResolver(beanFactory);
@@ -155,9 +156,6 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 	}
 
 	private MessageChannel resolveChannelForName(String channelName, Message<?> message) {
-		if (this.channelResolver == null) {
-			this.onInit();
-		}
 		Assert.state(this.channelResolver != null, "unable to resolve channel names, no ChannelResolver available");
 		MessageChannel channel = null;
 		try {
@@ -225,7 +223,7 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 			else if (channelKey instanceof Collection) {
 				addToCollection(channels, (Collection<?>) channelKey, message);
 			}
-			else if (this.getRequiredConversionService().canConvert(channelKey.getClass(), String.class)) {
+			else if (this.getConversionService().canConvert(channelKey.getClass(), String.class)) {
 				addChannelFromString(channels, this.getConversionService().convert(channelKey, String.class), message);
 			}
 			else {

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
@@ -44,7 +44,7 @@ class AbstractMessageProcessingRouter extends AbstractMappingMessageRouter {
 
 
 	@Override
-	public final void onInit() {
+	public final void onInit() throws Exception {
 		super.onInit();
 		if (this.messageProcessor instanceof AbstractMessageProcessor) {
 			((AbstractMessageProcessor<Object>) this.messageProcessor).setConversionService(this.getConversionService());

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageRouter.java
@@ -18,7 +18,6 @@ package org.springframework.integration.router;
 
 import java.util.Collection;
 
-import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
@@ -50,6 +49,14 @@ public abstract class AbstractMessageRouter extends AbstractMessageHandler {
 
 	private final MessagingTemplate messagingTemplate = new MessagingTemplate();
 
+	
+	@Override
+	protected void onInit() throws Exception {
+		super.onInit();
+		if (this.getConversionService() == null) {
+			this.setConversionService(new DefaultConversionService());
+		}
+	}
 
 	/**
 	 * Set the default channel where Messages should be sent if channel resolution
@@ -102,16 +109,6 @@ public abstract class AbstractMessageRouter extends AbstractMessageHandler {
 		return this.messagingTemplate;
 	}
 
-	protected ConversionService getRequiredConversionService() {
-		if (this.getConversionService() == null) {
-			synchronized (this) {
-				if (this.getConversionService() == null) {
-					this.setConversionService(new DefaultConversionService());
-				}
-			}
-		}
-		return this.getConversionService();
-	}
 
 	/**
 	 * Subclasses must implement this method to return a Collection of zero or more

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouterTests.java
@@ -75,6 +75,7 @@ public class ErrorMessageExceptionTypeRouterTests {
 		router.setChannelMappings(exceptionTypeChannelMap);
 		
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 
 		router.setDefaultOutputChannel(defaultChannel);
 		router.handleMessage(message);
@@ -97,6 +98,7 @@ public class ErrorMessageExceptionTypeRouterTests {
 		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "runtimeExceptionChannel");
 		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 
 		router.setDefaultOutputChannel(defaultChannel);
 		router.handleMessage(message);
@@ -118,6 +120,7 @@ public class ErrorMessageExceptionTypeRouterTests {
 		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
 		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setDefaultOutputChannel(defaultChannel);
 		router.handleMessage(message);
 		assertNotNull(messageHandlingExceptionChannel.receive(1000));
@@ -172,6 +175,7 @@ public class ErrorMessageExceptionTypeRouterTests {
 		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
 		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setDefaultOutputChannel(defaultChannel);
 		router.handleMessage(message);
 		assertNotNull(illegalArgumentChannel.receive(1000));
@@ -193,7 +197,9 @@ public class ErrorMessageExceptionTypeRouterTests {
 		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
 		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setDefaultOutputChannel(defaultChannel);
+		router.afterPropertiesSet();
 		router.handleMessage(message);
 		assertNotNull(illegalArgumentChannel.receive(1000));
 		assertNull(defaultChannel.receive(0));

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/PayloadTypeRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/PayloadTypeRouterTests.java
@@ -53,6 +53,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		router.setChannelMappings(payloadTypeChannelMap);
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		
 		Message<String> message1 = new GenericMessage<String>("test");
 		Message<Integer> message2 = new GenericMessage<Integer>(123);
@@ -110,6 +111,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		router.setChannelMappings(payloadTypeChannelMap);
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setDefaultOutputChannel(defaultChannel);
 		Message<Integer> message = new GenericMessage<Integer>(99);
 		router.handleMessage(message);
@@ -148,6 +150,7 @@ public class PayloadTypeRouterTests {
 		
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setChannelMappings(payloadTypeChannelMap);
 	
 		router.setDefaultOutputChannel(defaultChannel);
@@ -176,6 +179,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 			
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
@@ -203,6 +207,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 			
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
@@ -234,6 +239,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 			
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
@@ -265,6 +271,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 			
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
@@ -296,6 +303,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 			
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
@@ -325,6 +333,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
@@ -393,6 +402,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
@@ -422,6 +432,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setChannelMappings(payloadTypeChannelMap);
 		
 		Message<String> message1 = new GenericMessage<String>("test");
@@ -450,6 +461,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);
@@ -491,6 +503,7 @@ public class PayloadTypeRouterTests {
 		PayloadTypeRouter router = new PayloadTypeRouter();
 		
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 		router.setChannelMappings(payloadTypeChannelMap);
 		
 		router.setDefaultOutputChannel(defaultChannel);

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/RouterConcurrencyTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/RouterConcurrencyTest.java
@@ -37,6 +37,9 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.context.IntegrationObjectSupport;
+import org.springframework.test.util.ReflectionTestUtils;
+
 
 /**
  * @author Gary Russell
@@ -84,13 +87,14 @@ public class RouterConcurrencyTest {
 			}
 		}).when(beanFactory).containsBean(IntegrationContextUtils.INTEGRATION_CONVERSION_SERVICE_BEAN_NAME);
 		router.setBeanFactory(beanFactory);
+		router.afterPropertiesSet();
 
 		ExecutorService exec = Executors.newFixedThreadPool(2);
 		final List<ConversionService> returns = new ArrayList<ConversionService>();
 		Runnable runnable = new Runnable() {
 
 			public void run() {
-				ConversionService requiredConversionService = router.getRequiredConversionService();
+				ConversionService requiredConversionService = getConversionService(router);
 				System.out.println("Adding " + requiredConversionService);
 				returns.add(requiredConversionService);
 			}
@@ -102,6 +106,10 @@ public class RouterConcurrencyTest {
 		assertTrue(returns.size() == 2);
 		assertNotNull(returns.get(0));
 		assertNotNull(returns.get(1));
+	}
+	
+	private ConversionService getConversionService(IntegrationObjectSupport target) {
+		return (ConversionService) ReflectionTestUtils.invokeGetterMethod(target, "conversionService");
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/RouterTests.java
@@ -119,6 +119,7 @@ public class RouterTests {
 		GenericApplicationContext context = new GenericApplicationContext();
 		context.getBeanFactory().registerSingleton("testChannel", testChannel);
 		router.setBeanFactory(context);
+		router.afterPropertiesSet();
 		router.handleMessage(new GenericMessage<String>("test"));
 		Message<?> reply = testChannel.receive(0);
 		assertEquals("test", reply.getPayload());
@@ -142,6 +143,7 @@ public class RouterTests {
 		context.getBeanFactory().registerSingleton("testChannel2", testChannel2);
 		
 		router.setBeanFactory(context);
+		router.afterPropertiesSet();
 		router.handleMessage(new GenericMessage<String>("test"));
 		
 		Message<?> reply1 = testChannel1.receive(0);
@@ -185,6 +187,7 @@ public class RouterTests {
 		GenericApplicationContext context = new GenericApplicationContext();
 		context.getBeanFactory().registerSingleton("testChannel", testChannel);
 		router.setBeanFactory(context);
+		router.afterPropertiesSet();
 		router.handleMessage(new GenericMessage<String>("test"));
 		Message<?> reply = testChannel.receive(0);
 		assertEquals("test", reply.getPayload());
@@ -206,6 +209,7 @@ public class RouterTests {
 		GenericApplicationContext context = new GenericApplicationContext();
 		context.getBeanFactory().registerSingleton("testing_MyChannel", testChannel);
 		router.setBeanFactory(context);
+		router.afterPropertiesSet();
 		router.handleMessage(new GenericMessage<String>("test"));
 		Message<?> reply = testChannel.receive(0);
 		assertEquals("test", reply.getPayload());
@@ -246,6 +250,7 @@ public class RouterTests {
 		GenericApplicationContext context = new GenericApplicationContext();
 		context.getBeanFactory().registerSingleton("MyChannel_withSuffix", testChannel);
 		router.setBeanFactory(context);
+		router.afterPropertiesSet();
 		router.handleMessage(new GenericMessage<String>("test"));
 		Message<?> reply = testChannel.receive(0);
 		assertEquals("test", reply.getPayload());
@@ -297,6 +302,7 @@ public class RouterTests {
 		context.getBeanFactory().registerSingleton("channel2", testChannel2);
 
 		router.setBeanFactory(context);
+		router.afterPropertiesSet();
 		router.handleMessage(new GenericMessage<String>("test"));
 		
 		Message<?> reply1 = testChannel1.receive(0);
@@ -362,6 +368,7 @@ public class RouterTests {
 		context.getBeanFactory().registerSingleton("200", testChannel2);
 
 		router.setBeanFactory(context);
+		router.afterPropertiesSet();
 		router.handleMessage(new GenericMessage<String>("test"));
 		
 		Message<?> reply1 = testChannel1.receive(0);

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/MapToObjectTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/MapToObjectTransformerTests.java
@@ -111,6 +111,7 @@ public class MapToObjectTransformerTests {
 				beanFactory.getBean(IntegrationContextUtils.INTEGRATION_CONVERSION_SERVICE_BEAN_NAME, ConverterRegistry.class);
 		conversionService.addConverter(new StringToAddressConverter());
 		transformer.setBeanFactory(beanFactory);
+		transformer.afterPropertiesSet();
 
 		Message<?> newMessage = transformer.transform(message);
 		Person person = (Person) newMessage.getPayload();


### PR DESCRIPTION
- IntegrationObjectSupport: make the "integrationConversionService"
  initialization in the afterPropertiesSet() method
- AbstractMessageRouter: initialize the DefaultConversionService in
  onInit() in case none is set, remove getRequiredConversionService() as
  it has become obsolete.
- AbstractMappingMessageRouter: call super.onInit() in onInit() and
  remove the null check for channelResolver in resolveChannelForName()
- Adjust unit tests to call afterPropertiesSet()

For further details see
- https://jira.springsource.org/browse/INT-2934
- https://jira.springsource.org/browse/INT-2931
