### PR TITLE
Fix a compile error that happens on Eclipse import only

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/test/util/TestUtils.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/test/util/TestUtils.java
@@ -19,6 +19,7 @@ package org.springframework.integration.test.util;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.io.File;
 import java.util.Properties;
 import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
 
@@ -176,4 +177,13 @@ public abstract class TestUtils {
     	}
 		return component;
     }
+    
+    /**
+     * Update file path by replacing any '/' with the system's file separator.
+     * @param s The file path containing '/'.
+     * @return The updated file path (if necessary).
+     */
+	public static String applySystemFileSeparator(String s) {
+		return s.replaceAll("/", java.util.regex.Matcher.quoteReplacement(File.separator));
+	}
 }


### PR DESCRIPTION
The precise error is (copy pasted from Eclipse problems view):

The method applySystemFileSeparator(String) is undefined for the type TestUtils FileOutboundChannelAdapterIntegrationTests.java /spring-integration-file/src/test/java/org/springframework/integration/file line 124    Java Problem

This error does not happen when building / running tests with Gradle on the commandline.
I believe this is because Gradle separates 'test' and 'main' source sets but in Eclipse a project can only have a single classpath. Thus when importing to Eclipse the test and main source folders are merged together for the Eclipse compiler.

Because of this the two copies of TestUtils that exist in the code end up in the same eclipse classpath and unfortunately the TestUtils reference is resolved to the wrong one in this case.

As I figured the intention is for the two TestUtils classes to be the same I 'fixed' the problem by copying the implementation of the missing method from the other TestUtils class.
