### PR TITLE
INT-2972 FixedMethodFilter - Return Mutable List

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/FixedMethodFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/FixedMethodFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.util;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,8 +29,9 @@ import org.springframework.util.Assert;
  * the same Method instance within a single-element list if it is
  * present in the candidate list. If the Method is not present
  * in the candidate list, it will return an empty list.
- * 
+ *
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.0
  */
 public class FixedMethodFilter implements MethodFilter {
@@ -45,7 +47,9 @@ public class FixedMethodFilter implements MethodFilter {
 
 	public List<Method> filter(List<Method> methods) {
 		if (methods != null && methods.contains(this.method)) {
-			return Collections.singletonList(this.method);
+			List<Method> filteredList = new ArrayList<Method>(1);
+			filteredList.add(this.method);
+			return filteredList;
 		}
 		return Collections.<Method>emptyList();
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -28,10 +28,11 @@ import java.util.Properties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.Rule;
 import org.junit.Test;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.rules.ExpectedException;
+import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageHandlingException;
 import org.springframework.integration.annotation.Header;
@@ -301,6 +302,15 @@ public class MethodInvokingMessageProcessorTests {
 	}
 
 	@Test
+	public void testProcessMessageMethodNotFound() throws Exception {
+		expected.expect(new ExceptionCauseMatcher(SpelEvaluationException.class));
+		TestDifferentErrorService service = new TestDifferentErrorService();
+		Method method = TestErrorService.class.getMethod("checked", String.class);
+		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		processor.processMessage(new GenericMessage<String>("foo"));
+	}
+
+	@Test
 	public void messageAndHeaderWithAnnotatedMethod() throws Exception {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("messageAndHeader", Message.class, Integer.class);
@@ -348,7 +358,7 @@ public class MethodInvokingMessageProcessorTests {
 	private static class ExceptionCauseMatcher extends TypeSafeMatcher<Exception> {
 		private Throwable cause;
 
-		private Class<? extends Exception> type;
+		private final Class<? extends Exception> type;
 
 		public ExceptionCauseMatcher(Class<? extends Exception> type) {
 			this.type = type;
@@ -373,6 +383,13 @@ public class MethodInvokingMessageProcessorTests {
 			throw new UnsupportedOperationException("Expected test exception");
 		}
 
+		public String checked(String input) throws Exception {
+			throw new CheckedException("Expected test exception");
+		}
+	}
+
+	@SuppressWarnings("unused")
+	private static class TestDifferentErrorService {
 		public String checked(String input) throws Exception {
 			throw new CheckedException("Expected test exception");
 		}


### PR DESCRIPTION
Compatibility with SF 3.2.2

Previously the filter returned a Collections.singletonList() when
a match is found.

Spring 3.2.2 attempts to sort the results of MethodFilter.filter()
which fails because the list is immutable.

Continue to return Collections.emptyList() with no match; this
does not cause the sort to fail.

Several tests in MethodInvokingMessageProcessorTests reproduce this
problem with Spring 3.2.2.

Add a test to confirm the Collections.emptyList() does not cause
any problems.

**cherry-pick to 2.2.x**
