### PR TITLE
Do not attempt to evaluate uri variables that are not in the URL

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -81,6 +81,7 @@ import org.springframework.web.util.UriTemplate;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Wallace Wadge
  * @since 2.0
  */
 public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMessageHandler {
@@ -346,6 +347,9 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 		Assert.notNull(uri, "URI Expression evaluation cannot result in null");
 		List<String> uriVariableNames = new UriTemplate(uri).getVariableNames();
 		
+		if (logger.isWarnEnabled() && this.uriVariableExpressions.size() != uriVariableNames.size()){
+			logger.warn("The number of URI variables expecting resolution in the provided uri do not match those in the provided variables");
+		}
 		try {
 			Map<String, Object> uriVariables = new HashMap<String, Object>();
 			for (String var : uriVariableNames) {
@@ -353,7 +357,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 				if (exp != null){
 					Object value = exp.getValue(this.evaluationContext, requestMessage, String.class);
 					uriVariables.put(var, value);
-				}
+				} 
 			}
 
 			HttpMethod httpMethod = this.determineHttpMethod(requestMessage);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/UriVariableExpressionTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/UriVariableExpressionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.integration.message.GenericMessage;
 /**
  * @author Dave Syer
  * @author Mark Fisher
+ * @author Wallace Wadge
  * @since 2.0
  */
 public class UriVariableExpressionTests {
@@ -65,9 +66,10 @@ public class UriVariableExpressionTests {
 		assertEquals("intentional", exception.getCause().getMessage());
 		assertEquals("http://test/bar", uriHolder.get().toString());
 	}
-
+	
+	/** Test for INT-3054: Do not break if there are extra uri variables defined in the http outbound gateway. */
 	@Test
-	public void testFromMessageWithSuperfluousExpressions() throws Exception {
+	public void testFromMessageWithSuperfluousExpressionsInt3054() throws Exception {
 		final AtomicReference<URI> uriHolder = new AtomicReference<URI>();
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler("http://test/{foo}");
 		SpelExpressionParser parser = new SpelExpressionParser();


### PR DESCRIPTION
The http gateway might not know what uri variables it might obtain in the URI.
This patch makes sure that only the uri variables defined in the uri are parsed (the rest are ignored)

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
