### PR TITLE
INT-2629 Extract Gateway Argument Mapping Strategy

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
@@ -86,7 +86,7 @@ class GatewayMethodInboundMessageMapper implements InboundMessageMapper<Object[]
 
 	private final List<MethodParameter> parameterList;
 
-	private final InboundMessageMapper<MethodArgsHolder> argsMapper;
+	private final MethodArgsMessageMapper argsMapper;
 
 	private volatile Expression payloadExpression;
 
@@ -105,7 +105,7 @@ class GatewayMethodInboundMessageMapper implements InboundMessageMapper<Object[]
 	}
 
 	public GatewayMethodInboundMessageMapper(Method method, Map<String, Expression> headerExpressions,
-			Map<String, Expression> globalHeaderExpressions, InboundMessageMapper<MethodArgsHolder> mapper) {
+			Map<String, Expression> globalHeaderExpressions, MethodArgsMessageMapper mapper) {
 		Assert.notNull(method, "method must not be null");
 		this.method = method;
 		this.headerExpressions = headerExpressions;
@@ -258,7 +258,7 @@ class GatewayMethodInboundMessageMapper implements InboundMessageMapper<Object[]
 		return expression;
 	}
 
-	public class DefaultMethodArgsMessageMapper implements InboundMessageMapper<MethodArgsHolder> {
+	public class DefaultMethodArgsMessageMapper implements MethodArgsMessageMapper {
 
 		@Override
 		public Message<?> toMessage(MethodArgsHolder holder) throws Exception {

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -217,6 +217,11 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint implements Trackab
 		this.beanClassLoader = beanClassLoader;
 	}
 
+	/**
+	 * Provide a custom {@link InboundMessageMapper} to map from a method invocation
+	 * to a {@link Message}. The mapper must map from a {@link MethodArgsHolder}.
+	 * @param mapper the mapper.
+	 */
 	public final void setMapper(InboundMessageMapper<MethodArgsHolder> mapper) {
 		this.argsMapper = mapper;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -49,7 +49,6 @@ import org.springframework.integration.annotation.Payload;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.history.TrackableComponent;
-import org.springframework.integration.mapping.InboundMessageMapper;
 import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.support.channel.ChannelResolver;
 import org.springframework.util.Assert;
@@ -106,7 +105,7 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint implements Trackab
 
 	private volatile GatewayMethodMetadata globalMethodMetadata;
 
-	private volatile InboundMessageMapper<MethodArgsHolder> argsMapper;
+	private volatile MethodArgsMessageMapper argsMapper;
 
 	/**
 	 * Create a Factory whose service interface type can be configured by setter injection.
@@ -218,11 +217,11 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint implements Trackab
 	}
 
 	/**
-	 * Provide a custom {@link InboundMessageMapper} to map from a method invocation
-	 * to a {@link Message}. The mapper must map from a {@link MethodArgsHolder}.
+	 * Provide a custom {@link MethodArgsMessageMapper} to map from a {@link MethodArgsHolder}
+	 * to a {@link Message}.
 	 * @param mapper the mapper.
 	 */
-	public final void setMapper(InboundMessageMapper<MethodArgsHolder> mapper) {
+	public final void setMapper(MethodArgsMessageMapper mapper) {
 		this.argsMapper = mapper;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -49,6 +49,7 @@ import org.springframework.integration.annotation.Payload;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.history.TrackableComponent;
+import org.springframework.integration.mapping.InboundMessageMapper;
 import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.support.channel.ChannelResolver;
 import org.springframework.util.Assert;
@@ -104,6 +105,8 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint implements Trackab
 	private volatile Map<String, GatewayMethodMetadata> methodMetadataMap;
 
 	private volatile GatewayMethodMetadata globalMethodMetadata;
+
+	private volatile InboundMessageMapper<MethodArgsHolder> argsMapper;
 
 	/**
 	 * Create a Factory whose service interface type can be configured by setter injection.
@@ -212,6 +215,10 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint implements Trackab
 
 	public void setBeanClassLoader(ClassLoader beanClassLoader) {
 		this.beanClassLoader = beanClassLoader;
+	}
+
+	public final void setMapper(InboundMessageMapper<MethodArgsHolder> mapper) {
+		this.argsMapper = mapper;
 	}
 
 	@Override
@@ -395,7 +402,8 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint implements Trackab
 			}
 		}
 		GatewayMethodInboundMessageMapper messageMapper = new GatewayMethodInboundMessageMapper(method, headerExpressions,
-				this.globalMethodMetadata != null ? this.globalMethodMetadata.getHeaderExpressions() : null);
+				this.globalMethodMetadata != null ? this.globalMethodMetadata.getHeaderExpressions() : null,
+				this.argsMapper);
 		if (StringUtils.hasText(payloadExpression)) {
 			messageMapper.setPayloadExpression(payloadExpression);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MethodArgsHolder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MethodArgsHolder.java
@@ -18,6 +18,11 @@ package org.springframework.integration.gateway;
 import java.lang.reflect.Method;
 
 /**
+ * Simple wrapper class containing a {@link Method} and an object
+ * array containing the arguments for an invocation of that method.
+ * Used by an InboundMessageMapper with this generic type to provide
+ * custom argument mapping when creating a message in a GatewayProxyFactoryBean.
+ *
  * @author Gary Russell
  * @since 3.0
  *

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MethodArgsHolder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MethodArgsHolder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.gateway;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author Gary Russell
+ * @since 3.0
+ *
+ */
+public final class MethodArgsHolder {
+
+	private final Method method;
+
+	private final Object[] args;
+
+	public MethodArgsHolder(Method method, Object[] args) {
+		this.method = method;
+		this.args = args;
+	}
+
+	public final Method getMethod() {
+		return method;
+	}
+
+	public final Object[] getArgs() {
+		return args;
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MethodArgsMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MethodArgsMessageMapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.gateway;
+
+import org.springframework.integration.mapping.InboundMessageMapper;
+
+/**
+ * Implementations of this interface are {@link InboundMessageMapper}s that map a {@link MethodArgsHolder} to
+ * a {@link Message}.
+ *
+ * @author Gary Russell
+ * @since 3.0
+ *
+ */
+public interface MethodArgsMessageMapper extends InboundMessageMapper<MethodArgsHolder> {
+
+}

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -717,6 +717,22 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="mapper" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+										<![CDATA[
+					An InboundMessageMapper<MethodArgsHolder> to map the method arguments to a Message. When this
+					is provided, no payload-expressions or headers are allowed; the custom mapper is
+					responsible for creating the message.
+										]]>
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.mapping.InboundMessageMapper" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -728,7 +728,7 @@
 					</xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.mapping.InboundMessageMapper" />
+							<tool:expected-type type="org.springframework.integration.gateway.MethodArgsMessageMapper" />
 						</tool:annotation>
 					</xsd:appinfo>
 				</xsd:annotation>

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests-context.xml
@@ -20,4 +20,10 @@
 	<int:channel id="requestChannelBar"/>
 	<int:channel id="requestChannelBaz"/>
 
+	<int:gateway id="customMappedGateway"
+			service-interface="org.springframework.integration.gateway.GatewayInterfaceTests.Baz"
+			default-request-channel="requestChannelBaz" mapper="mapper"/>
+
+	<bean id="mapper" class="org.springframework.integration.gateway.GatewayInterfaceTests$BazMapper"/>
+
 </beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -40,7 +40,6 @@ import org.springframework.integration.annotation.Gateway;
 import org.springframework.integration.annotation.Header;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.core.MessageHandler;
-import org.springframework.integration.mapping.InboundMessageMapper;
 import org.springframework.integration.support.MessageBuilder;
 
 /**
@@ -284,7 +283,7 @@ public class GatewayInterfaceTests {
 		public void baz(String payload);
 	}
 
-	public static class BazMapper implements InboundMessageMapper<MethodArgsHolder> {
+	public static class BazMapper implements MethodArgsMessageMapper {
 
 		@Override
 		public Message<?> toMessage(MethodArgsHolder object) throws Exception {

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapperToMessageTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapperToMessageTests.java
@@ -34,6 +34,7 @@ import org.springframework.integration.Message;
 import org.springframework.integration.annotation.Header;
 import org.springframework.integration.annotation.Headers;
 import org.springframework.integration.annotation.Payload;
+import org.springframework.integration.mapping.MessageMappingException;
 import org.springframework.integration.support.MessageBuilder;
 
 /**
@@ -78,7 +79,7 @@ public class GatewayMethodInboundMessageMapperToMessageTests {
 		assertEquals("bar", message.getHeaders().get("foo"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = MessageMappingException.class)
 	public void toMessageWithPayloadAndRequiredHeaderButNullValue() throws Exception {
 		Method method = TestService.class.getMethod(
 				"sendPayloadAndHeader", String.class, String.class);
@@ -134,7 +135,7 @@ public class GatewayMethodInboundMessageMapperToMessageTests {
 		assertEquals("test", message.getPayload());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = MessageMappingException.class)
 	public void toMessageWithPayloadAndHeadersMapWithNonStringKey() throws Exception {
 		Method method = TestService.class.getMethod(
 				"sendPayloadAndHeadersMap", String.class, Map.class);
@@ -166,7 +167,7 @@ public class GatewayMethodInboundMessageMapperToMessageTests {
 		assertEquals("bar", message.getHeaders().get("foo"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = MessageMappingException.class)
 	public void toMessageWithMessageParameterAndRequiredHeaderButNullValue() throws Exception {
 		Method method = TestService.class.getMethod("sendMessageAndHeader", Message.class, String.class);
 		GatewayMethodInboundMessageMapper mapper = new GatewayMethodInboundMessageMapper(method);
@@ -197,7 +198,7 @@ public class GatewayMethodInboundMessageMapperToMessageTests {
 		assertNull(message.getHeaders().get("foo"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = MessageMappingException.class)
 	public void noArgs() throws Exception {
 		Method method = TestService.class.getMethod("noArgs", new Class<?>[] {});
 		GatewayMethodInboundMessageMapper mapper = new GatewayMethodInboundMessageMapper(method);
@@ -205,7 +206,7 @@ public class GatewayMethodInboundMessageMapperToMessageTests {
 		mapper.toMessage(new Object[] {});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = MessageMappingException.class)
 	public void onlyHeaders() throws Exception {
 		Method method = TestService.class.getMethod("onlyHeaders", String.class, String.class);
 		GatewayMethodInboundMessageMapper mapper = new GatewayMethodInboundMessageMapper(method);

--- a/src/reference/docbook/gateway.xml
+++ b/src/reference/docbook/gateway.xml
@@ -214,9 +214,9 @@ public String send2(Map foo, Map bar);
       <para>
         Alternatively, and whenever the conventions break down, you can take the entire responsibility for
         mapping the method calls to messages. To do this, implement an
-        <classname>InboundMessageMapper&lt;MethodArgHolder&gt;</classname> and provide it to the
-        <code>&lt;gateway/&gt;</code> using the <code>mapper</code> attribute. The
-        <classname>MethodArgHolder</classname> is a simple class wrapping the <classname>java.reflect.Method</classname>
+        <classname>MethodArgsMessageMapper</classname> and provide it to the
+        <code>&lt;gateway/&gt;</code> using the <code>mapper</code> attribute. The mapper maps a
+        <classname>MethodArgsHolder</classname>, which is a simple class wrapping the <classname>java.reflect.Method</classname>
         instance and an <code>Object[]</code> containing the arguments. When providing a custom mapper,
         the <code>default-payload-expression</code> attribute and <code>&lt;default-header/&gt;</code> elements
         are not allowed on the gateway; similarly, the <code>payload-expression</code> attribute and

--- a/src/reference/docbook/gateway.xml
+++ b/src/reference/docbook/gateway.xml
@@ -187,6 +187,43 @@ public interface Cafe {
     </para>
 
     </section>
+    <section id="gateway-mapping">
+      <title>Mapping Method Arguments to a Message</title>
+      <para>
+        Using the configuration techniques in the previous section allows control of how method arguments are mapped
+        to message elements (payload and header(s)). When no explicit configuration is used, certain conventions are
+        used to perform the mapping. In some cases, these conventions cannot determine which argument is the payload
+        and which should be mapped to headers.
+      </para>
+      <programlisting language="java"><![CDATA[
+public String send1(Object foo, Map bar);
+
+public String send2(Map foo, Map bar);
+      ]]></programlisting>
+      <para>
+        In the first case, the convention will map the first argument to the payload (as long as it is not a
+        <code>Map</code>) and the contents of the second become headers.
+      </para>
+      <para>
+        In the second case (or the first when the argument for parameter <code>foo</code> is a <code>Map</code>),
+        the framework cannot determine
+        which argument should be the payload; mapping will fail. This can generally be resolved using a
+        <code>payload-expression</code>, a <code>@Payload</code> annotation and/or a <code>@Headers</code>
+        annotation.
+      </para>
+      <para>
+        Alternatively, and whenever the conventions break down, you can take the entire responsibility for
+        mapping the method calls to messages. To do this, implement an
+        <classname>InboundMessageMapper&lt;MethodArgHolder&gt;</classname> and provide it to the
+        <code>&lt;gateway/&gt;</code> using the <code>mapper</code> attribute. The
+        <classname>MethodArgHolder</classname> is a simple class wrapping the <classname>java.reflect.Method</classname>
+        instance and an <code>Object[]</code> containing the arguments. When providing a custom mapper,
+        the <code>default-payload-expression</code> attribute and <code>&lt;default-header/&gt;</code> elements
+        are not allowed on the gateway; similarly, the <code>payload-expression</code> attribute and
+        <code>&lt;header/&gt;</code> elements are not allowed on any <code>&lt;method/&gt;</code> elements.
+      </para>
+    </section>
+
     <section id="gateway-calling-no-argument-methods">
       <title>Invoking No-Argument Methods</title>
       <para>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -163,6 +163,10 @@
 						It is now possible to set common headers across all gateway methods, and more options
 						are provided for adding, to the message, information about which method was invoked.
 					</listitem>
+					<listitem>
+						It is now possible to entirely customize the way that gateway method calls are mapped
+						to messages.
+					</listitem>
 				</itemizedlist>
 			</para>
 			<para>


### PR DESCRIPTION
https://jira.springsource.org/browse/INT-2629

Strategy for mapping gateway methods to map method arguments
to a message.

Default strategy works as today, but pluggable using attribute
'mapper' on `<gateway/>`.

A custom mapper should implement `InboundMessageMapper<MethodArgsHolder>`

where the `MethodArgsHolder` contains the `Method` object and the argument
values.

When using a custom mapper, the mapper is entirely responsible for
creating the `Message` - therefore 'payload-expression' attributes
and `<header/>` elements are not allowed.
