### PR TITLE
INT-3182 Fix JMX Operation Invoking With Primitive

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.util;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -23,6 +25,24 @@ import java.util.Set;
  * @since 2.0
  */
 public abstract class ClassUtils {
+
+	/**
+	 * Map with primitive wrapper type as key and corresponding primitive
+	 * type as value, for example: Integer.class -> int.class.
+	 */
+	private static final Map<Class<?>, Class<?>> primitiveWrapperTypeMap = new HashMap<Class<?>, Class<?>>(8);
+
+
+	static {
+		primitiveWrapperTypeMap.put(Boolean.class, boolean.class);
+		primitiveWrapperTypeMap.put(Byte.class, byte.class);
+		primitiveWrapperTypeMap.put(Character.class, char.class);
+		primitiveWrapperTypeMap.put(Double.class, double.class);
+		primitiveWrapperTypeMap.put(Float.class, float.class);
+		primitiveWrapperTypeMap.put(Integer.class, int.class);
+		primitiveWrapperTypeMap.put(Long.class, long.class);
+		primitiveWrapperTypeMap.put(Short.class, short.class);
+	}
 
 	public static Class<?> findClosestMatch(Class<?> type, Set<Class<?>> candidates, boolean failOnTie) {
 		int minTypeDiffWeight = Integer.MAX_VALUE;
@@ -35,7 +55,7 @@ public abstract class ClassUtils {
 			}
 			else if (failOnTie && typeDiffWeight < Integer.MAX_VALUE && (typeDiffWeight == minTypeDiffWeight)) {
 				throw new IllegalStateException("Unresolvable ambiguity while attempting to find closest match for [" +
-						type.getName() + "]. Candidate types [" + closestMatch.getName() + "] and [" + candidate.getName() + 
+						type.getName() + "]. Candidate types [" + closestMatch.getName() + "] and [" + candidate.getName() +
 						"] have equal weight.");
 			}
 		}
@@ -65,6 +85,16 @@ public abstract class ClassUtils {
 			result = result + 1;
 		}
 		return result;
+	}
+
+	/**
+	 * Resolve the given class if it is a primitive wrapper class,
+	 * returning the corresponding primitive type instead.
+	 * @param clazz the wrapper class to check
+	 * @return the corresponding primitive if the clazz is a wrapper, otherwise null
+	 */
+	public static Class<?> resolvePrimitiveType(Class<?> clazz) {
+		return primitiveWrapperTypeMap.get(clazz);
 	}
 
 }

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
@@ -37,6 +37,7 @@ import org.springframework.integration.MessageHandlingException;
 import org.springframework.integration.MessagingException;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.util.ClassUtils;
 import org.springframework.jmx.support.ObjectNameManager;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -68,19 +69,6 @@ public class OperationInvokingMessageHandler extends AbstractReplyProducingMessa
 	private volatile ObjectName objectName;
 
 	private volatile String operationName;
-
-	private static final Map<Class<?>, String> primitiveWrapperToPrimitiveTypeName = new HashMap<Class<?>, String>();
-
-	static {
-		primitiveWrapperToPrimitiveTypeName.put(Boolean.class, "boolean");
-		primitiveWrapperToPrimitiveTypeName.put(Byte.class, "byte");
-		primitiveWrapperToPrimitiveTypeName.put(Character.class, "char");
-		primitiveWrapperToPrimitiveTypeName.put(Double.class, "double");
-		primitiveWrapperToPrimitiveTypeName.put(Float.class, "float");
-		primitiveWrapperToPrimitiveTypeName.put(Integer.class, "int");
-		primitiveWrapperToPrimitiveTypeName.put(Long.class, "long");
-		primitiveWrapperToPrimitiveTypeName.put(Short.class, "short");
-	}
 
 	/**
 	 * Provide a reference to the MBeanServer within which the MBean
@@ -182,8 +170,8 @@ public class OperationInvokingMessageHandler extends AbstractReplyProducingMessa
 			return true;
 		}
 		else {
-			String primitiveTypeName = primitiveWrapperToPrimitiveTypeName.get(valueClass);
-			return primitiveTypeName != null && primitiveTypeName.equals(paramInfo.getType());
+			Class<?> primitiveType = ClassUtils.resolvePrimitiveType(valueClass);
+			return primitiveType != null && primitiveType.getName().equals(paramInfo.getType());
 		}
 	}
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingOutboundGatewayTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingOutboundGatewayTests-context.xml
@@ -33,6 +33,14 @@
 		</jmx:request-handler-advice-chain>
 	</jmx:operation-invoking-outbound-gateway>
 
+	<si:channel id="primitiveChannel"/>
+
+	<jmx:operation-invoking-outbound-gateway request-channel="primitiveChannel"
+			reply-channel="withReplyChannelOutput"
+			object-name="org.springframework.integration.jmx.config:type=TestBean,name=testBeanGateway"
+			operation-name="testPrimitiveArgs"
+			requires-reply="false" />
+
 	<si:chain id="operationInvokingWithinChain" input-channel="jmxOutboundGatewayInsideChain" output-channel="withReplyChannelOutput">
 		<jmx:operation-invoking-outbound-gateway operation-name="testWithReturn" requires-reply="true"
 						object-name="org.springframework.integration.jmx.config:type=TestBean,name=testBeanGateway"/>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingOutboundGatewayTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingOutboundGatewayTests.java
@@ -17,17 +17,25 @@
 package org.springframework.integration.jmx.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
+import org.springframework.integration.MessagingException;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
@@ -38,9 +46,11 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+
 /**
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Gary Russell
  *
  */
 @ContextConfiguration
@@ -48,15 +58,15 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class OperationInvokingOutboundGatewayTests {
 
 	@Autowired
-	@Qualifier("withReplyChannel")
 	private MessageChannel withReplyChannel;
 
 	@Autowired
-	@Qualifier("withReplyChannelOutput")
+	private MessageChannel primitiveChannel;
+
+	@Autowired
 	private PollableChannel withReplyChannelOutput;
 
 	@Autowired
-	@Qualifier("withNoReplyChannel")
 	private MessageChannel withNoReplyChannel;
 
 	@Autowired
@@ -90,6 +100,42 @@ public class OperationInvokingOutboundGatewayTests {
 	}
 
 	@Test
+	public void gatewayWithPrimitiveArgs() throws Exception {
+		primitiveChannel.send(new GenericMessage<Object[]>(new Object[] { true, 0L, 1 }));
+		assertEquals(1, testBean.messages.size());
+		List<Object> argList = new ArrayList<Object>();
+		argList.add(false);
+		argList.add(123L);
+		argList.add(42);
+		primitiveChannel.send(new GenericMessage<List<Object>>(argList));
+		assertEquals(2, testBean.messages.size());
+		Map<String, Object> argMap = new HashMap<String, Object>();
+		argMap.put("p1", true);
+		argMap.put("p2", 0L);
+		argMap.put("p3", 42);
+		primitiveChannel.send(new GenericMessage<Map<String, Object>>(argMap));
+		assertEquals(3, testBean.messages.size());
+		argMap.put("p2", true);
+		argMap.put("p1", 0L);
+		argMap.put("p3", 42);
+		try {
+			primitiveChannel.send(new GenericMessage<Map<String, Object>>(argMap));
+			fail("Expected Exception");
+		}
+		catch (Exception e) {
+			assertThat(e, Matchers.instanceOf(MessagingException.class));
+			assertThat(e.getMessage(), Matchers.containsString("failed to find JMX operation"));
+		}
+		// TODO: Uncomment when Spring Framework minimum is 3.2.3
+//		argMap = new HashMap<String, Object>();
+//		argMap.put("bool", true);
+//		argMap.put("time", 0L);
+//		argMap.put("foo", 42);
+//		primitiveChannel.send(new GenericMessage<Map<String, Object>>(argMap));
+//		assertEquals(4, testBean.messages.size());
+	}
+
+	@Test
 	public void gatewayWithNoReplyChannel() throws Exception {
 		withNoReplyChannel.send(new GenericMessage<String>("1"));
 		assertEquals(1, testBean.messages.size());
@@ -101,7 +147,7 @@ public class OperationInvokingOutboundGatewayTests {
 
 	@Test //INT-1029, INT-2822
 	public void testOutboundGatewayInsideChain() throws Exception {
-		List handlers = TestUtils.getPropertyValue(this.operationInvokingWithinChain, "handlers", List.class);
+		List<?> handlers = TestUtils.getPropertyValue(this.operationInvokingWithinChain, "handlers", List.class);
 		assertEquals(1, handlers.size());
 		Object handler = handlers.get(0);
 		assertTrue(handler instanceof OperationInvokingMessageHandler);

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/TestBean.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.jmx.export.annotation.ManagedResource;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.0
  */
 @ManagedResource
@@ -42,11 +43,16 @@ public class TestBean {
 	public void test(String text) {
 		this.messages.add(text);
 	}
-	
+
 	@ManagedOperation
 	public List<String> testWithReturn(String text) {
 		this.messages.add(text);
 		return messages;
+	}
+
+	@ManagedOperation
+	public void testPrimitiveArgs(boolean bool, long time, int foo) {
+		this.messages.add(bool + " " + time + " " + foo);
 	}
 
 }


### PR DESCRIPTION
Previously, methods with primitive parameters were not matched
with primitive wrapper objects.

Check, if the argument is a primitive wrapper, that the paramer type
can be the equivalent primitive.

Add test case.
