### PR TITLE
INT-3103 TCP Propagate Exceptions to GW Thread

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpInboundGateway.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpInboundGateway.java
@@ -32,6 +32,7 @@ import org.springframework.integration.ip.tcp.connection.ClientModeConnectionMan
 import org.springframework.integration.ip.tcp.connection.TcpConnection;
 import org.springframework.integration.ip.tcp.connection.TcpListener;
 import org.springframework.integration.ip.tcp.connection.TcpSender;
+import org.springframework.integration.message.ErrorMessage;
 import org.springframework.util.Assert;
 
 /**
@@ -53,7 +54,7 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 
 	private volatile AbstractClientConnectionFactory clientConnectionFactory;
 
-	private Map<String, TcpConnection> connections = new ConcurrentHashMap<String, TcpConnection>();
+	private final Map<String, TcpConnection> connections = new ConcurrentHashMap<String, TcpConnection>();
 
 	private volatile boolean isClientMode;
 
@@ -76,6 +77,13 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 			}
 		}
 		else {
+			if (message instanceof ErrorMessage) {
+				/*
+				 * Socket errors are sent here so they can be conveyed to any waiting thread.
+				 * There's not one here; simply ignore.
+				 */
+				return false;
+			}
 			this.activeCount.incrementAndGet();
 			try {
 				return doOnMessage(message);

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapter.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapter.java
@@ -28,6 +28,7 @@ import org.springframework.integration.ip.tcp.connection.ClientModeCapable;
 import org.springframework.integration.ip.tcp.connection.ClientModeConnectionManager;
 import org.springframework.integration.ip.tcp.connection.ConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.TcpListener;
+import org.springframework.integration.message.ErrorMessage;
 import org.springframework.util.Assert;
 
 /**
@@ -68,6 +69,13 @@ public class TcpReceivingChannelAdapter
 			}
 		}
 		else {
+			if (message instanceof ErrorMessage) {
+				/*
+				 * Socket errors are sent here so they can be conveyed to any waiting thread.
+				 * There's not one here; simply ignore.
+				 */
+				return false;
+			}
 			this.activeCount.incrementAndGet();
 			try {
 				sendMessage(message);

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.ip.tcp.connection;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketException;
@@ -596,6 +597,9 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 								if (key.channel().isOpen()) {
 									key.interestOps(SelectionKey.OP_READ);
 									selector.wakeup();
+								}
+								else {
+									connection.sendExceptionToListener(new EOFException("Connection is closed"));
 								}
 							}});
 					}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorSupport.java
@@ -19,6 +19,7 @@ package org.springframework.integration.ip.tcp.connection;
 import org.springframework.core.serializer.Deserializer;
 import org.springframework.core.serializer.Serializer;
 import org.springframework.integration.Message;
+import org.springframework.integration.message.ErrorMessage;
 
 /**
  * Base class for TcpConnectionIntercepters; passes all method calls through
@@ -131,7 +132,12 @@ public abstract class TcpConnectionInterceptorSupport extends TcpConnectionSuppo
 
 	public boolean onMessage(Message<?> message) {
 		if (this.tcpListener == null) {
-			throw new NoListenerException("No listener registered for message reception");
+			if (message instanceof ErrorMessage) {
+				return false;
+			}
+			else {
+				throw new NoListenerException("No listener registered for message reception");
+			}
 		}
 		return this.tcpListener.onMessage(message);
 	}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
@@ -248,6 +248,7 @@ public class TcpNetConnection extends TcpConnectionSupport {
 									 e.getClass().getSimpleName() +
 								     ":" + (e.getCause() != null ? e.getCause() + ":" : "") + e.getMessage());
 					}
+					this.sendExceptionToListener(e);
 				}
 			}
 		}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -201,23 +201,28 @@ public class TcpNioConnection extends TcpConnectionSupport {
 					if (message != null) {
 						sendToChannel(message);
 					}
-				} else {
+				}
+				else {
 					this.executionControl.decrementAndGet();
 				}
-			} catch (Exception e) {
+			}
+			catch (Exception e) {
 				if (logger.isTraceEnabled()) {
 					logger.error("Read exception " +
 							 this.getConnectionId(), e);
-				} else {
+				}
+				else {
 					logger.error("Read exception " +
 								 this.getConnectionId() + " " +
 								 e.getClass().getSimpleName() +
 							     ":" + e.getCause() + ":" + e.getMessage());
 				}
 				this.closeConnection();
+				this.sendExceptionToListener(e);
 				return;
 			}
-		} finally {
+		}
+		finally {
 			if (logger.isTraceEnabled()) {
 				logger.trace(this.getConnectionId() + " Nio message assembler exiting...");
 			}
@@ -228,7 +233,8 @@ public class TcpNioConnection extends TcpConnectionSupport {
 				if (this.isOpen() && dataAvailable()) {
 					checkForAssembler();
 				}
-			} catch (IOException e) {
+			}
+			catch (IOException e) {
 				logger.error("Exception when checking for assembler", e);
 			}
 		}
@@ -293,7 +299,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 		 */
 		if (this.isSingleUse() && ((!this.isServer() && !intercepted) || (this.isServer() && this.getSender() == null))) {
 			if (logger.isDebugEnabled()) {
-				logger.debug("Closing single use cbannel after inbound message " + this.getConnectionId());
+				logger.debug("Closing single use channel after inbound message " + this.getConnectionId());
 			}
 			this.closeConnection();
 		}
@@ -377,6 +383,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 				// only execute run() if we don't already have one running
 				this.executionControl.set(1);
 				this.taskExecutor.execute(this);
+				logger.debug("Running an assembler");
 			} else {
 				this.executionControl.decrementAndGet();
 			}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionTests.java
@@ -30,7 +30,6 @@ import java.nio.channels.SocketChannel;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.logging.Log;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -43,6 +42,7 @@ import org.springframework.integration.Message;
 import org.springframework.integration.ip.tcp.connection.TcpNioConnection.ChannelInputStream;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayStxEtxSerializer;
 import org.springframework.integration.ip.tcp.serializer.MapJsonSerializer;
+import org.springframework.integration.message.ErrorMessage;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.converter.MapMessageConverter;
 import org.springframework.integration.test.util.TestUtils;
@@ -133,7 +133,9 @@ public class TcpNetConnectionTests {
 		TcpListener listener = new TcpListener() {
 
 			public boolean onMessage(Message<?> message) {
-				inboundMessage.set(message);
+				if (!(message instanceof ErrorMessage)) {
+					inboundMessage.set(message);
+				}
 				return false;
 			}
 		};


### PR DESCRIPTION
Previously, when a calling thread was waiting for a reply, and an exception
occurred on the socket, the exception was not propagated to the thread and
it would eventually get a timeout, but with no indication of the problem.

Propagate the exception to the calling thread by invoking onMessage()
with an ErrorMessage.

Ignore the ErrorMessage in other TcpListeners (inbound adapter, gateway).

Ensure NIO closes are not missed by sending an ErrorMessage when the selector
thread detects a closed channel.

Add tests for Net, NIO, cached and failover connection factories.
