### PR TITLE
INT-3129: FTP local-filename-generator-expression

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
@@ -19,6 +19,7 @@ import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.config.ExpressionFactoryBean;
 import org.springframework.integration.config.xml.AbstractConsumerEndpointParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.util.StringUtils;
@@ -55,7 +56,16 @@ public abstract class AbstractRemoteFileOutboundGatewayParser extends AbstractCo
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "local-directory");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-create-local-directory");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "order");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "rename-expression");		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "requires-reply");		return builder;
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "rename-expression");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "requires-reply");
+		String localFileGeneratorExpression = element.getAttribute("local-filename-generator-expression");
+		if (StringUtils.hasText(localFileGeneratorExpression)) {
+			BeanDefinitionBuilder localFileGeneratorExpressionBuilder =
+					BeanDefinitionBuilder.genericBeanDefinition(ExpressionFactoryBean.class);
+			localFileGeneratorExpressionBuilder.addConstructorArgValue(localFileGeneratorExpression);
+			builder.addPropertyValue("localFilenameGeneratorExpression", localFileGeneratorExpressionBuilder.getBeanDefinition());
+		}
+		return builder;
 	}
 
 	protected void configureFilter(BeanDefinitionBuilder builder, Element element, ParserContext parserContext) {
@@ -77,21 +87,21 @@ public abstract class AbstractRemoteFileOutboundGatewayParser extends AbstractCo
 		}
 		else if (hasFileNamePattern) {
 			BeanDefinitionBuilder filterBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-					this.getSimplePatternFileListFilterClassname());
+					this.getSimplePatternFileListFilterClassName());
 			filterBuilder.addConstructorArgValue(fileNamePattern);
 			builder.addPropertyValue("filter", filterBuilder.getBeanDefinition());
 		}
 		else if (hasFileNameRegex) {
 			BeanDefinitionBuilder filterBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-					this.getRegexPatternFileListFilterClassname());
+					this.getRegexPatternFileListFilterClassName());
 			filterBuilder.addConstructorArgValue(fileNameRegex);
 			builder.addPropertyValue("filter", filterBuilder.getBeanDefinition());
 		}
 	}
 
-	protected abstract String getRegexPatternFileListFilterClassname();
+	protected abstract String getRegexPatternFileListFilterClassName();
 
-	protected abstract String getSimplePatternFileListFilterClassname();
+	protected abstract String getSimplePatternFileListFilterClassName();
 
 	protected abstract String getGatewayClassName();
 

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParser.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,30 @@
 package org.springframework.integration.ftp.config;
 
 import org.springframework.integration.file.config.AbstractRemoteFileOutboundGatewayParser;
+import org.springframework.integration.ftp.filters.FtpRegexPatternFileListFilter;
+import org.springframework.integration.ftp.filters.FtpSimplePatternFileListFilter;
+import org.springframework.integration.ftp.gateway.FtpOutboundGateway;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.1
  *
  */
 public class FtpOutboundGatewayParser extends AbstractRemoteFileOutboundGatewayParser {
 
-	private static final String BASE_PACKAGE = "org.springframework.integration.ftp";
-
 	public String getGatewayClassName() {
-		return BASE_PACKAGE + ".gateway.FtpOutboundGateway";
+		return FtpOutboundGateway.class.getName();
 	}
 
 	@Override
-	protected String getSimplePatternFileListFilterClassname() {
-		return BASE_PACKAGE + ".filters.FtpSimplePatternFileListFilter";
+	protected String getSimplePatternFileListFilterClassName() {
+		return FtpSimplePatternFileListFilter.class.getName();
 	}
 
 	@Override
-	protected String getRegexPatternFileListFilterClassname() {
-		return BASE_PACKAGE + ".filters.FtpRegexPatternFileListFilter";
+	protected String getRegexPatternFileListFilterClassName() {
+		return FtpRegexPatternFileListFilter.class.getName();
 	}
 
 }

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
@@ -394,6 +394,20 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="local-filename-generator-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide a SpEL expression to
+								generate the file name of
+								the local (transferred) file. The root
+								object of the SpEL
+								evaluation is the request Message, but the name of the original
+								remote file is presented as 'remoteFileName' variable.
+								For example, a valid expression would be:
+								"#remoteFileName.toUpperCase() + headers.foo".
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="local-directory" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
@@ -29,7 +29,12 @@
 		command-options="-1 -f"
 		expression="payload"
 		order="1"
+		local-filename-generator-expression="#remoteFileName.toUpperCase() + '.a' + @fooString"
 		/>
+
+	<bean id="fooString" class="java.lang.String">
+		<constructor-arg value="foo" />
+	</bean>
 
 	<int-ftp:outbound-gateway id="gateway2"
 		local-directory="local-test-dir"

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
@@ -21,10 +21,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.lang.reflect.Method;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.Message;
 import org.springframework.integration.endpoint.AbstractEndpoint;
@@ -39,6 +42,7 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Gary Russell
@@ -67,7 +71,7 @@ public class FtpOutboundGatewayParserTests {
 	private static volatile int adviceCalled;
 
 	@Test
-	public void testGateway1() {
+	public void testGateway1() throws Exception {
 		FtpOutboundGateway gateway = TestUtils.getPropertyValue(gateway1,
 				"handler", FtpOutboundGateway.class);
 		assertEquals("X", TestUtils.getPropertyValue(gateway, "remoteFileSeparator"));
@@ -77,14 +81,30 @@ public class FtpOutboundGatewayParserTests {
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "filter"));
 		assertEquals(Command.LS, TestUtils.getPropertyValue(gateway, "command"));
+
 		@SuppressWarnings("unchecked")
-		Set<String> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
+		Set<Option> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
 		assertTrue(options.contains(Option.NAME_ONLY));
 		assertTrue(options.contains(Option.NOSORT));
 
 		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout", Long.class);
 		assertEquals(Long.valueOf(777), sendTimeout);
 		assertTrue(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));
+
+		//INT-3129
+		assertNotNull(TestUtils.getPropertyValue(gateway, "localFilenameGeneratorExpression"));
+		final AtomicReference<Method> genMethod = new AtomicReference<Method>();
+		ReflectionUtils.doWithMethods(FtpOutboundGateway.class, new ReflectionUtils.MethodCallback() {
+
+			@Override
+			public void doWith(Method method) throws IllegalArgumentException, IllegalAccessException {
+				if ("generateLocalFileName".equals(method.getName())) {
+					method.setAccessible(true);
+					genMethod.set(method);
+				}
+			}
+		});
+		assertEquals("FOO.afoo", genMethod.get().invoke(gateway, new GenericMessage<String>(""), "foo"));
 	}
 
 	@Test

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParser.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,30 @@
 package org.springframework.integration.sftp.config;
 
 import org.springframework.integration.file.config.AbstractRemoteFileOutboundGatewayParser;
+import org.springframework.integration.sftp.filters.SftpRegexPatternFileListFilter;
+import org.springframework.integration.sftp.filters.SftpSimplePatternFileListFilter;
+import org.springframework.integration.sftp.gateway.SftpOutboundGateway;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.1
  *
  */
 public class SftpOutboundGatewayParser extends AbstractRemoteFileOutboundGatewayParser {
 
-	private static final String BASE_PACKAGE = "org.springframework.integration.sftp";
-
 	public String getGatewayClassName() {
-		return BASE_PACKAGE + ".gateway.SftpOutboundGateway";
+		return SftpOutboundGateway.class.getName();
 	}
 
 	@Override
-	protected String getSimplePatternFileListFilterClassname() {
-		return BASE_PACKAGE + ".filters.SftpSimplePatternFileListFilter";
+	protected String getSimplePatternFileListFilterClassName() {
+		return SftpSimplePatternFileListFilter.class.getName();
 	}
 
 	@Override
-	protected String getRegexPatternFileListFilterClassname() {
-		return BASE_PACKAGE + ".filters.SftpRegexPatternFileListFilter";
+	protected String getRegexPatternFileListFilterClassName() {
+		return SftpRegexPatternFileListFilter.class.getName();
 	}
 
 }

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
@@ -393,6 +393,20 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="local-filename-generator-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Allows you to provide a SpEL expression to
+								generate the file name of
+								the local (transferred) file. The root
+								object of the SpEL
+								evaluation is the request Message, but the name of the original
+								remote file is presented as 'remoteFileName' variable.
+								For example, a valid expression would be:
+								"#remoteFileName.toUpperCase() + headers.foo".
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="local-directory" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests-context.xml
@@ -29,7 +29,12 @@
 		command-options="-1 -f"
 		expression="payload"
 		order="1"
+		local-filename-generator-expression="#remoteFileName.toUpperCase() + '.a' + @fooString"
 		/>
+
+	<bean id="fooString" class="java.lang.String">
+		<constructor-arg value="foo" />
+	</bean>
 
 	<int-sftp:outbound-gateway id="gateway2"
 		local-directory="local-test-dir"

--- a/src/reference/docbook/ftp.xml
+++ b/src/reference/docbook/ftp.xml
@@ -422,7 +422,10 @@ protected void postProcessClientBeforeConnect(T client) throws IOException {
 		The payload of the result message is <code>Boolean.TRUE</code>.
 		The original remote directory is provided in the <code>file_remoteDirectory</code> header, and the filename is
 		provided in the <code>file_remoteFile</code> header. The new path is in
-		the <code>file_renameTo</code> header.
+		the <code>file_renameTo</code> header. The <emphasis>local-filename-generator-expression</emphasis> attribute
+		defines a SpEL expression to generate the name of local file(s) for <emphasis>get (mget)</emphasis> command.
+		The root object of the evaluation context is request Message, but in addition the <code>remoteFileName</code>
+		variable is also presented for evaluations.
 	  </para>
 	  <para>
 	    For all commands, the PATH that the command acts on is provided by the 'expression'
@@ -438,6 +441,7 @@ protected void postProcessClientBeforeConnect(T client) throws IOException {
     command="ls"
     command-options="-1"
     expression="payload"
+    local-filename-generator-expression="#remoteFileName.toUpperCase() + headers.foo"
     reply-channel="toSplitter"/>]]></programlisting>
 	</para>
 	<para>

--- a/src/reference/docbook/sftp.xml
+++ b/src/reference/docbook/sftp.xml
@@ -458,7 +458,10 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 		The payload of the result message is <code>Boolean.TRUE</code>.
 		The original remote directory is provided in the <code>file_remoteDirectory</code> header, and the filename is
 		provided in the <code>file_remoteFile</code> header. The new path is in
-		the <code>file_renameTo</code> header.
+		the <code>file_renameTo</code> header. The <emphasis>local-filename-generator-expression</emphasis> attribute
+		defines a SpEL expression to generate the name of local file(s) for <emphasis>get (mget)</emphasis> command.
+		The root object of the evaluation context is request Message, but in addition the <code>remoteFileName</code>
+		variable is also presented for evaluations.
 	  </para>
 	  <para>
 	    For all commands, the PATH that the command acts on is provided by the 'expression'
@@ -474,6 +477,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 		command="ls"
 		command-options="-1"
 		expression="payload"
+		local-filename-generator-expression="#remoteFileName.toUpperCase() + headers.foo"
 		reply-channel="toSplitter"/>
 ]]></programlisting>
 	</para>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -175,12 +175,18 @@
 				to be maintained across JVM executions, a custom filter that retains state, perhaps on
 				the file system, can now be configured.
 			</para>
+			<para>
+				For more information, see
+				<xref linkend="ftp-inbound"/> and <xref linkend="sftp-inbound"/>.
+			</para>
 		</section>
 		<section id="3.0-xFTP-gw">
 			<title>FTP, SFTP and FTPS Gateways</title>
 			<para>
 				The gateways now support the <code>mv</code> command, enabling the renaming of remote
-				files.
+				files and the <code>local-filename-generator-expression</code> attribute,
+				enabling the renaming of local files. For more information, see
+				<xref linkend="ftp-outbound-gateway"/> and <xref linkend="sftp-outbound-gateway"/>.
 			</para>
 		</section>
 		<section id="3.0-jdbc-mysql-v5_6_4">


### PR DESCRIPTION
- Add `local-filename-generator-expression` attribute to FTP and SFTP Outbound Gateway
- Refactoring for `(S)FtpOutboundGatewayParser`
- Add `local-filename-generator-expression` tests
- Add 'What's New' and attribute description

JIRA: https://jira.springsource.org/browse/INT-3129
