### PR TITLE
INT-2957-backport Remove Unnecessary AspectJ Dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,6 @@ project('spring-integration-core') {
 		compile "org.springframework:spring-tx:$springVersion"
 		compile "org.springframework.retry:spring-retry:$springRetryVersion"
 		compile("org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion", optional)
-		testCompile "org.aspectj:aspectjrt:$aspectjVersion"
 		testCompile "org.aspectj:aspectjweaver:$aspectjVersion"
 	}
 	bundlor {
@@ -461,8 +460,6 @@ project('spring-integration-jdbc') {
 		testCompile "org.apache.derby:derby:10.5.3.0_1"
 		testCompile "org.apache.derby:derbyclient:10.5.3.0_1"
 
-		testCompile "org.aspectj:aspectjrt:$aspectjVersion"
-		testCompile "org.aspectj:aspectjweaver:$aspectjVersion"
 		testCompile "org.powermock:powermock-module-junit4:1.4.12"
 		testCompile "org.powermock:powermock-api-mockito:1.4.12"
 
@@ -526,7 +523,6 @@ project('spring-integration-jmx') {
 	description = 'Spring Integration JMX Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile "org.aspectj:aspectjrt:$aspectjVersion"
 		compile "org.aspectj:aspectjweaver:$aspectjVersion"
 		compile "org.springframework:spring-context:$springVersion"
 		testCompile project(":spring-integration-test")
@@ -557,8 +553,6 @@ project('spring-integration-jpa') {
 		testCompile "com.h2database:h2:1.3.166"
 		testCompile "hsqldb:hsqldb:1.8.0.10"
 		testCompile "org.apache.derby:derby:10.5.3.0_1"
-		testCompile "org.aspectj:aspectjrt:$aspectjVersion"
-		testCompile "org.aspectj:aspectjweaver:$aspectjVersion"
 
 		testCompile "org.hibernate:hibernate-entitymanager:3.6.10.Final"
 		testCompile "org.eclipse.persistence:org.eclipse.persistence.jpa:2.3.2"


### PR DESCRIPTION
Core, JDBC, JMX, JPA each had dependencies for both
weaver and rt jars. weaver is a superset of rt.

Remove dependencies on the rt jar.

Further JDBC, JPA have no dependencies on AspectJ.

Finally, the JMX dependency was compile, when only
testCompile is needed.

However, to avoid breaking applications using 2.2.x
that might be relying on the transitive dependency
it is left at compile in this release.
