### PR TITLE
INT-3152 Speed Up Integration Build Times

### DIFF
--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2011 the original author or authors
+ * Copyright 2007-2013 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -15,6 +15,12 @@
  */
 package org.springframework.integration.gemfire.store;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -28,6 +34,7 @@ import junit.framework.AssertionFailedError;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -41,15 +48,10 @@ import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.util.Assert;
 
 import com.gemstone.gemfire.cache.Cache;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Oleg Zhurakousky
@@ -59,6 +61,9 @@ import static org.junit.Assert.assertTrue;
 public class GemfireGroupStoreTests {
 
 	private Cache cache;
+
+	@Rule
+	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Test
 	public void testNonExistingEmptyMessageGroup() throws Exception {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionTimeoutTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionTimeoutTests.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.context.ApplicationEvent;
@@ -35,6 +36,7 @@ import org.springframework.integration.Message;
 import org.springframework.integration.ip.util.TestingUtilities;
 import org.springframework.integration.message.ErrorMessage;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.integration.test.util.SocketUtils;
 import org.springframework.integration.test.util.TestUtils;
 
@@ -43,6 +45,9 @@ import org.springframework.integration.test.util.TestUtils;
  * @since 2.2
  */
 public class ConnectionTimeoutTests {
+
+	@Rule
+	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Test
 	public void testDefaultTimeout() throws Exception {

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineJmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineJmsTests.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -36,6 +37,7 @@ import org.springframework.integration.gateway.RequestReplyExchanger;
 import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.support.LongRunningIntegrationTest;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
@@ -46,6 +48,9 @@ public class PipelineJmsTests extends ActiveMQMultiContextTests {
 	private final Executor executor = Executors.newFixedThreadPool(30);
 
 	private static final Log logger = LogFactory.getLog(PipelineJmsTests.class);
+
+	@Rule
+	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Before
 	public void setLogLevel() {

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineNamedReplyQueuesJmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/PipelineNamedReplyQueuesJmsTests.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -37,6 +38,7 @@ import org.springframework.integration.gateway.RequestReplyExchanger;
 import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.support.LongRunningIntegrationTest;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
@@ -48,6 +50,9 @@ public class PipelineNamedReplyQueuesJmsTests extends ActiveMQMultiContextTests 
 	private final Executor executor = Executors.newFixedThreadPool(30);
 
 	private static final Log logger = LogFactory.getLog(PipelineJmsTests.class);
+
+	@Rule
+	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Before
 	public void setLogLevel() {

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCachedConsumersTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCachedConsumersTests.java
@@ -28,7 +28,9 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 
+import org.junit.Rule;
 import org.junit.Test;
+
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.gateway.RequestReplyExchanger;
@@ -36,6 +38,7 @@ import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.JmsOutboundGateway;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.jms.connection.CachingConnectionFactory;
 import org.springframework.jms.core.JmsTemplate;
@@ -50,6 +53,9 @@ import org.springframework.jms.support.converter.SimpleMessageConverter;
 public class RequestReplyScenariosWithCachedConsumersTests extends ActiveMQMultiContextTests {
 
 	private final SimpleMessageConverter converter = new SimpleMessageConverter();
+
+	@Rule
+	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Test(expected=MessageTimeoutException.class)
 	public void messageCorrelationBasedOnRequestMessageIdOptimized() throws Exception{

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCorrelationKeyProvidedTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCorrelationKeyProvidedTests.java
@@ -17,19 +17,25 @@ package org.springframework.integration.jms.request_reply;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Rule;
 import org.junit.Test;
+
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.gateway.RequestReplyExchanger;
 import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.JmsOutboundGateway;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.integration.test.util.TestUtils;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
  */
 public class RequestReplyScenariosWithCorrelationKeyProvidedTests extends ActiveMQMultiContextTests {
+
+	@Rule
+	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Test
 	public void messageCorrelationBasedCustomCorrelationKey() throws Exception{

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithNonCachedConsumersTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithNonCachedConsumersTests.java
@@ -24,7 +24,9 @@ import javax.jms.Message;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 
+import org.junit.Rule;
 import org.junit.Test;
+
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.MessageTimeoutException;
@@ -32,6 +34,7 @@ import org.springframework.integration.gateway.RequestReplyExchanger;
 import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.core.MessageCreator;
 /**
@@ -39,6 +42,9 @@ import org.springframework.jms.core.MessageCreator;
  * @author Gary Russell
  */
 public class RequestReplyScenariosWithNonCachedConsumersTests extends ActiveMQMultiContextTests {
+
+	@Rule
+	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Test(expected=MessageTimeoutException.class)
 	public void messageCorrelationBasedOnRequestMessageIdOptimized() throws Exception{

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithTempReplyQueuesTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithTempReplyQueuesTests.java
@@ -36,13 +36,16 @@ import javax.jms.TextMessage;
 
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.command.ActiveMQDestination;
+import org.junit.Rule;
 import org.junit.Test;
+
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.MessageDeliveryException;
 import org.springframework.integration.gateway.RequestReplyExchanger;
 import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.jms.connection.CachingConnectionFactory;
 import org.springframework.jms.core.JmsTemplate;
@@ -57,6 +60,9 @@ import org.springframework.jms.support.converter.SimpleMessageConverter;
 public class RequestReplyScenariosWithTempReplyQueuesTests extends ActiveMQMultiContextTests {
 
 	private final SimpleMessageConverter converter = new SimpleMessageConverter();
+
+	@Rule
+	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Test
 	public void messageCorrelationBasedOnRequestMessageId() throws Exception{

--- a/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/Int2307Tests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/Int2307Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -22,8 +22,11 @@ import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
 import javax.management.ObjectInstance;
 
+import org.junit.Rule;
 import org.junit.Test;
+
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.jmx.export.MBeanExporter;
 
@@ -33,6 +36,9 @@ import org.springframework.jmx.export.MBeanExporter;
  *
  */
 public class Int2307Tests {
+
+	@Rule
+	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@SuppressWarnings("unchecked")
 	@Test

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/support/LongRunningIntegrationTest.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/support/LongRunningIntegrationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.test.support;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Assume;
+import org.junit.rules.TestWatchman;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+/**
+ * Rule to prevent long running tests from running on every build; set environment
+ * variable RUN_LONG_INTEGRATION_TESTS on a CI nightly build to ensure coverage.
+ *
+ * @author Gary Russell
+ * @since 3.0
+ *
+ */
+public class LongRunningIntegrationTest extends TestWatchman {
+
+	private final static Log logger = LogFactory.getLog(LongRunningIntegrationTest.class);
+
+	@Override
+	public Statement apply(Statement base, FrameworkMethod method, Object target) {
+		boolean shouldRun = "true".equalsIgnoreCase(System.getenv("RUN_LONG_INTEGRATION_TESTS"));
+		if (!shouldRun) {
+			logger.info("Skipping long running test " + this.getClass().getSimpleName() + "." + method.getName());
+		}
+		Assume.assumeTrue(shouldRun);
+		return super.apply(base, method, target);
+	}
+
+}

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/support/LongRunningIntegrationTest.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/support/LongRunningIntegrationTest.java
@@ -17,9 +17,8 @@ package org.springframework.integration.test.support;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Assume;
-import org.junit.rules.TestWatchman;
-import org.junit.runners.model.FrameworkMethod;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 /**
@@ -30,18 +29,26 @@ import org.junit.runners.model.Statement;
  * @since 3.0
  *
  */
-public class LongRunningIntegrationTest extends TestWatchman {
+public class LongRunningIntegrationTest extends TestWatcher {
 
 	private final static Log logger = LogFactory.getLog(LongRunningIntegrationTest.class);
 
 	@Override
-	public Statement apply(Statement base, FrameworkMethod method, Object target) {
+	public Statement apply(Statement base, Description description) {
 		boolean shouldRun = "true".equalsIgnoreCase(System.getenv("RUN_LONG_INTEGRATION_TESTS"));
 		if (!shouldRun) {
-			logger.info("Skipping long running test " + this.getClass().getSimpleName() + "." + method.getName());
+			logger.info("Skipping long running test " + description.getDisplayName());
+			return new Statement() {
+
+				@Override
+				public void evaluate() throws Throwable {
+
+				}
+			};
 		}
-		Assume.assumeTrue(shouldRun);
-		return super.apply(base, method, target);
+		else {
+			return super.apply(base, description);
+		}
 	}
 
 }


### PR DESCRIPTION
Add a `@Rule` to skip long-runing tests during normal builds.

Add the rule to long-running tests in gemfire, ip, jms, jmx.

Add an environment variable `RUN_LONG_INTEGRATION_TESTS`; when set
to true, all tests are run.

Set the environment variable to true on all nightly builds.

Build now runs in 13 minutes on my 3 year old laptop.
