### PR TITLE
INT-2954 (S)FTP Fix AutoCreate Top Level Dir

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/handler/FileTransferringMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/handler/FileTransferringMessageHandler.java
@@ -283,19 +283,19 @@ public class FileTransferringMessageHandler<F> extends AbstractMessageHandler {
 	private void makeDirectories(String path, Session<F> session) throws IOException {
 		if (!session.exists(path)){
 
-			int nextSeparatorIndex = path.lastIndexOf(remoteFileSeparator);
+			int nextSeparatorIndex = path.lastIndexOf(this.remoteFileSeparator);
 
 			if (nextSeparatorIndex > -1){
 				List<String> pathsToCreate = new LinkedList<String>();
 				while (nextSeparatorIndex > -1){
 					String pathSegment = path.substring(0, nextSeparatorIndex);
-					if (session.exists(pathSegment)){
+					if (pathSegment.length() == 0 || session.exists(pathSegment)) {
 						// no more paths to create
 						break;
 					}
 					else {
 						pathsToCreate.add(0, pathSegment);
-						nextSeparatorIndex = pathSegment.lastIndexOf(remoteFileSeparator);
+						nextSeparatorIndex = pathSegment.lastIndexOf(this.remoteFileSeparator);
 					}
 				}
 


### PR DESCRIPTION
When autocreateDirectory is true, and the top level directory
did not exist, the mkdirs failed because the adapter tried
to create a directory name with a zero length string.

This caused an 'String index out of range: 0' exception in
SFTP.

Stop iteration when 'pathSegment' is zero length.

**cherry pick to 2.2.x**
