### PR TITLE
INT-2993: JCMStore: fix 'idCache' race condition

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -18,12 +18,16 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.sql.DataSource;
 
@@ -89,13 +93,21 @@ import org.springframework.util.StringUtils;
  * </p
  * >
  * @author Gunnar Hillert
+ * @author Artem Bilan
  * @since 2.2
  */
 @ManagedResource
 public class JdbcChannelMessageStore extends AbstractMessageGroupStore implements InitializingBean {
 
 	private static final Log logger = LogFactory.getLog(JdbcChannelMessageStore.class);
-	private final Set<String> idCache = Collections.newSetFromMap(new ConcurrentHashMap<String,Boolean>());
+
+	private final Set<String> idCache = new HashSet<String>();
+
+	private final ReadWriteLock idCacheLock = new ReentrantReadWriteLock();
+
+	private final Lock idCacheReadLock = idCacheLock.readLock();
+
+	private final Lock idCacheWriteLock = idCacheLock.writeLock();
 
 	/**
 	 * Default value for the table prefix property.
@@ -444,16 +456,22 @@ public class JdbcChannelMessageStore extends AbstractMessageGroupStore implement
 
 		final String query;
 
-		synchronized (idCache) {
+		final List<Message<?>> messages;
+
+		this.idCacheReadLock.lock();
+		try {
 			if (this.usingIdCache && !this.idCache.isEmpty()) {
 				query = getQuery(this.channelMessageStoreQueryProvider.getPollFromGroupExcludeIdsQuery());
 				parameters.addValue("message_ids", idCache);
 			} else {
 				query = getQuery(this.channelMessageStoreQueryProvider.getPollFromGroupQuery());
 			}
+			messages = namedParameterJdbcTemplate.query(query, parameters, messageRowMapper);
+		}
+		finally {
+			this.idCacheReadLock.unlock();
 		}
 
-		final List<Message<?>> messages = namedParameterJdbcTemplate.query(query, parameters, messageRowMapper);
 
 		Assert.isTrue(messages.size() == 0 || messages.size() == 1);
 		if (messages.size() > 0){
@@ -462,11 +480,16 @@ public class JdbcChannelMessageStore extends AbstractMessageGroupStore implement
 			final String messageId = message.getHeaders().getId().toString();
 
 			if (this.usingIdCache) {
+				this.idCacheWriteLock.lock();
+				try {
+					boolean added = this.idCache.add(messageId);
 
-				boolean added = this.idCache.add(messageId);
-
-				if (logger.isDebugEnabled()) {
-					logger.debug(String.format("Polled message with id '%s' added: '%s'.", messageId, added));
+					if (logger.isDebugEnabled()) {
+						logger.debug(String.format("Polled message with id '%s' added: '%s'.", messageId, added));
+					}
+				}
+				finally {
+					this.idCacheWriteLock.unlock();
 				}
 			}
 
@@ -612,7 +635,13 @@ public class JdbcChannelMessageStore extends AbstractMessageGroupStore implement
 		if (logger.isDebugEnabled()) {
 			logger.debug("Removing Message Id:" + messageId);
 		}
-		this.idCache.remove(messageId);
+		this.idCacheWriteLock.lock();
+		try {
+			this.idCache.remove(messageId);
+		}
+		finally {
+			this.idCacheWriteLock.unlock();
+		}
 	}
 
 	/**

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/HsqlTxTimeoutMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/HsqlTxTimeoutMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,6 +11,8 @@
  * specific language governing permissions and limitations under the License.
  */
 package org.springframework.integration.jdbc.store.channel;
+
+import java.util.concurrent.ExecutionException;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,9 +31,13 @@ public class HsqlTxTimeoutMessageStoreTests extends AbstractTxTimeoutMessageStor
 	@Test
 	@Override
 	public void test() throws InterruptedException {
-
 		super.test();
+	}
 
+	@Test
+	@Override
+	public void testInt2993IdCacheConcurrency() throws InterruptedException, ExecutionException {
+		super.testInt2993IdCacheConcurrency();
 	}
 
 }


### PR DESCRIPTION
Previously there was a concurrency race condition, where
`parameters` with `idCache` for poll Messages query had one state on building phase,
but had another one on execution phase.
- Introduce `ReentrantReadWriteLock` `idCacheLock` for operation around `idCache`
- Change `idCache` to simple `HashSet`, because thread-safety is guaranteed by `idCacheLock`
- Add a concurrency test-case, which failed before fix

JIRA: https://jira.springsource.org/browse/INT-2993
