### PR TITLE
INT-3125 Fix Handler MBean Names Within Chains

### DIFF
--- a/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -37,6 +37,7 @@ import javax.management.modelmbean.ModelMBean;
 import org.aopalliance.aop.Advice;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.aop.Advisor;
 import org.springframework.aop.PointcutAdvisor;
 import org.springframework.aop.TargetSource;
@@ -63,6 +64,7 @@ import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.endpoint.AbstractEndpoint;
+import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.jmx.export.MBeanExporter;
 import org.springframework.jmx.export.UnableToRegisterMBeanException;
 import org.springframework.jmx.export.annotation.AnnotationJmxAttributeSource;
@@ -1042,7 +1044,12 @@ public class IntegrationMBeanExporter extends MBeanExporter implements BeanPostP
 		}
 
 		if (name == null) {
-			name = monitor.getMessageHandler().toString();
+			if (monitor.getMessageHandler() instanceof NamedComponent) {
+				name = ((NamedComponent) monitor.getMessageHandler()).getComponentName();
+			}
+			if (name == null) {
+				name = monitor.getMessageHandler().toString();
+			}
 			source = "handler";
 		}
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanRegistrationTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanRegistrationTests-context.xml
@@ -26,4 +26,9 @@
 	
 	<int:logging-channel-adapter id="logger" channel="testChannel"/>
 	
+	<int:chain id="chain" input-channel="chainin">
+		<int:transformer id="t1" expression="'foo'"/>
+		<int:filter id="f1" expression="true"/>
+	</int:chain>
+
 </beans>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanRegistrationTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanRegistrationTests.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2010 the original author or authors.
- * 
+ * Copyright 2002-2013 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -15,6 +15,7 @@ package org.springframework.integration.jmx.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,12 +28,14 @@ import javax.management.ObjectName;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Dave Syer
+ * @author Gary Russell
  * @since 2.0
  */
 @ContextConfiguration
@@ -41,11 +44,14 @@ public class MBeanRegistrationTests {
 
 	@Autowired
 	private MBeanServer server;
-	
+
 	@Test
 	public void testHandlerMBeanRegistration() throws Exception {
 		Set<ObjectName> names = server.queryNames(new ObjectName("test.MBeanRegistration:type=MessageHandler,*"), null);
-		assertEquals(3, names.size());
+		assertEquals(6, names.size());
+		assertTrue(names.contains(new ObjectName("test.MBeanRegistration:type=MessageHandler,name=chain,bean=endpoint")));
+		assertTrue(names.contains(new ObjectName("test.MBeanRegistration:type=MessageHandler,name=chain$child.t1,bean=handler")));
+		assertTrue(names.contains(new ObjectName("test.MBeanRegistration:type=MessageHandler,name=chain$child.f1,bean=handler")));
 	}
 
 	@Test

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/NotificationPublishingChannelAdapterParserTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/NotificationPublishingChannelAdapterParserTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.util.Set;
+
 import javax.management.MBeanServer;
 import javax.management.Notification;
 import javax.management.ObjectName;
@@ -28,6 +29,7 @@ import javax.management.ObjectName;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.Message;
@@ -35,7 +37,6 @@ import org.springframework.integration.MessageChannel;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
 import org.springframework.integration.jmx.JmxHeaders;
-import org.springframework.integration.jmx.NotificationPublishingMessageHandler;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -126,7 +127,7 @@ public class NotificationPublishingChannelAdapterParserTests {
 		assertNull(notification.getUserData());
 		Set<ObjectName> names = server.queryNames(
 				new ObjectName("org.springframework.integration:type=MessageHandler," +
-						"name=chainWithJmxNotificationPublishing$child.jmx-notification-publishing-channel-adapter-within-chain.handler,*")
+						"name=chainWithJmxNotificationPublishing$child.jmx-notification-publishing-channel-adapter-within-chain,*")
 				, null);
 		assertEquals(1, names.size());
 	}


### PR DESCRIPTION
Some handlers get a componentName, but not a beanName. For example
the TransformerFactoryBean may create a Transformer that's not
a bean, to wrap a POJO, or expression. The AbstractSimpleMessageHandlerFactoryBean
transfers the component name to the transformer but it has a null
beanName. It would not be appropriate for the FB to change the beanName.

The IntegrationMBeanExporter's fallback, when it can't find the handler
as part of a stand-alone endpoint, is to use the handler's toString().

IntegrationObjectSupport (IOS) toString delegates to Object.toString()
if there is no beanName.

IOS's getComponentName() falls back to the beanName if there is no
component name.

Change the IMBE to use the componentName as the first fallback and,
if null, fallback to the current fallback.

One side effect is that handlers that do have a bean name
will no longer have '.handler' at the end of their name; but this
is not really an issue because the MBean is designated as a
handler anyway (via the bean component of the ObjectName).

However, identifying chain components is new in 3.0 so this is
not really a breaking change.
