### PR TITLE
INT-2822: 'requires-reply' for outbound gateways

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -29,6 +29,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
+ * @author Artem Bilan
  *
  * @since 2.1
  */
@@ -53,6 +54,7 @@ public class AmqpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "routing-key");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "routing-key-expression");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "requires-reply");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel", "outputChannel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "return-channel");
 

--- a/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-3.0.xsd
+++ b/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-3.0.xsd
@@ -199,6 +199,15 @@
 								]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="requires-reply" type="xsd:string" use="optional" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether this outbound gateway must return a non-null value. This value is
+								'true' by default, and a ReplyRequiredException will be thrown when
+								the underlying service returns a null value.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests-context.xml
@@ -40,6 +40,7 @@
 		routing-key="si.test.binding"
 		amqp-template="amqpTemplate"
 		order="5"
+		requires-reply="false"
 		mapped-request-headers="foo*"
 		mapped-reply-headers="bar*"/>
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
@@ -15,7 +15,12 @@
  */
 package org.springframework.integration.amqp.config;
 
+<<<<<<< HEAD
 import static org.junit.Assert.assertEquals;
+=======
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+>>>>>>> de75475... INT-2822: 'requires-reply' for outbound gateways
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -62,7 +67,7 @@ public class AmqpOutboundGatewayParserTests {
 		Object edc = context.getBean("rabbitGateway");
 		AmqpOutboundEndpoint gateway = TestUtils.getPropertyValue(edc, "handler", AmqpOutboundEndpoint.class);
 		assertEquals(5, gateway.getOrder());
-		assertTrue(context.containsBean("rabbitGateway"));
+		assertTrue(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));
 		assertEquals(context.getBean("fromRabbit"), TestUtils.getPropertyValue(gateway, "outputChannel"));
 		assertEquals("amqp:outbound-gateway", gateway.getComponentType());
 		MessageChannel returnChannel = context.getBean("returnChannel", MessageChannel.class);
@@ -80,6 +85,8 @@ public class AmqpOutboundGatewayParserTests {
 		Object eventDrivernConsumer = context.getBean("withHeaderMapperCustomRequestResponse");
 
 		AmqpOutboundEndpoint endpoint = TestUtils.getPropertyValue(eventDrivernConsumer, "handler", AmqpOutboundEndpoint.class);
+
+		assertFalse(TestUtils.getPropertyValue(endpoint, "requiresReply", Boolean.class));
 
 		Field amqpTemplateField = ReflectionUtils.findField(AmqpOutboundEndpoint.class, "amqpTemplate");
 		amqpTemplateField.setAccessible(true);

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
@@ -15,12 +15,8 @@
  */
 package org.springframework.integration.amqp.config;
 
-<<<<<<< HEAD
 import static org.junit.Assert.assertEquals;
-=======
-import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
->>>>>>> de75475... INT-2822: 'requires-reply' for outbound gateways
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractOutboundGatewayParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.util.StringUtils;
  * Base class for url-based outbound gateway parsers.
  *
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public abstract class AbstractOutboundGatewayParser extends AbstractConsumerEndpointParser {
 
@@ -45,6 +46,7 @@ public abstract class AbstractOutboundGatewayParser extends AbstractConsumerEndp
 		if (StringUtils.hasText(replyChannel)) {
 			builder.addPropertyReference("replyChannel", replyChannel);
 		}
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "requires-reply");
 		this.postProcessGateway(builder, element, parserContext);
 		return builder;
 	}

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -1075,7 +1075,6 @@
 		</xsd:complexType>
 	</xsd:element>
 
-
 	<xsd:complexType name="serviceActivatorType">
 		<xsd:complexContent>
 			<xsd:extension base="expressionOrInnerEndpointDefinitionAware">
@@ -1083,8 +1082,8 @@
 					<xsd:annotation>
 						<xsd:documentation>
 							Specify whether the service method must return a non-null value. This value will be
-								'false' by default, but if set to 'true', a ReplyRequiredException will be thrown when
-								the underlying service method (or expression) returns a null value.
+							'false' by default, but if set to 'true', a ReplyRequiredException will be thrown when
+							the underlying service method (or expression) returns a null value.
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -1083,10 +1083,8 @@
 					<xsd:annotation>
 						<xsd:documentation>
 							Specify whether the service method must return a non-null value. This value will be
-							FALSE by
-							default, but if set to TRUE, a MessageHandlingException will be thrown when
-							the underlying service method (or
-							expression) returns a NULL value.
+								'false' by default, but if set to 'true', a ReplyRequiredException will be thrown when
+								the underlying service method (or expression) returns a null value.
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
@@ -3153,9 +3151,9 @@ is provided, the return value is expected to match a channel name exactly.
 				<xsd:attribute name="requires-reply" type="xsd:string" use="optional">
 					<xsd:annotation>
 						<xsd:documentation>
-							Specify whether the splitter method must return a non-null value. This value will be
-							FALSE by default, but if set to TRUE, a MessageHandlingException will be thrown when
-							the underlying service method (or expression) returns a NULL value.
+							Specify whether the service method must return a non-null value. This value will be
+							'false' by default, but if set to 'true', a ReplyRequiredException will be thrown when
+							the underlying service method (or expression) returns a null value.
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
@@ -27,6 +27,7 @@ import org.w3c.dom.Element;
  * @author Gary Russell
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
+ * @author Artem Bilan
  *
  * @since 2.1
  */
@@ -59,8 +60,7 @@ public abstract class AbstractRemoteFileOutboundGatewayParser extends AbstractCo
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "local-directory");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-create-local-directory");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "order");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "rename-expression");
-		return builder;
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "rename-expression");		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "requires-reply");		return builder;
 	}
 
 	protected void configureFilter(BeanDefinitionBuilder builder, Element element, ParserContext parserContext) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileOutboundGatewayParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ public class FileOutboundGatewayParser extends AbstractConsumerEndpointParser {
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder handlerBuilder = FileWritingMessageHandlerBeanDefinitionBuilder.configure(element, true, parserContext);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(handlerBuilder, element, "reply-timeout", "sendTimeout");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(handlerBuilder, element, "requires-reply");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(handlerBuilder, element, "reply-channel", "outputChannel");
  		return handlerBuilder;
 	}

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-3.0.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-3.0.xsd
@@ -394,6 +394,15 @@ Only files matching this regular expression will be picked up by this adapter.
 							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="requires-reply" type="xsd:string" use="optional" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether this outbound gateway must return a non-null value. This value is
+								'true' by default, and a ReplyRequiredException will be thrown when
+								the underlying service returns a null value.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
                 </xsd:extension>
             </xsd:complexContent>
         </xsd:complexType>

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests-context.xml
@@ -19,7 +19,7 @@
 
 	<int-file:outbound-gateway id="gatewayWithDirectoryExpression"
 		request-channel="someChannel" directory-expression="'build/foo'"
-		auto-startup="false" order="777" filename-generator-expression="'foo.txt'">
+		auto-startup="false" order="777" filename-generator-expression="'foo.txt'" requires-reply="false">
 		<int-file:request-handler-advice-chain>
 			<beans:bean class="org.springframework.integration.file.config.FileOutboundGatewayParserTests$FooAdvice" />
 		</int-file:request-handler-advice-chain>
@@ -28,7 +28,7 @@
 	<int-file:outbound-gateway id="gatewayWithReplaceMode"
 		request-channel="gatewayWithReplaceModeChannel"
 		filename-generator-expression="'fileToAppend.txt'" mode="REPLACE"
-		directory="test" />
+		directory="test"  requires-reply="false"/>
 
 	<int-file:outbound-gateway id="gatewayWithAppendMode"
 		request-channel="gatewayWithAppendModeChannel"

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.file.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -27,10 +28,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.expression.Expression;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessageHandlingException;
+import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.file.DefaultFileNameGenerator;
@@ -45,6 +48,7 @@ import org.springframework.util.FileCopyUtils;
 /**
  * @author Mark Fisher
  * @author Gunnar Hillert
+ * @author Artem Bilan
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -69,6 +73,10 @@ public class FileOutboundGatewayParserTests {
 	MessageChannel gatewayWithReplaceModeChannel;
 
 	@Autowired
+    @Qualifier("gatewayWithReplaceMode.handler")
+	MessageHandler gatewayWithReplaceModeHandler;
+
+	@Autowired
 	MessageChannel gatewayWithFailModeLowercaseChannel;
 
 	private volatile static int adviceCalled;
@@ -82,6 +90,7 @@ public class FileOutboundGatewayParserTests {
 		assertEquals(Boolean.FALSE, gatewayAccessor.getPropertyValue("autoStartup"));
 		DirectFieldAccessor handlerAccessor = new DirectFieldAccessor(handler);
 		assertEquals(777, handlerAccessor.getPropertyValue("order"));
+		assertEquals(Boolean.TRUE, handlerAccessor.getPropertyValue("requiresReply"));
 		DefaultFileNameGenerator fileNameGenerator = (DefaultFileNameGenerator) handlerAccessor.getPropertyValue("fileNameGenerator");
 		assertNotNull(fileNameGenerator);
 		String expression = (String) TestUtils.getPropertyValue(fileNameGenerator, "expression");
@@ -263,6 +272,8 @@ public class FileOutboundGatewayParserTests {
 	 */
 	@Test
 	public void gatewayWithReplaceMode() throws Exception{
+
+		assertFalse(TestUtils.getPropertyValue(this.gatewayWithReplaceModeHandler, "requiresReply", Boolean.class));
 
 		final MessagingTemplate messagingTemplate = new MessagingTemplate(this.gatewayWithReplaceModeChannel);
 

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
@@ -435,6 +435,15 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="requires-reply" type="xsd:string" use="optional" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether this outbound gateway must return a non-null value. This value is
+								'true' by default, and a ReplyRequiredException will be thrown when
+								the underlying service returns a null value.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
@@ -41,6 +41,7 @@
 		command-options="-P"
 		expression="payload"
 		order="2"
+		requires-reply="false"
 		>
 		<int-ftp:request-handler-advice-chain>
 			<bean class="org.springframework.integration.ftp.config.FtpOutboundGatewayParserTests$FooAdvice" />

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
@@ -84,6 +84,7 @@ public class FtpOutboundGatewayParserTests {
 
 		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout", Long.class);
 		assertEquals(Long.valueOf(777), sendTimeout);
+		assertTrue(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));
 	}
 
 	@Test
@@ -101,6 +102,7 @@ public class FtpOutboundGatewayParserTests {
 		Set<String> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
 		assertTrue(options.contains(Option.PRESERVE_TIMESTAMP));
 		gateway.handleMessage(new GenericMessage<String>("foo"));
+		assertFalse(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));
 		assertEquals(1, adviceCalled);
 	}
 

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParser.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -24,6 +24,7 @@ import org.w3c.dom.Element;
 /**
  * @author Dave Syer
  * @author Gunnar Hillert
+ * @author Artem Bilan
  *
  * @since 2.0
  *
@@ -48,8 +49,7 @@ public class JdbcOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		String updateQuery = IntegrationNamespaceUtils.getTextFromAttributeOrNestedElement(element, "update",
 				parserContext);
 
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder
-				.genericBeanDefinition(JdbcOutboundGateway.class);
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(JdbcOutboundGateway.class);
 		if (refToDataSourceSet) {
 			builder.addConstructorArgReference(dataSourceRef);
 		}
@@ -68,6 +68,7 @@ public class JdbcOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "max-rows-per-poll");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "keys-generated");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "requires-reply");
 
 		String replyChannel = element.getAttribute("reply-channel");
 		if (StringUtils.hasText(replyChannel)) {

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/StoredProcOutboundGatewayParser.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/StoredProcOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -27,6 +27,7 @@ import org.w3c.dom.Element;
 
 /**
  * @author Gunnar Hillert
+ * @author Artem Bilan
  * @since 2.1
  *
  */
@@ -62,6 +63,7 @@ public class StoredProcOutboundGatewayParser extends AbstractConsumerEndpointPar
 
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "expect-single-result");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "requires-reply");
 
 		String replyChannel = element.getAttribute("reply-channel");
 		if (StringUtils.hasText(replyChannel)) {

--- a/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-3.0.xsd
+++ b/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-3.0.xsd
@@ -502,6 +502,15 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="requires-reply" type="xsd:string" use="optional" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether this outbound gateway must return a non-null value. This value is
+								'true' by default, and a ReplyRequiredException will be thrown when
+								the underlying service returns a null value.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -966,6 +975,15 @@
 				<xsd:simpleType>
 					<xsd:union memberTypes="xsd:boolean xsd:string" />
 				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="requires-reply" type="xsd:string" use="optional" default="false">
+				<xsd:annotation>
+					<xsd:documentation>
+						Specify whether this outbound gateway must return a non-null value. This value is
+						'false' by default, if it set to 'true', a ReplyRequiredException will be thrown when
+						the underlying service returns a null value.
+					</xsd:documentation>
+				</xsd:annotation>
 			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParserTests.java
@@ -209,16 +209,13 @@ public class JdbcOutboundGatewayParserTests {
 	@Test //INT-1029
 	public void testOutboundGatewayInsideChain() {
 		ConfigurableApplicationContext context = new ClassPathXmlApplicationContext("handlingMapPayloadJdbcOutboundGatewayTest.xml", getClass());
-		//INT-2755
-		assertNotNull(context.getBean("org.springframework.integration.handler.MessageHandlerChain#0$child.jdbc-outbound-gateway-within-chain.handler",
-				JdbcOutboundGateway.class));
+
+		JdbcOutboundGateway jdbcMessageHandler =
+				context.getBean("org.springframework.integration.handler.MessageHandlerChain#0$child.jdbc-outbound-gateway-within-chain.handler",
+				JdbcOutboundGateway.class);
 
 		MessageChannel channel = context.getBean("jdbcOutboundGatewayInsideChain", MessageChannel.class);
-		MessageHandler chainHandler = context.getBean("chainWithJdbcOutboundGateway.handler", MessageHandler.class);
-		List handlers = TestUtils.getPropertyValue(chainHandler, "handlers", List.class);
-		assertEquals(1, handlers.size());
-		Object jdbcMessageHandler = handlers.get(0);
-		Assert.assertTrue(jdbcMessageHandler instanceof JdbcOutboundGateway);
+
 		assertFalse(TestUtils.getPropertyValue(jdbcMessageHandler, "requiresReply", Boolean.class));
 
 		channel.send(MessageBuilder.withPayload(Collections.singletonMap("foo", "bar")).build());

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParserTests.java
@@ -14,14 +14,17 @@ package org.springframework.integration.jdbc.config;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import javax.sql.DataSource;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.ApplicationContext;
@@ -29,6 +32,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
+import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.endpoint.PollingConsumer;
@@ -75,6 +79,7 @@ public class JdbcOutboundGatewayParserTests {
 		assertEquals("bar", payload.get("name"));
 		JdbcOutboundGateway gateway = context.getBean("jdbcGateway.handler", JdbcOutboundGateway.class);
 		assertEquals(23, TestUtils.getPropertyValue(gateway, "order"));
+		Assert.assertTrue(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));
 		Object gw = context.getBean("jdbcGateway");
 		assertEquals(1, adviceCalled);
 	}
@@ -209,6 +214,13 @@ public class JdbcOutboundGatewayParserTests {
 				JdbcOutboundGateway.class));
 
 		MessageChannel channel = context.getBean("jdbcOutboundGatewayInsideChain", MessageChannel.class);
+		MessageHandler chainHandler = context.getBean("chainWithJdbcOutboundGateway.handler", MessageHandler.class);
+		List handlers = TestUtils.getPropertyValue(chainHandler, "handlers", List.class);
+		assertEquals(1, handlers.size());
+		Object jdbcMessageHandler = handlers.get(0);
+		Assert.assertTrue(jdbcMessageHandler instanceof JdbcOutboundGateway);
+		assertFalse(TestUtils.getPropertyValue(jdbcMessageHandler, "requiresReply", Boolean.class));
+
 		channel.send(MessageBuilder.withPayload(Collections.singletonMap("foo", "bar")).build());
 
 		PollableChannel outbound = context.getBean("replyChannel", PollableChannel.class);

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcOutboundGatewayParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcOutboundGatewayParserTests.java
@@ -47,6 +47,7 @@ import org.springframework.jdbc.core.SqlParameter;
 /**
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.1
  *
  */
@@ -65,6 +66,7 @@ public class StoredProcOutboundGatewayParserTests {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(this.outboundGateway);
 		Object source = accessor.getPropertyValue("handler");
 		accessor = new DirectFieldAccessor(source);
+		assertEquals(Boolean.TRUE, accessor.getPropertyValue("requiresReply"));
 		source = accessor.getPropertyValue("executor");
 		accessor = new DirectFieldAccessor(source);
 		Expression  storedProcedureName = (Expression) accessor.getPropertyValue("storedProcedureNameExpression");

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/handlingMapPayloadJdbcOutboundGatewayTest.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/handlingMapPayloadJdbcOutboundGatewayTest.xml
@@ -23,7 +23,7 @@
 		</request-handler-advice-chain>
 	</outbound-gateway>
 
-	<si:chain id="chainWithJdbcOutboundGateway" input-channel="jdbcOutboundGatewayInsideChain" output-channel="replyChannel">
+	<si:chain input-channel="jdbcOutboundGatewayInsideChain" output-channel="replyChannel">
 		<outbound-gateway id="jdbc-outbound-gateway-within-chain" query="select * from foos where id=:headers[id]"
 						  update="insert into foos (id, status, name) values (:headers[id], 0, :payload[foo])"
 						  data-source="dataSource" requires-reply="false"/>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/handlingMapPayloadJdbcOutboundGatewayTest.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/handlingMapPayloadJdbcOutboundGatewayTest.xml
@@ -23,10 +23,10 @@
 		</request-handler-advice-chain>
 	</outbound-gateway>
 
-	<si:chain input-channel="jdbcOutboundGatewayInsideChain" output-channel="replyChannel">
+	<si:chain id="chainWithJdbcOutboundGateway" input-channel="jdbcOutboundGatewayInsideChain" output-channel="replyChannel">
 		<outbound-gateway id="jdbc-outbound-gateway-within-chain" query="select * from foos where id=:headers[id]"
 						  update="insert into foos (id, status, name) values (:headers[id], 0, :payload[foo])"
-						  data-source="dataSource"/>
+						  data-source="dataSource" requires-reply="false"/>
 
 	</si:chain>
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/storedProcOutboundGatewayParserTest.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/storedProcOutboundGatewayParserTest.xml
@@ -18,7 +18,7 @@
 		data-source="datasource" auto-startup="true" id="storedProcedureOutboundGateway"
 		ignore-column-meta-data="false" is-function="false"
 		skip-undeclared-results="false" order="2" reply-channel="replyChannel"
-		reply-timeout="555" return-value-required="true">
+		reply-timeout="555" return-value-required="true" requires-reply="true">
 
 		<int-jdbc:sql-parameter-definition name="username" direction="IN" type="VARCHAR" />
 		<int-jdbc:sql-parameter-definition name="password" direction="OUT" />

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
@@ -33,6 +33,7 @@ import org.w3c.dom.Element;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class JmsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 
@@ -65,6 +66,7 @@ public class JmsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "time-to-live");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "priority");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "explicit-qos-enabled");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "requires-reply");
 
 		String deliveryPersistent = element.getAttribute("delivery-persistent");
 		if (StringUtils.hasText(deliveryPersistent)) {
@@ -119,7 +121,7 @@ public class JmsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(JmsOutboundGateway.ReplyContainerProperties.class);
 		Integer acknowledgeMode = JmsAdapterParserUtils.parseAcknowledgeMode(element, parserContext);
 		if (acknowledgeMode != null) {
-			if (acknowledgeMode.intValue() == JmsAdapterParserUtils.SESSION_TRANSACTED) {
+			if (JmsAdapterParserUtils.SESSION_TRANSACTED == acknowledgeMode) {
 				builder.addPropertyValue("sessionTransacted", Boolean.TRUE);
 			}
 			else {

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-3.0.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-3.0.xsd
@@ -1065,6 +1065,15 @@
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="requires-reply" type="xsd:string" use="optional" default="true">
+				<xsd:annotation>
+					<xsd:documentation>
+						Specify whether this outbound gateway must return a non-null value. This value is
+						'true' by default, and a ReplyRequiredException will be thrown when
+						the underlying service returns a null value.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsOutboundGatewayParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsOutboundGatewayParserTests.java
@@ -128,6 +128,7 @@ public class JmsOutboundGatewayParserTests {
 				new DirectFieldAccessor(endpoint).getPropertyValue("handler"));
 		Object order = accessor.getPropertyValue("order");
 		assertEquals(99, order);
+		assertEquals(Boolean.TRUE, accessor.getPropertyValue("requiresReply"));
 	}
 
 	@Test

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithDeliveryPersistent.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithDeliveryPersistent.xml
@@ -14,7 +14,7 @@
 			http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd">
 
 	<si:channel id="requestChannel"/>
-		
+
 	<jms:outbound-gateway id="jmsGateway"
 						  request-destination-name="requestQueue"
 						  request-channel="requestChannel"
@@ -47,7 +47,8 @@
 		request-destination-name="requestQueue"
 		request-channel="requestChannel"
 		delivery-persistent="true"
-		auto-startup="false">
+		auto-startup="false"
+		requires-reply="false">
 		<jms:request-handler-advice-chain>
 			<bean class="org.springframework.integration.jms.config.JmsOutboundGatewayParserTests$FooAdvice" />
 		</jms:request-handler-advice-chain>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithOrder.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithOrder.xml
@@ -15,7 +15,7 @@
 	<jms:outbound-gateway id="jmsGateway"
 	                      request-destination="requestQueue"
 	                      request-channel="requestChannel"
-	                      order="99"/>
+	                      order="99" requires-reply="true"/>
 
 	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/OperationInvokingOutboundGatewayParser.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/OperationInvokingOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.jmx.config;
 
 import org.w3c.dom.Element;
 
+import org.springframework.integration.jmx.OperationInvokingMessageHandler;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractConsumerEndpointParser;
@@ -25,10 +26,11 @@ import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  * @since 2.0
  */
 public class OperationInvokingOutboundGatewayParser extends AbstractConsumerEndpointParser {
-	
+
 	@Override
 	protected String getInputChannelAttributeName() {
 		return "request-channel";
@@ -36,12 +38,12 @@ public class OperationInvokingOutboundGatewayParser extends AbstractConsumerEndp
 
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(
-				"org.springframework.integration.jmx.OperationInvokingMessageHandler");
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(OperationInvokingMessageHandler.class);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "server");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "object-name");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "operation-name");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel", "outputChannel");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "requires-reply");
 		return builder;
 	}
 

--- a/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-3.0.xsd
+++ b/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-3.0.xsd
@@ -47,6 +47,15 @@
 					</xsd:all>
 					<xsd:attribute name="request-channel" type="xsd:string" />
 					<xsd:attribute name="reply-channel" type="xsd:string" use="optional" />
+					<xsd:attribute name="requires-reply" type="xsd:string" use="optional" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether this outbound gateway must return a non-null value. This value is
+								'true' by default, and ReplyRequiredException will be thrown when
+								the underlying service returns a null value.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingOutboundGatewayTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingOutboundGatewayTests-context.xml
@@ -29,18 +29,19 @@
 			object-name="org.springframework.integration.jmx.config:type=TestBean,name=testBeanGateway"
 			operation-name="testWithReturn">
 		<jmx:request-handler-advice-chain>
-			<bean class="org.springframework.integration.jmx.config.OperationInvokingOutboundGatewayTests$FooADvice" />
+			<bean class="org.springframework.integration.jmx.config.OperationInvokingOutboundGatewayTests.FooAdvice" />
 		</jmx:request-handler-advice-chain>
 	</jmx:operation-invoking-outbound-gateway>
 
-	<si:chain input-channel="jmxOutboundGatewayInsideChain" output-channel="withReplyChannelOutput">
-		<jmx:operation-invoking-outbound-gateway operation-name="testWithReturn"
+	<si:chain id="operationInvokingWithinChain" input-channel="jmxOutboundGatewayInsideChain" output-channel="withReplyChannelOutput">
+		<jmx:operation-invoking-outbound-gateway operation-name="testWithReturn" requires-reply="true"
 						object-name="org.springframework.integration.jmx.config:type=TestBean,name=testBeanGateway"/>
 	</si:chain>
 
 	<jmx:operation-invoking-outbound-gateway request-channel="withNoReplyChannel"
 			object-name="org.springframework.integration.jmx.config:type=TestBean,name=testBeanGateway"
-			operation-name="test"/>
+			operation-name="test"
+			requires-reply="false"/>
 
 	<bean id="testBeanGateway" class="org.springframework.integration.jmx.config.TestBean"/>
 </beans>

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/AbstractJpaOutboundGatewayParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/AbstractJpaOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.w3c.dom.Element;
  * The Abstract Parser for the JPA Outbound Gateways.
  *
  * @author Gunnar Hillert
+ * @author Artem Bilan
  *
  * @since 2.2
  *
@@ -46,6 +47,7 @@ public abstract class AbstractJpaOutboundGatewayParser extends AbstractConsumerE
 				.genericBeanDefinition(JpaOutboundGatewayFactoryBean.class);
 
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaOutboundGatewayBuilder, gatewayElement, "reply-timeout");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaOutboundGatewayBuilder, gatewayElement, "requires-reply");
 
 		final String replyChannel = gatewayElement.getAttribute("reply-channel");
 

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
@@ -71,7 +71,10 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 	private long replyTimeout;
 
 	private volatile boolean requiresReply = false;
-	private volatile String componentName;	/**
+
+	private volatile String componentName;
+
+	/**
 	 * Constructor taking an {@link JpaExecutor} that wraps all JPA Operations.
 	 *
 	 * @param jpaExecutor Must not be null
@@ -120,6 +123,7 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 	public void setRequiresReply(boolean requiresReply) {
 		this.requiresReply = requiresReply;
 	}
+
 	/**
 	 * Sets the name of the handler component.
 	 *
@@ -128,6 +132,7 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 	public void setComponentName(String componentName) {
 		this.componentName = componentName;
 	}
+
 	@Override
 	public Class<?> getObjectType() {
 		return MessageHandler.class;

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
@@ -70,9 +70,8 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 
 	private long replyTimeout;
 
-	private volatile String componentName;
-
-	/**
+	private volatile boolean requiresReply = false;
+	private volatile String componentName;	/**
 	 * Constructor taking an {@link JpaExecutor} that wraps all JPA Operations.
 	 *
 	 * @param jpaExecutor Must not be null
@@ -118,6 +117,9 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 		this.replyTimeout = replyTimeout;
 	}
 
+	public void setRequiresReply(boolean requiresReply) {
+		this.requiresReply = requiresReply;
+	}
 	/**
 	 * Sets the name of the handler component.
 	 *
@@ -126,7 +128,6 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 	public void setComponentName(String componentName) {
 		this.componentName = componentName;
 	}
-
 	@Override
 	public Class<?> getObjectType() {
 		return MessageHandler.class;
@@ -140,7 +141,8 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 		jpaOutboundGateway.setProducesReply(this.producesReply);
 		jpaOutboundGateway.setOutputChannel(this.outputChannel);
 		jpaOutboundGateway.setOrder(this.order);
-		jpaOutboundGateway.setSendTimeout(replyTimeout);
+		jpaOutboundGateway.setSendTimeout(this.replyTimeout);
+		jpaOutboundGateway.setRequiresReply(this.requiresReply);
 		jpaOutboundGateway.setComponentName(this.componentName);
 		if (this.adviceChain != null) {
 			jpaOutboundGateway.setAdviceChain(this.adviceChain);

--- a/spring-integration-jpa/src/main/resources/org/springframework/integration/jpa/config/xml/spring-integration-jpa-3.0.xsd
+++ b/spring-integration-jpa/src/main/resources/org/springframework/integration/jpa/config/xml/spring-integration-jpa-3.0.xsd
@@ -363,6 +363,15 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="requires-reply" type="xsd:string" use="optional" default="true">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specify whether this outbound gateway must return a non-null value. This value is
+					'true' by default, and a ReplyRequiredException will be thrown when
+					the underlying service returns a null value.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 	</xsd:attributeGroup>
 
 	<xsd:attributeGroup name="commonUpdatingJpaAttributes">

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaOutboundGatewayParserTests.xml
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaOutboundGatewayParserTests.xml
@@ -23,7 +23,8 @@
 		max-number-of-results="55"
 		request-channel="in"
 		reply-channel="out"
-		reply-timeout="100"/>
+		reply-timeout="100"
+		requires-reply="false"/>
 
 	<int-jpa:updating-outbound-gateway id="updatingJpaOutboundGateway"
 		entity-manager-factory="entityManagerFactory"
@@ -34,7 +35,8 @@
 		order="2"
 		request-channel="in"
 		reply-channel="out"
-		reply-timeout="100"/>
+		reply-timeout="100"
+		requires-reply="false"/>
 
 	<int-jpa:updating-outbound-gateway id="advised"
 		entity-manager-factory="entityManagerFactory"
@@ -48,8 +50,14 @@
 		reply-timeout="100">
 		<int-jpa:transactional/>
 		<int-jpa:request-handler-advice-chain>
-			<bean class="org.springframework.integration.jpa.config.xml.JpaOutboundGatewayParserTests$FooAdvice"/>
+			<ref bean="jpaFooAdvice"/>
 		</int-jpa:request-handler-advice-chain>
 	</int-jpa:updating-outbound-gateway>
+
+	<bean  id="jpaFooAdvice" class="org.mockito.Mockito" factory-method="spy">
+		<constructor-arg>
+			<bean class="org.springframework.integration.jpa.config.xml.JpaOutboundGatewayParserTests$FooAdvice"/>
+		</constructor-arg>
+	</bean>
 
 </beans>

--- a/spring-integration-rmi/src/main/resources/org/springframework/integration/rmi/config/spring-integration-rmi-3.0.xsd
+++ b/spring-integration-rmi/src/main/resources/org/springframework/integration/rmi/config/spring-integration-rmi-3.0.xsd
@@ -101,6 +101,15 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="requires-reply" type="xsd:string" use="optional" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether this outbound gateway must return a non-null value. This value is
+								'true' by default, and a ReplyRequiredException will be thrown when
+								the underlying service returns a null value.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/config/RmiOutboundGatewayParserTests.java
+++ b/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/config/RmiOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@
 package org.springframework.integration.rmi.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -60,6 +62,7 @@ public class RmiOutboundGatewayParserTests {
 				"rmiOutboundGatewayParserTests.xml", this.getClass());
 		RmiOutboundGateway gateway = context.getBean("gateway.handler", RmiOutboundGateway.class);
 		assertEquals(23, TestUtils.getPropertyValue(gateway, "order"));
+		assertTrue(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));
 	}
 
 	@Test
@@ -67,6 +70,9 @@ public class RmiOutboundGatewayParserTests {
 		ApplicationContext context = new ClassPathXmlApplicationContext(
 				"rmiOutboundGatewayParserTests.xml", this.getClass());
 		MessageChannel localChannel = (MessageChannel) context.getBean("advisedChannel");
+		RmiOutboundGateway gateway = context.getBean("advised.handler", RmiOutboundGateway.class);
+		assertFalse(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));
+
 		localChannel.send(new GenericMessage<String>("test"));
 		Message<?> result = testChannel.receive(1000);
 		assertNotNull(result);

--- a/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/config/rmiOutboundGatewayParserTests.xml
+++ b/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/config/rmiOutboundGatewayParserTests.xml
@@ -23,6 +23,7 @@
 	<rmi:outbound-gateway id="advised"
 						  request-channel="advisedChannel"
 						  remote-channel="testChannel"
+						  requires-reply="false"
 						  host="localhost">
 		<rmi:request-handler-advice-chain>
 			<beans:bean class="org.springframework.integration.rmi.config.RmiOutboundGatewayParserTests$FooAdvice" />
@@ -30,7 +31,7 @@
 	</rmi:outbound-gateway>
 
 	<chain input-channel="rmiOutboundGatewayInsideChain">
-		<rmi:outbound-gateway remote-channel="testChannel" host="localhost"/>
+		<rmi:outbound-gateway remote-channel="testChannel" host="localhost" requires-reply="false"/>
 	</chain>
 
 

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
@@ -432,6 +432,15 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="requires-reply" type="xsd:string" use="optional" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify whether this outbound gateway must return a non-null value. This value is
+								'true' by default, and a ReplyRequiredException will be thrown when
+								the underlying service returns a null value.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests-context.xml
@@ -41,6 +41,7 @@
 		command-options="-P"
 		expression="payload"
 		order="2"
+		requires-reply="false"
 		/>
 
 	<int-sftp:outbound-gateway id="gateway3"
@@ -65,6 +66,7 @@
 		command="get"
 		command-options="-P"
 		expression="payload"
+		requires-reply="false"
 		order="2">
 		<int-sftp:request-handler-advice-chain>
 			<bean class="org.springframework.integration.sftp.config.SftpOutboundGatewayParserTests$FooAdvice" />

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
@@ -73,6 +73,7 @@ public class SftpOutboundGatewayParserTests {
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
 		assertEquals(new File("local-test-dir"), TestUtils.getPropertyValue(gateway, "localDirectory"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
+		assertTrue(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "filter"));
 		assertEquals(Command.LS, TestUtils.getPropertyValue(gateway, "command"));
 		@SuppressWarnings("unchecked")
@@ -95,6 +96,7 @@ public class SftpOutboundGatewayParserTests {
 		assertEquals(new File("local-test-dir"), TestUtils.getPropertyValue(gateway, "localDirectory"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
 		assertEquals(Command.GET, TestUtils.getPropertyValue(gateway, "command"));
+		assertFalse(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));
 		@SuppressWarnings("unchecked")
 		Set<String> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
 		assertTrue(options.contains(Option.PRESERVE_TIMESTAMP));

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.xml.transform.TransformerException;
 
 import org.springframework.expression.Expression;
@@ -33,7 +32,6 @@ import org.springframework.integration.handler.AbstractReplyProducingMessageHand
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriTemplate;
 import org.springframework.ws.WebServiceMessage;
 import org.springframework.ws.WebServiceMessageFactory;
@@ -115,6 +113,11 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 	@Deprecated
 	public void setIgnoreEmptyResponses(boolean ignoreEmptyResponses) {
 		//No-op
+		if (logger.isWarnEnabled()) {
+			logger.warn("'ignoreEmptyResponses' is no longer supported. " +
+					"Use 'requiresReply = true' instead. " +
+					"If it is necessary, configure some downstream Filter to skip empty string payloads.");
+		}
 	}
 
 	public void setMessageFactory(WebServiceMessageFactory messageFactory) {

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
@@ -70,8 +70,6 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 
 	private volatile WebServiceMessageCallback requestCallback;
 
-	private volatile boolean ignoreEmptyResponses = true;
-
 	protected volatile SoapHeaderMapper headerMapper = new DefaultSoapHeaderMapper();
 
 	public AbstractWebServiceOutboundGateway(final String uri, WebServiceMessageFactory messageFactory) {
@@ -111,12 +109,12 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 	}
 
 	/**
-	 * Specify whether empty String response payloads should be ignored.
-	 * The default is <code>true</code>. Set this to <code>false</code> if
-	 * you want to send empty String responses in reply Messages.
+	 * Backward compatibility - with no op.
+	 * @deprecated in favor of {@link #setRequiresReply(boolean)}
 	 */
+	@Deprecated
 	public void setIgnoreEmptyResponses(boolean ignoreEmptyResponses) {
-		this.ignoreEmptyResponses = ignoreEmptyResponses;
+		//No-op
 	}
 
 	public void setMessageFactory(WebServiceMessageFactory messageFactory) {
@@ -167,15 +165,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 			throw new MessageDeliveryException(requestMessage, "Failed to determine URI for " +
 					"Web Service request in outbound gateway: " + this.getComponentName());
 		}
-		Object responsePayload = this.doHandle(uri.toString(), requestMessage, this.requestCallback);
-		if (responsePayload != null) {
-			boolean shouldIgnore = (this.ignoreEmptyResponses
-					&& responsePayload instanceof String && !StringUtils.hasText((String) responsePayload));
-			if (!shouldIgnore) {
-				return responsePayload;
-			}
-		}
-		return null;
+		return this.doHandle(uri.toString(), requestMessage, this.requestCallback);
 	}
 
 	protected abstract Object doHandle(String uri, Message<?> requestMessage, WebServiceMessageCallback requestCallback);

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
@@ -83,6 +83,7 @@ public class WebServiceOutboundGatewayParser extends AbstractOutboundGatewayPars
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "requires-reply");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "ignore-empty-responses");
 		this.postProcessGateway(builder, element, parserContext);
 

--- a/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws-3.0.xsd
+++ b/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws-3.0.xsd
@@ -148,8 +148,7 @@
 			<xsd:attribute name="ignore-empty-responses" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-	Indicates whether empty String response payloads should be ignored. The default is TRUE.
-	Set this to FALSE if you want to send empty String responses in reply Messages.
+	[DEPRECATED] with 'no-op' in favor of 'requires-reply' attribute.
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>

--- a/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws-3.0.xsd
+++ b/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws-3.0.xsd
@@ -87,6 +87,15 @@
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="requires-reply" type="xsd:string" use="optional" default="false">
+				<xsd:annotation>
+					<xsd:documentation>
+						Specify whether this outbound gateway must return a non-null value. This value is
+						'false' by default, otherwise a ReplyRequiredException will be thrown when
+						the underlying service returns a null value.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="uri" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -89,27 +89,14 @@ public class WebServiceOutboundGatewayParserTests {
 	}
 
 	@Test
-	public void simpleGatewayWithIgnoreEmptyResponseTrueByDefault() {
-		ApplicationContext context = new ClassPathXmlApplicationContext(
-				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
-		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithReplyChannel");
-		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
-		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
-		assertEquals(Boolean.TRUE, accessor.getPropertyValue("ignoreEmptyResponses"));
-	}
-
-	@Test
 	public void simpleGatewayWithIgnoreEmptyResponses() {
 		ApplicationContext context = new ClassPathXmlApplicationContext(
 				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());
-		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithIgnoreEmptyResponsesFalse");
+		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithRequiresReplyTrue");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
 		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
 		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
 		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
-		assertEquals(Boolean.FALSE, accessor.getPropertyValue("ignoreEmptyResponses"));
 		Assert.assertEquals(Boolean.TRUE, accessor.getPropertyValue("requiresReply"));
 	}
 

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import java.net.URI;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
@@ -72,6 +73,7 @@ public class WebServiceOutboundGatewayParserTests {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
 		Object expected = context.getBean("outputChannel");
 		assertEquals(expected, accessor.getPropertyValue("outputChannel"));
+		Assert.assertEquals(Boolean.FALSE, accessor.getPropertyValue("requiresReply"));
 
 		@SuppressWarnings("unchecked")
 		List<String> requestHeaders = TestUtils.getPropertyValue(endpoint, "handler.headerMapper.requestHeaderNames", List.class);
@@ -108,6 +110,7 @@ public class WebServiceOutboundGatewayParserTests {
 		assertEquals(SimpleWebServiceOutboundGateway.class, gateway.getClass());
 		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
 		assertEquals(Boolean.FALSE, accessor.getPropertyValue("ignoreEmptyResponses"));
+		Assert.assertEquals(Boolean.TRUE, accessor.getPropertyValue("requiresReply"));
 	}
 
 	@Test

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/simpleWebServiceOutboundGatewayParserTests.xml
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/simpleWebServiceOutboundGatewayParserTests.xml
@@ -31,7 +31,7 @@
 	                     mapped-request-headers="testRequest"
 	                     mapped-reply-headers="testReply"/>
 
-	<ws:outbound-gateway id="gatewayWithIgnoreEmptyResponsesFalse"
+	<ws:outbound-gateway id="gatewayWithRequiresReplyTrue"
 	                     request-channel="inputChannel"
 	                     uri="http://example.org"
 	                     ignore-empty-responses="false"

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/simpleWebServiceOutboundGatewayParserTests.xml
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/simpleWebServiceOutboundGatewayParserTests.xml
@@ -34,7 +34,8 @@
 	<ws:outbound-gateway id="gatewayWithIgnoreEmptyResponsesFalse"
 	                     request-channel="inputChannel"
 	                     uri="http://example.org"
-	                     ignore-empty-responses="false"/>
+	                     ignore-empty-responses="false"
+                         requires-reply="true"/>
 
 	<ws:outbound-gateway id="gatewayWithDefaultSourceExtractor"
 		                 request-channel="inputChannel"

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -223,7 +223,9 @@
 			<para>
 				For more information see <xref linkend="stored-procedures"/>.
 			</para>
-		</section>			<title>'requires-reply' attribute for Outbound Gateways</title>
+		</section>
+		<section id="3.0-outbound-gateway-requires-reply">
+			<title>'requires-reply' attribute for Outbound Gateways</title>
 			<para>
 				All Outbound Gateways (e.g. <code>&lt;ftp:outbound-gateway/&gt;</code> or <code>&lt;jms:outbound-gateway/&gt;</code>)
 				are designed for 'request-reply' scenario. In this case we are expecting that response from external service
@@ -260,6 +262,5 @@
 				the strategy used to generate message ids has been added.
 				For more information see <xref linkend="message-id-generation"/>.
 			</para>
-		</section>
-	</section>
+		</section>	</section>
 </chapter>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -223,6 +223,23 @@
 			<para>
 				For more information see <xref linkend="stored-procedures"/>.
 			</para>
+		</section>			<title>'requires-reply' attribute for Outbound Gateways</title>
+			<para>
+				All Outbound Gateways (e.g. <code>&lt;ftp:outbound-gateway/&gt;</code> or <code>&lt;jms:outbound-gateway/&gt;</code>)
+				are designed for 'request-reply' scenario. In this case we are expecting that response from external service
+				will be published to the <code>reply-channel</code>. But there are many cases where external system doesn't
+				return result, e.g. <code>&lt;jdbc:outbound-gateway/&gt;</code>, when SELECT ends with empty <interfacename>ResultSet</interfacename>
+				or the underlying Web Service is One-Way. So, we need an option when we can decide do not expect <emphasis>reply</emphasis>.
+				For this purpose <emphasis>requires-reply</emphasis> attribute was introduced for all Outbound Gateway components.
+				In most cases default value for <emphasis>requires-reply</emphasis> is <code>true</code> and if there is no any result
+				<classname>ReplyRequiredException</classname> will be thrown. Change it to <code>false</code>
+				means that, if an external service doesn't return anything, the message-flow will end on current Outbound Gateway,
+				similar to Outbound Channel Adapter.
+			</para>
+			<para>
+				Note, the <code>requiresReply</code> property is presented in the <classname>AbstractReplyProducingMessageHandler</classname>
+				but with value <code>false</code> and there wasn't any configuration ability on Outbound Gateways to change it before this release.
+			</para>
 		</section>
 		<section id="3.0-event-for-imap-idle">
 			<title>IMAP Idle Connection Exceptions</title>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -224,25 +224,6 @@
 				For more information see <xref linkend="stored-procedures"/>.
 			</para>
 		</section>
-		<section id="3.0-outbound-gateway-requires-reply">
-			<title>'requires-reply' attribute for Outbound Gateways</title>
-			<para>
-				All Outbound Gateways (e.g. <code>&lt;ftp:outbound-gateway/&gt;</code> or <code>&lt;jms:outbound-gateway/&gt;</code>)
-				are designed for 'request-reply' scenario. In this case we are expecting that response from external service
-				will be published to the <code>reply-channel</code>. But there are many cases where external system doesn't
-				return result, e.g. <code>&lt;jdbc:outbound-gateway/&gt;</code>, when SELECT ends with empty <interfacename>ResultSet</interfacename>
-				or the underlying Web Service is One-Way. So, we need an option when we can decide do not expect <emphasis>reply</emphasis>.
-				For this purpose <emphasis>requires-reply</emphasis> attribute was introduced for all Outbound Gateway components.
-				In most cases default value for <emphasis>requires-reply</emphasis> is <code>true</code> and if there is no any result
-				<classname>ReplyRequiredException</classname> will be thrown. Change it to <code>false</code>
-				means that, if an external service doesn't return anything, the message-flow will end on current Outbound Gateway,
-				similar to Outbound Channel Adapter.
-			</para>
-			<para>
-				Note, the <code>requiresReply</code> property is presented in the <classname>AbstractReplyProducingMessageHandler</classname>
-				but with value <code>false</code> and there wasn't any configuration ability on Outbound Gateways to change it before this release.
-			</para>
-		</section>
 		<section id="3.0-event-for-imap-idle">
 			<title>IMAP Idle Connection Exceptions</title>
 			<para>
@@ -262,5 +243,25 @@
 				the strategy used to generate message ids has been added.
 				For more information see <xref linkend="message-id-generation"/>.
 			</para>
-		</section>	</section>
+		</section>
+		<section id="3.0-outbound-gateway-requires-reply">
+			<title>'requires-reply' attribute for Outbound Gateways</title>
+			<para>
+				All Outbound Gateways (e.g. <code>&lt;ftp:outbound-gateway/&gt;</code> or <code>&lt;jms:outbound-gateway/&gt;</code>)
+				are designed for 'request-reply' scenario. In this case we are expecting that response from external service
+				will be published to the <code>reply-channel</code>. But there are many cases where external system doesn't
+				return result, e.g. <code>&lt;jdbc:outbound-gateway/&gt;</code>, when SELECT ends with empty <interfacename>ResultSet</interfacename>
+				or the underlying Web Service is One-Way. So, we need an option when we can decide do not expect <emphasis>reply</emphasis>.
+				For this purpose <emphasis>requires-reply</emphasis> attribute was introduced for all Outbound Gateway components.
+				In most cases default value for <emphasis>requires-reply</emphasis> is <code>true</code> and if there is no any result
+				<classname>ReplyRequiredException</classname> will be thrown. Change it to <code>false</code>
+				means that, if an external service doesn't return anything, the message-flow will end on current Outbound Gateway,
+				similar to Outbound Channel Adapter.
+			</para>
+			<para>
+				Note, the <code>requiresReply</code> property is presented in the <classname>AbstractReplyProducingMessageHandler</classname>
+				but with value <code>false</code> and there wasn't any configuration ability on Outbound Gateways to change it before this release.
+			</para>
+		</section>
+	</section>
 </chapter>

--- a/src/reference/docbook/ws.xml
+++ b/src/reference/docbook/ws.xml
@@ -79,16 +79,6 @@ as per standard Spring Web Services configuration.
     reply to another channel instead, then provide a 'reply-channel' attribute on the
     'outbound-gateway' element.
     </note>
-    <tip>
-    When invoking a Web Service that returns an empty response after using a String payload
-    for the request Message, <emphasis>no reply Message will be sent by default</emphasis>.
-    Therefore you don't need to set a 'reply-channel' or have a REPLY_CHANNEL header in the
-    request Message. If for any reason you actually <emphasis>do</emphasis> want to receive
-    the empty response as a Message, then provide the 'ignore-empty-responses' attribute with
-    a value of <emphasis>false</emphasis> (this only applies for Strings, because using a
-    Source or Document object simply leads to a NULL response and will therefore
-    <emphasis>never</emphasis> generate a reply Message).
-    </tip>
 
       To set up an inbound Web Service Gateway, use the "inbound-gateway":
       <programlisting language="xml"><![CDATA[<int-ws:inbound-gateway id="simpleGateway"


### PR DESCRIPTION
- Add `requires-reply` attribute for all adapters outbound gateways as `true` by default
- WS-outbound-gateway is still without it, because it has its own specific attribute `ignore-empty-responses`
- Make `requires-reply` as `false` by default for `jdbc:stored-proc-outbound-gateway` inasmuch as `jdbc:stored-proc-outbound-adapter`
  doesn't have ability to configure `returning-resultset`
- add parser tests for `requires-reply`

JIRA: https://jira.springsource.org/browse/INT-2822
