### PR TITLE
INT-3083 Update Spring Data Redis to 1.0.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ subprojects { subproject ->
 
 		springAmqpVersion = '1.2.0.M1'
 		springDataMongoVersion = '1.1.1.RELEASE'
-		springDataRedisVersion = '1.0.2.RELEASE'
+		springDataRedisVersion = '1.0.5.RELEASE'
 		springGemfireVersion = '1.3.1.RELEASE'
 		springSecurityVersion = '3.1.3.RELEASE'
 		springSocialTwitterVersion = '1.0.5.RELEASE'

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
@@ -161,7 +161,6 @@ public class SubscribableRedisChannel extends AbstractMessageChannel implements 
 	}
 
 	public void stop() {
-		this.connectionFactory.getConnection().discard();
 		if (this.container != null) {
 			this.container.stop();
 		}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisStoreMessageSource.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisStoreMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,6 +96,7 @@ public class RedisStoreMessageSource extends IntegrationObjectSupport
 
 		StringRedisTemplate redisTemplate = new StringRedisTemplate();
 		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.afterPropertiesSet();
 
 		this.redisTemplate = redisTemplate;
 		this.keyExpression = keyExpression;

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisMessageStore.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2012 the original author or authors
+ * Copyright 2007-2013 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.util.Assert;
  * Redis implementation of the key/value style {@link MessageStore} and {@link MessageGroupStore}
  *
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.1
  */
 public class RedisMessageStore extends AbstractKeyValueMessageStore {
@@ -46,6 +47,7 @@ public class RedisMessageStore extends AbstractKeyValueMessageStore {
 		this.redisTemplate.setConnectionFactory(connectionFactory);
 		this.redisTemplate.setKeySerializer(new StringRedisSerializer());
 		this.redisTemplate.setValueSerializer(new JdkSerializationRedisSerializer());
+		this.redisTemplate.afterPropertiesSet();
 	}
 
 	public void setValueSerializer(RedisSerializer<?> valueSerializer) {

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.redis.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +25,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
@@ -40,6 +42,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gunnar Hillert
+ * @author Gary Russell
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -67,9 +70,10 @@ public class RedisOutboundChannelAdapterParserTests extends RedisAvailableTests{
 	public void testOutboundChannelAdapterMessaging() throws Exception{
 		MessageChannel sendChannel = context.getBean("sendChannel", MessageChannel.class);
 		sendChannel.send(new GenericMessage<String>("Hello Redis"));
-		Thread.sleep(1000);
 		QueueChannel receiveChannel = context.getBean("receiveChannel", QueueChannel.class);
-		assertEquals("Hello Redis", receiveChannel.receive(1000).getPayload());
+		Message<?> message = receiveChannel.receive(5000);
+		assertNotNull(message);
+		assertEquals("Hello Redis", message.getPayload());
 	}
 
 	@Test //INT-2275
@@ -77,9 +81,10 @@ public class RedisOutboundChannelAdapterParserTests extends RedisAvailableTests{
 	public void testOutboundChannelAdapterWithinChain() throws Exception{
 		MessageChannel sendChannel = context.getBean("redisOutboudChain", MessageChannel.class);
 		sendChannel.send(new GenericMessage<String>("Hello Redis from chain"));
-		Thread.sleep(1000);
 		QueueChannel receiveChannel = context.getBean("receiveChannel", QueueChannel.class);
-		assertEquals("Hello Redis from chain", receiveChannel.receive(1000).getPayload());
+		Message<?> message = receiveChannel.receive(5000);
+		assertNotNull(message);
+		assertEquals("Hello Redis from chain", message.getPayload());
 	}
 
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/rules/RedisAvailableTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/rules/RedisAvailableTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.redis.rules;
 import java.util.UUID;
 
 import org.junit.Rule;
+
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
@@ -43,6 +44,7 @@ public class RedisAvailableTests {
 		jcf.afterPropertiesSet();
 		RedisTemplate rt = new RedisTemplate<UUID, Object>();
 		rt.setConnectionFactory(jcf);
+		rt.afterPropertiesSet();
 		rt.execute(new RedisCallback() {
 
 			public Object doInRedis(RedisConnection connection)


### PR DESCRIPTION
INT-3080 Invoke RedisTemplate.afterPropertiesSet() when instantiating
programmatically.

INT-3084 Redis channel was incorrectly calling discard() during stop() (a multi-operation).
INT-3084 Fix timing issue in test (NPE)
