### PR TITLE
INT-2991 Filtered Messages Marked SEEN

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -322,7 +322,9 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 					}
 				}
 			}
-			filteredMessages.add(message);
+			else {
+				filteredMessages.add(message);
+			}
 		}
 		return filteredMessages.toArray(new Message[filteredMessages.size()]);
 	}


### PR DESCRIPTION
Missing else clause caused filtered email messages to
still be marked as SEEN. Also marked un-filtered messages
twice if a filter was present.

Add else; add tests.

**cherry-pick to 2.2.x**
