### PR TITLE
INT-2945 - StoredProc isFunction property not set

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/StoredProcPollingChannelAdapterParser.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/StoredProcPollingChannelAdapterParser.java
@@ -48,7 +48,7 @@ public class StoredProcPollingChannelAdapterParser extends AbstractPollingInboun
 		final BeanDefinitionBuilder storedProcExecutorBuilder = StoredProcParserUtils.getStoredProcExecutorBuilder(element, parserContext);
 
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(storedProcExecutorBuilder, element, "return-value-required");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(storedProcExecutorBuilder, element, "function");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(storedProcExecutorBuilder, element, "is-function");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(storedProcExecutorBuilder, element, "skip-undeclared-results");
 
 		final ManagedMap<String, BeanDefinition> returningResultsetMap = StoredProcParserUtils.getReturningResultsetBeanDefinitions(element, parserContext);

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcOutboundGatewayParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -113,6 +113,54 @@ public class StoredProcOutboundGatewayParserTests {
 		accessor = new DirectFieldAccessor(source);
 		boolean returnValueRequired = (Boolean) accessor.getPropertyValue("returnValueRequired");
 		assertTrue(returnValueRequired);
+	}
+
+	@Test
+	public void testIsFunctionAttributeSet() throws Exception {
+		setUp("storedProcOutboundGatewayParserFunctionTest.xml", getClass());
+		DirectFieldAccessor accessor = new DirectFieldAccessor(this.outboundGateway);
+		Object source = accessor.getPropertyValue("handler");
+		accessor = new DirectFieldAccessor(source);
+		source = accessor.getPropertyValue("executor");
+		accessor = new DirectFieldAccessor(source);
+		boolean isFunction = (Boolean) accessor.getPropertyValue("isFunction");
+		assertTrue(isFunction);
+	}
+
+	@Test
+	public void testIsFunctionAttributeSetToFalse() throws Exception {
+		setUp("storedProcOutboundGatewayParserTest.xml", getClass());
+		DirectFieldAccessor accessor = new DirectFieldAccessor(this.outboundGateway);
+		Object source = accessor.getPropertyValue("handler");
+		accessor = new DirectFieldAccessor(source);
+		source = accessor.getPropertyValue("executor");
+		accessor = new DirectFieldAccessor(source);
+		boolean isFunction = (Boolean) accessor.getPropertyValue("isFunction");
+		assertFalse(isFunction);
+	}
+
+	@Test
+	public void testIsIgnoreColumnMetaDataSetToFalse() throws Exception {
+		setUp("storedProcOutboundGatewayParserTest.xml", getClass());
+		DirectFieldAccessor accessor = new DirectFieldAccessor(this.outboundGateway);
+		Object source = accessor.getPropertyValue("handler");
+		accessor = new DirectFieldAccessor(source);
+		source = accessor.getPropertyValue("executor");
+		accessor = new DirectFieldAccessor(source);
+		boolean ignoreColumnMetaData = (Boolean) accessor.getPropertyValue("ignoreColumnMetaData");
+		assertFalse(ignoreColumnMetaData);
+	}
+
+	@Test
+	public void testIsIgnoreColumnMetaDataSet() throws Exception {
+		setUp("storedProcOutboundGatewayParserFunctionTest.xml", getClass());
+		DirectFieldAccessor accessor = new DirectFieldAccessor(this.outboundGateway);
+		Object source = accessor.getPropertyValue("handler");
+		accessor = new DirectFieldAccessor(source);
+		source = accessor.getPropertyValue("executor");
+		accessor = new DirectFieldAccessor(source);
+		boolean ignoreColumnMetaData = (Boolean) accessor.getPropertyValue("ignoreColumnMetaData");
+		assertTrue(ignoreColumnMetaData);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcPollingChannelAdapterParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcPollingChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -262,6 +262,7 @@ public class StoredProcPollingChannelAdapterParserTests {
 		SourcePollingChannelAdapter autoChannelAdapter = context.getBean("autoChannel.adapter", SourcePollingChannelAdapter.class);
 		assertSame(autoChannel, TestUtils.getPropertyValue(autoChannelAdapter, "outputChannel"));
 		assertFalse(TestUtils.getPropertyValue(autoChannelAdapter, "source.executor.returnValueRequired", Boolean.class));
+		assertFalse(TestUtils.getPropertyValue(autoChannelAdapter, "source.executor.isFunction", Boolean.class));
 	}
 
 	@After

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcPollingChannelAdapterParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcPollingChannelAdapterParserTests.java
@@ -132,6 +132,18 @@ public class StoredProcPollingChannelAdapterParserTests {
 		assertTrue(returnValueRequired);
 	}
 
+	@Test
+	public void testIsFunctionAttributeSet() throws Exception {
+		setUp("storedProcPollingChannelAdapterParserTest.xml", getClass());
+		DirectFieldAccessor accessor = new DirectFieldAccessor(this.pollingAdapter);
+		Object source = accessor.getPropertyValue("source");
+		accessor = new DirectFieldAccessor(source);
+		source = accessor.getPropertyValue("executor");
+		accessor = new DirectFieldAccessor(source);
+		boolean isFunction = (Boolean) accessor.getPropertyValue("isFunction");
+		assertTrue(isFunction);
+	}
+
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testProcedurepParametersAreSet() throws Exception {

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/storedProcOutboundGatewayParserFunctionTest.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/storedProcOutboundGatewayParserFunctionTest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:int-jdbc="http://www.springframework.org/schema/integration/jdbc"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/jdbc http://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<int:channel id="requestChannel" />
+	<int:channel id="replyChannel" />
+
+	<jdbc:embedded-database id="datasource" type="HSQL" />
+
+	<int-jdbc:stored-proc-outbound-gateway auto-startup="false"
+		request-channel="requestChannel" stored-procedure-name="GET_PRIME_NUMBERS"
+		data-source="datasource" id="storedProcedureOutboundGateway"
+		ignore-column-meta-data="true" is-function="true"
+		skip-undeclared-results="true" reply-channel="replyChannel"
+		reply-timeout="555" return-value-required="false">
+	</int-jdbc:stored-proc-outbound-gateway>
+
+	<int:poller default="true" fixed-rate="10000" />
+</beans>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/storedProcPollingChannelAdapterParserTest.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/storedProcPollingChannelAdapterParserTest.xml
@@ -16,7 +16,7 @@
 				data-source="dataSource" channel="target"
 				stored-procedure-name="GET_PRIME_NUMBERS"
 				return-value-required="true"
-				is-function="false">
+				is-function="true">
 			<int-jdbc:sql-parameter-definition name="username" direction="IN"    type="VARCHAR"/>
 			<int-jdbc:sql-parameter-definition name="password" direction="OUT" />
 			<int-jdbc:sql-parameter-definition name="age"      direction="INOUT" type="INTEGER"  scale="5"/>


### PR DESCRIPTION
For reference see: https://jira.springsource.org/browse/INT-2945
- ensure that for _StoredProcedure Inbound Channel Adapter_ the _isFunction_ property is set
- add test

Also **Cherry Pick for 2.2.x**
