### PR TITLE
INT-3178 Defer Publishing of TCP Open Event

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
@@ -47,10 +47,10 @@ public abstract class AbstractClientConnectionFactory extends AbstractConnection
 		this.checkActive();
 		if (this.isSingleUse()) {
 			return obtainConnection();
-		} else {
+		}
+		else {
 			synchronized(this) {
 				TcpConnectionSupport connection = obtainConnection();
-				this.setTheConnection(connection);
 				return connection;
 			}
 		}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
@@ -17,6 +17,8 @@
 package org.springframework.integration.ip.tcp.connection;
 
 import java.net.Socket;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Abstract class for client connection factories; client connection factories
@@ -27,7 +29,9 @@ import java.net.Socket;
  */
 public abstract class AbstractClientConnectionFactory extends AbstractConnectionFactory {
 
-	private TcpConnectionSupport theConnection;
+	protected final ReadWriteLock theConnectionLock = new ReentrantReadWriteLock();
+
+	private volatile TcpConnectionSupport theConnection;
 
 	/**
 	 * Constructs a factory that will established connections to the host and port.
@@ -45,15 +49,7 @@ public abstract class AbstractClientConnectionFactory extends AbstractConnection
 	 */
 	public TcpConnectionSupport getConnection() throws Exception {
 		this.checkActive();
-		if (this.isSingleUse()) {
-			return obtainConnection();
-		}
-		else {
-			synchronized(this) {
-				TcpConnectionSupport connection = obtainConnection();
-				return connection;
-			}
-		}
+		return this.obtainConnection();
 	}
 
 	protected abstract TcpConnectionSupport obtainConnection() throws Exception;

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionSupport.java
@@ -127,7 +127,6 @@ public abstract class TcpConnectionSupport implements TcpConnection {
 		if (connectionFactoryName != null) {
 			this.connectionFactoryName = connectionFactoryName;
 		}
-		this.publishConnectionOpenEvent();
 		if (logger.isDebugEnabled()) {
 			logger.debug("New connection " + this.getConnectionId());
 		}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetClientConnectionFactory.java
@@ -66,6 +66,10 @@ public class TcpNetClientConnectionFactory extends
 		initializeConnection(connection, socket);
 		this.getTaskExecutor().execute(connection);
 		this.harvestClosedConnections();
+		if (!this.isSingleUse()) {
+			this.setTheConnection(connection);
+		}
+		connection.publishConnectionOpenEvent();
 		return connection;
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetClientConnectionFactory.java
@@ -51,26 +51,52 @@ public class TcpNetClientConnectionFactory extends
 	 */
 	@Override
 	protected TcpConnectionSupport obtainConnection() throws Exception {
-		TcpConnectionSupport theConnection = this.getTheConnection();
-		if (theConnection != null && theConnection.isOpen()) {
-			return theConnection;
-		}
-		if (logger.isDebugEnabled()) {
-			logger.debug("Opening new socket connection to " + this.getHost() + ":" + this.getPort());
-		}
-		Socket socket = createSocket(this.getHost(), this.getPort());
-		setSocketAttributes(socket);
-		TcpConnectionSupport connection = new TcpNetConnection(socket, false, this.isLookupHost(),
-				this.getApplicationEventPublisher(), this.getComponentName());
-		connection = wrapConnection(connection);
-		initializeConnection(connection, socket);
-		this.getTaskExecutor().execute(connection);
-		this.harvestClosedConnections();
+		boolean locked = false;
 		if (!this.isSingleUse()) {
-			this.setTheConnection(connection);
+			this.theConnectionLock.readLock().lockInterruptibly();
+			locked = true;
 		}
-		connection.publishConnectionOpenEvent();
-		return connection;
+		try {
+			TcpConnectionSupport theConnection = this.getTheConnection();
+			if (theConnection != null && theConnection.isOpen()) {
+				return theConnection;
+			}
+		}
+		finally {
+			if (locked) {
+				this.theConnectionLock.readLock().unlock();
+				locked = false;
+			}
+		}
+
+		if (!this.isSingleUse()) {
+			this.theConnectionLock.writeLock().lockInterruptibly();
+			locked = true;
+		}
+		try {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Opening new socket connection to " + this.getHost() + ":" + this.getPort());
+			}
+
+			Socket socket = createSocket(this.getHost(), this.getPort());
+			setSocketAttributes(socket);
+			TcpConnectionSupport connection = new TcpNetConnection(socket, false, this.isLookupHost(),
+					this.getApplicationEventPublisher(), this.getComponentName());
+			connection = wrapConnection(connection);
+			initializeConnection(connection, socket);
+			this.getTaskExecutor().execute(connection);
+			this.harvestClosedConnections();
+			if (!this.isSingleUse()) {
+				this.setTheConnection(connection);
+			}
+			connection.publishConnectionOpenEvent();
+			return connection;
+		}
+		finally {
+			if (locked) {
+				this.theConnectionLock.writeLock().unlock();
+			}
+		}
 	}
 
 	@Override

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetServerConnectionFactory.java
@@ -64,7 +64,8 @@ public class TcpNetServerConnectionFactory extends AbstractServerConnectionFacto
 		try {
 			if (this.getLocalAddress() == null) {
 				theServerSocket = createServerSocket(this.getPort(), this.getBacklog(), null);
-			} else {
+			}
+			else {
 				InetAddress whichNic = InetAddress.getByName(this.getLocalAddress());
 				theServerSocket = createServerSocket(this.getPort(), this.getBacklog(), whichNic);
 			}
@@ -80,7 +81,8 @@ public class TcpNetServerConnectionFactory extends AbstractServerConnectionFacto
 				 */
 				try {
 					socket = serverSocket.accept();
-				} catch (SocketTimeoutException ste) {
+				}
+				catch (SocketTimeoutException ste) {
 					if (logger.isDebugEnabled()) {
 						logger.debug("Timed out on accept; continuing");
 					}
@@ -104,9 +106,11 @@ public class TcpNetServerConnectionFactory extends AbstractServerConnectionFacto
 					this.initializeConnection(connection, socket);
 					this.getTaskExecutor().execute(connection);
 					this.harvestClosedConnections();
+					connection.publishConnectionOpenEvent();
 				}
 			}
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			// don't log an error if we had a good socket once and now it's closed
 			if (e instanceof SocketException && theServerSocket != null) {
 				logger.warn("Server Socket closed");

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
@@ -101,6 +101,10 @@ public class TcpNioClientConnectionFactory extends
 		this.channelMap.put(socketChannel, connection);
 		newChannels.add(socketChannel);
 		selector.wakeup();
+		if (!this.isSingleUse()) {
+			this.setTheConnection(connection);
+		}
+		connection.publishConnectionOpenEvent();
 		return wrappedConnection;
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
@@ -168,6 +168,7 @@ public class TcpNioServerConnectionFactory extends AbstractServerConnectionFacto
 				connection.setLastRead(now);
 				this.channelMap.put(channel, connection);
 				channel.register(selector, SelectionKey.OP_READ, connection);
+				connection.publishConnectionOpenEvent();
 			}
 			catch (Exception e) {
 				logger.error("Exception accepting new connection", e);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ConnectionToConnectionTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ConnectionToConnectionTests-context.xml
@@ -13,9 +13,9 @@
 
 	<bean id="tcpIpUtils" class="org.springframework.integration.test.util.SocketUtils" />
 
-	<int-ip:tcp-connection-factory id="server"
+	<int-ip:tcp-connection-factory id="serverNet"
 		type="server"
-		using-nio="true"
+		using-nio="false"
 		single-use="true"
 		port="#{tcpIpUtils.findAvailableServerSocket(10000)}"
 		task-executor="exec"
@@ -23,18 +23,44 @@
 		so-timeout="20000"
 	/>
 
-	<int-ip:tcp-connection-factory id="client"
+	<int-ip:tcp-connection-factory id="clientNet"
 		type="client"
 		host="localhost"
-		port="#{server.port}"
+		port="#{serverNet.port}"
 		single-use="true"
 		lookup-host="false"
 		so-timeout="100000"
 	/>
 
-	<int-ip:tcp-inbound-gateway id="looper"
+	<int-ip:tcp-connection-factory id="serverNio"
+		type="server"
+		using-nio="true"
+		single-use="true"
+		port="#{tcpIpUtils.findAvailableServerSocket(20000)}"
+		task-executor="exec"
+		lookup-host="false"
+		so-timeout="20000"
+	/>
+
+	<int-ip:tcp-connection-factory id="clientNio"
+		type="client"
+		host="localhost"
+		using-nio="true"
+		port="#{serverNio.port}"
+		single-use="true"
+		lookup-host="false"
+		so-timeout="100000"
+	/>
+
+	<int-ip:tcp-inbound-gateway id="gwNet"
 		request-channel="serverSideChannel"
-		connection-factory="server"
+		connection-factory="serverNet"
+		reply-timeout="1"
+		/>
+
+	<int-ip:tcp-inbound-gateway id="gwNio"
+		request-channel="serverSideChannel"
+		connection-factory="serverNio"
 		reply-timeout="1"
 		/>
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionEventTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionEventTests.java
@@ -52,10 +52,10 @@ public class ConnectionEventTests {
 				theEvent.add((TcpConnectionEvent) event);
 			}
 		}, "foo");
-		assertTrue(theEvent.size() > 0);
-		assertNotNull(theEvent.get(0));
-		assertTrue(theEvent.get(0) instanceof TcpConnectionOpenEvent);
-		assertTrue(theEvent.get(0).toString().endsWith("[factory=foo, connectionId=" + conn.getConnectionId() + "] **OPENED**"));
+		/*
+		 *  Open is not published by the connection itself; the factory publishes it after initialization.
+		 *  See ConnectionToConnectionTests.
+		 */
 		@SuppressWarnings("unchecked")
 		Serializer<Object> serializer = mock(Serializer.class);
 		RuntimeException toBeThrown = new RuntimeException("foo");
@@ -67,17 +67,17 @@ public class ConnectionEventTests {
 			fail("Expected exception");
 		}
 		catch (Exception e) {}
-		assertTrue(theEvent.size() > 1);
-		assertNotNull(theEvent.get(1));
-		assertTrue(theEvent.get(1) instanceof TcpConnectionExceptionEvent);
-		assertTrue(theEvent.get(1).toString().endsWith("[factory=foo, connectionId=" + conn.getConnectionId() + "]"));
-		assertTrue(theEvent.get(1).toString().contains("cause=java.lang.RuntimeException: foo]"));
-		TcpConnectionExceptionEvent event = (TcpConnectionExceptionEvent) theEvent.get(1);
+		assertTrue(theEvent.size() > 0);
+		assertNotNull(theEvent.get(0));
+		assertTrue(theEvent.get(0) instanceof TcpConnectionExceptionEvent);
+		assertTrue(theEvent.get(0).toString().endsWith("[factory=foo, connectionId=" + conn.getConnectionId() + "]"));
+		assertTrue(theEvent.get(0).toString().contains("cause=java.lang.RuntimeException: foo]"));
+		TcpConnectionExceptionEvent event = (TcpConnectionExceptionEvent) theEvent.get(0);
 		assertNotNull(event.getCause());
 		assertSame(toBeThrown, event.getCause());
-		assertTrue(theEvent.size() > 2);
-		assertNotNull(theEvent.get(2));
-		assertTrue(theEvent.get(2).toString().endsWith("[factory=foo, connectionId=" + conn.getConnectionId() + "] **CLOSED**"));
+		assertTrue(theEvent.size() > 1);
+		assertNotNull(theEvent.get(1));
+		assertTrue(theEvent.get(1).toString().endsWith("[factory=foo, connectionId=" + conn.getConnectionId() + "] **CLOSED**"));
 	}
 
 }


### PR DESCRIPTION
Previously, the TcpConnectionOpenEvent was published as soon
as the socket was connected, but the TcpConnection was not yet
ready for use.

Defer publishing the event until the connection is fully
initialized and registered with the factory and thus available
for use.

Update the test cases to reflect this behavior.

Since the event is now published by the appropriate concrete
factory implementations, enhance the ConnectionToConnectionTests
to verify proper eventing with both Net and NIO implementations.
