### PR TITLE
INT-3074: JDBC: Make generateSql as UP-TO-DATE

### DIFF
--- a/spring-integration-jdbc/build.gradle
+++ b/spring-integration-jdbc/build.gradle
@@ -26,7 +26,7 @@ task generateSql {
     doLast {
         ['hsqldb', 'h2', 'db2', 'derby', 'mysql', 'mysql-5_6_4',
          'oracle10g', 'postgresql', 'sqlserver', 'sybase'].each { dbType ->
-            ant.vppcopy(todir: generatedResourcesDir, overwrite: 'true') {
+            ant.vppcopy(todir: generatedResourcesDir) {
                 config {
                     context {
                         property key: 'includes', value: 'src/main/sql'
@@ -45,3 +45,7 @@ task generateSql {
 
 // tie schema generation to the build lifecycle
 compileJava.dependsOn generateSql
+
+task cleanSql (type: Delete) {
+	delete fileTree(dir: 'src/main/resources/org/springframework/integration/jdbc').include('*.sql').exclude('config', 'store/channel')
+}


### PR DESCRIPTION
- remove `overwrite: 'true'` from `generateSql` task
- add `cleanSql` task

Now, if we change some schema template (.vpp or .properties),
there is need to clean .sql files

JIRA: https://jira.springsource.org/browse/INT-3074

**Cherry-picked to 2.2.x**
