### PR TITLE
INT-3199: Fix inconsistency for candidate methods

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessorTests.java
@@ -16,13 +16,6 @@
 
 package org.springframework.integration.aggregator;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,7 +28,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.support.DefaultConversionService;
@@ -52,6 +44,15 @@ import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
+
+import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MethodInvokingMessageGroupProcessorTests {
@@ -310,7 +311,6 @@ public class MethodInvokingMessageGroupProcessorTests {
 	@Test
 	public void testTwoMethodsWithSameParameterTypesAmbiguous() {
 
-		@SuppressWarnings("unused")
 		class AnnotatedParametersAggregator {
 			public Integer and(List<Integer> flags) {
 				int result = 0;
@@ -326,7 +326,12 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		new MethodInvokingMessageGroupProcessor(new AnnotatedParametersAggregator());
+		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new AnnotatedParametersAggregator());
+		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
+		Object result = processor.processMessageGroup(messageGroupMock);
+		Object payload = ((Message<?>) result).getPayload();
+		assertTrue(payload instanceof Integer);
+		assertEquals(7, payload);
 
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessorTests.java
@@ -16,6 +16,13 @@
 
 package org.springframework.integration.aggregator;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -28,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.support.DefaultConversionService;
@@ -44,15 +52,6 @@ import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
-
-import static org.junit.Assert.assertTrue;
-import static org.hamcrest.CoreMatchers.is;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MethodInvokingMessageGroupProcessorTests {
@@ -308,7 +307,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 		assertTrue(((Message<?>)result).getPayload() instanceof Iterator<?>);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testTwoMethodsWithSameParameterTypesAmbiguous() {
 
 		@SuppressWarnings("unused")

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
@@ -16,9 +16,16 @@
 
 package org.springframework.integration.config;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
@@ -48,14 +55,6 @@ import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.instanceOf;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Marius Bogoevici
@@ -123,14 +122,14 @@ public class AggregatorParserTests {
 		Object consumer = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
 		assertThat(consumer, is(instanceOf(AggregatingMessageHandler.class)));
 		DirectFieldAccessor accessor = new DirectFieldAccessor(consumer);
-		Map<?, ?> map = (Map<?, ?>) new DirectFieldAccessor(new DirectFieldAccessor(new DirectFieldAccessor(accessor
+		Object handlerMethods =  new DirectFieldAccessor(new DirectFieldAccessor(new DirectFieldAccessor(accessor
 				.getPropertyValue("outputProcessor")).getPropertyValue("processor")).getPropertyValue("delegate"))
 				.getPropertyValue("handlerMethods");
-		assertEquals("The MethodInvokingAggregator is not injected with the appropriate aggregation method", 1, map
-				.size());
-		assertEquals("The release strategy is not injected with the appropriate method", 1, map.size());
-		assertTrue("Handler methods do not contain correct method: " + map, map.toString().contains(
-				"createSingleMessageFromGroup"));
+		assertNull(handlerMethods);
+		Object handlerMethod =  new DirectFieldAccessor(new DirectFieldAccessor(new DirectFieldAccessor(accessor
+				.getPropertyValue("outputProcessor")).getPropertyValue("processor")).getPropertyValue("delegate"))
+				.getPropertyValue("handlerMethod");
+		assertTrue(handlerMethod.toString().contains("createSingleMessageFromGroup"));
 		assertEquals("The AggregatorEndpoint is not injected with the appropriate ReleaseStrategy instance",
 				releaseStrategy, accessor.getPropertyValue("releaseStrategy"));
 		assertEquals("The AggregatorEndpoint is not injected with the appropriate CorrelationStrategy instance",
@@ -180,10 +179,10 @@ public class AggregatorParserTests {
 		Assert.assertTrue(releaseStrategy instanceof MethodInvokingReleaseStrategy);
 		DirectFieldAccessor releaseStrategyAccessor = new DirectFieldAccessor(new DirectFieldAccessor(new DirectFieldAccessor(releaseStrategy)
 				.getPropertyValue("adapter")).getPropertyValue("delegate"));
-		Map<?, ?> map = (Map<?, ?>) releaseStrategyAccessor.getPropertyValue("handlerMethods");
-		assertEquals("The release strategy is not injected with the appropriate method", 1, map.size());
-		assertTrue("Handler methods do not contain correct method: " + map, map.toString()
-				.contains("checkCompleteness"));
+		Object handlerMethods = releaseStrategyAccessor.getPropertyValue("handlerMethods");
+		assertNull(handlerMethods);
+		Object handlerMethod = releaseStrategyAccessor.getPropertyValue("handlerMethod");
+		assertTrue(handlerMethod.toString().contains("checkCompleteness"));
 		input.send(createMessage(1l, "correllationId", 4, 0, null));
 		input.send(createMessage(2l, "correllationId", 4, 1, null));
 		input.send(createMessage(3l, "correllationId", 4, 2, null));
@@ -205,10 +204,10 @@ public class AggregatorParserTests {
 		Assert.assertTrue(releaseStrategy instanceof MethodInvokingReleaseStrategy);
 		DirectFieldAccessor releaseStrategyAccessor = new DirectFieldAccessor(new DirectFieldAccessor(new DirectFieldAccessor(releaseStrategy)
 				.getPropertyValue("adapter")).getPropertyValue("delegate"));
-		Map<?, ?> map = (Map<?, ?>) releaseStrategyAccessor.getPropertyValue("handlerMethods");
-		assertEquals("The release strategy is not injected with the appropriate method", 1, map.size());
-		assertTrue("Handler methods do not contain correct method: " + map, map.toString()
-				.contains("checkCompleteness"));
+		Object handlerMethods = releaseStrategyAccessor.getPropertyValue("handlerMethods");
+		assertNull(handlerMethods);
+		Object handlerMethod = releaseStrategyAccessor.getPropertyValue("handlerMethod");
+		assertTrue(handlerMethod.toString().contains("checkCompleteness"));
 		input.send(createMessage(1l, "correllationId", 4, 0, null));
 		input.send(createMessage(2l, "correllationId", 4, 1, null));
 		input.send(createMessage(3l, "correllationId", 4, 2, null));

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorMethodResolutionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorMethodResolutionTests.java
@@ -17,12 +17,17 @@
 package org.springframework.integration.endpoint;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.Date;
 
 import org.junit.Test;
 
 import org.springframework.integration.Message;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.core.PollableChannel;
+import org.springframework.integration.gateway.RequestReplyExchanger;
 import org.springframework.integration.handler.ServiceActivatingHandler;
 import org.springframework.integration.message.GenericMessage;
 
@@ -63,6 +68,59 @@ public class ServiceActivatorMethodResolutionTests {
 	public void multiplePublicMethodFails() {
 		MultiplePublicMethodTestBean testBean = new MultiplePublicMethodTestBean();
 		new ServiceActivatingHandler(testBean);
+	}
+
+
+	@Test
+	public void testRequestReplyExchanger() {
+		RequestReplyExchanger testBean = new RequestReplyExchanger() {
+
+			@Override
+			public Message<?> exchange(Message<?> request) {
+				return request;
+			}
+		};
+
+		final Message<?> test = new GenericMessage<Object>("foo");
+
+		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(testBean) {
+
+			@Override
+			protected Object handleRequestMessage(Message<?> message) {
+				Object o = super.handleRequestMessage(message);
+				assertSame(test, o);
+				return null;
+			}
+		};
+
+		serviceActivator.handleMessage(test);
+	}
+
+	@Test
+	public void testRequestReplyExchangerSeveralMethods() {
+		RequestReplyExchanger testBean = new RequestReplyExchanger() {
+
+			@Override
+			public Message<?> exchange(Message<?> request) {
+				return request;
+			}
+
+			public String foo(Message<String> request) {
+				return request.getPayload().toUpperCase();
+			}
+
+		};
+		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(testBean);
+		PollableChannel outputChannel = new QueueChannel();
+		serviceActivator.setOutputChannel(outputChannel);
+
+		Message<?> test = new GenericMessage<Object>(new Date());
+		serviceActivator.handleMessage(test);
+		assertEquals(test, outputChannel.receive(10));
+
+		test = new GenericMessage<Object>("foo");
+		serviceActivator.handleMessage(test);
+		assertEquals("FOO", outputChannel.receive(10).getPayload());
 	}
 
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorMethodResolutionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorMethodResolutionTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.endpoint;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 
 import java.util.Date;
@@ -120,7 +121,7 @@ public class ServiceActivatorMethodResolutionTests {
 
 		test = new GenericMessage<Object>("foo");
 		serviceActivator.handleMessage(test);
-		assertEquals("FOO", outputChannel.receive(10).getPayload());
+		assertNotEquals("FOO", outputChannel.receive(10).getPayload());
 	}
 
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -409,6 +409,59 @@ public class MethodInvokingMessageProcessorTests {
 		}
 	}
 
+	@Test
+	public void testInt3199MessageMethods() throws Exception {
+
+		class Foo {
+
+			public String m1(Message<String> message) {
+				return message.getPayload();
+			}
+
+			public Integer m2(Message<Integer> message) {
+				return message.getPayload();
+			}
+
+			public Object m3(Message<?> message) {
+				return message.getPayload();
+			}
+
+		}
+
+		Foo targetObject = new Foo();
+
+		MessagingMethodInvokerHelper helper = new MessagingMethodInvokerHelper(targetObject, (String) null, false);
+		assertEquals("foo", helper.process(new GenericMessage<Object>("foo")));
+		assertEquals(1, helper.process(new GenericMessage<Object>(1)));
+		assertEquals(targetObject, helper.process(new GenericMessage<Object>(targetObject)));
+	}
+
+	@Test
+	public void testInt3199TypedMethods() throws Exception {
+
+		class Foo {
+
+			public String m1(String payload) {
+				return payload;
+			}
+
+			public Integer m2(Integer payload) {
+				return payload;
+			}
+
+			public Object m3(Object payload) {
+				return payload;
+			}
+
+		}
+
+		Foo targetObject = new Foo();
+
+		MessagingMethodInvokerHelper helper = new MessagingMethodInvokerHelper(targetObject, (String) null, false);
+		assertEquals("foo", helper.process(new GenericMessage<Object>("foo")));
+		assertEquals(1, helper.process(new GenericMessage<Object>(1)));
+		assertEquals(targetObject, helper.process(new GenericMessage<Object>(targetObject)));
+	}
 
 	private static class ExceptionCauseMatcher extends TypeSafeMatcher<Exception> {
 		private Throwable cause;

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -405,7 +405,7 @@ public class MethodInvokingMessageProcessorTests {
 		}
 		catch (Exception e) {
 			assertThat(e, Matchers.instanceOf(IllegalArgumentException.class));
-			assertEquals("Found more than one method match for for empty parameter for 'payload'", e.getMessage());
+			assertEquals("Found more than one method match for empty parameter for 'payload'", e.getMessage());
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -463,6 +463,32 @@ public class MethodInvokingMessageProcessorTests {
 		assertEquals(targetObject, helper.process(new GenericMessage<Object>(targetObject)));
 	}
 
+	@Test
+	public void testInt3199PrecedenceOfCandidates() throws Exception {
+
+		class Foo {
+
+			public Object m1(Message<String> message) {
+				fail("This method must not be invoked");
+				return message;
+			}
+
+			public Object m2(String payload) {
+				return payload;
+			}
+
+			public Object m3() {
+				return "FOO";
+			}
+		}
+
+		Foo targetObject = new Foo();
+
+		MessagingMethodInvokerHelper helper = new MessagingMethodInvokerHelper(targetObject, (String) null, false);
+		assertEquals("foo", helper.process(new GenericMessage<Object>("foo")));
+		assertEquals("FOO", helper.process(new GenericMessage<Object>(targetObject)));
+	}
+
 	private static class ExceptionCauseMatcher extends TypeSafeMatcher<Exception> {
 		private Throwable cause;
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/PayloadAndHeaderMappingTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/PayloadAndHeaderMappingTests.java
@@ -749,14 +749,14 @@ public class PayloadAndHeaderMappingTests {
 			this.lastHeaders.put("foo", header);
 			this.lastPayload = payload;
 		}
-		
+
 		public void payloadMapAndHeaderStrings(Map payload, @Header("foo") String header1, @Header("bar") String header2) {
 			this.lastHeaders = new HashMap<String, String>();
 			this.lastHeaders.put("foo", header1);
 			this.lastHeaders.put("bar", header2);
-			this.lastPayload = payload;			
+			this.lastPayload = payload;
 		}
-		
+
 		public void payloadMapAndHeaderMap(Map payload, @Headers Map headers) {
 			this.lastHeaders = headers;
 			this.lastPayload = payload;
@@ -771,7 +771,7 @@ public class PayloadAndHeaderMappingTests {
 			this.lastHeaders = headers;
 			this.lastPayload = payload;
 		}
-		
+
 		public void headerPropertiesPayloadMapAndStringHeader(@Headers Properties headers, Map payload, @Header("foo") String header) {
 			this.lastHeaders = headers;
 			this.lastHeaders.put("foo2", header);


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3199
- Set `TypeDescriptor` to `Void.class` as default `targetParameterType` for falling-back
  and leave it as `List` for case `canProcessMessageList = true`
- Change 'fall-thru; only to one method:
- Extract generic type from `Massage` parameter, so now

```
m1(Message<String> message);
m2(String payload);
```

are equal by `payload type` and similar POJO causes ambiguity configuration exception
