### PR TITLE
INT-3142: A flag to retain default converters when user has customized message converters for HttpRequestHandlingController, HttpInboundGateway

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpInboundEndpointParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpInboundEndpointParser.java
@@ -160,7 +160,7 @@ public class HttpInboundEndpointParser extends AbstractSingleBeanDefinitionParse
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "errors-key");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "error-code");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converters");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "register-default-converters");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "merge-with-default-converters");
 
 
 		//IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "header-mapper");

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpInboundEndpointParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpInboundEndpointParser.java
@@ -47,6 +47,7 @@ import org.w3c.dom.Element;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Biju Kunjummen
  */
 public class HttpInboundEndpointParser extends AbstractSingleBeanDefinitionParser {
 
@@ -159,6 +160,7 @@ public class HttpInboundEndpointParser extends AbstractSingleBeanDefinitionParse
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "errors-key");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "error-code");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converters");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "register-default-converters");
 
 
 		//IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "header-mapper");

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -41,6 +41,7 @@ import org.springframework.http.converter.ResourceHttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.feed.AtomFeedHttpMessageConverter;
 import org.springframework.http.converter.feed.RssChannelHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJacksonHttpMessageConverter;
 import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
 import org.springframework.http.converter.xml.SourceHttpMessageConverter;
@@ -57,6 +58,7 @@ import org.springframework.integration.http.multipart.MultipartHttpInputMessage;
 import org.springframework.integration.http.support.DefaultHttpHeaderMapper;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.support.json.JacksonJsonUtils;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -95,6 +97,7 @@ import org.springframework.web.util.UrlPathHelper;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Biju Kunjummen
  * @since 2.0
  */
 public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySupport
@@ -103,10 +106,6 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 	private static final boolean jaxb2Present = ClassUtils.isPresent("javax.xml.bind.Binder",
 			HttpRequestHandlingEndpointSupport.class.getClassLoader());
 
-	private static final boolean jacksonPresent = ClassUtils.isPresent("org.codehaus.jackson.map.ObjectMapper",
-			HttpRequestHandlingEndpointSupport.class.getClassLoader())
-			&& ClassUtils.isPresent("org.codehaus.jackson.JsonGenerator", HttpRequestHandlingEndpointSupport.class
-					.getClassLoader());
 
 	private static boolean romePresent = ClassUtils.isPresent("com.sun.syndication.feed.WireFeed",
 			HttpRequestHandlingEndpointSupport.class.getClassLoader());
@@ -116,6 +115,8 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 	private volatile Class<?> requestPayloadType = null;
 
 	private volatile List<HttpMessageConverter<?>> messageConverters = new ArrayList<HttpMessageConverter<?>>();
+
+	private volatile boolean registerDefaultConverters = false;
 
 	private volatile HeaderMapper<HttpHeaders> headerMapper = DefaultHttpHeaderMapper.inboundMapper();
 
@@ -143,26 +144,8 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 		this(true);
 	}
 
-	@SuppressWarnings("rawtypes")
 	public HttpRequestHandlingEndpointSupport(boolean expectReply) {
 		this.expectReply = expectReply;
-		this.messageConverters.add(new MultipartAwareFormHttpMessageConverter());
-		this.messageConverters.add(new ByteArrayHttpMessageConverter());
-		StringHttpMessageConverter stringHttpMessageConverter = new StringHttpMessageConverter();
-		stringHttpMessageConverter.setWriteAcceptCharset(false);
-		this.messageConverters.add(stringHttpMessageConverter);
-		this.messageConverters.add(new ResourceHttpMessageConverter());
-		this.messageConverters.add(new SourceHttpMessageConverter());
-		if (jaxb2Present) {
-			this.messageConverters.add(new Jaxb2RootElementHttpMessageConverter());
-		}
-		if (jacksonPresent) {
-			this.messageConverters.add(new MappingJacksonHttpMessageConverter());
-		}
-		if (romePresent) {
-			this.messageConverters.add(new AtomFeedHttpMessageConverter());
-			this.messageConverters.add(new RssChannelHttpMessageConverter());
-		}
 	}
 
 	/**
@@ -211,11 +194,21 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 	 */
 	public void setMessageConverters(List<HttpMessageConverter<?>> messageConverters) {
 		Assert.notEmpty(messageConverters, "'messageConverters' must not be empty");
-		this.messageConverters = messageConverters;
+		this.messageConverters.addAll(messageConverters);
 	}
 
 	protected List<HttpMessageConverter<?>> getMessageConverters() {
 		return this.messageConverters;
+	}
+	
+
+	/**
+	 * Flag which determines if the default converters should be available if the user has customized 
+	 * the list of message converters. The behavior will be to add the default converters after
+	 * the list of user customized converters
+	 */
+	public void setRegisterDefaultConverters(boolean registerDefaultConverters) {
+		this.registerDefaultConverters = registerDefaultConverters;
 	}
 
 	/**
@@ -306,8 +299,19 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 				}
 			}
 		}
-
+		registerConverters();
 		this.validateSupportedMethods();
+	}
+
+	/**
+	 * Register the list of {@link HttpMessageConverter}. If user has customized the set of converters, then
+	 * an additional flag 'registerDefaultConverters' can be set to add the list of default HttpMessageConverter 
+	 * to the  list of converters
+	 */
+	private void registerConverters() {
+		if (this.registerDefaultConverters || this.messageConverters.size() == 0) {
+			this.messageConverters.addAll(defaultMessageConverters());
+		}
 	}
 
 
@@ -566,6 +570,35 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 				}
 			}
 		}
+	}
+	
+	/**
+	 * Provides the list of default HttpMessageConverter
+	 */
+	@SuppressWarnings("rawtypes")
+	private List<HttpMessageConverter<?>> defaultMessageConverters() {
+		List<HttpMessageConverter<?>> defaultConverters = new ArrayList<HttpMessageConverter<?>>();
+		defaultConverters.add(new MultipartAwareFormHttpMessageConverter());
+		defaultConverters.add(new ByteArrayHttpMessageConverter());
+		StringHttpMessageConverter stringHttpMessageConverter = new StringHttpMessageConverter();
+		stringHttpMessageConverter.setWriteAcceptCharset(false);
+		defaultConverters.add(stringHttpMessageConverter);
+		defaultConverters.add(new ResourceHttpMessageConverter());
+		defaultConverters.add(new SourceHttpMessageConverter());
+		if (jaxb2Present) {
+			defaultConverters.add(new Jaxb2RootElementHttpMessageConverter());
+		}
+		if (JacksonJsonUtils.isJackson2Present()) {
+			defaultConverters.add(new MappingJackson2HttpMessageConverter());
+		}else if (JacksonJsonUtils.isJacksonPresent()) {
+			defaultConverters.add(new MappingJacksonHttpMessageConverter());
+		}
+		if (romePresent) {
+			defaultConverters.add(new AtomFeedHttpMessageConverter());
+			defaultConverters.add(new RssChannelHttpMessageConverter());
+		}
+		
+		return defaultConverters;
 	}
 
 	public int beforeShutdown() {

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -116,7 +116,7 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 
 	private volatile List<HttpMessageConverter<?>> messageConverters = new ArrayList<HttpMessageConverter<?>>();
 
-	private volatile boolean registerDefaultConverters = false;
+	private volatile boolean mergeWithDefaultConverters = false;
 
 	private volatile HeaderMapper<HttpHeaders> headerMapper = DefaultHttpHeaderMapper.inboundMapper();
 
@@ -203,12 +203,11 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 	
 
 	/**
-	 * Flag which determines if the default converters should be available if the user has customized 
-	 * the list of message converters. The behavior will be to add the default converters after
-	 * the list of user customized converters
+	 * Flag which determines if the default converters should be available after 
+	 * custom converters.
 	 */
-	public void setRegisterDefaultConverters(boolean registerDefaultConverters) {
-		this.registerDefaultConverters = registerDefaultConverters;
+	public void setMergeWithDefaultConverters(boolean mergeWithDefaultConverters) {
+		this.mergeWithDefaultConverters = mergeWithDefaultConverters;
 	}
 
 	/**
@@ -305,11 +304,12 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 
 	/**
 	 * Register the list of {@link HttpMessageConverter}. If user has customized the set of converters, then
-	 * an additional flag 'registerDefaultConverters' can be set to add the list of default HttpMessageConverter 
-	 * to the  list of converters
+	 * an additional flag 'mergeWithDefaultConverters' can be set to add the list of default HttpMessageConverter 
+	 * after the  list of custom converters. If there are no custom converters, the default converters will 
+	 * always be registered
 	 */
 	private void registerConverters() {
-		if (this.registerDefaultConverters || this.messageConverters.size() == 0) {
+		if (this.mergeWithDefaultConverters || this.messageConverters.size() == 0) {
 			this.messageConverters.addAll(defaultMessageConverters());
 		}
 	}

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-3.0.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-3.0.xsd
@@ -138,6 +138,17 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="register-default-converters" type="xsd:boolean" default="false">
+				<xsd:annotation>
+					<xsd:documentation>
+						Flag to indicate if the default converters should be registered if user 
+						has customized the converters. This flag is used only if message-converters 
+						are provided, otherwise all default converters will be registered.
+
+						Defaults to "false"
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="header-mapper" type="xsd:string">
 				<xsd:annotation>
 					<xsd:appinfo>
@@ -296,6 +307,17 @@ The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Re
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="register-default-converters" type="xsd:boolean" default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+								Flag to indicate if the default converters should be registered if user 
+								has customized the converters. This flag is used only if message-converters 
+								are provided, otherwise all default converters will be registered.
+								
+								Defaults to "false"
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>					
 					<xsd:attribute name="header-mapper" type="xsd:string">
 						<xsd:annotation>
 							<xsd:appinfo>

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-3.0.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-3.0.xsd
@@ -138,11 +138,11 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
-			<xsd:attribute name="register-default-converters" type="xsd:boolean" default="false">
+			<xsd:attribute name="merge-with-default-converters" type="xsd:boolean" default="false">
 				<xsd:annotation>
 					<xsd:documentation>
-						Flag to indicate if the default converters should be registered if user 
-						has customized the converters. This flag is used only if message-converters 
+						Flag to indicate if the default converters should be registered after
+						custom converters. This flag is used only if message-converters 
 						are provided, otherwise all default converters will be registered.
 
 						Defaults to "false"
@@ -307,11 +307,11 @@ The String "HTTP_REQUEST_HEADERS" will match against any of the standard HTTP Re
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
-					<xsd:attribute name="register-default-converters" type="xsd:boolean" default="false">
+					<xsd:attribute name="merge-with-default-converters" type="xsd:boolean" default="false">
 						<xsd:annotation>
 							<xsd:documentation>
-								Flag to indicate if the default converters should be registered if user 
-								has customized the converters. This flag is used only if message-converters 
+								Flag to indicate if the default converters should be registered after custom
+								converters. This flag is used only if message-converters 
 								are provided, otherwise all default converters will be registered.
 								
 								Defaults to "false"

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests-context.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans:beans xmlns="http://www.springframework.org/schema/integration/http"
+<beans:beans
+	xmlns="http://www.springframework.org/schema/integration/http"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:si="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
-			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd
-			http://www.springframework.org/schema/integration/http
-			http://www.springframework.org/schema/integration/http/spring-integration-http.xsd">
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
 	<si:message-history/>
 
@@ -19,6 +19,18 @@
 	<inbound-channel-adapter id="defaultAdapter" channel="requests" error-channel="errorChannel"/>
 
 	<inbound-channel-adapter id="postOnlyAdapter" channel="requests" supported-methods="POST"/>
+	
+	<inbound-channel-adapter id="adapterWithCustomConverterWithDefaults" message-converters="customConverters" 
+							channel="requests" supported-methods="POST" register-default-converters="true"/>	
+	
+	<inbound-channel-adapter id="adapterWithCustomConverterNoDefaults" message-converters="customConverters" 
+							channel="requests" supported-methods="POST" />	
+
+	<inbound-channel-adapter id="adapterNoCustomConverterNoDefaults" channel="requests" supported-methods="POST" />
+
+	<util:list id="customConverters">
+		<beans:bean class="org.springframework.integration.http.converter.SerializingHttpMessageConverter"/>
+	</util:list>
 
 	<inbound-channel-adapter id="putOrDeleteAdapter" channel="requests" supported-methods="PUT, delete"/>
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests-context.xml
@@ -21,7 +21,7 @@
 	<inbound-channel-adapter id="postOnlyAdapter" channel="requests" supported-methods="POST"/>
 	
 	<inbound-channel-adapter id="adapterWithCustomConverterWithDefaults" message-converters="customConverters" 
-							channel="requests" supported-methods="POST" register-default-converters="true"/>	
+							channel="requests" supported-methods="POST" merge-with-default-converters="true"/>	
 	
 	<inbound-channel-adapter id="adapterWithCustomConverterNoDefaults" message-converters="customConverters" 
 							channel="requests" supported-methods="POST" />	

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests-context.xml
@@ -26,6 +26,22 @@
 		reply-timeout="4567"
 		error-channel="errorChannel"/>
 
+	<inbound-gateway id="inboundGatewayWithDefaultConverters"
+		request-channel="requests"
+		reply-channel="responses"
+		message-converters="customConverters"/>
+
+	<inbound-gateway id="inboundGatewayNoDefaultConverters"
+		request-channel="requests"
+		reply-channel="responses"
+		message-converters="customConverters"
+		register-default-converters="false"/>
+
+	<util:list id="customConverters">
+		<beans:bean class="org.springframework.integration.http.converter.SerializingHttpMessageConverter"/>
+	</util:list>		
+
+
 	<inbound-gateway id="inboundController" request-channel="requests" reply-channel="responses" view-name="foo" error-code="oops"/>
 	
 	<inbound-gateway id="inboundControllerViewExp"

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests-context.xml
@@ -35,7 +35,7 @@
 		request-channel="requests"
 		reply-channel="responses"
 		message-converters="customConverters"
-		register-default-converters="false"/>
+		merge-with-default-converters="false"/>
 
 	<util:list id="customConverters">
 		<beans:bean class="org.springframework.integration.http.converter.SerializingHttpMessageConverter"/>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests.java
@@ -118,7 +118,7 @@ public class HttpInboundGatewayParserTests {
 		assertEquals(Long.valueOf(1234), TestUtils.getPropertyValue(messagingTemplate, "sendTimeout"));
 		assertEquals(Long.valueOf(4567), TestUtils.getPropertyValue(messagingTemplate, "receiveTimeout"));
 		
-		boolean registerDefaultConverters = TestUtils.getPropertyValue(gateway,"registerDefaultConverters", Boolean.class);
+		boolean registerDefaultConverters = TestUtils.getPropertyValue(gateway,"mergeWithDefaultConverters", Boolean.class);
 		assertFalse("By default the register-default-converters flag should be false", registerDefaultConverters);
 		@SuppressWarnings("unchecked")
 		List<HttpMessageConverter<?>> messageConverters = TestUtils.getPropertyValue(gateway,"messageConverters", List.class);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
 
 package org.springframework.integration.http.config;
 
-import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.any;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.springframework.integration.test.util.TestUtils.getPropertyValue;
 import static org.springframework.integration.test.util.TestUtils.handlerExpecting;
 
@@ -64,6 +67,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Gunnar Hillert
+ * @author Biju Kunjummen
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -73,6 +77,14 @@ public class HttpInboundGatewayParserTests {
 	@Qualifier("inboundGateway")
 	private HttpRequestHandlingMessagingGateway gateway;
 
+	@Autowired
+	@Qualifier("inboundGatewayWithDefaultConverters")
+	private HttpRequestHandlingMessagingGateway gatewayWithDefaultConverters;
+
+	@Autowired
+	@Qualifier("inboundGatewayNoDefaultConverters")
+	private HttpRequestHandlingMessagingGateway gatewayNoDefaultConverters;
+	
 	@Autowired
 	@Qualifier("withMappedHeaders")
 	private HttpRequestHandlingMessagingGateway withMappedHeaders;
@@ -105,6 +117,14 @@ public class HttpInboundGatewayParserTests {
 				gateway, "messagingTemplate", MessagingTemplate.class);
 		assertEquals(Long.valueOf(1234), TestUtils.getPropertyValue(messagingTemplate, "sendTimeout"));
 		assertEquals(Long.valueOf(4567), TestUtils.getPropertyValue(messagingTemplate, "receiveTimeout"));
+		
+		boolean registerDefaultConverters = TestUtils.getPropertyValue(gateway,"registerDefaultConverters", Boolean.class);
+		assertFalse("By default the register-default-converters flag should be false", registerDefaultConverters);
+		@SuppressWarnings("unchecked")
+		List<HttpMessageConverter<?>> messageConverters = TestUtils.getPropertyValue(gateway,"messageConverters", List.class);
+		
+		assertTrue("The default converters should have been registered, given there are no custom converters", 
+				messageConverters.size() > 0);
 	}
 
 	@Test(timeout=1000) @DirtiesContext
@@ -119,6 +139,7 @@ public class HttpInboundGatewayParserTests {
 		List<HttpMessageConverter<?>> converters = new ArrayList<HttpMessageConverter<?>>();
 		converters.add(new SerializingHttpMessageConverter());
 		gateway.setMessageConverters(converters);
+		gateway.afterPropertiesSet();
 
 		gateway.handleRequest(request, response);
 		assertThat(response.getStatus(), is(HttpServletResponse.SC_OK));
@@ -199,6 +220,29 @@ public class HttpInboundGatewayParserTests {
 		List<String> personHeaders = headers.get("X-person");
 		assertEquals("Oleg", personHeaders.get(0));
 	}
+
+	@Test
+	public void testInboundGatewayWithMessageConverterDefaults() {
+		@SuppressWarnings("unchecked")
+		List<HttpMessageConverter<?>> messageConverters = 
+			TestUtils.getPropertyValue(gatewayWithDefaultConverters, "messageConverters", List.class);
+		assertThat("There should be only 1 message converter, by default register-default-converters is off", 
+				messageConverters.size(), is(1));
+		
+		//The converter should be the customized one
+		assertThat(messageConverters.get(0), instanceOf(SerializingHttpMessageConverter.class));
+	}
+	
+	@Test
+	public void testInboundGatewayWithNoMessageConverterDefaults() {
+		@SuppressWarnings("unchecked")
+		List<HttpMessageConverter<?>> messageConverters = TestUtils.getPropertyValue(gatewayNoDefaultConverters, "messageConverters", List.class);
+		//First converter should be the customized one
+		assertThat(messageConverters.get(0), instanceOf(SerializingHttpMessageConverter.class));
+		
+		assertThat("There should be only 1 message converter, the register-default-converters is false", 
+				messageConverters.size(), is(1));
+	}	
 
 	public static class Person{
 		private String name;

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingControllerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingControllerTests.java
@@ -51,6 +51,7 @@ import org.springframework.web.servlet.View;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Gunnar Hillert
+ * @author Biju Kunjummen
  * @since 2.0
  */
 public class HttpRequestHandlingControllerTests {
@@ -62,6 +63,7 @@ public class HttpRequestHandlingControllerTests {
 		controller.setBeanFactory(mock(BeanFactory.class));
 		controller.setRequestChannel(requestChannel);
 		controller.setViewName("foo");
+		controller.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.setContent("hello".getBytes());
@@ -87,6 +89,7 @@ public class HttpRequestHandlingControllerTests {
 		controller.setRequestChannel(requestChannel);
 		Expression viewExpression = new SpelExpressionParser().parseExpression("'baz'");
 		controller.setViewExpression(viewExpression);
+		controller.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.setContent("hello".getBytes());
@@ -118,6 +121,7 @@ public class HttpRequestHandlingControllerTests {
 		controller.setBeanFactory(mock(BeanFactory.class));
 		controller.setRequestChannel(requestChannel);
 		controller.setViewName("foo");
+		controller.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 
@@ -151,6 +155,7 @@ public class HttpRequestHandlingControllerTests {
 		controller.setRequestChannel(requestChannel);
 		Expression viewExpression = new SpelExpressionParser().parseExpression("headers['bar']");
 		controller.setViewExpression(viewExpression);
+		controller.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.setContent("hello".getBytes());
@@ -181,6 +186,7 @@ public class HttpRequestHandlingControllerTests {
 		controller.setRequestChannel(requestChannel);
 		Expression viewExpression = new SpelExpressionParser().parseExpression("headers['bar']");
 		controller.setViewExpression(viewExpression);
+		controller.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.setContent("hello".getBytes());
@@ -209,6 +215,7 @@ public class HttpRequestHandlingControllerTests {
 		controller.setRequestChannel(requestChannel);
 		controller.setViewName("foo");
 		controller.setReplyKey("myReply");
+		controller.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.setContent("howdy".getBytes());
@@ -241,6 +248,7 @@ public class HttpRequestHandlingControllerTests {
 		controller.setRequestChannel(requestChannel);
 		controller.setViewName("foo");
 		controller.setExtractReplyPayload(false);
+		controller.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.setContent("abc".getBytes());
@@ -270,6 +278,7 @@ public class HttpRequestHandlingControllerTests {
 		HttpRequestHandlingController controller = new HttpRequestHandlingController(false);
 		controller.setBeanFactory(mock(BeanFactory.class));
 		controller.setRequestChannel(requestChannel);
+		controller.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.setContent("hello".getBytes());
@@ -308,6 +317,7 @@ public class HttpRequestHandlingControllerTests {
 		controller.setBeanFactory(mock(BeanFactory.class));
 		controller.setRequestChannel(requestChannel);
 		controller.setViewName("foo");
+		controller.afterPropertiesSet();
 		final MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.setContent("hello".getBytes());

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGatewayTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGatewayTests.java
@@ -55,6 +55,7 @@ import org.springframework.util.SerializationUtils;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Biju Kunjummen
  * @since 2.0
  */
 public class HttpRequestHandlingMessagingGatewayTests {
@@ -66,6 +67,7 @@ public class HttpRequestHandlingMessagingGatewayTests {
 		HttpRequestHandlingMessagingGateway gateway = new HttpRequestHandlingMessagingGateway(false);
 		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.setRequestChannel(requestChannel);
+		gateway.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("GET");
 		request.setParameter("foo", "bar");
@@ -86,6 +88,7 @@ public class HttpRequestHandlingMessagingGatewayTests {
 		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.setRequestPayloadType(String.class);
 		gateway.setRequestChannel(requestChannel);
+		gateway.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 
@@ -115,6 +118,7 @@ public class HttpRequestHandlingMessagingGatewayTests {
 		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.setRequestPayloadType(String.class);
 		gateway.setRequestChannel(requestChannel);
+		gateway.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.addHeader("Accept", "x-application/octet-stream");
@@ -142,6 +146,7 @@ public class HttpRequestHandlingMessagingGatewayTests {
 		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.setRequestPayloadType(String.class);
 		gateway.setRequestChannel(requestChannel);
+		gateway.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 
@@ -170,6 +175,7 @@ public class HttpRequestHandlingMessagingGatewayTests {
 		gateway.setRequestChannel(requestChannel);
 		gateway.setConvertExceptions(true);
 		gateway.setMessageConverters(Arrays.<HttpMessageConverter<?>>asList(new TestHttpMessageConverter()));
+		gateway.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Accept", "application/x-java-serialized-object");
 		request.setMethod("GET");
@@ -185,6 +191,7 @@ public class HttpRequestHandlingMessagingGatewayTests {
 		HttpRequestHandlingMessagingGateway gateway = new HttpRequestHandlingMessagingGateway(false);
 		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.setRequestChannel(channel);
+		gateway.afterPropertiesSet();
 		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
 		request.setParameter("foo", "123");
 		request.addParameter("bar", "456");
@@ -217,6 +224,7 @@ public class HttpRequestHandlingMessagingGatewayTests {
 		List<HttpMessageConverter<?>> converters = new ArrayList<HttpMessageConverter<?>>();
 		converters.add(new SerializingHttpMessageConverter());
 		gateway.setMessageConverters(converters);
+		gateway.afterPropertiesSet();
 
 		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/test");
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGatewayWithPathMappingTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGatewayWithPathMappingTests.java
@@ -40,6 +40,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Biju Kunjummen
  */
 public class HttpRequestHandlingMessagingGatewayWithPathMappingTests {
 
@@ -70,7 +71,8 @@ public class HttpRequestHandlingMessagingGatewayWithPathMappingTests {
 		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.setPath("/fname/{f}/lname/{l}");
 		gateway.setRequestChannel(echoChannel);
-
+		gateway.afterPropertiesSet();
+		
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
 		Object result =  gateway.doHandleRequest(request, response);
@@ -102,7 +104,8 @@ public class HttpRequestHandlingMessagingGatewayWithPathMappingTests {
 		gateway.setPath("/fname/{f}/lname/{l}");
 		gateway.setRequestChannel(echoChannel);
 		gateway.setPayloadExpression(PARSER.parseExpression("#pathVariables.f"));
-
+		gateway.afterPropertiesSet();
+		
 		Object result =  gateway.doHandleRequest(request, response);
 		assertTrue(result instanceof Message);
 		assertEquals("bill", ((Message<?>)result).getPayload());
@@ -134,7 +137,8 @@ public class HttpRequestHandlingMessagingGatewayWithPathMappingTests {
 		gateway.setPath("/fname/{f}/lname/{l}");
 		gateway.setRequestChannel(echoChannel);
 		gateway.setPayloadExpression(PARSER.parseExpression("#pathVariables"));
-
+		gateway.afterPropertiesSet();
+		
 		Object result =  gateway.doHandleRequest(request, response);
 		assertTrue(result instanceof Message);
 		assertEquals("bill", ((Map<String, Object>) ((Message<?>)result).getPayload()).get("f"));

--- a/src/reference/docbook/http.xml
+++ b/src/reference/docbook/http.xml
@@ -62,8 +62,8 @@
   customization of the mapping from <interfacename>HttpServletRequest</interfacename> to <interfacename>Message</interfacename>. The default converters
   encapsulate simple strategies, which for
   example will create a String message for a <emphasis>POST</emphasis> request where the content type starts with "text", see the Javadoc for
-  full details. An additional flag (<code>registerDefaultConverters</code>) can be set along with the list of 
-  custom <interfacename>HttpMessageConverter</interfacename> to indicate whether the default converters should be registered. 
+  full details. An additional flag (<code>mergeWithDefaultConverters</code>) can be set along with the list of 
+  custom <interfacename>HttpMessageConverter</interfacename> to add the default converters after the custom converters. 
   By default this flag is set to false.
       </para>
       <para>Starting with this release MultiPart File support was implemented. If the request has been wrapped as a

--- a/src/reference/docbook/http.xml
+++ b/src/reference/docbook/http.xml
@@ -62,7 +62,9 @@
   customization of the mapping from <interfacename>HttpServletRequest</interfacename> to <interfacename>Message</interfacename>. The default converters
   encapsulate simple strategies, which for
   example will create a String message for a <emphasis>POST</emphasis> request where the content type starts with "text", see the Javadoc for
-  full details.
+  full details. An additional flag (<code>registerDefaultConverters</code>) can be set along with the list of 
+  custom <interfacename>HttpMessageConverter</interfacename> to indicate whether the default converters should be registered. 
+  By default this flag is set to false.
       </para>
       <para>Starting with this release MultiPart File support was implemented. If the request has been wrapped as a
     <emphasis>MultipartHttpServletRequest</emphasis>, when using the default converters, that request will be converted

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -243,6 +243,15 @@
 				before sending the request. For more information see <xref linkend="http"/>.
 			</para>
 		</section>
+		<section id="3.0-http-register-default-converters">
+			<title>HTTP Inbound Adapter and HTTP Inbound Gateway 'register-default-converters' property</title>
+			<para>
+				<code>&lt;http:inbound-gateway/&gt;</code> and <code>&lt;http:inbound-channel-adapter/&gt;</code> now
+				have a  <code>register-default-converters</code> attribute to set the list of default
+				<interfacename>HttpMessageConverter</interfacename> to user customized set of message converters.
+				For more information see <xref linkend="http"/>.
+			</para>
+		</section>		
 		<section id="3.0-amqp-mapping">
 			<title>AMQP Outbound Gateway Header Mapping</title>
 			<para>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -244,11 +244,11 @@
 			</para>
 		</section>
 		<section id="3.0-http-register-default-converters">
-			<title>HTTP Inbound Adapter and HTTP Inbound Gateway 'register-default-converters' property</title>
+			<title>HTTP Inbound Adapter and HTTP Inbound Gateway 'merge-with-default-converters' property</title>
 			<para>
 				<code>&lt;http:inbound-gateway/&gt;</code> and <code>&lt;http:inbound-channel-adapter/&gt;</code> now
-				have a  <code>register-default-converters</code> attribute to set the list of default
-				<interfacename>HttpMessageConverter</interfacename> to user customized set of message converters.
+				have a <code>merge-with-default-converters</code> attribute to set the list of default
+				<interfacename>HttpMessageConverter</interfacename> after the custom message converters.
 				For more information see <xref linkend="http"/>.
 			</para>
 		</section>		


### PR DESCRIPTION
INT-3142: A flag to retain default converters when user has customized message converters for HttpRequestHandlingController, HttpInboundGateway
- Introduced a new flag in base class of `HttpRequHttpRequestHandlingController`, `HttpInboundGateway` - `registerDefaultConverters`
- Introduced a new attribute `register-default-converters` for `inbound-channel-adapter` and `inbound-gateway` to indicate if the default `HttpMessageConverter`'s need to be registered
- Http namespace parser related changes to set the new flag
- Added additional tests to test the flag and the namespace parser related changes

Reference:
https://jira.springsource.org/browse/INT-3142
