### PR TITLE
INT-3204 RemoteFileTemplate Phase II

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/InputStreamCallback.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/InputStreamCallback.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.file.remote;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * @author Gary Russell
+ * @since 3.0
+ *
+ */
+public interface InputStreamCallback {
+
+	void doInSession(InputStream stream) throws IOException;
+
+}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/InputStreamCallback.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/InputStreamCallback.java
@@ -19,12 +19,22 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
+ * Callback for stream-based file retrieval using a RemoteFileOperations.
+ *
  * @author Gary Russell
  * @since 3.0
  *
  */
 public interface InputStreamCallback {
 
-	void doInSession(InputStream stream) throws IOException;
+	/**
+	 * Called with the InputStream for the remote file. The caller will
+	 * take care of closing the stream and finalizing the file retrieval operation after
+	 * this method exits.
+	 *
+	 * @param stream The InputStream.
+	 * @throws IOException
+	 */
+	void doWithInputStream(InputStream stream) throws IOException;
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileOperations.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileOperations.java
@@ -35,6 +35,30 @@ public interface RemoteFileOperations<F> {
 	void send(Message<?> message);
 
 	/**
+	 * Retrieve a remote file as an InputStream, based on information in a message.
+	 *
+	 * @param callback the callback.
+	 * @return true if the operation was successful.
+	 */
+	boolean get(Message<?> message, InputStreamCallback callback);
+
+	/**
+	 * Remove a remote file.
+	 *
+	 * @param path The full path to the file.
+	 * @return true when successful
+	 */
+	boolean remove(String path);
+
+	/**
+	 * Rename a remote file, creating directories if needed.
+	 *
+	 * @param fromPath The current path.
+	 * @param toPath The new path.
+	 */
+	void rename(String fromPath, String toPath);
+
+	/**
 	 * Execute the callback's doInSession method after obtaining a session.
 	 * Reliably closes the session when the method exits.
 	 *

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/SessionCallback.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/SessionCallback.java
@@ -15,32 +15,17 @@
  */
 package org.springframework.integration.file.remote;
 
-import org.springframework.integration.Message;
+import java.io.IOException;
+
+import org.springframework.integration.file.remote.session.Session;
 
 /**
- * Strategy for performing operations on remote files.
- *
  * @author Gary Russell
  * @since 3.0
  *
  */
-public interface RemoteFileOperations<F> {
+public interface SessionCallback<F, T> {
 
-	/**
-	 * Send a file to a remote server, based on information in a message.
-	 *
-	 * @param message The message
-	 * @throws Exception
-	 */
-	void send(Message<?> message);
-
-	/**
-	 * Execute the callback's doInSession method after obtaining a session.
-	 * Reliably closes the session when the method exits.
-	 *
-	 * @param callback the SessionCallback.
-	 * @return The result of the callback method.
-	 */
-	<T> T execute(SessionCallback<F, T> callback);
+	T doInSession(Session<F> session) throws IOException;
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/SessionCallbackWithoutResult.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/SessionCallbackWithoutResult.java
@@ -20,14 +20,20 @@ import java.io.IOException;
 import org.springframework.integration.file.remote.session.Session;
 
 /**
- * Callback invoked by {@code RemoteFileOperations.execute()) - allows multiple operations
- * on a session.
+ * Simple convenience implementation of {@link SessionCallback} for cases where
+ * no result is returned.
  *
  * @author Gary Russell
  * @since 3.0
  *
  */
-public interface SessionCallback<F, T> {
+public abstract class SessionCallbackWithoutResult<F> implements SessionCallback<F, Object> {
+
+	@Override
+	public Object doInSession(Session<F> session) throws IOException {
+		this.doInSessionWithoutResult(session);
+		return null;
+	}
 
 	/**
 	 * Called within the context of a session.
@@ -35,9 +41,8 @@ public interface SessionCallback<F, T> {
 	 * care of closing the session after this method exits.
 	 *
 	 * @param session The session.
-	 * @return The result of type T.
 	 * @throws IOException
 	 */
-	T doInSession(Session<F> session) throws IOException;
+	protected abstract void doInSessionWithoutResult(Session<F> session) throws IOException;
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -34,6 +34,8 @@ import org.springframework.expression.Expression;
 import org.springframework.integration.MessagingException;
 import org.springframework.integration.expression.IntegrationEvaluationContextAware;
 import org.springframework.integration.file.filters.FileListFilter;
+import org.springframework.integration.file.remote.RemoteFileTemplate;
+import org.springframework.integration.file.remote.SessionCallback;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.util.Assert;
@@ -59,6 +61,8 @@ public abstract class AbstractInboundFileSynchronizer<F> implements InboundFileS
 
 	protected final Log logger = LogFactory.getLog(this.getClass());
 
+	private final RemoteFileTemplate<F> remoteFileTemplate;
+
 	private volatile EvaluationContext evaluationContext;
 
 	private volatile String remoteFileSeparator = "/";
@@ -74,11 +78,6 @@ public abstract class AbstractInboundFileSynchronizer<F> implements InboundFileS
 	 * the path on the remote mount as a String.
 	 */
 	private volatile String remoteDirectory;
-
-	/**
-	 * the {@link SessionFactory} for acquiring remote file Sessions.
-	 */
-	private final SessionFactory<F> sessionFactory;
 
 	/**
 	 * An {@link FileListFilter} that runs against the <em>remote</em> file system view.
@@ -102,7 +101,7 @@ public abstract class AbstractInboundFileSynchronizer<F> implements InboundFileS
 	 */
 	public AbstractInboundFileSynchronizer(SessionFactory<F> sessionFactory) {
 		Assert.notNull(sessionFactory, "sessionFactory must not be null");
-		this.sessionFactory = sessionFactory;
+		this.remoteFileTemplate = new RemoteFileTemplate<F>(sessionFactory);
 	}
 
 
@@ -144,6 +143,7 @@ public abstract class AbstractInboundFileSynchronizer<F> implements InboundFileS
 		this.evaluationContext = evaluationContext;
 	}
 
+	@Override
 	public final void afterPropertiesSet() {
 		Assert.notNull(this.remoteDirectory, "remoteDirectory must not be null");
 		Assert.notNull(this.evaluationContext, "evaluationContext must not be null");
@@ -157,35 +157,36 @@ public abstract class AbstractInboundFileSynchronizer<F> implements InboundFileS
 		return temporaryFileSuffix;
 	}
 
-	public void synchronizeToLocalDirectory(File localDirectory) {
-		Session<F> session = null;
+	@Override
+	public void synchronizeToLocalDirectory(final File localDirectory) {
 		try {
-			session = this.sessionFactory.getSession();
-			Assert.notNull(session, "failed to acquire a Session");
-			F[] files = session.list(this.remoteDirectory);
-			if (!ObjectUtils.isEmpty(files)) {
-				Collection<F> filteredFiles = this.filterFiles(files);
-				for (F file : filteredFiles) {
-					if (file != null) {
-						this.copyFileToLocalDirectory(this.remoteDirectory, file, localDirectory, session);
+			int transferred = this.remoteFileTemplate.execute(new SessionCallback<F, Integer>() {
+
+				@Override
+				public Integer doInSession(Session<F> session) throws IOException {
+					F[] files = session.list(AbstractInboundFileSynchronizer.this.remoteDirectory);
+					if (!ObjectUtils.isEmpty(files)) {
+						Collection<F> filteredFiles = AbstractInboundFileSynchronizer.this.filterFiles(files);
+						for (F file : filteredFiles) {
+							if (file != null) {
+								AbstractInboundFileSynchronizer.this.copyFileToLocalDirectory(
+										AbstractInboundFileSynchronizer.this.remoteDirectory, file, localDirectory,
+										session);
+							}
+						}
+						return filteredFiles.size();
+					}
+					else {
+						return 0;
 					}
 				}
+			});
+			if (logger.isDebugEnabled()) {
+				logger.debug(transferred + " files transferred");
 			}
 		}
-		catch (IOException e) {
+		catch (Exception e) {
 			throw new MessagingException("Problem occurred while synchronizing remote to local directory", e);
-		}
-		finally {
-			if (session != null) {
-				try {
-					session.close();
-				}
-				catch (Exception ignored) {
-					if (logger.isDebugEnabled()) {
-						logger.debug("failed to close Session", ignored);
-					}
-				}
-			}
 		}
 	}
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParserTests.java
@@ -84,7 +84,7 @@ public class FtpInboundChannelAdapterParserTests {
 		assertEquals("", remoteFileSeparator);
 		FtpSimplePatternFileListFilter filter = (FtpSimplePatternFileListFilter) TestUtils.getPropertyValue(fisync, "filter");
 		assertNotNull(filter);
-		Object sessionFactory = TestUtils.getPropertyValue(fisync, "sessionFactory");
+		Object sessionFactory = TestUtils.getPropertyValue(fisync, "remoteFileTemplate.sessionFactory");
 		assertTrue(DefaultFtpSessionFactory.class.isAssignableFrom(sessionFactory.getClass()));
 		FileListFilter<?> acceptAllFilter = ac.getBean("acceptAllFilter", FileListFilter.class);
 		assertTrue(TestUtils.getPropertyValue(inbound, "fileSource.scanner.filter.fileFilters", Collection.class).contains(acceptAllFilter));
@@ -107,7 +107,7 @@ public class FtpInboundChannelAdapterParserTests {
 		ApplicationContext ac = new ClassPathXmlApplicationContext(
 				"FtpInboundChannelAdapterParserTests-context.xml", this.getClass());
 		SourcePollingChannelAdapter adapter = ac.getBean("simpleAdapterWithCachedSessions", SourcePollingChannelAdapter.class);
-		Object sessionFactory = TestUtils.getPropertyValue(adapter, "source.synchronizer.sessionFactory");
+		Object sessionFactory = TestUtils.getPropertyValue(adapter, "source.synchronizer.remoteFileTemplate.sessionFactory");
 		assertEquals(CachingSessionFactory.class, sessionFactory.getClass());
 		FtpInboundFileSynchronizer fisync =
 			TestUtils.getPropertyValue(adapter, "source.synchronizer", FtpInboundFileSynchronizer.class);
@@ -142,6 +142,7 @@ public class FtpInboundChannelAdapterParserTests {
 
 	public static class TestSessionFactoryBean implements FactoryBean<DefaultFtpSessionFactory> {
 
+		@Override
 		@SuppressWarnings({ "rawtypes", "unchecked" })
 		public DefaultFtpSessionFactory getObject() throws Exception {
 			DefaultFtpSessionFactory factory = mock(DefaultFtpSessionFactory.class);
@@ -150,10 +151,12 @@ public class FtpInboundChannelAdapterParserTests {
 			return factory;
 		}
 
+		@Override
 		public Class<?> getObjectType() {
 			return DefaultFtpSessionFactory.class;
 		}
 
+		@Override
 		public boolean isSingleton() {
 			return true;
 		}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.lang.reflect.Method;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -75,7 +74,7 @@ public class FtpOutboundGatewayParserTests {
 		FtpOutboundGateway gateway = TestUtils.getPropertyValue(gateway1,
 				"handler", FtpOutboundGateway.class);
 		assertEquals("X", TestUtils.getPropertyValue(gateway, "remoteFileSeparator"));
-		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
+		assertNotNull(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
 		assertEquals("local-test-dir", TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
@@ -97,8 +96,8 @@ public class FtpOutboundGatewayParserTests {
 		FtpOutboundGateway gateway = TestUtils.getPropertyValue(gateway2,
 				"handler", FtpOutboundGateway.class);
 		assertEquals("X", TestUtils.getPropertyValue(gateway, "remoteFileSeparator"));
-		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
-		assertTrue(TestUtils.getPropertyValue(gateway, "sessionFactory") instanceof CachingSessionFactory);
+		assertNotNull(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory"));
+		assertTrue(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory") instanceof CachingSessionFactory);
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
 		assertEquals("local-test-dir", TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
@@ -130,7 +129,7 @@ public class FtpOutboundGatewayParserTests {
 	public void testGatewayMv() {
 		FtpOutboundGateway gateway = TestUtils.getPropertyValue(gateway3,
 				"handler", FtpOutboundGateway.class);
-		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
+		assertNotNull(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
 		assertEquals(Command.MV, TestUtils.getPropertyValue(gateway, "command"));
 		assertEquals("'foo'", TestUtils.getPropertyValue(gateway, "renameProcessor.expression.expression"));

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -52,6 +52,8 @@ import org.springframework.util.FileCopyUtils;
 
 /**
  * @author Artem Bilan
+ * @author Gary Russell
+ *
  * @since 3.0
  */
 @ContextConfiguration
@@ -208,7 +210,7 @@ public class FtpServerOutboundTests {
 		assertTrue(template.get(new GenericMessage<String>("ftpSource/ftpSource1.txt"), new InputStreamCallback() {
 
 			@Override
-			public void doInSession(InputStream stream) throws IOException {
+			public void doWithInputStream(InputStream stream) throws IOException {
 				FileCopyUtils.copy(stream, baos1);
 			}
 		}));
@@ -218,7 +220,7 @@ public class FtpServerOutboundTests {
 		assertTrue(template.get(new GenericMessage<String>("ftpSource/ftpSource2.txt"), new InputStreamCallback() {
 
 			@Override
-			public void doInSession(InputStream stream) throws IOException {
+			public void doWithInputStream(InputStream stream) throws IOException {
 				FileCopyUtils.copy(stream, baos2);
 			}
 		}));

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserCachingTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserCachingTests.java
@@ -46,7 +46,7 @@ public class InboundChannelAdapterParserCachingTests {
 
 	@Test
 	public void cachingAdapter() {
-		Object sessionFactory = TestUtils.getPropertyValue(cachingAdapter, "source.synchronizer.sessionFactory");
+		Object sessionFactory = TestUtils.getPropertyValue(cachingAdapter, "source.synchronizer.remoteFileTemplate.sessionFactory");
 		assertEquals(CachingSessionFactory.class, sessionFactory.getClass());
 		Properties sessionConfig = TestUtils.getPropertyValue(sessionFactory, "sessionFactory.sessionConfig", Properties.class);
 		assertNotNull(sessionConfig);
@@ -55,7 +55,7 @@ public class InboundChannelAdapterParserCachingTests {
 
 	@Test
 	public void nonCachingAdapter() {
-		Object sessionFactory = TestUtils.getPropertyValue(nonCachingAdapter, "source.synchronizer.sessionFactory");
+		Object sessionFactory = TestUtils.getPropertyValue(nonCachingAdapter, "source.synchronizer.remoteFileTemplate.sessionFactory");
 		assertEquals(DefaultSftpSessionFactory.class, sessionFactory.getClass());
 	}
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.lang.reflect.Method;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -73,7 +72,7 @@ public class SftpOutboundGatewayParserTests {
 		SftpOutboundGateway gateway = TestUtils.getPropertyValue(gateway1,
 				"handler", SftpOutboundGateway.class);
 		assertEquals("X", TestUtils.getPropertyValue(gateway, "remoteFileSeparator"));
-		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
+		assertNotNull(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
 		assertEquals("local-test-dir", TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
@@ -94,8 +93,8 @@ public class SftpOutboundGatewayParserTests {
 		SftpOutboundGateway gateway = TestUtils.getPropertyValue(gateway2,
 				"handler", SftpOutboundGateway.class);
 		assertEquals("X", TestUtils.getPropertyValue(gateway, "remoteFileSeparator"));
-		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
-		assertTrue(TestUtils.getPropertyValue(gateway, "sessionFactory") instanceof CachingSessionFactory);
+		assertNotNull(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory"));
+		assertTrue(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory") instanceof CachingSessionFactory);
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
 		assertEquals("local-test-dir", TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"));
 		assertFalse((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory"));
@@ -125,7 +124,7 @@ public class SftpOutboundGatewayParserTests {
 	public void testGatewayMv() {
 		SftpOutboundGateway gateway = TestUtils.getPropertyValue(gateway3,
 				"handler", SftpOutboundGateway.class);
-		assertNotNull(TestUtils.getPropertyValue(gateway, "sessionFactory"));
+		assertNotNull(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory"));
 		assertNotNull(TestUtils.getPropertyValue(gateway, "outputChannel"));
 		assertEquals(Command.MV, TestUtils.getPropertyValue(gateway, "command"));
 		assertEquals("'foo'", TestUtils.getPropertyValue(gateway, "renameProcessor.expression.expression"));


### PR DESCRIPTION
Inbound synchronizer, outbound gateway.

Note: most gateway functions use template.execute() because they do multiple operations on a session.
