### PR TITLE
INT-2964 - Make Spring Integration buildable with JDK8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,9 +82,7 @@ subprojects { subproject ->
 	// dependencies that are common across all java projects
 	dependencies {
 		testCompile "cglib:cglib-nodep:$cglibVersion"
-		testCompile("junit:junit:$junitVersion") {
-			exclude group: 'org.hamcrest', module: 'hamcrest-core'
-		}
+		testCompile "junit:junit:$junitVersion"
 		testCompile "log4j:log4j:$log4jVersion"
 		testCompile "org.easymock:easymock:$easymockVersion"
 		testCompile "org.easymock:easymockclassextension:$easymockVersion"
@@ -485,11 +483,9 @@ project('spring-integration-test') {
 	description = 'Spring Integration Test Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile("junit:junit:$junitVersion") {
-			exclude group: 'org.hamcrest', module: 'hamcrest-core'
-		}
+		compile "junit:junit:$junitVersion"
 		compile "org.hamcrest:hamcrest-all:$hamcrestVersion"
-		compile "org.mockito:mockito-all:$mockitoVersion"
+		compile "org.mockito:mockito-core:$mockitoVersion"
 		compile "org.springframework:spring-context:$springVersion"
 		compile "org.springframework:spring-test:$springVersion"
 	}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 
 	/**
 	 * {@inheritDoc}
-	 * <p/>
+	 * <p>
 	 * Shuts down the listener container.
 	 */
 	public int beforeShutdown() {
@@ -104,7 +104,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 
 	/**
 	 * {@inheritDoc}
-	 * <p/>No-op
+	 * <p>No-op
 	 */
 	public int afterShutdown() {
 		return 0;

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -31,7 +31,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Default implementation of {@link AmqpHeaderMapper}.
- * <p/>
+ * <p>
  * By default this implementation will only copy AMQP properties (e.g. contentType) to and from
  * Spring Integration MessageHeaders. Any user-defined headers within the AMQP
  * MessageProperties will NOT be copied to or from an AMQP Message unless
@@ -40,7 +40,7 @@ import org.springframework.util.StringUtils;
  * and {@link AbstractHeaderMapper#setReplyHeaderNames(String[])}}
  * as well as 'mapped-request-headers' and 'mapped-reply-headers' attributes of the AMQP adapters).
  * If you need to copy all user-defined headers simply use wild-card character '*'.
- * <p/>
+ * <p>
  * Constants for the AMQP header keys are defined in {@link AmqpHeaders}.
  *
  * @author Mark Fisher

--- a/spring-integration-core/src/main/java/org/springframework/integration/MessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/MessageChannel.java
@@ -18,7 +18,7 @@ package org.springframework.integration;
 
 /**
  * Base channel interface defining common behavior for sending messages.
- * 
+ *
  * @author Mark Fisher
  */
 public interface MessageChannel {
@@ -28,12 +28,12 @@ public interface MessageChannel {
 	 * non-recoverable errors. Otherwise, if the Message cannot be sent for a
 	 * non-fatal reason this method will return 'false', and if the Message is
 	 * sent successfully, it will return 'true'.
-	 * 
+	 *
 	 * <p>Depending on the implementation, this method may block indefinitely.
 	 * To provide a maximum wait time, use {@link #send(Message, long)}.
-	 * 
+	 *
 	 * @param message the {@link Message} to send
-	 * 
+	 *
 	 * @return whether the Message has been sent successfully
 	 */
 	boolean send(Message<?> message);
@@ -41,12 +41,12 @@ public interface MessageChannel {
 	/**
 	 * Send a message, blocking until either the message is accepted or the
 	 * specified timeout period elapses.
-	 * 
+	 *
 	 * @param message the {@link Message} to send
 	 * @param timeout the timeout in milliseconds
-	 * 
+	 *
 	 * @return <code>true</code> if the message is sent successfully,
-	 * <code>false</false> if the specified timeout period elapses or
+	 * <code>false</code> if the specified timeout period elapses or
 	 * the send is interrupted
 	 */
 	boolean send(Message<?> message, long timeout);

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -49,11 +49,11 @@ import org.springframework.util.CollectionUtils;
  * and is used as a base class for Aggregator - {@link AggregatingMessageHandler} and
  * Resequencer - {@link ResequencingMessageHandler},
  * or custom implementations requiring correlation.
- * <p/>
+ * <p>
  * To customize this handler inject {@link CorrelationStrategy},
  * {@link ReleaseStrategy}, and {@link MessageGroupProcessor} implementations as
  * you require.
- * <p/>
+ * <p>
  * By default the {@link CorrelationStrategy} will be a
  * {@link HeaderAttributeCorrelationStrategy} and the {@link ReleaseStrategy} will be a
  * {@link SequenceSizeReleaseStrategy}.

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageBarrier.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageBarrier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -33,11 +33,11 @@ import org.springframework.integration.store.SimpleMessageStore;
  * When a message can be processed it is up to the client to take care of the locking (potentially from the ReleaseStrategy's
  * {@link org.springframework.integration.aggregator.ReleaseStrategy#canRelease(org.springframework.integration.store.MessageGroup) canRelease(..)}
  * method).
- * <p/>
+ * <p>
  * This class differs from AbstractCorrelatingMessageHandler in that it completely decouples the receiver and the sender. It can
  * be applied in scenarios where completion of a message group is not well defined but only a certain amount of messages
  * for any given correlation key may be processed at a time.
- * <p/>
+ * <p>
  * The messages will be stored in a {@link org.springframework.integration.store.MessageGroupStore MessageStore}
  * for each correlation key.
  *

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MessageGroupProcessor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2011 the original author or authors.
- * 
+ * Copyright 2002-2013 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -27,7 +27,7 @@ public interface MessageGroupProcessor {
 	 * Process the given MessageGroup. Implementations are free to return as few or as many messages based on the
 	 * invocation as needed. For example an aggregating processor will return only a single message representing the
 	 * group, while a resequencing processor will return all messages whose preceding sequence has been satisfied.
-	 * <p/>
+	 * <p>
 	 * If a multiple messages are returned the return value must be a Collection&lt;Message&gt;.
 	 */
 	Object processMessageGroup(MessageGroup group);

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Payloads.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Payloads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,10 @@ import java.lang.annotation.Target;
  * This annotation marks a method parameter as being a list of message payloads, for POJO handlers that deal with lists
  * of messages (e.g. aggregators and release strategies).
  * <p>
- * Example: void foo(@Payloads("city.name") List<String> cityName) - will map the value of the 'name' property of the 'city'
+ * Example:
+ * {@code void foo(@Payloads("city.name") List<String> cityName)} - will map the value of the 'name' property of the 'city'
  * property of all the payload objects in the input list.
- * 
+ *
  * @author Dave Syer
  * @since 2.0
  */

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/DirectChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/DirectChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class DirectChannel extends AbstractSubscribableChannel {
 
 	/**
 	 * Create a DirectChannel with a {@link LoadBalancingStrategy}. The
-	 * strategy <emphasis>must not</emphasis> be null.
+	 * strategy <em>must not</em> be null.
 	 */
 	public DirectChannel(LoadBalancingStrategy loadBalancingStrategy) {
 		this.dispatcher.setLoadBalancingStrategy(loadBalancingStrategy);

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/ExecutorChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/ExecutorChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@ import org.springframework.util.ErrorHandler;
  * {@link UnicastingDispatcher} which in turn delegates all dispatching
  * invocations to an {@link Executor}.
  * <p>
- * <emphasis>NOTE: unlike DirectChannel, the ExecutorChannel does not support a
+ * <em><b>NOTE</b>: unlike DirectChannel, the ExecutorChannel does not support a
  * shared transactional context between sender and handler, because the
  * {@link Executor} typically does not block the sender's Thread since it
- * uses another Thread for the dispatch.</emphasis> (SyncTaskExecutor is an
+ * uses another Thread for the dispatch.</em> (SyncTaskExecutor is an
  * exception but would provide no value for this channel. If synchronous
  * dispatching is required, a DirectChannel should be used instead).
  *

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.util.StringUtils;
 /**
  * A base class that provides convenient access to the bean factory as
  * well as {@link TaskScheduler} and {@link ConversionService} instances.
- * <p/>
+ * <p>
  * <p>This is intended to be used as a base class for internal framework
  * components whereas code built upon the integration framework should not
  * require tight coupling with the context but rather rely on standard

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/MessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/MessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import org.springframework.integration.MessagingException;
 
 /**
  * Base interface for any component that handles Messages.
- * 
+ *
  * @author Mark Fisher
  * @author Iwein Fuld
  */
@@ -34,11 +34,11 @@ public interface MessageHandler {
 	 * message, but fails to do so, a <code>MessageHandlingException</code> is
 	 * thrown. In the last case it is recommended to treat the message as tainted
 	 * and go into an error scenario.
-	 * <p/>
+	 * <p>
 	 * When the handling results in a failure of another message being sent
 	 * (e.g. a "reply" message), that failure  will trigger a
 	 * <code>MessageDeliveryException</code>.
-	 * 
+	 *
 	 * @param message the message to be handled
 	 * @throws org.springframework.integration.MessageRejectedException if the handler doesn't accept the message
 	 * @throws org.springframework.integration.MessageHandlingException when something fails during the handling

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/OrderedAwareCopyOnWriteArraySet.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/OrderedAwareCopyOnWriteArraySet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import org.springframework.util.StringUtils;
  * of the insertion while maintaining the order of insertion for the un-ordered elements.
  * <p>
  * The class is package-protected and only intended for use by the AbstractDispatcher. It
- * <emphasis>must</emphasis> enforce safe concurrent access for all usage by the dispatcher.
+ * <em>must</em> enforce safe concurrent access for all usage by the dispatcher.
  *
  * @author Oleg Zhurakousky
  * @author Mark Fisher

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
@@ -35,11 +35,11 @@ import org.springframework.integration.core.MessageHandler;
  * as determined by the {@link LoadBalancingStrategy} if one is configured. As
  * soon as <em>one</em> of the handlers accepts the Message, the dispatcher will
  * return <code>true</code> and ignore the rest of its handlers.
- * <p/>
+ * <p>
  * If the dispatcher has no handlers, a {@link MessageDeliveryException} will be
  * thrown. If all handlers throw Exceptions, the dispatcher will throw an
  * {@link AggregateMessageDeliveryException}.
- * <p/>
+ * <p>
  * A load-balancing strategy may be provided to this class to control the order in
  * which the handlers will be tried.
  *

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
@@ -1,4 +1,4 @@
-/* Copyright 2002-2012 the original author or authors.
+/* Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,7 +152,7 @@ public class UnicastingDispatcher extends AbstractDispatcher {
 	/**
 	 * Handles Exceptions that occur while dispatching. If this dispatcher has
 	 * failover enabled, it will only throw an Exception when the handler list
-	 * is exhausted. The 'isLast' flag will be <emphasis>true</emphasis> if the
+	 * is exhausted. The 'isLast' flag will be <em>true</em> if the
 	 * Exception occurred during the final iteration of the MessageHandlers.
 	 * If failover is disabled for this dispatcher, it will re-throw any
 	 * Exception immediately.

--- a/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.springframework.util.Assert;
  * {@link MessageRejectedException} depending on the value of its
  * {@link #throwExceptionOnRejection} property. If a discard channel is
  * provided, the rejected Messages will be sent to that channel.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  */
@@ -56,14 +56,14 @@ public class MessageFilter extends AbstractReplyProducingMessageHandler {
 
 
 	/**
-	 * Specify whether this filter should throw a 
+	 * Specify whether this filter should throw a
 	 * {@link MessageRejectedException} when its selector does not accept a
 	 * Message. The default value is <code>false</code> meaning that rejected
 	 * Messages will be quietly dropped or sent to the discard channel if
 	 * available. Typically this value would not be <code>true</code> when
 	 * a discard channel is provided, but if so, it will still apply
 	 * (in such a case, the Message will be sent to the discard channel,
-	 * and <emphasis>then</emphasis> the exception will be thrown).
+	 * and <em>then</em> the exception will be thrown).
 	 * @see #setDiscardChannel(MessageChannel)
 	 */
 	public void setThrowExceptionOnRejection(boolean throwExceptionOnRejection) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ import org.springframework.util.StringUtils;
 /**
  * A Message Mapper implementation that supports mapping <i>to</i> a
  * Message from an argument array when invoking gateway methods.
- * <p/>
+ * <p>
  * Some examples of legal method signatures:<br/>
  * <tt>public void dealWith(Object payload);</tt><br/>
  * <tt>public void dealWith(Message message);</tt><br/>
@@ -60,7 +60,7 @@ import org.springframework.util.StringUtils;
  * <tt>public void dealWith(@Headers Map headers, Object payload);</tt><br/>
  * <tt>public void dealWith(@Headers Properties headers, Map payload);</tt><br/>
  * <tt>public void dealWith(Properties headers, Object payload);</tt><br/>
- * <p/>
+ * <p>
  * Some examples of illegal method signatures: <br/>
  * <tt>public void dealWith(Object payload, String payload);</tt><br/>
  * <tt>public void dealWith(Message message, Object payload);</tt><br/>

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
@@ -52,19 +52,19 @@ import org.springframework.util.StringUtils;
  * A Message Mapper implementation that supports mapping <i>to</i> a
  * Message from an argument array when invoking gateway methods.
  * <p>
- * Some examples of legal method signatures:<br/>
- * <tt>public void dealWith(Object payload);</tt><br/>
- * <tt>public void dealWith(Message message);</tt><br/>
- * <tt>public void dealWith(@Header String myHeader, Object payload);</tt><br/>
- * <br/>
- * <tt>public void dealWith(@Headers Map headers, Object payload);</tt><br/>
- * <tt>public void dealWith(@Headers Properties headers, Map payload);</tt><br/>
- * <tt>public void dealWith(Properties headers, Object payload);</tt><br/>
+ * Some examples of legal method signatures:<br>
+ * <tt>public void dealWith(Object payload);</tt><br>
+ * <tt>public void dealWith(Message message);</tt><br>
+ * <tt>public void dealWith(@Header String myHeader, Object payload);</tt><br>
+ * <br>
+ * <tt>public void dealWith(@Headers Map headers, Object payload);</tt><br>
+ * <tt>public void dealWith(@Headers Properties headers, Map payload);</tt><br>
+ * <tt>public void dealWith(Properties headers, Object payload);</tt><br>
  * <p>
- * Some examples of illegal method signatures: <br/>
- * <tt>public void dealWith(Object payload, String payload);</tt><br/>
- * <tt>public void dealWith(Message message, Object payload);</tt><br/>
- * <tt>public void dealWith(Properties headers, Map payload);</tt><br/>
+ * Some examples of illegal method signatures: <br>
+ * <tt>public void dealWith(Object payload, String payload);</tt><br>
+ * <tt>public void dealWith(Message message, Object payload);</tt><br>
+ * <tt>public void dealWith(Properties headers, Map payload);</tt><br>
  *
  * @author Mark Fisher
  * @author Iwein Fuld

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/BridgeHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/BridgeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,12 @@ import org.springframework.integration.Message;
  * directly to the output channel without modifying it. The main purpose of this
  * handler is to bridge a PollableChannel to a SubscribableChannel or
  * vice-versa.
- * <p/>
+ * <p>
  * The BridgeHandler can be used as a stopper at the end of an assembly line of
  * channels. In this setup the output channel doesn't have to be set, but if the
  * output channel is omitted the <tt>REPLY_CHANNEL</tt> MUST be set on the
  * message. Otherwise, a MessagingException will be thrown at runtime.
- * 
+ *
  * @author Mark Fisher
  * @author Iwein Fuld
  */

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -49,12 +49,12 @@ import org.springframework.util.CollectionUtils;
  * therefore, the calling thread does not block. The advantage of this approach
  * is that many delays can be managed concurrently, even very long delays,
  * without producing a buildup of blocked Threads.
- * <p/>
+ * <p>
  * One thing to keep in mind, however, is that any active transactional context
  * will not propagate from the original sender to the eventual recipient. This
  * is a side-effect of passing the Message to the output channel after the
  * delay with a different Thread in control.
- * <p/>
+ * <p>
  * When this handler's 'delayHeaderName' property is configured, that value, if
  * present on a Message, will take precedence over the handler's 'defaultDelay'
  * value. The actual header value may be a long, a String that can be parsed

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -137,7 +137,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 	}
 
 	/**
-	 * Specify the <code>List<Advice></code> to advise {@link DelayHandler.ReleaseMessageHandler} proxy.
+	 * Specify the {@code List<Advice>} to advise {@link DelayHandler.ReleaseMessageHandler} proxy.
 	 * Usually used to add transactions to delayed messages retrieved from a transactional message store.
 	 *
 	 * @see #createReleaseMessageTask
@@ -182,7 +182,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 	 * Checks if 'requestMessage' wasn't delayed before
 	 * ({@link #releaseMessageAfterDelay} and {@link DelayHandler.DelayedMessageWrapper}).
 	 * Than determine 'delay' for 'requestMessage' ({@link #determineDelayForMessage})
-	 * and if <code>delay > 0</code> schedules 'releaseMessage' task after 'delay'.
+	 * and if {@code delay > 0} schedules 'releaseMessage' task after 'delay'.
 	 *
 	 * @param requestMessage - the Message which may be delayed.
 	 * @return - <code>null</code> if 'requestMessage' is delayed,

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 	/**
 	 * Set the default delay in milliseconds. If no 'delayHeaderName' property
 	 * has been provided, the default delay will be applied to all Messages. If
-	 * a delay should <emphasis>only</emphasis> be applied to Messages with a
+	 * a delay should <em>only</em> be applied to Messages with a
 	 * header, then set this value to 0.
 	 */
 	public void setDefaultDelay(long defaultDelay) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageHandlerChain.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageHandlerChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.SmartLifecycle;
-import org.springframework.core.Ordered;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessageHandlingException;
@@ -40,21 +39,21 @@ import java.util.concurrent.locks.ReentrantLock;
 /**
  * A composite {@link MessageHandler} implementation that invokes a chain of
  * MessageHandler instances in order.
- * <p/>
+ * <p>
  * Each of the handlers except for the last one <b>must</b> implement the
  * {@link MessageProducer} interface. The last handler must also <b>if</b>
  * the chain itself has an output channel configured. No other assumptions
  * are made about the type of handler.
- * <p/>
+ * <p>
  * It is expected that each handler will produce reply messages and send them to
  * its output channel, although this is not enforced. It is possible to filter
  * messages in the middle of the chain, for example using a
  * {@link MessageFilter}. A {@link MessageHandler} returning null will have the
  * same effect, although this option is less expressive.
- * <p/>
+ * <p>
  * This component can be used from the namespace to improve the readability of
  * the configuration by removing channels that can be created implicitly.
- * <p/>
+ * <p>
  *
  * <pre>
  * &lt;chain&gt;

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
@@ -99,8 +99,9 @@ public abstract class AbstractRequestHandlerAdvice extends IntegrationObjectSupp
 	}
 
 	/**
-	 * Subclasses implement this method to apply behavior to the {@link MessageHandler}.<p/> callback.execute()
-	 * invokes the handler method and returns its result, or null.
+	 * Subclasses implement this method to apply behavior to the {@link MessageHandler}.
+	 * <p>
+	 * callback.execute() invokes the handler method and returns its result, or null.
 	 *
 	 * @param callback Subclasses invoke the execute() method on this interface to invoke the handler method.
 	 * @param target   The target handler.

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	/**
 	 * Specify a prefix to be prepended to the header name for any integration
 	 * message header that is being mapped to or from a user-defined value.
-	 * <p/>
+	 * <p>
 	 * This does not affect the standard properties for the particular protocol, such as
 	 * contentType for AMQP, etc. The header names used for mapping such properties are
 	 * defined in a corresponding Headers class as constants (e.g. AmqpHeaders).

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
@@ -31,7 +31,7 @@ import org.springframework.util.Assert;
  * &lt;recipient-list-router id="simpleRouter" input-channel="routingChannelA"&gt;
  *     &lt;recipient channel="channel1"/&gt;
  *     &lt;recipient channel="channel2"/&gt;
- * &lt;/recipient-list-router>
+ * &lt;/recipient-list-router&gt;
  * </pre>
  * <p>
  * A Message Router that sends Messages to a list of recipient channels. The

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,23 +33,23 @@ import org.springframework.util.Assert;
  *     &lt;recipient channel="channel2"/&gt;
  * &lt;/recipient-list-router>
  * </pre>
- * <p/>
+ * <p>
  * A Message Router that sends Messages to a list of recipient channels. The
  * recipients can be provided as a static list of {@link MessageChannel}
  * instances via the {@link #setChannels(List)} method, or for dynamic behavior,
  * the values can be provided via the {@link #setRecipients(List)} method.
- * <p/>
+ * <p>
  * For more advanced, programmatic control of dynamic recipient lists, consider
  * using the @Router annotation or extending {@link AbstractMappingMessageRouter} instead.
- * <p/>
+ * <p>
  * Contrary to a standard &lt;router .../&gt; this handler will try to send to
  * all channels that are configured as recipients. It is to channels what a
  * publish subscribe channel is to endpoints.
- * <p/>
+ * <p>
  * Using this class only makes sense if it is essential to send messages on
  * multiple channels instead of sending them to multiple handlers. If the latter
  * is an option using a publish subscribe channel is the more flexible solution.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  */

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,11 @@ import java.util.Collection;
 import org.springframework.integration.Message;
 
 /**
- * A group of messages that are correlated with each other and should be processed in the same context. 
- * <p/>
+ * A group of messages that are correlated with each other and should be processed in the same context.
+ * <p>
  * The message group allows implementations to be mutable, but this behavior is optional. Implementations should take
  * care to document their thread safety and mutability.
- * 
+ *
  * @author Dave Syer
  * @author Oleg Zhurakousky
  */
@@ -45,7 +45,7 @@ public interface MessageGroup {
 	 * @return the key that links these messages together
 	 */
 	Object getGroupId();
-	
+
 	/**
 	 * Returns the sequenceNumber of the last released message. Used in Resequencer use cases only
 	 */
@@ -55,9 +55,9 @@ public interface MessageGroup {
 	 * @return true if the group is complete (i.e. no more messages are expected to be added)
 	 */
 	boolean isComplete();
-	
+
 	/**
-	 * 
+	 *
 	 */
 	void complete();
 
@@ -80,7 +80,7 @@ public interface MessageGroup {
 	 * @return the timestamp (milliseconds since epoch) associated with the creation of this group
 	 */
 	long getTimestamp();
-	
+
 	/**
 	 * @return the timestamp (milliseconds since epoch) associated with the time this group was last updated
 	 */

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/HeaderEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/HeaderEnricher.java
@@ -41,7 +41,7 @@ import org.springframework.integration.support.MessageBuilder;
  * Accepts the boolean 'overwrite' property that specifies whether values should
  * be overwritten. By default, any existing header values for a given key, will
  * <em>not</em> be replaced.
- * 
+ *
  * @author Mark Fisher
  * @author David Turanski
  * @author Artem Bilan
@@ -83,7 +83,7 @@ public class HeaderEnricher implements Transformer, BeanNameAware, InitializingB
 	/**
 	 * Specify whether <code>null</code> values, such as might be returned from
 	 * an expression evaluation, should be skipped. The default value is
-	 * <code>true</code>. Set this to <code>false</false> if a
+	 * <code>true</code>. Set this to <code>false</code> if a
 	 * <code>null</code> value should trigger <i>removal</i> of the
 	 * corresponding header instead.
 	 */
@@ -220,7 +220,7 @@ public class HeaderEnricher implements Transformer, BeanNameAware, InitializingB
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.springframework.beans.factory.BeanNameAware#setBeanName(java.lang
 	 * .String)
@@ -232,7 +232,7 @@ public class HeaderEnricher implements Transformer, BeanNameAware, InitializingB
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
 	 */

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/DefaultLockRegistry.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/DefaultLockRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -22,7 +22,7 @@ import org.springframework.util.Assert;
  * the array is based on the 'mask' parameter passed in the constructor. The default mask is 0xFF which will create
  * and array consisting of 256 {@link ReentrantLock} instances.
  * When the {@link #obtain(Object)} method is called with the lockKey (e.g., Object) the index of the {@link Lock}
- * is determined by masking the object's hashCode (e.g., object.hashCode & mask) and the {@link Lock} is returned.
+ * is determined by masking the object's hashCode (e.g., {@code object.hashCode & mask}) and the {@link Lock} is returned.
  *
  * @author Oleg Zhurakousky
  * @author Gary Russell
@@ -48,8 +48,10 @@ public final class DefaultLockRegistry implements LockRegistry {
 	 * mask - the mask must have a value Math.pow(2, n) - 1 where n
 	 * is 1 to 31, creating a hash of Math.pow(2, n) locks.
 	 * <p> Examples:
+	 * <ul>
 	 * <li>0x3ff (1023) - 1024 locks</li>
 	 * <li>0xfff (4095) - 4096 locks</li>
+	 * </ul>
 	 * <p>
 	 * @param mask
 	 */

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/SimplePool.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/SimplePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,7 +133,9 @@ public class SimplePool<T> implements Pool<T> {
 
 	/**
 	 * Adjusts the wait timeout - the time for which getItem() will wait if no idle
-	 * entries are available. <br/>Default: infinity.
+	 * entries are available.
+	 * <br>
+	 * Default: infinity.
 	 * @param waitTimeout The wait timeout in milliseconds.
 	 */
 	public void setWaitTimeout(long waitTimeout) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/scenarios/AggregationResendTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/scenarios/AggregationResendTests.java
@@ -58,7 +58,7 @@ public class AggregationResendTests {
 	 * explicit timeout value of 1 second on the aggregator. What we'll see is
 	 * that we get one aggregate Message back immediately.
 	 *
-	 * <p>We should <emphasis>not</emphasis> get another 3 after the 1 second.
+	 * <p>We should <em>not</em> get another 3 after the 1 second.
 	 */
 	@Test
 	@Ignore // timeout is no longer supported
@@ -72,7 +72,7 @@ public class AggregationResendTests {
 	 * after 60 seconds. What we'll see is that we get one aggregate Message back
 	 * immediately.
 	 *
-	 * <p>We should <emphasis>not</emphasis> get another 3 after the 60 seconds.
+	 * <p>We should <em>not</em> get another 3 after the 60 seconds.
 	 */
 	@Test
 	@Ignore // disabling from normal testing, should be the same behavior whether explicit or default

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/DefaultDirectoryScanner.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/DefaultDirectoryScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.springframework.integration.file.filters.FileListFilter;
 /**
  * Default directory scanner and base class for other directory scanners.
  * Manages the default interrelations between filtering, scanning and locking.
- * 
+ *
  * @author Iwein Fuld
  * @since 2.0
  */
@@ -52,7 +52,7 @@ public class DefaultDirectoryScanner implements DirectoryScanner {
 
 	/**
 	 * {@inheritDoc}
-	 * <p/>
+	 * <p>
 	 * This class takes the minimal implementation and merely delegates to the
 	 * locker if set.
 	 */
@@ -72,7 +72,7 @@ public class DefaultDirectoryScanner implements DirectoryScanner {
 	/**
 	 * Subclasses may refine the listing strategy by overriding this method. The
 	 * files returned here are passed onto the filter.
-	 * 
+	 *
 	 * @param directory root directory to use for listing
 	 * @return the files this scanner should consider
 	 */

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/DirectoryScanner.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/DirectoryScanner.java
@@ -27,7 +27,7 @@ import org.springframework.integration.file.filters.FileListFilter;
  * intended to enable the customization of selection, locking and ordering of
  * files in a directory like RecursiveDirectoryScanner. If the only requirement
  * is to ignore certain files a EntryListFilter implementation should suffice.
- * 
+ *
  * @author Iwein Fuld
  */
 public interface DirectoryScanner {
@@ -36,7 +36,7 @@ public interface DirectoryScanner {
 	 * Scans the directory according to the strategy particular to this
 	 * implementation and returns the selected files as a File array. This
 	 * method may never return files that are rejected by the filter.
-	 * 
+	 *
 	 * @param directory the directory to scan for files
 	 * @return a list of files representing the content of the directory
 	 * @throws IllegalArgumentException if the input is incorrect
@@ -48,7 +48,7 @@ public interface DirectoryScanner {
 	 * chance to reject files before the scanner presents them through its
 	 * listFiles method. A scanner may use additional filtering that is out of
 	 * the control of the provided filter.
-	 * 
+	 *
 	 * @param filter
 	 *            the custom filter to be used
 	 */
@@ -57,7 +57,7 @@ public interface DirectoryScanner {
 	/**
 	 * Sets a custom locker to be used by this scanner. The locker will get a
 	 * chance to lock files and reject claims on files that are already locked.
-	 * 
+	 *
 	 * @param locker
 	 *            the custom locker to be used
 	 */
@@ -67,10 +67,9 @@ public interface DirectoryScanner {
 	 * Claim the file to process. It is up to the implementation to decide what
 	 * additional safe guards are required to attain a claim to the file. But if
 	 * a locker is set implementations MUST invoke its <code>lock</code> method
-	 * and MUST return <code>false<code> if the locker did not grant the lock.
-	 * 
-	 * @param file
-	 *            file to be claimed
+	 * and MUST return <code>false</code> if the locker did not grant the lock.
+	 *
+	 * @param file file to be claimed
 	 * @return true if the claim was granted false otherwise
 	 */
 	boolean tryClaim(File file);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileMessageHolder.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileMessageHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.io.File;
 import org.springframework.integration.Message;
 
 /**
- * A simple wrapper for a Message<File>; used for
+ * A simple wrapper for a {@code Message<File>;} used for
  * file disposition after the send completes, or
  * after the transaction commits with a transactional
  * poller.

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
@@ -43,7 +43,7 @@ import org.springframework.util.Assert;
  * default, an
  * {@link AcceptOnceFileListFilter}
  * is used. It ensures files are picked up only once from the directory.
- * <p/>
+ * <p>
  * A common problem with reading files is that a file may be detected before it
  * is ready. The default {@link AcceptOnceFileListFilter}
  * does not prevent this. In most cases, this can be prevented if the
@@ -51,12 +51,12 @@ import org.springframework.util.Assert;
  * pattern-matching filter that accepts only files that are ready (e.g. based on
  * a known suffix), composed with the default {@link AcceptOnceFileListFilter}
  * would allow for this.
- * <p/>
+ * <p>
  * A {@link Comparator} can be used to ensure internal ordering of the Files in
  * a {@link PriorityBlockingQueue}. This does not provide the same guarantees as
  * a {@link ResequencingMessageGroupProcessor}, but in cases where writing files
  * and failure downstream are rare it might be sufficient.
- * <p/>
+ * <p>
  * FileReadingMessageSource is fully thread-safe under concurrent
  * <code>receive()</code> invocations and message delivery callbacks.
  *
@@ -120,12 +120,12 @@ public class FileReadingMessageSource extends IntegrationObjectSupport implement
 	/**
 	 * Creates a FileReadingMessageSource with a {@link PriorityBlockingQueue}
 	 * ordered with the passed in {@link Comparator}
-	 * <p/>
+	 * <p>
 	 * The size of the queue used should be large enough to hold all the files
 	 * in the input directory in order to sort all of them, so restricting the
 	 * size of the queue is mutually exclusive with ordering. No guarantees
 	 * about file delivery order can be made under concurrent access.
-	 * <p/>
+	 * <p>
 	 *
 	 * @param receptionOrderComparator
 	 *            the comparator to be used to order the files in the internal
@@ -180,7 +180,7 @@ public class FileReadingMessageSource extends IntegrationObjectSupport implement
 	 * filters are required a
 	 * {@link org.springframework.integration.file.filters.CompositeFileListFilter}
 	 * can be used to group them together.
-	 * <p/>
+	 * <p>
 	 * <b>The supplied filter must be thread safe.</b>.
 	 *
 	 * @param filter a filter
@@ -193,7 +193,7 @@ public class FileReadingMessageSource extends IntegrationObjectSupport implement
 	/**
 	 * Optional. Sets a {@link FileLocker} to be used to guard files against
 	 * duplicate processing.
-	 * <p/>
+	 * <p>
 	 * <b>The supplied FileLocker must be thread safe</b>
 	 *
 	 * @param locker a locker
@@ -206,7 +206,7 @@ public class FileReadingMessageSource extends IntegrationObjectSupport implement
 	/**
 	 * Optional. Set this flag if you want to make sure the internal queue is
 	 * refreshed with the latest content of the input directory on each poll.
-	 * <p/>
+	 * <p>
 	 * By default this implementation will empty its queue before looking at the
 	 * directory again. In cases where order is relevant it is important to
 	 * consider the effects of setting this flag. The internal

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,7 +160,7 @@ public class FileReadingMessageSource extends IntegrationObjectSupport implement
 	/**
 	 * Specify whether to create the source directory automatically if it does
 	 * not yet exist upon initialization. By default, this value is
-	 * <emphasis>true</emphasis>. If set to <emphasis>false</emphasis> and the
+	 * <em>true</em>. If set to <em>false</em> and the
 	 * source directory does not exist, an Exception will be thrown upon
 	 * initialization.
 	 *

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 	/**
 	 * Specify whether to create the destination directory automatically if it
 	 * does not yet exist upon initialization. By default, this value is
-	 * <emphasis>true</emphasis>. If set to <emphasis>false</emphasis> and the
+	 * <em>true</em>. If set to <em>false</em> and the
 	 * destination directory does not exist, an Exception will be thrown upon
 	 * initialization.
 	 */

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AcceptOnceFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AcceptOnceFileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  * {@link FileListFilter} that passes files only one time. This can
  * conveniently be used to prevent duplication of files, as is done in
  * {@link org.springframework.integration.file.FileReadingMessageSource}.
- * <p/>
+ * <p>
  * This implementation is thread safe.
  *
  * @author Iwein Fuld

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
@@ -65,7 +65,7 @@ public class CompositeFileListFilter<F> implements FileListFilter<F> {
 
 	/**
 	 * Not thread safe. Only a single thread may add filters at a time.
-	 * <p/>
+	 * <p>
 	 * Add the new filters to this CompositeFileListFilter while maintaining the existing filters.
 	 *
 	 * @param filtersToAdd a list of filters to add

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/locking/FileChannelCache.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/locking/FileChannelCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,9 +39,9 @@ final class FileChannelCache {
     /**
      * Try to get a lock for this file while guaranteeing that the same channel will be used for all file locks in this
      * VM. If the lock could not be acquired this method will return <code>null</code>.
-     * <p/>
+     * <p>
      * Locks acquired through this method should be passed back to #closeChannelFor to prevent memory leaks.
-     * <p/>
+     * <p>
      * Thread safe.
      */
     public static FileLock tryLockFor(File fileToLock) throws IOException {
@@ -65,7 +65,7 @@ final class FileChannelCache {
 
     /**
      * Close the channel for the file passed in.
-     * <p/>
+     * <p>
      * Thread safe.
      */
     public static void closeChannelFor(File fileToUnlock) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/locking/NioFileLocker.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/locking/NioFileLocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import java.util.concurrent.ConcurrentMap;
  * File locking strategy that uses java.nio. The locks taken by FileChannel are shared with all the threads in a single
  * JVM, so this locking strategy <b>does not</b> prevent files being picked up multiple times within the same JVM.
  * {@link FileReadingMessageSource}s sharing a Locker will not pick up the same files.
- * <p/>
+ * <p>
  * This implementation will acquire or create a {@link FileLock} for the given file. Caching locks might be expensive,
  * so this locking strategy is not recommended for scenarios where many files are accessed in parallel.
  *

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	private volatile String temporaryFileSuffix = ".writing";
 
 	/**
-	 * An {@link FileListFilter} that runs against the <emphasis>remote</emphasis> file system view.
+	 * An {@link FileListFilter} that runs against the <em>remote</em> file system view.
 	 */
 	private volatile FileListFilter<F> filter;
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/session/CachingSessionFactory.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/session/CachingSessionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class CachingSessionFactory<F> implements SessionFactory<F>, DisposableBe
 	public CachingSessionFactory(SessionFactory<F> sessionFactory) {
 		this(sessionFactory, 0);
 	}
-	
+
 	public CachingSessionFactory(SessionFactory<F> sessionFactory, int sessionCacheSize) {
 		this.sessionFactory = sessionFactory;
 		this.pool = new SimplePool<Session<F>>(sessionCacheSize, new SimplePool.PoolItemCallback<Session<F>>() {
@@ -67,9 +67,9 @@ public class CachingSessionFactory<F> implements SessionFactory<F>, DisposableBe
 
 
 	/**
-	 * Sets the limit of how long to wait for a session to become available. 
-	 * 
-	 * @throws {@link IllegalStateException} if the wait expires prior to a Session becoming available.
+	 * Sets the limit of how long to wait for a session to become available.
+	 *
+	 * @throws IllegalStateException if the wait expires prior to a Session becoming available.
 	 */
 	public void setSessionWaitTimeout(long sessionWaitTimeout) {
 		this.pool.setWaitTimeout(sessionWaitTimeout);
@@ -140,7 +140,7 @@ public class CachingSessionFactory<F> implements SessionFactory<F>, DisposableBe
 		public boolean mkdir(String directory) throws IOException {
 			return this.targetSession.mkdir(directory);
 		}
-		
+
 		public boolean exists(String path) throws IOException{
 			return this.targetSession.exists(path);
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ import org.springframework.util.ObjectUtils;
  * The implementation should run through any configured
  * {@link org.springframework.integration.file.filters.FileListFilter}s to
  * ensure the file entry is acceptable.
- * 
+ *
  * @author Josh Long
  * @author Mark Fisher
  * @author Oleg Zhurakousky
@@ -76,12 +76,12 @@ public abstract class AbstractInboundFileSynchronizer<F> implements InboundFileS
 	private final SessionFactory<F> sessionFactory;
 
 	/**
-	 * An {@link FileListFilter} that runs against the <emphasis>remote</emphasis> file system view.
+	 * An {@link FileListFilter} that runs against the <em>remote</em> file system view.
 	 */
 	private volatile FileListFilter<F> filter;
 
 	/**
-	 * Should we <emphasis>delete</emphasis> the remote <b>source</b> files
+	 * Should we <em>delete</em> the remote <b>source</b> files
 	 * after copying to the local directory? By default this is false.
 	 */
 	private volatile boolean deleteRemoteFiles;
@@ -132,7 +132,7 @@ public abstract class AbstractInboundFileSynchronizer<F> implements InboundFileS
 	protected final List<F> filterFiles(F[] files) {
 		return (this.filter != null) ? this.filter.filterFiles(files) : Arrays.asList(files);
 	}
-	
+
 	protected String getTemporaryFileSuffix() {
 		return temporaryFileSuffix;
 	}
@@ -179,7 +179,7 @@ public abstract class AbstractInboundFileSynchronizer<F> implements InboundFileS
 			}
 			return;
 		}
-				
+
 		File localFile = new File(localDirectory, localFileName);
 		if (!localFile.exists()) {
 			String tempFileName = localFile.getAbsolutePath() + this.temporaryFileSuffix;
@@ -211,7 +211,7 @@ public abstract class AbstractInboundFileSynchronizer<F> implements InboundFileS
 				catch (Exception ignored2) {
 				}
 			}
-			
+
 			if (tempFile.renameTo(localFile)) {
 				if (this.deleteRemoteFiles) {
 					session.remove(remoteFilePath);
@@ -222,7 +222,7 @@ public abstract class AbstractInboundFileSynchronizer<F> implements InboundFileS
 			}
 		}
 	}
-	
+
 	private String generateLocalFileName(String remoteFileName){
 		if (this.localFilenameGeneratorExpression != null){
 			return this.localFilenameGeneratorExpression.getValue(evaluationContext, remoteFileName, String.class);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -40,7 +40,7 @@ import org.springframework.util.ObjectUtils;
 /**
  * Base class charged with knowing how to connect to a remote file system,
  * scan it for new files and then download the files.
- * <p/>
+ * <p>
  * The implementation should run through any configured
  * {@link org.springframework.integration.file.filters.FileListFilter}s to
  * ensure the file entry is acceptable.

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,12 +40,12 @@ import org.springframework.util.Assert;
  * files TO the remote file system that exist uniquely in the local file system.
  * It only handles pulling from the remote file system - as you would expect
  * from an 'inbound' adapter).
- * <p/>
+ * <p>
  * The base class supports configuration of whether the remote file system and
  * local file system's directories should be created on start (what 'creating a
  * directory' means to the specific adapter is of course implementation
  * specific).
- * <p/>
+ * <p>
  * This class is to be used as a pair with an implementation of
  * {@link AbstractInboundFileSynchronizer}. The synchronizer must
  * handle the work of actually connecting to the remote file system and

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/config/FtpNamespaceHandler.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/config/FtpNamespaceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors
+ * Copyright 2002-2013 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import org.springframework.integration.file.config.RemoteFileOutboundChannelAdap
 
 /**
  * Provides namespace support for using FTP
- * <p/>
+ * <p>
  * This is *heavily* influenced by the good work done by Iwein before.
  *
  * @author Josh Long

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingController.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,9 +40,9 @@ import org.springframework.web.servlet.mvc.Controller;
 /**
  * Inbound HTTP endpoint that implements Spring's {@link Controller} interface to be used with a DispatcherServlet front
  * controller.
- * <p/>
+ * <p>
  * The {@link #setViewName(String) viewName} will be passed into the ModelAndView return value.
- * <p/>
+ * <p>
  * This endpoint will have request/reply behavior by default. That can be overridden by passing <code>false</code> to
  * the constructor. In the request/reply case, the core map will be passed to the view, and it will contain either the
  * reply Message or payload depending on the value of {@link #extractReplyPayload} (true by default, meaning just the

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -73,20 +73,20 @@ import org.springframework.web.util.UrlPathHelper;
 
 /**
  * Base class for HTTP request handling endpoints.
- * <p/>
+ * <p>
  * By default GET and POST requests are accepted, but the 'supportedMethods' property may be set to include others or
  * limit the options (e.g. POST only). A GET request will generate a payload containing its 'parameterMap' while a POST
  * request will be converted to a Message payload according to the registered {@link HttpMessageConverter}s. Several are
  * registered by default, but the list can be explicitly set via {@link #setMessageConverters(List)}.
- * <p/>
+ * <p>
  * To customize the mapping of request headers to the MessageHeaders, provide a reference to a {@link HeaderMapper
  * HeaderMapper<HttpHeaders>} implementation to the {@link #setHeaderMapper(HeaderMapper)} method.
- * <p/>
+ * <p>
  * The behavior is "request/reply" by default. Pass <code>false</code> to the constructor to force send-only as opposed
  * to sendAndReceive. Send-only means that as soon as the Message is created and passed to the
  * {@link #setRequestChannel(org.springframework.integration.MessageChannel) request channel}, a response will be
  * generated. Subclasses determine how that response is generated (e.g. simple status response or rendering a View).
- * <p/>
+ * <p>
  * In a request-reply scenario, the reply Message's payload will be extracted prior to generating a response by default.
  * To have the entire serialized Message available for the response, switch the {@link #extractReplyPayload} value to
  * <code>false</code>.

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -79,8 +79,9 @@ import org.springframework.web.util.UrlPathHelper;
  * request will be converted to a Message payload according to the registered {@link HttpMessageConverter}s. Several are
  * registered by default, but the list can be explicitly set via {@link #setMessageConverters(List)}.
  * <p>
- * To customize the mapping of request headers to the MessageHeaders, provide a reference to a {@link HeaderMapper
- * HeaderMapper<HttpHeaders>} implementation to the {@link #setHeaderMapper(HeaderMapper)} method.
+ * To customize the mapping of request headers to the MessageHeaders, provide a
+ * reference to a {@code HeaderMapper<HttpHeaders>} implementation
+ * to the {@link #setHeaderMapper(HeaderMapper)} method.
  * <p>
  * The behavior is "request/reply" by default. Pass <code>false</code> to the constructor to force send-only as opposed
  * to sendAndReceive. Send-only means that as soon as the Message is created and passed to the

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGateway.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,16 +42,16 @@ import org.springframework.web.HttpRequestHandler;
  * same name. If the {@link #expectReply} property is set to true, a response can generated from a reply Message.
  * Otherwise, the gateway will play the role of a unidirectional Channel Adapter with a simple status-based response
  * (e.g. 200 OK).
- * <p/>
+ * <p>
  * The default supported request methods are GET and POST, but the list of values can be configured with the
  * {@link #supportedMethods} property. The payload generated from a GET request (or HEAD or OPTIONS if supported) will
  * be a {@link MultiValueMap} containing the parameter values. For a request containing a body (e.g. a POST), the type
  * of the payload is determined by the {@link #setRequestPayloadType(Class) request payload type}.
- * <p/>
+ * <p>
  * If the HTTP request is a multipart and a "multipartResolver" bean has been defined in the context, then it will be
  * converted by the {@link MultipartAwareFormHttpMessageConverter} as long as the default message converters have not
  * been overwritten (although providing a customized instance of the Multipart-aware converter is also an option).
- * <p/>
+ * <p>
  * By default a number of {@link HttpMessageConverter}s are already configured. The list can be overridden by calling
  * the {@link #setMessageConverters(List)} method.
  *

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests.java
@@ -51,8 +51,8 @@ import com.sun.net.httpserver.HttpServer;
  * @author Gary Russell
  * @since 2.2
  *
- *         <p/>
- *         see https://jira.springsource.org/browse/INT-2397
+ * <p>
+ * see https://jira.springsource.org/browse/INT-2397
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2012 the original author or authors.
+ * Copyright 2001-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ import org.springframework.util.Assert;
  * single use connections, each request is blocked until the previous response is received
  * (or times out). Asynchronous requests/responses over the same connection are not
  * supported - use a pair of outbound/inbound adapters for that use case.
- * <p/>
+ * <p>
  * {@link SmartLifecycle} methods delegate to the underlying {@link AbstractConnectionFactory}
  *
  *

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -397,7 +397,7 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 
 	/**
 	 * How often we clean up closed NIO connections if soTimeout is 0.
-	 * Ignored when soTimeout > 0 because the clean up
+	 * Ignored when {@code soTimeout > 0} because the clean up
 	 * process is run as part of the timeout handling.
 	 * Default 2000 milliseconds.
 	 * @param nioHarvestInterval The interval in milliseconds.
@@ -504,7 +504,8 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 
 	/**
 	 *
-	 * Times out any expired connections then, if selectionCount > 0, processes the selected keys.
+	 * Times out any expired connections then, if {@code selectionCount > 0},
+	 * processes the selected keys.
 	 * Removes closed connections from the connections field, and from the connections parameter.
 	 *
 	 * @param selectionCount Number of IO Events, if 0 we were probably woken up by a close.

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/ClientModeCapable.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/ClientModeCapable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import org.springframework.jmx.export.annotation.ManagedOperation;
  * of running in client-mode. For inbound endpoints,
  * this means that the endpoint establishes the connection
  * and then receives incoming data.
- * <p/>
+ * <p>
  * For an outbound adapter, it means that the adapter
  * will establish the connection rather than waiting
  * for a message to cause the connection to be

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
@@ -59,17 +59,17 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 	 * data need a Listener to send the messages to.
 	 * This applies to client factories used for outbound gateways
 	 * or for a pair of collaborating channel adapters.
-	 * <p/>
+	 * <p>
 	 * During initialization, if a factory detects it has no listener
 	 * it's listening logic (active thread) is terminated.
-	 * <p/>
+	 * <p>
 	 * The listener registered with a factory is provided to each
 	 * connection it creates so it can call the onMessage() method.
-	 * <p/>
+	 * <p>
 	 * This code satisfies the first requirement in that this
 	 * listener signals to the factory that it needs to run
 	 * its listening logic.
-	 * <p/>
+	 * <p>
 	 * When we wrap actual connections with FailoverTcpConnections,
 	 * the connection is given the wrapper as a listener, so it
 	 * can enhance the headers in onMessage(); the wrapper then invokes

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
@@ -78,7 +78,7 @@ public class TcpMessageMapper implements
 	 * Override to provide additional headers. The standard headers cannot be overridden
 	 * and any such headers will be ignored if provided in the result.
 	 * @param connection the connection.
-	 * @return A Map of <String, ?> headers to be added to the message.
+	 * @return A Map of {@code <String, ?>} headers to be added to the message.
 	 */
 	protected Map<String, ?> supplyCustomHeaders(TcpConnection connection) {
 		return null;

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpSSLContextSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpSSLContextSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,8 @@ public interface TcpSSLContextSupport {
 	/**
 	 * Gets an SSLContext.
 	 * @return the SSLContext.
-	 * @throws Exception
+	 * @throws GeneralSecurityException
+	 * @throws IOException
 	 */
 	SSLContext getSSLContext() throws GeneralSecurityException, IOException;
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayLengthHeaderSerializer.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayLengthHeaderSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,51 +26,51 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * Reads data in an InputStream to a byte[]; data must be preceded by
- * a binary length (network byte order, not included in resulting byte[]). 
- * 
+ * a binary length (network byte order, not included in resulting byte[]).
+ *
  * Writes a byte[] to an OutputStream after a binary length.
  * The length field contains the length of data following the length
  * field. (network byte order).
- * 
+ *
  * The default length field is a 4 byte signed integer. During deserialization,
  * negative values will be rejected.
  * Other options are an unsigned byte, and unsigned short.
- * 
+ *
  * For other header formats, override {@link #readHeader(InputStream)} and
  * {@link #writeHeader(OutputStream, int)}.
- * 
+ *
  * @author Gary Russell
  * @since 2.0
  */
 public class ByteArrayLengthHeaderSerializer extends AbstractByteArraySerializer {
-	
-	
+
+
 	/**
 	 * Default length-header field, allows for data up to 2**31-1 bytes.
 	 */
 	public static final int HEADER_SIZE_INT = 4; // default
-	
+
 	/**
 	 * A single unsigned byte, for data up to 255 bytes.
 	 */
 	public static final int HEADER_SIZE_UNSIGNED_BYTE = 1;
-	
+
 	/**
 	 * An unsigned short, for data up to 2**16 bytes.
 	 */
 	public static final int HEADER_SIZE_UNSIGNED_SHORT = 2;
-	
+
 	private final int headerSize;
-	
+
 	private Log logger = LogFactory.getLog(this.getClass());
-	
+
 	/**
 	 * Constructs the serializer using {@link #HEADER_SIZE_INT}
 	 */
 	public ByteArrayLengthHeaderSerializer() {
 		this(HEADER_SIZE_INT);
 	}
-	
+
 	/**
 	 * Constructs the serializer using the supplied header size.
 	 * Valid header sizes are {@link #HEADER_SIZE_INT} (default),
@@ -85,21 +85,21 @@ public class ByteArrayLengthHeaderSerializer extends AbstractByteArraySerializer
 		}
 		this.headerSize = headerSize;
 	}
-	
+
 	/**
 	 * Reads the header from the stream and then reads the provided length
 	 * from the stream and returns the data in a byte[]. Throws an
 	 * IOException if the length field exceeds the maxMessageSize.
 	 * Throws a {@link SoftEndOfStreamException} if the stream
-	 * is closed between messages.  
+	 * is closed between messages.
 	 */
 	public byte[] deserialize(InputStream inputStream) throws IOException {
 		int messageLength = this.readHeader(inputStream);
 		if (logger.isDebugEnabled()) {
 			logger.debug("Message length is " + messageLength);
-		}	
+		}
 		if (messageLength > this.maxMessageSize) {
-			throw new IOException("Message length " + messageLength + 
+			throw new IOException("Message length " + messageLength +
 					" exceeds max message length: " + this.maxMessageSize);
 		}
 		byte[] messagePart = new byte[messageLength];
@@ -122,10 +122,10 @@ public class ByteArrayLengthHeaderSerializer extends AbstractByteArraySerializer
 	 * buffer is full or a socket timeout occurs.
 	 * @param buffer
 	 * @param header true if we are reading the header
-	 * @return < 0 if socket closed and not in the middle of a message
+	 * @return {@code< 0} if socket closed and not in the middle of a message
 	 * @throws IOException
 	 */
-	protected int read(InputStream inputStream, byte[] buffer, boolean header) 
+	protected int read(InputStream inputStream, byte[] buffer, boolean header)
 			throws IOException {
 		int lengthRead = 0;
 		int needed = buffer.length;
@@ -141,7 +141,7 @@ public class ByteArrayLengthHeaderSerializer extends AbstractByteArraySerializer
 			}
 			lengthRead += len;
 			if (logger.isDebugEnabled()) {
-				logger.debug("Read " + len + " bytes, buffer is now at " + 
+				logger.debug("Read " + len + " bytes, buffer is now at " +
 							 lengthRead + " of " +
 							 needed);
 			}
@@ -153,13 +153,13 @@ public class ByteArrayLengthHeaderSerializer extends AbstractByteArraySerializer
 	 * Writes the header, according to the header format.
 	 * @param outputStream
 	 * @param length
-	 * @throws IOException 
+	 * @throws IOException
 	 */
 	protected void writeHeader(OutputStream outputStream, int length) throws IOException {
 		ByteBuffer lengthPart = ByteBuffer.allocate(this.headerSize);
 		switch (this.headerSize) {
 		case HEADER_SIZE_INT:
-			lengthPart.putInt(length);			
+			lengthPart.putInt(length);
 			break;
 		case HEADER_SIZE_UNSIGNED_BYTE:
 			if (length > 0xff) {
@@ -178,7 +178,7 @@ public class ByteArrayLengthHeaderSerializer extends AbstractByteArraySerializer
 			lengthPart.putShort((short) length);
 			break;
 		default:
-			throw new IllegalArgumentException("Bad header size:" + headerSize);			
+			throw new IllegalArgumentException("Bad header size:" + headerSize);
 		}
 		outputStream.write(lengthPart.array());
 	}
@@ -187,7 +187,8 @@ public class ByteArrayLengthHeaderSerializer extends AbstractByteArraySerializer
 	 * Reads the header and returns the length of the data part.
 	 * @param inputStream
 	 * @return The length of the data part
-	 * @throws IOException, {@link SoftEndOfStreamException} if socket closes
+	 * @throws IOException
+	 * @throws SoftEndOfStreamException if socket closes
 	 * before any length data read.
 	 */
 	protected int readHeader(InputStream inputStream) throws IOException {
@@ -202,7 +203,7 @@ public class ByteArrayLengthHeaderSerializer extends AbstractByteArraySerializer
 			messageLength = ByteBuffer.wrap(lengthPart).getInt();
 			if (messageLength < 0) {
 				throw new IllegalArgumentException("Length header:"
-						+ messageLength 
+						+ messageLength
 						+ " is negative");
 			}
 			break;
@@ -213,7 +214,7 @@ public class ByteArrayLengthHeaderSerializer extends AbstractByteArraySerializer
 			messageLength = ByteBuffer.wrap(lengthPart).getShort() & 0xffff;
 			break;
 		default:
-			throw new IllegalArgumentException("Bad header size:" + headerSize);			
+			throw new IllegalArgumentException("Bad header size:" + headerSize);
 		}
 		return messageLength;
 	}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayRawSerializer.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayRawSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,12 @@ import java.io.OutputStream;
  * A byte array (de)serializer that does nothing with the payload; sends it raw.
  * Message termination for assembly purposes is signaled by the client closing the
  * connection. The serializer does not, itself, close the connection after
- * writing the bytes.<p/>
+ * writing the bytes.
+ * <p>
  * Because the socket must be closed to indicate message end, this (de)serializer
- * can only be used by uni-directional (non-collaborating) channel adapters, and 
+ * can only be used by uni-directional (non-collaborating) channel adapters, and
  * not by gateways.
- * 
+ *
  * @author Gary Russell
  * @since 2.0.3
  *

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/util/RegexUtils.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/util/RegexUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,26 +18,28 @@ package org.springframework.integration.ip.util;
 
 /**
  * Regular Expression Utilities.
- * 
+ *
  * @author Gary Russell
  * @since 2.0
  */
 public abstract class RegexUtils {
 
 	/**
-	 * Escapes (precedes with \) any characters in the parameter in the set<br/><br/>
-	 * <code>.$[]^*+{}()\?|</code><br/><br/>
+	 * Escapes (precedes with \) any characters in the parameter in the set
+	 * <p>
+	 * <code>.$[]^*+{}()\?|</code>
+	 * <p>
 	 * Used to escape a string that is used as a regular expression pattern, to remove
 	 * the special meaning of these characters.
 	 * @param stringToEscape The string to escape.
 	 * @return The escaped string.
 	 */
 	public static String escapeRegexSpecials(String stringToEscape) {
-		// In the following, we look for all the specials and any we find 
-		// are escaped in the output string, allowing that string to 
+		// In the following, we look for all the specials and any we find
+		// are escaped in the output string, allowing that string to
 		// be used as a pattern containing the literal specials.
 		String out = stringToEscape.replaceAll(
-				"(\\.|\\$|\\[|\\]|\\^|\\*|\\+|\\{|\\}|\\(|\\)|\\\\|\\?|\\|)", 
+				"(\\.|\\$|\\[|\\]|\\^|\\*|\\+|\\{|\\}|\\(|\\)|\\\\|\\?|\\|)",
 				"\\\\$1");
 		return out;
 	}

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/ExpressionEvaluatingSqlParameterSourceFactory.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/ExpressionEvaluatingSqlParameterSourceFactory.java
@@ -68,8 +68,9 @@ public class ExpressionEvaluatingSqlParameterSourceFactory extends AbstractExpre
 	 * context: generally in an outbound setting it is a Message, and in an inbound setting it is a result set row (a
 	 * Map or a domain object if a RowMapper has been provided). The {@link #setStaticParameters(Map) static parameters}
 	 * can be referred to in an expression using the variable <code>#staticParameters</code>, for example:
-	 *
-	 * <table border="1" cellspacing="1" cellpadding="1">
+	 * <p>
+	 * <table>
+	 * <caption>Parameter Expressions Samples</caption>
 	 * <tr>
 	 * <th><b>Key</b></th>
 	 * <th><b>Value (Expression)</b></th>
@@ -77,20 +78,21 @@ public class ExpressionEvaluatingSqlParameterSourceFactory extends AbstractExpre
 	 * </tr>
 	 * <tr>
 	 * <td>id</td>
-	 * <td>payload.businessKey</td>
-	 * <td>select * from items where id=:id</td>
+	 * <td>{@code payload.businessKey}</td>
+	 * <td>{@code select * from items where id=:id}</td>
 	 * </tr>
 	 * <tr>
 	 * <td>date</td>
-	 * <td>headers['timestamp']</td>
-	 * <td>select * from items where created>:date</td>
+	 * <td>{@code headers['timestamp']}</td>
+	 * <td>{@code select * from items where created>:date}</td>
 	 * </tr>
 	 * <tr>
 	 * <td>key</td>
-	 * <td>#staticParameters['foo'].toUpperCase()</td>
-	 * <td>select * from items where name=:key</td>
+	 * <td>{@code #staticParameters['foo'].toUpperCase()}</td>
+	 * <td>{@code select * from items where name=:key}</td>
 	 * </tr>
-	 * </pre>
+	 * </table>
+	 * <p>
 	 *
 	 * @param parameterExpressions the parameter expressions to set
 	 */

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
@@ -33,7 +33,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Default implementation of {@link JmsHeaderMapper}.
- * <p/>
+ * <p>
  * This implementation copies JMS API headers (e.g. JMSReplyTo) to and from
  * Spring Integration Messages. Any user-defined properties will also be copied
  * from a JMS Message to a Spring Integration Message, and any other headers
@@ -41,7 +41,7 @@ import org.springframework.util.StringUtils;
  * be copied to a JMS Message. Those other headers will be copied to the
  * general properties of a JMS Message whereas the JMS API headers are passed
  * to the appropriate setter methods (e.g. setJMSReplyTo).
- * <p/>
+ * <p>
  * Constants for the JMS API headers are defined in {@link JmsHeaders}.
  * Note that the JMSMessageID and JMSRedelivered flag are only copied
  * <em>from</em> a JMS Message. Those values will <em>not</em> be passed
@@ -67,7 +67,7 @@ public class DefaultJmsHeaderMapper implements JmsHeaderMapper {
 	 * Specify a prefix to be appended to the integration message header name
 	 * for any JMS property that is being mapped into the MessageHeaders.
 	 * The Default is an empty string (no prefix).
-	 * <p/>
+	 * <p>
 	 * This does not affect the JMS properties covered by the specification/API,
 	 * such as JMSCorrelationID, etc. The header names used for mapping such
 	 * properties are all defined in our {@link JmsHeaders}.
@@ -80,7 +80,7 @@ public class DefaultJmsHeaderMapper implements JmsHeaderMapper {
 	 * Specify a prefix to be appended to the JMS property name for any
 	 * integration message header that is being mapped into the JMS Message.
 	 * The Default is an empty string (no prefix).
-	 * <p/>
+	 * <p>
 	 * This does not affect the JMS properties covered by the specification/API,
 	 * such as JMSCorrelationID, etc. The header names used for mapping such
 	 * properties are all defined in our {@link JmsHeaders}.

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/NotificationPublishingMessageHandler.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/NotificationPublishingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,9 +81,9 @@ public class NotificationPublishingMessageHandler extends AbstractMessageHandler
 
 	/**
 	 * Specify a dot-delimited String representing the Notification type to
-	 * use by default when <emphasis>no</emphasis> explicit Notification mapper
+	 * use by default when <em>no</em> explicit Notification mapper
 	 * has been configured. If not provided, then a notification type header will
-	 * be required for each message being mapped into a Notification. 
+	 * be required for each message being mapped into a Notification.
 	 */
 	public void setDefaultNotificationType(String defaultNotificationType) {
 		this.defaultNotificationType = defaultNotificationType;

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/ExponentialMovingAverageRatio.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/ExponentialMovingAverageRatio.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2009-2010 the original author or authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -23,7 +23,8 @@ package org.springframework.integration.monitor;
  * last measurement time, <code>t</code> is the current time and <code>T</code> is the lapse period)</li>
  * <li>per measurement according to the lapse window supplied: <code>weight = exp(-i/L)</code> where <code>L</code> is
  * the lapse window and <code>i</code> is the sequence number of the measurement.</li>
- * 
+ * </ul>
+ *
  * @author Dave Syer
  * @since 2.0
  */

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/RemoteMBeanServerTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/RemoteMBeanServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,11 +33,11 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * To run, add JVM Args:
- * <p/>
+ * <p>
  * -Dspring.profiles.active=remote
- * -Dcom.sun.management.jmxremote.port=11099<p/>
- * -Dcom.sun.management.jmxremote.authenticate=false<p/>
- * -Dcom.sun.management.jmxremote.ssl=false<p/>
+ * -Dcom.sun.management.jmxremote.port=11099<p>
+ * -Dcom.sun.management.jmxremote.authenticate=false<p>
+ * -Dcom.sun.management.jmxremote.ssl=false<p>
  *
  * @author Gary Russell
  * @since 2.2

--- a/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/Int2307Tests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/Int2307Tests.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2002-2011 the original author or authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -45,6 +45,7 @@ public class Int2307Tests {
 		int bits = 0;
 		int count = 0;
 		for (ObjectInstance mbean : mbeans) {
+			Thread.sleep(500); //Added in order to pass test with Java 8
 			if (mbean.toString().startsWith("org.springframework.integration.router.RecipientListRouter[test.domain:type=RecipientListRouter,name=rlr,random=")) {
 				bits |= 1;
 				count++;
@@ -70,7 +71,7 @@ public class Int2307Tests {
 		// make sure there are no duplicate MBean ObjectNames if 2 contexts loaded from same config
 		new ClassPathXmlApplicationContext("single-config.xml", this.getClass());
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt2307_CustomMBeanExporter() throws Exception{

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2012 the original author or authors
+ * Copyright 2007-2013 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -227,14 +227,14 @@ public class RedisStoreWritingMessageHandler extends AbstractMessageHandler {
 	 * Will extract the payload from the Message and store it in the collection identified by the
 	 * key (which may be determined by an expression). The type of collection is specified by the
 	 * {@link #collectionType} property. The default CollectionType is LIST.
-	 * <p/>
+	 * <p>
 	 * The rules for storing the payload are:
-	 * <p/>
+	 * <p>
 	 * <b>LIST/SET</b>
 	 * If the payload is of type Collection and {@link #extractPayloadElements} is 'true' (default),
 	 * the payload will be added using the addAll() method. If {@link #extractPayloadElements}
 	 * is set to 'false', then regardless of the payload type, the payload will be added using add().
-	 * <p/>
+	 * <p>
 	 * <b>ZSET</b>
 	 * In addition to the rules described for LIST/SET, ZSET allows 'score' information
 	 * to be provided. The score can be provided using the {@link RedisHeaders#ZSET_SCORE} message header
@@ -242,7 +242,7 @@ public class RedisStoreWritingMessageHandler extends AbstractMessageHandler {
 	 * value to be saved and each corresponding Map 'value' is the score assigned to it.
 	 * If {@link #extractPayloadElements} is set to 'false' the map will be stored as a single entry.
 	 * If the 'score' can not be determined, the default value (1) will be used.
-	 * <p/>
+	 * <p>
 	 * <b>MAP/PROPERTIES</b>
 	 * You can also add items to a Map or Properties based store.
 	 * If the payload itself is of type Map or Properties, it can be stored either as a batch or single

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/HeaderMatcher.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/HeaderMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,13 +28,12 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 
 /**
- * <h2>Are the {@link MessageHeaders} of a {@link Message} containing any entry
- * or multiple that match?</h2>
- *
- *
- * <h3>
+ * Are the {@link MessageHeaders} of a {@link Message} containing any entry
+ * or multiple that match?
+ * <p>
  * For example using {@link Assert#assertThat(Object, Matcher)} for a single
- * entry:</h3>
+ * entry:
+ * <p>
  *
  * <pre>
  * ANY_HEADER_KEY = &quot;foo&quot;;
@@ -44,9 +43,9 @@ import static org.hamcrest.CoreMatchers.is;
  * assertThat(message, hasEntry(ANY_HEADER_KEY, notNullValue()));
  * assertThat(message, hasEntry(ANY_HEADER_KEY, is(ANY_HEADER_VALUE)));
  * </pre>
- *
- * <h3>For multiple entries to match all:</h3>
- *
+ * <p>
+ * For multiple entries to match all:
+ * <p>
  * <pre>
  * Map&lt;String, Object&gt; expectedInHeaderMap = new HashMap&lt;String, Object&gt;();
  * expectedInHeaderMap.put(ANY_HEADER_KEY, ANY_HEADER_VALUE);
@@ -54,8 +53,9 @@ import static org.hamcrest.CoreMatchers.is;
  * assertThat(message, HeaderMatcher.hasAllEntries(expectedInHeaderMap));
  * </pre>
  *
- * <h3>
- * For a single key:</h3>
+ * <p>
+ * For a single key:
+ * <p>
  *
  * <pre>
  * ANY_HEADER_KEY = &quot;foo&quot;;

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/MockitoMessageMatchers.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/MockitoMessageMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,18 +26,18 @@ import org.mockito.Mockito;
 import org.springframework.integration.Message;
 
 /**
- * <h2>Mockito matcher factory for {@link Message} matcher creation.</h2>
+ * Mockito matcher factory for {@link Message} matcher creation.
  * <p>
  * This class contains expressive factory methods for the most common Mockito
  * matchers needed when matching {@link Message}s. If you need a different
  * matching strategy, any Hamcrest matcher can be used in Mockito through
  * {@link Mockito#argThat(Matcher)}.
- * 
- * <h3>Example usage:</h3>
+ *
+ * Example usage:
  * <p>
  * With {@link Mockito#verify(Object)}:
  * </p>
- * 
+ *
  * <pre>
  * &#064;Mock
  * MessageHandler handler;
@@ -49,16 +49,16 @@ import org.springframework.integration.Message;
  * <p>
  * With {@link Mockito#when(Object)}:
  * </p>
- * 
+ *
  * <pre>
  * ...
  * when(channel.send(messageWithPayload(SOME_PAYLOAD))).thenReturn(true);
  * assertThat(channel.send(message), is(true));
  * </pre>
- * 
+ *
  * @author Alex Peters
  * @author Iwein Fuld
- * 
+ *
  */
 public class MockitoMessageMatchers {
 

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/PayloadAndHeaderMatcher.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/PayloadAndHeaderMatcher.java
@@ -1,5 +1,17 @@
-/**
- * 
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.springframework.integration.test.matcher;
 
@@ -15,23 +27,25 @@ import org.springframework.integration.MessageHeaders;
 
 /**
  * Matcher to make assertions about message equality easier. Usage:
- * 
+ *
  * <pre>
+ * {@code
  * &#064;Test
  * public void testSomething() {
  *   Message<String> expected = ...;
  *   Message<String> result = ...;
  *   assertThat(result, sameExceptImmutableHeaders(expected));
  * }
- * 
+ *
  * &#064;Factory
  * public static Matcher<Message<?>> sameExceptImmutableHeaders(Message<?> expected) {
  *   return new PayloadAndHeaderMatcher(expected);
  * }
+ * }
  * </pre>
- * 
+ *
  * @author Dave Syer
- * 
+ *
  */
 public class PayloadAndHeaderMatcher extends BaseMatcher<Message<?>> {
 

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/PayloadMatcher.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/PayloadMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,35 +23,33 @@ import org.junit.Assert;
 import org.springframework.integration.Message;
 
 /**
- * <h2>Is the payload of a {@link Message} equal to a given value or is matching
- * a given matcher?</h2>
- * 
- * <h3>
+ * Is the payload of a {@link Message} equal to a given value or is matching
+ * a given matcher?
+ * <p>
  * A Junit example using {@link Assert#assertThat(Object, Matcher)} could look
- * like this to test a payload value:</h3>
- * 
+ * like this to test a payload value:
+ * <p>
  * <pre>
  * ANY_PAYLOAD = new BigDecimal(&quot;1.123&quot;);
  * Message&lt;BigDecimal message = MessageBuilder.withPayload(ANY_PAYLOAD).build();
  * assertThat(message, hasPayload(ANY_PAYLOjAD));
  * </pre>
- * 
- * <h3>
+ * <p>
  * An example using {@link Assert#assertThat(Object, Matcher)} delegating to
- * another {@link Matcher}.</h3>
- * 
+ * another {@link Matcher}.
+ * <p>
  * <pre>
  * ANY_PAYLOAD = new BigDecimal(&quot;1.123&quot;);
  * assertThat(message, PayloadMatcher.hasPayload(is(BigDecimal.class)));
  * assertThat(message, PayloadMatcher.hasPayload(notNullValue()));
  * assertThat(message, not((PayloadMatcher.hasPayload(is(String.class))))); *
  * </pre>
- * 
- * 
- * 
+ *
+ *
+ *
  * @author Alex Peters
  * @author Iwein Fuld
- * 
+ *
  */
 @SuppressWarnings("rawtypes")
 public class PayloadMatcher extends TypeSafeMatcher<Message> {

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/TypeSafeMatcher.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/matcher/TypeSafeMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import java.lang.reflect.Method;
 /**
  * This class was copied from JUnit to avoid using it from org.junit.internal (causing a backwards compatibility issue).
  * If you want to extend this class use a recent version of JUnit, and extend
- * <code>org.junit.matchers.TypeSafeMatcher</code> 
- * <p/>
+ * <code>org.junit.matchers.TypeSafeMatcher</code>
+ * <p>
  * Convenient base class for Matchers that require a non-null value of a specific type.
  * This simply implements the null check, checks the type and then casts.
  *

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceInboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,14 +31,14 @@ import org.springframework.ws.support.MarshallingUtils;
  * @since 1.0.2
  */
 public class MarshallingWebServiceInboundGateway extends AbstractWebServiceInboundGateway {
-	
+
 	private volatile Marshaller marshaller;
 
 	private volatile Unmarshaller unmarshaller;
 
 	/**
 	 * Creates a new <code>MarshallingWebServiceInboundGateway</code>.
-	 * The {@link Marshaller} and {@link Unmarshaller} must be injected using properties. 
+	 * The {@link Marshaller} and {@link Unmarshaller} must be injected using properties.
 	 */
 	public MarshallingWebServiceInboundGateway() {
 	}
@@ -47,10 +47,10 @@ public class MarshallingWebServiceInboundGateway extends AbstractWebServiceInbou
 	 * Creates a new <code>MarshallingWebServiceInboundGateway</code> with the given marshaller.
 	 * The Marshaller must also implement {@link Unmarshaller}, since it is used for both marshalling and
 	 * unmarshalling.
-	 * <p/>
+	 * <p>
 	 * Note that all {@link Marshaller} implementations in Spring-OXM also implement the {@link Unmarshaller}
 	 * interface, so you can safely use this constructor for any of those implementations.
-	 * 
+	 *
 	 * @param marshaller object used as marshaller and unmarshaller
 	 * @throws IllegalArgumentException when <code>marshaller</code> does not implement {@link Unmarshaller}
 	 * @see #MarshallingWebServiceInboundGateway(Marshaller, Unmarshaller)
@@ -76,13 +76,13 @@ public class MarshallingWebServiceInboundGateway extends AbstractWebServiceInbou
 	public void setMarshaller(Marshaller marshaller) {
 		Assert.notNull(marshaller, "'marshaller' must no be null");
 		this.marshaller = marshaller;
-	}	
+	}
 
 	public void setUnmarshaller(Unmarshaller unmarshaller) {
 		Assert.notNull(unmarshaller, "'unmarshaller' must no be null");
 		this.unmarshaller = unmarshaller;
 	}
-	
+
 	protected void onInit() throws Exception {
 		super.onInit();
 		Assert.notNull(marshaller, "This implementation requires Marshaller");
@@ -95,16 +95,16 @@ public class MarshallingWebServiceInboundGateway extends AbstractWebServiceInbou
 		Assert.notNull(request, "Invalid message context: request was null.");
 		Object requestObject = MarshallingUtils.unmarshal(unmarshaller, request);
 		MessageBuilder<?> builder = MessageBuilder.withPayload(requestObject);
-		
+
 		this.fromSoapHeaders(messageContext, builder);
-		
+
 		Message<?> replyMessage = this.sendAndReceiveMessage(builder.build());
-		
+
 		if (replyMessage != null) {
 			WebServiceMessage response = messageContext.getResponse();
 			this.toSoapHeaders(response, replyMessage);
 
 			MarshallingUtils.marshal(marshaller, replyMessage.getPayload(), response);
-		}		
+		}
 	}
 }

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/XsltPayloadTransformer.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/XsltPayloadTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,22 +57,22 @@ import org.springframework.xml.transform.StringSource;
  * Thread safe XSLT transformer implementation which returns a transformed
  * {@link Source}, {@link Document}, or {@link String}. If
  * alwaysUseSourceResultFactories is false (default) the following logic occurs
- * <p/>
+ * <p>
  * {@link String} payload in results in {@link String} payload out
- * <p/>
+ * <p>
  * {@link Document} payload in results in {@link Document} payload out
- * <p/>
+ * <p>
  * {@link Source} payload in results in {@link Result} payload out, type will be
  * determined by the {@link ResultFactory}, {@link DomResultFactory} by default.
  * If an instance of {@link ResultTransformer} is registered this will be used
  * to convert the result.
- * <p/>
+ * <p>
  * If alwaysUseSourceResultFactories is true then the ResultFactory and
  * {@link SourceFactory} will be used to create the {@link Source} from the
  * payload and the {@link Result} to pass into the transformer. An instance of
  * {@link ResultTransformer} can also be provided to convert the Result prior to
  * returning.
- * 
+ *
  * @author Jonas Partner
  * @author Mark Fisher
  * @author Oleg Zhurakousky


### PR DESCRIPTION
For reference see: https://jira.springsource.org/browse/INT-2964
- `<li></li>` should be wrapped in `<ul></ul>`
- wrap code snippets in {@code myCode()}
- change `<code>false</false>` to `<code>false</code>`
- `<p/>` should be `<p>`
- `<emphasis>` should be `<em>`
- Mockito-all dependency causes JavaDoc error. Change dependency to Mockito-Core.
- In Java 8 there seems to be a timing issue coming up with test:

`org.springframework.integration_.mbeanexporterhelper.Int2307Tests#testInt2307_DefaultMBeanExporter()`
- Adding Thread.sleep(500) seems to help (But not completely solve test fairlures). May need to revisit with more recent JDK8 builds. If setting lower values, intermittent test failures start to appear.
