### PR TITLE
INT-2981 Add Support for 'mv' to (S)FTP Outbound Gateways

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileHeaders.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,5 +34,7 @@ public abstract class FileHeaders {
 	public static final String REMOTE_DIRECTORY = PREFIX + "remoteDirectory";
 
 	public static final String REMOTE_FILE = PREFIX + "remoteFile";
+
+	public static final String RENAME_TO = PREFIX + "renameTo";
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,13 @@
  */
 package org.springframework.integration.file.config;
 
-import org.w3c.dom.Element;
-
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractConsumerEndpointParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.file.remote.session.SessionFactoryFactoryBean;
 import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
 
 /**
  * @author Gary Russell
@@ -60,6 +59,7 @@ public abstract class AbstractRemoteFileOutboundGatewayParser extends AbstractCo
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "local-directory");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-create-local-directory");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "order");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "rename-expression");
 		return builder;
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileUtils.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.file.remote;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.springframework.integration.file.remote.session.Session;
+
+/**
+ * Utility methods for supporting remote file operations.
+ * @author Gary Russell
+ * @since 3.0
+ *
+ */
+public class RemoteFileUtils {
+
+	private RemoteFileUtils() {}
+
+	/**
+	 * Recursively create remote directories.
+	 * @param <F> The session type.
+	 * @param path The directory path.
+	 * @param session The session.
+	 * @throws IOException
+	 */
+	public static <F> void makeDirectories(String path, Session<F> session, String remoteFileSeparator, Log logger)
+			throws IOException {
+
+		if (!session.exists(path)){
+
+			int nextSeparatorIndex = path.lastIndexOf(remoteFileSeparator);
+
+			if (nextSeparatorIndex > -1){
+				List<String> pathsToCreate = new LinkedList<String>();
+				while (nextSeparatorIndex > -1){
+					String pathSegment = path.substring(0, nextSeparatorIndex);
+					if (pathSegment.length() == 0 || session.exists(pathSegment)) {
+						// no more paths to create
+						break;
+					}
+					else {
+						pathsToCreate.add(0, pathSegment);
+						nextSeparatorIndex = pathSegment.lastIndexOf(remoteFileSeparator);
+					}
+				}
+
+				for (String pathToCreate : pathsToCreate) {
+					if (logger.isDebugEnabled()){
+						logger.debug("Creating '" + pathToCreate + "'");
+					}
+					session.mkdir(pathToCreate);
+				}
+			}
+			else {
+				session.mkdir(path);
+			}
+		}
+	}
+
+}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -57,11 +57,29 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 
 	protected final Command command;
 
+	/**
+	 * Enumeration of commands supported by the gateways.
+	 */
 	public static enum Command {
+		/**
+		 * List remote files.
+		 */
 		LS("ls"),
+		/**
+		 * Retrieve a remote file.
+		 */
 		GET("get"),
+		/**
+		 * Remove a remote file (path - including wildcards).
+		 */
 		RM("rm"),
+		/**
+		 * Retrieve multiple files matching a wildcard path.
+		 */
 		MGET("mget"),
+		/**
+		 * Move (rename) a remote file.
+		 */
 		MV("mv");
 
 		private String command;
@@ -84,13 +102,38 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 		}
 	}
 
+	/**
+	 * Enumeration of options supported by various commands.
+	 *
+	 */
 	public static enum Option {
+		/**
+		 * Don't return full file information; just the name (ls).
+		 */
 		NAME_ONLY("-1"),
+		/**
+		 * Include directories {@code .} and {@code ..} in the results (ls).
+		 */
 		ALL("-a"),
+		/**
+		 * Do not sort the results (ls with NAME_ONLY).
+		 */
 		NOSORT("-f"),
+		/**
+		 * Include directories in the results (ls).
+		 */
 		SUBDIRS("-dirs"),
+		/**
+		 * Include links in the results (ls).
+		 */
 		LINKS("-links"),
+		/**
+		 * Preserve the server timestamp (get, mget).
+		 */
 		PRESERVE_TIMESTAMP("-P"),
+		/**
+		 * Throw an exception if no files returned (mget).
+		 */
 		EXCEPTION_WHEN_EMPTY("-x");
 
 		private String option;

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -35,6 +35,7 @@ import org.springframework.integration.MessagingException;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.AbstractFileInfo;
+import org.springframework.integration.file.remote.RemoteFileUtils;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
@@ -520,7 +521,11 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	}
 
 	protected void mv(Session<?> session, String remoteFilePath, String remoteFileNewPath) throws IOException {
-		// TODO: auto mkdir target path?
+		int lastSeparator = remoteFileNewPath.lastIndexOf(this.remoteFileSeparator);
+		if (lastSeparator > 0) {
+			String remoteFileDirectory = remoteFileNewPath.substring(0, lastSeparator + 1);
+			RemoteFileUtils.makeDirectories(remoteFileDirectory, session, this.remoteFileSeparator, this.logger);
+		}
 		session.rename(remoteFilePath, remoteFileNewPath);
 	}
 

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-3.0.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-3.0.xsd
@@ -562,4 +562,14 @@ Only files matching this regular expression will be picked up by this adapter.
 		</xsd:restriction>
 	</xsd:simpleType>
 
+	<xsd:simpleType name="remoteGatewayCommand">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="ls"/>
+			<xsd:enumeration value="get"/>
+			<xsd:enumeration value="rm"/>
+			<xsd:enumeration value="mget"/>
+			<xsd:enumeration value="mv"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
 </xsd:schema>

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -52,7 +52,7 @@ import org.springframework.integration.message.GenericMessage;
 @SuppressWarnings("rawtypes")
 public class RemoteFileOutboundGatewayTests {
 
-	private String tmpDir = System.getProperty("java.io.tmpdir");
+	private final String tmpDir = System.getProperty("java.io.tmpdir");
 
 
 	@Test(expected=IllegalArgumentException.class)
@@ -650,7 +650,7 @@ class TestRemoteFileOutboundGateway extends AbstractRemoteFileOutboundGateway<Te
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public TestRemoteFileOutboundGateway(SessionFactory sessionFactory,
 			String command, String expression) {
-		super(sessionFactory, command, expression);
+		super(sessionFactory, Command.toCommand(command), expression);
 	}
 
 	@Override
@@ -683,12 +683,12 @@ class TestRemoteFileOutboundGateway extends AbstractRemoteFileOutboundGateway<Te
 
 class TestLsEntry extends AbstractFileInfo<TestLsEntry> {
 
-	private String filename;
-	private int size;
-	private boolean dir;
-	private boolean link;
-	private long modified;
-	private String permissions;
+	private final String filename;
+	private final int size;
+	private final boolean dir;
+	private final boolean link;
+	private final long modified;
+	private final String permissions;
 
 	public TestLsEntry(String filename, int size, boolean dir, boolean link,
 			long modified, String permissions) {

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
@@ -241,7 +241,7 @@
 					<xsd:attribute name="command" use="required" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
-								FTP command - ls, get or rm
+								FTP command - ls, get, rm, mget or mv.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
@@ -267,6 +267,15 @@
 								SpEL expression representing the path in the
 								command (e.g. ls path to
 								list the files in directory path).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="rename-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								SpEL expression representing the path for the
+								new filename when using the 'mv' command. Defaults
+								to "headers.['file_renameTo']".
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
@@ -3,6 +3,7 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:tool="http://www.springframework.org/schema/tool"
 	xmlns:integration="http://www.springframework.org/schema/integration"
+	xmlns:int-file="http://www.springframework.org/schema/integration/file"
 	targetNamespace="http://www.springframework.org/schema/integration/ftp"
 	elementFormDefault="qualified" attributeFormDefault="unqualified">
 
@@ -10,6 +11,8 @@
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/integration"
 		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
+	<xsd:import namespace="http://www.springframework.org/schema/integration/file"
+		schemaLocation="http://www.springframework.org/schema/integration/file/spring-integration-file-3.0.xsd" />
 
 	<xsd:element name="outbound-channel-adapter">
 		<xsd:annotation>
@@ -238,12 +241,15 @@
 					<xsd:all>
 						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
 					</xsd:all>
-					<xsd:attribute name="command" use="required" type="xsd:string">
+					<xsd:attribute name="command" use="required">
 						<xsd:annotation>
 							<xsd:documentation>
-								FTP command - ls, get, rm, mget or mv.
+								FTP command.
 							</xsd:documentation>
 						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="int-file:remoteGatewayCommand xsd:string"/>
+						</xsd:simpleType>
 					</xsd:attribute>
 					<xsd:attribute name="command-options" type="xsd:string">
 						<xsd:annotation>
@@ -515,6 +521,5 @@
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
-
 
 </xsd:schema>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
@@ -47,6 +47,17 @@
 		</int-ftp:request-handler-advice-chain>
 	</int-ftp:outbound-gateway>
 
+	<int-ftp:outbound-gateway id="gateway3"
+		session-factory="sf"
+		request-channel="inbound1"
+		reply-channel="outbound"
+		auto-startup="false"
+		command="mv"
+		expression="payload"
+		rename-expression="'foo'"
+		order="1"
+		/>
+
 	<int-ftp:outbound-gateway id="withBeanExpression"
 		local-directory="local-test-dir"
 		session-factory="sf"

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
@@ -243,7 +243,7 @@
 					<xsd:attribute name="command" use="required" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
-								sftp command - ls, get or rm
+								sftp command - ls, get, rm, mget or mv.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
@@ -269,6 +269,15 @@
 								SpEL expression representing the path in the
 								command (e.g. ls path to
 								list the files in directory path).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="rename-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								SpEL expression representing the path for the
+								new filename when using the 'mv' command. Defaults
+								to "headers.['file_renameTo']".
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
@@ -3,6 +3,7 @@
 	xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:tool="http://www.springframework.org/schema/tool"
 	xmlns:integration="http://www.springframework.org/schema/integration"
+	xmlns:int-file="http://www.springframework.org/schema/integration/file"
 	targetNamespace="http://www.springframework.org/schema/integration/sftp"
 	elementFormDefault="qualified" attributeFormDefault="unqualified">
 
@@ -10,7 +11,8 @@
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/integration"
 		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd" />
-
+	<xsd:import namespace="http://www.springframework.org/schema/integration/file"
+		schemaLocation="http://www.springframework.org/schema/integration/file/spring-integration-file-3.0.xsd" />
 
 	<xsd:element name="outbound-channel-adapter">
 		<xsd:annotation>
@@ -240,12 +242,15 @@
 					<xsd:all>
 						<xsd:element name="request-handler-advice-chain" type="integration:adviceChainType" minOccurs="0" maxOccurs="1" />
 					</xsd:all>
-					<xsd:attribute name="command" use="required" type="xsd:string">
+					<xsd:attribute name="command" use="required">
 						<xsd:annotation>
 							<xsd:documentation>
-								sftp command - ls, get, rm, mget or mv.
+								sftp command.
 							</xsd:documentation>
 						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="int-file:remoteGatewayCommand xsd:string"/>
+						</xsd:simpleType>
 					</xsd:attribute>
 					<xsd:attribute name="command-options" type="xsd:string">
 						<xsd:annotation>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests-context.xml
@@ -43,6 +43,16 @@
 		order="2"
 		/>
 
+	<int-sftp:outbound-gateway id="gateway3"
+		session-factory="sf"
+		request-channel="inbound1"
+		reply-channel="outbound"
+		command="mv"
+		expression="payload"
+		rename-expression="'foo'"
+		order="1"
+		/>
+
 	<int-sftp:outbound-gateway id="advised"
 		local-directory="local-test-dir"
 		session-factory="sf"

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.Message;
 import org.springframework.integration.endpoint.AbstractEndpoint;
+import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway.Command;
+import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway.Option;
 import org.springframework.integration.file.remote.session.CachingSessionFactory;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
 import org.springframework.integration.message.GenericMessage;
@@ -55,6 +57,9 @@ public class SftpOutboundGatewayParserTests {
 	AbstractEndpoint gateway2;
 
 	@Autowired
+	AbstractEndpoint gateway3;
+
+	@Autowired
 	AbstractEndpoint advised;
 
 	private static volatile int adviceCalled;
@@ -69,11 +74,11 @@ public class SftpOutboundGatewayParserTests {
 		assertEquals(new File("local-test-dir"), TestUtils.getPropertyValue(gateway, "localDirectory"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "filter"));
-		assertEquals("ls", TestUtils.getPropertyValue(gateway, "command"));
+		assertEquals(Command.LS, TestUtils.getPropertyValue(gateway, "command"));
 		@SuppressWarnings("unchecked")
 		Set<String> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
-		assertTrue(options.contains("-1"));
-		assertTrue(options.contains("-f"));
+		assertTrue(options.contains(Option.NAME_ONLY));
+		assertTrue(options.contains(Option.NOSORT));
 
 		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout", Long.class);
 		assertEquals(Long.valueOf(777), sendTimeout);
@@ -89,10 +94,20 @@ public class SftpOutboundGatewayParserTests {
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
 		assertEquals(new File("local-test-dir"), TestUtils.getPropertyValue(gateway, "localDirectory"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
-		assertEquals("get", TestUtils.getPropertyValue(gateway, "command"));
+		assertEquals(Command.GET, TestUtils.getPropertyValue(gateway, "command"));
 		@SuppressWarnings("unchecked")
 		Set<String> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
-		assertTrue(options.contains("-P"));
+		assertTrue(options.contains(Option.PRESERVE_TIMESTAMP));
+	}
+
+	@Test
+	public void testGatewayMv() {
+		SftpOutboundGateway gateway = TestUtils.getPropertyValue(gateway3,
+				"handler", SftpOutboundGateway.class);
+		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
+		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
+		assertEquals(Command.MV, TestUtils.getPropertyValue(gateway, "command"));
+		assertEquals("'foo'", TestUtils.getPropertyValue(gateway, "renameProcessor.expression.expression"));
 	}
 
 	@Test

--- a/src/reference/docbook/ftp.xml
+++ b/src/reference/docbook/ftp.xml
@@ -406,8 +406,9 @@ protected void postProcessClientBeforeConnect(T client) throws IOException {
 		The <emphasis>expression</emphasis> attribute defines the "from" path and the
 		<emphasis>rename-expression</emphasis> attribute defines the "to" path. By default, the
 		<emphasis>rename-expression</emphasis> is <code>headers['file_renameTo']</code>. This
-		expression must not evaluate to null, or an empty <code>String</code>. The payload of
-		the result message is <code>Boolean.TRUE</code>.
+		expression must not evaluate to null, or an empty <code>String</code>. If necessary,
+		any remote directories needed will be created.
+		The payload of the result message is <code>Boolean.TRUE</code>.
 		The original remote directory is provided in the <code>file_remoteDirectory</code> header, and the filename is
 		provided in the <code>file_remoteFile</code> header. The new path is in
 		the <code>file_renameTo</code> header.

--- a/src/reference/docbook/ftp.xml
+++ b/src/reference/docbook/ftp.xml
@@ -327,6 +327,7 @@ protected void postProcessClientBeforeConnect(T client) throws IOException {
 		  <listitem>get (retrieve file)</listitem>
 		  <listitem>mget (retrieve file(s))</listitem>
 		  <listitem>rm (remove file(s))</listitem>
+		  <listitem>mv (move/rename file)</listitem>
 	    </itemizedlist>
 	  </para>
 	  <para><emphasis>ls</emphasis></para>
@@ -397,8 +398,22 @@ protected void postProcessClientBeforeConnect(T client) throws IOException {
 	    The remote directory is provided in the <classname>file_remoteDirectory</classname> header, and the filename is
 	    provided in the <classname>file_remoteFile</classname> header.
 	  </para>
+	  <para><emphasis>mv</emphasis></para>
 	  <para>
-	    In each case, the PATH that these commands act on is provided by the 'expression'
+		The <emphasis>mv</emphasis> command has no options.
+	  </para>
+	  <para>
+		The <emphasis>expression</emphasis> attribute defines the "from" path and the
+		<emphasis>rename-expression</emphasis> attribute defines the "to" path. By default, the
+		<emphasis>rename-expression</emphasis> is <code>headers['file_renameTo']</code>. This
+		expression must not evaluate to null, or an empty <code>String</code>. The payload of
+		the result message is <code>Boolean.TRUE</code>.
+		The original remote directory is provided in the <code>file_remoteDirectory</code> header, and the filename is
+		provided in the <code>file_remoteFile</code> header. The new path is in
+		the <code>file_renameTo</code> header.
+	  </para>
+	  <para>
+	    For all commands, the PATH that the command acts on is provided by the 'expression'
 	    property of the gateway. For the mget command, the expression might evaluate to '*', meaning
 	    retrieve all files, or 'somedirectory/*' etc.
 	  </para>

--- a/src/reference/docbook/sftp.xml
+++ b/src/reference/docbook/sftp.xml
@@ -439,8 +439,9 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 		The <emphasis>expression</emphasis> attribute defines the "from" path and the
 		<emphasis>rename-expression</emphasis> attribute defines the "to" path. By default, the
 		<emphasis>rename-expression</emphasis> is <code>headers['file_renameTo']</code>. This
-		expression must not evaluate to null, or an empty <code>String</code>. The payload of
-		the result message is <code>Boolean.TRUE</code>.
+		expression must not evaluate to null, or an empty <code>String</code>. If necessary,
+		any remote directories needed will be created.
+		The payload of the result message is <code>Boolean.TRUE</code>.
 		The original remote directory is provided in the <code>file_remoteDirectory</code> header, and the filename is
 		provided in the <code>file_remoteFile</code> header. The new path is in
 		the <code>file_renameTo</code> header.

--- a/src/reference/docbook/sftp.xml
+++ b/src/reference/docbook/sftp.xml
@@ -360,6 +360,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 		  <listitem>get (retrieve file)</listitem>
 		  <listitem>mget (retrieve file(s))</listitem>
 		  <listitem>rm (remove file(s))</listitem>
+		  <listitem>mv (move/rename file)</listitem>
 	    </itemizedlist>
 	  </para>
 	  <para><emphasis>ls</emphasis></para>
@@ -430,8 +431,22 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 	    The remote directory is provided in the <classname>file_remoteDirectory</classname> header, and the filename is
 	    provided in the <classname>file_remoteFile</classname> header.
 	  </para>
+	  <para><emphasis>mv</emphasis></para>
 	  <para>
-	    In each case, the PATH that these commands act on is provided by the 'expression'
+		The <emphasis>mv</emphasis> command has no options.
+	  </para>
+	  <para>
+		The <emphasis>expression</emphasis> attribute defines the "from" path and the
+		<emphasis>rename-expression</emphasis> attribute defines the "to" path. By default, the
+		<emphasis>rename-expression</emphasis> is <code>headers['file_renameTo']</code>. This
+		expression must not evaluate to null, or an empty <code>String</code>. The payload of
+		the result message is <code>Boolean.TRUE</code>.
+		The original remote directory is provided in the <code>file_remoteDirectory</code> header, and the filename is
+		provided in the <code>file_remoteFile</code> header. The new path is in
+		the <code>file_renameTo</code> header.
+	  </para>
+	  <para>
+	    For all commands, the PATH that the command acts on is provided by the 'expression'
 	    property of the gateway. For the mget command, the expression might evaluate to '*', meaning
 	    retrieve all files, or 'somedirectory/*' etc.
 	  </para>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -78,6 +78,13 @@
 				URI-schemes supported by Spring Web Services. For more information see <xref linkend="outbound-uri"/>.
 			</para>
 		</section>
+		<section id="3.0-xFTP-gw">
+			<title>(S)FTP(S) Gateways</title>
+			<para>
+				The gateways now support the <code>mv</code> command, enabling the renaming of remote
+				files.
+			</para>
+		</section>
 	</section>
 
 </chapter>


### PR DESCRIPTION
I took the opportunity to do a little refatoring (mainly change commands and options to `enum`s, and change a big if/else block to a switch statement).

You may find it easier to review each commit individually.
