### PR TITLE
INT-3180: Fix `FtpParserInboundTests`

### DIFF
--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpParserInboundTests-fail-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpParserInboundTests-fail-context.xml
@@ -3,12 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:ftp="http://www.springframework.org/schema/integration/ftp"
 	   xmlns:int="http://www.springframework.org/schema/integration"
-	   xmlns:context="http://www.springframework.org/schema/context"
-	   xmlns:ftps="http://www.springframework.org/schema/integration/ftps"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	    http://www.springframework.org/schema/integration/ftps http://www.springframework.org/schema/integration/ftp/spring-integration-ftps.xsd
         http://www.springframework.org/schema/integration  http://www.springframework.org/schema/integration/spring-integration.xsd
-       http://www.springframework.org/schema/integration/ftp http://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+       http://www.springframework.org/schema/integration/ftp http://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd">
 
 	<bean id="ftpSessionFactory" class="org.springframework.integration.ftp.session.DefaultFtpSessionFactory">
 		<property name="host" value="localhost"/>
@@ -19,10 +16,10 @@
 		<property name="fileType" value="2"/>
 	</bean>
 
-	<ftp:inbound-channel-adapter id="adapterFtpDontAutoCreate" 
+	<ftp:inbound-channel-adapter id="adapterFtpDontAutoCreate"
 								 channel="ftpIn"
 								 session-factory="ftpSessionFactory"
-								 filter="filter" 
+								 filter="filter"
 								 local-directory="file:target/bar"
 								 remote-directory="foo/bar"
 								 auto-create-local-directory="false"
@@ -31,9 +28,9 @@
 	</ftp:inbound-channel-adapter>
 
 	<bean id="filter" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.integration.file.entries.EntryListFilter"/>
+		<constructor-arg value="org.springframework.integration.file.filters.FileListFilter"/>
 	</bean>
-	
+
 	<int:channel id="ftpIn">
 		<int:queue/>
 	</int:channel>


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3180
- Change non-existing interface in the config to existing one
- Change `@Test(expected=BeanCreationException.class)` to `try...catch` block
  and check the StackTrace for appropriate, expected `Exception`
