### PR TITLE
INT-3007 Add WARN Log When Advice Skipped

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
@@ -21,6 +21,7 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.aop.ProxyMethodInvocation;
 import org.springframework.integration.Message;
 import org.springframework.integration.context.IntegrationObjectSupport;
@@ -50,6 +51,11 @@ public abstract class AbstractRequestHandlerAdvice extends IntegrationObjectSupp
 				&& (arguments.length == 1 && arguments[0] instanceof Message);
 
 		if (!isMessageMethod) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("This advice " + this.getClass().getName() +
+						" can only be used for MessageHandlers; an attempt to advise method '" + method.getName() +
+						"' in '" + method.getDeclaringClass().getName() + "' is ignored");
+			}
 			return invocation.proceed();
 		}
 		else {


### PR DESCRIPTION
Trivial.

Previously, when a MessageHandlerAdvice is applied to something
other than a MessageHandler, the advice was silently skipped.

Add a WARN log message that warns that the advice is not applied.

Add a test case that ensure the log is emitted when the
advice is applied to a Poller.
