### PR TITLE
INT-2935: Improve `AELMP` performance

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ExpressionMessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ExpressionMessageProducerSupport.java
@@ -17,6 +17,9 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 
 /**
+ * A {@link MessageProducerSupport} sub-class that provides {@linkplain #payloadExpression}
+ * evaluation with result as a payload for Message to send.
+ *
  * @author David Turanski
  * @author Artem Bilan
  * @since 2.1
@@ -24,15 +27,9 @@ import org.springframework.integration.endpoint.MessageProducerSupport;
  */
 public abstract class ExpressionMessageProducerSupport extends MessageProducerSupport {
 
-	private volatile Expression payloadExpression;
-
 	private final SpelExpressionParser parser = new SpelExpressionParser();
 
-
-	@Override
-	protected void onInit(){
-		super.onInit();
-	}
+	private volatile Expression payloadExpression;
 
 	public void setPayloadExpression(String payloadExpression) {
 		if (payloadExpression == null) {
@@ -43,7 +40,7 @@ public abstract class ExpressionMessageProducerSupport extends MessageProducerSu
 		}
 	}
 
-	protected Object evaluationResult(Object payload){
+	protected Object evaluatePayloadExpression(Object payload){
 		Object evaluationResult = payload;
 		if (payloadExpression != null) {
 			evaluationResult = payloadExpression.getValue(payload);

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ExpressionMessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ExpressionMessageProducerSupport.java
@@ -1,16 +1,16 @@
 /*
- * Copyright 2002-2011 the original author or authors.
- * 
+ * Copyright 2002-2013 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.springframework.integration.gemfire.inbound;
+package org.springframework.integration.endpoint;
 
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -18,21 +18,22 @@ import org.springframework.integration.endpoint.MessageProducerSupport;
 
 /**
  * @author David Turanski
+ * @author Artem Bilan
  * @since 2.1
  *
  */
-abstract class SpelMessageProducerSupport extends MessageProducerSupport {
-	
+public abstract class ExpressionMessageProducerSupport extends MessageProducerSupport {
+
 	private volatile Expression payloadExpression;
 
 	private final SpelExpressionParser parser = new SpelExpressionParser();
 
-	
+
 	@Override
 	protected void onInit(){
 		super.onInit();
 	}
-	
+
 	public void setPayloadExpression(String payloadExpression) {
 		if (payloadExpression == null) {
 			this.payloadExpression = null;
@@ -41,7 +42,7 @@ abstract class SpelMessageProducerSupport extends MessageProducerSupport {
 			this.payloadExpression = this.parser.parseExpression(payloadExpression);
 		}
 	}
-	
+
 	protected Object evaluationResult(Object payload){
 		Object evaluationResult = payload;
 		if (payloadExpression != null) {
@@ -49,6 +50,5 @@ abstract class SpelMessageProducerSupport extends MessageProducerSupport {
 		}
 		return evaluationResult;
 	}
-		
 
 }

--- a/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducer.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,103 +16,108 @@
 
 package org.springframework.integration.event.inbound;
 
+import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.springframework.context.ApplicationEvent;
-import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ApplicationContextEvent;
-import org.springframework.expression.Expression;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.SmartApplicationListener;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.core.Ordered;
 import org.springframework.integration.Message;
-import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.integration.endpoint.ExpressionMessageProducerSupport;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 
 /**
- * An inbound Channel Adapter that passes Spring {@link ApplicationEvent ApplicationEvents} within messages.
+ * An inbound Channel Adapter that implements {@link ApplicationListener} and
+ * passes Spring {@link ApplicationEvent ApplicationEvents} within messages.
  * If a {@link #setPayloadExpression(String) payloadExpression} is provided, it will be evaluated against
  * the ApplicationEvent instance to create the Message payload. Otherwise, the event itself will be the payload.
- * 
+ *
  * @author Mark Fisher
+ * @author Artem Bilan
+ *
+ * @see ApplicationEventMulticaster
+ * @see ExpressionMessageProducerSupport
  */
-public class ApplicationEventListeningMessageProducer extends MessageProducerSupport implements ApplicationListener<ApplicationEvent> {
+public class ApplicationEventListeningMessageProducer extends ExpressionMessageProducerSupport implements SmartApplicationListener {
 
 	private final Set<Class<? extends ApplicationEvent>> eventTypes = new CopyOnWriteArraySet<Class<? extends ApplicationEvent>>();
 
-	private volatile Expression payloadExpression;
-
-	private volatile boolean active;
-
-	private final SpelExpressionParser parser = new SpelExpressionParser();
-
+	private ApplicationEventMulticaster applicationEventMulticaster;
 
 	/**
 	 * Set the list of event types (classes that extend ApplicationEvent) that
 	 * this adapter should send to the message channel. By default, all event
 	 * types will be sent.
+	 * In additional this method re-register current instance as a {@link ApplicationListener}
+	 * in the {@link ApplicationEventMulticaster} to clear listeners cache and get a fresh cache entry
+	 * on next appropriate {@link ApplicationEvent}.
+	 *
+	 * @see ApplicationEventMulticaster#addApplicationListener
+	 * @see #supportsEventType
 	 */
-	@SuppressWarnings("unchecked")
-	public void setEventTypes(Class<? extends ApplicationEvent>[] eventTypes) {
+	public void setEventTypes(Class<? extends ApplicationEvent>... eventTypes) {
 		Assert.notEmpty(eventTypes, "at least one event type is required");
 		synchronized (this.eventTypes) {
 			this.eventTypes.clear();
-			this.eventTypes.addAll(CollectionUtils.arrayToList(eventTypes));
+			this.eventTypes.addAll(Arrays.asList(eventTypes));
+			if (this.applicationEventMulticaster != null) {
+				this.applicationEventMulticaster.addApplicationListener(this);
+			}
 		}
-	}
 
-	/**
-	 * Provide an expression to be evaluated against the received ApplicationEvent
-	 * instance (the "root object") in order to create the Message payload. If none
-	 * is provided, the ApplicationEvent itself will be used as the payload.
-	 */
-	public void setPayloadExpression(String payloadExpression) {
-		if (payloadExpression == null) {
-			this.payloadExpression = null;
-		}
-		else {
-			this.payloadExpression = this.parser.parseExpression(payloadExpression);
-		}
 	}
 
 	public String getComponentType() {
 		return "event:inbound-channel-adapter";
 	}
 
+	@Override
+	protected void onInit() {
+		super.onInit();
+		this.applicationEventMulticaster = this.getBeanFactory()
+				.getBean(AbstractApplicationContext.APPLICATION_EVENT_MULTICASTER_BEAN_NAME, ApplicationEventMulticaster.class);
+		Assert.notNull(this.applicationEventMulticaster,
+				"To use ApplicationListeners the 'applicationEventMulticaster' bean must be supplied within ApplicationContext.");
+	}
+
+	@Override
 	public void onApplicationEvent(ApplicationEvent event) {
-		if (this.active || event instanceof ApplicationContextEvent) {
-			if (CollectionUtils.isEmpty(this.eventTypes)) {
-				this.sendEventAsMessage(event);
-				return;
+		if (event instanceof ApplicationContextEvent || this.isRunning()) {
+			if (event.getSource() instanceof Message<?>) {
+				this.sendMessage((Message<?>) event.getSource());
 			}
-			for (Class<? extends ApplicationEvent> eventType : this.eventTypes) {
-				if (eventType.isAssignableFrom(event.getClass())) {
-					this.sendEventAsMessage(event);
-					return;
-				}
+			else {
+				Object payload = this.evaluationResult(event);
+				this.sendMessage(MessageBuilder.withPayload(payload).build());
 			}
 		}
 	}
 
 	@Override
-	protected void doStart() {
-		this.active = true;
+	public boolean supportsEventType(Class<? extends ApplicationEvent> eventType) {
+		for (Class<? extends ApplicationEvent> type : this.eventTypes) {
+			if (type.isAssignableFrom(eventType)) {
+				return true;
+			}
+		}
+		return this.eventTypes.isEmpty();
 	}
 
 	@Override
-	protected void doStop() {
-		this.active = false;
+	public boolean supportsSourceType(Class<?> sourceType) {
+		return true;
 	}
 
-	private void sendEventAsMessage(ApplicationEvent event) {
-		if (event.getSource() instanceof Message<?>) {
-			this.sendMessage((Message<?>) event.getSource());
-		}
-		else {
-			Object payload = (this.payloadExpression != null) ? this.payloadExpression.getValue(event) : event;
-			this.sendMessage(MessageBuilder.withPayload(payload).build());
-		}
+	@Override
+	public int getOrder() {
+		return Ordered.LOWEST_PRECEDENCE;
 	}
 
 }
+

--- a/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducer.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducer.java
@@ -17,7 +17,9 @@
 package org.springframework.integration.event.inbound;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.context.ApplicationEvent;
@@ -31,6 +33,7 @@ import org.springframework.integration.Message;
 import org.springframework.integration.endpoint.ExpressionMessageProducerSupport;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 
 /**
  * An inbound Channel Adapter that implements {@link ApplicationListener} and
@@ -40,7 +43,6 @@ import org.springframework.util.Assert;
  *
  * @author Mark Fisher
  * @author Artem Bilan
- *
  * @see ApplicationEventMulticaster
  * @see ExpressionMessageProducerSupport
  */
@@ -63,8 +65,12 @@ public class ApplicationEventListeningMessageProducer extends ExpressionMessageP
 	 * @see ApplicationEventMulticaster#addApplicationListener
 	 * @see #supportsEventType
 	 */
+	@SuppressWarnings("unchecked")
 	public void setEventTypes(Class<? extends ApplicationEvent>... eventTypes) {
-		this.eventTypes = new HashSet<Class<? extends ApplicationEvent>>(Arrays.asList(eventTypes));
+		Set<Class<? extends ApplicationEvent>> eventSet = new HashSet<Class<? extends ApplicationEvent>>(CollectionUtils.arrayToList(eventTypes));
+		eventSet.remove(null);
+		this.eventTypes = (eventSet.size() > 0 ? eventSet : null);
+
 		if (this.applicationEventMulticaster != null) {
 			this.applicationEventMulticaster.addApplicationListener(this);
 		}

--- a/spring-integration-event/src/test/java/log4j.properties
+++ b/spring-integration-event/src/test/java/log4j.properties
@@ -2,7 +2,7 @@ log4j.rootCategory=WARN, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%c{1}: %m%n
+log4j.appender.stdout.layout.ConversionPattern=%c{1}: (%t) %m%n
 
 log4j.category.org.springframework.integration=WARN
-log4j.category.org.springframework.integration.event=WARN
+log4j.category.org.springframework.integration.event=INFO

--- a/spring-integration-event/src/test/java/log4j.properties
+++ b/spring-integration-event/src/test/java/log4j.properties
@@ -5,4 +5,4 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%c{1}: %m%n
 
 log4j.category.org.springframework.integration=WARN
-log4j.category.org.springframework.integration.file=WARN
+log4j.category.org.springframework.integration.event=WARN

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests.java
@@ -22,6 +22,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -87,11 +90,12 @@ public class EventInboundChannelAdapterParserTests {
 		Assert.assertTrue(adapter instanceof ApplicationEventListeningMessageProducer);
 		DirectFieldAccessor adapterAccessor = new DirectFieldAccessor(adapter);
 		Assert.assertEquals(context.getBean("inputFiltered"), adapterAccessor.getPropertyValue("outputChannel"));
-		Set<Class<? extends ApplicationEvent>> eventTypes = (Set<Class<? extends ApplicationEvent>>) adapterAccessor.getPropertyValue("eventTypes");
+		Class<? extends ApplicationEvent>[] eventTypes = (Class<? extends ApplicationEvent>[]) adapterAccessor.getPropertyValue("eventTypes");
 		assertNotNull(eventTypes);
-		assertTrue(eventTypes.size() == 2);
-		assertTrue(eventTypes.contains(SampleEvent.class));
-		assertTrue(eventTypes.contains(AnotherSampleEvent.class));
+		List<Class<? extends ApplicationEvent>> eventTypeList = Arrays.asList(eventTypes);
+		assertTrue(eventTypeList.size() == 2);
+		assertTrue(eventTypeList.contains(SampleEvent.class));
+		assertTrue(eventTypeList.contains(AnotherSampleEvent.class));
 		assertNull(adapterAccessor.getPropertyValue("errorChannel"));
 	}
 
@@ -103,11 +107,12 @@ public class EventInboundChannelAdapterParserTests {
 		Assert.assertTrue(adapter instanceof ApplicationEventListeningMessageProducer);
 		DirectFieldAccessor adapterAccessor = new DirectFieldAccessor(adapter);
 		Assert.assertEquals(context.getBean("inputFilteredPlaceHolder"), adapterAccessor.getPropertyValue("outputChannel"));
-		Set<Class<? extends ApplicationEvent>> eventTypes = (Set<Class<? extends ApplicationEvent>>) adapterAccessor.getPropertyValue("eventTypes");
+		Class<? extends ApplicationEvent>[] eventTypes = (Class<? extends ApplicationEvent>[]) adapterAccessor.getPropertyValue("eventTypes");
 		assertNotNull(eventTypes);
-		assertTrue(eventTypes.size() == 2);
-		assertTrue(eventTypes.contains(SampleEvent.class));
-		assertTrue(eventTypes.contains(AnotherSampleEvent.class));
+		List<Class<? extends ApplicationEvent>> eventTypeList = Arrays.asList(eventTypes);
+		assertTrue(eventTypeList.size() == 2);
+		assertTrue(eventTypeList.contains(SampleEvent.class));
+		assertTrue(eventTypeList.contains(AnotherSampleEvent.class));
 	}
 
 	@Test

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests.java
@@ -22,9 +22,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -90,12 +87,11 @@ public class EventInboundChannelAdapterParserTests {
 		Assert.assertTrue(adapter instanceof ApplicationEventListeningMessageProducer);
 		DirectFieldAccessor adapterAccessor = new DirectFieldAccessor(adapter);
 		Assert.assertEquals(context.getBean("inputFiltered"), adapterAccessor.getPropertyValue("outputChannel"));
-		Class<? extends ApplicationEvent>[] eventTypes = (Class<? extends ApplicationEvent>[]) adapterAccessor.getPropertyValue("eventTypes");
+		Set<Class<? extends ApplicationEvent>> eventTypes = (Set<Class<? extends ApplicationEvent>>) adapterAccessor.getPropertyValue("eventTypes");
 		assertNotNull(eventTypes);
-		List<Class<? extends ApplicationEvent>> eventTypeList = Arrays.asList(eventTypes);
-		assertTrue(eventTypeList.size() == 2);
-		assertTrue(eventTypeList.contains(SampleEvent.class));
-		assertTrue(eventTypeList.contains(AnotherSampleEvent.class));
+		assertTrue(eventTypes.size() == 2);
+		assertTrue(eventTypes.contains(SampleEvent.class));
+		assertTrue(eventTypes.contains(AnotherSampleEvent.class));
 		assertNull(adapterAccessor.getPropertyValue("errorChannel"));
 	}
 
@@ -107,12 +103,11 @@ public class EventInboundChannelAdapterParserTests {
 		Assert.assertTrue(adapter instanceof ApplicationEventListeningMessageProducer);
 		DirectFieldAccessor adapterAccessor = new DirectFieldAccessor(adapter);
 		Assert.assertEquals(context.getBean("inputFilteredPlaceHolder"), adapterAccessor.getPropertyValue("outputChannel"));
-		Class<? extends ApplicationEvent>[] eventTypes = (Class<? extends ApplicationEvent>[]) adapterAccessor.getPropertyValue("eventTypes");
+		Set<Class<? extends ApplicationEvent>> eventTypes = (Set<Class<? extends ApplicationEvent>>) adapterAccessor.getPropertyValue("eventTypes");
 		assertNotNull(eventTypes);
-		List<Class<? extends ApplicationEvent>> eventTypeList = Arrays.asList(eventTypes);
-		assertTrue(eventTypeList.size() == 2);
-		assertTrue(eventTypeList.contains(SampleEvent.class));
-		assertTrue(eventTypeList.contains(AnotherSampleEvent.class));
+		assertTrue(eventTypes.size() == 2);
+		assertTrue(eventTypes.contains(SampleEvent.class));
+		assertTrue(eventTypes.contains(AnotherSampleEvent.class));
 	}
 
 	@Test

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducerTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,30 @@
 package org.springframework.integration.event.inbound;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ApplicationEventMulticaster;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.ContextStartedEvent;
 import org.springframework.context.event.ContextStoppedEvent;
+import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageHandlingException;
 import org.springframework.integration.channel.DirectChannel;
@@ -35,10 +49,12 @@ import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.event.core.MessagingEvent;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.util.TestUtils;
 
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class ApplicationEventListeningMessageProducerTests {
 
@@ -50,7 +66,9 @@ public class ApplicationEventListeningMessageProducerTests {
 		adapter.start();
 		Message<?> message1 = channel.receive(0);
 		assertNull(message1);
+		assertTrue(adapter.supportsEventType(TestApplicationEvent1.class));
 		adapter.onApplicationEvent(new TestApplicationEvent1());
+		assertTrue(adapter.supportsEventType(TestApplicationEvent2.class));
 		adapter.onApplicationEvent(new TestApplicationEvent2());
 		Message<?> message2 = channel.receive(20);
 		assertNotNull(message2);
@@ -66,17 +84,17 @@ public class ApplicationEventListeningMessageProducerTests {
 		QueueChannel channel = new QueueChannel();
 		ApplicationEventListeningMessageProducer adapter = new ApplicationEventListeningMessageProducer();
 		adapter.setOutputChannel(channel);
-		adapter.setEventTypes(new Class[]{TestApplicationEvent1.class});
+		adapter.setEventTypes(TestApplicationEvent1.class);
 		adapter.start();
 		Message<?> message1 = channel.receive(0);
 		assertNull(message1);
+		assertTrue(adapter.supportsEventType(TestApplicationEvent1.class));
 		adapter.onApplicationEvent(new TestApplicationEvent1());
-		adapter.onApplicationEvent(new TestApplicationEvent2());
+		assertFalse(adapter.supportsEventType(TestApplicationEvent2.class));
 		Message<?> message2 = channel.receive(20);
 		assertNotNull(message2);
 		assertEquals("event1", ((ApplicationEvent) message2.getPayload()).getSource());
-		Message<?> message3 = channel.receive(0);
-		assertNull(message3);
+		assertNull(channel.receive(0));
 	}
 
 	@Test
@@ -170,6 +188,63 @@ public class ApplicationEventListeningMessageProducerTests {
 		adapter.onApplicationEvent(new TestApplicationEvent1());
 	}
 
+	@Test
+	@SuppressWarnings({"unchecked", "serial"})
+	public void testInt2935CheckRetrieverCache() {
+		GenericApplicationContext ctx = TestUtils.createTestApplicationContext();
+		ConfigurableListableBeanFactory beanFactory = ctx.getBeanFactory();
+
+		QueueChannel channel = new QueueChannel();
+		ApplicationEventListeningMessageProducer listenerMessageProducer = new ApplicationEventListeningMessageProducer();
+		listenerMessageProducer.setOutputChannel(channel);
+		listenerMessageProducer.setEventTypes(TestApplicationEvent2.class);
+		beanFactory.registerSingleton("testListenerMessageProducer", listenerMessageProducer);
+
+		AtomicInteger listenerCounter = new AtomicInteger();
+		beanFactory.registerSingleton("testListener", new TestApplicationListener(listenerCounter));
+
+		ctx.refresh();
+
+		ApplicationEventMulticaster multicaster =
+				ctx.getBean(AbstractApplicationContext.APPLICATION_EVENT_MULTICASTER_BEAN_NAME, ApplicationEventMulticaster.class);
+		Map retrieverCache = TestUtils.getPropertyValue(multicaster, "retrieverCache", Map.class);
+
+		ctx.publishEvent(new TestApplicationEvent1());
+
+		//Before retrieverCache grew exponentially: the same ApplicationEventListeningMessageProducer for each event
+		assertEquals(2, retrieverCache.size());
+		for (Object key : retrieverCache.keySet()) {
+			Class<? extends ApplicationEvent> event = TestUtils.getPropertyValue(key, "eventType", Class.class);
+			assertThat(event, Matchers.is(Matchers.isOneOf(ContextRefreshedEvent.class, TestApplicationEvent1.class)));
+			Set listeners = TestUtils.getPropertyValue(retrieverCache.get(key), "applicationListenerBeans", Set.class);
+			assertEquals(1, listeners.size());
+			assertEquals("testListener", listeners.iterator().next());
+		}
+
+		TestApplicationEvent2 event2 = new TestApplicationEvent2();
+		ctx.publishEvent(event2);
+		assertEquals(3, retrieverCache.size());
+		for (Object key : retrieverCache.keySet()) {
+			Class event = TestUtils.getPropertyValue(key, "eventType", Class.class);
+			if (TestApplicationEvent2.class.isAssignableFrom(event)) {
+				Set listeners = TestUtils.getPropertyValue(retrieverCache.get(key), "applicationListenerBeans", Set.class);
+				assertEquals(2, listeners.size());
+				for (Object listener : listeners) {
+					assertThat((String) listener, Matchers.is(Matchers.isOneOf("testListenerMessageProducer", "testListener")));
+				}
+				break;
+			}
+		}
+
+		ctx.publishEvent(new ApplicationEvent("Some event") {});
+
+		assertEquals(4, listenerCounter.get());
+
+		final Message<?> receive = channel.receive(10);
+		assertNotNull(receive);
+		assertSame(event2, receive.getPayload());
+		assertNull(channel.receive(1));
+	}
 
 	@SuppressWarnings("serial")
 	private static class TestApplicationEvent1 extends ApplicationEvent {
@@ -194,6 +269,19 @@ public class ApplicationEventListeningMessageProducerTests {
 
 		public TestMessagingEvent(Message<?> message) {
 			super(message);
+		}
+	}
+
+	private static class TestApplicationListener implements ApplicationListener<ApplicationEvent> {
+
+		private final AtomicInteger counter;
+
+		private TestApplicationListener(AtomicInteger counter) {
+			this.counter = counter;
+		}
+
+		public void onApplicationEvent(ApplicationEvent event) {
+			this.counter.incrementAndGet();
 		}
 	}
 

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducerTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducerTests.java
@@ -95,6 +95,18 @@ public class ApplicationEventListeningMessageProducerTests {
 		assertNotNull(message2);
 		assertEquals("event1", ((ApplicationEvent) message2.getPayload()).getSource());
 		assertNull(channel.receive(0));
+
+		adapter.setEventTypes((Class<? extends ApplicationEvent>) null);
+		assertTrue(adapter.supportsEventType(TestApplicationEvent1.class));
+		assertTrue(adapter.supportsEventType(TestApplicationEvent2.class));
+
+		adapter.setEventTypes(null, TestApplicationEvent2.class, null);
+		assertFalse(adapter.supportsEventType(TestApplicationEvent1.class));
+		assertTrue(adapter.supportsEventType(TestApplicationEvent2.class));
+
+		adapter.setEventTypes(null, null);
+		assertTrue(adapter.supportsEventType(TestApplicationEvent1.class));
+		assertTrue(adapter.supportsEventType(TestApplicationEvent2.class));
 	}
 
 	@Test

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/CacheListeningMessageProducer.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/CacheListeningMessageProducer.java
@@ -123,7 +123,7 @@ public class CacheListeningMessageProducer extends ExpressionMessageProducerSupp
 		}
 
 		private void processEvent(EntryEvent event) {
-				this.publish(evaluationResult(event));
+				this.publish(evaluatePayloadExpression(event));
 
 		}
 

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/CacheListeningMessageProducer.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/CacheListeningMessageProducer.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.integration.endpoint.ExpressionMessageProducerSupport;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.util.Assert;
 
@@ -37,13 +38,13 @@ import com.gemstone.gemfire.cache.util.CacheListenerAdapter;
  * enum for all options. A SpEL expression may be provided to generate a Message payload by
  * evaluating that expression against the {@link EntryEvent} instance as the root object. If no
  * payloadExpression is provided, the {@link EntryEvent} itself will be the payload.
- * 
+ *
  * @author Mark Fisher
  * @author David Turanski
  * @since 2.1
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class CacheListeningMessageProducer extends SpelMessageProducerSupport {
+public class CacheListeningMessageProducer extends ExpressionMessageProducerSupport {
 
 	private final Log logger = LogFactory.getLog(this.getClass());
 
@@ -58,7 +59,7 @@ public class CacheListeningMessageProducer extends SpelMessageProducerSupport {
 	public CacheListeningMessageProducer(Region<?, ?> region) {
 		Assert.notNull(region, "region must not be null");
 		this.region = region;
-		this.listener = new MessageProducingCacheListener();   
+		this.listener = new MessageProducingCacheListener();
 	}
 
 
@@ -81,16 +82,16 @@ public class CacheListeningMessageProducer extends SpelMessageProducerSupport {
 		if (logger.isInfoEnabled()) {
 			logger.info("removing MessageProducingCacheListener from GemFire Region '" + this.region.getName() + "'");
 		}
-		try { 
+		try {
 			this.region.getAttributesMutator().removeCacheListener(this.listener);
 		} catch (CacheClosedException e) {
 			if (logger.isDebugEnabled()){
 				logger.debug(e.getMessage(),e);
 			}
 		}
-		 
+
 	}
- 
+
 	private class MessageProducingCacheListener extends CacheListenerAdapter {
 
 		@Override
@@ -121,16 +122,16 @@ public class CacheListeningMessageProducer extends SpelMessageProducerSupport {
 			}
 		}
 
-		private void processEvent(EntryEvent event) { 
+		private void processEvent(EntryEvent event) {
 				this.publish(evaluationResult(event));
-			 
+
 		}
 
 		private void publish(Object payload) {
 			sendMessage(MessageBuilder.withPayload(payload).build());
 		}
 	}
-	
-	
+
+
 
 }

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/ContinuousQueryMessageProducer.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/ContinuousQueryMessageProducer.java
@@ -114,7 +114,7 @@ public class ContinuousQueryMessageProducer extends ExpressionMessageProducerSup
 				logger.debug(String.format("processing cq event key [%s] event [%s]", event.getQueryOperation()
 						.toString(), event.getKey()));
 			}
-			Message<?> cqEventMessage = MessageBuilder.withPayload(evaluationResult(event)).build();
+			Message<?> cqEventMessage = MessageBuilder.withPayload(evaluatePayloadExpression(event)).build();
 			sendMessage(cqEventMessage);
 		}
 	}

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/ContinuousQueryMessageProducer.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/ContinuousQueryMessageProducer.java
@@ -26,6 +26,7 @@ import org.springframework.data.gemfire.listener.ContinuousQueryDefinition;
 import org.springframework.data.gemfire.listener.ContinuousQueryListener;
 import org.springframework.data.gemfire.listener.ContinuousQueryListenerContainer;
 import org.springframework.integration.Message;
+import org.springframework.integration.endpoint.ExpressionMessageProducerSupport;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.util.Assert;
 
@@ -36,13 +37,13 @@ import com.gemstone.gemfire.cache.query.CqEvent;
  * constantly evaluated against a cache
  * {@link com.gemstone.gemfire.cache.Region}. This is much faster than
  * re-querying the cache manually.
- * 
+ *
  * @author Josh Long
  * @author David Turanski
  * @since 2.1
- * 
+ *
  */
-public class ContinuousQueryMessageProducer extends SpelMessageProducerSupport implements ContinuousQueryListener {
+public class ContinuousQueryMessageProducer extends ExpressionMessageProducerSupport implements ContinuousQueryListener {
 	private static Log logger = LogFactory.getLog(ContinuousQueryMessageProducer.class);
 
 	private final String query;
@@ -57,7 +58,7 @@ public class ContinuousQueryMessageProducer extends SpelMessageProducerSupport i
 			CqEventType.UPDATED));
 
 	/**
-	 * 
+	 *
 	 * @param queryListenerContainer a {@link org.springframework.data.gemfire.listener.ContinuousQueryListenerContainer}
 	 * @param query the query string
 	 */
@@ -69,7 +70,7 @@ public class ContinuousQueryMessageProducer extends SpelMessageProducerSupport i
 	}
 
 	/**
-	 * 
+	 *
 	 * @param queryName optional query name
 	 */
 	public void setQueryName(String queryName) {
@@ -77,7 +78,7 @@ public class ContinuousQueryMessageProducer extends SpelMessageProducerSupport i
 	}
 
 	/**
-	 * 
+	 *
 	 * @param durable true if the query is a durable subscription
 	 */
 	public void setDurable(boolean durable) {
@@ -102,7 +103,7 @@ public class ContinuousQueryMessageProducer extends SpelMessageProducerSupport i
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.springframework.data.gemfire.listener.QueryListener#onEvent(com.gemstone
 	 * .gemfire.cache.query.CqEvent)
@@ -119,8 +120,8 @@ public class ContinuousQueryMessageProducer extends SpelMessageProducerSupport i
 	}
 
 	private boolean isEventSupported(CqEvent event) {
-		 
-		 String eventName = event.getQueryOperation().toString() + 
+
+		 String eventName = event.getQueryOperation().toString() +
 		 	(event.getQueryOperation().toString().endsWith("Y")? "ED" : "D");
 		 CqEventType eventType = CqEventType.valueOf(eventName);
 		 return supportedEventTypes.contains(eventType);


### PR DESCRIPTION
Before `ApplicationEventListeningMessageProducer` accepted all `ApplicationEvent`'s and than filtered them.
It caused some `ApplicationEventMulticaster.retrieverCache` overhead.
- Improve `ApplicationEventListeningMessageProducer` to `implements SmartApplicationListener`.
  It allows to make filtering earlier on first appropriate `ApplicationEvent` from `ApplicationEventListeningMessageProducer#supportsEventType`
  and caching the `ApplicationListener` only for that `ApplicationEvent`.
- Re-register `ApplicationEventListeningMessageProducer` in the `ApplicationEventMulticaster` on `ApplicationEventListeningMessageProducer#setEventTypes`
  to clear `ApplicationEventMulticaster.retrieverCache` and make filtering on next the `ApplicationEvent`.
- Move `org.springframework.integration.gemfire.inbound.SpelMessageProducerSupport` to core `ExpressionMessageProducerSupport` as useful component.
- Add test about new logic of `ApplicationEventListeningMessageProducer` and its behavior with respect to the `ApplicationEventMulticaster.retrieverCache`.

JIRA: https://jira.springsource.org/browse/INT-2935
