### PR TITLE
INT-2243: Delayer: add support of 'expression'

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springframework.integration.config.xml;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.config.ExpressionFactoryBean;
+import org.springframework.integration.expression.DynamicExpression;
 import org.springframework.integration.handler.DelayHandler;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
@@ -43,13 +45,22 @@ public class DelayerParser extends AbstractConsumerEndpointParser {
 
 		String defaultDelay = element.getAttribute("default-delay");
 		String delayHeaderName = element.getAttribute("delay-header-name");
+		String expression = element.getAttribute(EXPRESSION_ATTRIBUTE);
+		Element expressionElement = DomUtils.getChildElementByTagName(element, "expression");
 
 		boolean hasDefaultDelay = StringUtils.hasText(defaultDelay);
 		boolean hasDelayHeaderName = StringUtils.hasText(delayHeaderName);
+		boolean hasExpression = StringUtils.hasText(expression);
+		boolean hasExpressionElement = expressionElement != null;
 
-		if (!(hasDefaultDelay | hasDelayHeaderName)) {
+		if (!(hasDefaultDelay | hasDelayHeaderName | hasExpression | hasExpressionElement)) {
 			parserContext.getReaderContext()
-					.error("The 'default-delay' or 'delay-header-name' attributes should be provided.", element);
+					.error("The 'default-delay' or 'delay-header-name', or 'expression' attributes, or 'expression' sub-element should be provided.", element);
+		}
+
+		if (hasExpression & hasExpressionElement) {
+			parserContext.getReaderContext()
+					.error("'expression' attribute and 'expression' sub-element are mutually exclusive.", element);
 		}
 
 		builder.addConstructorArgValue(id + ".messageGroupId");
@@ -62,6 +73,25 @@ public class DelayerParser extends AbstractConsumerEndpointParser {
 		if (hasDefaultDelay) {
 			builder.addPropertyValue("defaultDelay", defaultDelay);
 		}
+
+		BeanDefinitionBuilder expressionBuilder = null;
+		if (hasExpression) {
+			expressionBuilder = BeanDefinitionBuilder.genericBeanDefinition(ExpressionFactoryBean.class);
+			expressionBuilder.addConstructorArgValue(expression);
+		}
+		else if(expressionElement != null) {
+			expressionBuilder = BeanDefinitionBuilder.genericBeanDefinition(
+					DynamicExpression.class);
+			String key = expressionElement.getAttribute("key");
+			String expressionSourceReference = expressionElement.getAttribute("source");
+			expressionBuilder.addConstructorArgValue(key);
+			expressionBuilder.addConstructorArgReference(expressionSourceReference);
+		}
+
+		if (expressionBuilder != null) {
+			builder.addPropertyValue("delayExpression", expressionBuilder.getBeanDefinition());
+		}
+
 		if (hasDelayHeaderName) {
 			builder.addPropertyValue("delayHeaderName", delayHeaderName);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
@@ -58,9 +58,9 @@ public class DelayerParser extends AbstractConsumerEndpointParser {
 					.error("The 'default-delay' or 'delay-header-name', or 'expression' attributes, or 'expression' sub-element should be provided.", element);
 		}
 
-		if (hasExpression & hasExpressionElement) {
+		if ((hasDelayHeaderName & (hasExpression | hasExpressionElement)) | (hasExpression & hasExpressionElement)) {
 			parserContext.getReaderContext()
-					.error("'expression' attribute and 'expression' sub-element are mutually exclusive.", element);
+					.error("'delay-header-name', 'expression' attribute and 'expression' sub-element are mutually exclusive.", element);
 		}
 
 		builder.addConstructorArgValue(id + ".messageGroupId");

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DelayerParser.java
@@ -98,6 +98,7 @@ public class DelayerParser extends AbstractConsumerEndpointParser {
 
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-store");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "send-timeout");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "ignore-expression-failures");
 
 		Element txElement = DomUtils.getChildElementByTagName(element, "transactional");
 		Element adviceChainElement = DomUtils.getChildElementByTagName(element, "advice-chain");

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -282,7 +282,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 			messageWrapper = (DelayedMessageWrapper) message.getPayload();
 		}
 		else {
-			messageWrapper = new DelayedMessageWrapper(message);
+			messageWrapper = new DelayedMessageWrapper(message, System.currentTimeMillis());
 			delayedMessage = MessageBuilder.withPayload(messageWrapper).copyHeaders(message.getHeaders()).build();
 			this.messageStore.addMessageToGroup(this.messageGroupId, delayedMessage);
 		}
@@ -381,12 +381,13 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 
 		private static final long serialVersionUID = -4739802369074947045L;
 
-		private final long requestDate = System.currentTimeMillis();
+		private final long requestDate;
 
 		private final Message<?> original;
 
-		private DelayedMessageWrapper(Message<?> original) {
+		DelayedMessageWrapper(Message<?> original, long requestDate) {
 			this.original = original;
+			this.requestDate = requestDate;
 		}
 
 		public long getRequestDate() {

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -1354,8 +1354,8 @@
 			<xsd:documentation>
 				Defines an endpoint that passes a Message to the output-channel after a
 				delay. The delay may
-				be
-				retrieved from a Message header or else fallback to the
+				be dynamically determined by evaluating an expression
+				(such as a Message header) or fallback to the
 				'default-delay' of this endpoint.
 			</xsd:documentation>
 		</xsd:annotation>
@@ -1382,7 +1382,8 @@
 			<xsd:element name="expression" type="innerExpressionType" minOccurs="0" maxOccurs="1" >
 				<xsd:annotation>
 					<xsd:documentation>
-						Specify the SpEL expression to evaluate the delay value.
+						Specify the SpEL expression to evaluate the delay value in milliseconds,
+						or a java.util.Date.
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
@@ -1402,7 +1403,8 @@
 		<xsd:attribute name="expression" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation>
-					Specify the SpEL expression to evaluate the delay value.
+					Specify the SpEL expression to evaluate the delay value in milliseconds,
+					or a java.util.Date.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -1379,6 +1379,13 @@
 					to proxy DelayHandler's 'release Message task'.
 				</xsd:documentation>
 			</xsd:annotation>
+			<xsd:element name="expression" type="innerExpressionType" minOccurs="0" maxOccurs="1" >
+				<xsd:annotation>
+					<xsd:documentation>
+						Specify the SpEL expression to evaluate the delay value.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="transactional" type="transactionalType" minOccurs="0" maxOccurs="1" />
 			<xsd:element name="advice-chain" type="adviceChainType" minOccurs="0" maxOccurs="1" />
 		</xsd:choice>
@@ -1388,22 +1395,27 @@
 					Specify the default delay in milliseconds. This value can be set to 0
 					if the only Messages
 					that
-					should be delayed are those with a particular header (in that
-					case, be sure to provide
-					a value for the
-					'delay-header-name' attribute).
+					should be delayed are those with a particular expression evaluation result.
 					</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="expression" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specify the SpEL expression to evaluate the delay value.
+				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="delay-header-name" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation>
-					Specify the name of the header that should contain the delay value.
+					[DEPRECATED]Specify the name of the header that should contain the delay value.
 					This value can either
 					represent the number of milliseconds to delay counting from the current
 					time or it can be an
 					absolute Date until
 					which the Message should be delayed.
+					This attribute is deprecated in favor of 'expression' attribute or sub-element.
 					</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -1408,6 +1408,18 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="ignore-expression-failures" type="xsd:string" default="true">
+			<xsd:annotation>
+				<xsd:documentation>
+					Specify whether Exceptions thrown by 'expression' evaluation should be
+					ignored (only logged). In this case case the delayer makes fallback to the
+					 to the 'default-delay'. Default behaviour.
+					If this attribute is specified as 'false', any
+					'expression' evaluation Exception will be thrown to the caller without
+					fallback to the to the 'default-delay'.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="delay-header-name" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests-context.xml
@@ -60,7 +60,8 @@
 	<delayer id="delayerWithExpression"
 			 input-channel="input"
 			 output-channel="output"
-			 expression="100"/>
+			 expression="100"
+			 ignore-expression-failures="false"/>
 
 	<beans:bean id="delayerSource"
 		  class="org.springframework.integration.expression.ReloadableResourceBundleExpressionSource"

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests-context.xml
@@ -57,6 +57,21 @@
 		</advice-chain>
 	</delayer>
 
+	<delayer id="delayerWithExpression"
+			 input-channel="input"
+			 output-channel="output"
+			 expression="100"/>
+
+	<beans:bean id="delayerSource"
+		  class="org.springframework.integration.expression.ReloadableResourceBundleExpressionSource"
+		  p:basename="org/springframework/integration/config/xml/delayer-expression"/>
+
+	<delayer id="delayerWithExpressionSubElement"
+			 input-channel="input"
+			 output-channel="output">
+		<expression key="delay" source="delayerSource"/>
+	</delayer>
+
 	<beans:bean id="testScheduler" class="org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler"
 				p:poolSize="7"
 				p:waitForTasksToCompleteOnShutdown="true"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
@@ -137,6 +137,7 @@ public class DelayerParserTests {
 		DelayHandler delayHandler = context.getBean("delayerWithExpression.handler", DelayHandler.class);
 		assertNull(TestUtils.getPropertyValue(delayHandler, "delayHeaderName"));
 		assertEquals("100", TestUtils.getPropertyValue(delayHandler, "delayExpression", Expression.class).getExpressionString());
+		assertFalse(TestUtils.getPropertyValue(delayHandler, "ignoreExpressionFailures", Boolean.class));
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
@@ -32,6 +32,7 @@ import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.Ordered;
+import org.springframework.expression.Expression;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.handler.DelayHandler;
 import org.springframework.integration.test.util.TestUtils;
@@ -58,19 +59,16 @@ public class DelayerParserTests {
 
 	@Test
 	public void defaultScheduler() {
-		Object endpoint = context.getBean("delayerWithDefaultScheduler");
-		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object handler = TestUtils.getPropertyValue(endpoint, "handler");
-		assertEquals(DelayHandler.class, handler.getClass());
-		DelayHandler delayHandler = (DelayHandler) handler;
+		DelayHandler delayHandler = context.getBean("delayerWithDefaultScheduler.handler", DelayHandler.class);
 		assertEquals(99, delayHandler.getOrder());
-		DirectFieldAccessor accessor = new DirectFieldAccessor(delayHandler);
-		assertEquals(context.getBean("output"), accessor.getPropertyValue("outputChannel"));
-		assertEquals(new Long(1234), accessor.getPropertyValue("defaultDelay"));
-		assertEquals("foo", accessor.getPropertyValue("delayHeaderName"));
-		assertEquals(new Long(987), new DirectFieldAccessor(
-				accessor.getPropertyValue("messagingTemplate")).getPropertyValue("sendTimeout"));
-		assertNull(accessor.getPropertyValue("taskScheduler"));
+		assertEquals(context.getBean("output"), TestUtils.getPropertyValue(delayHandler, "outputChannel"));
+		assertEquals(new Long(1234), TestUtils.getPropertyValue(delayHandler, "defaultDelay", Long.class));
+		assertEquals("foo", TestUtils.getPropertyValue(delayHandler, "delayHeaderName"));
+		//INT-2243
+		assertNotNull(TestUtils.getPropertyValue(delayHandler, "delayExpression"));
+		assertEquals("headers['foo']", TestUtils.getPropertyValue(delayHandler, "delayExpression", Expression.class).getExpressionString());
+		assertEquals(new Long(987), TestUtils.getPropertyValue(delayHandler, "messagingTemplate.sendTimeout", Long.class));
+		assertNull(TestUtils.getPropertyValue(delayHandler, "taskScheduler"));
 	}
 
 	@Test
@@ -132,6 +130,20 @@ public class DelayerParserTests {
 		assertEquals(NameMatchTransactionAttributeSource.class, transactionAttributeSource.getClass());
 		HashMap<?, ?> nameMap = TestUtils.getPropertyValue(transactionAttributeSource, "nameMap", HashMap.class);
 		assertEquals("{*=PROPAGATION_REQUIRES_NEW,ISOLATION_DEFAULT,readOnly}", nameMap.toString());
+	}
+
+	@Test
+	public void testInt2243Expression() {
+		DelayHandler delayHandler = context.getBean("delayerWithExpression.handler", DelayHandler.class);
+		assertNull(TestUtils.getPropertyValue(delayHandler, "delayHeaderName"));
+		assertEquals("100", TestUtils.getPropertyValue(delayHandler, "delayExpression", Expression.class).getExpressionString());
+	}
+
+	@Test
+	public void testInt2243ExpressionSubElement() {
+		DelayHandler delayHandler = context.getBean("delayerWithExpressionSubElement.handler", DelayHandler.class);
+		assertNull(TestUtils.getPropertyValue(delayHandler, "delayHeaderName"));
+		assertEquals("headers.timestamp + 1000", TestUtils.getPropertyValue(delayHandler, "delayExpression", Expression.class).getExpressionString());
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests-context.xml
@@ -55,4 +55,15 @@
 
 	<beans:bean id="sampleHandler" class="org.springframework.integration.config.xml.DelayerUsageTests$SampleService"/>
 
+	<channel id="inputC"/>
+
+	<channel id="outputC">
+		<queue/>
+	</channel>
+
+	<beans:bean id="time" class="java.util.Calendar" factory-method="getInstance"/>
+
+	<delayer id="delayerExpression" input-channel="inputC" output-channel="outputC" expression="new java.util.Date(@time.timeInMillis + 5000)"/>
+
+
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerUsageTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,13 @@ public class DelayerUsageTests {
 	@Autowired @Qualifier("outputB1")
 	private PollableChannel outputB1;
 
+	@Autowired
+	private MessageChannel inputC;
+
+	@Autowired
+	private PollableChannel outputC;
+
+
 	@Test
 	public void testDelayWithDefaultScheduler(){
 		long start = System.currentTimeMillis();
@@ -107,6 +114,16 @@ public class DelayerUsageTests {
 		assertNotNull(message);
 		assertTrue((System.currentTimeMillis() - start) >= 1000);
 		assertEquals("hello", message.getPayload());
+	}
+
+	@Test
+	public void testInt2243DelayerExpression() {
+		long start = System.currentTimeMillis();
+		this.inputC.send(new GenericMessage<String>("test"));
+		Message<?> message = this.outputC.receive(10000);
+		assertNotNull(message);
+		assertTrue((System.currentTimeMillis() - start) >= 1000);
+		assertEquals("test", message.getPayload());
 	}
 
 	public static class SampleService{

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/delayer-expression.properties
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/delayer-expression.properties
@@ -1,0 +1,1 @@
+delay=headers.timestamp + 1000

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
@@ -53,6 +53,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gunnar Hillert
+ * @author Gary Russell
  * @since 1.0.3
  */
 public class DelayHandlerTests {
@@ -111,7 +112,7 @@ public class DelayHandlerTests {
 	@Test
 	public void delayHeaderAndDefaultDelayWouldTimeout() throws Exception {
 		delayHandler.setDefaultDelay(5000);
-		setDelayExpression();
+		this.setDelayExpression();
 		this.startDelayerHandler();
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", 100).build();
@@ -124,7 +125,7 @@ public class DelayHandlerTests {
 	@Test
 	public void delayHeaderIsNegativeAndDefaultDelayWouldTimeout() throws Exception {
 		delayHandler.setDefaultDelay(5000);
-		setDelayExpression();
+		this.setDelayExpression();
 		this.startDelayerHandler();
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", -7000).build();
@@ -137,7 +138,7 @@ public class DelayHandlerTests {
 	@Test
 	public void delayHeaderIsInvalidFallsBackToDefaultDelay() throws Exception {
 		delayHandler.setDefaultDelay(5);
-		setDelayExpression();
+		this.setDelayExpression();
 		this.startDelayerHandler();
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", "not a number").build();
@@ -150,7 +151,7 @@ public class DelayHandlerTests {
 	@Test
 	public void delayHeaderIsDateInTheFutureAndDefaultDelayWouldTimeout() throws Exception {
 		delayHandler.setDefaultDelay(5000);
-		setDelayExpression();
+		this.setDelayExpression();
 		this.startDelayerHandler();
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", new Date(new Date().getTime() + 150)).build();
@@ -163,7 +164,7 @@ public class DelayHandlerTests {
 	@Test
 	public void delayHeaderIsDateInThePastAndDefaultDelayWouldTimeout() throws Exception {
 		delayHandler.setDefaultDelay(5000);
-		setDelayExpression();
+		this.setDelayExpression();
 		this.startDelayerHandler();
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", new Date(new Date().getTime() - 60 * 1000)).build();
@@ -175,7 +176,7 @@ public class DelayHandlerTests {
 
 	@Test
 	public void delayHeaderIsNullDateAndDefaultDelayIsZero() throws Exception {
-		setDelayExpression();
+		this.setDelayExpression();
 		this.startDelayerHandler();
 		Date nullDate = null;
 		Message<?> message = MessageBuilder.withPayload("test")
@@ -188,7 +189,7 @@ public class DelayHandlerTests {
 
 	@Test(expected = TestTimedOutException.class)
 	public void delayHeaderIsFutureDateAndTimesOut() throws Exception {
-		setDelayExpression();
+		this.setDelayExpression();
 		this.startDelayerHandler();
 		Date future = new Date(new Date().getTime() + 60 * 1000);
 		Message<?> message = MessageBuilder.withPayload("test")
@@ -202,7 +203,7 @@ public class DelayHandlerTests {
 	@Test
 	public void delayHeaderIsValidStringAndDefaultDelayWouldTimeout() throws Exception {
 		delayHandler.setDefaultDelay(5000);
-		setDelayExpression();
+		this.setDelayExpression();
 		this.startDelayerHandler();
 		Message<?> message = MessageBuilder.withPayload("test")
 			.setHeader("delay", "20").build();
@@ -278,7 +279,7 @@ public class DelayHandlerTests {
 		MessagePublishingErrorHandler errorHandler = new MessagePublishingErrorHandler();
 		errorHandler.setDefaultErrorChannel(errorChannel);
 		taskScheduler.setErrorHandler(errorHandler);
-		setDelayExpression();
+		this.setDelayExpression();
 		this.startDelayerHandler();
 		output.unsubscribe(resultHandler);
 		errorChannel.subscribe(resultHandler);
@@ -311,7 +312,7 @@ public class DelayHandlerTests {
 		MessagePublishingErrorHandler errorHandler = new MessagePublishingErrorHandler();
 		errorHandler.setBeanFactory(context);
 		taskScheduler.setErrorHandler(errorHandler);
-		setDelayExpression();
+		this.setDelayExpression();
 		this.startDelayerHandler();
 		output.unsubscribe(resultHandler);
 		customErrorChannel.subscribe(resultHandler);
@@ -342,7 +343,7 @@ public class DelayHandlerTests {
 		MessagePublishingErrorHandler errorHandler = new MessagePublishingErrorHandler();
 		errorHandler.setBeanFactory(context);
 		taskScheduler.setErrorHandler(errorHandler);
-		setDelayExpression();
+		this.setDelayExpression();
 		this.startDelayerHandler();
 		output.unsubscribe(resultHandler);
 		defaultErrorChannel.subscribe(resultHandler);
@@ -365,7 +366,7 @@ public class DelayHandlerTests {
 
 	private void setDelayExpression() {
 		Expression expression = new SpelExpressionParser().parseExpression("headers.delay");
-		delayHandler.setDelayExpression(expression);
+		this.delayHandler.setDelayExpression(expression);
 	}
 
 

--- a/src/reference/docbook/delayer.xml
+++ b/src/reference/docbook/delayer.xml
@@ -28,7 +28,7 @@
       If you need per-Message determination of the delay, then you can also provide the SpEL expression
       using the 'expression' attribute:
       <programlisting language="xml"><![CDATA[<int:delayer id="delayer" input-channel="input" output-channel="output"
-             default-delay="3000" expression="headers.delay"/>]]></programlisting>
+             default-delay="3000" expression="headers['delay']"/>]]></programlisting>
       In the example above, the 3 second delay would only apply when the expression evaluates to
       <emphasis>null</emphasis> for a given inbound Message. If you only want to apply a delay to Messages that have
       a valid result of the expression evaluation, then you can use a 'default-delay' of 0 (the default).
@@ -45,7 +45,32 @@
         sender's Thread. If the expression evaluation result is not a Date, and can not be parsed as a Long, the default
         delay (if any) will be applied.
       </tip>
+      <important>
+        The expression evaluation may not just result to non-valid delay value. It may throws an evaluation Exception
+        in cases the Message is not valid or the system is in some inconsistent state (if you are using some scoped beans from
+        'expression'). Do not ignore similar exceptions and don't fallback to the default delay and just throw those
+        exceptions to the caller, along with 'expression' support, was introduced <code>ignore-expression-failures</code> attribute.
+        By default this attribute has value <code>true</code> and the Delayer behaviour is as described above.
+        However, if there is a reason do not ignore expression evaluation exceptions and throw them to the delayer's caller,
+        it is necessary to set <code>ignore-expression-failures</code> attribute to <code>false</code>.
+      </important>
     </para>
+	  <tip>
+		  If you noticed above the delay expression is specified as <code>headers['delay']</code>.
+		  It is SpEL <emphasis>Indexer</emphasis> syntax. In case of <interfacename>Map</interfacename> expression variable
+		  (as it is for <classname>MessageHeaders</classname>), it is equals to: <code>headers.get("delay");</code>.
+		  There is another shortcut trick - SpEL <emphasis>dot accessor</emphasis> syntax, where, the mention above header expression,
+		  can be specify as <code>headers.delay</code>. But, on the background, the SpEL engine uses other APIs to get the value of that
+		  expression evaluation, and, if there is no similar map entry in the 'headers' Map variable, the evaluation ends up with
+		  something like this:
+		  <programlisting language="java"><![CDATA[ org.springframework.expression.spel.SpelEvaluationException: EL1008E:(pos 8):
+		   Field or property 'delay' cannot be found on object of type 'org.springframework.integration.MessageHeaders']]></programlisting>
+		  So, if you don't interested in similar exceptions and getting the <code>null</code> value from 'headers'
+		  (or any other Map expression variable) for specified <code>key</code> is appropriate, it's recommended to use
+		  <emphasis>Indexer</emphasis> syntax instead of <emphasis>dot property accessor</emphasis> syntax. It's especially
+		  valuable for Delayer, when it does fallback to the default 'delay', if the expression evaluation results to the <code>null</code>:
+		  it won't be so expensive, than catch '<emphasis>property not found</emphasis>' SpEL Exception.
+	  </tip>
     <para>
       The delayer delegates to an instance of Spring's <interfacename>TaskScheduler</interfacename> abstraction.
       The default scheduler used by the delayer is the <classname>ThreadPoolTaskScheduler</classname> instance

--- a/src/reference/docbook/delayer.xml
+++ b/src/reference/docbook/delayer.xml
@@ -21,22 +21,21 @@
     <para>
       The <code>&lt;delayer&gt;</code> element is used to delay the Message flow between two Message Channels.
       As with the other endpoints, you can provide the 'input-channel' and 'output-channel' attributes,
-      but the delayer also has 'default-delay' and 'delay-header-name' attributes that are used to
-      determine the number of milliseconds
-      that each Message should be delayed. The following delays all messages by 3 seconds:
+      but the delayer also has 'default-delay' and 'expression' attributes (or 'expression' sub-element) that are used to
+      determine the number of milliseconds that each Message should be delayed. The following delays all messages by 3 seconds:
       <programlisting language="xml"><![CDATA[<int:delayer id="delayer" input-channel="input"
              default-delay="3000" output-channel="output"/>]]></programlisting>
-      If you need per-Message determination of the delay, then you can also provide the name of a header
-      using the 'delay-header-name' attribute:
+      If you need per-Message determination of the delay, then you can also provide the SpEL expression
+      using the 'expression' attribute:
       <programlisting language="xml"><![CDATA[<int:delayer id="delayer" input-channel="input" output-channel="output"
-             default-delay="3000" delay-header-name="delay"/>]]></programlisting>
-      In the example above the 3 second delay would only apply in the case that the header value is
-      not present for a given inbound Message. If you only want to apply a delay to Messages that have
-      an explicit header value, then you can set the 'default-delay' to 0 or don't use it at all (by default it is 0).
+             default-delay="3000" expression="headers.delay"/>]]></programlisting>
+      In the example above the 3 second delay would only apply in the case that the expression evaluation is resulted to
+      <emphasis>null</emphasis> for a given inbound Message. If you only want to apply a delay to Messages that have
+      a valid result of expression evaluation, then you can set the 'default-delay' to 0 or don't use it at all (by default it is 0).
       For any Message that has a delay of 0 (or less), the Message will be sent directly. In fact, if there is not a positive delay
       value for a Message, it will be sent to the output channel on the calling Thread.
       <tip>
-        The delay handler supports header values that represent an interval in milliseconds (any
+        The delay handler supports expression evaluation results that represent an interval in milliseconds (any
         Object whose <methodname>toString()</methodname> method produces a value that can be parsed into a
         Long) as well as <classname>java.util.Date</classname> instances representing an absolute time.
         In the first case, the milliseconds will be counted from the current time (e.g. a value of 5000
@@ -44,7 +43,7 @@
         With a Date instance, the Message will not be released until that Date
         occurs. In either case, a value that equates to a non-positive delay, or a Date in the past, will
         not result in any delay. Instead, it will be sent directly to the output channel on the original
-        sender's Thread. If the header is not a Date, and can not be parsed as a Long, the default
+        sender's Thread. If the expression evaluation result is not a Date, and can not be parsed as a Long, the default
         delay (if any) will be applied.
       </tip>
     </para>
@@ -55,7 +54,7 @@
       If you want to delegate to a different scheduler, you can provide a reference through the delayer element's
       'scheduler' attribute:
       <programlisting language="xml"><![CDATA[<int:delayer id="delayer" input-channel="input" output-channel="output"
-    delay-header-name="delay"
+    expression="headers.delay"
     scheduler="exampleTaskScheduler"/>
 
 <task:scheduler id="exampleTaskScheduler" pool-size="3"/>]]></programlisting>
@@ -106,7 +105,7 @@
       <interfacename>org.aopalliance.aop.Advice</interfacename> implementation within the <code>&lt;advice-chain&gt;</code>.
       A sample configuration of the <code>&lt;delayer&gt;</code> may look like this:
       <programlisting language="xml"><![CDATA[<int:delayer id="delayer" input-channel="input" output-channel="output"
-    delay-header-name="delay"
+    expression="headers.delay"
     message-store="jdbcMessageStore">
     <int:advice-chain>
         <beans:ref bean="customAdviceBean"/>

--- a/src/reference/docbook/delayer.xml
+++ b/src/reference/docbook/delayer.xml
@@ -29,19 +29,18 @@
       using the 'expression' attribute:
       <programlisting language="xml"><![CDATA[<int:delayer id="delayer" input-channel="input" output-channel="output"
              default-delay="3000" expression="headers.delay"/>]]></programlisting>
-      In the example above the 3 second delay would only apply in the case that the expression evaluation is resulted to
+      In the example above, the 3 second delay would only apply when the expression evaluates to
       <emphasis>null</emphasis> for a given inbound Message. If you only want to apply a delay to Messages that have
-      a valid result of expression evaluation, then you can set the 'default-delay' to 0 or don't use it at all (by default it is 0).
-      For any Message that has a delay of 0 (or less), the Message will be sent directly. In fact, if there is not a positive delay
-      value for a Message, it will be sent to the output channel on the calling Thread.
+      a valid result of the expression evaluation, then you can use a 'default-delay' of 0 (the default).
+      For any Message that has a delay of 0 (or less), the Message will be sent immediately, on the calling Thread.
       <tip>
         The delay handler supports expression evaluation results that represent an interval in milliseconds (any
         Object whose <methodname>toString()</methodname> method produces a value that can be parsed into a
         Long) as well as <classname>java.util.Date</classname> instances representing an absolute time.
         In the first case, the milliseconds will be counted from the current time (e.g. a value of 5000
         would delay the Message for at least 5 seconds from the time it is received by the Delayer).
-        With a Date instance, the Message will not be released until that Date
-        occurs. In either case, a value that equates to a non-positive delay, or a Date in the past, will
+        With a Date instance, the Message will not be released until the time represented by that Date object.
+        In either case, a value that equates to a non-positive delay, or a Date in the past, will
         not result in any delay. Instead, it will be sent directly to the output channel on the original
         sender's Thread. If the expression evaluation result is not a Date, and can not be parsed as a Long, the default
         delay (if any) will be applied.

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -191,7 +191,7 @@
 				For more information see <xref linkend="chain"/>.
 			</para>
 		</section>
-<section id="3.0-stored-proc-sql-return-type">
+		<section id="3.0-stored-proc-sql-return-type">
 			<title>SqlReturnType support for Stored Procedure components</title>
 			<para>
 				For more complex database-specific types, not supported by the standard
@@ -210,13 +210,15 @@
 		<section id="3.0-dalay-expression">
 			<title>Delayer: delay expression</title>
 			<para>
-				Previously, the <code>&lt;delayer&gt;</code> provided a <code>delay-header-name</code> attribute
+				Previously, the <code>&lt;delayer&gt;</code> provided a <code>delay-header-name</code> attribute only
 				to determine the <emphasis>delay</emphasis> value at runtime. In complex cases it was necessary
 				to precede the <code>&lt;delayer&gt;</code> with a <code>&lt;header-enricher&gt;</code>.
 				Spring Integration 3.0 introduced the <code>expression</code> attribute and <code>expression</code>
 				sub-element for dynamic delay determination. The <code>delay-header-name</code> attribute is now deprecated
-				because a header can be specified in the <code>expression</code>.
+				because the header evaluation can be specified in the <code>expression</code>. In addition to power of
+				<code>expression</code> support was introduced an <code>ignore-expression-failures</code> boolean attribute.
 				For more information see <xref linkend="delayer"/>.
 			</para>
-		</section>	</section>
+		</section>
+	</section>
 </chapter>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -191,7 +191,7 @@
 				For more information see <xref linkend="chain"/>.
 			</para>
 		</section>
-		<section id="3.0-stored-proc-sql-return-type">
+<section id="3.0-stored-proc-sql-return-type">
 			<title>SqlReturnType support for Stored Procedure components</title>
 			<para>
 				For more complex database-specific types, not supported by the standard
@@ -207,5 +207,15 @@
 				For more information see <xref linkend="stored-procedures"/>.
 			</para>
 		</section>
-	</section>
+		<section id="3.0-dalay-expression">
+			<title>Delayer: delay expression</title>
+			<para>
+				Previously, the <code>&lt;delayer&gt;</code> provided only <code>delay-header-name</code> attribute
+				to determine the <emphasis>delay</emphasis> value at runtime. In complex cases there was need
+				to precede the <code>&lt;delayer&gt;</code> with <code>&lt;header-enricher&gt;</code>.
+				Spring Integration 3.0 introduced <code>expression</code> attribute and <code>expression</code>
+				sub-element for dinamic expression. <code>delay-header-name</code> attribute was deprecated.
+				For more information see <xref linkend="delayer"/>.
+			</para>
+		</section>	</section>
 </chapter>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -210,11 +210,12 @@
 		<section id="3.0-dalay-expression">
 			<title>Delayer: delay expression</title>
 			<para>
-				Previously, the <code>&lt;delayer&gt;</code> provided only <code>delay-header-name</code> attribute
-				to determine the <emphasis>delay</emphasis> value at runtime. In complex cases there was need
-				to precede the <code>&lt;delayer&gt;</code> with <code>&lt;header-enricher&gt;</code>.
-				Spring Integration 3.0 introduced <code>expression</code> attribute and <code>expression</code>
-				sub-element for dinamic expression. <code>delay-header-name</code> attribute was deprecated.
+				Previously, the <code>&lt;delayer&gt;</code> provided a <code>delay-header-name</code> attribute
+				to determine the <emphasis>delay</emphasis> value at runtime. In complex cases it was necessary
+				to precede the <code>&lt;delayer&gt;</code> with a <code>&lt;header-enricher&gt;</code>.
+				Spring Integration 3.0 introduced the <code>expression</code> attribute and <code>expression</code>
+				sub-element for dynamic delay determination. The <code>delay-header-name</code> attribute is now deprecated
+				because a header can be specified in the <code>expression</code>.
 				For more information see <xref linkend="delayer"/>.
 			</para>
 		</section>	</section>


### PR DESCRIPTION
Previously, the `<delayer>` provided only `delay-header-name` attribute.
In complex cases there was need to precede it with `<header-enricher>`.
- Add support for 'expression' attribute and sub-element
- Deprecate `delay-header-name`
- Make `DelayHandler.DelayedMessageWrapper` _public_ to allow access for Messages in the Store
- Add tests
- Add 'What's new' section
- Polishing Delayer's doc regarding new abilities

JIRA: https://jira.springsource.org/browse/INT-2243, https://jira.springsource.org/browse/INT-3049
