### PR TITLE
INT-2312b: Compatibility with SPR 3.2.x and 4.0

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -150,7 +150,6 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 		stringHttpMessageConverter.setWriteAcceptCharset(false);
 		this.defaultMessageConverters.add(stringHttpMessageConverter);
 		this.defaultMessageConverters.add(new ResourceHttpMessageConverter());
-		@SuppressWarnings("rawtypes")
 		SourceHttpMessageConverter<?> sourceConverter = new SourceHttpMessageConverter();
 		this.defaultMessageConverters.add(sourceConverter);
 		if (jaxb2Present) {
@@ -271,7 +270,7 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 		this.requestMapping = requestMapping;
 	}
 
-	public RequestMapping getRequestMapping() {
+	public final RequestMapping getRequestMapping() {
 		return requestMapping;
 	}
 
@@ -521,7 +520,6 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 	/**
 	 * Converts a servlet request's parameterMap to a {@link MultiValueMap}.
 	 */
-	@SuppressWarnings("rawtypes")
 	private MultiValueMap<String, String> convertParameterMap(Map<String, String[]> parameterMap) {
 		MultiValueMap<String, String> convertedMap = new LinkedMultiValueMap<String, String>(parameterMap.size());
 		for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/IntegrationRequestMappingHandlerMapping.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/IntegrationRequestMappingHandlerMapping.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.web.HttpRequestHandler;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -96,7 +97,9 @@ public final class IntegrationRequestMappingHandlerMapping extends RequestMappin
 			handler = this.getApplicationContext().getBean((String) handler);
 		}
 		RequestMappingInfo mapping = this.getMappingForEndpoint((HttpRequestHandlingEndpointSupport) handler);
-		this.registerHandlerMethod(handler, HANDLE_REQUEST_METHOD, mapping);
+		if (mapping != null) {
+			this.registerHandlerMethod(handler, HANDLE_REQUEST_METHOD, mapping);
+		}
 	}
 
 	/**
@@ -106,6 +109,10 @@ public final class IntegrationRequestMappingHandlerMapping extends RequestMappin
 	 */
 	private RequestMappingInfo getMappingForEndpoint(HttpRequestHandlingEndpointSupport endpoint) {
 		final RequestMapping requestMapping = endpoint.getRequestMapping();
+
+		if (ObjectUtils.isEmpty(requestMapping.getPathPatterns())) {
+			return null;
+		}
 
 		org.springframework.web.bind.annotation.RequestMapping requestMappingAnnotation =
 				new org.springframework.web.bind.annotation.RequestMapping() {


### PR DESCRIPTION
From SPR 3.2.x the 'the path mapping' is **required** for `Controller`,
But in case of SI it is OK, because we can configure HTTP Inbound Endpoint via `HttpRequestHandlerServlet`.

So, add check if `requestMapping.getPathPatterns()` has values and don't register HTTP Inbound Endpoint
as `HandlerMethod` and just rely on user choice.

JIRA: https://jira.springsource.org/browse/INT-2312
