### PR TITLE
INT-2992 - Upgrade Derby Test Dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ subprojects { subproject ->
 		aspectjVersion = '1.6.8'
 		cglibVersion = '2.2'
 		commonsNetVersion = '3.0.1'
+		derbyVersion = '10.9.1.0'
 		easymockVersion = '2.3'
 		groovyVersion = '2.1.0'
 		hamcrestVersion = '1.3'
@@ -294,8 +295,8 @@ project('spring-integration-jdbc') {
 		testCompile project(":spring-integration-test")
 		testCompile "com.h2database:h2:1.3.160"
 		testCompile "hsqldb:hsqldb:1.8.0.10"
-		testCompile "org.apache.derby:derby:10.5.3.0_1"
-		testCompile "org.apache.derby:derbyclient:10.5.3.0_1"
+		testCompile "org.apache.derby:derby:$derbyVersion"
+		testCompile "org.apache.derby:derbyclient:$derbyVersion"
 
 		testCompile "org.powermock:powermock-module-junit4:1.5"
 		testCompile "org.powermock:powermock-api-mockito:1.5"
@@ -348,7 +349,7 @@ project('spring-integration-jpa') {
 		testCompile project(":spring-integration-test")
 		testCompile "com.h2database:h2:1.3.166"
 		testCompile "hsqldb:hsqldb:1.8.0.10"
-		testCompile "org.apache.derby:derby:10.5.3.0_1"
+		testCompile "org.apache.derby:derby:$derbyVersion"
 
 		testCompile "org.hibernate:hibernate-entitymanager:3.6.10.Final"
 		testCompile "org.eclipse.persistence:org.eclipse.persistence.jpa:2.3.2"

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreChannelTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreChannelTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" 
+<beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration" xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:int-jdbc="http://www.springframework.org/schema/integration/jdbc"
@@ -8,8 +8,13 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration/jdbc http://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd">
 
-	<jdbc:embedded-database id="dataSource" type="DERBY"/>
-	
+	<bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource" >
+		<property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+		<property name="url" value="jdbc:derby:memory:myDB;create=true" />
+		<property name="username" value="sa" />
+		<property name="password" value="sa" />
+	</bean>
+
 	<jdbc:initialize-database data-source="dataSource" ignore-failures="DROPS">
 		<jdbc:script location="${int.drop.script}" />
 		<jdbc:script location="${int.schema.script}" />
@@ -22,7 +27,7 @@
 	</channel>
 
 	<int:channel id="output"/>
-	
+
 	<int:logging-channel-adapter channel="output"/>
 
 	<bean id="queue" class="org.springframework.integration.store.MessageGroupQueue">

--- a/spring-integration-jdbc/src/test/resources/derby-stored-procedures-setup-context.xml
+++ b/spring-integration-jdbc/src/test/resources/derby-stored-procedures-setup-context.xml
@@ -5,7 +5,12 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<jdbc:embedded-database id="dataSource" type="DERBY"/>
+	<bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource" >
+		<property name="driverClassName" value="org.apache.derby.jdbc.EmbeddedDriver" />
+		<property name="url" value="jdbc:derby:memory:myDB;create=true" />
+		<property name="username" value="sa" />
+		<property name="password" value="sa" />
+	</bean>
 
 	<jdbc:initialize-database data-source="dataSource" ignore-failures="DROPS" >
 		<jdbc:script location="classpath:derby-stored-procedures-drops.sql"/>


### PR DESCRIPTION
- Upgrade Derby test dependencies to 10.9.1.0
- Due to test-failures switch from using the embedded-database namespace support for Derby to explicitly configured DataSource beans (DriverManagerDataSource)

For more details see: https://jira.springsource.org/browse/INT-2992
