### PR TITLE
Adds an MBeanTreePollingMessageSource (INT-3124)

### DIFF
--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/DefaultMBeanAttributeFilter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/DefaultMBeanAttributeFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jmx;
+
+import javax.management.ObjectName;
+
+/**
+ * @author Stuart Williams
+ * @since 3.0
+ *
+ */
+public class DefaultMBeanAttributeFilter implements MBeanAttributeFilter {
+
+	@Override
+	public boolean accept(ObjectName objectName, String attributeName) {
+		return true;
+	}
+
+}

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/DefaultMBeanObjectConverter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/DefaultMBeanObjectConverter.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jmx;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.RuntimeMBeanException;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.TabularData;
+
+/**
+ * @author Stuart Williams
+ * @since 3.0
+ *
+ */
+public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.integration.jmx.MBeanObjectConverter#convert(javax.management.MBeanServerConnection, javax.management.ObjectInstance)
+	 */
+	@Override
+	public Object convert(MBeanServerConnection connection, ObjectInstance instance) {
+		Map<String, Object> attributeMap = new HashMap<String, Object>();
+
+		try {
+			ObjectName objName = instance.getObjectName();
+			if (!connection.isRegistered(objName)) {
+				return attributeMap;
+			}
+
+			MBeanInfo info = connection.getMBeanInfo(objName);
+			MBeanAttributeInfo[] attributeInfos = info.getAttributes();
+
+			for (MBeanAttributeInfo attrInfo : attributeInfos) {
+				// we don't need to repeat name of this as an attribute
+				if ("ObjectName".equals(attrInfo.getName())) continue;
+
+				Object value;
+				try {
+					value = connection.getAttribute(objName, attrInfo.getName());
+				}
+				catch (RuntimeMBeanException e) {
+					// try to unwrap the exception somewhat; not sure this is ideal
+					Throwable t = e;
+					while (t.getCause() != null) {
+						t = t.getCause();
+					}
+					value = String.format("%s[%s]", t.getClass().getName(), t.getMessage());
+				}
+
+				attributeMap.put(attrInfo.getName(), checkAndConvert(value));
+			}
+
+		} catch (Exception e) {
+			throw new IllegalArgumentException(e);
+		}
+
+		return attributeMap;
+	}
+
+	/**
+	 * @param input
+	 * @return recursively mapped object
+	 */
+	private Object checkAndConvert(Object input) {
+		if (input == null) return input;
+		else if (input.getClass().isArray()) {
+
+			if (CompositeData.class.isAssignableFrom(input.getClass().getComponentType())) {
+				List<Object> converted = new ArrayList<Object>();
+				int length = Array.getLength(input);
+				for (int i=0; i<length; i++) {
+					Object value = checkAndConvert(Array.get(input, i));
+					converted.add(value);
+				}
+				return converted;
+			}
+			if (TabularData.class.isAssignableFrom(input.getClass().getComponentType())) {
+				// TODO haven't hit this yet, but expect to
+				throw new UnsupportedOperationException("TabularData.isAssignableFrom(getComponentType) for " + input.toString());
+			}
+		}
+		else if (input instanceof CompositeData) {
+			CompositeData data = (CompositeData) input;
+
+			if (data.getCompositeType().isArray()) {
+				// TODO? I haven't found an example where this gets thrown - but need to test it on Tomcat/Jetty or something
+				throw new UnsupportedOperationException("(data.getCompositeType().isArray for " + input.toString());
+			}
+			else {
+				Map<String, Object> returnable = new HashMap<String, Object>();
+				Set<String> keys = data.getCompositeType().keySet();
+				for (String key : keys) {
+					// we don't need to repeat name of this as an attribute
+					if ("ObjectName".equals(key)) continue;
+					Object value = checkAndConvert(data.get(key));
+					returnable.put(key, value);
+				}
+				return returnable;
+			}
+		}
+		else if (input instanceof TabularData) {
+			TabularData data = (TabularData) input;
+
+			if (data.getTabularType().isArray()) {
+				// TODO? I haven't found an example where this gets thrown, so might not be required
+				throw new UnsupportedOperationException("TabularData.isArray for " + input.toString());
+			}
+			else {
+
+				Map<Object, Object> returnable = new HashMap<Object, Object>();
+				@SuppressWarnings("unchecked")
+				Set<List<?>> keySet = (Set<List<?>>) data.keySet();
+				for (List<?> keys : keySet) {
+					CompositeData cd = data.get(keys.toArray());
+					Object value = checkAndConvert(cd);
+
+					if (keys.size() == 1 && (value instanceof Map) && ((Map<?,?>) value).size() == 2) {
+
+						Object actualKey = keys.get(0);
+						Map<?,?> valueMap = (Map<?,?>) value;
+
+						if (valueMap.containsKey("key") && valueMap.containsKey("value") && actualKey.equals(valueMap.get("key"))) {
+							returnable.put(valueMap.get("key"), valueMap.get("value"));
+						}
+						else {
+							returnable.put(actualKey, value);
+						}
+					}
+					else {
+
+						returnable.put(keys, value);
+					}
+				}
+				
+				return returnable;
+			}
+		}
+
+		return input;
+	}
+}

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/DefaultMBeanObjectConverter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/DefaultMBeanObjectConverter.java
@@ -31,12 +31,17 @@ import javax.management.RuntimeMBeanException;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 /**
  * @author Stuart Williams
  * @since 3.0
  *
  */
 public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
+
+	private static final Log log = LogFactory.getLog(DefaultMBeanObjectConverter.class);
 
 	/*
 	 * (non-Javadoc)
@@ -66,6 +71,13 @@ public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
 					value = connection.getAttribute(objName, attrInfo.getName());
 				}
 				catch (RuntimeMBeanException e) {
+					// N.B. standard MemoryUsage MBeans will throw an exception when some 
+					// measurement is unsupported.  Logging at trace rather than debug to
+					// avoid confusion.
+					if (log.isTraceEnabled()) {
+						log.trace("Error getting attribute '" + attrInfo.getName() + "' on '" + objName + "'", e);
+					}
+
 					// try to unwrap the exception somewhat; not sure this is ideal
 					Throwable t = e;
 					while (t.getCause() != null) {
@@ -105,7 +117,7 @@ public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
 			}
 			if (TabularData.class.isAssignableFrom(input.getClass().getComponentType())) {
 				// TODO haven't hit this yet, but expect to
-				throw new UnsupportedOperationException("TabularData.isAssignableFrom(getComponentType) for " + input.toString());
+				log.warn("TabularData.isAssignableFrom(getComponentType) for " + input.toString());
 			}
 		}
 		else if (input instanceof CompositeData) {
@@ -113,7 +125,7 @@ public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
 
 			if (data.getCompositeType().isArray()) {
 				// TODO? I haven't found an example where this gets thrown - but need to test it on Tomcat/Jetty or something
-				throw new UnsupportedOperationException("(data.getCompositeType().isArray for " + input.toString());
+				log.warn("(data.getCompositeType().isArray for " + input.toString());
 			}
 			else {
 				Map<String, Object> returnable = new HashMap<String, Object>();
@@ -132,7 +144,7 @@ public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
 
 			if (data.getTabularType().isArray()) {
 				// TODO? I haven't found an example where this gets thrown, so might not be required
-				throw new UnsupportedOperationException("TabularData.isArray for " + input.toString());
+				log.warn("TabularData.isArray for " + input.toString());
 			}
 			else {
 

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/DefaultMBeanObjectConverter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/DefaultMBeanObjectConverter.java
@@ -43,6 +43,16 @@ public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
 
 	private static final Log log = LogFactory.getLog(DefaultMBeanObjectConverter.class);
 
+	private MBeanAttributeFilter filter;
+
+	public DefaultMBeanObjectConverter() {
+		this(new DefaultMBeanAttributeFilter());
+	}
+
+	public DefaultMBeanObjectConverter(MBeanAttributeFilter filter) {
+		this.filter = filter;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.integration.jmx.MBeanObjectConverter#convert(javax.management.MBeanServerConnection, javax.management.ObjectInstance)
@@ -62,7 +72,8 @@ public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
 
 			for (MBeanAttributeInfo attrInfo : attributeInfos) {
 				// we don't need to repeat name of this as an attribute
-				if ("ObjectName".equals(attrInfo.getName())) {
+				if ("ObjectName".equals(attrInfo.getName()) || 
+						!filter.accept(objName, attrInfo.getName())) {
 					continue;
 				}
 
@@ -132,7 +143,9 @@ public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
 				Set<String> keys = data.getCompositeType().keySet();
 				for (String key : keys) {
 					// we don't need to repeat name of this as an attribute
-					if ("ObjectName".equals(key)) continue;
+					if ("ObjectName".equals(key)) {
+						continue;
+					}
 					Object value = checkAndConvert(data.get(key));
 					returnable.put(key, value);
 				}

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/DefaultMBeanObjectConverter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/DefaultMBeanObjectConverter.java
@@ -57,7 +57,9 @@ public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
 
 			for (MBeanAttributeInfo attrInfo : attributeInfos) {
 				// we don't need to repeat name of this as an attribute
-				if ("ObjectName".equals(attrInfo.getName())) continue;
+				if ("ObjectName".equals(attrInfo.getName())) {
+					continue;
+				}
 
 				Object value;
 				try {
@@ -87,7 +89,9 @@ public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
 	 * @return recursively mapped object
 	 */
 	private Object checkAndConvert(Object input) {
-		if (input == null) return input;
+		if (input == null) {
+			return input;
+		}
 		else if (input.getClass().isArray()) {
 
 			if (CompositeData.class.isAssignableFrom(input.getClass().getComponentType())) {
@@ -152,7 +156,6 @@ public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
 						}
 					}
 					else {
-
 						returnable.put(keys, value);
 					}
 				}

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/MBeanAttributeFilter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/MBeanAttributeFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jmx;
+
+import javax.management.ObjectName;
+
+/**
+ * @author Stuart Williams
+ * @since 3.0
+ *
+ */
+public interface MBeanAttributeFilter {
+
+	/**
+	 * @param objectName
+	 * @param attributeName
+	 * @return outcome of test
+	 */
+	boolean accept(ObjectName objectName, String attributeName);
+
+}

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/MBeanObjectConverter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/MBeanObjectConverter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jmx;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectInstance;
+
+
+/**
+ * @author Stuart Williams
+ * @since 3.0
+ *
+ */
+public interface MBeanObjectConverter {
+
+	/**
+	 * @param connection
+	 * @param instance
+	 * @return mapped object instance
+	 */
+	Object convert(MBeanServerConnection connection, ObjectInstance instance);
+
+}

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/MBeanTreePollingMessageSource.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/MBeanTreePollingMessageSource.java
@@ -49,19 +49,12 @@ public class MBeanTreePollingMessageSource extends AbstractMessageSource<Object>
 	private final MBeanObjectConverter converter;
 
 	/**
-	 * 
-	 */
-	public MBeanTreePollingMessageSource() {
-		this(new DefaultMBeanObjectConverter());
-	}
-
-	/**
 	 * @param converter
 	 */
 	public MBeanTreePollingMessageSource(MBeanObjectConverter converter) {
 		this.converter = converter;
 	}
-	
+
 	/**
 	 * Provides the mapped tree object
 	 */
@@ -98,7 +91,7 @@ public class MBeanTreePollingMessageSource extends AbstractMessageSource<Object>
 	public void setQueryName(String queryName) {
 		Assert.notNull(queryName, "'queryName' must not be null");
 		try {
-			setQueryName(ObjectName.getInstance(queryName));
+			setQueryNameReference(ObjectName.getInstance(queryName));
 		} catch (MalformedObjectNameException e) {
 			throw new IllegalArgumentException(e);
 		}
@@ -107,7 +100,7 @@ public class MBeanTreePollingMessageSource extends AbstractMessageSource<Object>
 	/**
 	 * @param queryName
 	 */
-	public void setQueryName(ObjectName queryName) {
+	public void setQueryNameReference(ObjectName queryName) {
 		this.queryName = queryName;
 	}
 
@@ -117,7 +110,7 @@ public class MBeanTreePollingMessageSource extends AbstractMessageSource<Object>
 	public void setQueryExpression(String queryExpression) {
 		Assert.notNull(queryExpression, "'queryExpression' must not be null");
 		try {
-			setQueryExpression(ObjectName.getInstance(queryExpression));
+			setQueryExpressionReference(ObjectName.getInstance(queryExpression));
 		} catch (MalformedObjectNameException e) {
 			throw new IllegalArgumentException(e);
 		}
@@ -126,7 +119,7 @@ public class MBeanTreePollingMessageSource extends AbstractMessageSource<Object>
 	/**
 	 * @param queryExpression
 	 */
-	public void setQueryExpression(QueryExp queryExpression) {
+	public void setQueryExpressionReference(QueryExp queryExpression) {
 		this.queryExpression = queryExpression;
 	}
 }

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/MBeanTreePollingMessageSource.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/MBeanTreePollingMessageSource.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jmx;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.QueryExp;
+
+import org.springframework.integration.MessagingException;
+import org.springframework.integration.core.MessageSource;
+import org.springframework.integration.endpoint.AbstractMessageSource;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link MessageSource} implementation that retrieves a snapshot of
+ * a filtered subset of the MBean tree.
+ * 
+ * @author Stuart Williams
+ * @since 3.0
+ *
+ */
+public class MBeanTreePollingMessageSource extends AbstractMessageSource<Object> {
+
+	private volatile MBeanServerConnection server;
+
+	private volatile ObjectName queryName = null;
+
+	private volatile QueryExp queryExpression = ObjectName.WILDCARD;
+
+	private final MBeanObjectConverter converter;
+
+	/**
+	 * 
+	 */
+	public MBeanTreePollingMessageSource() {
+		this(new DefaultMBeanObjectConverter());
+	}
+
+	/**
+	 * @param converter
+	 */
+	public MBeanTreePollingMessageSource(MBeanObjectConverter converter) {
+		this.converter = converter;
+	}
+	
+	/**
+	 * Provides the mapped tree object
+	 */
+	@Override
+	protected Object doReceive() {
+		Assert.notNull(this.server, "MBeanServer is required");
+
+		try {
+			Map<String, Object> beans = new HashMap<String, Object>();
+			Set<ObjectInstance> results = server.queryMBeans(queryName, queryExpression);
+
+			for (ObjectInstance instance : results) {
+				Object result = converter.convert(server, instance);
+				beans.put(instance.getObjectName().getCanonicalName(), result);
+			}
+			
+			return beans;
+
+		} catch (Exception e) {
+			throw new MessagingException("Failed to retrieve tree snapshot", e);
+		}
+	}
+
+	/**
+	 * Provide the MBeanServer where the JMX MBean has been registered.
+	 */
+	public void setServer(MBeanServerConnection server) {
+		this.server = server;
+	}
+
+	/**
+	 * @param queryName
+	 */
+	public void setQueryName(String queryName) {
+		Assert.notNull(queryName, "'queryName' must not be null");
+		try {
+			setQueryName(ObjectName.getInstance(queryName));
+		} catch (MalformedObjectNameException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	/**
+	 * @param queryName
+	 */
+	public void setQueryName(ObjectName queryName) {
+		this.queryName = queryName;
+	}
+
+	/**
+	 * @param queryExpression
+	 */
+	public void setQueryExpression(String queryExpression) {
+		Assert.notNull(queryExpression, "'queryExpression' must not be null");
+		try {
+			setQueryExpression(ObjectName.getInstance(queryExpression));
+		} catch (MalformedObjectNameException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	/**
+	 * @param queryExpression
+	 */
+	public void setQueryExpression(QueryExp queryExpression) {
+		this.queryExpression = queryExpression;
+	}
+}

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/NamedFieldsMBeanAttributeFilter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/NamedFieldsMBeanAttributeFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jmx;
+
+import javax.management.ObjectName;
+
+/**
+ * @author Stuart Williams
+ * @since 3.0
+ *
+ */
+public class NamedFieldsMBeanAttributeFilter implements MBeanAttributeFilter {
+
+	private String[] namedFields;
+
+	/**
+	 * @param namedFields
+	 */
+	public NamedFieldsMBeanAttributeFilter(String[] namedFields) {
+		this.namedFields = namedFields;
+	}
+
+	@Override
+	public boolean accept(ObjectName objectName, String attributeName) {
+		for (String namedField : namedFields) {
+			if (namedField.equals(attributeName)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/NotNamedFieldsMBeanAttributeFilter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/NotNamedFieldsMBeanAttributeFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jmx;
+
+import javax.management.ObjectName;
+
+/**
+ * @author Stuart Williams
+ * @since 3.0
+ *
+ */
+public class NotNamedFieldsMBeanAttributeFilter implements MBeanAttributeFilter {
+
+	private String[] namedFields;
+
+	/**
+	 * @param namedFields
+	 */
+	public NotNamedFieldsMBeanAttributeFilter(String[] namedFields) {
+		this.namedFields = namedFields;
+	}
+
+	@Override
+	public boolean accept(ObjectName objectName, String attributeName) {
+		for (String namedField : namedFields) {
+			if (namedField.equals(attributeName)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+}

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/JmxNamespaceHandler.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/JmxNamespaceHandler.java
@@ -32,6 +32,7 @@ public class JmxNamespaceHandler extends AbstractIntegrationNamespaceHandler {
 		this.registerBeanDefinitionParser("operation-invoking-channel-adapter", new OperationInvokingChannelAdapterParser());
 		this.registerBeanDefinitionParser("operation-invoking-outbound-gateway", new OperationInvokingOutboundGatewayParser());
 		this.registerBeanDefinitionParser("attribute-polling-channel-adapter", new AttributePollingChannelAdapterParser());
+		this.registerBeanDefinitionParser("tree-polling-channel-adapter", new MBeanTreePollingChannelAdapterParser());
 		this.registerBeanDefinitionParser("notification-listening-channel-adapter", new NotificationListeningChannelAdapterParser());
 		this.registerBeanDefinitionParser("notification-publishing-channel-adapter", new NotificationPublishingChannelAdapterParser());
 		this.registerBeanDefinitionParser("mbean-export", new MBeanExporterParser());

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParser.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParser.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jmx.config;
+
+import org.springframework.beans.BeanMetadataElement;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.config.xml.AbstractPollingInboundChannelAdapterParser;
+import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.w3c.dom.Element;
+
+/**
+ * @author Stuart Williams
+ * @since 3.0
+ *
+ */
+public class MBeanTreePollingChannelAdapterParser extends AbstractPollingInboundChannelAdapterParser {
+
+	@Override
+	protected boolean shouldGenerateIdAsFallback() {
+		return true;
+	}
+
+	@Override
+	protected BeanMetadataElement parseSource(Element element, ParserContext parserContext) {
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(
+				"org.springframework.integration.jmx.MBeanTreePollingMessageSource");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "server", "server");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "query-name");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "query-expression");
+		// TODO provide constructor parameter as inner bean?
+		return builder.getBeanDefinition();
+	}
+
+}

--- a/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-3.0.xsd
+++ b/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-3.0.xsd
@@ -42,8 +42,32 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="treeType">
-					<xsd:sequence minOccurs="0" maxOccurs="1">
-						<xsd:element ref="integration:poller" />
+					<xsd:sequence>
+						<xsd:choice minOccurs="0" maxOccurs="1" >
+							<xsd:sequence>
+								<xsd:element ref="integration:poller" />
+								<xsd:choice minOccurs="0" maxOccurs="1">
+									<xsd:element ref="beans:ref">
+										<xsd:annotation>
+											<xsd:appinfo>
+												<tool:annotation kind="ref">
+													<tool:expected-type type="org.springframework.integration.jmx.MBeanObjectConverter" />
+												</tool:annotation>
+											</xsd:appinfo>
+										</xsd:annotation>
+									</xsd:element>
+									<xsd:element ref="beans:bean">
+										<xsd:annotation>
+											<xsd:appinfo>
+												<tool:annotation kind="ref">
+													<tool:expected-type type="org.springframework.integration.jmx.MBeanObjectConverter" />
+												</tool:annotation>
+											</xsd:appinfo>
+										</xsd:annotation>
+									</xsd:element>
+								</xsd:choice>
+							</xsd:sequence>
+						</xsd:choice>
 					</xsd:sequence>
 					<xsd:attribute name="auto-startup" type="xsd:string" default="true" />
 				</xsd:extension>
@@ -209,8 +233,44 @@
 		<xsd:complexContent>
 			<xsd:extension base="mbeanServerIdentifyerType">
 				<xsd:attribute name="channel" type="xsd:string" />
-				<xsd:attribute name="query-name" type="xsd:string" use="optional" />
-				<xsd:attribute name="query-expression" type="xsd:string" use="optional" />
+				<xsd:attribute name="query-name" type="xsd:string" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							A string to be parsed into an ObjectName object
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="query-name-ref" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							A reference to an ObjectName instance
+						</xsd:documentation>
+						<xsd:appinfo>
+							<tool:annotation>
+								<tool:expected-type type="javax.management.ObjectName"/>
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="query-expression" type="xsd:string" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							A string to be parsed into a QueryExp object
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="query-expression-ref" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							A reference to a QueryExp instance
+						</xsd:documentation>
+						<xsd:appinfo>
+							<tool:annotation>
+								<tool:expected-type type="javax.management.QueryExp"/>
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-3.0.xsd
+++ b/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-3.0.xsd
@@ -32,6 +32,25 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
+
+	<xsd:element name="tree-polling-channel-adapter">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines an inbound Channel Adapter that polls for JMX MBeans.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:complexContent>
+				<xsd:extension base="treeType">
+					<xsd:sequence minOccurs="0" maxOccurs="1">
+						<xsd:element ref="integration:poller" />
+					</xsd:sequence>
+					<xsd:attribute name="auto-startup" type="xsd:string" default="true" />
+				</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+	</xsd:element>
+
 	<xsd:element name="operation-invoking-outbound-gateway">
 		<xsd:annotation>
 			<xsd:documentation>
@@ -180,6 +199,21 @@
 			</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
+
+	<xsd:complexType name="treeType">
+		<xsd:annotation>
+			<xsd:documentation>
+				Defines inbound operation invoking type
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="mbeanServerIdentifyerType">
+				<xsd:attribute name="channel" type="xsd:string" />
+				<xsd:attribute name="query-name" type="xsd:string" use="optional" />
+				<xsd:attribute name="query-expression" type="xsd:string" use="optional" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
 
 	<xsd:complexType name="adapterType">
 		<xsd:annotation>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/MBeanAttributeFilterTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/MBeanAttributeFilterTests-context.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int-jmx="http://www.springframework.org/schema/integration/jmx"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<context:mbean-export/>
+
+	<context:mbean-server/>
+
+	<int-jmx:mbean-export/>
+
+	<int-jmx:tree-polling-channel-adapter id="adapter"
+		channel="in"
+		query-expression="org.springframework.integration:type=MessageChannel,name=*"
+		auto-startup="false">
+		<int:poller max-messages-per-poll="1" fixed-rate="5000"/>
+		<bean class="org.springframework.integration.jmx.DefaultMBeanObjectConverter">
+			<constructor-arg>
+				<bean class="org.springframework.integration.jmx.NamedFieldsMBeanAttributeFilter">
+					<constructor-arg>
+						<array>
+							<value type="java.lang.String">SendCount</value>
+							<value type="java.lang.String">SendErrorCount</value>
+						</array>
+					</constructor-arg>
+				</bean>
+			</constructor-arg>
+		</bean>
+	</int-jmx:tree-polling-channel-adapter>
+
+	<int:channel id="in">
+	</int:channel>
+
+	<int:service-activator id="pass"
+		input-channel="in"
+		output-channel="out"
+		expression="payload">
+	</int:service-activator>
+
+	<int:channel id="out">
+		<int:queue/>
+	</int:channel>
+
+</beans>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/MBeanAttributeFilterTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/MBeanAttributeFilterTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jmx;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.integration.Message;
+import org.springframework.integration.core.PollableChannel;
+import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Stuart Williams
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class MBeanAttributeFilterTests {
+
+	@Autowired
+	@Qualifier("out")
+	private PollableChannel channel;
+
+	@Autowired
+	private SourcePollingChannelAdapter adapter;
+
+	private long testTimeout = 1000L;
+
+	@Test
+	public void testAttributeFilter() {
+		adapter.start();
+
+		Message<?> result = channel.receive(testTimeout);
+		assertNotNull(result);
+		assertEquals(HashMap.class, result.getPayload().getClass());
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> payload = (Map<String, Object>) result.getPayload();
+		assertEquals(4, payload.size());
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> bean = (Map<String, Object>)
+				payload.get("org.springframework.integration:name=in,type=MessageChannel");
+
+		assertEquals(2, bean.size());
+		assertTrue(bean.containsKey("SendCount"));
+		assertTrue(bean.containsKey("SendErrorCount"));
+
+		adapter.stop();
+	}
+
+}

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/MBeanTreePollingMessageSourceTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/MBeanTreePollingMessageSourceTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jmx;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.MBeanServer;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.jmx.support.MBeanServerFactoryBean;
+
+/**
+ * @author Stuart Williams
+ *
+ */
+public class MBeanTreePollingMessageSourceTests {
+
+	private MBeanServer server;
+
+	@Before
+	public void setup() {
+		MBeanServerFactoryBean factoryBean = new MBeanServerFactoryBean();
+		factoryBean.setLocateExistingServerIfPossible(true);
+		factoryBean.afterPropertiesSet();
+		this.server = factoryBean.getObject();
+	}
+
+	@Test
+	public void testDefaultPoll() {
+
+		MBeanObjectConverter converter = new DefaultMBeanObjectConverter();
+		MBeanTreePollingMessageSource source = new MBeanTreePollingMessageSource(converter);
+		source.setServer(server);
+
+		Object received = source.doReceive();
+
+		assertEquals(HashMap.class, received.getClass());
+		
+		@SuppressWarnings("unchecked")
+		Map<String, Object> beans = (Map<String, Object>) received;
+
+		// test for a couple of MBeans
+		assertTrue(beans.containsKey("java.lang:type=OperatingSystem"));
+		assertTrue(beans.containsKey("java.lang:type=Runtime"));
+	}
+
+	@Test
+	public void testQueryNameFilteredPoll() {
+		MBeanObjectConverter converter = new DefaultMBeanObjectConverter();
+		MBeanTreePollingMessageSource source = new MBeanTreePollingMessageSource(converter);
+		source.setServer(server);
+		source.setQueryName("java.lang:*");
+
+		Object received = source.doReceive();
+
+		assertEquals(HashMap.class, received.getClass());
+		
+		@SuppressWarnings("unchecked")
+		Map<String, Object> beans = (Map<String, Object>) received;
+
+		// test for a few MBeans
+		assertTrue(beans.containsKey("java.lang:type=OperatingSystem"));
+		assertTrue(beans.containsKey("java.lang:type=Runtime"));
+		assertFalse(beans.containsKey("java.util.logging:type=Logging"));
+	}
+
+	@Test
+	public void testQueryExpressionFilteredPoll() {
+		MBeanObjectConverter converter = new DefaultMBeanObjectConverter();
+		MBeanTreePollingMessageSource source = new MBeanTreePollingMessageSource(converter);
+		source.setServer(server);
+		source.setQueryExpression("*:type=Logging");
+
+		Object received = source.doReceive();
+
+		assertEquals(HashMap.class, received.getClass());
+		
+		@SuppressWarnings("unchecked")
+		Map<String, Object> beans = (Map<String, Object>) received;
+
+		// test for a few MBeans
+		assertFalse(beans.containsKey("java.lang:type=OperatingSystem"));
+		assertFalse(beans.containsKey("java.lang:type=Runtime"));
+		assertTrue(beans.containsKey("java.util.logging:type=Logging"));
+	}
+
+}

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParserTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParserTests-context.xml
@@ -16,14 +16,71 @@
 	<context:mbean-export/>
 	<context:mbean-server/>
 
-	<si:channel id="channel">
+	<jmx:tree-polling-channel-adapter id="adapter-default"
+			channel="channel1"
+			auto-startup="false">
+		<si:poller max-messages-per-poll="1" fixed-rate="5000"/>
+	</jmx:tree-polling-channel-adapter>
+
+	<si:channel id="channel1">
 		<si:queue/>
 	</si:channel>
 
-	<jmx:tree-polling-channel-adapter id="adapter"
-			channel="channel"
+	<jmx:tree-polling-channel-adapter id="adapter-inner"
+			channel="channel2"
 			auto-startup="false">
-		<si:poller max-messages-per-poll="1" fixed-rate="2000"/>
+		<si:poller max-messages-per-poll="1" fixed-rate="5000"/>
+		<bean class="org.springframework.integration.jmx.DefaultMBeanObjectConverter"></bean>
 	</jmx:tree-polling-channel-adapter>
+
+	<si:channel id="channel2">
+		<si:queue/>
+	</si:channel>
+
+	<jmx:tree-polling-channel-adapter id="adapter-query-name"
+			channel="channel3"
+			auto-startup="false"
+			query-name="java.lang:type=Runtime"
+			query-expression="*:type=*">
+		<si:poller max-messages-per-poll="1" fixed-rate="5000"/>
+	</jmx:tree-polling-channel-adapter>
+
+	<si:channel id="channel3">
+		<si:queue/>
+	</si:channel>
+
+	<jmx:tree-polling-channel-adapter id="adapter-query-name-bean"
+			channel="channel4"
+			auto-startup="false"
+			query-name-ref="queryName">
+		<si:poller max-messages-per-poll="1" fixed-rate="5000"/>
+	</jmx:tree-polling-channel-adapter>
+
+	<bean id="queryName" class="javax.management.ObjectName">
+		<constructor-arg>
+			<value type="java.lang.String">java.lang:type=OperatingSystem</value>
+		</constructor-arg>
+	</bean>
+
+	<si:channel id="channel4">
+		<si:queue/>
+	</si:channel>
+
+	<jmx:tree-polling-channel-adapter id="adapter-query-expr-bean"
+			channel="channel5"
+			auto-startup="false"
+			query-expression-ref="queryExp">
+		<si:poller max-messages-per-poll="1" fixed-rate="5000"/>
+	</jmx:tree-polling-channel-adapter>
+
+	<bean id="queryExp" class="javax.management.ObjectName">
+		<constructor-arg>
+			<value type="java.lang.String">java.lang:type=Runtime</value>
+		</constructor-arg>
+	</bean>
+
+	<si:channel id="channel5">
+		<si:queue/>
+	</si:channel>
 
 </beans>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParserTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParserTests-context.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:si="http://www.springframework.org/schema/integration"
+	xmlns:jmx="http://www.springframework.org/schema/integration/jmx"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+			http://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/context
+			http://www.springframework.org/schema/context/spring-context.xsd
+			http://www.springframework.org/schema/integration
+			http://www.springframework.org/schema/integration/spring-integration.xsd
+			http://www.springframework.org/schema/integration/jmx
+			http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd">
+
+	<context:mbean-export/>
+	<context:mbean-server/>
+
+	<si:channel id="channel">
+		<si:queue/>
+	</si:channel>
+
+	<jmx:tree-polling-channel-adapter id="adapter"
+			channel="channel"
+			auto-startup="false">
+		<si:poller max-messages-per-poll="1" fixed-rate="2000"/>
+	</jmx:tree-polling-channel-adapter>
+
+</beans>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParserTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParserTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.jmx.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.Message;
+import org.springframework.integration.core.PollableChannel;
+import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Stuart Williams
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class MBeanTreePollingChannelAdapterParserTests {
+
+	@Autowired
+	private PollableChannel channel;
+
+	@Autowired
+	private SourcePollingChannelAdapter adapter;
+
+	@Test
+	public void pollForBeans() throws Exception {
+		adapter.start();
+
+		Message<?> result = channel.receive(1000);
+		assertNotNull(result);
+
+		assertEquals(HashMap.class, result.getPayload().getClass());
+		
+		@SuppressWarnings("unchecked")
+		Map<String, Object> beans = (Map<String, Object>) result.getPayload();
+
+		// test for a couple of MBeans
+		assertTrue(beans.containsKey("java.lang:type=OperatingSystem"));
+		assertTrue(beans.containsKey("java.lang:type=Runtime"));
+	}
+
+}

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParserTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParserTests.java
@@ -23,6 +23,10 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.QueryExp;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +34,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.Message;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -81,6 +86,9 @@ public class MBeanTreePollingChannelAdapterParserTests {
 	@Qualifier("adapter-query-expr-bean")
 	private SourcePollingChannelAdapter adapterQueryExprBean;
 
+	@Autowired
+	private MBeanServer mbeanServer;
+
 	private long testTimeout = 2000L;
 
 	@Test
@@ -91,7 +99,7 @@ public class MBeanTreePollingChannelAdapterParserTests {
 		assertNotNull(result);
 
 		assertEquals(HashMap.class, result.getPayload().getClass());
-		
+
 		@SuppressWarnings("unchecked")
 		Map<String, Object> beans = (Map<String, Object>) result.getPayload();
 
@@ -110,7 +118,7 @@ public class MBeanTreePollingChannelAdapterParserTests {
 		assertNotNull(result);
 
 		assertEquals(HashMap.class, result.getPayload().getClass());
-		
+
 		@SuppressWarnings("unchecked")
 		Map<String, Object> beans = (Map<String, Object>) result.getPayload();
 
@@ -124,6 +132,12 @@ public class MBeanTreePollingChannelAdapterParserTests {
 	@Test
 	public void pollQueryNameAdapter() throws Exception {
 		adapterQueryName.start();
+
+		ObjectName queryName = TestUtils.getPropertyValue(adapterQueryName, "source.queryName", ObjectName.class);
+		assertEquals("java.lang:type=Runtime", queryName.getCanonicalName());
+
+		QueryExp queryExp = TestUtils.getPropertyValue(adapterQueryName, "source.queryExpression", QueryExp.class);
+		assertTrue(queryExp.apply(new ObjectName("java.lang:type=Runtime")));
 
 		Message<?> result = channel3.receive(testTimeout);
 		assertNotNull(result);

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParserTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParserTests.java
@@ -16,6 +16,7 @@
 package org.springframework.integration.jmx.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -25,6 +26,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.Message;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
@@ -40,16 +42,52 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class MBeanTreePollingChannelAdapterParserTests {
 
 	@Autowired
-	private PollableChannel channel;
+	@Qualifier("channel1")
+	private PollableChannel channel1;
 
 	@Autowired
-	private SourcePollingChannelAdapter adapter;
+	@Qualifier("channel2")
+	private PollableChannel channel2;
+
+	@Autowired
+	@Qualifier("channel3")
+	private PollableChannel channel3;
+
+	@Autowired
+	@Qualifier("channel4")
+	private PollableChannel channel4;
+
+	@Autowired
+	@Qualifier("channel5")
+	private PollableChannel channel5;
+
+	@Autowired
+	@Qualifier("adapter-default")
+	private SourcePollingChannelAdapter adapterDefault;
+
+	@Autowired
+	@Qualifier("adapter-inner")
+	private SourcePollingChannelAdapter adapterInner;
+
+	@Autowired
+	@Qualifier("adapter-query-name")
+	private SourcePollingChannelAdapter adapterQueryName;
+
+	@Autowired
+	@Qualifier("adapter-query-name-bean")
+	private SourcePollingChannelAdapter adapterQueryNameBean;
+
+	@Autowired
+	@Qualifier("adapter-query-expr-bean")
+	private SourcePollingChannelAdapter adapterQueryExprBean;
+
+	private long testTimeout = 2000L;
 
 	@Test
-	public void pollForBeans() throws Exception {
-		adapter.start();
+	public void pollDefaultAdapter() throws Exception {
+		adapterDefault.start();
 
-		Message<?> result = channel.receive(1000);
+		Message<?> result = channel1.receive(testTimeout);
 		assertNotNull(result);
 
 		assertEquals(HashMap.class, result.getPayload().getClass());
@@ -60,6 +98,84 @@ public class MBeanTreePollingChannelAdapterParserTests {
 		// test for a couple of MBeans
 		assertTrue(beans.containsKey("java.lang:type=OperatingSystem"));
 		assertTrue(beans.containsKey("java.lang:type=Runtime"));
+
+		adapterDefault.stop();
+	}
+
+	@Test
+	public void pollInnerAdapter() throws Exception {
+		adapterInner.start();
+
+		Message<?> result = channel2.receive(testTimeout);
+		assertNotNull(result);
+
+		assertEquals(HashMap.class, result.getPayload().getClass());
+		
+		@SuppressWarnings("unchecked")
+		Map<String, Object> beans = (Map<String, Object>) result.getPayload();
+
+		// test for a couple of MBeans
+		assertTrue(beans.containsKey("java.lang:type=OperatingSystem"));
+		assertTrue(beans.containsKey("java.lang:type=Runtime"));
+
+		adapterDefault.stop();
+	}
+
+	@Test
+	public void pollQueryNameAdapter() throws Exception {
+		adapterQueryName.start();
+
+		Message<?> result = channel3.receive(testTimeout);
+		assertNotNull(result);
+
+		assertEquals(HashMap.class, result.getPayload().getClass());
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> beans = (Map<String, Object>) result.getPayload();
+
+		// test for a couple of MBeans
+		assertFalse(beans.containsKey("java.lang:type=OperatingSystem"));
+		assertTrue(beans.containsKey("java.lang:type=Runtime"));
+
+		adapterDefault.stop();
+	}
+
+	@Test
+	public void pollQueryNameBeanAdapter() throws Exception {
+		adapterQueryNameBean.start();
+
+		Message<?> result = channel4.receive(testTimeout);
+		assertNotNull(result);
+
+		assertEquals(HashMap.class, result.getPayload().getClass());
+		
+		@SuppressWarnings("unchecked")
+		Map<String, Object> beans = (Map<String, Object>) result.getPayload();
+
+		// test for a couple of MBeans
+		assertTrue(beans.containsKey("java.lang:type=OperatingSystem"));
+		assertFalse(beans.containsKey("java.lang:type=Runtime"));
+
+		adapterDefault.stop();
+	}
+
+	@Test
+	public void pollQueryExprBeanAdapter() throws Exception {
+		adapterQueryExprBean.start();
+
+		Message<?> result = channel5.receive(testTimeout);
+		assertNotNull(result);
+
+		assertEquals(HashMap.class, result.getPayload().getClass());
+		
+		@SuppressWarnings("unchecked")
+		Map<String, Object> beans = (Map<String, Object>) result.getPayload();
+
+		// test for a couple of MBeans
+		assertFalse(beans.containsKey("java.lang:type=OperatingSystem"));
+		assertTrue(beans.containsKey("java.lang:type=Runtime"));
+
+		adapterDefault.stop();
 	}
 
 }

--- a/src/reference/docbook/jmx.xml
+++ b/src/reference/docbook/jmx.xml
@@ -137,6 +137,24 @@
 </int-jmx:attribute-polling-channel-adapter>]]></programlisting>
 	</section>
 
+	<section id="tree-polling-channel-adapter">
+		<title>Tree Polling Channel Adapter</title>
+		<para>
+			The <emphasis>Tree Polling Channel Adapter</emphasis> queries the JMX MBean tree and 
+			sends a message with a payload that is the graph of objects that matches the query. By 
+			default the MBeans are mapped to primitives and simple Objects like Map, List and arrays - 
+			permitting simple transformation, for example, to JSON. An MBeanServer reference is also 
+			required, but it will automatically check for a bean named <emphasis>mbeanServer</emphasis> 
+			by default, just like the <emphasis>Notification-listening Channel Adapter</emphasis> 
+			described above. A basic configuration would be:
+		</para>
+		<programlisting language="xml"><![CDATA[<int-jmx:tree-polling-channel-adapter id="adapter"
+    channel="channel"
+    query-name="example.domain:type=*">
+        <int:poller max-messages-per-poll="1" fixed-rate="5000"/>
+</int-jmx:tree-polling-channel-adapter>]]></programlisting>
+	</section>
+
 	<section id="jmx-operation-invoking-channel-adapter">
 		<title>Operation Invoking Channel Adapter</title>
 

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -60,6 +60,17 @@
 				<xref linkend="syslog"/>.
 			</para>
 		</section>
+		<section id="3.0-jmx">
+			<title>JMX Support</title>
+			<para>
+				A new <code>&lt;int-jmx:tree-polling-channel-adapter/&gt;</code> is provided; this
+				adapter queries the JMX MBean tree and sends a message with a payload that is the 
+				graph of objects that matches the query. By default the MBeans are mapped to 
+				primitives and simple Objects like Map, List and arrays - permitting simple 
+				transformation, for example, to JSON
+				<xref linkend="jmx"/>.
+			</para>
+		</section>
 		<section id="3.0-tail">
 			<title>'Tail' Support</title>
 			<para>


### PR DESCRIPTION
Adds an MBeanTreePollingMessageSource that produces a graph of simple objects representing the JMX tree (INT-3124).

The DefaultMBeanObjectConverter converts MBean objects into a graph of Lists, Maps and arrays or primitives.
