### PR TITLE
INT-2989 Increase JMS Test Timeouts

### DIFF
--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/ActiveMQMultiContextTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/ActiveMQMultiContextTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.transport.vm.VMTransport;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.springframework.jms.connection.CachingConnectionFactory;
+
+/**
+ * Keeps an ActiveMQ {@link VMTransport} open for the duration of
+ * all tests (avoids cycling the transport each time the last
+ * connection is closed).
+ * @author Gary Russell
+ * @since 3.0
+ *
+ */
+public abstract class ActiveMQMultiContextTests {
+
+	private static final CachingConnectionFactory connectionFactory = new CachingConnectionFactory(
+			new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false"));
+
+	@BeforeClass
+	public static void startUp() throws Exception {
+		connectionFactory.createConnection().close();
+	}
+
+	@AfterClass
+	public static void shutDown() {
+		connectionFactory.resetConnection();
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineNamedReplyQueuesJmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineNamedReplyQueuesJmsTests.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.message.GenericMessage;
 /**
@@ -35,7 +36,7 @@ import org.springframework.integration.message.GenericMessage;
  * @author Gary Russell
  * @author Artem Bilan
  */
-public class PipelineNamedReplyQueuesJmsTests {
+public class PipelineNamedReplyQueuesJmsTests extends ActiveMQMultiContextTests {
 
 	private final Executor executor = Executors.newFixedThreadPool(30);
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineNamedReplyQueuesJmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineNamedReplyQueuesJmsTests.java
@@ -166,7 +166,7 @@ public class PipelineNamedReplyQueuesJmsTests extends ActiveMQMultiContextTests 
 					}
 				});
 			}
-			assertTrue(latch.await(60, TimeUnit.SECONDS));
+			assertTrue(latch.await(120, TimeUnit.SECONDS));
 			// technically all we care that its > 0,
 			// but reality of this test it has to be something more then 0
 			assertTrue(successCounter.get() > 10);

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCachedConsumersTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCachedConsumersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.JmsOutboundGateway;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.message.GenericMessage;
@@ -44,8 +45,9 @@ import org.springframework.jms.listener.SessionAwareMessageListener;
 import org.springframework.jms.support.converter.SimpleMessageConverter;
 /**
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
-public class RequestReplyScenariosWithCachedConsumersTests {
+public class RequestReplyScenariosWithCachedConsumersTests extends ActiveMQMultiContextTests {
 
 	private final SimpleMessageConverter converter = new SimpleMessageConverter();
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCorrelationKeyProvidedTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCorrelationKeyProvidedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,18 @@ package org.springframework.integration.jms.request_reply;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.JmsOutboundGateway;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 /**
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
-public class RequestReplyScenariosWithCorrelationKeyProvidedTests {
+public class RequestReplyScenariosWithCorrelationKeyProvidedTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void messageCorrelationBasedCustomCorrelationKey() throws Exception{

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithNonCachedConsumersTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithNonCachedConsumersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,14 +29,16 @@ import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.core.MessageCreator;
 /**
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
-public class RequestReplyScenariosWithNonCachedConsumersTests {
+public class RequestReplyScenariosWithNonCachedConsumersTests extends ActiveMQMultiContextTests {
 
 	@Test(expected=MessageTimeoutException.class)
 	public void messageCorrelationBasedOnRequestMessageIdOptimized() throws Exception{

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithTempReplyQueuesTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithTempReplyQueuesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +37,10 @@ import javax.jms.TextMessage;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.command.ActiveMQDestination;
 import org.junit.Test;
-
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.MessageDeliveryException;
 import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.test.util.TestUtils;
@@ -52,8 +52,9 @@ import org.springframework.jms.listener.SessionAwareMessageListener;
 import org.springframework.jms.support.converter.SimpleMessageConverter;
 /**
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
-public class RequestReplyScenariosWithTempReplyQueuesTests {
+public class RequestReplyScenariosWithTempReplyQueuesTests extends ActiveMQMultiContextTests {
 
 	private final SimpleMessageConverter converter = new SimpleMessageConverter();
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-01.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-01.xml
@@ -10,7 +10,8 @@
 	<int:gateway default-request-channel="pipeline01" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline01"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
+		receive-timeout="10000"
 		request-destination-name="pipeline01-queue-01">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -30,7 +31,8 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
+		receive-timeout="10000"
 		request-destination-name="pipeline01-queue-02">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-02.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-02.xml
@@ -10,8 +10,9 @@
 	<int:gateway default-request-channel="pipeline02" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline02"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="pipeline02-queue-01"
+		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -31,7 +32,8 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
+		receive-timeout="10000"
 		request-destination-name="pipeline02-queue-02">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-03.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-03.xml
@@ -10,8 +10,9 @@
 	<int:gateway default-request-channel="pipeline03" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline03"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="pipeline03-queue-01"
+		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -31,8 +32,9 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="pipeline03-queue-02"
+		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-04.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-04.xml
@@ -10,7 +10,8 @@
 	<int:gateway default-request-channel="pipeline04" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline04"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
+		receive-timeout="10000"
 		request-destination-name="pipeline04-queue-01">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -30,8 +31,9 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="pipeline04-queue-02"
+		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-05.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-05.xml
@@ -10,8 +10,9 @@
 	<int:gateway default-request-channel="pipeline05" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline05"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="pipeline05-queue-01"
+		receive-timeout="10000"
 		correlation-key="foo">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -32,7 +33,8 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
+		receive-timeout="10000"
 		request-destination-name="pipeline05-queue-02">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-06.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-06.xml
@@ -10,7 +10,8 @@
 	<int:gateway default-request-channel="pipeline06" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline06"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
+		receive-timeout="10000"
 		request-destination-name="pipeline06-queue-01">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -30,8 +31,9 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="pipeline06-queue-02"
+		receive-timeout="10000"
 		correlation-key="foo">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-07.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-07.xml
@@ -10,8 +10,9 @@
 	<int:gateway default-request-channel="pipeline07" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline07"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="pipeline07-queue-01"
+		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -31,8 +32,9 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="pipeline07-queue-02"
+		receive-timeout="10000"
 		correlation-key="foo">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-08.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-08.xml
@@ -10,8 +10,9 @@
 	<int:gateway default-request-channel="pipeline08" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline08"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="pipeline08-queue-01"
+		receive-timeout="10000"
 		correlation-key="foo">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -32,8 +33,9 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="pipeline08-queue-02"
+		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-09.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-09.xml
@@ -10,8 +10,9 @@
 	<int:gateway default-request-channel="pipeline09" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline09"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="pipeline09-queue-01"
+		receive-timeout="10000"
 		correlation-key="foo">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -32,8 +33,9 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="pipeline09-queue-02"
+		receive-timeout="10000"
 		correlation-key="bar">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-01.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-01.xml
@@ -10,8 +10,9 @@
 	<int:gateway default-request-channel="pipeline01" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline01"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline01-01"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline01-01"
+		receive-timeout="10000"
 		request-destination-name="siOutQueue01-01">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -31,7 +32,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination-name="anotherGatewayQueue01-01">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02.xml
@@ -10,9 +10,10 @@
 	<int:gateway default-request-channel="pipeline02" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline02"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline02-01"
-	    correlation-key="corr02"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline02-01"
+		correlation-key="corr02"
+		receive-timeout="10000"
 		request-destination-name="siOutQueue02">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -33,16 +34,17 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline02-02"
-	    correlation-key="corr02"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline02-02"
+		correlation-key="corr02"
+		receive-timeout="10000"
 		request-destination-name="anotherGatewayQueue02">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="anotherGatewayQueue02"
-	    correlation-key="corr02"
+		correlation-key="corr02"
 		connection-factory="connectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
@@ -50,8 +52,9 @@
 	<int:transformer input-channel="anotherIn" expression="payload" output-channel="toThird" />
 
 	<int-jms:outbound-gateway request-channel="toThird"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline02-03"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline02-03"
+		receive-timeout="10000"
 		request-destination-name="thirdGatewayQueue02">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02a.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02a.xml
@@ -10,9 +10,10 @@
 	<int:gateway default-request-channel="pipeline02" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline02"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline02a-01"
-	    correlation-key="corr02a"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline02a-01"
+		correlation-key="corr02a"
+		receive-timeout="10000"
 		request-destination-name="siOutQueue02a">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -33,9 +34,10 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline02a-01"
-	   	correlation-key="corr02a"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline02a-01"
+		correlation-key="corr02a"
+		receive-timeout="10000"
 		request-destination-name="anotherGatewayQueue02a">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -50,9 +52,10 @@
 	<int:transformer input-channel="anotherIn" expression="payload" output-channel="toThird" />
 
 	<int-jms:outbound-gateway request-channel="toThird"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline02a-01"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline02a-01"
 		correlation-key="corr02a"
+		receive-timeout="10000"
 		request-destination-name="thirdGatewayQueue02a">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03.xml
@@ -10,9 +10,10 @@
 	<int:gateway default-request-channel="pipeline03" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline03"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline03-01"
-	    correlation-key="JMSCorrelationID"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline03-01"
+		correlation-key="JMSCorrelationID"
+		receive-timeout="10000"
 		request-destination-name="siOutQueue03">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -32,9 +33,10 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline03-02"
-	    correlation-key="corr03"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline03-02"
+		correlation-key="corr03"
+		receive-timeout="10000"
 		request-destination-name="anotherGatewayQueue03">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -49,9 +51,10 @@
 	<int:transformer input-channel="anotherIn" expression="payload" output-channel="toThird" />
 
 	<int-jms:outbound-gateway request-channel="toThird"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline03-03"
-	    correlation-key="corr03"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline03-03"
+		correlation-key="corr03"
+		receive-timeout="10000"
 		request-destination-name="thirdGatewayQueue03">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03a.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03a.xml
@@ -10,9 +10,10 @@
 	<int:gateway default-request-channel="pipeline03" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline03"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline03a-01"
-	    correlation-key="JMSCorrelationID"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline03a-01"
+		correlation-key="JMSCorrelationID"
+		receive-timeout="30000"
 		request-destination-name="siOutQueue03a">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -32,9 +33,10 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline03a-01"
-	    correlation-key="corr03a"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline03a-01"
+		correlation-key="corr03a"
+		receive-timeout="30000"
 		request-destination-name="anotherGatewayQueue03a">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -51,8 +53,9 @@
 	<int-jms:outbound-gateway request-channel="toThird"
 		reply-channel="add10kOnTheWayBack"
 		correlation-key="corr03a"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline03a-01"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline03a-01"
+		receive-timeout="30000"
 		request-destination-name="thirdGatewayQueue03a">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-04.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-04.xml
@@ -10,9 +10,10 @@
 	<int:gateway default-request-channel="pipeline04" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline04"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline04-01"
-	    correlation-key="foo"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline04-01"
+		correlation-key="foo"
+		receive-timeout="10000"
 		request-destination-name="siOutQueue04">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -33,8 +34,9 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline04-02"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline04-02"
+		receive-timeout="10000"
 		request-destination-name="anotherGatewayQueue04">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-05.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-05.xml
@@ -10,9 +10,10 @@
 	<int:gateway default-request-channel="pipeline05" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline05"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline05-01"
-	    correlation-key="foo"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline05-01"
+		correlation-key="foo"
+		receive-timeout="10000"
 		request-destination-name="siOutQueue05">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -33,9 +34,10 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline05-02"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline05-02"
 		request-destination-name="anotherGatewayQueue05"
+		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-06.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-06.xml
@@ -10,9 +10,10 @@
 	<int:gateway default-request-channel="pipeline06" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline06"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline06-01"
-	    correlation-key="JMSCorrelationID"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline06-01"
+		correlation-key="JMSCorrelationID"
+		receive-timeout="10000"
 		request-destination-name="siOutQueue06">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -33,9 +34,10 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline06-02"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline06-02"
 		request-destination-name="anotherGatewayQueue06"
+		receive-timeout="10000"
 		correlation-key="foo">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-07.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-07.xml
@@ -10,9 +10,10 @@
 	<int:gateway default-request-channel="pipeline07" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline07"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline07-01"
-	    correlation-key="foo"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline07-01"
+		correlation-key="foo"
+		receive-timeout="10000"
 		request-destination-name="siOutQueue07">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -33,9 +34,10 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-	    connection-factory="connectionFactory"
-	    reply-destination-name="pipeline07-02"
+		connection-factory="connectionFactory"
+		reply-destination-name="pipeline07-02"
 		request-destination-name="anotherGatewayQueue07"
+		receive-timeout="10000"
 		correlation-key="bar">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-cached-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-cached-consumers.xml
@@ -9,9 +9,10 @@
 	<int:gateway id="standardMessageIdCopyingConsumerWithOptimization" default-request-channel="jmsInOptimizedA"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInOptimizedA"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination="siOutQueueOptimizedA"
 		reply-destination="siInQueueOptimizedA"
+		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -30,8 +31,9 @@
 	<int:gateway id="standardMessageIdCopyingConsumerWithoutOptimization" default-request-channel="jmsInNonOptimizedB"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedB"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination="siOutQueueNonOptimizedB"
+		receive-timeout="10000"
 		reply-destination="siInQueueNonOptimizedB">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-no-cached-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-no-cached-consumers.xml
@@ -9,9 +9,10 @@
 	<int:gateway id="optimized" default-request-channel="jmsInOptimized"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInOptimized"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination="siOutQueueA"
 		reply-destination="siInQueueA"
+		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
@@ -29,7 +30,8 @@
 	<int:gateway id="nonoptimized" default-request-channel="jmsInNonOptimized"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInNonOptimized"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
+		receive-timeout="10000"
 		request-destination="siOutQueueB"
 		reply-destination="siInQueueB">
 		<int-jms:reply-listener />
@@ -48,8 +50,9 @@
 	<int:gateway id="optimizedMessageId" default-request-channel="jmsInOptimizedC"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInOptimizedC"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination="siOutQueueC"
+		receive-timeout="10000"
 		reply-destination="siInQueueC"
 		correlation-key="JMSCorrelationID">
 		<int-jms:reply-listener />
@@ -68,8 +71,9 @@
 	<int:gateway id="nonoptimizedMessageId" default-request-channel="jmsInNonOptimizedD"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedD"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
 		request-destination="siOutQueueD"
+		receive-timeout="10000"
 		reply-destination="siInQueueD">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-temp-reply-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-temp-reply-consumers.xml
@@ -9,7 +9,8 @@
 	<int:gateway default-request-channel="jmsIn"/>
 
 	<int-jms:outbound-gateway request-channel="jmsIn"
-	    connection-factory="connectionFactory"
+		connection-factory="connectionFactory"
+		receive-timeout="10000"
 		request-destination="siOutQueue">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>


### PR DESCRIPTION
The default 5 second timeout is insufficient in some cases
for the larger volume tests. In most cases, increase to
10 seconds; in some cases to 30 seconds.

Also, add code to keep the ActiveMQ VMTransport running for
the entire test class (by keeping a connection open).

Avoids cycling the broker, which can cause other issues.

Also close the context in a finally block in PipeLineJmsTests.

Clean up some whitespace violations in config files.

This, together with the try/finally block makes the commit
look bigger than it really is; suggest using 'git log -p -b'
to review.
