### PR TITLE
Support Twitter API v1.1 in spring-integration-twitter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ subprojects { subproject ->
 		springDataRedisVersion = '1.0.2.RELEASE'
 		springGemfireVersion = '1.3.1.RELEASE'
 		springSecurityVersion = '3.1.3.RELEASE'
-		springSocialTwitterVersion = '1.0.1.RELEASE'
+		springSocialTwitterVersion = '1.0.4.BUILD-SNAPSHOT'
 		springWsVersion = '2.1.1.RELEASE'
 		springRetryVersion = '1.0.2.RELEASE'
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ subprojects { subproject ->
 		springDataRedisVersion = '1.0.2.RELEASE'
 		springGemfireVersion = '1.3.1.RELEASE'
 		springSecurityVersion = '3.1.3.RELEASE'
-		springSocialTwitterVersion = '1.0.4.BUILD-SNAPSHOT'
+		springSocialTwitterVersion = '1.0.4.RELEASE'
 		springWsVersion = '2.1.1.RELEASE'
 		springRetryVersion = '1.0.2.RELEASE'
 	}

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/inbound/MentionsReceivingMessageSource.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/inbound/MentionsReceivingMessageSource.java
@@ -42,7 +42,7 @@ public class MentionsReceivingMessageSource extends AbstractTwitterMessageSource
 
 	@Override
 	protected List<Tweet> pollForTweets(long sinceId) {
-		return this.getTwitter().timelineOperations().getMentions(1, 20, sinceId, 0);
+		return this.getTwitter().timelineOperations().getMentions(20, sinceId, 0);
 	}
 
 }

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSource.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSource.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.springframework.social.twitter.api.SearchResults;
 import org.springframework.social.twitter.api.Tweet;
 import org.springframework.social.twitter.api.Twitter;
+import org.springframework.social.twitter.api.impl.SearchParameters;
 import org.springframework.util.Assert;
 
 /**
@@ -51,7 +52,8 @@ public class SearchReceivingMessageSource extends AbstractTwitterMessageSource<T
 
 	@Override
 	protected List<Tweet> pollForTweets(long sinceId) {
-		SearchResults results = this.getTwitter().searchOperations().search(query, 20, sinceId, 0);
+		SearchParameters searchParameters = new SearchParameters(query).count(20).sinceId(sinceId);
+		SearchResults results = this.getTwitter().searchOperations().search(searchParameters);
 		return (results != null) ? results.getTweets() : Collections.<Tweet>emptyList();
 	}
 

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSource.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSource.java
@@ -51,7 +51,7 @@ public class SearchReceivingMessageSource extends AbstractTwitterMessageSource<T
 
 	@Override
 	protected List<Tweet> pollForTweets(long sinceId) {
-		SearchResults results = this.getTwitter().searchOperations().search(query, 1, 20, sinceId, 0);
+		SearchResults results = this.getTwitter().searchOperations().search(query, 20, sinceId, 0);
 		return (results != null) ? results.getTweets() : Collections.<Tweet>emptyList();
 	}
 

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/inbound/TimelineReceivingMessageSource.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/inbound/TimelineReceivingMessageSource.java
@@ -43,7 +43,7 @@ public class TimelineReceivingMessageSource extends AbstractTwitterMessageSource
 
 	@Override
 	protected List<Tweet> pollForTweets(long sinceId) {
-		return this.getTwitter().timelineOperations().getHomeTimeline(1, 20, sinceId, 0);
+		return this.getTwitter().timelineOperations().getHomeTimeline(20, sinceId, 0);
 	}
 
 }

--- a/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceTests.java
+++ b/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceTests.java
@@ -16,13 +16,8 @@
 
 package org.springframework.integration.twitter.inbound;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -36,6 +31,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.integration.Message;
 import org.springframework.integration.store.metadata.SimpleMetadataStore;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.social.twitter.api.SearchMetadata;
 import org.springframework.social.twitter.api.SearchOperations;
 import org.springframework.social.twitter.api.SearchResults;
 import org.springframework.social.twitter.api.Tweet;
@@ -118,7 +114,7 @@ public class SearchReceivingMessageSourceTests {
         final SearchOperations so = mock(SearchOperations.class);
 
 		when(twitterTemplate.searchOperations()).thenReturn(so);
-	    when(twitterTemplate.searchOperations().search(SEARCH_QUERY, 1, 20, 0, 0)).thenReturn(null);
+	    when(twitterTemplate.searchOperations().search(SEARCH_QUERY, 20, 0, 0)).thenReturn(null);
 
 		final SearchReceivingMessageSource messageSource = new SearchReceivingMessageSource(twitterTemplate);
 		messageSource.setQuery(SEARCH_QUERY);
@@ -155,12 +151,12 @@ public class SearchReceivingMessageSourceTests {
 		tweets.add(tweet2);
 		tweets.add(tweet3);
 
-		final SearchResults results = new SearchResults(tweets, 111, 111);
+		final SearchResults results = new SearchResults(tweets, new SearchMetadata(111, 111));
 
 		twitterTemplate = mock(TwitterTemplate.class);
 
 		when(twitterTemplate.searchOperations()).thenReturn(so);
-        when(twitterTemplate.searchOperations().search(SEARCH_QUERY, 1, 20, 0, 0)).thenReturn(results);
+		when(twitterTemplate.searchOperations().search(SEARCH_QUERY, 20, 0, 0)).thenReturn(results);
 
 		final SearchReceivingMessageSource messageSource = new SearchReceivingMessageSource(twitterTemplate);
 
@@ -168,8 +164,8 @@ public class SearchReceivingMessageSourceTests {
 
 		final List<Tweet> tweetSearchResults = messageSource.pollForTweets(0);
 
-        assertNotNull(tweetSearchResults);
-        assertTrue(tweetSearchResults.size() == 3);
+		assertNotNull(tweetSearchResults);
+		assertTrue(tweetSearchResults.size() == 3);
 
 	}
 

--- a/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceTests.java
+++ b/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceTests.java
@@ -36,6 +36,7 @@ import org.springframework.social.twitter.api.SearchOperations;
 import org.springframework.social.twitter.api.SearchResults;
 import org.springframework.social.twitter.api.Tweet;
 import org.springframework.social.twitter.api.Twitter;
+import org.springframework.social.twitter.api.impl.SearchParameters;
 import org.springframework.social.twitter.api.impl.TwitterTemplate;
 
 
@@ -156,7 +157,8 @@ public class SearchReceivingMessageSourceTests {
 		twitterTemplate = mock(TwitterTemplate.class);
 
 		when(twitterTemplate.searchOperations()).thenReturn(so);
-		when(twitterTemplate.searchOperations().search(SEARCH_QUERY, 20, 0, 0)).thenReturn(results);
+		SearchParameters params = new SearchParameters(SEARCH_QUERY).count(20).sinceId(0);
+		when(twitterTemplate.searchOperations().search(params)).thenReturn(results);
 
 		final SearchReceivingMessageSource messageSource = new SearchReceivingMessageSource(twitterTemplate);
 
@@ -165,7 +167,7 @@ public class SearchReceivingMessageSourceTests {
 		final List<Tweet> tweetSearchResults = messageSource.pollForTweets(0);
 
 		assertNotNull(tweetSearchResults);
-		assertTrue(tweetSearchResults.size() == 3);
+		assertEquals(3, tweetSearchResults.size());
 
 	}
 


### PR DESCRIPTION
Updated spring-integration-twitter's dependency on Spring Social Twitter to 1.0.4.BUILD-SNAPSHOT (and transitively to Spring Social Core to 1.0.3.BUILD-SNAPSHOT) to be able to use Twitter API 1.1.

Twitter API v1.0 will be retired on June 11, 2013, making this change necessary.

Note that although these dependencies are currently set to snapshot builds, I intend to push Spring Social Twitter 1.0.4.RELEASE and Spring Social Core 1.0.3.RELEASE builds on June 6, 2013. At that time, these dependencies can be updated accordingly.
