### PR TITLE
INT-3108: add requires-reply for s-a within chain

### DIFF
--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -1068,23 +1068,31 @@
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
-				<xsd:extension base="expressionOrInnerEndpointDefinitionAware">
+				<xsd:extension base="serviceActivatorType">
 					<xsd:attributeGroup ref="inputOutputChannelGroup" />
-					<xsd:attribute name="requires-reply" type="xsd:string" use="optional">
-						<xsd:annotation>
-							<xsd:documentation>
-								Specify whether the service method must return a non-null value. This value will be
-								FALSE by
-								default, but if set to TRUE, a MessageHandlingException will be thrown when
-								the underlying service method (or
-								expression) returns a NULL value.
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
+
+
+	<xsd:complexType name="serviceActivatorType">
+		<xsd:complexContent>
+			<xsd:extension base="expressionOrInnerEndpointDefinitionAware">
+				<xsd:attribute name="requires-reply" type="xsd:string" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							Specify whether the service method must return a non-null value. This value will be
+							FALSE by
+							default, but if set to TRUE, a MessageHandlingException will be thrown when
+							the underlying service method (or
+							expression) returns a NULL value.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
 
 	<xsd:complexType name="handlerEndpointType">
 		<xsd:annotation>
@@ -1491,7 +1499,7 @@
 				<xsd:choice minOccurs="0" maxOccurs="unbounded">
 					<xsd:any processContents="strict" namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
 
-					<xsd:element name="service-activator" type="expressionOrInnerEndpointDefinitionAware"/>
+					<xsd:element name="service-activator" type="serviceActivatorType"/>
 					<xsd:element name="splitter" type="splitter-type"/>
 					<xsd:element name="transformer" type="expressionOrInnerEndpointDefinitionAware"/>
 					<xsd:element name="header-enricher" type="header-enricher-type"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserSmartLifecycleAttributesTest.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserSmartLifecycleAttributesTest.xml
@@ -12,7 +12,7 @@
 		   auto-startup="false"
 		   phase="256"
 		   send-timeout="3000">
-		<service-activator expression="payload"/>
+		<service-activator id="sa-within-chain" expression="payload" requires-reply="true"/>
 	</chain>
 
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserTests.java
@@ -339,6 +339,9 @@ public class ChainParserTests {
 		assertEquals(256, handlerChain.getPhase());
 		assertEquals(3000L, TestUtils.getPropertyValue(handlerChain, "sendTimeout"));
 		assertEquals(false, TestUtils.getPropertyValue(handlerChain, "running"));
+		//INT-3108
+		MessageHandler serviceActivator = ctx.getBean("chain$child.sa-within-chain.handler", MessageHandler.class);
+		assertTrue(TestUtils.getPropertyValue(serviceActivator, "requiresReply", Boolean.class));
 	}
 
 	@Test


### PR DESCRIPTION
`<service-activator>` has had an attribute `requires-reply`,
but it wasn't available within `chain`.
Introduce new XSD type `serviceActivatorType`
and use it for root `<service-activator>` element and within `<chain>` as well.

JIRA: https://jira.springsource.org/browse/INT-3108
