### PR TITLE
INT-3089 Fix FileExistsMode.IGNORE

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -25,6 +25,7 @@ import java.nio.charset.Charset;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.context.expression.MapAccessor;
@@ -43,6 +44,7 @@ import org.springframework.integration.util.PassThruLockRegistry;
 import org.springframework.integration.util.WhileLockedProcessor;
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * A {@link MessageHandler} implementation that writes the Message payload to a
@@ -68,6 +70,7 @@ import org.springframework.util.FileCopyUtils;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gunnar Hillert
+ * @author Gary Russell
  */
 public class FileWritingMessageHandler extends AbstractReplyProducingMessageHandler {
 
@@ -268,7 +271,9 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 					"The destination file already exists at '" + resultFile.getAbsolutePath() + "'.");
 		}
 
-		final boolean ignore = FileExistsMode.IGNORE.equals(this.fileExistsMode) && resultFile.exists();
+		final boolean ignore = FileExistsMode.IGNORE.equals(this.fileExistsMode) &&
+				(resultFile.exists() ||
+						(StringUtils.hasText(this.temporaryFileSuffix) && tempFile.exists()));
 
 		if (!ignore) {
 
@@ -413,7 +418,7 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 	}
 
 	private void cleanUpAfterCopy(File fileToWriteTo, File resultFile, File originalFile) throws IOException{
-		if (!FileExistsMode.APPEND.equals(this.fileExistsMode)) {
+		if (!FileExistsMode.APPEND.equals(this.fileExistsMode) && StringUtils.hasText(this.temporaryFileSuffix)) {
 			this.renameTo(fileToWriteTo, resultFile);
 		}
 


### PR DESCRIPTION
When writing files with this mode setting, the FWMH detected
that the final file already exists, but did not detect that
the temporary (default ....writing) file exists. This could
happen if two adapters were simulataneously processing the same
file.

Also, while a comment in the setter said an empty temp file
suffix is allowed, it did not work because the file rename
is performed unconditionally, fails, and throws an exception.

Add a check for the temporary file (if the suffix is not "").

Don't rename if the file was written in-place (no temp file suffix).

Add test cases for the FileExistsMode.IGNORE for both the final
and temporary files. Add a test where the temporary file suffix
is "", a ...writing file exists, the final file does not exist
and so is created by the handler. The ...writing file is untouched.

**cherry-pick to 2.2.x**
