### PR TITLE
INT-3114 Call MessageHandlers Directly

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractSimpleMessageHandlerFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractSimpleMessageHandlerFactoryBean.java
@@ -16,6 +16,8 @@ package org.springframework.integration.config;
 import java.util.List;
 
 import org.aopalliance.aop.Advice;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -40,6 +42,8 @@ import org.springframework.util.CollectionUtils;
  */
 public abstract class AbstractSimpleMessageHandlerFactoryBean<H extends MessageHandler>
 		implements FactoryBean<MessageHandler>, BeanFactoryAware {
+
+	protected final Log logger = LogFactory.getLog(this.getClass());
 
 	private volatile H handler;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractDelegatingConsumerEndpointParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractDelegatingConsumerEndpointParser.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.config.xml;
 
+import org.w3c.dom.Element;
+
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -23,7 +25,6 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.expression.DynamicExpression;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
-import org.w3c.dom.Element;
 
 /**
  * Base parser class for endpoints that delegate to a method invoker or

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.integration.annotation.ServiceActivator;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Gary Russell
  */
 public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandler {
 
@@ -74,6 +75,7 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 		}
 	}
 
+	@Override
 	public String toString() {
 		return "ServiceActivator for [" + this.processor + "]";
 	}

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -2480,7 +2480,13 @@
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
-				<xsd:attribute name="throw-exception-on-rejection" type="xsd:string" default="false" />
+				<xsd:attribute name="throw-exception-on-rejection" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+						Throw an exception if the filter rejects the message (default false).
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
@@ -3105,7 +3111,7 @@ is provided, the return value is expected to match a channel name exactly.
 				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="ignore-send-failures" default="false">
+		<xsd:attribute name="ignore-send-failures">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 					If set to "true", failures to send to a message channel will
@@ -3124,7 +3130,7 @@ is provided, the return value is expected to match a channel name exactly.
                 <xsd:union memberTypes="xsd:boolean xsd:string" />
             </xsd:simpleType>
 		</xsd:attribute>
-		<xsd:attribute name="apply-sequence" default="false">
+		<xsd:attribute name="apply-sequence">
 			<xsd:annotation>
 				<xsd:documentation>
 					Specify whether sequence number and size headers should be added to each
@@ -3135,7 +3141,7 @@ is provided, the return value is expected to match a channel name exactly.
                 <xsd:union memberTypes="xsd:boolean xsd:string" />
             </xsd:simpleType>
 		</xsd:attribute>
-        <xsd:attribute name="resolution-required" default="true">
+        <xsd:attribute name="resolution-required">
             <xsd:annotation>
                 <xsd:documentation>
                     Specify whether channel names must always be successfully resolved

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelegatingConsumerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelegatingConsumerParserTests-context.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<int:channel id="in" />
+
+	<int:channel id="discard">
+		<int:queue />
+	</int:channel>
+
+	<!-- Filters -->
+
+	<int:filter id="directFilter" input-channel="in"
+			discard-channel="discard" send-timeout="123" throw-exception-on-rejection="true">
+		<bean class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyFilter" />
+	</int:filter>
+
+	<int:filter id="refFilter" input-channel="in" ref="myFilter" />
+
+	<bean id="myFilter" class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyFilter" />
+
+	<int:filter id="filterWithMessageSelectorThatsAlsoAnARPMH" input-channel="in">
+		<bean class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MySelectorShouldntBeUsedAsTheHandler" />
+	</int:filter>
+
+	<!-- Routers -->
+
+	<int:router id="directRouter" input-channel="in">
+		<bean class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyRouter" />
+	</int:router>
+
+	<int:router id="refRouter" input-channel="in" ref="myRouter" />
+
+	<bean id="myRouter" class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyRouter" />
+
+	<int:router id="directRouterMH" input-channel="in">
+		<bean class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyRouterMH" />
+	</int:router>
+
+	<int:router id="refRouterMH" input-channel="in" ref="myRouterMH" />
+
+	<bean id="myRouterMH" class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyRouterMH" />
+
+	<int:router id="directRouterARPMH" input-channel="in">
+		<bean class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyRouterARPMH" />
+	</int:router>
+
+	<int:router id="refRouterARPMH" input-channel="in" ref="myRouterARPMH" />
+
+	<bean id="myRouterARPMH" class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyRouterARPMH" />
+
+	<!-- Service Activators -->
+
+	<int:service-activator id="directServiceARPMH" input-channel="in">
+		<bean class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyServiceARPMH" />
+	</int:service-activator>
+
+	<int:transformer id="refServiceARPMH" input-channel="in" ref="myServiceARPMH"/>
+
+	<bean id="myServiceARPMH" class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyServiceARPMH" />
+
+	<!-- Splitters -->
+	
+	<int:splitter id="directSplitter" input-channel="in">
+		<bean class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MySplitter" />
+	</int:splitter>
+
+	<int:splitter id="refSplitter" input-channel="in" ref="mySplitter"/>
+
+	<bean id="mySplitter" class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MySplitter" />
+
+	<int:splitter id="splitterWithARPMH" input-channel="in">
+		<bean class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MySplitterThatsAnARPMH" />
+	</int:splitter>
+
+	<int:splitter id="splitterWithARPMHWithAtts" input-channel="in" ref="splitterARPMH" send-timeout="123"/> 
+
+	<bean id="splitterARPMH" class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MySplitterThatsAnARPMH" />
+
+<!-- 	<int:splitter id="splitterWithARPMHWithSplitterAtts" input-channel="in" ref="splitterARPMH2" method="handleMessage" apply-sequence="false"/>  -->
+
+<!-- 	<bean id="splitterARPMH2" class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MySplitterThatsAnARPMH" /> -->
+
+	<!-- Transformers -->
+
+	<int:transformer id="directTransformer" input-channel="in">
+		<bean class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyTransformer" />
+	</int:transformer>
+
+	<int:transformer id="refTransformer" input-channel="in" ref="myTransformer" />
+
+	<bean id="myTransformer" class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyTransformer" />
+
+	<int:transformer id="directTransformerARPMH" input-channel="in">
+		<bean class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyTransformerARPMH" />
+	</int:transformer>
+
+	<int:transformer id="refTransformerARPMH" input-channel="in" ref="myTransformerARPMH"/>
+
+	<bean id="myTransformerARPMH" class="org.springframework.integration.config.xml.DelegatingConsumerParserTests$MyTransformerARPMH" />
+
+</beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelegatingConsumerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelegatingConsumerParserTests.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.config.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.integration.Message;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.MessagingException;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.ServiceActivatorFactoryBean;
+import org.springframework.integration.core.MessageHandler;
+import org.springframework.integration.core.MessageSelector;
+import org.springframework.integration.filter.MessageFilter;
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.router.AbstractMessageRouter;
+import org.springframework.integration.splitter.AbstractMessageSplitter;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.integration.transformer.AbstractTransformer;
+import org.springframework.integration.transformer.MessageTransformingHandler;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 3.0
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class DelegatingConsumerParserTests {
+
+	@Autowired @Qualifier("directFilter.handler")
+	private MessageHandler directFilter;
+
+	@Autowired @Qualifier("refFilter.handler")
+	private MessageHandler refFilter;
+
+	@Autowired @Qualifier("filterWithMessageSelectorThatsAlsoAnARPMH.handler")
+	private MessageHandler filterWithMessageSelectorThatsAlsoAnARPMH;
+
+	@Autowired @Qualifier("directRouter.handler")
+	private MessageHandler directRouter;
+
+	@Autowired @Qualifier("refRouter.handler")
+	private MessageHandler refRouter;
+
+	@Autowired @Qualifier("directRouterMH.handler")
+	private MessageHandler directRouterMH;
+
+	@Autowired @Qualifier("refRouterMH.handler")
+	private MessageHandler refRouterMH;
+
+	@Autowired @Qualifier("directRouterARPMH.handler")
+	private MessageHandler directRouterARPMH;
+
+	@Autowired @Qualifier("refRouterARPMH.handler")
+	private MessageHandler refRouterARPMH;
+
+	@Autowired @Qualifier("directServiceARPMH.handler")
+	private MessageHandler directServiceARPMH;
+
+	@Autowired @Qualifier("refServiceARPMH.handler")
+	private MessageHandler refServiceARPMH;
+
+	@Autowired @Qualifier("directSplitter.handler")
+	private MessageHandler directSplitter;
+
+	@Autowired @Qualifier("refSplitter.handler")
+	private MessageHandler refSplitter;
+
+	@Autowired @Qualifier("splitterWithARPMH.handler")
+	private MessageHandler splitterWithARPMH;
+
+	@Autowired @Qualifier("splitterWithARPMHWithAtts.handler")
+	private MessageHandler splitterWithARPMHWithAtts;
+
+	@Autowired @Qualifier("directTransformer.handler")
+	private MessageHandler directTransformer;
+
+	@Autowired @Qualifier("refTransformer.handler")
+	private MessageHandler refTransformer;
+
+	@Autowired @Qualifier("directTransformerARPMH.handler")
+	private MessageHandler directTransformerARPMH;
+
+	@Autowired @Qualifier("refTransformerARPMH.handler")
+	private MessageHandler refTransformerARPMH;
+
+	private static QueueChannel replyChannel = new QueueChannel();
+
+	@Test
+	public void testDelegates() {
+		assertTrue(directFilter instanceof MyFilter);
+		testHandler(directFilter);
+		assertTrue(refFilter instanceof MyFilter);
+		testHandler(refFilter);
+		// MessageSelector (wrapped in MessageFilter) wins here
+		assertTrue(filterWithMessageSelectorThatsAlsoAnARPMH instanceof MessageFilter);
+		testHandler(filterWithMessageSelectorThatsAlsoAnARPMH);
+
+		assertTrue(directRouter instanceof MyRouter);
+		testHandler(directRouter);
+		assertTrue(refRouter instanceof MyRouter);
+		testHandler(refRouter);
+		assertTrue(directRouterMH instanceof MyRouterMH);
+		testHandler(directRouterMH);
+		assertTrue(refRouterMH instanceof MyRouterMH);
+		testHandler(refRouterMH);
+		assertTrue(directRouterARPMH instanceof MyRouterARPMH);
+		testHandler(directRouterARPMH);
+		assertTrue(refRouterARPMH instanceof MyRouterARPMH);
+		testHandler(refRouterARPMH);
+
+		assertTrue(directServiceARPMH instanceof MyServiceARPMH);
+		testHandler(directServiceARPMH);
+		assertTrue(refServiceARPMH instanceof MyServiceARPMH);
+		testHandler(refServiceARPMH);
+
+		assertTrue(directSplitter instanceof MySplitter);
+		testHandler(directSplitter);
+		assertTrue(refSplitter instanceof MySplitter);
+		testHandler(refSplitter);
+		assertTrue(splitterWithARPMH instanceof MySplitterThatsAnARPMH);
+		testHandler(splitterWithARPMH);
+		assertTrue(splitterWithARPMHWithAtts instanceof MySplitterThatsAnARPMH);
+		assertEquals(Long.valueOf(123), TestUtils.getPropertyValue(splitterWithARPMHWithAtts, "messagingTemplate.sendTimeout", Long.class));
+		testHandler(splitterWithARPMHWithAtts);
+
+		assertTrue(directTransformer instanceof MessageTransformingHandler);
+		assertTrue(TestUtils.getPropertyValue(directTransformer, "transformer") instanceof MyTransformer);
+		testHandler(directTransformer);
+		assertTrue(refTransformer instanceof MessageTransformingHandler);
+		assertTrue(TestUtils.getPropertyValue(refTransformer, "transformer") instanceof MyTransformer);
+		testHandler(refTransformer);
+		assertTrue(directTransformerARPMH instanceof MyTransformerARPMH);
+		testHandler(directTransformerARPMH);
+		assertTrue(refTransformerARPMH instanceof MyTransformerARPMH);
+		testHandler(refTransformerARPMH);
+
+	}
+
+	@Test
+	public void testOneRefOnly() throws Exception {
+		ServiceActivatorFactoryBean fb = new ServiceActivatorFactoryBean();
+		fb.setBeanFactory(mock(BeanFactory.class));
+		MyServiceARPMH service = new MyServiceARPMH();
+		service.setBeanName("foo");
+		fb.setTargetObject(service);
+		fb.getObject();
+		fb = new ServiceActivatorFactoryBean();
+		fb.setBeanFactory(mock(BeanFactory.class));
+		fb.setTargetObject(service);
+		try {
+			fb.getObject();
+			fail("expected exception");
+		}
+		catch (Exception e) {
+			assertEquals("An AbstractReplyProducingMessageHandler may only be referenced once (foo)", e.getMessage());
+		}
+	}
+
+	private void testHandler(MessageHandler handler) {
+		Message<?> message = MessageBuilder.withPayload("foo")
+				.setReplyChannel(replyChannel)
+				.build();
+		handler.handleMessage(message);
+		assertNotNull(replyChannel.receive(0));
+
+	}
+
+	public static class MyFilter extends MessageFilter {
+
+		public MyFilter() {
+			super(new MessageSelector() {
+
+				@Override
+				public boolean accept(Message<?> message) {
+					return true;
+				}
+			});
+		}
+
+	}
+
+	public static class MySelectorShouldntBeUsedAsTheHandler extends AbstractReplyProducingMessageHandler
+			implements MessageSelector {
+
+		@Override
+		protected Object handleRequestMessage(Message<?> requestMessage) {
+			return null;
+		}
+
+		@Override
+		public boolean accept(Message<?> message) {
+			return true;
+		}
+
+	}
+
+	public static class MyRouter extends AbstractMessageRouter {
+
+		@Override
+		protected Collection<MessageChannel> determineTargetChannels(Message<?> message) {
+			List<MessageChannel> channels = new ArrayList<MessageChannel>();
+			channels.add(replyChannel);
+			return channels;
+		}
+
+	}
+
+	public static class MyRouterMH implements MessageHandler {
+
+		@Override
+		public void handleMessage(Message<?> message) throws MessagingException {
+			replyChannel.send(message);
+		}
+
+	}
+
+	public static class MyRouterARPMH extends AbstractReplyProducingMessageHandler {
+
+		@Override
+		protected Object handleRequestMessage(Message<?> requestMessage) {
+			replyChannel.send(requestMessage);
+			return null;
+		}
+
+	}
+
+	public static class MyServiceARPMH extends AbstractReplyProducingMessageHandler {
+
+		@Override
+		protected Object handleRequestMessage(Message<?> requestMessage) {
+			return requestMessage;
+		}
+
+	}
+
+	public static class MyTransformer extends AbstractTransformer {
+
+		@Override
+		protected Object doTransform(Message<?> message) throws Exception {
+			return message;
+		}
+
+	}
+
+	public static class MyTransformerARPMH extends AbstractReplyProducingMessageHandler {
+
+		@Override
+		protected Object handleRequestMessage(Message<?> requestMessage) {
+			return requestMessage;
+		}
+
+	}
+
+	public static class MySplitter extends AbstractMessageSplitter {
+
+		@Override
+		protected Object splitMessage(Message<?> message) {
+			return message;
+		}
+
+	}
+
+	public static class MySplitterThatsAnARPMH extends AbstractReplyProducingMessageHandler {
+
+		@Override
+		protected Object handleRequestMessage(Message<?> requestMessage) {
+			return requestMessage;
+		}
+
+	}
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/ServiceActivatorDefaultFrameworkMethodTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/ServiceActivatorDefaultFrameworkMethodTests-context.xml
@@ -11,7 +11,32 @@
 
 	<service-activator id="gatewayTestService" input-channel="gatewayTestInputChannel" ref="gateway"/>
 
-	<service-activator id="handlerTestService" input-channel="handlerTestInputChannel" ref="testMessageHandler"/>
+	<service-activator id="replyingHandlerTestService" input-channel="replyingHandlerTestInputChannel">
+		<beans:bean
+			class="org.springframework.integration.handler.ServiceActivatorDefaultFrameworkMethodTests$TestReplyingMessageHandler"/>
+	</service-activator>
+
+	<service-activator id="optimizedRefReplyingHandlerTestService"
+		input-channel="optimizedRefReplyingHandlerTestInputChannel" ref="testReplyingMessageHandler"/>
+
+	<service-activator id="replyingHandlerWithStandardMethodTestService"
+		 input-channel="replyingHandlerWithStandardMethodTestInputChannel"
+		 method="handleMessage">
+		 <beans:bean
+			class="org.springframework.integration.handler.ServiceActivatorDefaultFrameworkMethodTests$TestReplyingMessageHandler"/>
+	</service-activator>
+
+	<service-activator id="replyingHandlerWithOtherMethodTestService"
+		 input-channel="replyingHandlerWithOtherMethodTestInputChannel"
+		 method="foo">
+		 <beans:bean
+			class="org.springframework.integration.handler.ServiceActivatorDefaultFrameworkMethodTests$TestReplyingMessageHandler"/>
+	</service-activator>
+
+	<service-activator id="handlerTestService" input-channel="handlerTestInputChannel">
+		<beans:bean
+			class="org.springframework.integration.handler.ServiceActivatorDefaultFrameworkMethodTests$TestMessageHandler"/>
+	</service-activator>
 
 	<service-activator id="processorTestService" input-channel="processorTestInputChannel" ref="testMessageProcessor"/>
 
@@ -25,7 +50,8 @@
 		<queue/>
 	</channel>
 
-	<beans:bean id="testMessageHandler" class="org.springframework.integration.handler.ServiceActivatorDefaultFrameworkMethodTests$TestMessageHandler"/>
+	<beans:bean id="testReplyingMessageHandler"
+		class="org.springframework.integration.handler.ServiceActivatorDefaultFrameworkMethodTests$TestReplyingMessageHandler"/>
 
 	<beans:bean id="testMessageProcessor" class="org.springframework.integration.handler.ServiceActivatorDefaultFrameworkMethodTests$TestMessageProcessor">
 		<beans:property name="prefix" value="foo"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/ServiceActivatorDefaultFrameworkMethodTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/ServiceActivatorDefaultFrameworkMethodTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,32 +18,27 @@ package org.springframework.integration.handler;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
-import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.util.Map;
-
 /**
  * See INT-1688 for background.
- * 
+ *
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 2.0.1
  */
 @ContextConfiguration
@@ -52,6 +47,18 @@ public class ServiceActivatorDefaultFrameworkMethodTests {
 
 	@Autowired
 	private MessageChannel gatewayTestInputChannel;
+
+	@Autowired
+	private MessageChannel replyingHandlerTestInputChannel;
+
+	@Autowired
+	private MessageChannel optimizedRefReplyingHandlerTestInputChannel;
+
+	@Autowired
+	private MessageChannel replyingHandlerWithStandardMethodTestInputChannel;
+
+	@Autowired
+	private MessageChannel replyingHandlerWithOtherMethodTestInputChannel;
 
 	@Autowired
 	private MessageChannel handlerTestInputChannel;
@@ -75,13 +82,57 @@ public class ServiceActivatorDefaultFrameworkMethodTests {
 	}
 
 	@Test
+	public void testReplyingMessageHandler() {
+		QueueChannel replyChannel = new QueueChannel();
+		Message<?> message = MessageBuilder.withPayload("test").setReplyChannel(replyChannel).build();
+		this.replyingHandlerTestInputChannel.send(message);
+		Message<?> reply = replyChannel.receive(0);
+		assertEquals("TEST", reply.getPayload());
+		assertEquals("replyingHandlerTestInputChannel,replyingHandlerTestService", reply.getHeaders().get("history").toString());
+		StackTraceElement[] st = (StackTraceElement[]) reply.getHeaders().get("callStack");
+		assertEquals("doDispatch", st[3].getMethodName()); // close to the metal
+	}
+
+	@Test
+	public void testNotOptimizedReplyingMessageHandler() {
+		QueueChannel replyChannel = new QueueChannel();
+		Message<?> message = MessageBuilder.withPayload("test").setReplyChannel(replyChannel).build();
+		this.optimizedRefReplyingHandlerTestInputChannel.send(message);
+		Message<?> reply = replyChannel.receive(0);
+		assertEquals("TEST", reply.getPayload());
+		assertEquals("optimizedRefReplyingHandlerTestInputChannel,optimizedRefReplyingHandlerTestService",
+				reply.getHeaders().get("history").toString());
+		StackTraceElement[] st = (StackTraceElement[]) reply.getHeaders().get("callStack");
+		assertEquals("doDispatch", st[3].getMethodName());
+	}
+
+	@Test
+	public void testReplyingMessageHandlerWithStandardMethod() {
+		QueueChannel replyChannel = new QueueChannel();
+		Message<?> message = MessageBuilder.withPayload("test").setReplyChannel(replyChannel).build();
+		this.replyingHandlerWithStandardMethodTestInputChannel.send(message);
+		Message<?> reply = replyChannel.receive(0);
+		assertEquals("TEST", reply.getPayload());
+		assertEquals("replyingHandlerWithStandardMethodTestInputChannel,replyingHandlerWithStandardMethodTestService", reply.getHeaders().get("history").toString());
+		StackTraceElement[] st = (StackTraceElement[]) reply.getHeaders().get("callStack");
+		assertEquals("doDispatch", st[3].getMethodName()); // close to the metal
+	}
+
+	@Test
+	public void testReplyingMessageHandlerWithOtherMethod() {
+		QueueChannel replyChannel = new QueueChannel();
+		Message<?> message = MessageBuilder.withPayload("test").setReplyChannel(replyChannel).build();
+		this.replyingHandlerWithOtherMethodTestInputChannel.send(message);
+		Message<?> reply = replyChannel.receive(0);
+		assertEquals("bar", reply.getPayload());
+		assertEquals("replyingHandlerWithOtherMethodTestInputChannel,replyingHandlerWithOtherMethodTestService", reply.getHeaders().get("history").toString());
+	}
+
+	@Test
 	public void testMessageHandler() {
 		QueueChannel replyChannel = new QueueChannel();
 		Message<?> message = MessageBuilder.withPayload("test").setReplyChannel(replyChannel).build();
 		this.handlerTestInputChannel.send(message);
-		Message<?> reply = replyChannel.receive(0);
-		assertEquals("TEST", reply.getPayload());
-		assertEquals("handlerTestInputChannel,handlerTestService,testMessageHandler", reply.getHeaders().get("history").toString());
 	}
 
 //	INT-2399
@@ -100,19 +151,38 @@ public class ServiceActivatorDefaultFrameworkMethodTests {
 
 
 	@SuppressWarnings("unused")
-	private static class TestMessageHandler extends AbstractReplyProducingMessageHandler {
+	private static class TestReplyingMessageHandler extends AbstractReplyProducingMessageHandler {
 
 		@Override
 		protected Object handleRequestMessage(Message<?> requestMessage) {
-			return requestMessage.getPayload().toString().toUpperCase();
+			Exception e = new RuntimeException();
+			StackTraceElement[] st = e.getStackTrace();
+			return MessageBuilder.withPayload(requestMessage.getPayload().toString().toUpperCase())
+					.setHeader("callStack", st);
 		}
+
+		public String foo(String in) {
+			return "bar";
+		}
+
 	}
 
+	@SuppressWarnings("unused")
+	private static class TestMessageHandler implements MessageHandler {
+
+		@Override
+		public void handleMessage(Message<?> requestMessage) {
+			Exception e = new RuntimeException();
+			StackTraceElement[] st = e.getStackTrace();
+			assertEquals("doDispatch", st[4].getMethodName());
+		}
+	}
 
 	private static class TestMessageProcessor implements MessageProcessor<String> {
 
 		private String prefix;
 
+		@SuppressWarnings("unused")
 		public void setPrefix(String prefix) {
 			this.prefix = prefix;
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/transformerContextTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/transformerContextTests.xml
@@ -21,4 +21,12 @@
 
 	<beans:bean id="testBean" class="org.springframework.integration.transformer.TestBean"/>
 
+	<transformer input-channel="direct" output-channel="output">
+		<beans:bean class="org.springframework.integration.transformer.TransformerContextTests$Bar"/>
+	</transformer>
+
+	<transformer input-channel="directRef" output-channel="output" ref="trans" method="handleMessage"/>
+	
+	<beans:bean id="trans" class="org.springframework.integration.transformer.TransformerContextTests$Bar"/>
+
 </beans:beans>


### PR DESCRIPTION
**For review/discusion only at this time**

It's a pretty small/straightforward change, but ...

All tests pass and I added test cases to verify we're invoked directly by the dispatcher.

One side effect is that the message history is shortened; see 

```
-    assertEquals("handlerTestInputChannel,handlerTestService,testMessageHandler", reply.getHeaders().get("history").toString());
+    assertEquals("replyingHandlerTestInputChannel,replyingHandlerTestService", reply.getHeaders().get("history").toString());
```

in `ServiceActivatorDefaultFrameworkMethodTests`

Before, we had channel, service-activator, ref'd bean (actual service).

now it's just channel, service-activator.

Maybe that's a good thing.
