### PR TITLE
INT-2433: Get Rid of MessageProcessors wrapping

### DIFF
--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -60,7 +60,7 @@ def customizePom(pom, gradleProject) {
 				developer {
 					id = 'markfisher'
 					name = 'Mark Fisher'
-					email = 'markfisher@gopivotal.com'
+					email = 'mfisher@gopivotal.com'
 					roles = ["project founder and lead emeritus"]
 				}
 				developer {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractStandardMessageHandlerFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractStandardMessageHandlerFactoryBean.java
@@ -135,7 +135,7 @@ abstract class AbstractStandardMessageHandlerFactoryBean extends AbstractSimpleM
 	}
 
 	<T> MessageHandler createMessageProcessingHandler(MessageProcessor<T> processor) {
-		return this.createMethodInvokingHandler(processor, "processMessage");
+		return this.createMethodInvokingHandler(processor, null);
 	}
 
 	MessageHandler createDefaultHandler() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/filter/MethodInvokingSelector.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/filter/MethodInvokingSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,15 @@ import java.lang.reflect.Method;
 
 import org.springframework.integration.annotation.Filter;
 import org.springframework.integration.core.MessageSelector;
+import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.handler.MethodInvokingMessageProcessor;
 import org.springframework.util.Assert;
 
 /**
  * A method-invoking implementation of {@link MessageSelector}.
- * 
+ *
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public class MethodInvokingSelector extends AbstractMessageProcessingSelector {
 
@@ -42,8 +44,10 @@ public class MethodInvokingSelector extends AbstractMessageProcessingSelector {
 		super(new MethodInvokingMessageProcessor<Boolean>(object, methodName));
 	}
 
+	@SuppressWarnings("unchecked")
 	public MethodInvokingSelector(Object object) {
-		super(new MethodInvokingMessageProcessor<Boolean>(object, Filter.class));
+		super(object instanceof MessageProcessor<?> ? (MessageProcessor<Boolean>) object :
+				new MethodInvokingMessageProcessor<Boolean>(object, Filter.class));
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,16 +28,16 @@ import org.springframework.util.Assert;
 /**
  * A base class for Router implementations that delegate to a
  * {@link MessageProcessor} instance.
- * 
+ *
  * @author Mark Fisher
  * @since 2.0
  */
 class AbstractMessageProcessingRouter extends AbstractMappingMessageRouter {
 
-	private final MessageProcessor<Object> messageProcessor;
+	private final MessageProcessor<?> messageProcessor;
 
 
-	AbstractMessageProcessingRouter(MessageProcessor<Object> messageProcessor) {
+	AbstractMessageProcessingRouter(MessageProcessor<?> messageProcessor) {
 		Assert.notNull(messageProcessor, "messageProcessor must not be null");
 		this.messageProcessor = messageProcessor;
 	}
@@ -47,7 +47,7 @@ class AbstractMessageProcessingRouter extends AbstractMappingMessageRouter {
 	public final void onInit() {
 		super.onInit();
 		if (this.messageProcessor instanceof AbstractMessageProcessor) {
-			((AbstractMessageProcessor<Object>) this.messageProcessor).setConversionService(this.getConversionService());
+			((AbstractMessageProcessor<?>) this.messageProcessor).setConversionService(this.getConversionService());
 		}
 		if (this.messageProcessor instanceof BeanFactoryAware) {
 			((BeanFactoryAware) this.messageProcessor).setBeanFactory(this.getBeanFactory());

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/MethodInvokingRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/MethodInvokingRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.router;
 import java.lang.reflect.Method;
 
 import org.springframework.integration.annotation.Router;
+import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.handler.MethodInvokingMessageProcessor;
 import org.springframework.integration.support.channel.ChannelResolver;
 
@@ -28,8 +29,9 @@ import org.springframework.integration.support.channel.ChannelResolver;
  * String to be interpreted as a channel name, or a Collection (or Array) of
  * either type. If the method returns channel names, then a
  * {@link ChannelResolver} is required.
- * 
+ *
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public class MethodInvokingRouter extends AbstractMessageProcessingRouter {
 
@@ -42,7 +44,8 @@ public class MethodInvokingRouter extends AbstractMessageProcessingRouter {
 	}
 
 	public MethodInvokingRouter(Object object) {
-		super(new MethodInvokingMessageProcessor<Object>(object, Router.class));
+		super(object instanceof MessageProcessor<?> ? (MessageProcessor<?>) object :
+				new MethodInvokingMessageProcessor<Object>(object, Router.class));
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/splitter/MethodInvokingSplitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/splitter/MethodInvokingSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 
 import org.springframework.integration.annotation.Splitter;
+import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.handler.MethodInvokingMessageProcessor;
 
 /**
@@ -28,8 +29,9 @@ import org.springframework.integration.handler.MethodInvokingMessageProcessor;
  * is a Collection or Array. If the return value is not a Collection or
  * Array, then the single Object will be returned as the payload of a
  * single reply Message.
- * 
+ *
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public class MethodInvokingSplitter extends AbstractMessageProcessingSplitter {
 
@@ -41,8 +43,10 @@ public class MethodInvokingSplitter extends AbstractMessageProcessingSplitter {
 		super(new MethodInvokingMessageProcessor<Collection<?>>(object, methodName));
 	}
 
+	@SuppressWarnings("unchecked")
 	public MethodInvokingSplitter(Object object) {
-		super(new MethodInvokingMessageProcessor<Collection<?>>(object, Splitter.class));
+		super(object instanceof MessageProcessor<?> ? (MessageProcessor<Collection<?>>) object :
+				new MethodInvokingMessageProcessor<Collection<?>>(object, Splitter.class));
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/MethodInvokingTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/MethodInvokingTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.transformer;
 import java.lang.reflect.Method;
 
 import org.springframework.integration.annotation.Transformer;
+import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.handler.MethodInvokingMessageProcessor;
 
 /**
@@ -26,8 +27,9 @@ import org.springframework.integration.handler.MethodInvokingMessageProcessor;
  * on the given object. The method's return value will be considered as
  * the payload of a new Message unless the return value is itself already
  * a Message.
- * 
+ *
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public class MethodInvokingTransformer extends AbstractMessageProcessingTransformer {
 
@@ -40,7 +42,8 @@ public class MethodInvokingTransformer extends AbstractMessageProcessingTransfor
 	}
 
 	public MethodInvokingTransformer(Object object) {
-		super(new MethodInvokingMessageProcessor<Object>(object, Transformer.class));
+		super(object instanceof MessageProcessor<?> ? (MessageProcessor<?>) object :
+				new MethodInvokingMessageProcessor<Object>(object, Transformer.class));
 	}
 
 }

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyFilterTests-context.xml
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyFilterTests-context.xml
@@ -7,7 +7,7 @@
 		http://www.springframework.org/schema/integration/groovy http://www.springframework.org/schema/integration/groovy/spring-integration-groovy.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<filter input-channel="referencedScriptInput">
+	<filter id="groovyFilter" input-channel="referencedScriptInput">
 		<groovy:script location="org/springframework/integration/groovy/config/GroovyFilterTests.groovy"/>
 	</filter>
 

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyFilterTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,20 +19,30 @@ package org.springframework.integration.groovy.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.core.MessageHandler;
+import org.springframework.integration.core.MessageSelector;
+import org.springframework.integration.filter.MessageFilter;
+import org.springframework.integration.filter.MethodInvokingSelector;
+import org.springframework.integration.groovy.GroovyScriptExecutingMessageProcessor;
+import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  * @since 2.0
  */
 @ContextConfiguration
@@ -45,6 +55,9 @@ public class GroovyFilterTests {
 	@Autowired
 	private MessageChannel inlineScriptInput;
 
+	@Autowired
+	@Qualifier("groovyFilter.handler")
+	private MessageHandler groovyFilterMessageHandler;
 
 	@Test
 	public void referencedScript() {
@@ -57,7 +70,7 @@ public class GroovyFilterTests {
 		Message<?> message2 = MessageBuilder.withPayload("test-2")
 				.setReplyChannel(replyChannel)
 				.setHeader("type", "good")
-				.build();		
+				.build();
 		this.referencedScriptInput.send(message1);
 		this.referencedScriptInput.send(message2);
 		assertEquals("test-2", replyChannel.receive(0).getPayload());
@@ -69,7 +82,7 @@ public class GroovyFilterTests {
 		QueueChannel replyChannel = new QueueChannel();
 		replyChannel.setBeanName("returnAddress");
 		Message<?> message1 = MessageBuilder.withPayload("bad").setReplyChannel(replyChannel).build();
-		Message<?> message2 = MessageBuilder.withPayload("good").setReplyChannel(replyChannel).build();		
+		Message<?> message2 = MessageBuilder.withPayload("good").setReplyChannel(replyChannel).build();
 		this.inlineScriptInput.send(message1);
 		this.inlineScriptInput.send(message2);
 		Message<?> received = replyChannel.receive(0);
@@ -77,6 +90,16 @@ public class GroovyFilterTests {
 		assertEquals("good", received.getPayload());
 		assertEquals(message2, received);
 		assertNull(replyChannel.receive(0));
+	}
+
+	@Test
+	public void testInt2433VerifyRiddingOfMessageProcessorsWrapping() {
+		assertTrue(this.groovyFilterMessageHandler instanceof MessageFilter);
+		MessageSelector selector = TestUtils.getPropertyValue(this.groovyFilterMessageHandler, "selector",
+				MethodInvokingSelector.class);
+		MessageProcessor messageProcessor = TestUtils.getPropertyValue(selector, "messageProcessor", MessageProcessor.class);
+		//before it was MethodInvokingMessageProcessor
+		assertTrue(messageProcessor instanceof GroovyScriptExecutingMessageProcessor);
 	}
 
 }

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyRouterTests-context.xml
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyRouterTests-context.xml
@@ -15,7 +15,7 @@
 		<queue/>
 	</channel>
 
-	<router input-channel="referencedScriptInput">
+	<router id="groovyRouter" input-channel="referencedScriptInput">
 		<groovy:script location="org/springframework/integration/groovy/config/GroovyRouterTests.groovy"/>
 	</router>
 

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyRouterTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyRouterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +18,28 @@ package org.springframework.integration.groovy.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
+import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.PollableChannel;
+import org.springframework.integration.groovy.GroovyScriptExecutingMessageProcessor;
+import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.router.MethodInvokingRouter;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  * @since 2.0
  */
 @ContextConfiguration
@@ -50,6 +58,9 @@ public class GroovyRouterTests {
 	@Autowired
 	private PollableChannel shortStrings;
 
+	@Autowired
+	@Qualifier("groovyRouter.handler")
+	private MessageHandler groovyRouterMessageHandler;
 
 	@Test
 	public void referencedScript() { // long is > 3
@@ -91,6 +102,15 @@ public class GroovyRouterTests {
 		assertEquals("elephant", longStrings.receive(0).getPayload());
 		assertNull(shortStrings.receive(0));
 		assertNull(longStrings.receive(0));
+	}
+
+	@Test
+	public void testInt2433VerifyRiddingOfMessageProcessorsWrapping() {
+		assertTrue(this.groovyRouterMessageHandler instanceof MethodInvokingRouter);
+		MessageProcessor messageProcessor = TestUtils.getPropertyValue(this.groovyRouterMessageHandler,
+				"messageProcessor", MessageProcessor.class);
+		//before it was MethodInvokingMessageProcessor
+		assertTrue(messageProcessor instanceof GroovyScriptExecutingMessageProcessor);
 	}
 
 }

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovySplitterTests-context.xml
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovySplitterTests-context.xml
@@ -7,7 +7,7 @@
 		http://www.springframework.org/schema/integration/groovy http://www.springframework.org/schema/integration/groovy/spring-integration-groovy.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<splitter input-channel="referencedScriptInput">
+	<splitter id="groovySplitter" input-channel="referencedScriptInput">
 		<groovy:script location="org/springframework/integration/groovy/config/GroovySplitterTests.groovy"/>
 	</splitter>
 

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovySplitterTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovySplitterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +18,28 @@ package org.springframework.integration.groovy.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.core.MessageHandler;
+import org.springframework.integration.groovy.GroovyScriptExecutingMessageProcessor;
+import org.springframework.integration.handler.MessageProcessor;
+import org.springframework.integration.splitter.MethodInvokingSplitter;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  * @since 2.0
  */
 @ContextConfiguration
@@ -44,6 +52,9 @@ public class GroovySplitterTests {
 	@Autowired
 	private MessageChannel inlineScriptInput;
 
+	@Autowired
+	@Qualifier("groovySplitter.handler")
+	private MessageHandler groovySplitterMessageHandler;
 
 	@Test
 	public void referencedScript() {
@@ -67,6 +78,15 @@ public class GroovySplitterTests {
 		assertEquals("b", replyChannel.receive(0).getPayload());
 		assertEquals("c", replyChannel.receive(0).getPayload());
 		assertNull(replyChannel.receive(0));
+	}
+
+	@Test
+	public void testInt2433VerifyRiddingOfMessageProcessorsWrapping() {
+	    assertTrue(this.groovySplitterMessageHandler instanceof MethodInvokingSplitter);
+	    MessageProcessor messageProcessor = TestUtils.getPropertyValue(this.groovySplitterMessageHandler,
+				"messageProcessor", MessageProcessor.class);
+	    //before it was MethodInvokingMessageProcessor
+		assertTrue(messageProcessor instanceof GroovyScriptExecutingMessageProcessor);
 	}
 
 }

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyTransformerTests-context.xml
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyTransformerTests-context.xml
@@ -7,7 +7,7 @@
 		http://www.springframework.org/schema/integration/groovy http://www.springframework.org/schema/integration/groovy/spring-integration-groovy.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<transformer input-channel="referencedScriptInput">
+	<transformer id="groovyTransformer" input-channel="referencedScriptInput">
 		<groovy:script location="org/springframework/integration/groovy/config/GroovyTransformerTests.groovy"/>
 	</transformer>
 

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyTransformerTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +18,30 @@ package org.springframework.integration.groovy.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.core.MessageHandler;
+import org.springframework.integration.groovy.GroovyScriptExecutingMessageProcessor;
+import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.integration.transformer.AbstractMessageProcessingTransformer;
+import org.springframework.integration.transformer.MessageTransformingHandler;
+import org.springframework.integration.transformer.Transformer;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  * @since 2.0
  */
 @ContextConfiguration
@@ -44,6 +54,9 @@ public class GroovyTransformerTests {
 	@Autowired
 	private MessageChannel inlineScriptInput;
 
+	@Autowired
+	@Qualifier("groovyTransformer.handler")
+	private MessageHandler groovyTransformerMessageHandler;
 
 	@Test
 	public void referencedScript() {
@@ -73,4 +86,13 @@ public class GroovyTransformerTests {
 		assertNull(replyChannel.receive(0));
 	}
 
+	@Test
+	public void testInt2433VerifyRiddingOfMessageProcessorsWrapping() {
+	    assertTrue(this.groovyTransformerMessageHandler instanceof MessageTransformingHandler);
+	    Transformer transformer = TestUtils.getPropertyValue(this.groovyTransformerMessageHandler, "transformer", Transformer.class);
+	    assertTrue(transformer instanceof AbstractMessageProcessingTransformer);
+	    MessageProcessor messageProcessor = TestUtils.getPropertyValue(transformer, "messageProcessor", MessageProcessor.class);
+	    //before it was MethodInvokingMessageProcessor
+		assertTrue(messageProcessor instanceof GroovyScriptExecutingMessageProcessor);
+	}
 }


### PR DESCRIPTION
Previously, provided `MessageProcessor` to create a `MessageHandler`
for endpoint was wrapped to `MethodInvokingMessageProcessor`,
e.g. `GroovyScriptExecutingMessageProcessor`.

Check the type of provided object in the constructor
of `MethodInvoking*` strategies and use it directly if it is `MessageProcessor`

JIRA: https://jira.springsource.org/browse/INT-2433
