### PR TITLE
INT-2996 Fix Class and Package Cycles

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@ package org.springframework.integration.context;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.integration.MessageChannel;
-import org.springframework.integration.store.MetadataStore;
+import org.springframework.integration.store.metadata.MetadataStore;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 
 /**
  * Utility methods for accessing common integration components from the BeanFactory.
- * 
+ *
  * @author Mark Fisher
  * @author Josh Long
  */

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/metadata/MetadataStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/metadata/MetadataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.store;
+package org.springframework.integration.store.metadata;
 
 /**
  * Strategy interface for storing metadata from certain adapters
  * to avoid duplicate delivery of messages, for example.
- * 
+ *
  * @author Josh Long
  * @author Oleg Zhurakousky
  * @author Mark Fisher

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/metadata/PropertiesPersistingMetadataStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/metadata/PropertiesPersistingMetadataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.store;
+package org.springframework.integration.store.metadata;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -24,7 +24,6 @@ import java.util.Properties;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
@@ -32,10 +31,10 @@ import org.springframework.util.DefaultPropertiesPersister;
 
 /**
  * Properties file-based implementation of {@link MetadataStore}. To avoid conflicts
- * each instance should be constructed with the unique key from which unique file name 
+ * each instance should be constructed with the unique key from which unique file name
  * will be generated. The file name will be 'persistentKey' + ".last.entry".
  * Files will be written to the 'java.io.tmpdir' +  "/spring-integration/".
- * 
+ *
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @since 2.0
@@ -68,7 +67,7 @@ public class PropertiesPersistingMetadataStore implements MetadataStore, Initial
 			}
 		}
 		catch (Exception e) {
-			throw new IllegalArgumentException("Failed to create metadata-store file '" 
+			throw new IllegalArgumentException("Failed to create metadata-store file '"
 					+ this.file.getAbsolutePath() + "'", e);
 		}
 		this.loadMetadata();
@@ -91,7 +90,7 @@ public class PropertiesPersistingMetadataStore implements MetadataStore, Initial
 		try {
 			outputStream = new FileOutputStream(this.file);
 			this.persister.store(this.metadata, outputStream, "Last feed entry");
-		} 
+		}
 		catch (IOException e) {
 			// not fatal for the functionality of the component
 			logger.warn("Failed to persist feed entry. This may result in a duplicate "
@@ -102,7 +101,7 @@ public class PropertiesPersistingMetadataStore implements MetadataStore, Initial
 				if (outputStream != null) {
 					outputStream.close();
 				}
-			} 
+			}
 			catch (IOException e) {
 				// not fatal for the functionality of the component
 				logger.warn("Failed to close FileOutputStream to " + this.file.getAbsolutePath(), e);

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/metadata/SimpleMetadataStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/metadata/SimpleMetadataStore.java
@@ -1,25 +1,26 @@
 /*
- * Copyright 2002-2010 the original author or authors.
- * 
+ * Copyright 2002-2013 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 
-package org.springframework.integration.store;
+package org.springframework.integration.store.metadata;
 
 import java.util.HashMap;
 import java.util.Map;
 
+
 /**
  * Simple implementation of {@link MetadataStore} that uses an in-memory map only.
  * The metadata will not be persisted across application restarts.
- * 
+ *
  * @author Mark Fisher
  * @since 2.0
  */

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/metadata/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/metadata/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides classes supporting metadata stores.
+ */
+package org.springframework.integration.store.metadata;

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/metadata/PropertiesPersistingMetadataStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/metadata/PropertiesPersistingMetadataStoreTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.store;
+package org.springframework.integration.store.metadata;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
-import org.springframework.integration.store.PropertiesPersistingMetadataStore;
+import org.springframework.integration.store.metadata.PropertiesPersistingMetadataStore;
 
 /**
  * @author Oleg Zhurakousky

--- a/spring-integration-feed/src/main/java/org/springframework/integration/feed/inbound/FeedEntryMessageSource.java
+++ b/spring-integration-feed/src/main/java/org/springframework/integration/feed/inbound/FeedEntryMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@ import org.springframework.integration.MessagingException;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.core.MessageSource;
-import org.springframework.integration.store.MetadataStore;
-import org.springframework.integration.store.SimpleMetadataStore;
+import org.springframework.integration.store.metadata.MetadataStore;
+import org.springframework.integration.store.metadata.SimpleMetadataStore;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -48,7 +48,7 @@ import com.sun.syndication.fetcher.impl.HttpURLFeedFetcher;
 /**
  * This implementation of {@link MessageSource} will produce individual
  * {@link SyndEntry}s for a feed identified with the 'feedUrl' attribute.
- * 
+ *
  * @author Josh Long
  * @author Mario Gray
  * @author Oleg Zhurakousky
@@ -102,6 +102,7 @@ public class FeedEntryMessageSource extends IntegrationObjectSupport implements 
 		this.metadataStore = metadataStore;
 	}
 
+	@Override
 	public String getComponentType() {
 		return "feed:inbound-channel-adapter";
 	}
@@ -186,7 +187,7 @@ public class FeedEntryMessageSource extends IntegrationObjectSupport implements 
 				Collections.sort(retrievedEntries, this.syndEntryComparator);
 				for (SyndEntry entry : retrievedEntries) {
 					Date entryDate = getLastModifiedDate(entry);
-					if ((entryDate != null && entryDate.getTime() > this.lastTime) 
+					if ((entryDate != null && entryDate.getTime() > this.lastTime)
 						|| (entryDate == null && withinNewEntries)) {
 						this.entries.add(entry);
 						withinNewEntries = true;

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests-file-usage-context.xml
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests-file-usage-context.xml
@@ -21,6 +21,6 @@
 
 	<bean id="fileUrlFeedFetcher" class="org.springframework.integration.feed.inbound.FileUrlFeedFetcher"/>
 
-	<bean id="metadataStore" class="org.springframework.integration.store.PropertiesPersistingMetadataStore"/>
+	<bean id="metadataStore" class="org.springframework.integration.store.metadata.PropertiesPersistingMetadataStore"/>
 
 </beans>

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
@@ -17,8 +17,8 @@
 package org.springframework.integration.feed.config;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -33,7 +33,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
@@ -44,7 +43,7 @@ import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.feed.inbound.FeedEntryMessageSource;
 import org.springframework.integration.history.MessageHistory;
-import org.springframework.integration.store.MetadataStore;
+import org.springframework.integration.store.metadata.MetadataStore;
 import org.springframework.integration.test.util.TestUtils;
 
 import com.sun.syndication.feed.synd.SyndEntry;

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FeedEntryMessageSourceTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FeedEntryMessageSourceTests.java
@@ -25,10 +25,8 @@ import java.net.URL;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.integration.Message;
-import org.springframework.integration.feed.inbound.FeedEntryMessageSource;
-import org.springframework.integration.store.PropertiesPersistingMetadataStore;
+import org.springframework.integration.store.metadata.PropertiesPersistingMetadataStore;
 
 import com.sun.syndication.feed.synd.SyndEntry;
 import com.sun.syndication.fetcher.FeedFetcher;

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionEvent.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionEvent.java
@@ -44,7 +44,7 @@ public class TcpConnectionEvent extends ApplicationEvent {
 
 	private final Throwable throwable;
 
-	public TcpConnectionEvent(TcpConnectionSupport connection, EventType type,
+	public TcpConnectionEvent(TcpConnection connection, EventType type,
 			String connectionFactoryName) {
 		super(connection);
 		this.type = type;
@@ -52,7 +52,7 @@ public class TcpConnectionEvent extends ApplicationEvent {
 		this.connectionFactoryName = connectionFactoryName;
 	}
 
-	public TcpConnectionEvent(TcpConnectionSupport connection, Throwable t,
+	public TcpConnectionEvent(TcpConnection connection, Throwable t,
 			String connectionFactoryName) {
 		super(connection);
 		this.type = TcpConnectionEventType.EXCEPTION;

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/inbound/AbstractTwitterMessageSource.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/inbound/AbstractTwitterMessageSource.java
@@ -1,4 +1,4 @@
-/* Copyright 2002-2012 the original author or authors.
+/* Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import org.springframework.integration.MessagingException;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.core.MessageSource;
-import org.springframework.integration.store.MetadataStore;
-import org.springframework.integration.store.SimpleMetadataStore;
+import org.springframework.integration.store.metadata.MetadataStore;
+import org.springframework.integration.store.metadata.SimpleMetadataStore;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.social.twitter.api.DirectMessage;
 import org.springframework.social.twitter.api.Tweet;

--- a/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceTests.java
+++ b/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceTests.java
@@ -16,6 +16,11 @@
 
 package org.springframework.integration.twitter.inbound;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,18 +29,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
 import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.config.PropertiesFactoryBean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.integration.Message;
-import org.springframework.integration.store.SimpleMetadataStore;
+import org.springframework.integration.store.metadata.SimpleMetadataStore;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.social.twitter.api.SearchOperations;
 import org.springframework.social.twitter.api.SearchResults;


### PR DESCRIPTION
INT-2996 Fix Package Cycle

Move interface ...store.MetadataStore to ...store.metadata.

INT-2996 Fix Class Tangle

TcpConnectionEvent incorrectly referenced the
concrete TcpConnectionSupport instead of TcpConnection.
