### PR TITLE
INT-3063: 'Expires' HTTP header workaround

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ import org.springframework.util.StringUtils;
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.0
  */
 public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanFactoryAware, InitializingBean{
@@ -826,8 +827,17 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			return (StringUtils.hasText(eTag)) ? eTag : null;
 		}
 		else if (EXPIRES.equalsIgnoreCase(name)) {
-			long expires = source.getExpires();
-			return (expires > -1) ? expires : null;
+			try {
+				long expires = source.getExpires();
+				return (expires > -1) ? expires : null;
+			}
+			catch (Exception e) {
+				if(logger.isDebugEnabled()) {
+					logger.debug(e.getMessage());
+				}
+				// According to RFC 2616
+				return null;
+			}
 		}
 		else if (IF_NONE_MATCH.equalsIgnoreCase(name)) {
 			return source.getIfNoneMatch();

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
@@ -42,6 +42,7 @@ import org.springframework.util.CollectionUtils;
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @author Gunnar Hillert
+ * @author Artem Bilan
  * @since 2.0.1
  */
 public class DefaultHttpHeaderMapperFromMessageOutboundTests {
@@ -658,4 +659,13 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
         mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
         assertNull(headers.get("Content-Length"));
     }
+
+	@Test
+	public void testInt3063InvalidExpiresHeader() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Expires", "-1");
+		Map<String, Object> messageHeaders = DefaultHttpHeaderMapper.outboundMapper().toHeaders(headers);
+		assertEquals(0, messageHeaders.size());
+	}
+
 }


### PR DESCRIPTION
According to RFC 2616 HTTP clients should ignore invalid values
for date-aware headers, but Spring MVC `HttpHeaders` raises
`IllegalArgumentException` in this case.
Proposal fix to Spring Integration just to `try...catch` call of
`HttpHeaders.getExpires()` and `return null`.

**Cherry-picked to 2.2.x**

JIRA: https://jira.springsource.org/browse/INT-3063
