### PR TITLE
INT-3163 (Backport) Force Connection Close on Send Exception

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
@@ -72,7 +72,13 @@ public class TcpNetConnection extends AbstractTcpConnection {
 	public synchronized void send(Message<?> message) throws Exception {
 		Object object = this.getMapper().fromMessage(message);
 		this.lastSend = System.currentTimeMillis();
-		((Serializer<Object>) this.getSerializer()).serialize(object, this.socket.getOutputStream());
+		try {
+			((Serializer<Object>) this.getSerializer()).serialize(object, this.socket.getOutputStream());
+		}
+		catch (Exception e) {
+			this.closeConnection(true);
+			throw e;
+		}
 		this.afterSend(message);
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -118,10 +118,16 @@ public class TcpNioConnection extends AbstractTcpConnection {
 
 	@SuppressWarnings("unchecked")
 	public void send(Message<?> message) throws Exception {
-		synchronized(this.getMapper()) {
+		synchronized(this.socketChannel) {
 			Object object = this.getMapper().fromMessage(message);
 			this.lastSend = System.currentTimeMillis();
-			((Serializer<Object>) this.getSerializer()).serialize(object, this.getChannelOutputStream());
+			try {
+				((Serializer<Object>) this.getSerializer()).serialize(object, this.getChannelOutputStream());
+			}
+			catch (Exception e) {
+				this.closeConnection(true);
+				throw e;
+			}
 			this.afterSend(message);
 		}
 	}


### PR DESCRIPTION
Previously, when an exception occurred on a send, the
connection was not forcibly closed. When using a
CachingClientConnectionFactory, this prevented the connection
(albeit stale) from being returned to the cache.

Perform a forced (physical) close whenever a send fails.

Add test cases for both Net and NIO implementations, using
a CCCF, to verify the connection is returned to the pool so
the closed state can be detected on the next retrieval, causing
a refresh.

Also, change the synchronization in the NIO send to
synchronize on the socketChannel, not the mapper (which is
shared).

Conflicts:

```
spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
```

Resolved.
