### PR TITLE
INT-2867: add script support to inbound-c-a

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,8 @@ public class ConsumerEndpointFactoryBean
 
 	private volatile boolean autoStartup = true;
 
+	private volatile int phase = 0;
+
 	private volatile MessageChannel inputChannel;
 
 	private volatile ConfigurableBeanFactory beanFactory;
@@ -110,6 +112,10 @@ public class ConsumerEndpointFactoryBean
 
 	public void setAutoStartup(boolean autoStartup) {
 		this.autoStartup = autoStartup;
+	}
+
+	public void setPhase(int phase) {
+		this.phase = phase;
 	}
 
 	public void setBeanName(String beanName) {
@@ -239,6 +245,7 @@ public class ConsumerEndpointFactoryBean
 			this.endpoint.setBeanName(this.beanName);
 			this.endpoint.setBeanFactory(this.beanFactory);
 			this.endpoint.setAutoStartup(this.autoStartup);
+			this.endpoint.setPhase(this.phase);
 			this.endpoint.afterPropertiesSet();
 			this.initialized = true;
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,8 @@ public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<Sourc
 
 	private volatile boolean autoStartup = true;
 
+	private volatile int phase = 0;
+
 	private volatile Long sendTimeout;
 
 	private volatile String beanName;
@@ -80,6 +82,10 @@ public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<Sourc
 
 	public void setAutoStartup(boolean autoStartup) {
 		this.autoStartup = autoStartup;
+	}
+
+	public void setPhase(int phase) {
+		this.phase = phase;
 	}
 
 	public void setBeanFactory(BeanFactory beanFactory) {
@@ -145,6 +151,7 @@ public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<Sourc
 			spca.setErrorHandler(this.pollerMetadata.getErrorHandler());
 			spca.setBeanClassLoader(this.beanClassLoader);
 			spca.setAutoStartup(this.autoStartup);
+			spca.setPhase(this.phase);
 			spca.setBeanName(this.beanName);
 			spca.setBeanFactory(this.beanFactory);
 			spca.setTransactionSynchronizationFactory(this.pollerMetadata.getTransactionSynchronizationFactory());

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractOutboundChannelAdapterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractOutboundChannelAdapterParser.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.config.xml;
 
+import org.w3c.dom.Element;
+
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -27,7 +29,6 @@ import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
-import org.w3c.dom.Element;
 
 /**
  * Base class for outbound Channel Adapter parsers.
@@ -71,6 +72,7 @@ public abstract class AbstractOutboundChannelAdapterParser extends AbstractChann
 		}
 		builder.addPropertyValue("inputChannelName", channelName);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-startup");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "phase");
 
 		this.configureRequestHandlerAdviceChain(element, parserContext, handlerBeanComponentDefinition.getBeanDefinition(), builder);
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractPollingInboundChannelAdapterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractPollingInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ public abstract class AbstractPollingInboundChannelAdapterParser extends Abstrac
 			IntegrationNamespaceUtils.configurePollerMetadata(pollerElement, adapterBuilder, parserContext);
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(adapterBuilder, element, "auto-startup");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(adapterBuilder, element, "phase");
 		return adapterBuilder.getBeanDefinition();
 	}
 

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -783,15 +783,10 @@
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:sequence>
+				<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1"/>
 				<xsd:choice minOccurs="0" maxOccurs="1" >
-					<xsd:sequence>
-						<xsd:element name="poller" type="basePollerType" />
-						<xsd:element ref="beans:bean" minOccurs="0" maxOccurs="1" />
-					</xsd:sequence>
-					<xsd:sequence>
-						<xsd:element ref="beans:bean" />
-						<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1" />
-					</xsd:sequence>
+					<xsd:element name="expression" type="innerExpressionType"/>
+					<xsd:any namespace="##other"/>
 				</xsd:choice>
 				<xsd:element name="header" type="headerSubElementType" minOccurs="0" maxOccurs="unbounded" />
 			</xsd:sequence>
@@ -1016,6 +1011,16 @@
 				<xsd:documentation>
 					Lifecycle attribute signaling if this component should be started during Application Context startup.
 				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="phase" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<xsd:documentation>
+						The Lifecycle attribute determining the start/stop order
+						of the underlying MessageHandlerChain.
+					</xsd:documentation>
+				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:attributeGroup>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -779,6 +779,9 @@
 			<xsd:documentation>
 				Defines a Channel Adapter that receives from a MessageSource and sends to a
 				MessageChannel.
+				Note, is used 'expression' attribute, 'expression' or 'script' sub-element
+				there is no context of inbound Message and
+				the 'payload' and 'headers' variables can't be used.
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChannelAdapterParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChannelAdapterParserTests-context.xml
@@ -15,21 +15,22 @@
 		<queue capacity="1"/>
 	</channel>
 
-	<outbound-channel-adapter id="outboundWithImplicitChannel" ref="consumer"/>
+	<outbound-channel-adapter id="outboundWithImplicitChannel" ref="consumer" auto-startup="false" phase="-1"/>
 
 	<outbound-channel-adapter id="methodInvokingConsumer" ref="testBean" method="store"/>
 
 	<outbound-channel-adapter id="expressionConsumer" expression="@testBean.store(payload)"/>
 
-	<inbound-channel-adapter id="methodInvokingSource" ref="testBean" method="getMessage" 
-							 channel="queueChannel" auto-startup="false">
+	<inbound-channel-adapter id="methodInvokingSource" ref="testBean" method="getMessage"
+							 channel="queueChannel" auto-startup="false" phase="-1">
 		<poller max-messages-per-poll="1" fixed-delay="10000"/>
 	</inbound-channel-adapter>
-	
+
 	<channel id="withTimeoutChannel">
 		<queue/>
 	</channel>
-	<inbound-channel-adapter id="methodInvokingSourceWithTimeout" ref="testBean" method="getMessage" 
+
+	<inbound-channel-adapter id="methodInvokingSourceWithTimeout" ref="testBean" method="getMessage"
 							 channel="withTimeoutChannel" auto-startup="false"
 							 send-timeout="999">
 		<poller max-messages-per-poll="1" fixed-rate="800"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/InboundChannelAdapterExpressionTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/InboundChannelAdapterExpressionTests-context.xml
@@ -41,6 +41,15 @@
 		<poller trigger="customTrigger"/>
 	</inbound-channel-adapter>
 
+	<inbound-channel-adapter id="expressionElement" channel="triggerRefChannel">
+		<poller fixed-delay="1000"/>
+		<expression key="test.greeting"/>
+	</inbound-channel-adapter>
+
+	<beans:bean id="expressionSource" class="org.springframework.integration.expression.ReloadableResourceBundleExpressionSource">
+		<beans:property name="basename" value="org/springframework/integration/expression/expressions"/>
+	</beans:bean>
+
 	<beans:bean id="customTrigger" class="org.springframework.scheduling.support.PeriodicTrigger">
 		<beans:constructor-arg value="9999"/>
 	</beans:bean>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/InboundChannelAdapterExpressionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/InboundChannelAdapterExpressionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  * @since 2.0
  */
 @ContextConfiguration
@@ -109,12 +110,20 @@ public class InboundChannelAdapterExpressionTests {
 	public void headerExpressions() {
 		SourcePollingChannelAdapter adapter = context.getBean("headerExpressionsProducer", SourcePollingChannelAdapter.class);
 		assertFalse(adapter.isAutoStartup());
-		Map<String, Expression> headerExpressions = TestUtils.getPropertyValue(adapter, "source.headerExpressions", Map.class); 
+		Map<String, Expression> headerExpressions = TestUtils.getPropertyValue(adapter, "source.headerExpressions", Map.class);
 		assertEquals(2, headerExpressions.size());
 		assertEquals("6 * 7", headerExpressions.get("foo").getExpressionString());
 		assertEquals("x", headerExpressions.get("bar").getExpressionString());
 		assertEquals(42, headerExpressions.get("foo").getValue());
 		assertEquals("x", headerExpressions.get("bar").getValue());
+	}
+
+	@Test
+	public void testInt2867InnerExpression() {
+		SourcePollingChannelAdapter adapter = context.getBean("expressionElement", SourcePollingChannelAdapter.class);
+		Expression expression = TestUtils.getPropertyValue(adapter, "source.expression", Expression.class);
+		assertEquals("'Hello World!'", expression.getExpressionString());
+
 	}
 
 }

--- a/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/ScriptExecutingMessageSource.java
+++ b/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/ScriptExecutingMessageSource.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.scripting;
+
+import org.springframework.integration.endpoint.AbstractMessageSource;
+
+/**
+ * The {@link org.springframework.integration.core.MessageSource} strategy implementation
+ * to produce a {@link org.springframework.integration.Message} from underlying
+ * {@linkplain #scriptMessageProcessor} for polling endpoints.
+ *
+ * @author Artem Bilan
+ * @since 3.0
+ */
+class ScriptExecutingMessageSource extends AbstractMessageSource<Object> {
+
+	private final AbstractScriptExecutingMessageProcessor<?> scriptMessageProcessor;
+
+	public ScriptExecutingMessageSource(AbstractScriptExecutingMessageProcessor<?> scriptMessageProcessor) {
+		this.scriptMessageProcessor = scriptMessageProcessor;
+	}
+
+	@Override
+	protected Object doReceive() {
+		return scriptMessageProcessor.processMessage(null);
+	}
+}

--- a/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223InboundChannelAdapterTests-context.xml
+++ b/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223InboundChannelAdapterTests-context.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:script="http://www.springframework.org/schema/integration/scripting"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/scripting http://www.springframework.org/schema/integration/scripting/spring-integration-scripting.xsd">
+
+	<channel id="inbound-channel-adapter-channel">
+		<queue/>
+	</channel>
+
+	<inbound-channel-adapter channel="inbound-channel-adapter-channel">
+		<poller max-messages-per-poll="1" fixed-delay="100"/>
+		<script:script lang="ruby">
+			<![CDATA[
+			require "java"
+			include_class 'java.util.Date'
+
+			Date.new
+			]]>
+		</script:script>
+		<header name="foo" value="bar"/>
+	</inbound-channel-adapter>
+
+</beans:beans>

--- a/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223InboundChannelAdapterTests.java
+++ b/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223InboundChannelAdapterTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.scripting.config.jsr223;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Date;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.hamcrest.Matchers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.integration.Message;
+import org.springframework.integration.core.PollableChannel;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Artem Bilan
+ * @since 2.0
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class Jsr223InboundChannelAdapterTests {
+
+	@Autowired
+	@Qualifier("inbound-channel-adapter-channel")
+	private PollableChannel inboundChannelAdapterChannel;
+
+	@Test
+	public void testInt2867InboundChannelAdapter() throws Exception {
+		Message<?> message = this.inboundChannelAdapterChannel.receive(2000);
+		assertNotNull(message);
+		Object payload = message.getPayload();
+		assertThat(payload, Matchers.instanceOf(Date.class));
+		assertTrue(((Date) payload).before(new Date()));
+		assertEquals("bar", message.getHeaders().get("foo"));
+
+		message = this.inboundChannelAdapterChannel.receive(1000);
+		assertNotNull(message);
+
+		message = this.inboundChannelAdapterChannel.receive(10);
+		assertNull(message);
+	}
+
+}

--- a/src/reference/docbook/channel-adapter.xml
+++ b/src/reference/docbook/channel-adapter.xml
@@ -29,6 +29,26 @@
     <int:poller cron="30 * 9-17 * * MON-FRI"/>
 </int:channel-adapter>]]></programlisting>
     </para>
+    <para>
+	  As many other components in the Spring Integration <code>&lt;int:inbound-channel-adapter/&gt;</code> can be configured
+      with SpEL 'expression'(<code>&lt;expression/&gt;</code>) or even with <code>&lt;script/&gt;</code> sub-element. In most
+      cases it is useful when expression (or script) is external (refreshable) resource, so it maybe make sense to correlate
+      polling period with resource <emphasis>cache-seconds</emphasis> (<emphasis>refresh-check-delay</emphasis>):
+      <programlisting language="xml"><![CDATA[<int:inbound-channel-adapter ref="source1" method="method1" channel="channel1">
+    <int:poller max-messages-per-poll="1" fixed-delay="5000"/>
+    <script:script lang="ruby" location="Foo.rb" refresh-check-delay="5000"/>
+</int:inbound-channel-adapter>]]></programlisting>
+      For more information regarding expressions see <xref linkend="spel"/>, regarding scripts - <xref linkend="groovy"/>
+      and <xref linkend="scripting"/>.
+	</para>
+    <important>
+       <para>
+		 As far as <code>&lt;int:inbound-channel-adapter/&gt;</code> is an endpoint, who starts message flow
+         via periodic triggering some underlying <interfacename>MessageSource</interfacename>, there is no inbound (request)
+         Message context, so expressions and scripts are very limited with variables and <emphasis>payload</emphasis>
+         and <emphasis>headers</emphasis> properties aren't available in this case.
+       </para>
+    </important>
     <note>
       <para>
         If no poller is provided, then a single default poller must be registered within the context.

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -75,8 +75,15 @@
 			<title>'Tail' Support</title>
 			<para>
 				File 'tail'ing inbound channel adapters are now provided to generate messages when
-				lines are added to the end of text files.
-				<xref linkend="file-tailing"/>.
+				lines are added to the end of text files: see <xref linkend="file-tailing"/>.
+			</para>
+		</section>
+		<section id="3.0-inbound-script">
+			<title>Inbound Channel Adapter Script Support</title>
+			<para>
+				<code>&lt;int:inbound-channel-adapter/&gt;</code> now supports <code>&lt;expression/&gt;</code>
+				and <code>&lt;script/&gt;</code> sub-elements to create an appropriate
+				<interfacename>MessageSource</interfacename>: see <xref linkend="channel-adapter-namespace-inbound"/>.
 			</para>
 		</section>
 		<section id="3.0-spel-customization">


### PR DESCRIPTION
- Add `<script>` and `<expression>` to `<int:inbound-channel-adapter>`
- Refactoring for `DefaultInboundChannelAdapterParser`
- Introduce `ScriptExecutingMessageSource` to allow scripts' `MessageProcessor`
  implementations work as a source for polling endpoint

JIRA: https://jira.springsource.org/browse/INT-2867
