### PR TITLE
INT-2943: Retry: don't wrap to MessagingException

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
@@ -71,6 +71,9 @@ public abstract class AbstractRequestHandlerAdvice extends IntegrationObjectSupp
 						try {
 							return invocation.proceed();
 						}
+						catch (Exception e) {
+							throw e;
+						}
 						catch (Throwable e) {
 							throw new ThrowableHolderException(e);
 						}
@@ -91,6 +94,9 @@ public abstract class AbstractRequestHandlerAdvice extends IntegrationObjectSupp
 												" so please raise an issue if you see this exception");
 							}
 						}
+						catch (Exception e) {
+							throw e;
+						}
 						catch (Throwable e) {
 							throw new ThrowableHolderException(e);
 						}
@@ -98,12 +104,7 @@ public abstract class AbstractRequestHandlerAdvice extends IntegrationObjectSupp
 				}, invocationThis, message);
 			}
 			catch (Exception e) {
-				if (e instanceof ThrowableHolderException) {
-					throw e.getCause();
-				}
-				else {
-					throw e;
-				}
+				throw this.unwrapThrowableIfNecessary(e);
 			}
 		}
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -17,6 +17,7 @@ package org.springframework.integration.handler.advice;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.MessagingException;
@@ -31,6 +32,7 @@ import org.springframework.util.Assert;
  * retry exhaustion.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.2
  *
  */

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -60,14 +60,11 @@ public class ErrorMessageSendingRecoverer implements RecoveryCallback<Object> {
 					"this can occur, for example, if the RetryPolicy allowed zero attempts to execute the handler; " +
 					"RetryContext: " + context.toString());
 		}
+		else if (!(lastThrowable instanceof MessagingException)) {
+			lastThrowable = new MessagingException((Message<?>) context.getAttribute("message"), lastThrowable);
+		}
 		if (logger.isDebugEnabled()) {
-			String supplement = "";
-			if (lastThrowable instanceof MessagingException) {
-				supplement = ":failedMessage: " + ((MessagingException) lastThrowable).getFailedMessage();
-			}
-			else {
-				lastThrowable = new MessagingException((Message<?>) context.getAttribute("message"), lastThrowable);
-			}
+			String supplement = ":failedMessage:" + ((MessagingException) lastThrowable).getFailedMessage();
 			logger.debug("Sending ErrorMessage " + supplement, lastThrowable);
 		}
 		messagingTemplate.send(new ErrorMessage(lastThrowable));

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
 /**
  * RecoveryCallback that sends the final throwable as an ErrorMessage after
  * retry exhaustion.
+ *
  * @author Gary Russell
  * @since 2.2
  *
@@ -60,7 +61,10 @@ public class ErrorMessageSendingRecoverer implements RecoveryCallback<Object> {
 		if (logger.isDebugEnabled()) {
 			String supplement = "";
 			if (lastThrowable instanceof MessagingException) {
-				supplement = ":failedMessage:" + ((MessagingException) lastThrowable).getFailedMessage();
+				supplement = ":failedMessage: " + ((MessagingException) lastThrowable).getFailedMessage();
+			}
+			else {
+				lastThrowable = new MessagingException((Message<?>) context.getAttribute("message"), lastThrowable);
 			}
 			logger.debug("Sending ErrorMessage " + supplement, lastThrowable);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
@@ -83,7 +83,7 @@ public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice
 		try {
 			return retryTemplate.execute(new RetryCallback<Object>() {
 				public Object doWithRetry(RetryContext context) throws Exception {
-						return callback.cloneAndExecute();
+					return callback.cloneAndExecute();
 				}
 			}, this.recoveryCallback, retryState);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
@@ -83,21 +83,19 @@ public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice
 		try {
 			return retryTemplate.execute(new RetryCallback<Object>() {
 				public Object doWithRetry(RetryContext context) throws Exception {
-					try {
 						return callback.cloneAndExecute();
-					}
-					catch (MessagingException e) {
-						if (e.getFailedMessage() == null) {
-							e.setFailedMessage(message);
-						}
-						throw e;
-					}
-					catch (Exception e) {
-						throw new MessagingException(message, "Failed to invoke handler",
-								unwrapExceptionIfNecessary(e));
-					}
 				}
 			}, this.recoveryCallback, retryState);
+		}
+		catch (MessagingException e) {
+			if (e.getFailedMessage() == null) {
+				e.setFailedMessage(message);
+			}
+			throw e;
+		}
+		catch (Exception e) {
+			throw new MessagingException(message, "Failed to invoke handler",
+					unwrapExceptionIfNecessary(e));
 		}
 		finally {
 			messageHolder.remove();

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -936,7 +936,16 @@ public class AdvisedMessageHandlerTests {
 	}
 
 	@Test
-	public void testInt2943RetryWithExceptionClassifier() {
+	public void testInt2943RetryWithExceptionClassifierFalse() {
+		testInt2943RetryWithExceptionClassifier(false, 1);
+	}
+
+	@Test
+	public void testInt2943RetryWithExceptionClassifierTrue() {
+		testInt2943RetryWithExceptionClassifier(true, 3);
+	}
+
+	private void testInt2943RetryWithExceptionClassifier(boolean retryForMyException, int expected) {
 		final AtomicInteger counter = new AtomicInteger(0);
 
 		@SuppressWarnings("serial")
@@ -960,7 +969,7 @@ public class AdvisedMessageHandlerTests {
 		RetryTemplate retryTemplate = new RetryTemplate();
 
 		Map<Class<? extends Throwable>, Boolean> retryableExceptions = new HashMap<Class<? extends Throwable>, Boolean>();
-		retryableExceptions.put(MyException.class, false);
+		retryableExceptions.put(MyException.class, retryForMyException);
 		retryableExceptions.put(MessagingException.class, true);
 
 		retryTemplate.setRetryPolicy(new SimpleRetryPolicy(3, retryableExceptions));
@@ -982,7 +991,7 @@ public class AdvisedMessageHandlerTests {
 			assertThat(e.getCause(), Matchers.instanceOf(MyException.class));
 		}
 
-		assertEquals(1, counter.get());
+		assertEquals(expected, counter.get());
 
 	}
 


### PR DESCRIPTION
Previously, `RequestHandlerRetryAdvice` wrapped Handler's (business) Exceptions to
`MessagingException` on each retry withing `RetryCallback#doWithRetry`
and before `RetryPolicy#canRetry`.
It made useless some retry framework out-of-the-box features like `BinaryExceptionClassifier`
- Push wrapping to `MessagingException` after `retryTemplate#execute`
- Polishing `ErrorMessageSendingRecoverer` regarding new logic
- Add `retryableExceptions` test

JIRA: https://jira.springsource.org/browse/INT-2943
