### PR TITLE
INT-3185 Fix Direct Handlers When Exposed as MBean

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractStandardMessageHandlerFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractStandardMessageHandlerFactoryBean.java
@@ -77,10 +77,10 @@ abstract class AbstractStandardMessageHandlerFactoryBean extends AbstractSimpleM
 		if (this.targetObject != null) {
 			Assert.state(this.expression == null,
 					"The 'targetObject' and 'expression' properties are mutually exclusive.");
-			boolean targetIsDirectReplyProducingHandler = this.extractTypeIfPossible(targetObject,
-										AbstractReplyProducingMessageHandler.class) != null
-							&& this.canBeUsedDirect(
-									(AbstractReplyProducingMessageHandler) targetObject) // give subclasses a say
+			AbstractReplyProducingMessageHandler actualHandler = this.extractTypeIfPossible(targetObject,
+										AbstractReplyProducingMessageHandler.class);
+			boolean targetIsDirectReplyProducingHandler = actualHandler != null
+							&& this.canBeUsedDirect(actualHandler) // give subclasses a say
 							&& this.methodIsHandleMessageOrEmpty(this.targetMethodName);
 			if (this.targetObject instanceof MessageProcessor<?>) {
 				handler = this.createMessageProcessingHandler((MessageProcessor<?>) this.targetObject);
@@ -89,9 +89,9 @@ abstract class AbstractStandardMessageHandlerFactoryBean extends AbstractSimpleM
 				if (logger.isDebugEnabled()) {
 					logger.debug("Wiring handler (" + beanName + ") directly into endpoint");
 				}
+				this.checkReuse(actualHandler);
+				this.postProcessReplyProducer(actualHandler);
 				handler = (MessageHandler) targetObject;
-				this.checkReuse((AbstractReplyProducingMessageHandler) handler);
-				this.postProcessReplyProducer((AbstractReplyProducingMessageHandler) handler);
 			}
 			else {
 				handler = this.createMethodInvokingHandler(this.targetObject, this.targetMethodName);

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/ServiceActivatorDefaultFrameworkMethodTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/ServiceActivatorDefaultFrameworkMethodTests-context.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:int-jmx="http://www.springframework.org/schema/integration/jmx"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+	<context:mbean-server/>
+	<int-jmx:mbean-export/>
+
+	<message-history/>
+
+	<service-activator id="gatewayTestService" input-channel="gatewayTestInputChannel" ref="gateway"/>
+
+	<service-activator id="replyingHandlerTestService" input-channel="replyingHandlerTestInputChannel">
+		<beans:bean
+			class="org.springframework.integration.jmx.ServiceActivatorDefaultFrameworkMethodTests$TestReplyingMessageHandler"/>
+	</service-activator>
+
+	<service-activator id="optimizedRefReplyingHandlerTestService"
+		input-channel="optimizedRefReplyingHandlerTestInputChannel" ref="testReplyingMessageHandler"/>
+
+	<service-activator id="replyingHandlerWithStandardMethodTestService"
+		 input-channel="replyingHandlerWithStandardMethodTestInputChannel"
+		 method="handleMessage">
+		 <beans:bean
+			class="org.springframework.integration.jmx.ServiceActivatorDefaultFrameworkMethodTests$TestReplyingMessageHandler"/>
+	</service-activator>
+
+	<service-activator id="replyingHandlerWithOtherMethodTestService"
+		 input-channel="replyingHandlerWithOtherMethodTestInputChannel"
+		 method="foo">
+		 <beans:bean
+			class="org.springframework.integration.jmx.ServiceActivatorDefaultFrameworkMethodTests$TestReplyingMessageHandler"/>
+	</service-activator>
+
+	<service-activator id="handlerTestService" input-channel="handlerTestInputChannel">
+		<beans:bean
+			class="org.springframework.integration.jmx.ServiceActivatorDefaultFrameworkMethodTests$TestMessageHandler"/>
+	</service-activator>
+
+	<service-activator id="processorTestService" input-channel="processorTestInputChannel" ref="testMessageProcessor"/>
+
+	<gateway id="gateway" default-request-channel="requestChannel" default-reply-channel="replyChannel"/>
+
+	<channel id="requestChannel"/>
+
+	<bridge id="bridge" input-channel="requestChannel" output-channel="replyChannel"/>
+
+	<channel id="replyChannel">
+		<queue/>
+	</channel>
+
+	<beans:bean id="testReplyingMessageHandler"
+		class="org.springframework.integration.jmx.ServiceActivatorDefaultFrameworkMethodTests$TestReplyingMessageHandler"/>
+
+	<beans:bean id="testMessageProcessor" class="org.springframework.integration.jmx.ServiceActivatorDefaultFrameworkMethodTests$TestMessageProcessor">
+		<beans:property name="prefix" value="foo"/>
+	</beans:bean>
+
+</beans:beans>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/ServiceActivatorDefaultFrameworkMethodTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/ServiceActivatorDefaultFrameworkMethodTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.handler;
+package org.springframework.integration.jmx;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -28,6 +28,8 @@ import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
@@ -70,7 +72,7 @@ public class ServiceActivatorDefaultFrameworkMethodTests {
 	private EventDrivenConsumer processorTestService;
 
 	@Autowired
-	private TestMessageProcessor testMessageProcessor;
+	private MessageProcessor<?> testMessageProcessor;
 
 	@Test
 	public void testGateway() {
@@ -90,7 +92,7 @@ public class ServiceActivatorDefaultFrameworkMethodTests {
 		assertEquals("TEST", reply.getPayload());
 		assertEquals("replyingHandlerTestInputChannel,replyingHandlerTestService", reply.getHeaders().get("history").toString());
 		StackTraceElement[] st = (StackTraceElement[]) reply.getHeaders().get("callStack");
-		assertEquals("doDispatch", st[3].getMethodName()); // close to the metal
+		assertEquals("doDispatch", st[15].getMethodName()); // close to the metal
 	}
 
 	@Test
@@ -103,7 +105,7 @@ public class ServiceActivatorDefaultFrameworkMethodTests {
 		assertEquals("optimizedRefReplyingHandlerTestInputChannel,optimizedRefReplyingHandlerTestService",
 				reply.getHeaders().get("history").toString());
 		StackTraceElement[] st = (StackTraceElement[]) reply.getHeaders().get("callStack");
-		assertEquals("doDispatch", st[3].getMethodName());
+		assertEquals("doDispatch", st[15].getMethodName());
 	}
 
 	@Test
@@ -115,7 +117,7 @@ public class ServiceActivatorDefaultFrameworkMethodTests {
 		assertEquals("TEST", reply.getPayload());
 		assertEquals("replyingHandlerWithStandardMethodTestInputChannel,replyingHandlerWithStandardMethodTestService", reply.getHeaders().get("history").toString());
 		StackTraceElement[] st = (StackTraceElement[]) reply.getHeaders().get("callStack");
-		assertEquals("doDispatch", st[3].getMethodName()); // close to the metal
+		assertEquals("doDispatch", st[15].getMethodName()); // close to the metal
 	}
 
 	@Test
@@ -138,7 +140,7 @@ public class ServiceActivatorDefaultFrameworkMethodTests {
 //	INT-2399
 	@Test
 	public void testMessageProcessor() {
-		Object processor = TestUtils.getPropertyValue(processorTestService, "handler.processor");
+		Object processor = TestUtils.getPropertyValue(processorTestService, "handler.h.advised.targetSource.target.processor");
 		assertSame(testMessageProcessor, processor);
 
 		QueueChannel replyChannel = new QueueChannel();
@@ -149,9 +151,14 @@ public class ServiceActivatorDefaultFrameworkMethodTests {
 		assertEquals("processorTestInputChannel,processorTestService", reply.getHeaders().get("history").toString());
 	}
 
+	private interface Foo {
+
+		public String foo(String in);
+
+	}
 
 	@SuppressWarnings("unused")
-	private static class TestReplyingMessageHandler extends AbstractReplyProducingMessageHandler {
+	private static class TestReplyingMessageHandler extends AbstractReplyProducingMessageHandler implements Foo {
 
 		@Override
 		protected Object handleRequestMessage(Message<?> requestMessage) {
@@ -174,15 +181,15 @@ public class ServiceActivatorDefaultFrameworkMethodTests {
 		public void handleMessage(Message<?> requestMessage) {
 			Exception e = new RuntimeException();
 			StackTraceElement[] st = e.getStackTrace();
-			assertEquals("doDispatch", st[4].getMethodName());
+			assertEquals("doDispatch", st[28].getMethodName());
 		}
 	}
 
+	@SuppressWarnings("unused")
 	private static class TestMessageProcessor implements MessageProcessor<String> {
 
 		private String prefix;
 
-		@SuppressWarnings("unused")
 		public void setPrefix(String prefix) {
 			this.prefix = prefix;
 		}


### PR DESCRIPTION
When determining candidates for direct invocation, we need
to use the target of any existing proxy (such as JMX Metrics).

Copy ServiceActivatorDefaultFrameworkMethodTests to the JMX project
and adjust to work with JMX Proxies.
