### PR TITLE
INT-2961 Make ARPMH.onInit() Final; Add doInit()

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
@@ -82,8 +82,7 @@ public class AmqpOutboundEndpoint extends AbstractReplyProducingMessageHandler
 	private volatile MessageChannel returnChannel;
 
 	@Override
-	protected void onInit() {
-		super.onInit();
+	protected void doInit() {
 		Assert.state(exchangeNameExpression == null || exchangeName == null,
 				"Either an exchangeName or an exchangeNameExpression can be provided, but not both");
 		Assert.state(this.confirmCorrelationExpression == null || !this.expectReply,
@@ -116,7 +115,7 @@ public class AmqpOutboundEndpoint extends AbstractReplyProducingMessageHandler
 		}
 		if (this.returnChannel != null) {
 			Assert.isTrue(amqpTemplate instanceof RabbitTemplate, "RabbitTemplate implementation is required for publisher returns");
-			(		(RabbitTemplate) this.amqpTemplate).setReturnCallback(this);
+			((RabbitTemplate) this.amqpTemplate).setReturnCallback(this);
 		}
 	}
 
@@ -289,7 +288,7 @@ public class AmqpOutboundEndpoint extends AbstractReplyProducingMessageHandler
 
 	public void returnedMessage(org.springframework.amqp.core.Message message, int replyCode, String replyText,
 			String exchange, String routingKey) {
-		// safe to cast; we asserted we have a RabbitTemplate in onInit()
+		// safe to cast; we asserted we have a RabbitTemplate in doInit()
 		MessageConverter converter = ((RabbitTemplate) this.amqpTemplate).getMessageConverter();
 		Object returnedObject = converter.fromMessage(message);
 		MessageBuilder<?> builder = (returnedObject instanceof Message)

--- a/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
@@ -98,8 +98,7 @@ public class MessageFilter extends AbstractReplyProducingPostProcessingMessageHa
 	}
 
 	@Override
-	public final void onInit() {
-		super.onInit();
+	public final void doInit() {
 		if (this.selector instanceof AbstractMessageProcessingSelector) {
 			((AbstractMessageProcessingSelector) this.selector).setConversionService(this.getConversionService());
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
@@ -98,7 +98,7 @@ public class MessageFilter extends AbstractReplyProducingPostProcessingMessageHa
 	}
 
 	@Override
-	public final void doInit() {
+	protected void doInit() {
 		if (this.selector instanceof AbstractMessageProcessingSelector) {
 			((AbstractMessageProcessingSelector) this.selector).setConversionService(this.getConversionService());
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
@@ -19,6 +19,7 @@ package org.springframework.integration.handler;
 import java.util.List;
 
 import org.aopalliance.aop.Advice;
+
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.integration.Message;
@@ -114,7 +115,7 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 
 
 	@Override
-	protected void onInit() {
+	protected final void onInit() {
 		if (this.getBeanFactory() != null) {
 			this.messagingTemplate.setBeanFactory(getBeanFactory());
 		}
@@ -125,6 +126,10 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 			}
 			this.advisedRequestHandler = (RequestHandler) proxyFactory.getProxy(this.beanClassLoader);
 		}
+		this.doInit();
+	}
+
+	protected void doInit() {
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -196,8 +196,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 	}
 
 	@Override
-	protected void onInit() {
-		super.onInit();
+	protected void doInit() {
 		if (this.messageStore == null) {
 			this.messageStore = new SimpleMessageStore();
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
@@ -55,8 +55,7 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 	}
 
 	@Override
-	public final void onInit() {
-		super.onInit();
+	public final void doInit() {
 		if (processor instanceof AbstractMessageProcessor) {
 			((AbstractMessageProcessor<?>) this.processor).setConversionService(this.getConversionService());
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
@@ -55,7 +55,7 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 	}
 
 	@Override
-	public final void doInit() {
+	protected void doInit() {
 		if (processor instanceof AbstractMessageProcessor) {
 			((AbstractMessageProcessor<?>) this.processor).setConversionService(this.getConversionService());
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageProcessingSplitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageProcessingSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.springframework.util.Assert;
 /**
  * Base class for Message Splitter implementations that delegate to a
  * {@link MessageProcessor} instance.
- * 
+ *
  * @author Mark Fisher
  * @since 2.0
  */
@@ -43,8 +43,7 @@ abstract class AbstractMessageProcessingSplitter extends AbstractMessageSplitter
 	}
 
 	@Override
-	public void onInit() {
-		super.onInit();
+	public void doInit() {
 		ConversionService conversionService = this.getConversionService();
 		if (conversionService != null && this.messageProcessor instanceof AbstractMessageProcessor) {
 			((AbstractMessageProcessor<?>) this.messageProcessor).setConversionService(conversionService);

--- a/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageProcessingSplitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageProcessingSplitter.java
@@ -43,7 +43,7 @@ abstract class AbstractMessageProcessingSplitter extends AbstractMessageSplitter
 	}
 
 	@Override
-	public void doInit() {
+	protected void doInit() {
 		ConversionService conversionService = this.getConversionService();
 		if (conversionService != null && this.messageProcessor instanceof AbstractMessageProcessor) {
 			((AbstractMessageProcessor<?>) this.messageProcessor).setConversionService(conversionService);

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
@@ -194,8 +194,7 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler implem
      * the requestChannel is set.
      */
 	@Override
-	public void onInit() {
-		super.onInit();
+	public void doInit() {
 		if (this.replyChannel != null) {
 			Assert.notNull(this.requestChannel, "If the replyChannel is set, then the requestChannel must not be null");
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
@@ -194,7 +194,7 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler implem
      * the requestChannel is set.
      */
 	@Override
-	public void doInit() {
+	protected void doInit() {
 		if (this.replyChannel != null) {
 			Assert.notNull(this.requestChannel, "If the replyChannel is set, then the requestChannel must not be null");
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,8 +54,7 @@ public class MessageTransformingHandler extends AbstractReplyProducingMessageHan
 	}
 
 	@Override
-	protected void onInit() {
-		super.onInit();
+	protected void doInit() {
 		if (this.getBeanFactory() != null && this.transformer instanceof BeanFactoryAware) {
 			((BeanFactoryAware) this.transformer).setBeanFactory(this.getBeanFactory());
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -218,9 +218,7 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 	}
 
 	@Override
-	public final void onInit() {
-
-		super.onInit();
+	public final void doInit() {
 
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -218,7 +218,7 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 	}
 
 	@Override
-	public final void doInit() {
+	protected void doInit() {
 
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -286,8 +286,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 
 
 	@Override
-	protected void onInit() {
-		super.onInit();
+	protected void doInit() {
 		Assert.notNull(this.command, "command must not be null");
 		if (Command.RM.equals(this.command) ||
 				Command.GET.equals(this.command)) {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -78,7 +78,7 @@ public class RemoteFileOutboundGatewayTests {
 				(sessionFactory, "get", "payload");
 		gw.setFilter(new TestPatternFilter(""));
 		try {
-			gw.onInit();
+			gw.afterPropertiesSet();
 			fail("Exception expected");
 		}
 		catch (IllegalArgumentException e) {
@@ -93,7 +93,7 @@ public class RemoteFileOutboundGatewayTests {
 				(sessionFactory, "rm", "payload");
 		gw.setFilter(new TestPatternFilter(""));
 		try {
-			gw.onInit();
+			gw.afterPropertiesSet();
 			fail("Exception expected");
 		}
 		catch (IllegalArgumentException e) {

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -291,7 +291,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 	}
 
 	@Override
-	public void doInit() {
+	protected void doInit() {
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());
 
 		ConversionService conversionService = this.getConversionService();

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -291,8 +291,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 	}
 
 	@Override
-	public void onInit() {
-		super.onInit();
+	public void doInit() {
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());
 
 		ConversionService conversionService = this.getConversionService();

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcOutboundGateway.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,9 +107,7 @@ public class JdbcOutboundGateway extends AbstractReplyProducingMessageHandler im
 	}
 
 	@Override
-	protected void onInit() {
-		super.onInit();
-
+	protected void doInit() {
 		if (this.maxRowsPerPoll != null) {
 			Assert.notNull(poller, "If you want to set 'maxRowsPerPoll', then you must provide a 'selectQuery'.");
 			poller.setMaxRowsPerPoll(this.maxRowsPerPoll);

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/StoredProcOutboundGateway.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/StoredProcOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,8 +88,7 @@ public class StoredProcOutboundGateway extends AbstractReplyProducingMessageHand
 	 * when {@link ProcedureParameter} are passed in.
 	 */
 	@Override
-	protected void onInit() {
-		super.onInit();
+	protected void doInit() {
 	};
 
 	@Override

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcOutboundGatewayTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcOutboundGatewayTests.java
@@ -12,15 +12,14 @@
  */
 package org.springframework.integration.jdbc;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import javax.sql.DataSource;
 
 import org.junit.Assert;
-
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Test;
+
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
@@ -42,7 +41,7 @@ public class JdbcOutboundGatewayTests {
 
 		try {
 			jdbcOutboundGateway.setMaxRowsPerPoll(10);
-			jdbcOutboundGateway.onInit();
+			jdbcOutboundGateway.afterPropertiesSet();
 
 		} catch (IllegalArgumentException e) {
 			assertEquals("If you want to set 'maxRowsPerPoll', then you must provide a 'selectQuery'.", e.getMessage());

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
@@ -459,7 +459,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler imp
 	}
 
 	@Override
-	public final void doInit() {
+	protected void doInit() {
 		synchronized (this.initializationMonitor) {
 			if (this.initialized) {
 				return;

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
@@ -459,7 +459,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler imp
 	}
 
 	@Override
-	public final void onInit() {
+	public final void doInit() {
 		synchronized (this.initializationMonitor) {
 			if (this.initialized) {
 				return;
@@ -469,7 +469,6 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler imp
 					^ this.requestDestinationName != null
 					^ this.requestDestinationExpressionProcessor != null,
 					"Exactly one of 'requestDestination', 'requestDestinationName', or 'requestDestinationExpression' is required.");
-			super.onInit();
 			if (this.requestDestinationExpressionProcessor != null) {
 				this.requestDestinationExpressionProcessor.setBeanFactory(getBeanFactory());
 				this.requestDestinationExpressionProcessor.setConversionService(getConversionService());

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
@@ -102,9 +102,8 @@ public class OperationInvokingMessageHandler extends AbstractReplyProducingMessa
 	}
 
 	@Override
-	public final void onInit() {
+	public final void doInit() {
 		Assert.notNull(this.server, "MBeanServer is required.");
-		super.onInit();
 	}
 
 	@Override

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
@@ -102,7 +102,7 @@ public class OperationInvokingMessageHandler extends AbstractReplyProducingMessa
 	}
 
 	@Override
-	public final void doInit() {
+	protected void doInit() {
 		Assert.notNull(this.server, "MBeanServer is required.");
 	}
 

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGateway.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGateway.java
@@ -62,12 +62,8 @@ public class JpaOutboundGateway extends AbstractReplyProducingMessageHandler {
 
 	}
 
-	/**
-	 *
-	 */
 	@Override
-	protected void onInit() {
-		super.onInit();
+	protected void doInit() {
 		this.jpaExecutor.setBeanFactory(this.getBeanFactory());
 	}
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
@@ -144,8 +144,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 	}
 
 	@Override
-	public void onInit() {
-		super.onInit();
+	public void doInit() {
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());
 		Assert.state(this.destinationProvider == null || CollectionUtils.isEmpty(this.uriVariableExpressions),
 				"uri variables are not supported when a DestinationProvider is supplied.");

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
@@ -144,7 +144,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 	}
 
 	@Override
-	public void doInit() {
+	protected void doInit() {
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());
 		Assert.state(this.destinationProvider == null || CollectionUtils.isEmpty(this.uriVariableExpressions),
 				"uri variables are not supported when a DestinationProvider is supplied.");


### PR DESCRIPTION
https://jira.springsource.org/browse/INT-2961

onInit() relied on subclasses calling super.onInit() to apply the
advice chain and add the BeanFactory to the MessagingTemplate.

At least one extension (smpp) failed to do this, disabling these features.

Make onInit() final and call doInit() for subclass initialization (no-op in ARPMH).

**Needs migration guide entry**
