### PR TITLE
INT-2956 Fix NIO With Custom Deserializers

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -548,6 +548,33 @@ public class TcpNioConnection extends TcpConnectionSupport {
 		private volatile boolean isClosed;
 
 		@Override
+		public int read(byte[] b, int off, int len) throws IOException {
+			Assert.notNull(b, "byte[] cannot be null");
+			if (off < 0 || len < 0 || len > b.length - off) {
+			    throw new IndexOutOfBoundsException();
+			}
+			else if (len == 0) {
+			    return 0;
+			}
+
+			int n = 0;
+			while ((this.available.get() > 0 || n == 0) &&
+						n < len) {
+				int bite = read();
+				if (bite < 0) {
+					if (n == 0) {
+						return -1;
+					}
+					else {
+						return n;
+					}
+				}
+				b[off + n++] = (byte) bite;
+			}
+			return n;
+		}
+
+		@Override
 		public synchronized int read() throws IOException {
 			if (this.isClosed && available.get() == 0) {
 				return -1;


### PR DESCRIPTION
The TcpNioConnection uses an internal InputStream.

The standard deserializers only use the read() method.

Custom Deserializers might use read(byte[]); the
internal InputStream did not override these methods, possibly
causing the deserializer to hang awaiting data, when none
was coming.

Override these methods, with the appropriate semantics
from the super class...
- Block until at least one byte arrives.
- Return early if no data is available after at least one byte arrives.
- Return -1 if closed when no data arrived.
- Return the number of bytes actually read.
