### PR TITLE
Added support for "flatten-map" attribute in object-to-map transformer.

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ObjectToMapTransformerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ObjectToMapTransformerParser.java
@@ -33,5 +33,8 @@ public class ObjectToMapTransformerParser extends AbstractTransformerParser {
 
 	@Override
 	protected void parseTransformer(Element element, ParserContext parserContext, BeanDefinitionBuilder builder) {
+        if (element.hasAttribute("flatten-map")) {
+            builder.addPropertyValue("shouldFlattenKeys", element.getAttribute("flatten-map"));
+        }
 	}
 }

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-3.0.xsd
@@ -2169,6 +2169,7 @@
 			<xsd:complexContent>
 				<xsd:extension base="specialized-transformer-type">
 					<xsd:attributeGroup ref="inputOutputChannelGroup" />
+                    <xsd:attribute name="flatten-map" type="xsd:boolean" use="optional" default="true"/>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ObjectToMapTransformerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ObjectToMapTransformerParserTests-context.xml
@@ -15,4 +15,11 @@
 
 	<object-to-map-transformer input-channel="directInput" output-channel="output"/>
 
+    <channel id="nestedInput"/>
+
+    <channel id="nestedOutput">
+        <queue capacity="1"/>
+    </channel>
+
+    <object-to-map-transformer input-channel="nestedInput" output-channel="nestedOutput" flatten-map="false" />
 </beans:beans>


### PR DESCRIPTION
I've added an attribute "flatten-map" to object-to-map transformer in order to configure to flatten or not flatten the keys generated by transformer.
