### PR TITLE
INT-2866: Add (S)FTP `local-directory-expression`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ subprojects { subproject ->
 		log4jVersion = '1.2.12'
 		mockitoVersion = '1.9.5'
 		eaioUUIDVersion = '3.2'
-		ftpserverVersion = '1.0.6'
+		ftpServerVersion = '1.0.6'
 
 		springVersionDefault = '3.1.4.RELEASE'
 		springVersion = project.hasProperty('springVersion') ? getProperty('springVersion') : springVersionDefault
@@ -70,10 +70,6 @@ subprojects { subproject ->
 		springSocialTwitterVersion = '1.0.5.RELEASE'
 		springWsVersion = '2.1.1.RELEASE'
 		springRetryVersion = '1.0.2.RELEASE'
-	}
-
-	idea.module {
-		downloadSources = downloadJavadoc = true
 	}
 
 	eclipse {
@@ -244,7 +240,7 @@ project('spring-integration-ftp') {
 		compile "org.springframework:spring-context-support:$springVersion"
 		compile("javax.activation:activation:$javaxActivationVersion", optional)
 		testCompile project(":spring-integration-test")
-		testCompile "org.apache.ftpserver:ftpserver-core:$ftpserverVersion"
+		testCompile "org.apache.ftpserver:ftpserver-core:$ftpServerVersion"
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ subprojects { subproject ->
 		log4jVersion = '1.2.12'
 		mockitoVersion = '1.9.5'
 		eaioUUIDVersion = '3.2'
+		ftpserverVersion = '1.0.6'
 
 		springVersionDefault = '3.1.4.RELEASE'
 		springVersion = project.hasProperty('springVersion') ? getProperty('springVersion') : springVersionDefault
@@ -69,6 +70,10 @@ subprojects { subproject ->
 		springSocialTwitterVersion = '1.0.5.RELEASE'
 		springWsVersion = '2.1.1.RELEASE'
 		springRetryVersion = '1.0.2.RELEASE'
+	}
+
+	idea.module {
+		downloadSources = downloadJavadoc = true
 	}
 
 	eclipse {
@@ -239,6 +244,7 @@ project('spring-integration-ftp') {
 		compile "org.springframework:spring-context-support:$springVersion"
 		compile("javax.activation:activation:$javaxActivationVersion", optional)
 		testCompile project(":spring-integration-test")
+		testCompile "org.apache.ftpserver:ftpserver-core:$ftpserverVersion"
 	}
 }
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
@@ -17,6 +17,7 @@ package org.springframework.integration.file.config;
 
 import org.w3c.dom.Element;
 
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.ExpressionFactoryBean;
@@ -53,7 +54,12 @@ public abstract class AbstractRemoteFileOutboundGatewayParser extends AbstractCo
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel", "outputChannel");
 		this.configureFilter(builder, element, parserContext);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "remote-file-separator");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "local-directory");
+
+		BeanDefinition localDirExpressionDef = IntegrationNamespaceUtils
+				.createExpressionDefinitionFromValueOrExpression("local-directory", "local-directory-expression",
+						parserContext, element, false);
+		builder.addPropertyValue("localDirectoryExpression", localDirExpressionDef);
+
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-create-local-directory");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "order");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "rename-expression");

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -476,6 +476,9 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 		F[] files = null;
 		if (lsFirst) {
 			files = session.list(remoteFilePath);
+			if (files == null) {
+				throw new MessagingException("Session returned null when listing " + remoteFilePath);
+			}
 			if (files.length != 1 || isDirectory(files[0]) || isLink(files[0])) {
 				throw new MessagingException(remoteFilePath + " is not a file");
 			}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -226,8 +226,9 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	 * @param localDirectory the localDirectory to set
 	 */
 	public void setLocalDirectory(File localDirectory) {
-		Assert.notNull(localDirectory, "localDirectory must not be null");
-		this.localDirectoryExpression = new LiteralExpression(localDirectory.getAbsolutePath());
+		if (localDirectory != null) {
+			this.localDirectoryExpression = new LiteralExpression(localDirectory.getAbsolutePath());
+		}
 	}
 
 	public void setLocalDirectoryExpression(Expression localDirectoryExpression) {
@@ -279,7 +280,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 				|| Command.MGET.equals(this.command)) {
 			Assert.notNull(this.localDirectoryExpression, "localDirectory must not be null");
 			if (this.localDirectoryExpression instanceof LiteralExpression) {
-				File localDirectory = new File(this.localDirectoryExpression.getValue(String.class));
+				File localDirectory = new File(this.localDirectoryExpression.getExpressionString());
 				try {
 					if (!localDirectory.exists()) {
 						if (this.autoCreateLocalDirectory) {

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
@@ -418,6 +418,22 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="local-directory-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies SpEL expression to
+								generate the directory path where file will be
+								transferred TO.
+								The root object of the SpEL evaluation is the request Message,
+								but the name of the original
+								remote directory is also provided as the 'remotePath' variable.
+								For example, a valid expression would be:
+								"'/local' + #remotePath.toUpperCase() + headers.foo".
+								Only used with 'get' and 'mget' commands.
+								This attribute is mutually exclusive with 'local-directory'
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="auto-create-local-directory"
 						type="xsd:boolean">
 						<xsd:annotation>

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
@@ -427,9 +427,9 @@
 								transferred TO.
 								The root object of the SpEL evaluation is the request Message,
 								but the name of the original
-								remote directory is also provided as the 'remotePath' variable.
+								remote directory is also provided as the 'remoteDirectory' variable.
 								For example, a valid expression would be:
-								"'/local' + #remotePath.toUpperCase() + headers.foo".
+								"'/local/' + #remoteDirectory.toUpperCase() + headers.foo".
 								Only used with 'get' and 'mget' commands.
 								This attribute is mutually exclusive with 'local-directory'.
 							</xsd:documentation>

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-3.0.xsd
@@ -415,6 +415,7 @@
 								Identifies directory path (e.g.,
 								"/local/mytransfers") where file will be
 								transferred TO.
+								This attribute is mutually exclusive with 'local-directory-expression'.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
@@ -430,7 +431,7 @@
 								For example, a valid expression would be:
 								"'/local' + #remotePath.toUpperCase() + headers.foo".
 								Only used with 'get' and 'mget' commands.
-								This attribute is mutually exclusive with 'local-directory'
+								This attribute is mutually exclusive with 'local-directory'.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpServerRule.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpServerRule.java
@@ -130,16 +130,13 @@ public class FtpServerRule extends ExternalResource {
 		this.localFolder.create();
 
 		FtpServerFactory serverFactory = new FtpServerFactory();
-		ListenerFactory factory = new ListenerFactory();
-
-		factory.setPort(FTP_PORT);
-
 		serverFactory.setUserManager(new TestUserManager(this.ftpRootFolder.getAbsolutePath()));
 
+		ListenerFactory factory = new ListenerFactory();
+		factory.setPort(FTP_PORT);
 		serverFactory.addListener("default", factory.createListener());
 
 		server = serverFactory.createServer();
-
 		server.start();
 	}
 
@@ -173,7 +170,6 @@ public class FtpServerRule extends ExternalResource {
 					new WritePermission(),
 					new TransferRatePermission(1024, 1024)));
 			this.testUser.setHomeDirectory(homeDirectory);
-//			this.testUser.setMaxIdleTime(60000);
 			this.testUser.setName("TEST_USER");
 		}
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpServerRule.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpServerRule.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.ftp;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.ftpserver.FtpServer;
+import org.apache.ftpserver.FtpServerFactory;
+import org.apache.ftpserver.ftplet.Authentication;
+import org.apache.ftpserver.ftplet.AuthenticationFailedException;
+import org.apache.ftpserver.ftplet.FtpException;
+import org.apache.ftpserver.ftplet.User;
+import org.apache.ftpserver.ftplet.UserManager;
+import org.apache.ftpserver.listener.ListenerFactory;
+import org.apache.ftpserver.usermanager.impl.BaseUser;
+import org.apache.ftpserver.usermanager.impl.ConcurrentLoginPermission;
+import org.apache.ftpserver.usermanager.impl.TransferRatePermission;
+import org.apache.ftpserver.usermanager.impl.WritePermission;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
+
+import org.springframework.integration.test.util.SocketUtils;
+
+/**
+ * @author Artem Bilan
+ * @since 3.0
+ */
+public class FtpServerRule extends ExternalResource {
+
+	public static int FTP_PORT = SocketUtils.findAvailableServerSocket();
+
+	private final TemporaryFolder ftpFolder;
+
+	private final TemporaryFolder localFolder;
+
+	private volatile File ftpRootFolder;
+
+	private volatile File sourceFtpDirectory;
+
+	private volatile File targetFtpDirectory;
+
+	private volatile File sourceLocalDirectory;
+
+	private volatile File targetLocalDirectory;
+
+	private volatile FtpServer server;
+
+	public FtpServerRule(final String root) {
+		this.ftpFolder = new TemporaryFolder() {
+
+			@Override
+			public void create() throws IOException {
+				super.create();
+				ftpRootFolder = this.newFolder(root);
+				sourceFtpDirectory = new File(ftpRootFolder, "ftpSource");
+				sourceFtpDirectory.mkdir();
+				File file = new File(sourceFtpDirectory, "ftpSource1.txt");
+				file.createNewFile();
+				file = new File(sourceFtpDirectory, "ftpSource2.txt");
+				file.createNewFile();
+
+				File subSourceFtpDirectory = new File(sourceFtpDirectory, "subFtpSource");
+				subSourceFtpDirectory.mkdir();
+				file = new File(subSourceFtpDirectory, "subFtpSource1.txt");
+				file.createNewFile();
+
+				targetFtpDirectory = new File(ftpRootFolder, "ftpTarget");
+				targetFtpDirectory.mkdirs();
+			}
+		};
+		this.localFolder  = new TemporaryFolder() {
+
+			@Override
+			public void create() throws IOException {
+				super.create();
+				File rootFolder = this.newFolder(root);
+				sourceLocalDirectory = new File(rootFolder, "localSource");
+				sourceLocalDirectory.mkdirs();
+				File file = new File(sourceLocalDirectory, "localSource1.txt");
+				file.createNewFile();
+				file = new File(sourceLocalDirectory, "localSource2.txt");
+				file.createNewFile();
+
+				File subSourceLocalDirectory = new File(sourceLocalDirectory, "subLocalSource");
+				subSourceLocalDirectory.mkdir();
+				file = new File(subSourceLocalDirectory, "subLocalSource1.txt");
+				file.createNewFile();
+
+				targetLocalDirectory = new File(rootFolder, "localTarget");
+				targetLocalDirectory.mkdirs();
+			}
+		};
+	}
+
+	public File getSourceFtpDirectory() {
+		return sourceFtpDirectory;
+	}
+
+	public File getTargetFtpDirectory() {
+		return targetFtpDirectory;
+	}
+
+	public File getSourceLocalDirectory() {
+		return sourceLocalDirectory;
+	}
+
+	public File getTargetLocalDirectory() {
+		return targetLocalDirectory;
+	}
+
+	@Override
+	protected void before() throws Throwable {
+		this.ftpFolder.create();
+		this.localFolder.create();
+
+		FtpServerFactory serverFactory = new FtpServerFactory();
+		ListenerFactory factory = new ListenerFactory();
+
+		factory.setPort(FTP_PORT);
+
+		serverFactory.setUserManager(new TestUserManager(this.ftpRootFolder.getAbsolutePath()));
+
+		serverFactory.addListener("default", factory.createListener());
+
+		server = serverFactory.createServer();
+
+		server.start();
+	}
+
+
+	@Override
+	protected void after() {
+		this.server.stop();
+		this.ftpFolder.delete();
+		this.localFolder.delete();
+	}
+
+
+	public static void recursiveDelete(File file) {
+		File[] files = file.listFiles();
+		if (files != null) {
+			for (File each : files) {
+				recursiveDelete(each);
+			}
+		}
+		file.delete();
+	}
+
+
+	private class TestUserManager implements UserManager {
+
+		private final BaseUser testUser;
+
+		private TestUserManager(String homeDirectory) {
+			this.testUser = new BaseUser();
+			this.testUser.setAuthorities(Arrays.asList(new ConcurrentLoginPermission(1024, 1024),
+					new WritePermission(),
+					new TransferRatePermission(1024, 1024)));
+			this.testUser.setHomeDirectory(homeDirectory);
+//			this.testUser.setMaxIdleTime(60000);
+			this.testUser.setName("TEST_USER");
+		}
+
+
+		@Override
+		public User getUserByName(String s) throws FtpException {
+			return this.testUser;
+		}
+
+		@Override
+		public String[] getAllUserNames() throws FtpException {
+			return new String[]{"TEST_USER"};
+		}
+
+		@Override
+		public void delete(String s) throws FtpException {
+		}
+
+		@Override
+		public void save(User user) throws FtpException {
+		}
+
+		@Override
+		public boolean doesExist(String s) throws FtpException {
+			return true;
+		}
+
+		@Override
+		public User authenticate(Authentication authentication) throws AuthenticationFailedException {
+			return this.testUser;
+		}
+
+		@Override
+		public String getAdminName() throws FtpException {
+			return "admin";
+		}
+
+		@Override
+		public boolean isAdmin(String s) throws FtpException {
+			return s.equals("admin");
+		}
+
+	}
+
+}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
@@ -77,7 +77,7 @@ public class FtpOutboundGatewayParserTests {
 		assertEquals("X", TestUtils.getPropertyValue(gateway, "remoteFileSeparator"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
-		assertEquals(new File("local-test-dir"), TestUtils.getPropertyValue(gateway, "localDirectory"));
+		assertEquals("local-test-dir", TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "filter"));
 		assertEquals(Command.LS, TestUtils.getPropertyValue(gateway, "command"));
@@ -100,7 +100,7 @@ public class FtpOutboundGatewayParserTests {
 		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
 		assertTrue(TestUtils.getPropertyValue(gateway, "sessionFactory") instanceof CachingSessionFactory);
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
-		assertEquals(new File("local-test-dir"), TestUtils.getPropertyValue(gateway, "localDirectory"));
+		assertEquals("local-test-dir", TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
 		assertEquals(Command.GET, TestUtils.getPropertyValue(gateway, "command"));
 		@SuppressWarnings("unchecked")

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -37,7 +37,7 @@
 							  request-channel="invalidDirExpression"
 							  command="get"
 							  expression="payload"
-							  local-directory-expression="'\' + #remotePath + '?:'"
+							  local-directory-expression="T(System).getProperty('file.separator') + #remotePath + '?:'"
 							  reply-channel="output"/>
 
 	<int:channel id="inboundMGet"/>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -27,7 +27,7 @@
 							  request-channel="inboundGet"
 							  command="get"
 							  expression="payload"
-							  local-directory-expression="#localDir() + #remotePath.toUpperCase()"
+							  local-directory-expression="#localDir() + #remoteDirectory.toUpperCase()"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 
@@ -37,7 +37,7 @@
 							  request-channel="invalidDirExpression"
 							  command="get"
 							  expression="payload"
-							  local-directory-expression="T(java.io.File).separator + #remotePath + '?:'"
+							  local-directory-expression="T(java.io.File).separator + #remoteDirectory + '?:'"
 							  reply-channel="output"/>
 
 	<int:channel id="inboundMGet"/>
@@ -46,7 +46,7 @@
 							  request-channel="inboundMGet"
 							  command="mget"
 							  expression="payload"
-							  local-directory-expression="#localDir() + #remotePath"
+							  local-directory-expression="#localDir() + #remoteDirectory"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-ftp="http://www.springframework.org/schema/integration/ftp"
+	   xmlns:int="http://www.springframework.org/schema/integration"
+	   xsi:schemaLocation="http://www.springframework.org/schema/integration/ftp
+	 http://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="ftpSessionFactory" class="org.springframework.integration.ftp.session.DefaultFtpSessionFactory">
+		<property name="host" value="localhost"/>
+		<property name="port" value="#{T(org.springframework.integration.ftp.FtpServerRule).FTP_PORT}"/>
+		<property name="username" value="foo"/>
+		<property name="password" value="foo"/>
+	</bean>
+
+	<int:spel-function id="localDir" class="org.springframework.integration.ftp.outbound.FtpServerOutboundTests" method="localDirectory"/>
+
+	<int:channel id="output">
+		<int:queue/>
+	</int:channel>
+
+	<int:channel id="inboundGet"/>
+
+	<int-ftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="inboundGet"
+							  command="get"
+							  expression="payload"
+							  local-directory-expression="#localDir().absolutePath + #remotePath.toUpperCase()"
+							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
+							  reply-channel="output"/>
+
+	<int:channel id="invalidDirExpression"/>
+
+	<int-ftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="invalidDirExpression"
+							  command="get"
+							  expression="payload"
+							  local-directory-expression="'\' + #remotePath + '?:'"
+							  reply-channel="output"/>
+
+	<int:channel id="inboundMGet"/>
+
+	<int-ftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="inboundMGet"
+							  command="mget"
+							  expression="payload"
+							  local-directory-expression="#localDir().absolutePath + #remotePath"
+							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
+							  reply-channel="output"/>
+
+
+</beans>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -27,7 +27,7 @@
 							  request-channel="inboundGet"
 							  command="get"
 							  expression="payload"
-							  local-directory-expression="#localDir().absolutePath + #remotePath.toUpperCase()"
+							  local-directory-expression="#localDir() + #remotePath.toUpperCase()"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 
@@ -37,7 +37,7 @@
 							  request-channel="invalidDirExpression"
 							  command="get"
 							  expression="payload"
-							  local-directory-expression="T(System).getProperty('file.separator') + #remotePath + '?:'"
+							  local-directory-expression="T(java.io.File).separator + #remotePath + '?:'"
 							  reply-channel="output"/>
 
 	<int:channel id="inboundMGet"/>
@@ -46,7 +46,7 @@
 							  request-channel="inboundMGet"
 							  command="mget"
 							  expression="payload"
-							  local-directory-expression="#localDir().absolutePath + #remotePath"
+							  local-directory-expression="#localDir() + #remotePath"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -125,8 +125,8 @@ public class FtpServerOutboundTests {
 		}
 	}
 
-	public static File localDirectory() {
-		return FTP_SERVER.getTargetLocalDirectory();
+	public static String localDirectory() {
+		return FTP_SERVER.getTargetLocalDirectory().getAbsolutePath() + File.separator;
 	}
 
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.ftp.outbound;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.Message;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.core.PollableChannel;
+import org.springframework.integration.ftp.FtpServerRule;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Artem Bilan
+ * @since 3.0
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class FtpServerOutboundTests {
+
+	@ClassRule
+	public static final FtpServerRule FTP_SERVER = new FtpServerRule(FtpServerOutboundTests.class.getSimpleName());
+
+	@Autowired
+	private PollableChannel output;
+
+	@Autowired
+	private DirectChannel inboundGet;
+
+	@Autowired
+	private DirectChannel invalidDirExpression;
+
+	@Autowired
+	private DirectChannel inboundMGet;
+
+	@Before
+	public void setup() {
+		FtpServerRule.recursiveDelete(FTP_SERVER.getTargetLocalDirectory());
+		FtpServerRule.recursiveDelete(FTP_SERVER.getTargetFtpDirectory());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testInt2866LocalDirectoryExpressionGET() {
+		String dir = "/ftpSource/";
+		this.inboundGet.send(new GenericMessage<Object>(dir + "ftpSource1.txt"));
+		Message<?> result = this.output.receive(1000);
+		assertNotNull(result);
+		File localFile = (File) result.getPayload();
+		assertThat(localFile.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+				Matchers.containsString(dir.toUpperCase()));
+
+		dir = "/ftpSource/subFtpSource/";
+		this.inboundGet.send(new GenericMessage<Object>(dir + "subFtpSource1.txt"));
+		result = this.output.receive(1000);
+		assertNotNull(result);
+		localFile = (File) result.getPayload();
+		assertThat(localFile.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+				Matchers.containsString(dir.toUpperCase()));
+	}
+
+	@Test
+	public void testInt2866InvalidLocalDirectoryExpression() {
+		try {
+			this.invalidDirExpression.send(new GenericMessage<Object>("/ftpSource/ftpSource1.txt"));
+			fail("Exception expected.");
+		}
+		catch (Exception e) {
+			Throwable cause = e.getCause();
+			assertThat(cause, Matchers.instanceOf(IllegalArgumentException.class));
+			assertThat(cause.getMessage(), Matchers.startsWith("Failed to make local directory"));
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testInt2866LocalDirectoryExpressionMGET() {
+		String dir = "/ftpSource/";
+		this.inboundMGet.send(new GenericMessage<Object>(dir + "*.txt"));
+		Message<?> result = this.output.receive(1000);
+		assertNotNull(result);
+		List<File> localFiles = (List<File>) result.getPayload();
+
+		for (File file : localFiles) {
+			assertThat(file.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+					Matchers.containsString(dir));
+		}
+
+		dir = "/ftpSource/subFtpSource/";
+		this.inboundMGet.send(new GenericMessage<Object>(dir + "*.txt"));
+		result = this.output.receive(1000);
+		assertNotNull(result);
+		localFiles = (List<File>) result.getPayload();
+
+		for (File file : localFiles) {
+			assertThat(file.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+					Matchers.containsString(dir));
+		}
+	}
+
+	public static File localDirectory() {
+		return FTP_SERVER.getTargetLocalDirectory();
+	}
+
+
+}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -18,7 +18,6 @@ package org.springframework.integration.ftp.outbound;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -69,9 +68,8 @@ public class FtpServerOutboundTests {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testInt2866LocalDirectoryExpressionGET() {
-		String dir = "/ftpSource/";
+		String dir = "ftpSource/";
 		this.inboundGet.send(new GenericMessage<Object>(dir + "ftpSource1.txt"));
 		Message<?> result = this.output.receive(1000);
 		assertNotNull(result);
@@ -79,7 +77,7 @@ public class FtpServerOutboundTests {
 		assertThat(localFile.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
 				Matchers.containsString(dir.toUpperCase()));
 
-		dir = "/ftpSource/subFtpSource/";
+		dir = "ftpSource/subFtpSource/";
 		this.inboundGet.send(new GenericMessage<Object>(dir + "subFtpSource1.txt"));
 		result = this.output.receive(1000);
 		assertNotNull(result);
@@ -104,7 +102,7 @@ public class FtpServerOutboundTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testInt2866LocalDirectoryExpressionMGET() {
-		String dir = "/ftpSource/";
+		String dir = "ftpSource/";
 		this.inboundMGet.send(new GenericMessage<Object>(dir + "*.txt"));
 		Message<?> result = this.output.receive(1000);
 		assertNotNull(result);
@@ -115,7 +113,7 @@ public class FtpServerOutboundTests {
 					Matchers.containsString(dir));
 		}
 
-		dir = "/ftpSource/subFtpSource/";
+		dir = "ftpSource/subFtpSource/";
 		this.inboundMGet.send(new GenericMessage<Object>(dir + "*.txt"));
 		result = this.output.receive(1000);
 		assertNotNull(result);

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
@@ -414,9 +414,27 @@
 								Identifies directory path (e.g.,
 								"/local/mytransfers") where file will be
 								transferred TO.
+								This attribute is mutually exclusive with 'local-directory-expression'
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="local-directory-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specifies SpEL expression to
+								generate the directory path where file will be
+								transferred TO.
+								The root object of the SpEL evaluation is the request Message,
+								but the name of the original
+								remote directory is also provided as the 'remotePath' variable.
+								For example, a valid expression would be:
+								"'/local' + #remotePath.toUpperCase() + headers.foo".
+								Only used with 'get' and 'mget' commands.
+								This attribute is mutually exclusive with 'local-directory'
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+
 					<xsd:attribute name="auto-create-local-directory"
 						type="xsd:boolean">
 						<xsd:annotation>

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
@@ -414,7 +414,7 @@
 								Identifies directory path (e.g.,
 								"/local/mytransfers") where file will be
 								transferred TO.
-								This attribute is mutually exclusive with 'local-directory-expression'
+								This attribute is mutually exclusive with 'local-directory-expression'.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
@@ -430,7 +430,7 @@
 								For example, a valid expression would be:
 								"'/local' + #remotePath.toUpperCase() + headers.foo".
 								Only used with 'get' and 'mget' commands.
-								This attribute is mutually exclusive with 'local-directory'
+								This attribute is mutually exclusive with 'local-directory'.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-3.0.xsd
@@ -426,9 +426,9 @@
 								transferred TO.
 								The root object of the SpEL evaluation is the request Message,
 								but the name of the original
-								remote directory is also provided as the 'remotePath' variable.
+								remote directory is also provided as the 'remoteDirectory' variable.
 								For example, a valid expression would be:
-								"'/local' + #remotePath.toUpperCase() + headers.foo".
+								"'/local/' + #remoteDirectory.toUpperCase() + headers.foo".
 								Only used with 'get' and 'mget' commands.
 								This attribute is mutually exclusive with 'local-directory'.
 							</xsd:documentation>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
@@ -75,7 +75,7 @@ public class SftpOutboundGatewayParserTests {
 		assertEquals("X", TestUtils.getPropertyValue(gateway, "remoteFileSeparator"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
-		assertEquals(new File("local-test-dir"), TestUtils.getPropertyValue(gateway, "localDirectory"));
+		assertEquals("local-test-dir", TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
 		assertTrue(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "filter"));
@@ -97,7 +97,7 @@ public class SftpOutboundGatewayParserTests {
 		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
 		assertTrue(TestUtils.getPropertyValue(gateway, "sessionFactory") instanceof CachingSessionFactory);
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
-		assertEquals(new File("local-test-dir"), TestUtils.getPropertyValue(gateway, "localDirectory"));
+		assertEquals("local-test-dir", TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
 		assertEquals(Command.GET, TestUtils.getPropertyValue(gateway, "command"));
 		assertFalse(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
@@ -24,13 +24,6 @@
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<bean id="ftpSessionFactory"
-		  class="org.springframework.integration.sftp.session.DefaultSftpSessionFactory">
-		<property name="host" value="localhost"/>
-		<property name="user" value="ftptest"/>
-		<property name="password" value="ftptest"/>
-	</bean>
-
 	<int:channel id="output">
 		<int:queue/>
 	</int:channel>
@@ -41,7 +34,7 @@
 							  request-channel="inboundGet"
 							  command="get"
 							  expression="payload"
-							  local-directory-expression="'/tmp/out' + #remotePath.toUpperCase()"
+							  local-directory-expression="'/tmp/sftpOutboundTests/' + #remotePath.toUpperCase()"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 
@@ -51,7 +44,7 @@
 							  request-channel="invalidDirExpression"
 							  command="get"
 							  expression="payload"
-							  local-directory-expression="'\' + #remotePath + '?:'"
+							  local-directory-expression="T(System).getProperty('file.separator') + #remotePath + '?:'"
 							  reply-channel="output"/>
 
 	<int:channel id="inboundMGet"/>
@@ -60,9 +53,21 @@
 							  request-channel="inboundMGet"
 							  command="mget"
 							  expression="payload"
-							  local-directory-expression="'/tmp/out' + #remotePath"
+							  local-directory-expression="'/tmp/sftpOutboundTests/' + #remotePath"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 
+	<bean id="ftpSessionFactory" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.integration.file.remote.session.SessionFactory" />
+	</bean>
+
+	<beans profile="realSSH">
+		<bean id="ftpSessionFactory"
+			  class="org.springframework.integration.sftp.session.DefaultSftpSessionFactory">
+			<property name="host" value="localhost"/>
+			<property name="user" value="ftptest"/>
+			<property name="password" value="ftptest"/>
+		</bean>
+	</beans>
 
 </beans>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
@@ -1,20 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2013 the original author or authors.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~       http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:int-sftp="http://www.springframework.org/schema/integration/sftp"
@@ -44,7 +28,7 @@
 							  request-channel="invalidDirExpression"
 							  command="get"
 							  expression="payload"
-							  local-directory-expression="T(System).getProperty('file.separator') + #remotePath + '?:'"
+							  local-directory-expression="T(java.io.File).separator + #remotePath + '?:'"
 							  reply-channel="output"/>
 
 	<int:channel id="inboundMGet"/>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
@@ -18,7 +18,7 @@
 							  request-channel="inboundGet"
 							  command="get"
 							  expression="payload"
-							  local-directory-expression="'/tmp/sftpOutboundTests/' + #remotePath.toUpperCase()"
+							  local-directory-expression="'/tmp/sftpOutboundTests/' + #remoteDirectory.toUpperCase()"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 
@@ -28,7 +28,7 @@
 							  request-channel="invalidDirExpression"
 							  command="get"
 							  expression="payload"
-							  local-directory-expression="T(java.io.File).separator + #remotePath + '?:'"
+							  local-directory-expression="T(java.io.File).separator + #remoteDirectory + '?:'"
 							  reply-channel="output"/>
 
 	<int:channel id="inboundMGet"/>
@@ -37,7 +37,7 @@
 							  request-channel="inboundMGet"
 							  command="mget"
 							  expression="payload"
-							  local-directory-expression="'/tmp/sftpOutboundTests/' + #remotePath"
+							  local-directory-expression="'/tmp/sftpOutboundTests/' + #remoteDirectory"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2013 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-sftp="http://www.springframework.org/schema/integration/sftp"
+	   xmlns:int="http://www.springframework.org/schema/integration"
+	   xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
+	 http://www.springframework.org/schema/integration/sftp/spring-integration-sftp.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="ftpSessionFactory"
+		  class="org.springframework.integration.sftp.session.DefaultSftpSessionFactory">
+		<property name="host" value="localhost"/>
+		<property name="user" value="ftptest"/>
+		<property name="password" value="ftptest"/>
+	</bean>
+
+	<int:channel id="output">
+		<int:queue/>
+	</int:channel>
+
+	<int:channel id="inboundGet"/>
+
+	<int-sftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="inboundGet"
+							  command="get"
+							  expression="payload"
+							  local-directory-expression="'/tmp/out' + #remotePath.toUpperCase()"
+							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
+							  reply-channel="output"/>
+
+	<int:channel id="invalidDirExpression"/>
+
+	<int-sftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="invalidDirExpression"
+							  command="get"
+							  expression="payload"
+							  local-directory-expression="'\' + #remotePath + '?:'"
+							  reply-channel="output"/>
+
+	<int:channel id="inboundMGet"/>
+
+	<int-sftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="inboundMGet"
+							  command="mget"
+							  expression="payload"
+							  local-directory-expression="'/tmp/out' + #remotePath"
+							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
+							  reply-channel="output"/>
+
+
+</beans>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
@@ -19,14 +19,16 @@ package org.springframework.integration.sftp.outbound;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 import org.hamcrest.Matchers;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,17 +36,36 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.Message;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.core.PollableChannel;
+import org.springframework.integration.file.remote.session.Session;
+import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.integration.sftp.session.SftpFileInfo;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import com.jcraft.jsch.ChannelSftp.LsEntry;
+import com.jcraft.jsch.SftpATTRS;
+
 /**
+ * Run with -Dspring-profiles-active=realSSH to run with a real SSH server.
+ *
+ * Assumes ftptest account on localhost with the following directory tree in the user's root...
+ *
+ * <pre class="code">
+ *  $ tree sftpSource/
+ *  sftpSource/
+ *  ├── sftpSource1.txt
+ *  ├── sftpSource2.txt
+ *  └── subSftpSource
+ *      └── subSftpSource1.txt
+ * </pre>
+ *
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 3.0
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
-@Ignore
 public class SftpServerOutboundTests {
 
 	@Autowired
@@ -59,10 +80,74 @@ public class SftpServerOutboundTests {
 	@Autowired
 	private DirectChannel inboundMGet;
 
+	@Autowired
+	private SessionFactory<SftpFileInfo> sessionFactory;
+
+	@Before
+	public void setup() throws Exception {
+		purge();
+		setUpMocksIfNeeded();
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private void setUpMocksIfNeeded() throws IOException {
+		if (sessionFactory.toString().startsWith("Mock for")) {
+			Session session = mock(Session.class);
+			when(sessionFactory.getSession()).thenReturn(session);
+			LsEntry entry1 = mock(LsEntry.class);
+			SftpATTRS attrs1 = mock(SftpATTRS.class);
+			when(entry1.getAttrs()).thenReturn(attrs1);
+			when(entry1.getFilename()).thenReturn("sftpSource1.txt");
+			LsEntry entry2 = mock(LsEntry.class);
+			SftpATTRS attrs2 = mock(SftpATTRS.class);
+			when(entry2.getAttrs()).thenReturn(attrs2);
+			when(entry2.getFilename()).thenReturn("sftpSource2.txt");
+			LsEntry entry3 = mock(LsEntry.class);
+			when(entry3.getFilename()).thenReturn("subSftpSource");
+			SftpATTRS attrs3 = mock(SftpATTRS.class);
+			when(entry3.getAttrs()).thenReturn(attrs3);
+			when(attrs3.isDir()).thenReturn(true);
+			LsEntry entry4 = mock(LsEntry.class);
+			SftpATTRS attrs4 = mock(SftpATTRS.class);
+			when(entry4.getAttrs()).thenReturn(attrs4);
+			when(entry4.getFilename()).thenReturn("subSftpSource1.txt");
+			when(session.list("sftpSource/sftpSource1.txt")).thenReturn(new LsEntry[] {
+					entry1
+			});
+			when(session.list("sftpSource/")).thenReturn(new LsEntry[] {
+					entry1, entry2, entry3
+			});
+			when(session.list("sftpSource/subSftpSource/")).thenReturn(new LsEntry[] {
+					entry4
+			});
+			when(session.list("sftpSource/subSftpSource/subSftpSource1.txt")).thenReturn(new LsEntry[] {
+					entry4
+			});
+		}
+	}
+
+	@After
+	public void purge() {
+		File local = new File("/tmp/sftpOutboundTests/");
+		purge(local);
+		local.delete();
+	}
+
+	private void purge(File local) {
+		File[] files = local.listFiles();
+		if (files != null) {
+			for (File file : files) {
+				if (file.isDirectory()) {
+					this.purge(file);
+				}
+				file.delete();
+			}
+		}
+	}
+
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testInt2866LocalDirectoryExpressionGET() {
-		String dir = "/sftpSource/";
+		String dir = "sftpSource/";
 		this.inboundGet.send(new GenericMessage<Object>(dir + "sftpSource1.txt"));
 		Message<?> result = this.output.receive(1000);
 		assertNotNull(result);
@@ -70,7 +155,7 @@ public class SftpServerOutboundTests {
 		assertThat(localFile.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
 				Matchers.containsString(dir.toUpperCase()));
 
-		dir = "/sftpSource/subSftpSource/";
+		dir = "sftpSource/subSftpSource/";
 		this.inboundGet.send(new GenericMessage<Object>(dir + "subSftpSource1.txt"));
 		result = this.output.receive(1000);
 		assertNotNull(result);
@@ -82,7 +167,7 @@ public class SftpServerOutboundTests {
 	@Test
 	public void testInt2866InvalidLocalDirectoryExpression() {
 		try {
-			this.invalidDirExpression.send(new GenericMessage<Object>("/sftpSource/sftpSource1.txt"));
+			this.invalidDirExpression.send(new GenericMessage<Object>("sftpSource/sftpSource1.txt"));
 			fail("Exception expected.");
 		}
 		catch (Exception e) {
@@ -95,7 +180,7 @@ public class SftpServerOutboundTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testInt2866LocalDirectoryExpressionMGET() {
-		String dir = "/sftpSource/";
+		String dir = "sftpSource/";
 		this.inboundMGet.send(new GenericMessage<Object>(dir + "*.txt"));
 		Message<?> result = this.output.receive(1000);
 		assertNotNull(result);
@@ -106,7 +191,7 @@ public class SftpServerOutboundTests {
 					Matchers.containsString(dir));
 		}
 
-		dir = "/sftpSource/subSftpSource/";
+		dir = "sftpSource/subSftpSource/";
 		this.inboundMGet.send(new GenericMessage<Object>(dir + "*.txt"));
 		result = this.output.receive(1000);
 		assertNotNull(result);

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.sftp.outbound;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.Message;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.core.PollableChannel;
+import org.springframework.integration.message.GenericMessage;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Artem Bilan
+ * @since 3.0
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+@Ignore
+public class SftpServerOutboundTests {
+
+	@Autowired
+	private PollableChannel output;
+
+	@Autowired
+	private DirectChannel inboundGet;
+
+	@Autowired
+	private DirectChannel invalidDirExpression;
+
+	@Autowired
+	private DirectChannel inboundMGet;
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testInt2866LocalDirectoryExpressionGET() {
+		String dir = "/sftpSource/";
+		this.inboundGet.send(new GenericMessage<Object>(dir + "sftpSource1.txt"));
+		Message<?> result = this.output.receive(1000);
+		assertNotNull(result);
+		File localFile = (File) result.getPayload();
+		assertThat(localFile.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+				Matchers.containsString(dir.toUpperCase()));
+
+		dir = "/sftpSource/subSftpSource/";
+		this.inboundGet.send(new GenericMessage<Object>(dir + "subSftpSource1.txt"));
+		result = this.output.receive(1000);
+		assertNotNull(result);
+		localFile = (File) result.getPayload();
+		assertThat(localFile.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+				Matchers.containsString(dir.toUpperCase()));
+	}
+
+	@Test
+	public void testInt2866InvalidLocalDirectoryExpression() {
+		try {
+			this.invalidDirExpression.send(new GenericMessage<Object>("/sftpSource/sftpSource1.txt"));
+			fail("Exception expected.");
+		}
+		catch (Exception e) {
+			Throwable cause = e.getCause();
+			assertThat(cause, Matchers.instanceOf(IllegalArgumentException.class));
+			assertThat(cause.getMessage(), Matchers.startsWith("Failed to make local directory"));
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testInt2866LocalDirectoryExpressionMGET() {
+		String dir = "/sftpSource/";
+		this.inboundMGet.send(new GenericMessage<Object>(dir + "*.txt"));
+		Message<?> result = this.output.receive(1000);
+		assertNotNull(result);
+		List<File> localFiles = (List<File>) result.getPayload();
+
+		for (File file : localFiles) {
+			assertThat(file.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+					Matchers.containsString(dir));
+		}
+
+		dir = "/sftpSource/subSftpSource/";
+		this.inboundMGet.send(new GenericMessage<Object>(dir + "*.txt"));
+		result = this.output.receive(1000);
+		assertNotNull(result);
+		localFiles = (List<File>) result.getPayload();
+
+		for (File file : localFiles) {
+			assertThat(file.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+					Matchers.containsString(dir));
+		}
+	}
+
+}

--- a/src/reference/docbook/ftp.xml
+++ b/src/reference/docbook/ftp.xml
@@ -433,7 +433,16 @@ protected void postProcessClientBeforeConnect(T client) throws IOException {
 		defines a SpEL expression to generate the name of local file(s) during the transfer.
 		The root object of the evaluation context is the request Message but, in addition, the <code>remoteFileName</code>
 		variable is also available, which is particularly useful for <emphasis>mget</emphasis>, for
-		example: <code>local-filename-generator-expression="#remoteFileName.toUpperCase() + headers.foo"</code>
+		example: <code>local-filename-generator-expression="#remoteFileName.toUpperCase() + headers.foo"</code>.
+	  </para>
+	  <para>
+		The <emphasis>get</emphasis> and <emphasis>mget</emphasis> commands support
+		the <emphasis>local-directory-expression</emphasis> attribute. It
+		defines a SpEL expression to generate the name of local directory(ies) during the transfer.
+		The root object of the evaluation context is the request Message but, in addition, the <code>remotePath</code>
+		variable is also available, which is particularly useful for <emphasis>mget</emphasis>, for
+		example: <code>local-directory-expression="'/tmp/local/' + #remotePath.toUpperCase() + headers.foo"</code>.
+		This attribute is mutually exclusive with <emphasis>local-directory</emphasis> attribute.
 	  </para>
 	  <para>
 		For all commands, the PATH that the command acts on is provided by the 'expression'

--- a/src/reference/docbook/ftp.xml
+++ b/src/reference/docbook/ftp.xml
@@ -439,9 +439,9 @@ protected void postProcessClientBeforeConnect(T client) throws IOException {
 		The <emphasis>get</emphasis> and <emphasis>mget</emphasis> commands support
 		the <emphasis>local-directory-expression</emphasis> attribute. It
 		defines a SpEL expression to generate the name of local directory(ies) during the transfer.
-		The root object of the evaluation context is the request Message but, in addition, the <code>remotePath</code>
+		The root object of the evaluation context is the request Message but, in addition, the <code>remoteDirectory</code>
 		variable is also available, which is particularly useful for <emphasis>mget</emphasis>, for
-		example: <code>local-directory-expression="'/tmp/local/' + #remotePath.toUpperCase() + headers.foo"</code>.
+		example: <code>local-directory-expression="'/tmp/local/' + #remoteDirectory.toUpperCase() + headers.foo"</code>.
 		This attribute is mutually exclusive with <emphasis>local-directory</emphasis> attribute.
 	  </para>
 	  <para>

--- a/src/reference/docbook/sftp.xml
+++ b/src/reference/docbook/sftp.xml
@@ -475,9 +475,9 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 		The <emphasis>get</emphasis> and <emphasis>mget</emphasis> commands support
 		the <emphasis>local-directory-expression</emphasis> attribute. It
 		defines a SpEL expression to generate the name of local directory(ies) during the transfer.
-		The root object of the evaluation context is the request Message but, in addition, the <code>remotePath</code>
+		The root object of the evaluation context is the request Message but, in addition, the <code>remoteDirectory</code>
 		variable is also available, which is particularly useful for <emphasis>mget</emphasis>, for
-		example: <code>local-directory-expression="'/tmp/local/' + #remotePath.toUpperCase() + headers.foo"</code>.
+		example: <code>local-directory-expression="'/tmp/local/' + #remoteDirectory.toUpperCase() + headers.foo"</code>.
 		This attribute is mutually exclusive with <emphasis>local-directory</emphasis> attribute.
 	  </para>
 	  <para>

--- a/src/reference/docbook/sftp.xml
+++ b/src/reference/docbook/sftp.xml
@@ -472,6 +472,15 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 		example: <code>local-filename-generator-expression="#remoteFileName.toUpperCase() + headers.foo"</code>
 	  </para>
 	  <para>
+		The <emphasis>get</emphasis> and <emphasis>mget</emphasis> commands support
+		the <emphasis>local-directory-expression</emphasis> attribute. It
+		defines a SpEL expression to generate the name of local directory(ies) during the transfer.
+		The root object of the evaluation context is the request Message but, in addition, the <code>remotePath</code>
+		variable is also available, which is particularly useful for <emphasis>mget</emphasis>, for
+		example: <code>local-directory-expression="'/tmp/local/' + #remotePath.toUpperCase() + headers.foo"</code>.
+		This attribute is mutually exclusive with <emphasis>local-directory</emphasis> attribute.
+	  </para>
+	  <para>
 		For all commands, the PATH that the command acts on is provided by the 'expression'
 		property of the gateway. For the mget command, the expression might evaluate to '*', meaning
 		retrieve all files, or 'somedirectory/*' etc.

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -244,8 +244,14 @@
 			<para>
 				The <code>local-filename-generator-expression</code> attribute is now supported,
 				enabling the naming of local files during transfer. By default, the same
-				name as the remote file is used. For more information, see
-				<xref linkend="ftp-outbound-gateway"/> and <xref linkend="sftp-outbound-gateway"/>.
+				name as the remote file is used.
+			</para>
+			<para>
+				The <code>local-directory-expression</code> attribute is now supported,
+				enabling the naming of local directories during transfer based on remote path.
+			</para>
+			<para>
+			    For more information, see <xref linkend="ftp-outbound-gateway"/> and <xref linkend="sftp-outbound-gateway"/>.
 			</para>
 		</section>
 		<section id="3.0-jdbc-mysql-v5_6_4">

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -248,7 +248,7 @@
 			</para>
 			<para>
 				The <code>local-directory-expression</code> attribute is now supported,
-				enabling the naming of local directories during transfer based on remote path.
+				enabling the naming of local directories during transfer based on remote directory.
 			</para>
 			<para>
 			    For more information, see <xref linkend="ftp-outbound-gateway"/> and <xref linkend="sftp-outbound-gateway"/>.


### PR DESCRIPTION
- Add `local-directory-expression` to (S)FTP Outbound Gateways
- Add `FtpServerRule` to Apache Mina embedded FtpServer
- Add tests for (M)GET and `local-directory-expression`:
  FTP tests uses `FtpServerRule`, SFTP tests need testing on real SFTP server

JIRA: https://jira.springsource.org/browse/INT-2866
