### PR TITLE
INT-3177: generic RedisTemplate for PublishingMH

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParser.java
@@ -46,7 +46,16 @@ public class RedisInboundChannelAdapterParser extends AbstractChannelAdapterPars
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "topics");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "serializer");
+//		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "serializer");
+		if (element.hasAttribute("serializer")) {
+			String serializer = element.getAttribute("serializer");
+			if (StringUtils.hasText(serializer)) {
+				builder.addPropertyReference("serializer", serializer);
+			}
+			else {
+				builder.addPropertyValue("serializer", null);
+			}
+		}
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParser.java
@@ -23,20 +23,21 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.redis.inbound.RedisInboundChannelAdapter;
 import org.springframework.util.StringUtils;
 
 /**
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.1
  */
 public class RedisInboundChannelAdapterParser extends AbstractChannelAdapterParser {
 
 	@Override
 	protected AbstractBeanDefinition doParse(Element element, ParserContext parserContext, String channelName) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
-				"org.springframework.integration.redis.inbound.RedisInboundChannelAdapter");
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(RedisInboundChannelAdapter.class);
 		String connectionFactory = element.getAttribute("connection-factory");
 		if (!StringUtils.hasText(connectionFactory)) {
 			connectionFactory = "redisConnectionFactory";
@@ -46,16 +47,8 @@ public class RedisInboundChannelAdapterParser extends AbstractChannelAdapterPars
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "topics");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
-//		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "serializer");
-		if (element.hasAttribute("serializer")) {
-			String serializer = element.getAttribute("serializer");
-			if (StringUtils.hasText(serializer)) {
-				builder.addPropertyReference("serializer", serializer);
-			}
-			else {
-				builder.addPropertyValue("serializer", null);
-			}
-		}
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "serializer", true);
+
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParser.java
@@ -18,10 +18,10 @@ package org.springframework.integration.redis.config;
 
 import org.w3c.dom.Element;
 
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.springframework.integration.config.ExpressionFactoryBean;
 import org.springframework.integration.config.xml.AbstractOutboundChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.redis.outbound.RedisPublishingMessageHandler;
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author Artem Bilan
  * @since 2.1
  */
 public class RedisOutboundChannelAdapterParser extends AbstractOutboundChannelAdapterParser {
@@ -44,17 +45,14 @@ public class RedisOutboundChannelAdapterParser extends AbstractOutboundChannelAd
 			connectionFactory = "redisConnectionFactory";
 		}
 		builder.addConstructorArgReference(connectionFactory);
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "topic", "defaultTopic");
+
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "serializer");
-		String topicExpression = element.getAttribute("topic-expression");
-		if (StringUtils.hasText(topicExpression)) {
-			AbstractBeanDefinition topicExpressionDefinition =
-					BeanDefinitionBuilder.genericBeanDefinition(ExpressionFactoryBean.class)
-							.addConstructorArgValue(topicExpression)
-							.getBeanDefinition();
-			builder.addPropertyValue("topicExpression", topicExpressionDefinition);
-		}
+
+		BeanDefinition topicExpression = IntegrationNamespaceUtils
+				.createExpressionDefinitionFromValueOrExpression("topic", "topic-expression", parserContext, element, true);
+		builder.addPropertyValue("topicExpression", topicExpression);
+
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapter.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2012 the original author or authors
+ * Copyright 2007-2013 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.1
  */
 public class RedisInboundChannelAdapter extends MessageProducerSupport {
@@ -52,7 +53,6 @@ public class RedisInboundChannelAdapter extends MessageProducerSupport {
 	}
 
 	public void setSerializer(RedisSerializer<?> serializer) {
-		Assert.notNull(serializer, "'serializer' must not be null");
 		this.serializer = serializer;
 	}
 
@@ -99,16 +99,16 @@ public class RedisInboundChannelAdapter extends MessageProducerSupport {
 		this.container.stop();
 	}
 
-	private Message<?> convertMessage(String s) {
-		return this.messageConverter.toMessage(s);
+	private Message<?> convertMessage(Object object) {
+		return this.messageConverter.toMessage(object);
 	}
 
 
 	private class MessageListenerDelegate {
 
 		@SuppressWarnings("unused")
-		public void handleMessage(String s) {
-			sendMessage(convertMessage(s));
+		public void handleMessage(Object object) {
+			sendMessage(convertMessage(object));
 		}
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisPublishingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisPublishingMessageHandler.java
@@ -39,7 +39,7 @@ public class RedisPublishingMessageHandler extends AbstractMessageHandler implem
 
 	private final RedisTemplate<?, ?> template;
 
-	private EvaluationContext evaluationContext;
+	private volatile EvaluationContext evaluationContext;
 
 	private volatile MessageConverter messageConverter = new SimpleMessageConverter();
 
@@ -77,6 +77,11 @@ public class RedisPublishingMessageHandler extends AbstractMessageHandler implem
 	public void setDefaultTopic(String defaultTopic) {
 		Assert.hasText(defaultTopic, "'defaultTopic' must not be empty string.");
 		this.setTopicExpression(new LiteralExpression(defaultTopic));
+	}
+
+	public void setTopic(String topic) {
+		Assert.hasText(topic, "'topic' must not be empty string.");
+		this.setTopicExpression(new LiteralExpression(topic));
 	}
 
 	public void setTopicExpression(Expression topicExpression) {

--- a/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-3.0.xsd
+++ b/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-3.0.xsd
@@ -174,7 +174,8 @@
 				<xsd:annotation>
 					<xsd:appinfo>
 						<xsd:documentation>
-						Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer
+						Reference to an instance of org.springframework.data.redis.serializer.RedisSerializer.
+						This attribute can apply an empty value, which determines as a 'null' for underlying adapter.
 						</xsd:documentation>
 						<tool:annotation kind="ref">
 							<tool:expected-type type="org.springframework.data.redis.serializer.RedisSerializer"/>
@@ -197,7 +198,20 @@
 					<xsd:sequence>
 						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
 					</xsd:sequence>
-					<xsd:attribute name="topic" type="xsd:string"/>
+					<xsd:attribute name="topic" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Specifies the Redis topic.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="topic-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation><![CDATA[
+								Specifies the SpEL expression to determine Redis topic against Message at runtime.
+							]]></xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="message-converter" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[

--- a/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-3.0.xsd
+++ b/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-3.0.xsd
@@ -202,6 +202,7 @@
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 								Specifies the Redis topic.
+								This attribute is mutually exclusive with 'topic-expression' attribute.
 							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
@@ -209,6 +210,7 @@
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 								Specifies the SpEL expression to determine Redis topic against Message at runtime.
+								This attribute is mutually exclusive with 'topic' attribute.
 							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/channel/SubscribableRedisChannelTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/channel/SubscribableRedisChannelTests.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
@@ -53,7 +52,7 @@ public class SubscribableRedisChannelTests extends RedisAvailableTests {
 
 	@Test
 	@RedisAvailable
-	public void pubSubChannelTest() throws Exception{
+	public void pubSubChannelTest() throws Exception {
 		RedisConnectionFactory connectionFactory = this.getConnectionFactoryForTest();
 
 		SubscribableRedisChannel channel = new SubscribableRedisChannel(connectionFactory, "si.test.channel");
@@ -61,14 +60,7 @@ public class SubscribableRedisChannelTests extends RedisAvailableTests {
 		channel.afterPropertiesSet();
 		channel.start();
 
-		RedisConnection connection = TestUtils.getPropertyValue(channel, "container.subscriptionTask.connection",
-				RedisConnection.class);
-
-		int n = 0;
-		while (n++ < 100 && !connection.isSubscribed()) {
-			Thread.sleep(100);
-		}
-		assertTrue(n < 100);
+		this.awaitContainerSubscribed(TestUtils.getPropertyValue(channel, "container", RedisMessageListenerContainer.class));
 
 		final CountDownLatch latch = new CountDownLatch(3);
 		MessageHandler handler = new MessageHandler() {

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests-context.xml
@@ -32,4 +32,7 @@
 
 	<int:bridge input-channel="autoChannel" output-channel="nullChannel"/>
 
+	<int-redis:inbound-channel-adapter id="withoutSerializer" topics="foo" serializer=""/>
+
+
 </beans>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
@@ -17,6 +17,8 @@
 package org.springframework.integration.redis.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
@@ -67,6 +69,10 @@ public class RedisInboundChannelAdapterParserTests extends RedisAvailableTests {
 		Object converterBean = context.getBean("testConverter");
 		assertEquals(converterBean, accessor.getPropertyValue("messageConverter"));
 		assertEquals(context.getBean("serializer"), accessor.getPropertyValue("serializer"));
+
+		Object bean = context.getBean("withoutSerializer.adapter");
+		assertNotNull(bean);
+		assertNull(TestUtils.getPropertyValue(bean, "serializer"));
 	}
 
 	@Test

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests-context.xml
@@ -12,12 +12,19 @@
 	<int-redis:outbound-channel-adapter id="outboundAdapter"
 			channel="sendChannel"
 			topic="foo"
+			topic-expression="headers.topic"
 			message-converter="testConverter"
 			serializer="serializer"/>
 
 	<int-redis:inbound-channel-adapter channel="receiveChannel" topics="foo"/>
 
 	<int:channel id="receiveChannel">
+		<int:queue/>
+	</int:channel>
+
+	<int-redis:inbound-channel-adapter channel="barChannel" topics="bar"/>
+
+	<int:channel id="barChannel">
 		<int:queue/>
 	</int:channel>
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests-context.xml
@@ -11,8 +11,7 @@
 
 	<int-redis:outbound-channel-adapter id="outboundAdapter"
 			channel="sendChannel"
-			topic="foo"
-			topic-expression="headers.topic"
+			topic-expression="headers['topic'] ?: 'foo'"
 			message-converter="testConverter"
 			serializer="serializer"/>
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
@@ -62,10 +62,9 @@ public class RedisOutboundChannelAdapterParserTests extends RedisAvailableTests{
 				new DirectFieldAccessor(adapter).getPropertyValue("handler");
 		assertEquals("outboundAdapter", adapter.getComponentName());
 		DirectFieldAccessor accessor = new DirectFieldAccessor(handler);
-		assertEquals("foo", accessor.getPropertyValue("defaultTopic"));
 		Object topicExpression = accessor.getPropertyValue("topicExpression");
 		assertNotNull(topicExpression);
-		assertEquals("headers.topic", ((Expression) topicExpression).getExpressionString());
+		assertEquals("headers['topic'] ?: 'foo'", ((Expression) topicExpression).getExpressionString());
 		Object converterBean = context.getBean("testConverter");
 		assertEquals(converterBean, accessor.getPropertyValue("messageConverter"));
 		assertEquals(context.getBean("serializer"), accessor.getPropertyValue("serializer"));

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapterTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapterTests.java
@@ -21,8 +21,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -42,8 +40,6 @@ import org.springframework.integration.test.util.TestUtils;
  * @since 2.1
  */
 public class RedisInboundChannelAdapterTests extends RedisAvailableTests{
-
-	private final Log logger = LogFactory.getLog(this.getClass());
 
 	@Test
 	@RedisAvailable
@@ -96,7 +92,7 @@ public class RedisInboundChannelAdapterTests extends RedisAvailableTests{
 
 		this.awaitContainerSubscribed(TestUtils.getPropertyValue(adapter, "container", RedisMessageListenerContainer.class));
 
-		RedisTemplate<?, ?> template = new RedisTemplate();
+		RedisTemplate<?, ?> template = new RedisTemplate<Object, Object>();
 		template.setConnectionFactory(connectionFactory);
 		template.setEnableDefaultSerializer(false);
 		template.afterPropertiesSet();

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapterTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapterTests.java
@@ -18,13 +18,16 @@ package org.springframework.integration.redis.inbound;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.integration.Message;
@@ -35,6 +38,7 @@ import org.springframework.integration.test.util.TestUtils;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  * @since 2.1
  */
 public class RedisInboundChannelAdapterTests extends RedisAvailableTests{
@@ -57,7 +61,7 @@ public class RedisInboundChannelAdapterTests extends RedisAvailableTests{
 		RedisConnectionFactory connectionFactory = this.getConnectionFactoryForTest();
 
 		RedisInboundChannelAdapter adapter = new RedisInboundChannelAdapter(connectionFactory);
-		adapter.setTopics("testRedisInboundChannelAdapterChannel");
+		adapter.setTopics(redisChannelName);
 		adapter.setOutputChannel(channel);
 		adapter.afterPropertiesSet();
 		adapter.start();
@@ -69,7 +73,6 @@ public class RedisInboundChannelAdapterTests extends RedisAvailableTests{
 		for (int i = 0; i < numToTest; i++) {
 			String message = "test-" + i + " iteration " + iteration;
 			redisTemplate.convertAndSend(redisChannelName, message);
-			logger.debug("Sent " + message);
 		}
 		int counter = 0;
 		for (int i = 0; i < numToTest; i++) {
@@ -81,6 +84,42 @@ public class RedisInboundChannelAdapterTests extends RedisAvailableTests{
 			assertTrue(message.getPayload().toString().startsWith("test-"));
 			counter++;
 		}
+		assertEquals(numToTest, counter);
+		adapter.stop();
+
+		redisChannelName = "testRedisBytesInboundChannelAdapterChannel";
+
+		adapter.setTopics(redisChannelName);
+		adapter.setSerializer(null);
+		adapter.afterPropertiesSet();
+		adapter.start();
+
+		this.awaitContainerSubscribed(TestUtils.getPropertyValue(adapter, "container", RedisMessageListenerContainer.class));
+
+		RedisTemplate<?, ?> template = new RedisTemplate();
+		template.setConnectionFactory(connectionFactory);
+		template.setEnableDefaultSerializer(false);
+		template.afterPropertiesSet();
+
+		for (int i = 0; i < numToTest; i++) {
+			String message = "test-" + i + " iteration " + iteration;
+			template.convertAndSend(redisChannelName, message.getBytes());
+		}
+
+		counter = 0;
+		for (int i = 0; i < numToTest; i++) {
+			Message<?> message = channel.receive(5000);
+			if (message == null){
+				throw new RuntimeException("Failed to receive message # " + i + " iteration " + iteration);
+			}
+			assertNotNull(message);
+			Object payload = message.getPayload();
+			assertThat(payload, Matchers.instanceOf(byte[].class));
+
+			assertTrue(new String((byte[]) payload).startsWith("test-"));
+			counter++;
+		}
+
 		assertEquals(numToTest, counter);
 		adapter.stop();
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisPublishingMessageHandlerTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisPublishingMessageHandlerTests.java
@@ -30,6 +30,7 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.Topic;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.redis.rules.RedisAvailable;
 import org.springframework.integration.redis.rules.RedisAvailableTests;
 import org.springframework.integration.support.MessageBuilder;
@@ -64,7 +65,7 @@ public class RedisPublishingMessageHandlerTests extends RedisAvailableTests {
 		this.awaitContainerSubscribed(container);
 
 		final RedisPublishingMessageHandler handler = new RedisPublishingMessageHandler(connectionFactory);
-		handler.setDefaultTopic(topic);
+		handler.setTopicExpression(new LiteralExpression(topic));
 
 		for (int i = 0; i < numToTest; i++) {
 			handler.handleMessage(MessageBuilder.withPayload("test-" + i).build());
@@ -90,6 +91,7 @@ public class RedisPublishingMessageHandlerTests extends RedisAvailableTests {
 		public void handleMessage(String s) {
 			this.latch.countDown();
 		}
+
 	}
 
 }

--- a/src/reference/docbook/redis.xml
+++ b/src/reference/docbook/redis.xml
@@ -187,14 +187,13 @@ rt.setConnectionFactory(redisConnectionFactory);]]></programlisting>
       <para>
          Since <emphasis>Spring Integration 3.0</emphasis> <code>&lt;int-redis:outbound-channel-adapter&gt;</code>,
          alongside with <code>topic</code> attribute, has <code>topic-expression</code> attribute to determine
-         Redis topic against Message at runtime. These attributes are not mutually exclusive: if adapter can't
-		 evaluate expression or evaluation result is <code>null</code>, the adapter does fallback to <code>defaultTopic</code>, if any.
+         Redis topic against Message at runtime. These attributes are mutually exclusive.
       </para>
     </section>
     <section id="redis-queue-inbound-channel-adapter">
        <title>Redis Queue Inbound Channel Adapter</title>
        <para>
-          Since <emphasis>Spring Integration 3.0</emphasis>, a Queue Inbound Channel Adapter 
+          Since <emphasis>Spring Integration 3.0</emphasis>, a Queue Inbound Channel Adapter
 		  is available to 'right pop' messages from a Redis List.
 		  The adapter is message-driven using an internal listener thread and does not use a poller.
 		<programlisting language="xml"><![CDATA[<int-redis:queue-inbound-channel-adapter id="" ]]><co id="redis-m-d-c-a-id"/><![CDATA[

--- a/src/reference/docbook/redis.xml
+++ b/src/reference/docbook/redis.xml
@@ -152,6 +152,12 @@ rt.setConnectionFactory(redisConnectionFactory);]]></programlisting>
 
       <para>Inbound adapters can subscribe to multiple topic names hence the comma-delimited set of values in the
       <code>topics</code> attribute.</para>
+      <para>
+         Inbound adapters can apply <classname>RedisSerializer</classname> to deserialize body of Redis Messages.
+		 The <code>serializer</code> attribute of <code>&lt;int-redis:inbound-channel-adapter&gt;</code> can apply
+         empty value, which determines as <code>null</code> value for <classname>RedisSerializer</classname> property.
+         In this case the body of Redis Messages return as <code>byte[]</code>.
+      </para>
     </section>
 
     <section id="redis-outbound-channel-adapter">
@@ -177,6 +183,12 @@ rt.setConnectionFactory(redisConnectionFactory);]]></programlisting>
       As you can see the configuration is similar to the Redis Inbound Channel Adapter. The adapter is implicitly injected with
       a <classname>RedisConnectionFactory</classname> which was defined with '<code>redisConnectionFactory</code>' as its bean name.
       This example also includes the optional, custom <classname>MessageConverter</classname> (the '<code>testConverter</code>' bean).
+      </para>
+      <para>
+         Since <emphasis>Spring Integration 3.0</emphasis> <code>&lt;int-redis:outbound-channel-adapter&gt;</code>,
+         alongside with <code>topic</code> attribute, has <code>topic-expression</code> attribute to determine
+         Redis topic against Message at runtime. These attributes are not mutually exclusive: if adapter can't
+		 evaluate expression or evaluation result is <code>null</code>, the adapter does fallback to <code>defaultTopic</code>, if any.
       </para>
     </section>
     <section id="redis-queue-inbound-channel-adapter">

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -572,5 +572,23 @@
 			    result set respectively. For more information see <xref linkend="jpa"/>.
 			</para>
 		</section>
+		<section id="3.0-xFTP-gw">
+			<title>Redis Adapters Changers</title>
+			<para>
+				<itemizedlist>
+					<listitem>
+						The Redis Inbound Channel Adapter now can apply <code>null</code> value for <code>serializer</code>
+						property.
+					</listitem>
+					<listitem>
+						The Redis Outbound Channel Adapter now has <code>topic-expression</code> property to determine
+						Redis topic against Message at runtime.
+					</listitem>
+				</itemizedlist>
+			</para>
+			<para>
+				For more information, see <xref linkend="redis"/>.
+			</para>
+		</section>
 	</section>
 </chapter>


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3177
- Change `RedisPublishingMessageHandler.StringRedisTemplate` to `RedisTemplate<?, ?>`
- Don't provide `serializer` to the `template`
- Use `serializer` directly for values which are not `byte[]`
- Add `RedisAvailableTests#awaitContainerSubscribed` for tests to avoid race conditions
- Refactor some tests
- Add test for `byte[]` payload
