### PR TITLE
INT-3111 Fix Close Cached TCP Connection

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactory.java
@@ -17,8 +17,6 @@ package org.springframework.integration.ip.tcp.connection;
 
 import java.util.concurrent.Executor;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.core.serializer.Deserializer;
 import org.springframework.core.serializer.Serializer;
 import org.springframework.integration.Message;
@@ -33,8 +31,6 @@ import org.springframework.integration.util.SimplePool;
  *
  */
 public class CachingClientConnectionFactory extends AbstractClientConnectionFactory {
-
-	private final Log logger = LogFactory.getLog(this.getClass());
 
 	private final AbstractClientConnectionFactory targetConnectionFactory;
 
@@ -158,6 +154,10 @@ public class CachingClientConnectionFactory extends AbstractClientConnectionFact
 					.build());
 			close(); // return to pool after response is received
 			return true; // true so the single-use connection doesn't close itself
+		}
+
+		private void physicallyClose() {
+			this.getTheConnection().close();
 		}
 
 	}
@@ -355,6 +355,16 @@ public class CachingClientConnectionFactory extends AbstractClientConnectionFact
 	@Override
 	public boolean isLookupHost() {
 		return targetConnectionFactory.isLookupHost();
+	}
+
+
+	@Override
+	public void forceClose(TcpConnection connection) {
+		if (connection instanceof CachedConnection) {
+			((CachedConnection) connection).physicallyClose();
+		}
+		// will be returned to pool but stale, so will be re-established
+		super.forceClose(connection);
 	}
 
 	@Override


### PR DESCRIPTION
A TCP Connection is closed when an outbound gateway times out.

However, with the CachingClientConnectionFactory, the connection
was returned to the pool instead of being physically closed.

Override forceClose() and physically close the connection so the
next time it is retrieved from the pool it is detected as stale
and re-established.

Refactor test case and invoke it twice; once with a regular connection
factory and once with a cached factory.

Remove an unused logger.

**cherry-pick to 2.2.x**
