### PR TITLE
INT-3069 Add Global Gateway Method Metadata

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GatewayParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,9 +34,10 @@ import org.springframework.util.xml.DomUtils;
 
 /**
  * Parser for the &lt;gateway/&gt; element.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
 public class GatewayParser extends AbstractSimpleBeanDefinitionParser {
 
@@ -53,7 +54,8 @@ public class GatewayParser extends AbstractSimpleBeanDefinitionParser {
 	protected String getBeanClassName(Element element) {
 		return IntegrationNamespaceUtils.BASE_PACKAGE + ".gateway.GatewayProxyFactoryBean";
 	}
-	
+
+	@Override
 	protected boolean shouldGenerateIdAsFallback() {
 		return true;
 	}
@@ -62,6 +64,7 @@ public class GatewayParser extends AbstractSimpleBeanDefinitionParser {
 	protected boolean isEligibleAttribute(String attributeName) {
 		return !ObjectUtils.containsElement(referenceAttributes, attributeName)
 				&& !ObjectUtils.containsElement(innerAttributes, attributeName)
+				&& !("default-payload-expression".equals(attributeName))
 				&& super.isEligibleAttribute(attributeName);
 	}
 
@@ -79,7 +82,7 @@ public class GatewayParser extends AbstractSimpleBeanDefinitionParser {
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "request-channel", "defaultRequestChannel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel", "defaultReplyChannel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "request-timeout", "defaultRequestTimeout");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "defaultReplyTimeout");		
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "defaultReplyTimeout");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "async-executor");
 	}
@@ -88,6 +91,17 @@ public class GatewayParser extends AbstractSimpleBeanDefinitionParser {
 		for (String attributeName : referenceAttributes) {
 			IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, attributeName);
 		}
+
+		BeanDefinitionBuilder methodMetadataBuilder = BeanDefinitionBuilder.genericBeanDefinition(
+				"org.springframework.integration.gateway.GatewayMethodMetadata");
+		List<Element> invocationHeaders = DomUtils.getChildElementsByTagName(element, "default-header");
+		if (!CollectionUtils.isEmpty(invocationHeaders)) {
+			this.setMethodInvocationHeaders(methodMetadataBuilder, invocationHeaders);
+		}
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(methodMetadataBuilder, element,
+				"default-payload-expression", "payloadExpression");
+		builder.addPropertyValue("globalMethodMetadata", methodMetadataBuilder.getBeanDefinition());
+
 		List<Element> elements = DomUtils.getChildElementsByTagName(element, "method");
 		ManagedMap<String, BeanDefinition> methodMetadataMap = null;
 		if (elements != null && elements.size() > 0) {
@@ -95,14 +109,14 @@ public class GatewayParser extends AbstractSimpleBeanDefinitionParser {
 		}
 		for (Element methodElement : elements) {
 			String methodName = methodElement.getAttribute("name");
-			BeanDefinitionBuilder methodMetadataBuilder = BeanDefinitionBuilder.genericBeanDefinition(
+			methodMetadataBuilder = BeanDefinitionBuilder.genericBeanDefinition(
 					"org.springframework.integration.gateway.GatewayMethodMetadata");
 			methodMetadataBuilder.addPropertyValue("requestChannelName", methodElement.getAttribute("request-channel"));
 			methodMetadataBuilder.addPropertyValue("replyChannelName", methodElement.getAttribute("reply-channel"));
 			methodMetadataBuilder.addPropertyValue("requestTimeout", methodElement.getAttribute("request-timeout"));
 			methodMetadataBuilder.addPropertyValue("replyTimeout", methodElement.getAttribute("reply-timeout"));
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(methodMetadataBuilder, methodElement, "payload-expression");
-			List<Element> invocationHeaders = DomUtils.getChildElementsByTagName(methodElement, "header");
+			invocationHeaders = DomUtils.getChildElementsByTagName(methodElement, "header");
 			if (!CollectionUtils.isEmpty(invocationHeaders)) {
 				this.setMethodInvocationHeaders(methodMetadataBuilder, invocationHeaders);
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
@@ -234,9 +234,7 @@ class GatewayMethodInboundMessageMapper implements InboundMessageMapper<Object[]
 		// TODO deprecated in 3.0/4.0 - retained for backwards compatibility
 		context.setVariable("method", this.method.getName());
 
-		context.setVariable("methodName", this.method.getName());
-		context.setVariable("methodString", this.method.toString());
-		context.setVariable("methodObject", this.method);
+		context.setVariable("gatewayMethod", this.method);
 		return context;
 	}
 

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -515,8 +515,7 @@
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
-			<xsd:sequence>
-			  <xsd:choice  minOccurs="0" maxOccurs="unbounded">
+			  <xsd:sequence minOccurs="0" maxOccurs="1">
 				<xsd:element name="default-header" minOccurs="0" maxOccurs="unbounded" type="headerSubElementType">
 					<xsd:annotation>
 						<xsd:documentation>
@@ -527,7 +526,7 @@
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
-				<xsd:element name="method">
+				<xsd:element name="method" minOccurs="0" maxOccurs="unbounded">
 					<xsd:annotation>
 						<xsd:documentation>
 							<![CDATA[
@@ -616,7 +615,6 @@
 						</xsd:attribute>
 					</xsd:complexType>
 				</xsd:element>
-			  </xsd:choice>
 			</xsd:sequence>
 			<xsd:attribute name="id" type="xsd:string" use="optional" />
 			<xsd:attribute name="service-interface" type="xsd:string" use="optional">

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -516,7 +516,18 @@
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:sequence>
-				<xsd:element name="method" minOccurs="0" maxOccurs="unbounded">
+			  <xsd:choice  minOccurs="0" maxOccurs="unbounded">
+				<xsd:element name="default-header" minOccurs="0" maxOccurs="unbounded" type="headerSubElementType">
+					<xsd:annotation>
+						<xsd:documentation>
+							<![CDATA[
+	Provides a mechanism to enrich the message with custom message headers. These default headers are created for
+	all methods on the service-interface (unless overridden by a specific method element).
+							]]>
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="method">
 					<xsd:annotation>
 						<xsd:documentation>
 							<![CDATA[
@@ -530,7 +541,7 @@
 								<xsd:annotation>
 									<xsd:documentation>
 										<![CDATA[
-				Provides mechanism to enrich content of the message with custom message headers. When this method is going to be invoked
+				Provides a mechanism to enrich the message with custom message headers. When this method is invoked,
 				the generated message will be enriched with these headers.
 										]]>
 									</xsd:documentation>
@@ -605,6 +616,7 @@
 						</xsd:attribute>
 					</xsd:complexType>
 				</xsd:element>
+			  </xsd:choice>
 			</xsd:sequence>
 			<xsd:attribute name="id" type="xsd:string" use="optional" />
 			<xsd:attribute name="service-interface" type="xsd:string" use="optional">
@@ -619,6 +631,17 @@
 							<tool:expected-type type="java.lang.Class" />
 						</tool:annotation>
 					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="default-payload-expression" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+										<![CDATA[
+				An expression that will be used to generate the payload for all methods in the service interface
+				unless explicitly overriden by a method declaration. Variables include #args, #methodName, #methodString
+				and #methodObject; a bean resolver is also available, enabling expressions like "@someBean(#args)".
+										]]>
+					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="default-request-channel" type="xsd:string">

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests-context.xml
@@ -8,9 +8,9 @@
 	<int:gateway id="sampleGateway"
 			service-interface="org.springframework.integration.gateway.GatewayInterfaceTests.Bar"
 			default-request-channel="requestChannelBaz">
-		<int:default-header name="name" expression="#methodName"/>
-		<int:default-header name="string" expression="#methodString"/>
-		<int:default-header name="object" expression="#methodObject"/>
+		<int:default-header name="name" expression="#gatewayMethod.name"/>
+		<int:default-header name="string" expression="#gatewayMethod.toString()"/>
+		<int:default-header name="object" expression="#gatewayMethod"/>
 		<int:method name="baz">
 			<int:header name="name" value="overrideGlobal"/>
 		</int:method>

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests2-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests2-context.xml
@@ -7,7 +7,7 @@
 
 	<int:gateway id="sampleGateway"
 			service-interface="org.springframework.integration.gateway.GatewayInterfaceTests.Bar"
-			default-request-channel="requestChannelBaz">
+			default-request-channel="requestChannelBaz" default-payload-expression="'foo'">
 		<int:default-header name="name" expression="#methodName"/>
 		<int:default-header name="string" expression="#methodString"/>
 		<int:default-header name="object" expression="#methodObject"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests2-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests2-context.xml
@@ -8,9 +8,9 @@
 	<int:gateway id="sampleGateway"
 			service-interface="org.springframework.integration.gateway.GatewayInterfaceTests.Bar"
 			default-request-channel="requestChannelBaz" default-payload-expression="'foo'">
-		<int:default-header name="name" expression="#methodName"/>
-		<int:default-header name="string" expression="#methodString"/>
-		<int:default-header name="object" expression="#methodObject"/>
+		<int:default-header name="name" expression="#gatewayMethod.name"/>
+		<int:default-header name="string" expression="#gatewayMethod.toString()"/>
+		<int:default-header name="object" expression="#gatewayMethod"/>
 		<int:method name="baz">
 			<int:header name="name" value="overrideGlobal"/>
 		</int:method>

--- a/src/reference/docbook/gateway.xml
+++ b/src/reference/docbook/gateway.xml
@@ -116,9 +116,10 @@ public interface Cafe {
 
      <programlisting language="xml"><![CDATA[<int:gateway id="myGateway" service-interface="org.foo.bar.TestGateway"
       default-request-channel="inputC">
+  <int:default-header name="calledMethod" expression="#methodName"/>
   <int:method name="echo" request-channel="inputA" reply-timeout="2" request-timeout="200"/>
-      <int:method name="echoUpperCase" request-channel="inputB"/>
-      <int:method name="echoViaDefault"/>
+  <int:method name="echoUpperCase" request-channel="inputB"/>
+  <int:method name="echoViaDefault"/>
 </int:gateway>]]></programlisting>
 
     <para>
@@ -144,6 +145,33 @@ public interface Cafe {
     <para>
       In the above case you can clearly see how a different value will be set for the 'RESPONSE_TYPE'
       header based on the gateway's method.
+    </para>
+    <para><emphasis role="bold">Expressions and "Global" Headers</emphasis></para>
+    <para>
+      The <code>&lt;header/&gt;</code> element supports <code>expression</code> instead of <code>value</code>.
+      In which case the SpEL expression is evaluated to determine the value of the header. There is no
+      <code>#root</code> object but the following variables are available:
+      <itemizedlist>
+        <listitem>
+          #args - an <code>Object[]</code> containing the method arguments
+        </listitem>
+        <listitem>
+          #methodName - the name of the gateway method
+        </listitem>
+        <listitem>
+          #methodString - a String representation of the method (including return type and parameter types)
+        </listitem>
+        <listitem>
+          #methodObject - the <classname>java.reflect.Method</classname> object representing the method.
+        </listitem>
+      </itemizedlist>
+    </para>
+    <para>
+      Since 3.0, &lt;default-header/&gt;s can be defined to add headers to all messages produced
+      by the gateway, regardless of method invoked. Specific headers defined for a method take precendence
+      over default headers. Specific headers defined for a method here will override any <code>@Header</code> annotations
+      in the service interface. However, default headers will NOT override  any <code>@Header</code> annotations
+      in the service interface. The gateway now also supports a <code>default-payload-expression</code>.
     </para>
 
     </section>

--- a/src/reference/docbook/gateway.xml
+++ b/src/reference/docbook/gateway.xml
@@ -148,30 +148,42 @@ public interface Cafe {
     </para>
     <para><emphasis role="bold">Expressions and "Global" Headers</emphasis></para>
     <para>
-      The <code>&lt;header/&gt;</code> element supports <code>expression</code> instead of <code>value</code>.
-      In which case the SpEL expression is evaluated to determine the value of the header. There is no
+      The <code>&lt;header/&gt;</code> element supports <code>expression</code> as an alternative to
+      <code>value</code>. The SpEL expression is evaluated to determine the value of the header. There is no
       <code>#root</code> object but the following variables are available:
       <itemizedlist>
         <listitem>
           #args - an <code>Object[]</code> containing the method arguments
         </listitem>
         <listitem>
-          #methodName - the name of the gateway method
-        </listitem>
-        <listitem>
-          #methodString - a String representation of the method (including return type and parameter types)
-        </listitem>
-        <listitem>
-          #methodObject - the <classname>java.reflect.Method</classname> object representing the method.
+          #gatewayMethod - the <classname>java.reflect.Method</classname> object representing the method in the
+          <code>service-interface</code> that was invoked. A header containing this variable can be used
+          later in the flow, for example, for routing. For example, if you wish to route on the simple method
+          name, you might add a header, with expression <code>#gatewayMethod.name</code>.
+          <note>
+            The <classname>java.reflect.Method</classname> is not serializable; a header with expression
+            <code>#gatewayMethod</code> will be lost if you later serialize the message. So, you may wish
+            to use <code>#gatewayMethod.name</code> or <code>#gatewayMethod.toString()</code> in those cases;
+            the <code>toString()</code> method provides a String representation of the method, including
+            parameter and return types.
+          </note>
+          <note>
+            Prior to 3.0, the <code>#method</code> variable was available, representing the method name only.
+            This is still available, but deprecated; use <code>#gatewayMethod.name</code> instead.
+          </note>
         </listitem>
       </itemizedlist>
     </para>
     <para>
       Since 3.0, &lt;default-header/&gt;s can be defined to add headers to all messages produced
-      by the gateway, regardless of method invoked. Specific headers defined for a method take precendence
+      by the gateway, regardless of the method invoked. Specific headers defined for a method take precedence
       over default headers. Specific headers defined for a method here will override any <code>@Header</code> annotations
       in the service interface. However, default headers will NOT override  any <code>@Header</code> annotations
-      in the service interface. The gateway now also supports a <code>default-payload-expression</code>.
+      in the service interface.
+    </para>
+    <para>
+      The gateway now also supports a <code>default-payload-expression</code> which will be applied for all methods
+      (unless overridden).
     </para>
 
     </section>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -155,6 +155,20 @@
 	<section id="3.0-general">
 		<title>General Changes</title>
 
+		<section id="3.0-gateway">
+			<title>&lt;gateway&gt; Changes</title>
+			<para>
+				<itemizedlist>
+					<listitem>
+						It is now possible to set common headers across all gateway methods, and more options
+						are provided for adding, to the message, information about which method was invoked.
+					</listitem>
+				</itemizedlist>
+			</para>
+			<para>
+				For more information see <xref linkend="gateway"/>.
+			</para>
+		</section>
 		<section id="3.0-corr-endpoint-empty-groups">
 			<title>Aggregator 'empty-group-min-timeout' property</title>
 				<para><classname>AbstractCorrelatingMessageHandler</classname> provides a new property


### PR DESCRIPTION
https://jira.springsource.org/browse/INT-3069

Provide a mechanism to specify headers and payload-expression that can
be applied to all methods in the gateway.
- Headers defined as 'default' are globally applied to all gateway methods.
- Also supports 'default-payload-expression'.
- Headers defined on a specific method override the global settings.
- An `@Header` in the interface is overridden by a specific `<header/>` for that method (current behavior)
- An `@Header` in the interface is NOT overridden by a  `<default-header/>`
- Add 3 new SpEL variables:
  -- #methodName (synonym for #method - deprecated)
  -- #methodString (a string representation of the method showing return type and arg types)
  -- #methodObject (the Method object)

```
<int:gateway id="sampleGateway"
            service-interface="org.springframework.integration.gateway.GatewayInterfaceTests.Bar"
            default-request-channel="requestChannelBaz">
        <int:default-header name="name" expression="#methodName"/>
        <int:default-header name="string" expression="#methodString"/>
        <int:default-header name="object" expression="#methodObject"/>
        <int:method name="baz">
            <int:header name="name" value="overrideGlobal"/>
        </int:method>
    </int:gateway>
```
