### PR TITLE
INT-2959 Correct Schema GW reply-timeout Doc.

### DIFF
--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.1.xsd
@@ -508,8 +508,9 @@
 								<xsd:documentation>
 										<![CDATA[
 								Allows you to specify how long this gateway will wait for the reply message
-								before throwing an exception. By default it will wait indefinitely.
-								Value is specified in milliseconds
+								before returning. By default it will wait indefinitely. 'null' is returned
+								if the gateway times out.
+								Value is specified in milliseconds.
 										]]>
 								</xsd:documentation>
 							</xsd:annotation>
@@ -588,7 +589,8 @@
 					<xsd:documentation>
 							<![CDATA[
 					Allows you to specify how long this gateway will wait for the reply message
-					before throwing an exception. By default it will wait indefinitely.
+					before returning. By default it will wait indefinitely. 'null' is returned
+					if the gateway times out.
 					Value is specified in milliseconds.
 							]]>
 					</xsd:documentation>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-2.2.xsd
@@ -587,8 +587,9 @@
 								<xsd:documentation>
 										<![CDATA[
 								Allows you to specify how long this gateway will wait for the reply message
-								before throwing an exception. By default it will wait indefinitely.
-								Value is specified in milliseconds
+								before returning. By default it will wait indefinitely. 'null' is returned
+								if the gateway times out.
+								Value is specified in milliseconds.
 										]]>
 								</xsd:documentation>
 							</xsd:annotation>
@@ -667,7 +668,8 @@
 					<xsd:documentation>
 							<![CDATA[
 					Allows you to specify how long this gateway will wait for the reply message
-					before throwing an exception. By default it will wait indefinitely.
+					before returning. By default it will wait indefinitely. 'null' is returned
+					if the gateway times out.
 					Value is specified in milliseconds.
 							]]>
 					</xsd:documentation>


### PR DESCRIPTION
Incorrectly indicated that an exception is thrown when
the gateway times out.
