### PR TITLE
INT-2421 Support 'container-class' on JMS MDCA

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpInboundEndpointParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpInboundEndpointParser.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.http.config;
 
 import java.util.List;
+
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.BeanDefinitionStoreException;
@@ -74,7 +75,7 @@ public class HttpInboundEndpointParser extends AbstractSingleBeanDefinitionParse
 			throws BeanDefinitionStoreException {
 		String id = super.resolveId(element, definition, parserContext);
 
-		if (!element.hasAttribute(getInputChannelAttributeName())) {
+		if (!this.expectReply && !element.hasAttribute("channel")) {
 			// the created channel will get the 'id', so the adapter's bean name includes a suffix
 			id = id + ".adapter";
 		}

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-3.0.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-3.0.xsd
@@ -1201,9 +1201,30 @@
 			<xsd:extension base="jmsInboundAdapterType">
 				<xsd:attribute name="container" type="xsd:string">
 					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+			A reference to a custom listener container implementation.
+			Note that a custom container class will typically be a subclass of DefaultMessageListenerContainer.
+			This attribute is mutually exclusive with 'container'.
+						]]></xsd:documentation>
 						<xsd:appinfo>
 							<tool:annotation kind="ref">
 								<tool:expected-type type="org.springframework.jms.listener.AbstractMessageListenerContainer"/>
+							</tool:annotation>
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="container-class" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation><![CDATA[
+			A custom listener container implementation class as fully qualified class name.
+			Default is Spring's standard DefaultMessageListenerContainer.
+			Note that a custom container class will typically be a subclass of this
+			standard container class. This attribute is mutually exclusive with 'container'.
+						]]></xsd:documentation>
+						<xsd:appinfo>
+							<tool:annotation>
+								<tool:expected-type type="java.lang.Class"/>
+								<tool:assignable-to type="org.springframework.jms.listener.AbstractMessageListenerContainer"/>
 							</tool:annotation>
 						</xsd:appinfo>
 					</xsd:annotation>

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-3.0.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-3.0.xsd
@@ -1204,7 +1204,7 @@
 						<xsd:documentation><![CDATA[
 			A reference to a custom listener container implementation.
 			Note that a custom container class will typically be a subclass of DefaultMessageListenerContainer.
-			This attribute is mutually exclusive with 'container'.
+			This attribute is mutually exclusive with 'container-class'.
 						]]></xsd:documentation>
 						<xsd:appinfo>
 							<tool:annotation kind="ref">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
@@ -143,4 +143,20 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		gateway.stop();
 	}
 
+	@Test
+	public void testGatewayWithContainerClass() {
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
+				"jmsInboundWithContainerClass.xml", this.getClass());
+		JmsMessageDrivenEndpoint gateway = (JmsMessageDrivenEndpoint) context.getBean("adapterWithIdleConsumerLimit");
+		gateway.start();
+		FooContainer container = TestUtils.getPropertyValue(gateway, "listenerContainer", FooContainer.class);
+		assertEquals(33, new DirectFieldAccessor(container).getPropertyValue("idleConsumerLimit"));
+		assertEquals(3, new DirectFieldAccessor(container).getPropertyValue("cacheLevel"));
+		gateway.stop();
+	}
+
+	public static final class FooContainer extends DefaultMessageListenerContainer {
+
+	}
+
 }

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.Message;
+import org.springframework.integration.MessageChannel;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.jms.JmsMessageDrivenEndpoint;
@@ -38,6 +39,7 @@ import org.springframework.jms.support.destination.JmsDestinationAccessor;
 /**
  * @author Mark Fisher
  * @author Michael Bannister
+ * @author Gary Russell
  */
 public class JmsMessageDrivenChannelAdapterParserTests {
 
@@ -87,7 +89,7 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 	public void adapterWithTaskExecutor() {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"jmsInboundWithTaskExecutor.xml", this.getClass());
-		JmsMessageDrivenEndpoint endpoint = context.getBean("messageDrivenAdapter", JmsMessageDrivenEndpoint.class);
+		JmsMessageDrivenEndpoint endpoint = context.getBean("messageDrivenAdapter.adapter", JmsMessageDrivenEndpoint.class);
 		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(endpoint, "listenerContainer",
 				DefaultMessageListenerContainer.class);
 		assertSame(context.getBean("exec"), TestUtils.getPropertyValue(container, "taskExecutor"));
@@ -95,64 +97,66 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 	}
 
 	@Test
-	public void testGatewayWithReceiveTimeout() {
+	public void testAdapterWithReceiveTimeout() {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"jmsInboundWithContainerSettings.xml", this.getClass());
-		JmsMessageDrivenEndpoint gateway = (JmsMessageDrivenEndpoint) context.getBean("adapterWithReceiveTimeout");
-		gateway.start();
+		JmsMessageDrivenEndpoint adapter = (JmsMessageDrivenEndpoint) context.getBean("adapterWithReceiveTimeout.adapter");
+		adapter.start();
 		AbstractMessageListenerContainer container = (AbstractMessageListenerContainer)
-				new DirectFieldAccessor(gateway).getPropertyValue("listenerContainer");
+				new DirectFieldAccessor(adapter).getPropertyValue("listenerContainer");
 		assertEquals(1111L, new DirectFieldAccessor(container).getPropertyValue("receiveTimeout"));
-		gateway.stop();
+		adapter.stop();
 	}
 
 	@Test
-	public void testGatewayWithRecoveryInterval() {
+	public void testAdapterWithRecoveryInterval() {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"jmsInboundWithContainerSettings.xml", this.getClass());
-		JmsMessageDrivenEndpoint gateway = (JmsMessageDrivenEndpoint) context.getBean("adapterWithRecoveryInterval");
-		gateway.start();
+		JmsMessageDrivenEndpoint adapter = (JmsMessageDrivenEndpoint) context.getBean("adapterWithRecoveryInterval.adapter");
+		adapter.start();
 		AbstractMessageListenerContainer container = (AbstractMessageListenerContainer)
-				new DirectFieldAccessor(gateway).getPropertyValue("listenerContainer");
+				new DirectFieldAccessor(adapter).getPropertyValue("listenerContainer");
 		assertEquals(2222L, new DirectFieldAccessor(container).getPropertyValue("recoveryInterval"));
-		gateway.stop();
+		adapter.stop();
 	}
 
 	@Test
-	public void testGatewayWithIdleTaskExecutionLimit() {
+	public void testAdapterWithIdleTaskExecutionLimit() {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"jmsInboundWithContainerSettings.xml", this.getClass());
-		JmsMessageDrivenEndpoint gateway = (JmsMessageDrivenEndpoint) context.getBean("adapterWithIdleTaskExecutionLimit");
-		gateway.start();
+		JmsMessageDrivenEndpoint adapter = (JmsMessageDrivenEndpoint) context.getBean("adapterWithIdleTaskExecutionLimit.adapter");
+		adapter.start();
 		AbstractMessageListenerContainer container = (AbstractMessageListenerContainer)
-				new DirectFieldAccessor(gateway).getPropertyValue("listenerContainer");
+				new DirectFieldAccessor(adapter).getPropertyValue("listenerContainer");
 		assertEquals(7, new DirectFieldAccessor(container).getPropertyValue("idleTaskExecutionLimit"));
-		gateway.stop();
+		adapter.stop();
 	}
 
 	@Test
-	public void testGatewayWithIdleConsumerLimit() {
+	public void testAdapterWithIdleConsumerLimit() {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"jmsInboundWithContainerSettings.xml", this.getClass());
-		JmsMessageDrivenEndpoint gateway = (JmsMessageDrivenEndpoint) context.getBean("adapterWithIdleConsumerLimit");
-		gateway.start();
+		JmsMessageDrivenEndpoint adapter = (JmsMessageDrivenEndpoint) context.getBean("adapterWithIdleConsumerLimit.adapter");
+		adapter.start();
 		AbstractMessageListenerContainer container = (AbstractMessageListenerContainer)
-				new DirectFieldAccessor(gateway).getPropertyValue("listenerContainer");
+				new DirectFieldAccessor(adapter).getPropertyValue("listenerContainer");
 		assertEquals(33, new DirectFieldAccessor(container).getPropertyValue("idleConsumerLimit"));
 		assertEquals(3, new DirectFieldAccessor(container).getPropertyValue("cacheLevel"));
-		gateway.stop();
+		adapter.stop();
 	}
 
 	@Test
-	public void testGatewayWithContainerClass() {
+	public void testAdapterWithContainerClass() {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"jmsInboundWithContainerClass.xml", this.getClass());
-		JmsMessageDrivenEndpoint gateway = (JmsMessageDrivenEndpoint) context.getBean("adapterWithIdleConsumerLimit");
-		gateway.start();
-		FooContainer container = TestUtils.getPropertyValue(gateway, "listenerContainer", FooContainer.class);
+		JmsMessageDrivenEndpoint adapter = context.getBean("adapterWithIdleConsumerLimit.adapter", JmsMessageDrivenEndpoint.class);
+		MessageChannel channel = context.getBean("adapterWithIdleConsumerLimit", MessageChannel.class);
+		assertSame(channel, TestUtils.getPropertyValue(adapter, "listener.gatewayDelegate.requestChannel"));
+		adapter.start();
+		FooContainer container = TestUtils.getPropertyValue(adapter, "listenerContainer", FooContainer.class);
 		assertEquals(33, new DirectFieldAccessor(container).getPropertyValue("idleConsumerLimit"));
 		assertEquals(3, new DirectFieldAccessor(container).getPropertyValue("cacheLevel"));
-		gateway.stop();
+		adapter.stop();
 	}
 
 	public static final class FooContainer extends DefaultMessageListenerContainer {

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithContainerClass.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithContainerClass.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:si="http://www.springframework.org/schema/integration"
+	xmlns:jms="http://www.springframework.org/schema/integration/jms"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+			http://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/integration
+			http://www.springframework.org/schema/integration/spring-integration.xsd
+			http://www.springframework.org/schema/integration/jms
+			http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd">
+
+	<jms:message-driven-channel-adapter id="adapterWithIdleConsumerLimit"
+						 connection-factory="testConnectionFactory"
+						 destination-name="testQueue"
+						 container-class="org.springframework.integration.jms.config.JmsMessageDrivenChannelAdapterParserTests$FooContainer"
+						 idle-consumer-limit="33"
+						 cache-level="3"
+						 auto-startup="false" />
+
+	<bean id="testConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+		<constructor-arg>
+			<bean class="org.springframework.integration.jms.StubConnection">
+				<constructor-arg value="message-driven-test"/>
+			</bean>
+		</constructor-arg>
+	</bean>
+
+</beans>

--- a/src/reference/docbook/jms.xml
+++ b/src/reference/docbook/jms.xml
@@ -87,12 +87,21 @@
       message-driven Channel Adapter with a <classname>Destination</classname> reference.
       <programlisting language="xml"><![CDATA[<int-jms:message-driven-channel-adapter id="jmsIn" destination="inQueue" channel="exampleChannel"/>]]></programlisting>
       <note>
+       <para>
         The Message-Driven adapter also accepts several properties that pertain to the MessageListener container.
-        These values are only considered if you do not provide an actual 'container' reference. In that case,
+        These values are only considered if you do not provide a <code>container</code> reference. In that case,
         an instance of DefaultMessageListenerContainer will be created and configured based on these properties.
         For example, you can specify the "transaction-manager" reference, the "concurrent-consumers" value, and
         several other property references and values. Refer to the JavaDoc and Spring Integration's JMS Schema
-        (spring-integration-jms.xsd) for more detail.
+        (spring-integration-jms.xsd) for more details.
+       </para>
+       <para>
+        If you have a custom listener container implementation (usually a subclass of
+        <classname>DefaultMessageListenerContainer</classname>), you can either provide a reference to an instance
+        of it using the <code>container</code> attribute, or simply provide its fully qualified class name using
+        the <code>container-class</code> attribute. In that case, the attributes on the adapter
+        are transferred to an instance of your custom container.
+       </para>
       </note>
     </para>
     <para>


### PR DESCRIPTION
Convenience for configuring a custom listener container - avoids
having to transfer many attributes from the adapter to the
bean when switching to a custom implementation.

JIRA: https://jira.springsource.org/browse/INT-2421
