### PR TITLE
INT-3147 Twitter/Feed expose MessageSources as beans

### DIFF
--- a/spring-integration-feed/src/main/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParser.java
+++ b/spring-integration-feed/src/main/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 package org.springframework.integration.feed.config;
 
 import org.w3c.dom.Element;
-
 import org.springframework.beans.BeanMetadataElement;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractPollingInboundChannelAdapterParser;
@@ -31,6 +31,7 @@ import org.springframework.util.StringUtils;
  * @author Josh Long
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class FeedInboundChannelAdapterParser extends AbstractPollingInboundChannelAdapterParser {
@@ -45,7 +46,14 @@ public class FeedInboundChannelAdapterParser extends AbstractPollingInboundChann
 			sourceBuilder.addConstructorArgReference(feedFetcherRef);
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(sourceBuilder, element, "metadata-store");
-		return sourceBuilder.getBeanDefinition();
+
+		final String channelAdapterId = this.resolveId(element, sourceBuilder.getRawBeanDefinition(), parserContext);
+		final String sourceBeanName = channelAdapterId + ".source";
+
+		parserContext.getRegistry().registerBeanDefinition(sourceBeanName, sourceBuilder.getBeanDefinition());
+
+		return new RuntimeBeanReference(sourceBeanName);
+
 	}
 
 }

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.feed.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.atLeast;
@@ -83,6 +84,24 @@ public class FeedInboundChannelAdapterParserTests {
 		context.destroy();
 	}
 
+	/**
+	 * Test-case for INT-3147
+	 */
+	@Test
+	public void testThatMessageSourceIsRegisteredAsBean(){
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				"FeedInboundChannelAdapterParserTests-file-context.xml", this.getClass());
+
+		FeedEntryMessageSource source = context.getBean("feedAdapter.source", FeedEntryMessageSource.class);
+		assertNotNull(source);
+
+		String metadataKey = TestUtils.getPropertyValue(source, "metadataKey", String.class);
+		assertTrue("The metadataKey should start with 'feed:inbound-channel-adapter.feedAdapter.source.' "
+				+ "but it was " + metadataKey,
+				metadataKey.startsWith("feed:inbound-channel-adapter.feedAdapter.source."));
+
+	}
+
 	public void validateSuccessfulHttpConfigurationWithCustomMetadataStore() {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"FeedInboundChannelAdapterParserTests-http-context.xml", this.getClass());
@@ -98,7 +117,7 @@ public class FeedInboundChannelAdapterParserTests {
 
 	@Test
 	public void validateSuccessfulNewsRetrievalWithFileUrlAndMessageHistory() throws Exception {
-		File persisterFile = new File(System.getProperty("java.io.tmpdir") + "/spring-integration/", "message-store.properties");
+		File persisterFile = new File(System.getProperty("java.io.tmpdir") + "/spring-integration/", "metadata-store.properties");
 		if (persisterFile.exists()) {
 			persisterFile.delete();
 		}

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/config/TwitterInboundChannelAdapterParser.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/config/TwitterInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors
+ * Copyright 2002-2013 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -16,9 +16,8 @@
 
 package org.springframework.integration.twitter.config;
 
-import org.w3c.dom.Element;
-
 import org.springframework.beans.BeanMetadataElement;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractPollingInboundChannelAdapterParser;
@@ -29,11 +28,13 @@ import org.springframework.integration.twitter.inbound.SearchReceivingMessageSou
 import org.springframework.integration.twitter.inbound.TimelineReceivingMessageSource;
 import org.springframework.social.twitter.api.impl.TwitterTemplate;
 import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
 
 /**
  * Parser for inbound Twitter Channel Adapters.
- * 
+ *
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  * @since 2.0
  */
 public class TwitterInboundChannelAdapterParser extends AbstractPollingInboundChannelAdapterParser {
@@ -51,9 +52,14 @@ public class TwitterInboundChannelAdapterParser extends AbstractPollingInboundCh
 			builder.addConstructorArgValue(templateBuilder.getBeanDefinition());
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "query");
-		return builder.getBeanDefinition();
-	}
 
+		final String channelAdapterId = this.resolveId(element, builder.getRawBeanDefinition(), parserContext);
+		final String sourceBeanName = channelAdapterId + ".source";
+
+		parserContext.getRegistry().registerBeanDefinition(sourceBeanName, builder.getBeanDefinition());
+
+		return new RuntimeBeanReference(sourceBeanName);
+	}
 
 	private static Class<?> determineClass(Element element, ParserContext parserContext) {
 		Class<?> clazz = null;

--- a/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/config/TestReceivingMessageSourceParserTests.java
+++ b/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/config/TestReceivingMessageSourceParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,9 @@ import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
  */
 public class TestReceivingMessageSourceParserTests {
-
-	
 
 	@Test
 	public void testReceivingAdapterConfigurationAutoStartup(){
@@ -47,9 +46,40 @@ public class TestReceivingMessageSourceParserTests {
 		assertNotNull(dms);
 
 		spca = ac.getBean("updateAdapter", SourcePollingChannelAdapter.class);
-		
+
 		spca = ac.getBean("updateAdapter", SourcePollingChannelAdapter.class);
 		TimelineReceivingMessageSource tms = TestUtils.getPropertyValue(spca, "source", TimelineReceivingMessageSource.class);
+		assertNotNull(tms);
+	}
+
+	@Test
+	public void testThatMessageSourcesAreRegisteredAsBeans(){
+		ApplicationContext ac = new ClassPathXmlApplicationContext("TestReceivingMessageSourceParser-context.xml", this.getClass());
+
+		MentionsReceivingMessageSource ms = ac.getBean("mentionAdapter.source", MentionsReceivingMessageSource.class);
+		assertNotNull(ms);
+
+		DirectMessageReceivingMessageSource dms = ac.getBean("dmAdapter.source", DirectMessageReceivingMessageSource.class);
+		assertNotNull(dms);
+
+		TimelineReceivingMessageSource tms = ac.getBean("updateAdapter.source", TimelineReceivingMessageSource.class);
+		assertNotNull(tms);
+	}
+
+	@Test
+	public void testThatMessageSourcesAreRegisteredAsBeansWithoutIds(){
+		ApplicationContext ac = new ClassPathXmlApplicationContext("TestReceivingMessageSourceParserWithoutIds-context.xml", this.getClass());
+
+		final String mentionAdapterSourceId = "org.springframework.integration.twitter.inbound.MentionsReceivingMessageSource#0.source";
+		MentionsReceivingMessageSource ms = ac.getBean(mentionAdapterSourceId, MentionsReceivingMessageSource.class);
+		assertNotNull(ms);
+
+		final String dmAdapterSourceId = "org.springframework.integration.twitter.inbound.DirectMessageReceivingMessageSource#0.source";
+		DirectMessageReceivingMessageSource dms = ac.getBean(dmAdapterSourceId, DirectMessageReceivingMessageSource.class);
+		assertNotNull(dms);
+
+		final String updateAdapterSourceId = "org.springframework.integration.twitter.inbound.TimelineReceivingMessageSource#0.source";
+		TimelineReceivingMessageSource tms = ac.getBean(updateAdapterSourceId, TimelineReceivingMessageSource.class);
 		assertNotNull(tms);
 	}
 

--- a/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/config/TestReceivingMessageSourceParserWithoutIds-context.xml
+++ b/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/config/TestReceivingMessageSourceParserWithoutIds-context.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int-twitter="http://www.springframework.org/schema/integration/twitter"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+						http://www.springframework.org/schema/integration/twitter http://www.springframework.org/schema/integration/twitter/spring-integration-twitter.xsd">
+
+	<bean id="twitter" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.social.twitter.api.Twitter"/>
+	</bean>
+
+	<int:channel id="inbound_mentions"/>
+
+	<int-twitter:mentions-inbound-channel-adapter
+						twitter-template="twitter"
+						channel="inbound_mentions"
+						auto-startup="false">
+		<int:poller fixed-rate="5000" max-messages-per-poll="3"/>
+	</int-twitter:mentions-inbound-channel-adapter>
+
+	<int-twitter:dm-inbound-channel-adapter
+						twitter-template="twitter"
+						channel="inbound_mentions"
+						auto-startup="false">
+		<int:poller fixed-rate="5000" max-messages-per-poll="3"/>
+	</int-twitter:dm-inbound-channel-adapter>
+
+	<int-twitter:inbound-channel-adapter
+						twitter-template="twitter"
+						channel="inbound_mentions"
+						auto-startup="false">
+		<int:poller fixed-rate="5000" max-messages-per-poll="3"/>
+	</int-twitter:inbound-channel-adapter>
+
+</beans>

--- a/src/reference/docbook/feed.xml
+++ b/src/reference/docbook/feed.xml
@@ -107,5 +107,12 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/feed
 			<interfacename>MetadataStore</interfacename> interface (e.g. JdbcMetadataStore)
 			and configure it as bean in the Application Context.
 		</para>
+		<note>
+			The key used to persist the latest <emphasis>published date</emphasis> is auto-generated
+			and consists of <emphasis role="bold">component type + component name + ".source" + feedUrl</emphasis>.
+			For example, if you use a Feed Inbound Channel Adapter with an
+			id of <code>myadapter</code>, then the metadata store key may look like
+			<emphasis role="bold">feed:inbound-channel-adapter.myadapter.source.http://feeds.bbci.co.uk/news/rss.xml</emphasis>.
+		</note>
 	</section>
 </chapter>

--- a/src/reference/docbook/twitter.xml
+++ b/src/reference/docbook/twitter.xml
@@ -165,8 +165,18 @@ twitter.oauth.accessTokenSecret=AbRxUAvyNCtqQtxFK8w5ZMtMj20KFhB6o]]></programlis
 	</warning>
     <programlisting language="xml"><![CDATA[<bean id="metadataStore" class="o.s.i.store.PropertiesPersistingMetadataStore"/>
 ]]></programlisting>
-The Poller that is configured as part of any Inbound Twitter Adapter (see below) will simply poll from this MetadataStore to determine the latest tweet
-received.
+	<para>
+		The Poller that is configured as part of any Inbound Twitter Adapter (see below)
+		will simply poll from this MetadataStore to determine the latest tweet received.
+	</para>
+	<note>
+		The key used to persist the latest Tweet timestamp is auto-generated
+		and consists of <emphasis role="bold">component type + component name + ".source" + profileId (if using authorization)</emphasis>.
+		For example, if you use a Twitter Search Inbound Channel Adapter with an
+		id of <code>myadapter</code>, then the metadata store key may look like
+		<emphasis role="bold">twitter:search-inbound-channel-adapter.myadapter.source.123456789</emphasis>.
+	</note>
+
   	<section id="inbound-twitter-update">
   		<title>Inbound Message Channel Adapter</title>
   		<para>


### PR DESCRIPTION
- In the Twitter Inbound Channel Adapter Parser, expose the MessageSource as top-level bean rather than as inner bean
- In the Feed Inbound Channel Adapter Parser, expose the MessageSource as top-level bean rather than as inner bean
- Add tests
- Add documentation to Twitter + Feed chapter

Jira: https://jira.springsource.org/browse/INT-3147
