### PR TITLE
INT-2958: XSD: move 'charset' from common attrs

### DIFF
--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -1504,7 +1504,7 @@
 					<xsd:element name="payload-serializing-transformer" type="payload-serializing-transformer-type"/>
 					<xsd:element name="payload-deserializing-transformer"
 								 type="payload-deserializing-transformer-type"/>
-					<xsd:element name="object-to-string-transformer" type="specialized-transformer-type"/>
+					<xsd:element name="object-to-string-transformer" type="specialized-transformer-charset-aware-type"/>
 					<xsd:element name="object-to-map-transformer" type="specialized-transformer-type"/>
 					<xsd:element name="map-to-object-transformer" type="map-to-object-transformer-type"/>
 					<xsd:element name="object-to-json-transformer" type="object-to-json-transformer-type"/>
@@ -2023,7 +2023,7 @@
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
-				<xsd:extension base="specialized-transformer-type">
+				<xsd:extension base="specialized-transformer-charset-aware-type">
 					<xsd:attributeGroup ref="inputOutputChannelGroupWithId" />
 				</xsd:extension>
 			</xsd:complexContent>
@@ -2357,6 +2357,21 @@
 			<xsd:any processContents="strict" namespace="##other" minOccurs="0" maxOccurs="unbounded" />
 			<xsd:element ref="poller" />
 		</xsd:choice>
+	</xsd:complexType>
+
+	<xsd:complexType name="specialized-transformer-charset-aware-type">
+		<xsd:complexContent>
+			<xsd:extension base="specialized-transformer-type">
+				<xsd:attribute name="charset" type="xsd:string" default="UTF-8">
+					<xsd:annotation>
+						<xsd:documentation>
+							Allows you to specify the Charset (e.g., US-ASCII,
+							ISO-8859-1, UTF-8) to be used when transforming byte[]. [UTF-8] is the default
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
 	</xsd:complexType>
 
 	<xsd:element name="filter">
@@ -3837,15 +3852,6 @@ endpoint itself is a Polling Consumer for a channel with a queue.
                 <xsd:union memberTypes="xsd:boolean xsd:string" />
             </xsd:simpleType>
         </xsd:attribute>
-		<xsd:attribute name="charset" type="xsd:string"
-			default="UTF-8">
-			<xsd:annotation>
-				<xsd:documentation>
-					Allows you to specify the Charset (e.g., US-ASCII,
-					ISO-8859-1, UTF-8) to be used when transforming byte[]. [UTF-8] is the default
-				</xsd:documentation>
-			</xsd:annotation>
-		</xsd:attribute>
 	</xsd:attributeGroup>
 
 	<xsd:attributeGroup name="inputOutputChannelGroupWithId">

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserTests-context.xml
@@ -101,6 +101,7 @@
 	</chain>
 
 	<chain id="logChain" input-channel="loggingChannelAdapterChannel">
+		<object-to-string-transformer charset="cp1251"/>
 		<transformer expression="payload.toUpperCase()"/>
 		<logging-channel-adapter level="WARN"/>
 	</chain>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserTests.java
@@ -30,6 +30,9 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.commons.logging.Log;
 import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
@@ -57,9 +60,6 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.StringUtils;
-
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Mark Fisher
@@ -277,7 +277,7 @@ public class ChainParserTests {
 		assertSame(successMessage, testConsumer.getLastMessage());
 	}
 
-	@Test //INT-2275
+	@Test //INT-2275, INT-2958
 	public void chainWithLoggingChannelAdapter() {
 		Log logger = mock(Log.class);
 		final AtomicReference<String> log = new AtomicReference<String>();
@@ -291,12 +291,12 @@ public class ChainParserTests {
 
 		@SuppressWarnings("unchecked")
 		List<MessageHandler> handlers = TestUtils.getPropertyValue(this.logChain, "handlers", List.class);
-		MessageHandler handler = handlers.get(1);
+		MessageHandler handler = handlers.get(2);
 		assertTrue(handler instanceof LoggingHandler);
 		DirectFieldAccessor dfa = new DirectFieldAccessor(handler);
 		dfa.setPropertyValue("messageLogger", logger);
 
-		this.loggingChannelAdapterChannel.send(MessageBuilder.withPayload("test").build());
+		this.loggingChannelAdapterChannel.send(MessageBuilder.withPayload(new byte[] {116, 101, 115, 116}).build());
 		assertNotNull(log.get());
 		assertEquals("TEST", log.get());
 	}


### PR DESCRIPTION
`charset` for `<object-to-string-transformer>` was placed in the common `inputOutputChannelGroup` attributeGroup.
`charset` wasn't available  within `<chain>`.
- Move 'charset' from `inputOutputChannelGroup` to the new `specialized-transformer-charset-aware-type` complexType
- Add test for 'charset' within `<chain>`

JIRA: https://jira.springsource.org/browse/INT-2958
