### PR TITLE
INT-3027: Headers Enrichment for <enricher>

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/HeaderEnricherParserSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/HeaderEnricherParserSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,7 +179,7 @@ public abstract class HeaderEnricherParserSupport extends AbstractTransformerPar
 						Object headerValue = (headerType != null) ?
 								new TypedStringValue(value, headerType) : value;
 						valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-								IntegrationNamespaceUtils.BASE_PACKAGE + ".transformer.HeaderEnricher$StaticHeaderValueMessageProcessor");
+								IntegrationNamespaceUtils.BASE_PACKAGE + ".transformer.support.StaticHeaderValueMessageProcessor");
 						valueProcessorBuilder.addConstructorArgValue(headerValue);
 					}
 					else if (isExpression) {
@@ -188,7 +188,7 @@ public abstract class HeaderEnricherParserSupport extends AbstractTransformerPar
 									"The 'method' attribute cannot be used with the 'expression' attribute.", element);
 						}
 						valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-								IntegrationNamespaceUtils.BASE_PACKAGE + ".transformer.HeaderEnricher$ExpressionEvaluatingHeaderValueMessageProcessor");
+								IntegrationNamespaceUtils.BASE_PACKAGE + ".transformer.support.ExpressionEvaluatingHeaderValueMessageProcessor");
 						if (expressionElement != null) {
 							BeanDefinitionBuilder dynamicExpressionBuilder = BeanDefinitionBuilder.genericBeanDefinition(DynamicExpression.class);
 							dynamicExpressionBuilder.addConstructorArgValue(expressionElement.getAttribute("key"));
@@ -207,7 +207,7 @@ public abstract class HeaderEnricherParserSupport extends AbstractTransformerPar
 						}
 						if (hasMethod || isScript) {
 							valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-									IntegrationNamespaceUtils.BASE_PACKAGE + ".transformer.HeaderEnricher$MessageProcessingHeaderValueMessageProcessor");
+									IntegrationNamespaceUtils.BASE_PACKAGE + ".transformer.support.MessageProcessingHeaderValueMessageProcessor");
 							valueProcessorBuilder.addConstructorArgValue(innerComponentDefinition);
 							if (hasMethod) {
 								valueProcessorBuilder.addConstructorArgValue(method);
@@ -215,7 +215,7 @@ public abstract class HeaderEnricherParserSupport extends AbstractTransformerPar
 						}
 						else {
 							valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-									IntegrationNamespaceUtils.BASE_PACKAGE + ".transformer.HeaderEnricher$StaticHeaderValueMessageProcessor");
+									IntegrationNamespaceUtils.BASE_PACKAGE + ".transformer.support.StaticHeaderValueMessageProcessor");
 							valueProcessorBuilder.addConstructorArgValue(innerComponentDefinition);
 						}
 					}
@@ -226,13 +226,13 @@ public abstract class HeaderEnricherParserSupport extends AbstractTransformerPar
 						}
 						if (hasMethod) {
 							valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-									IntegrationNamespaceUtils.BASE_PACKAGE + ".transformer.HeaderEnricher$MessageProcessingHeaderValueMessageProcessor");
+									IntegrationNamespaceUtils.BASE_PACKAGE + ".transformer.support.MessageProcessingHeaderValueMessageProcessor");
 							valueProcessorBuilder.addConstructorArgReference(ref);
 							valueProcessorBuilder.addConstructorArgValue(method);
 						}
 						else {
 							valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-									IntegrationNamespaceUtils.BASE_PACKAGE + ".transformer.HeaderEnricher$StaticHeaderValueMessageProcessor");
+									IntegrationNamespaceUtils.BASE_PACKAGE + ".transformer.support.StaticHeaderValueMessageProcessor");
 							valueProcessorBuilder.addConstructorArgReference(ref);
 						}
 					}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
@@ -281,7 +281,7 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler implem
 				String header = entry.getKey();
 				HeaderValueMessageProcessor<?> valueProcessor = entry.getValue();
 				Boolean overwrite = valueProcessor.isOverwrite();
-				overwrite = overwrite != null ? overwrite : false;
+				overwrite = overwrite != null ? overwrite : true;
 				if (overwrite || !requestMessage.getHeaders().containsKey(header)) {
 					Object value = valueProcessor.processMessage(replyMessage);
 					targetHeaders.put(header, value);

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
@@ -82,12 +82,12 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler implem
 	 */
 	public void setPropertyExpressions(Map<String, Expression> propertyExpressions) {
 		Assert.notEmpty(propertyExpressions, "propertyExpressions must not be empty");
+		Assert.noNullElements(propertyExpressions.keySet().toArray(), "propertyExpressions keys must not be empty");
+		Assert.noNullElements(propertyExpressions.values().toArray(), "propertyExpressions values must not be empty");
 		Map<Expression, Expression> localMap = new HashMap<Expression, Expression>(propertyExpressions.size());
 		for (Map.Entry<String, Expression> entry : propertyExpressions.entrySet()) {
 			String key = entry.getKey();
 			Expression value = entry.getValue();
-			Assert.notNull(key, "propertyExpression key must not be null");
-			Assert.notNull(value, "propertyExpression value must not be null");
 			localMap.put(parser.parseExpression(key), value);
 		}
 		this.propertyExpressions = localMap;
@@ -100,6 +100,8 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler implem
 	 */
 	public void setHeaderExpressions(Map<String, Expression> headerExpressions) {
 		Assert.notEmpty(headerExpressions, "headerExpressions must not be empty");
+		Assert.noNullElements(headerExpressions.keySet().toArray(), "headerExpressions keys must not be empty");
+		Assert.noNullElements(headerExpressions.values().toArray(), "headerExpressions values must not be empty");
 		this.headerExpressions = new HashMap<String, Expression>(headerExpressions);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/AbstractHeaderValueMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/AbstractHeaderValueMessageProcessor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.transformer.support;
+
+/**
+ * @author Mark Fisher
+ * @author Artem Bilan
+ * @since 3.0
+ */
+abstract class AbstractHeaderValueMessageProcessor<T> implements HeaderValueMessageProcessor<T> {
+
+	// null indicates no explicit setting
+	private volatile Boolean overwrite = null;
+
+	public void setOverwrite(Boolean overwrite) {
+		this.overwrite = overwrite;
+	}
+
+	public Boolean isOverwrite() {
+		return this.overwrite;
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/ExpressionEvaluatingHeaderValueMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/ExpressionEvaluatingHeaderValueMessageProcessor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.transformer.support;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.SpelParserConfiguration;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.integration.Message;
+import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
+
+/**
+ * @author Mark Fisher
+ * @author Artem Bilan
+ * @since 3.0
+ */
+class ExpressionEvaluatingHeaderValueMessageProcessor<T> extends AbstractHeaderValueMessageProcessor<T>
+		implements BeanFactoryAware {
+
+	private static final ExpressionParser expressionParser = new SpelExpressionParser(new SpelParserConfiguration(
+			true, true));
+
+	private final ExpressionEvaluatingMessageProcessor<T> targetProcessor;
+
+	/**
+	 * Create a header value processor for the given Expression and the
+	 * expected type of the expression evaluation result. The expectedType
+	 * may be null if unknown.
+	 */
+	public ExpressionEvaluatingHeaderValueMessageProcessor(Expression expression, Class<T> expectedType) {
+		this.targetProcessor = new ExpressionEvaluatingMessageProcessor<T>(expression, expectedType);
+	}
+
+	/**
+	 * Create a header value processor for the given expression string and
+	 * the expected type of the expression evaluation result. The
+	 * expectedType may be null if unknown.
+	 */
+	public ExpressionEvaluatingHeaderValueMessageProcessor(String expressionString, Class<T> expectedType) {
+		Expression expression = expressionParser.parseExpression(expressionString);
+		this.targetProcessor = new ExpressionEvaluatingMessageProcessor<T>(expression, expectedType);
+	}
+
+	public void setBeanFactory(BeanFactory beanFactory) {
+		this.targetProcessor.setBeanFactory(beanFactory);
+	}
+
+	public T processMessage(Message<?> message) {
+		return this.targetProcessor.processMessage(message);
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/HeaderValueMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/HeaderValueMessageProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.transformer.support;
+
+import org.springframework.integration.handler.MessageProcessor;
+
+/**
+ * @author Mark Fisher
+ * @author Artem Bilan
+ * @since 3.0
+ */
+public interface HeaderValueMessageProcessor<T> extends MessageProcessor<T> {
+
+	Boolean isOverwrite();
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/MessageProcessingHeaderValueMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/MessageProcessingHeaderValueMessageProcessor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.transformer.support;
+
+import org.springframework.integration.Message;
+import org.springframework.integration.handler.MessageProcessor;
+import org.springframework.integration.handler.MethodInvokingMessageProcessor;
+
+/**
+ * @author Mark Fisher
+ * @author Artem Bilan
+ * @since 3.0
+ */
+class MessageProcessingHeaderValueMessageProcessor extends AbstractHeaderValueMessageProcessor<Object> {
+
+	private final MessageProcessor<?> targetProcessor;
+
+	public <T> MessageProcessingHeaderValueMessageProcessor(MessageProcessor<T> targetProcessor) {
+		this.targetProcessor = targetProcessor;
+	}
+
+	public MessageProcessingHeaderValueMessageProcessor(Object targetObject) {
+		this(targetObject, null);
+	}
+
+	public MessageProcessingHeaderValueMessageProcessor(Object targetObject, String method) {
+		this.targetProcessor = new MethodInvokingMessageProcessor<Object>(targetObject, method);
+	}
+
+	public Object processMessage(Message<?> message) {
+		return this.targetProcessor.processMessage(message);
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/StaticHeaderValueMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/StaticHeaderValueMessageProcessor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.transformer.support;
+
+import org.springframework.integration.Message;
+
+/**
+ * @author Mark Fisher
+ * @author Artem Bilan
+ * @since 3.0
+ */
+class StaticHeaderValueMessageProcessor<T> extends AbstractHeaderValueMessageProcessor<T> {
+
+	private final T value;
+
+	public StaticHeaderValueMessageProcessor(T value) {
+		this.value = value;
+	}
+
+	public T processMessage(Message<?> message) {
+		return this.value;
+	}
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Contains support classes for Transformers.
+ *
+ * @since 3.0
+ *
+ */
+package org.springframework.integration.transformer.support;

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -1242,12 +1242,13 @@
 				<xsd:complexType >
 					<xsd:complexContent>
 						<xsd:extension base="propertySubElementType">
-							<xsd:attribute name="overwrite">
+							<xsd:attribute name="overwrite" default="true">
 								<xsd:annotation>
 									<xsd:documentation>
 										Boolean value to indicate whether this header value should overwrite an
 										existing header value for
-										the same name.
+										the same name. unlike Header Enricher this attribute by default 'true',
+										similar to 'property' attribute.
 									</xsd:documentation>
 								</xsd:annotation>
 								<xsd:simpleType>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -1229,6 +1229,19 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="header" type="propertySubElementType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>
+						Each header sub-element provides the name of a message header (via the required 'name' attribute).
+						Exactly one of the 'value' or 'expression' attributes must be provided as well.
+						The former for a literal value to set, and the latter for a SpEL expression to be evaluated.
+						The root object of the evaluation context is the Message that was returned from the flow initiated
+						by this enricher.
+						Note, in contradistinction to header-enricher, enricher component always override an existed header
+						in the inbound Message.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element name="request-handler-advice-chain" type="adviceChainType" minOccurs="0" maxOccurs="1" />
 		</xsd:sequence>
 		<xsd:attribute name="request-channel" type="xsd:string" use="optional">

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -1229,7 +1229,7 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="header" type="propertySubElementType" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="header" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>
 						Each header sub-element provides the name of a message header (via the required 'name' attribute).
@@ -1237,10 +1237,33 @@
 						The former for a literal value to set, and the latter for a SpEL expression to be evaluated.
 						The root object of the evaluation context is the Message that was returned from the flow initiated
 						by this enricher.
-						Note, in contradistinction to header-enricher, enricher component always override an existed header
-						in the inbound Message.
 					</xsd:documentation>
 				</xsd:annotation>
+				<xsd:complexType >
+					<xsd:complexContent>
+						<xsd:extension base="propertySubElementType">
+							<xsd:attribute name="overwrite">
+								<xsd:annotation>
+									<xsd:documentation>
+										Boolean value to indicate whether this header value should overwrite an
+										existing header value for
+										the same name.
+									</xsd:documentation>
+								</xsd:annotation>
+								<xsd:simpleType>
+									<xsd:union memberTypes="xsd:boolean xsd:string" />
+								</xsd:simpleType>
+							</xsd:attribute>
+							<xsd:attribute name="type" type="xsd:string">
+								<xsd:annotation>
+									<xsd:documentation source="java:java.lang.Class">
+										The fully qualified class name of the header value's expected type.
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
+						</xsd:extension>
+					</xsd:complexContent>
+				</xsd:complexType>
 			</xsd:element>
 			<xsd:element name="request-handler-advice-chain" type="adviceChainType" minOccurs="0" maxOccurs="1" />
 		</xsd:sequence>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParserTests-context.xml
@@ -25,11 +25,16 @@
 
 		<header name="foo" value="bar"/>
 		<header name="testBean" expression="@testBean"/>
-		<header name="sourceName" expression="payload.sourceName"/>
+		<header name="sourceName" expression="payload.sourceName" overwrite="true"/>
+		<header name="notOverwrite" expression="payload.sourceName"/>
 
 		<request-handler-advice-chain>
 			<beans:bean class="org.springframework.integration.config.xml.EnricherParserTests$FooAdvice" />
 		</request-handler-advice-chain>
+	</enricher>
+
+	<enricher input-channel="input2" output-channel="output">
+		<header name="foo" expression="new java.util.Date()" type="int"/>
 	</enricher>
 
 	<beans:bean id="testBean" class="java.lang.String">

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParserTests-context.xml
@@ -25,8 +25,8 @@
 
 		<header name="foo" value="bar"/>
 		<header name="testBean" expression="@testBean"/>
-		<header name="sourceName" expression="payload.sourceName" overwrite="true"/>
-		<header name="notOverwrite" expression="payload.sourceName"/>
+		<header name="sourceName" expression="payload.sourceName"/>
+		<header name="notOverwrite" expression="payload.sourceName" overwrite="false"/>
 
 		<request-handler-advice-chain>
 			<beans:bean class="org.springframework.integration.config.xml.EnricherParserTests$FooAdvice" />

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParserTests-context.xml
@@ -15,14 +15,18 @@
 
 	<channel id="requests"/>
 
-	<enricher id="enricher" input-channel="input" 
+	<enricher id="enricher" input-channel="input"
 	                        request-channel="requests" request-timeout="1234"
 	                        reply-timeout="9876"
 	                        order="99" should-clone-payload="true" output-channel="output">
 		<property name="name" expression="payload.sourceName"/>
 		<property name="age" value="42"/>
 		<property name="gender" expression="@testBean"/>
-		
+
+		<header name="foo" value="bar"/>
+		<header name="testBean" expression="@testBean"/>
+		<header name="sourceName" expression="payload.sourceName"/>
+
 		<request-handler-advice-chain>
 			<beans:bean class="org.springframework.integration.config.xml.EnricherParserTests$FooAdvice" />
 		</request-handler-advice-chain>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.expression.Expression;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
+import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
@@ -46,6 +47,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Mark Fisher
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 2.1
  */
@@ -124,7 +126,7 @@ public class EnricherParserTests {
 			}
 		});
 		Target original = new Target();
-		Message<?> request = MessageBuilder.withPayload(original).build();
+		Message<?> request = MessageBuilder.withPayload(original).setHeader("sourceName", "test").build();
 		context.getBean("input", MessageChannel.class).send(request);
 		Message<?> reply = context.getBean("output", PollableChannel.class).receive(0);
 		Target enriched = (Target) reply.getPayload();
@@ -133,6 +135,11 @@ public class EnricherParserTests {
 		assertEquals("male", enriched.getGender());
 		assertNotSame(original, enriched);
 		assertEquals(1, adviceCalled);
+
+		MessageHeaders headers = reply.getHeaders();
+		assertEquals("bar", headers.get("foo"));
+		assertEquals("male", headers.get("testBean"));
+		assertEquals("foo", headers.get("sourceName"));
 	}
 
 	private static class Source {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParserTests.java
@@ -19,24 +19,30 @@ package org.springframework.integration.config.xml;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.expression.Expression;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
+import org.springframework.integration.MessageHandlingException;
 import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
+import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.transformer.ContentEnricher;
@@ -126,7 +132,10 @@ public class EnricherParserTests {
 			}
 		});
 		Target original = new Target();
-		Message<?> request = MessageBuilder.withPayload(original).setHeader("sourceName", "test").build();
+		Message<?> request = MessageBuilder.withPayload(original)
+				.setHeader("sourceName", "test")
+				.setHeader("notOverwrite", "test")
+				.build();
 		context.getBean("input", MessageChannel.class).send(request);
 		Message<?> reply = context.getBean("output", PollableChannel.class).receive(0);
 		Target enriched = (Target) reply.getPayload();
@@ -140,6 +149,21 @@ public class EnricherParserTests {
 		assertEquals("bar", headers.get("foo"));
 		assertEquals("male", headers.get("testBean"));
 		assertEquals("foo", headers.get("sourceName"));
+		assertEquals("test", headers.get("notOverwrite"));
+	}
+
+	@Test
+	public void testInt3027WrongHeaderType() {
+		MessageChannel input = context.getBean("input2", MessageChannel.class);
+		try {
+			input.send(new GenericMessage<Object>("test"));
+		}
+		catch (Exception e) {
+			assertThat(e, Matchers.instanceOf(MessageHandlingException.class));
+			assertThat(e.getCause(), Matchers.instanceOf(TypeMismatchException.class));
+			assertThat(e.getCause().getMessage(),
+					Matchers.startsWith("Failed to convert value of type 'java.util.Date' to required type 'int'"));
+		}
 	}
 
 	private static class Source {

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyHeaderEnricherTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyHeaderEnricherTests.java
@@ -32,7 +32,7 @@ import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.groovy.GroovyScriptExecutingMessageProcessor;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.test.util.TestUtils;
-import org.springframework.integration.transformer.HeaderEnricher;
+import org.springframework.integration.transformer.support.HeaderValueMessageProcessor;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -71,11 +71,11 @@ public class GroovyHeaderEnricherTests {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void inlineScript() throws Exception{
-		Map<String, HeaderEnricher.HeaderValueMessageProcessor<?>> headers =
+		Map<String, HeaderValueMessageProcessor<?>> headers =
 				TestUtils.getPropertyValue(headerEnricherWithInlineGroovyScript, "handler.transformer.headersToAdd", Map.class);
 		assertEquals(1, headers.size());
-		HeaderEnricher.HeaderValueMessageProcessor<?> headerValueMessageProcessor = headers.get("TEST_HEADER");
-		assertThat(headerValueMessageProcessor.getClass().getName(), Matchers.containsString("HeaderEnricher$MessageProcessingHeaderValueMessageProcessor"));
+		HeaderValueMessageProcessor<?> headerValueMessageProcessor = headers.get("TEST_HEADER");
+		assertThat(headerValueMessageProcessor.getClass().getName(), Matchers.containsString("MessageProcessingHeaderValueMessageProcessor"));
 		Object targetProcessor = TestUtils.getPropertyValue(headerValueMessageProcessor, "targetProcessor");
 		assertEquals(GroovyScriptExecutingMessageProcessor.class, targetProcessor.getClass());
 

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/XPathHeaderEnricher.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/XPathHeaderEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.w3c.dom.Node;
 
 import org.springframework.integration.Message;
 import org.springframework.integration.transformer.HeaderEnricher;
+import org.springframework.integration.transformer.support.HeaderValueMessageProcessor;
 import org.springframework.integration.xml.DefaultXmlPayloadConverter;
 import org.springframework.integration.xml.XmlPayloadConverter;
 import org.springframework.integration.xml.xpath.XPathEvaluationType;
@@ -33,7 +34,7 @@ import org.springframework.xml.xpath.XPathExpressionFactory;
  * Transformer implementation that evaluates XPath expressions against the
  * message payload and inserts the result of the evaluation into a message
  * header. The header names will match the keys in the map of expressions.
- * 
+ *
  * @author Jonas Partner
  * @author Mark Fisher
  * @since 2.0

--- a/src/reference/docbook/content-enrichment.xml
+++ b/src/reference/docbook/content-enrichment.xml
@@ -227,6 +227,8 @@
     <int:poller></int:poller>                             ]]><co id="payload-enricher10-co" linkends="payload-enricher10" /><![CDATA[
     <int:property name="" expression=""/>  ]]><co id="payload-enricher11-co" linkends="payload-enricher11" /><![CDATA[
     <int:property name="" value=""/>
+	<int:header name="" expression=""/>  ]]><co id="payload-enricher12-co" linkends="payload-enricher12" /><![CDATA[
+    <int:header name="" value=""/>
 </int:enricher>]]></programlisting>
 
 	        <para>
@@ -357,6 +359,22 @@
                             input Message if there is no request channel, or the
                             application context (using the '@&lt;beanName&gt;.&lt;beanProperty&gt;'
                             SpEL syntax).
+	                    </para>
+	                </callout>
+					<callout arearefs="payload-enricher12-co" id="payload-enricher12">
+	                    <para>
+                            Each <code>header</code> sub-element provides the
+                            name of a Message header (via the mandatory <code>name</code>
+                            attribute). Exactly one of the <code>value</code>
+                            or <code>expression</code> attributes must be provided
+                            as well. The former for a literal value to set, and the
+                            latter for a SpEL expression to be evaluated. The root
+                            object of the evaluation context is the Message that was
+                            returned from the flow initiated by this enricher, the
+                            input Message if there is no request channel, or the
+                            application context (using the '@&lt;beanName&gt;.&lt;beanProperty&gt;'
+                            SpEL syntax). Note, if the header is presented in the input Message
+							it will be overrided by the evaluation result of this configuration.
 	                    </para>
 	                </callout>
 	            </calloutlist>

--- a/src/reference/docbook/content-enrichment.xml
+++ b/src/reference/docbook/content-enrichment.xml
@@ -32,6 +32,9 @@
 	        Please go to the adapter specific sections of this reference manual
 	        to learn more about those adapters.
 	    </para>
+		<para>
+			For more info regarding expressions support, please see <xref linkend="spel" />.
+		</para>
     </section>
 
     <section id="header-enricher">
@@ -373,8 +376,7 @@
                             returned from the flow initiated by this enricher, the
                             input Message if there is no request channel, or the
                             application context (using the '@&lt;beanName&gt;.&lt;beanProperty&gt;'
-                            SpEL syntax). Note, if the header is presented in the input Message
-							it will be overrided by the evaluation result of this configuration.
+                            SpEL syntax).
 	                    </para>
 	                </callout>
 	            </calloutlist>

--- a/src/reference/docbook/content-enrichment.xml
+++ b/src/reference/docbook/content-enrichment.xml
@@ -231,7 +231,7 @@
     <int:property name="" expression=""/>  ]]><co id="payload-enricher11-co" linkends="payload-enricher11" /><![CDATA[
     <int:property name="" value=""/>
 	<int:header name="" expression=""/>  ]]><co id="payload-enricher12-co" linkends="payload-enricher12" /><![CDATA[
-    <int:header name="" value=""/>
+    <int:header name="" value="" overwrite="" type=""/>
 </int:enricher>]]></programlisting>
 
 	        <para>
@@ -377,6 +377,11 @@
                             input Message if there is no request channel, or the
                             application context (using the '@&lt;beanName&gt;.&lt;beanProperty&gt;'
                             SpEL syntax).
+							Note, similar to <code>&lt;header-enricher&gt;</code> <code>&lt;enricher&gt;</code>'s
+							<code>header</code> element has <code>type</code> and <code>overwrite</code> attributes.
+							But in case of <code>&lt;enricher&gt;</code> the <code>overwrite</code> by default has
+							value <code>true</code> to be consistent with <code>&lt;enricher&gt;</code>'s
+							<code>&lt;property&gt;</code> sub-element.
 	                    </para>
 	                </callout>
 	            </calloutlist>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -89,7 +89,7 @@
 		<section id="3.0-content-enricher-headers">
 			<title>Content Enricher: Headers Enrichment Support</title>
 			<para>
-				Content Enricher are now provide configuration for <code>&lt;header/&gt;</code>
+				Content Enricher now provides configuration for <code>&lt;header/&gt;</code>
 				sub-elements to enrich outbound Message with headers based on reply Message from underlying
 				message flow. For more information see <xref linkend="payload-enricher"/>.
 			</para>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -86,6 +86,14 @@
 				<interfacename>MessageSource</interfacename>; see <xref linkend="channel-adapter-expressions-and-scripts"/>.
 			</para>
 		</section>
+		<section id="3.0-content-enricher-headers">
+			<title>Content Enricher: Headers Enrichment Support</title>
+			<para>
+				Content Enricher are now provide configuration for <code>&lt;header/&gt;</code>
+				sub-elements to enrich outbound Message with headers based on reply Message from underlying
+				message flow. For more information see <xref linkend="payload-enricher"/>.
+			</para>
+		</section>
 		<section id="3.0-spel-customization">
 			<title>Spring Expression Language (SpEL) Configuration</title>
 			<para>


### PR DESCRIPTION
- Add `<header>` sub-element to `<enricher>`
- Refactoring to `EnricherParser`
- Add Headers Enrichment logic to `ContentEnricher`
- Add tests
- What's new and Content Enricher's `<header>` note

JIRA: https://jira.springsource.org/browse/INT-3027
