### PR TITLE
INT-3138: add `awaitTermination` to delayer tests

### DIFF
--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
@@ -31,6 +31,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessagingException;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.handler.DelayHandler;
@@ -41,6 +42,7 @@ import org.springframework.integration.util.UUIDConverter;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -80,9 +82,11 @@ public class DelayerHandlerRescheduleIntegrationTests {
 		input.send(MessageBuilder.withPayload("test2").build());
 
 		// Emulate restart and check DB state before next start
+		// Interrupt taskScheduler as quickly as possible
+		ThreadPoolTaskScheduler taskScheduler = (ThreadPoolTaskScheduler) IntegrationContextUtils.getTaskScheduler(context);
+		taskScheduler.shutdown();
+		taskScheduler.getScheduledExecutor().awaitTermination(10, TimeUnit.SECONDS);
 		context.destroy();
-
-		Thread.sleep(100);
 
 		try {
 			context.getBean("input", MessageChannel.class);


### PR DESCRIPTION
`DelayerHandlerRescheduleIntegrationTests` fail sometimes
on asserts. Looks like `context.destroy()` works very slow
and `<delayer>` manages to send delayed Messages

JIRA: https://jira.springsource.org/browse/INT-3138
