### PR TITLE
INT-3001 Field Order in SyslogToMapTransformer

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/SyslogToMapTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/SyslogToMapTransformer.java
@@ -19,7 +19,7 @@ import java.io.UnsupportedEncodingException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -74,7 +74,7 @@ public class SyslogToMapTransformer extends AbstractPayloadTransformer<Object, M
 	}
 
 	private Map<String, ?> transform(String payload) {
-		Map<String, Object> map = new HashMap<String, Object>();
+		Map<String, Object> map = new LinkedHashMap<String, Object>();
 		Matcher matcher = pattern.matcher(payload);
 		if (matcher.matches()) {
 			try {

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/SysLogTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/SysLogTransformerTests.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Date;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.junit.Test;
 
@@ -44,6 +45,24 @@ public class SysLogTransformerTests {
 		assertEquals("WEBERN", transformed.get(SyslogToMapTransformer.HOST));
 		assertEquals("TESTING[70729]", transformed.get(SyslogToMapTransformer.TAG));
 		assertEquals("TEST SYSLOG MESSAGE", transformed.get(SyslogToMapTransformer.MESSAGE));
+
+		String[] fields = new String[] {SyslogToMapTransformer.FACILITY,
+				SyslogToMapTransformer.SEVERITY, SyslogToMapTransformer.TIMESTAMP, SyslogToMapTransformer.HOST,
+				SyslogToMapTransformer.TAG, SyslogToMapTransformer.MESSAGE};
+		Object[] values = new Object[] {19, 6, date, "WEBERN", "TESTING[70729]", "TEST SYSLOG MESSAGE"};
+		// check iteration order
+		int n = 0;
+		for (Entry<String, ?> entry : transformed.entrySet()) {
+			assertEquals(fields[n++], entry.getKey());
+		}
+		n = 0;
+		for (String key : transformed.keySet()) {
+			assertEquals(fields[n++], key);
+		}
+		n = 0;
+		for (Object value : transformed.values()) {
+			assertEquals(values[n++], value);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Use a LinkedHashMap instead of HashMap so iterators
retain the original field order.
