### PR TITLE
INT-3172 Add Recursion to LS/MGET

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -289,7 +289,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	protected void onInit() {
 		super.onInit();
 		Assert.notNull(this.command, "command must not be null");
-		if (Command.RM.equals(this.command) || Command.MGET.equals(this.command) ||
+		if (Command.RM.equals(this.command) ||
 				Command.GET.equals(this.command)) {
 			Assert.isNull(this.filter, "Filters are not supported with the rm, get, and mget commands");
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -66,22 +66,27 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	 * Enumeration of commands supported by the gateways.
 	 */
 	public static enum Command {
+
 		/**
 		 * List remote files.
 		 */
 		LS("ls"),
+
 		/**
 		 * Retrieve a remote file.
 		 */
 		GET("get"),
+
 		/**
 		 * Remove a remote file (path - including wildcards).
 		 */
 		RM("rm"),
+
 		/**
 		 * Retrieve multiple files matching a wildcard path.
 		 */
 		MGET("mget"),
+
 		/**
 		 * Move (rename) a remote file.
 		 */
@@ -112,34 +117,42 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	 *
 	 */
 	public static enum Option {
+
 		/**
 		 * Don't return full file information; just the name (ls).
 		 */
 		NAME_ONLY("-1"),
+
 		/**
-		 * Include directories {@code .} and {@code ..} in the results (ls).
+		 * Include files beginning with {@code .}, including directories {@code .} and {@code ..} in the results (ls).
 		 */
 		ALL("-a"),
+
 		/**
 		 * Do not sort the results (ls with NAME_ONLY).
 		 */
 		NOSORT("-f"),
+
 		/**
 		 * Include directories in the results (ls).
 		 */
 		SUBDIRS("-dirs"),
+
 		/**
 		 * Include links in the results (ls).
 		 */
 		LINKS("-links"),
+
 		/**
 		 * Preserve the server timestamp (get, mget).
 		 */
 		PRESERVE_TIMESTAMP("-P"),
+
 		/**
 		 * Throw an exception if no files returned (mget).
 		 */
 		EXCEPTION_WHEN_EMPTY("-x"),
+
 		/**
 		 * Recursive (ls, mget)
 		 */
@@ -453,7 +466,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 							lsFiles.add(file);
 						}
 					}
-					if (recursing && this.isDirectory(file)) {
+					if (recursing && this.isDirectory(file) && !(".".equals(fileName)) && !("..".equals(fileName))) {
 						lsFiles.addAll(listFilesInRemoteDir(session, directory,  subDirectory + fileName + File.separator));
 					}
 				}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -291,7 +291,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 		Assert.notNull(this.command, "command must not be null");
 		if (Command.RM.equals(this.command) ||
 				Command.GET.equals(this.command)) {
-			Assert.isNull(this.filter, "Filters are not supported with the rm, get, and mget commands");
+			Assert.isNull(this.filter, "Filters are not supported with the rm and get commands");
 		}
 		if (Command.GET.equals(this.command)
 				|| Command.MGET.equals(this.command)) {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -850,6 +850,11 @@ class TestRemoteFileOutboundGateway extends AbstractRemoteFileOutboundGateway<Te
 	}
 
 	@Override
+	protected String getFilename(AbstractFileInfo<TestLsEntry> file) {
+		return file.getFilename();
+	}
+
+	@Override
 	protected long getModified(TestLsEntry file) {
 		return file.getModified();
 	}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -87,21 +87,6 @@ public class RemoteFileOutboundGatewayTests {
 	}
 
 	@Test
-	public void testBadFilterMGet() throws Exception {
-		SessionFactory sessionFactory = mock(SessionFactory.class);
-		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway
-				(sessionFactory, "mget", "payload");
-		gw.setFilter(new TestPatternFilter(""));
-		try {
-			gw.onInit();
-			fail("Exception expected");
-		}
-		catch (IllegalArgumentException e) {
-			assertTrue(e.getMessage().startsWith("Filters are not supported"));
-		}
-	}
-
-	@Test
 	public void testBadFilterRm() throws Exception {
 		SessionFactory sessionFactory = mock(SessionFactory.class);
 		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
@@ -56,6 +56,11 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 	}
 
 	@Override
+	protected String getFilename(AbstractFileInfo<FTPFile> file) {
+		return file.getFilename();
+	}
+
+	@Override
 	protected long getModified(FTPFile file) {
 		return file.getTimestamp().getTimeInMillis();
 	}

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.net.ftp.FTPFile;
+
 import org.springframework.integration.file.remote.AbstractFileInfo;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
 import org.springframework.integration.file.remote.session.SessionFactory;
@@ -28,7 +29,7 @@ import org.springframework.integration.ftp.session.FtpFileInfo;
 
 /**
  * Outbound Gateway for performing remote file operations via FTP/FTPS.
- *  
+ *
  * @author Gary Russell
  * @since 2.1
  */
@@ -68,5 +69,12 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 		return canonicalFiles;
 
 	}
+
+	@Override
+	protected FTPFile enhanceNameWithSubDirectory(FTPFile file, String directory) {
+		file.setName(directory + file.getName());
+		return file;
+	}
+
 
 }

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/TesFtpServer.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/TesFtpServer.java
@@ -20,6 +20,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
 import org.apache.ftpserver.FtpServer;
 import org.apache.ftpserver.FtpServerFactory;
 import org.apache.ftpserver.ftplet.Authentication;
@@ -32,7 +35,6 @@ import org.apache.ftpserver.usermanager.impl.BaseUser;
 import org.apache.ftpserver.usermanager.impl.ConcurrentLoginPermission;
 import org.apache.ftpserver.usermanager.impl.TransferRatePermission;
 import org.apache.ftpserver.usermanager.impl.WritePermission;
-import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
 
 import org.springframework.context.annotation.Bean;
@@ -49,7 +51,7 @@ import org.springframework.integration.test.util.SocketUtils;
  * @since 3.0
  */
 @Configuration
-public class FtpServerRule extends ExternalResource {
+public class TesFtpServer {
 
 	private final int ftpPort = SocketUtils.findAvailableServerSocket();
 
@@ -69,7 +71,7 @@ public class FtpServerRule extends ExternalResource {
 
 	private volatile FtpServer server;
 
-	public FtpServerRule(final String root) {
+	public TesFtpServer(final String root) {
 		this.ftpFolder = new TemporaryFolder() {
 
 			@Override
@@ -146,8 +148,8 @@ public class FtpServerRule extends ExternalResource {
 		return factory;
 	}
 
-	@Override
-	protected void before() throws Throwable {
+	@PostConstruct
+	public void before() throws Throwable {
 		this.ftpFolder.create();
 		this.localFolder.create();
 
@@ -163,8 +165,8 @@ public class FtpServerRule extends ExternalResource {
 	}
 
 
-	@Override
-	protected void after() {
+	@PreDestroy
+	public void after() {
 		this.server.stop();
 		this.ftpFolder.delete();
 		this.localFolder.delete();

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -50,5 +50,16 @@
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 
+	<int:channel id="inboundMGetRecursive"/>
+
+	<int-ftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="inboundMGetRecursive"
+							  command="mget"
+							  expression="payload"
+							  command-options="-R"
+							  local-directory-expression="#localDir() + #remoteDirectory"
+							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
+							  reply-channel="output"/>
+
 
 </beans>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -8,7 +8,7 @@
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<bean id="ftpServer" class="org.springframework.integration.ftp.FtpServerRule">
+	<bean id="ftpServer" class="org.springframework.integration.ftp.TesFtpServer">
 		<constructor-arg value="FtpServerOutboundTests"/>
 	</bean>
 
@@ -56,5 +56,16 @@
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 
+	<int:channel id="inboundMGetRecursiveFiltered"/>
+
+	<int-ftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="inboundMGetRecursive"
+							  command="mget"
+							  expression="payload"
+							  command-options="-R"
+							  filename-regex="(subFtpSource|.*1.txt)"
+							  local-directory-expression="@ftpServer.targetLocalDirectoryName + #remoteDirectory"
+							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
+							  reply-channel="output"/>
 
 </beans>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -8,14 +8,9 @@
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<bean id="ftpSessionFactory" class="org.springframework.integration.ftp.session.DefaultFtpSessionFactory">
-		<property name="host" value="localhost"/>
-		<property name="port" value="#{T(org.springframework.integration.ftp.FtpServerRule).FTP_PORT}"/>
-		<property name="username" value="foo"/>
-		<property name="password" value="foo"/>
+	<bean id="ftpServer" class="org.springframework.integration.ftp.FtpServerRule">
+		<constructor-arg value="FtpServerOutboundTests"/>
 	</bean>
-
-	<int:spel-function id="localDir" class="org.springframework.integration.ftp.outbound.FtpServerOutboundTests" method="localDirectory"/>
 
 	<int:channel id="output">
 		<int:queue/>
@@ -27,7 +22,7 @@
 							  request-channel="inboundGet"
 							  command="get"
 							  expression="payload"
-							  local-directory-expression="#localDir() + #remoteDirectory.toUpperCase()"
+							  local-directory-expression="@ftpServer.targetLocalDirectoryName + #remoteDirectory.toUpperCase()"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 
@@ -46,7 +41,7 @@
 							  request-channel="inboundMGet"
 							  command="mget"
 							  expression="payload"
-							  local-directory-expression="#localDir() + #remoteDirectory"
+							  local-directory-expression="@ftpServer.targetLocalDirectoryName + #remoteDirectory"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 
@@ -57,7 +52,7 @@
 							  command="mget"
 							  expression="payload"
 							  command-options="-R"
-							  local-directory-expression="#localDir() + #remoteDirectory"
+							  local-directory-expression="@ftpServer.targetLocalDirectoryName + #remoteDirectory"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -143,6 +143,8 @@ public class FtpServerOutboundTests {
 			assertThat(file.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
 					Matchers.containsString(dir));
 		}
+		assertThat(localFiles.get(2).getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+				Matchers.containsString(dir + "subFtpSource"));
 
 	}
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.ftp.outbound;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -60,6 +61,9 @@ public class FtpServerOutboundTests {
 
 	@Autowired
 	private DirectChannel inboundMGet;
+
+	@Autowired
+	private DirectChannel inboundMGetRecursive;
 
 	@Before
 	public void setup() {
@@ -123,6 +127,23 @@ public class FtpServerOutboundTests {
 			assertThat(file.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
 					Matchers.containsString(dir));
 		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testInt3172LocalDirectoryExpressionMGETRecursive() {
+		String dir = "ftpSource/";
+		this.inboundMGetRecursive.send(new GenericMessage<Object>(dir + "*"));
+		Message<?> result = this.output.receive(1000);
+		assertNotNull(result);
+		List<File> localFiles = (List<File>) result.getPayload();
+		assertEquals(3, localFiles.size());
+
+		for (File file : localFiles) {
+			assertThat(file.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+					Matchers.containsString(dir));
+		}
+
 	}
 
 	public static String localDirectory() {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;
-import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -47,8 +47,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class FtpServerOutboundTests {
 
-	@ClassRule
-	public static final FtpServerRule FTP_SERVER = new FtpServerRule(FtpServerOutboundTests.class.getSimpleName());
+	@Rule
+	@Autowired
+	public FtpServerRule ftpServer;
 
 	@Autowired
 	private PollableChannel output;
@@ -67,8 +68,8 @@ public class FtpServerOutboundTests {
 
 	@Before
 	public void setup() {
-		FtpServerRule.recursiveDelete(FTP_SERVER.getTargetLocalDirectory());
-		FtpServerRule.recursiveDelete(FTP_SERVER.getTargetFtpDirectory());
+		FtpServerRule.recursiveDelete(ftpServer.getTargetLocalDirectory());
+		FtpServerRule.recursiveDelete(ftpServer.getTargetFtpDirectory());
 	}
 
 	@Test
@@ -147,10 +148,5 @@ public class FtpServerOutboundTests {
 				Matchers.containsString(dir + "subFtpSource"));
 
 	}
-
-	public static String localDirectory() {
-		return FTP_SERVER.getTargetLocalDirectory().getAbsolutePath() + File.separator;
-	}
-
 
 }

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/gateway/SftpOutboundGateway.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/gateway/SftpOutboundGateway.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.integration.file.remote.AbstractFileInfo;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
 import org.springframework.integration.file.remote.session.SessionFactory;
@@ -29,7 +30,7 @@ import com.jcraft.jsch.ChannelSftp.LsEntry;
 
 /**
  * Outbound Gateway for performing remote file operations via SFTP.
- * 
+ *
  * @author Gary Russell
  * @since 2.1
  */
@@ -71,6 +72,13 @@ public class SftpOutboundGateway extends AbstractRemoteFileOutboundGateway<LsEnt
 	@Override
 	protected long getModified(LsEntry file) {
 		return ((long)file.getAttrs().getMTime()) * 1000;
+	}
+
+	@Override
+	protected LsEntry enhanceNameWithSubDirectory(LsEntry file, String directory) {
+		DirectFieldAccessor accessor = new DirectFieldAccessor(file);
+		accessor.setPropertyValue("filename", directory + file.getFilename());
+		return file;
 	}
 
 }

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/gateway/SftpOutboundGateway.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/gateway/SftpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,11 @@ public class SftpOutboundGateway extends AbstractRemoteFileOutboundGateway<LsEnt
 
 	@Override
 	protected String getFilename(LsEntry file) {
+		return file.getFilename();
+	}
+
+	@Override
+	protected String getFilename(AbstractFileInfo<LsEntry> file) {
 		return file.getFilename();
 	}
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
@@ -52,6 +52,18 @@
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 
+	<int:channel id="inboundMGetRecursiveFiltered"/>
+
+	<int-sftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="inboundMGetRecursive"
+							  command="mget"
+							  expression="payload"
+							  command-options="-R"
+							  filename-regex="(subSftpSource|.*1.txt)"
+							  local-directory-expression="'/tmp/sftpOutboundTests/' + #remoteDirectory"
+							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
+							  reply-channel="output"/>
+
 	<bean id="ftpSessionFactory" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.integration.file.remote.session.SessionFactory" />
 	</bean>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
@@ -41,6 +41,17 @@
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 
+	<int:channel id="inboundMGetRecursive"/>
+
+	<int-sftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="inboundMGetRecursive"
+							  command="mget"
+							  expression="payload"
+							  command-options="-R"
+							  local-directory-expression="'/tmp/sftpOutboundTests/' + #remoteDirectory"
+							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
+							  reply-channel="output"/>
+
 	<bean id="ftpSessionFactory" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.integration.file.remote.session.SessionFactory" />
 	</bean>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.sftp.outbound;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -32,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.Message;
 import org.springframework.integration.channel.DirectChannel;
@@ -81,6 +83,9 @@ public class SftpServerOutboundTests {
 	private DirectChannel inboundMGet;
 
 	@Autowired
+	private DirectChannel inboundMGetRecursive;
+
+	@Autowired
 	private SessionFactory<SftpFileInfo> sessionFactory;
 
 	@Before
@@ -110,7 +115,9 @@ public class SftpServerOutboundTests {
 			LsEntry entry4 = mock(LsEntry.class);
 			SftpATTRS attrs4 = mock(SftpATTRS.class);
 			when(entry4.getAttrs()).thenReturn(attrs4);
-			when(entry4.getFilename()).thenReturn("subSftpSource1.txt");
+			// recursion uses a DFA to update the filename to include the subdirectory
+			new DirectFieldAccessor(entry4).setPropertyValue("filename", "subSftpSource1.txt");
+			when(entry4.getFilename()).thenCallRealMethod();
 			when(session.list("sftpSource/sftpSource1.txt")).thenReturn(new LsEntry[] {
 					entry1
 			});
@@ -201,6 +208,25 @@ public class SftpServerOutboundTests {
 			assertThat(file.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
 					Matchers.containsString(dir));
 		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testInt3172LocalDirectoryExpressionMGETRecursive() {
+		String dir = "sftpSource/";
+		this.inboundMGetRecursive.send(new GenericMessage<Object>(dir + "*"));
+		Message<?> result = this.output.receive(1000);
+		assertNotNull(result);
+		List<File> localFiles = (List<File>) result.getPayload();
+		assertEquals(3, localFiles.size());
+
+		for (File file : localFiles) {
+			assertThat(file.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+					Matchers.containsString(dir));
+		}
+		assertThat(localFiles.get(2).getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+				Matchers.containsString(dir + "subSftpSource"));
+
 	}
 
 }

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
@@ -229,4 +229,24 @@ public class SftpServerOutboundTests {
 
 	}
 
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testInt3172LocalDirectoryExpressionMGETRecursiveFiltered() {
+		String dir = "sftpSource/";
+		this.inboundMGetRecursive.send(new GenericMessage<Object>(dir + "*"));
+		Message<?> result = this.output.receive(1000);
+		assertNotNull(result);
+		List<File> localFiles = (List<File>) result.getPayload();
+		// should have filtered sftpSource2.txt
+		assertEquals(2, localFiles.size());
+
+		for (File file : localFiles) {
+			assertThat(file.getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+					Matchers.containsString(dir));
+		}
+		assertThat(localFiles.get(1).getPath().replaceAll(java.util.regex.Matcher.quoteReplacement(File.separator), "/"),
+				Matchers.containsString(dir + "subSftpSource"));
+
+	}
+
 }

--- a/src/reference/docbook/ftp.xml
+++ b/src/reference/docbook/ftp.xml
@@ -369,7 +369,7 @@ protected void postProcessClientBeforeConnect(T client) throws IOException {
 	  </para>
 	  <para>
 	    When using the recursive option (<code>-R</code>), the <code>fileName</code> includes any subdirectory
-	    elements, representing a relative path to the file (relative to the remoe directory). If the <code>-dirs</code>
+	    elements, representing a relative path to the file (relative to the remote directory). If the <code>-dirs</code>
 	    option is included, each recursed directory is also returned as an element in the list. In this case,
 	    it is recommended that the <code>-1</code> is not used because you would not be able to determine files Vs.
 	    directories, which is achievable using the <code>FileInfo</code> objects.

--- a/src/reference/docbook/ftp.xml
+++ b/src/reference/docbook/ftp.xml
@@ -351,6 +351,7 @@ protected void postProcessClientBeforeConnect(T client) throws IOException {
 		  <listitem>-f - do not sort the list</listitem>
 		  <listitem>-dirs - include directories (excluded by default)</listitem>
 		  <listitem>-links - include symbolic links (excluded by default)</listitem>
+		  <listitem>-R - list the remote directory recursively</listitem>
 	    </itemizedlist>
 	  </para>
 	  <para>
@@ -365,6 +366,13 @@ protected void postProcessClientBeforeConnect(T client) throws IOException {
 	  <para>
 	    The remote directory that the <emphasis>ls</emphasis> command acted on is provided
 	    in the <classname>file_remoteDirectory</classname> header.
+	  </para>
+	  <para>
+	    When using the recursive option (<code>-R</code>), the <code>fileName</code> includes any subdirectory
+	    elements, representing a relative path to the file (relative to the remoe directory). If the <code>-dirs</code>
+	    option is included, each recursed directory is also returned as an element in the list. In this case,
+	    it is recommended that the <code>-1</code> is not used because you would not be able to determine files Vs.
+	    directories, which is achievable using the <code>FileInfo</code> objects.
 	  </para>
 	  <para><emphasis role="bold">get</emphasis></para>
 	  <para>
@@ -399,6 +407,27 @@ protected void postProcessClientBeforeConnect(T client) throws IOException {
 	    for the filenames is
 	    provided in the <classname>file_remoteFile</classname> header.
 	  </para>
+	  <note>
+	    <title>Notes for when using recursion (<code>-R</code>)</title>
+	    <para>
+	      The pattern is ignored, and <code>*</code> is assumed. By
+	      default, the entire remote tree is retrieved. However, files in the tree can be filtered, by providing a
+	      <classname>FileListFilter</classname>; directories in the tree can also be filtered this way.
+	      A <classname>FileListFilter</classname> can be provided by reference or by <code>filename-pattern</code>
+	      or <code>filename-regex</code> attributes. For example,
+	      <code>filename-regex="(subDir|.*1.txt)"</code> will retrieve all files ending with <code>1.txt</code> in the
+	      remote directory and the subdirectory <code>subDir</code>. If a subdirectory is filtered, no additional
+	      traversal of that subdirectory is performed.
+	    </para>
+	    <para>
+	      The <code>-dirs</code> option is not allowed (the recursive mget uses the recursive <code>ls</code> to
+	      obtain the directory tree and the directories themselves cannot be included in the list).
+	    </para>
+	    <para>
+	      Typically, you would use the <code>#remoteDirectory</code> variable in the <code>local-directory-expression</code>
+	      so that the remote directory structure is retained locally.
+	    </para>
+	  </note>
 	  <para><emphasis role="bold">rm</emphasis></para>
 	  <para>
 	    The <emphasis>rm</emphasis> command has no options.

--- a/src/reference/docbook/sftp.xml
+++ b/src/reference/docbook/sftp.xml
@@ -405,7 +405,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 	  </para>
 	  <para>
 	    When using the recursive option (<code>-R</code>), the <code>fileName</code> includes any subdirectory
-	    elements, representing a relative path to the file (relative to the remoe directory). If the <code>-dirs</code>
+	    elements, representing a relative path to the file (relative to the remote directory). If the <code>-dirs</code>
 	    option is included, each recursed directory is also returned as an element in the list. In this case,
 	    it is recommended that the <code>-1</code> is not used because you would not be able to determine files Vs.
 	    directories, which is achievable using the <code>FileInfo</code> objects.

--- a/src/reference/docbook/sftp.xml
+++ b/src/reference/docbook/sftp.xml
@@ -387,6 +387,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 		  <listitem>-f - do not sort the list</listitem>
 		  <listitem>-dirs - include directories (excluded by default)</listitem>
 		  <listitem>-links - include symbolic links (excluded by default)</listitem>
+		  <listitem>-R - list the remote directory recursively</listitem>
 	    </itemizedlist>
 	  </para>
 	  <para>
@@ -401,6 +402,13 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 	  <para>
 	    The remote directory that the <emphasis>ls</emphasis> command acted on is provided
 	    in the <classname>file_remoteDirectory</classname> header.
+	  </para>
+	  <para>
+	    When using the recursive option (<code>-R</code>), the <code>fileName</code> includes any subdirectory
+	    elements, representing a relative path to the file (relative to the remoe directory). If the <code>-dirs</code>
+	    option is included, each recursed directory is also returned as an element in the list. In this case,
+	    it is recommended that the <code>-1</code> is not used because you would not be able to determine files Vs.
+	    directories, which is achievable using the <code>FileInfo</code> objects.
 	  </para>
 	  <para><emphasis role="bold">get</emphasis></para>
 	  <para>
@@ -435,6 +443,27 @@ xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
 	    for the filenames is
 	    provided in the <classname>file_remoteFile</classname> header.
 	  </para>
+	  <note>
+	    <title>Notes for when using recursion (<code>-R</code>)</title>
+	    <para>
+	      The pattern is ignored, and <code>*</code> is assumed. By
+	      default, the entire remote tree is retrieved. However, files in the tree can be filtered, by providing a
+	      <classname>FileListFilter</classname>; directories in the tree can also be filtered this way.
+	      A <classname>FileListFilter</classname> can be provided by reference or by <code>filename-pattern</code>
+	      or <code>filename-regex</code> attributes. For example,
+	      <code>filename-regex="(subDir|.*1.txt)"</code> will retrieve all files ending with <code>1.txt</code> in the
+	      remote directory and the subdirectory <code>subDir</code>. If a subdirectory is filtered, no additional
+	      traversal of that subdirectory is performed.
+	    </para>
+	    <para>
+	      The <code>-dirs</code> option is not allowed (the recursive mget uses the recursive <code>ls</code> to
+	      obtain the directory tree and the directories themselves cannot be included in the list).
+	    </para>
+	    <para>
+	      Typically, you would use the <code>#remoteDirectory</code> variable in the <code>local-directory-expression</code>
+	      so that the remote directory structure is retained locally.
+	    </para>
+	  </note>
 	  <para><emphasis role="bold">rm</emphasis></para>
 	  <para>
 	    The <emphasis>rm</emphasis> command has no options.

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -238,17 +238,25 @@
 		<section id="3.0-xFTP-gw">
 			<title>FTP, SFTP and FTPS Gateways</title>
 			<para>
-				The gateways now support the <code>mv</code> command, enabling the renaming of remote
-				files.
-			</para>
-			<para>
-				The <code>local-filename-generator-expression</code> attribute is now supported,
-				enabling the naming of local files during transfer. By default, the same
-				name as the remote file is used.
-			</para>
-			<para>
-				The <code>local-directory-expression</code> attribute is now supported,
-				enabling the naming of local directories during transfer based on the remote directory.
+				<itemizedlist>
+					<listitem>
+						The gateways now support the <code>mv</code> command, enabling the renaming of remote
+						files.
+					</listitem>
+					<listitem>
+						The gateways now support recursive <code>ls</code> and <code>mget</code> commands, enabling
+						the retrieval of a remote file tree.
+					</listitem>
+					<listitem>
+						The <code>local-filename-generator-expression</code> attribute is now supported,
+						enabling the naming of local files during transfer. By default, the same
+						name as the remote file is used.
+					</listitem>
+					<listitem>
+						The <code>local-directory-expression</code> attribute is now supported,
+						enabling the naming of local directories during transfer based on the remote directory.
+					</listitem>
+				</itemizedlist>
 			</para>
 			<para>
 			    For more information, see <xref linkend="ftp-outbound-gateway"/> and <xref linkend="sftp-outbound-gateway"/>.


### PR DESCRIPTION
INT-3172 (S)FTP - Add Recursion Option to LS Cmd

When recursing, the returned filenames are relative to
the top level directory.

INT-3172 (S)FTP - Add Recursion to MGET Command

https://jira.springsource.org/browse/INT-3172
