### PR TITLE
INT-3053 Allow task-executor on <reply-listener/>

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
@@ -24,6 +24,7 @@ import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.jms.JmsOutboundGateway;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
+
 import org.w3c.dom.Element;
 
 /**
@@ -123,6 +124,7 @@ public class JmsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "idle-consumer-limit");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "idle-task-execution-limit");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "cache-level");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "task-executor");
 
 		gatewayBuilder.addPropertyValue("replyContainerProperties", builder.getBeanDefinition());
 	}

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-2.2.xsd
@@ -760,6 +760,20 @@
 						</xsd:attribute>
 						<xsd:attributeGroup ref="dmlcAttributeGroup" />
 						<xsd:attribute name="receive-timeout" type="xsd:string"/>
+						<xsd:attribute name="task-executor" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation><![CDATA[
+		A reference to a Spring TaskExecutor (or standard JDK 1.5+ Executor) for receiving
+		the replies and handing them over to the sending thread.
+		Default is a SimpleAsyncTaskExecutor.
+								]]></xsd:documentation>
+								<xsd:appinfo>
+									<tool:annotation kind="ref">
+										<tool:expected-type type="java.util.concurrent.Executor"/>
+									</tool:annotation>
+								</xsd:appinfo>
+							</xsd:annotation>
+						</xsd:attribute>
 					</xsd:complexType>
 				</xsd:element>
 			</xsd:choice>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsOutboundGatewayTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsOutboundGatewayTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jms;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import javax.jms.ConnectionFactory;
+
+import org.springframework.integration.jms.JmsOutboundGateway.ReplyContainerProperties;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.util.ObjectUtils;
+
+import org.junit.Test;
+
+/**
+ * @author Gary Russell
+ * @since 3.0
+ *
+ */
+public class JmsOutboundGatewayTests {
+
+	@Test
+	public void testContainerBeanNameWhenNoGatewayBeanName() {
+		JmsOutboundGateway gateway = new JmsOutboundGateway();
+		gateway.setConnectionFactory(mock(ConnectionFactory.class));
+		gateway.setRequestDestinationName("foo");
+		gateway.setUseReplyContainer(true);
+		gateway.setReplyContainerProperties(new ReplyContainerProperties());
+		gateway.afterPropertiesSet();
+		assertEquals("JMS_OutboundGateway@" + ObjectUtils.getIdentityHexString(gateway) +
+				".replyListener",
+			TestUtils.getPropertyValue(gateway, "replyContainer.beanName"));
+	}
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsOutboundGatewayParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsOutboundGatewayParserTests.java
@@ -30,6 +30,7 @@ import javax.jms.DeliveryMode;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
@@ -80,6 +81,7 @@ public class JmsOutboundGatewayParserTests {
 		assertEquals(2, TestUtils.getPropertyValue(container, "idleTaskExecutionLimit"));
 		assertEquals(3, TestUtils.getPropertyValue(container, "cacheLevel"));
 		assertTrue(container.isSessionTransacted());
+		assertSame(context.getBean("exec"), TestUtils.getPropertyValue(container, "taskExecutor"));
 	}
 
 	@Test

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithDeliveryPersistent.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithDeliveryPersistent.xml
@@ -3,10 +3,13 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:si="http://www.springframework.org/schema/integration"
 	xmlns:jms="http://www.springframework.org/schema/integration/jms"
+	xmlns:task="http://www.springframework.org/schema/task"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
 			http://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
 			http://www.springframework.org/schema/integration/spring-integration.xsd
+			http://www.springframework.org/schema/task
+			http://www.springframework.org/schema/task/spring-task.xsd
 			http://www.springframework.org/schema/integration/jms
 			http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd">
 
@@ -26,8 +29,11 @@
 			recovery-interval="10000"
 			idle-consumer-limit="7"
 			idle-task-execution-limit="2"
+			task-executor="exec"
 			cache-level="3" />
 	</jms:outbound-gateway>
+
+	<task:executor id="exec" />
 
 	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>


### PR DESCRIPTION
JMS Outbound Gateway did not allow the specification of
a task executor on the <reply-listener/> element.

This could prevent the gateway being used with a
listener in a JEE container.

Allow setting a task-executor.

Add a bean name to the reply listener container so
that a default TE will create suitably named threads.

**this is a cherry-pick from master, excluding the 3.0 schema**
