### PR TITLE
INT-2955 Fix Collection/Map Conversion

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/BeanFactoryTypeConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/BeanFactoryTypeConverter.java
@@ -27,6 +27,9 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.expression.TypeConverter;
+import org.springframework.integration.MessageHeaders;
+import org.springframework.integration.history.MessageHistory;
+import org.springframework.util.ClassUtils;
 
 /**
  * @author Dave Syer
@@ -106,10 +109,15 @@ public class BeanFactoryTypeConverter implements TypeConverter, BeanFactoryAware
 		 *  INT-2630 Spring 3.1 now converts ALL arguments; we know we don't need to convert MessageHeaders
 		 *  or MessageHistory; the MapToMap converter requires a no-arg constructor.
 		 *  Also INT-2650 - don't convert large byte[]
-		 *  This reverts the effective logic to Spring 3.0.
 		 */
-		if (sourceType != null && sourceType.isAssignableTo(targetType)) {
-			return value;
+		if (sourceType != null) {
+			Class<?> sourceClass = sourceType.getType();
+			Class<?> targetClass = targetType.getType();
+			if ((sourceClass == MessageHeaders.class && targetClass == MessageHeaders.class) ||
+				(sourceClass == MessageHistory.class && targetClass == MessageHistory.class) ||
+				(sourceType.isAssignableTo(targetType) && ClassUtils.isPrimitiveArray(sourceClass))) {
+				return value;
+			}
 		}
 		if (conversionService.canConvert(sourceType, targetType)) {
 			return conversionService.convert(value, sourceType, targetType);
@@ -125,7 +133,7 @@ public class BeanFactoryTypeConverter implements TypeConverter, BeanFactoryAware
 					editor.setValue(value);
 					text = editor.getAsText();
 				}
-				if (String.class.isAssignableFrom(targetType.getClass())) {
+				if (String.class.isAssignableFrom(targetType.getType())) {
 					return text;
 				}
 				return convertValue(text, TypeDescriptor.valueOf(String.class), targetType);


### PR DESCRIPTION
The fix for INT-2650 (to avoid unnecessary array copying) was
too general in that it also prevented types in collections and
maps from being converted.

Add tests to illustrate that such payloads are not converted.

Change code to only short circuit the conversion process if
the payload is a primitive array.

An existing test ensures that arrays are not copied.

Add more tests to complete coverage - discovered another
bug - the early exit after using a property editor to convert
to a String was never taken - it was testing against the
Class of the TypeConverter instead of the Type. If the
target type is a String, we don't need to perform
conversion after the property editor has done its
conversion.

Fix MessageHistory test (was testing MessageHeaders).

**needs cherry-pick to 2.2.x, 2.1.x**
