### PR TITLE
INT-3106 Fix Bogus Warning Logs

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
@@ -50,11 +50,15 @@ public abstract class AbstractRequestHandlerAdvice extends IntegrationObjectSupp
 		boolean isMessageMethod = (method.getName().equals("handleRequestMessage") || method.getName().equals("handleMessage"))
 				&& (arguments.length == 1 && arguments[0] instanceof Message);
 
+		Object invocationThis = invocation.getThis();
 		if (!isMessageMethod) {
-			if (logger.isWarnEnabled()) {
+			boolean isMessageHandler = invocationThis != null
+					&& MessageHandler.class.isAssignableFrom(invocationThis.getClass());
+			if (!isMessageHandler && logger.isWarnEnabled()) {
+				String clazzName = invocationThis == null ? method.getDeclaringClass().getName() : invocationThis.getClass().getName();
 				logger.warn("This advice " + this.getClass().getName() +
 						" can only be used for MessageHandlers; an attempt to advise method '" + method.getName() +
-						"' in '" + method.getDeclaringClass().getName() + "' is ignored");
+						"' in '" + clazzName + "' is ignored");
 			}
 			return invocation.proceed();
 		}
@@ -91,7 +95,7 @@ public abstract class AbstractRequestHandlerAdvice extends IntegrationObjectSupp
 							throw new ThrowableHolderException(e);
 						}
 					}
-				}, invocation.getThis(), message);
+				}, invocationThis, message);
 			}
 			catch (Exception e) {
 				if (e instanceof ThrowableHolderException) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -851,7 +851,8 @@ public class AdvisedMessageHandlerTests {
 		assertFalse(called.get());
 		assertNotNull(logMessage.get());
 		assertTrue(logMessage.get().endsWith("can only be used for MessageHandlers; " +
-				"an attempt to advise method 'call' in 'java.util.concurrent.Callable' is ignored"));
+				"an attempt to advise method 'call' in " +
+				"'org.springframework.integration.endpoint.AbstractPollingEndpoint$1' is ignored"));
 	}
 
 	public void filterDiscardNoAdvice() {


### PR DESCRIPTION
INT-3007 introduced a warning log when advising a non-message handler
class. However, the log was also emitted when other methods on a
real MessageHandler were invoked.

Suppress the message in these cases and improve the log by
including the concrete class for the method rather than the
interface on which the method is declared.
