### PR TITLE
INT-3120: remove `Accept-Charset` from Response

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -147,7 +147,9 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 		this.expectReply = expectReply;
 		this.messageConverters.add(new MultipartAwareFormHttpMessageConverter());
 		this.messageConverters.add(new ByteArrayHttpMessageConverter());
-		this.messageConverters.add(new StringHttpMessageConverter());
+		StringHttpMessageConverter stringHttpMessageConverter = new StringHttpMessageConverter();
+		stringHttpMessageConverter.setWriteAcceptCharset(false);
+		this.messageConverters.add(stringHttpMessageConverter);
 		this.messageConverters.add(new ResourceHttpMessageConverter());
 		this.messageConverters.add(new SourceHttpMessageConverter());
 		if (jaxb2Present) {

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGatewayTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGatewayTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.http.inbound;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
@@ -53,6 +54,7 @@ import org.springframework.util.SerializationUtils;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Gunnar Hillert
+ * @author Artem Bilan
  * @since 2.0
  */
 public class HttpRequestHandlingMessagingGatewayTests {
@@ -151,6 +153,8 @@ public class HttpRequestHandlingMessagingGatewayTests {
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		gateway.handleRequest(request, response);
 		assertEquals("HELLO", response.getContentAsString());
+		//INT-3120
+		assertNull(response.getHeader("Accept-Charset"));
 	}
 
 	@Test


### PR DESCRIPTION
`StringHttpMessageConverter` adds `Accept-Charset` header by default.
By RFC 2616 `Accept-Charset` is a Request header,
so it won't be presented in the Response.

Turn off `writeAcceptCharset` in the `HttpRequestHandlingEndpointSupport`.

JIRA: https://jira.springsource.org/browse/INT-3120
