### PR TITLE
INT-2971: AMPQ 'header-mapper' XSD polishing

### DIFF
--- a/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-3.0.xsd
+++ b/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-3.0.xsd
@@ -418,9 +418,14 @@ The order for this consumer when multiple consumers are registered thereby enabl
 		</xsd:attribute>
 		<xsd:attribute name="header-mapper" type="xsd:string">
 			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The reference to the 'AmqpHeaderMapper' implementation bean to map AMQP Headers from the AMQP request into the MessageHeaders
+and from the Spring Integration MessageHeaders to the AMQP Headers.
+This is mutually exclusive with 'mapped-request-headers' or 'mapped-reply-headers'.
+						]]></xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper" />
+						<tool:expected-type type="org.springframework.integration.amqp.support.AmqpHeaderMapper" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -478,9 +483,14 @@ property set to TRUE.
 		</xsd:attribute>
 		<xsd:attribute name="header-mapper" type="xsd:string">
 			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+The reference to the 'AmqpHeaderMapper' implementation bean to map AMQP Headers from the AMQP request into the MessageHeaders
+and from the Spring Integration MessageHeaders to the AMQP Headers.
+This is mutually exclusive with 'mapped-request-headers' or 'mapped-reply-headers'.
+						]]></xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper" />
+						<tool:expected-type type="org.springframework.integration.amqp.support.AmqpHeaderMapper" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests-headerMapper-fail-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests-headerMapper-fail-context.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:amqp="http://www.springframework.org/schema/integration/amqp"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="amqpHeaderMapper" class="org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper"/>
+
+	<amqp:inbound-channel-adapter id="rabbitInbound" queue-names="test.queue"
+								  mapped-request-headers="*"
+								  header-mapper="amqpHeaderMapper"/>
+
+</beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests-headerMapper-fail-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests-headerMapper-fail-context.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:amqp="http://www.springframework.org/schema/integration/amqp"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="amqpHeaderMapper" class="org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper"/>
+
+	<amqp:inbound-gateway request-channel="requests" queue-names="test"
+						  mapped-request-headers="foo*, STANDARD_REQUEST_HEADERS"
+						  mapped-reply-headers="bar*"
+						  header-mapper="amqpHeaderMapper"/>
+
+</beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests-context.xml
@@ -25,6 +25,14 @@
 								   exchange-name="outboundchanneladapter.test.1"
 								   mapped-request-headers="foo*"/>
 
+	<bean id="customHeaderMapper" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.integration.amqp.support.AmqpHeaderMapper"/>
+	</bean>
+
+	<amqp:outbound-channel-adapter id="withCustomHeaderMapper"
+								   exchange-name="test.exchange"
+								   header-mapper="customHeaderMapper"/>
+
 	<int:channel id="requestChannel"/>
 
 	<int:chain id="chainWithRabbitOutbound" input-channel="amqpOutboundChannelAdapterWithinChain">

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests-headerMapper-fail-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests-headerMapper-fail-context.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:amqp="http://www.springframework.org/schema/integration/amqp"
+	   xsi:schemaLocation="http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="amqpHeaderMapper" class="org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper"/>
+
+	<amqp:outbound-channel-adapter id="rabbitOutbound" exchange-name="test.queue"
+								   mapped-request-headers="foo*"
+								   header-mapper="amqpHeaderMapper"/>
+
+</beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests-headerMapper-fail-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests-headerMapper-fail-context.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:amqp="http://www.springframework.org/schema/integration/amqp"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="amqpHeaderMapper" class="org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper"/>
+
+	<amqp:outbound-gateway request-channel="toRabbit0"
+						   mapped-request-headers="foo*, STANDARD_REQUEST_HEADERS"
+						   mapped-reply-headers="bar*"
+						   header-mapper="amqpHeaderMapper"/>
+
+
+</beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
@@ -263,6 +264,18 @@ public class AmqpOutboundGatewayParserTests {
 		assertNull(replyMessage.getHeaders().get(AmqpHeaders.APP_ID));
 
 	}
+
+	@Test
+	public void testInt2971HeaderMapperAndMappedHeadersExclusivity() {
+		try {
+			new ClassPathXmlApplicationContext("AmqpOutboundGatewayParserTests-headerMapper-fail-context.xml", this.getClass());
+		}
+		catch (BeanDefinitionParsingException e) {
+			assertTrue(e.getMessage().startsWith("Configuration problem: The 'header-mapper' attribute " +
+					"is mutually exclusive with 'mapped-request-headers' or 'mapped-reply-headers'"));
+		}
+	}
+
 
 	public static class FooAdvice extends AbstractRequestHandlerAdvice {
 

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -27,7 +27,7 @@
         (<ulink url="http://www.springsource.org/spring-amqp">http://www.springsource.org/spring-amqp</ulink>)
         which "applies core Spring concepts to the development of AMQP-based
         messaging solutions". Spring AMQP provides similar semantics as Spring JMS
-        (<ulink url="http://static.springsource.org/spring/docs/current/spring-framework-reference/htmlsingle/spring-framework-reference.html#jms">http://.../spring-framework-reference.html#jms</ulink>).
+        (<ulink url="http://static.springsource.org/spring/docs/current/spring-framework-reference/html/jms.html">http://static.springsource.org/spring/docs/current/spring-framework-reference/html/jms.html</ulink>).
     </para>
     <para>
         Whereas the provided AMQP Channel Adapters are intended for unidirectional
@@ -133,12 +133,12 @@
                 <emphasis>Optional (Defaults to true)</emphasis>.</para>
             </callout>
             <callout arearefs="amqp-inbound-channel-adapter-xml-11-co" id="amqp-inbound-channel-adapter-xml-11">
-                <para><classname>HeaderMapper</classname> to use when receiving AMQP Messages.
+                <para><interfacename>AmqpHeaderMapper</interfacename> to use when receiving AMQP Messages.
                 <emphasis>Optional</emphasis>.
                 By default only standard AMQP properties (e.g. contentType) will be copied to and from
  			    Spring Integration MessageHeaders. Any user-defined headers within the AMQP
                 MessageProperties will NOT be copied to or from an AMQP Message unless
-                explicitly identified via 'requestHeaderNames' and/or 'replyHeaderNames' properties of this <classname>HeaderMapper</classname>.
+                explicitly identified via 'requestHeaderNames' and/or 'replyHeaderNames' properties of this <classname>DefaultAmqpHeaderMapper</classname>.
 				If you need to copy all user-defined headers simply use wild-card character '*'.
                 </para>
             </callout>
@@ -155,7 +155,7 @@ this list can also be simple patterns to be matched against the header names (e.
 	this list can also be simple patterns to be matched against the header names (e.g. "*" or "foo*, bar" or "*foo").</para>
             </callout>
             <callout arearefs="amqp-inbound-channel-adapter-xml-14-co" id="amqp-inbound-channel-adapter-xml-14">
-                <para>Reference to the <interface>SimpleMessageListenerContainer</interface>
+                <para>Reference to the <interfacename>SimpleMessageListenerContainer</interfacename>
                       to use for receiving AMQP Messages. If this attribute is provided,
                       then no other attribute related to the listener container
                       configuration should be provided. In other words, by
@@ -538,9 +538,9 @@ this list can also be simple patterns to be matched against the header names (e.
 			The Spring Integration AMPQ Adapters will map standard AMQP  properties
 			automatically. These properties will be copied by default to and from
 			Spring Integration
-			<classname><ulink url="http://static.springsource.org/spring-integration/docs/latest-ga/api/org/springframework/integration/MessageHeaders.html">MessageHeaders</ulink></classname>
+			<classname><ulink url="http://static.springsource.org/spring-integration/api/org/springframework/integration/MessageHeaders.html">MessageHeaders</ulink></classname>
 			using the
-			<classname><ulink url="http://static.springsource.org/spring-integration/docs/latest-ga/api/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.html">DefaultAmqpHeaderMapper</ulink></classname>.
+			<classname><ulink url="http://static.springsource.org/spring-integration/api/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.html">DefaultAmqpHeaderMapper</ulink></classname>.
 		</para>
 		<para>
 			Of course, you can pass in your own implementation of AMQP specific header
@@ -552,7 +552,7 @@ this list can also be simple patterns to be matched against the header names (e.
 			will NOT be copied to or from an AMQP Message, unless explicitly specified
 			by the <emphasis>requestHeaderNames</emphasis> and/or
 			<emphasis>replyHeaderNames</emphasis> properties of the
-			<classname>HeaderMapper</classname>.
+			<classname>DefaultAmqpHeaderMapper</classname>.
 		</para>
 		<tip>
 			When mapping user-defined headers, the values can also contain simple


### PR DESCRIPTION
- Change expected type from the `HeaderMapper` to the `AmqpHeaderMapper`
- Add 'header-mapper' mutually exclusivity failing tests
- Change AMQP doc to say about `AmqpHeaderMapper` not `HeaderMapper`

JIRA: https://jira.springsource.org/browse/INT-2971
