### PR TITLE
INT-2990 Remove System.Outs in PipelineJmsTests

### DIFF
--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineJmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineJmsTests.java
@@ -23,6 +23,12 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.MessageTimeoutException;
@@ -37,6 +43,12 @@ import org.springframework.integration.message.GenericMessage;
 public class PipelineJmsTests extends ActiveMQMultiContextTests {
 
 	private final Executor executor = Executors.newFixedThreadPool(30);
+	private static Log logger = LogFactory.getLog(PipelineJmsTests.class);
+
+	@Before
+	public void setLogLevel() {
+		LogManager.getLogger(getClass()).setLevel(Level.INFO);
+	}
 
 	int requests = 50;
 
@@ -159,9 +171,9 @@ public class PipelineJmsTests extends ActiveMQMultiContextTests {
 			latch.await();
 		}
 		finally {
-			System.out.println("Success: " + successCounter.get());
-			System.out.println("Timeout: " + timeoutCounter.get());
-			System.out.println("Failure: " + failureCounter.get());
+			logger.info("Success: " + successCounter.get());
+			logger.info("Timeout: " + timeoutCounter.get());
+			logger.info("Failure: " + failureCounter.get());
 			// technically all we care that its > 0,
 			// but reality of this test it has to be something more then 0
 			assertTrue(successCounter.get() > 10);


### PR DESCRIPTION
PipelineJmsTests contains a few System.out.println statements. Consider replacing them with a log statement.
