### PR TITLE
INT-3198: Add 'recovery-interval' for redis-q-c-a

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParser.java
@@ -50,6 +50,7 @@ public class RedisQueueInboundChannelAdapterParser extends AbstractChannelAdapte
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "expect-message");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "receive-timeout");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "recovery-interval");
 		builder.addPropertyReference("outputChannel", channelName);
 
 		return builder.getBeanDefinition();

--- a/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-3.0.xsd
+++ b/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-3.0.xsd
@@ -392,6 +392,15 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="recovery-interval" type="xsd:string" default="5000">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify the timeout in milliseconds to sleep the listener task after catching
+								an Exception on Redis operation before 'restart' the listener task.
+								Default is 5 second.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="expect-message" type="xsd:string" default="false">
 						<xsd:annotation>
 							<xsd:documentation>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests-context.xml
@@ -28,6 +28,7 @@
 											  serializer="serializer"
 											  error-channel="errorChannel"
 											  receive-timeout="2000"
+											  recovery-interval="3000"
 											  task-executor="executor"
 											  auto-startup="false"
 											  phase="100"/>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests.java
@@ -46,7 +46,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
-public class RedisMessageDrivenEndpointParserTests {
+public class RedisQueueInboundChannelAdapterParserTests {
 
 	@Autowired
 	@Qualifier("redisConnectionFactory")
@@ -90,6 +90,7 @@ public class RedisMessageDrivenEndpointParserTests {
 		assertEquals("si.test.Int3017.Inbound1", TestUtils.getPropertyValue(this.defaultAdapter, "boundListOperations.key"));
 		assertFalse(TestUtils.getPropertyValue(this.defaultAdapter, "expectMessage", Boolean.class));
 		assertEquals(new Long(1000), TestUtils.getPropertyValue(this.defaultAdapter, "receiveTimeout", Long.class));
+		assertEquals(new Long(5000), TestUtils.getPropertyValue(this.defaultAdapter, "recoveryInterval", Long.class));
 		assertNull(TestUtils.getPropertyValue(this.defaultAdapter, "errorChannel"));
 		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "taskExecutor"), Matchers.instanceOf(ErrorHandlingTaskExecutor.class));
 		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "serializer"), Matchers.instanceOf(JdkSerializationRedisSerializer.class));
@@ -103,6 +104,7 @@ public class RedisMessageDrivenEndpointParserTests {
 		assertEquals("si.test.Int3017.Inbound2", TestUtils.getPropertyValue(this.customAdapter, "boundListOperations.key"));
 		assertTrue(TestUtils.getPropertyValue(this.customAdapter, "expectMessage", Boolean.class));
 		assertEquals(new Long(2000), TestUtils.getPropertyValue(this.customAdapter, "receiveTimeout", Long.class));
+		assertEquals(new Long(3000), TestUtils.getPropertyValue(this.customAdapter, "recoveryInterval", Long.class));
 		assertSame(this.errorChannel, TestUtils.getPropertyValue(this.customAdapter, "errorChannel"));
 		assertSame(this.taskExecutor, TestUtils.getPropertyValue(this.customAdapter, "taskExecutor"));
 		assertSame(this.serializer, TestUtils.getPropertyValue(this.customAdapter, "serializer"));

--- a/src/reference/docbook/redis.xml
+++ b/src/reference/docbook/redis.xml
@@ -205,6 +205,7 @@ rt.setConnectionFactory(redisConnectionFactory);]]></programlisting>
                     error-channel="" ]]><co id="redis-m-d-c-a-errorChannel"/><![CDATA[
                     serializer="" ]]><co id="redis-m-d-c-a-serializer"/><![CDATA[
                     receive-timeout="" ]]><co id="redis-m-d-c-a-receiveTimeout"/><![CDATA[
+                    recovery-interval="" ]]><co id="redis-m-d-c-a-recoveryInterval"/><![CDATA[
                     expect-message="" ]]><co id="redis-m-d-c-a-expectMessage"/><![CDATA[
                     task-executor=""/> ]]><co id="redis-m-d-c-a-task-executor"/>
 		</programlisting>
@@ -247,7 +248,9 @@ rt.setConnectionFactory(redisConnectionFactory);]]></programlisting>
 			<callout arearefs="redis-m-d-c-a-errorChannel">
 				<para>
 					The <interfacename>MessageChannel</interfacename> to which to send <interfacename>ErrorMessage</interfacename>s with
-					<interfacename>Exception</interfacename>s from the listening task of the Endpoint.
+					<interfacename>Exception</interfacename>s from the listening task of the Endpoint. By default
+					the underlying <classname>MessagePublishingErrorHandler</classname> uses a
+					default <code>errorChannel</code> from the application context.
 				</para>
 			</callout>
 			<callout arearefs="redis-m-d-c-a-serializer">
@@ -260,6 +263,12 @@ rt.setConnectionFactory(redisConnectionFactory);]]></programlisting>
 			<callout arearefs="redis-m-d-c-a-receiveTimeout">
 				<para>
 					The timeout in milliseconds for 'right pop' operation to wait for a Redis message from the queue. Default is 1 second.
+				</para>
+			</callout>
+			<callout arearefs="redis-m-d-c-a-recoveryInterval">
+				<para>
+					The timeout in milliseconds for sleeping the listener task after exceptions on 'right pop' operation
+					and before 'restart' the listener task.
 				</para>
 			</callout>
 			<callout arearefs="redis-m-d-c-a-expectMessage">
@@ -342,6 +351,21 @@ rt.setConnectionFactory(redisConnectionFactory);]]></programlisting>
 					  </para>
 				  </callout>
 			  </calloutlist>
+		  </para>
+	  </section>
+	  <section id="redis-application-events">
+		  <title>Redis Application Events</title>
+		  <para>
+			  Since <emphasis>Spring Integration 3.0</emphasis>, the Redis module provides an implementation
+			  of <classname>IntegrationEvent</classname> abstraction - a custom case of
+			  <interfacename>org.springframework.context.ApplicationEvent</interfacename>. The <classname>RedisExceptionEvent</classname>
+			  is presented to hold an <classname>Exception</classname>s from Redis operations and the Endpoint as a <code>source</code>
+			  of the event and the <classname>Exception</classname> respectively. E.g. <code>&lt;int-redis:queue-inbound-channel-adapter/&gt;</code>
+			  emits those events after catching <classname>Exception</classname>s from the <code>BoundListOperations.rightPop</code>.
+			  It may be any generic <classname>org.springframework.data.redis.RedisSystemException</classname> or
+			  even <classname>org.springframework.data.redis.RedisConnectionFailureException</classname>.
+			  Handling these events via <code>&lt;int-event:inbound-channel-adapter/&gt;</code> can be useful to determine
+			  problems with background Redis tasks and to do some administrative manipulations.
 		  </para>
 	  </section>
   </section>


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3198
- Expose `RedisQueueMessageDrivenEndpoint.recoveryInterval` to Namespace support
- Add parser's tests
- Rename parser test class
- Polishing for concurrency of`RedisQueueMessageDrivenEndpointTests#testInt3196Recovery` test
- Add documentation
