### PR TITLE
INT-3067: Xslt method=text StringResult coercion

### DIFF
--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/config/XmlNamespaceUtils.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/config/XmlNamespaceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,10 @@ import org.springframework.util.StringUtils;
 
 /**
  * Utility methods for the XML namespace.
- * 
+ *
  * @author Jonas Partner
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 abstract class XmlNamespaceUtils {
 
@@ -54,7 +55,7 @@ abstract class XmlNamespaceUtils {
 		else if (resultType.equals(STRING_RESULT)) {
 			builder.addPropertyValue("resultFactory", new StringResultFactory());
 		}
-		else {
+		else if (resultType.equals(DOM_RESULT)) {
 			builder.addPropertyValue("resultFactory", new DomResultFactory());
 		}
 	}

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/XsltPayloadTransformer.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/XsltPayloadTransformer.java
@@ -76,6 +76,7 @@ import org.springframework.xml.transform.StringSource;
  * @author Jonas Partner
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  */
 public class XsltPayloadTransformer extends AbstractTransformer {
 
@@ -92,6 +93,8 @@ public class XsltPayloadTransformer extends AbstractTransformer {
 	private volatile SourceFactory sourceFactory = new DomSourceFactory();
 
 	private volatile ResultFactory resultFactory = new DomResultFactory();
+
+	private volatile boolean resultFactoryExplicitlySet;
 
 	private volatile boolean alwaysUseSourceFactory = false;
 
@@ -135,6 +138,7 @@ public class XsltPayloadTransformer extends AbstractTransformer {
 	public void setResultFactory(ResultFactory resultFactory) {
 		Assert.notNull(sourceFactory, "ResultFactory must not be null");
 		this.resultFactory = resultFactory;
+		this.resultFactoryExplicitlySet = true;
 	}
 
 	/**
@@ -214,7 +218,13 @@ public class XsltPayloadTransformer extends AbstractTransformer {
 	}
 
 	private Object transformSource(Source source, Object payload, Transformer transformer) throws TransformerException {
-		Result result = this.resultFactory.createResult(payload);
+		Result result;
+		if (!this.resultFactoryExplicitlySet && "text".equals(transformer.getOutputProperties().getProperty("method"))) {
+			result = new StringResult();
+		}
+		else {
+			result = this.resultFactory.createResult(payload);
+		}
 		transformer.transform(source, result);
 		if (this.resultTransformer != null) {
 			return this.resultTransformer.transformResult(result);

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/XsltTransformerTests-context.xml
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/XsltTransformerTests-context.xml
@@ -53,6 +53,12 @@
                               xsl-resource="classpath:org/springframework/integration/xml/transformer/transform-tostring.xsl">
     </int-xml:xslt-transformer>
 
+	<int-xml:xslt-transformer id="outputFileAsString"
+							  input-channel="outputFileAsStringChannel"
+							  output-channel="output" result-transformer="resultToStringTransformer"
+							  xsl-resource="classpath:org/springframework/integration/xml/transformer/transform-tostring.xsl">
+	</int-xml:xslt-transformer>
+
     <bean id="resultToStringTransformer" class="org.springframework.integration.xml.transformer.ResultToStringTransformer" />
 
 

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/XsltTransformerTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/XsltTransformerTests.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -28,6 +30,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
@@ -41,6 +44,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Oleg Zhurakousky
  * @author Jonas Partner
  * @author Gunnar Hillert
+ * @author Artem Bilan
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -126,6 +130,17 @@ public class XsltTransformerTests {
         assertEquals("Wrong payload type", String.class, resultMessage.getPayload().getClass());
         String stringPayload = (String)resultMessage.getPayload();
         assertEquals("Wrong content of payload", "hello world text",stringPayload.trim());
+    }
+
+	@Test
+    public void testInt3067OutputFileAsString() throws IOException {
+        MessageChannel input = applicationContext.getBean("outputFileAsStringChannel", MessageChannel.class);
+        Message<?> message = MessageBuilder.withPayload(new ClassPathResource("org/springframework/integration/xml/transformer/xsl-text-file.xml").getFile()).build();
+        input.send(message);
+        Message<?> resultMessage = output.receive();
+        assertEquals("Wrong payload type", String.class, resultMessage.getPayload().getClass());
+        String stringPayload = (String) resultMessage.getPayload();
+        assertEquals("Wrong content of payload", "hello world text", stringPayload.trim());
     }
 
 }

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/xsl-text-file.xml
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/xsl-text-file.xml
@@ -1,0 +1,3 @@
+<order>
+	<orderItem>test</orderItem>
+</order>

--- a/src/reference/docbook/xml.xml
+++ b/src/reference/docbook/xml.xml
@@ -727,6 +727,13 @@
 			<classname>String</classname>, the resulting payload will be of type
 			<classname><ulink url="http://docs.oracle.com/javase/6/docs/api/org/w3c/dom/Document.html">Document</ulink></classname>.
 		</para>
+		<para><emphasis>XsltPayloadTransformer and &lt;xsl:output method="text"/&gt;</emphasis></para>
+		<para>&lt;xsl:output method="text"/&gt; says to XSLT template to produce just only text content from source.
+		In this case there is no reason to have any <classname>DomResult</classname>. So <classname>XsltPayloadTransformer</classname>
+		makes coercion to <classname>StringResult</classname>, if output method of <classname>javax.xml.transform.Transformer</classname>
+		is equal to <code>"text"</code> value, independently of inbound payload type. This 'smart' behaviour is available, if
+		<code>result-type</code> or <code>result-factory</code> attributes aren't provided for the <code>&lt;int-xml:xslt-transformer&gt;</code>
+		component.</para>
 	</section>
 </section>
   <section id="xml-xpath-transformer">


### PR DESCRIPTION
Previously there was need to add `result-type="StringResult"`
to `<int-xml:xslt-transformer>` for xslt output `method='text'`
in case payload was non-standard type (e.g. `File`), if we wanted to get
result as text.
- Add coercion to `StringResult` code, if `Transformer`'s property `method` is 'text'
  and there is no explicit `resultFactory` provided.

JIRA: https://jira.springsource.org/browse/INT-3067
