### PR TITLE
INT-3209 DefaultFileNameGenerator - SpEL Parsing

### DIFF
--- a/spring-integration-file/src/test/java/org/springframework/integration/file/DefaultFileNameGeneratorTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/DefaultFileNameGeneratorTests.java
@@ -123,6 +123,17 @@ public class DefaultFileNameGeneratorTests {
 	}
 
 	@Test
+	public void customExpressionTakesPrecedenceOverFilePayload() {
+		DefaultFileNameGenerator generator = new DefaultFileNameGenerator();
+		generator.setBeanFactory(mock(BeanFactory.class));
+		generator.setExpression("'foobar'");
+		File payload = new File("/some/path/ignore");
+		Message<?> message = MessageBuilder.withPayload(payload).build();
+		String filename = generator.generateFileName(message);
+		assertEquals("foobar", filename);
+	}
+
+	@Test
 	public void customHeaderNameTakesPrecedenceOverDefault() {
 		DefaultFileNameGenerator generator = new DefaultFileNameGenerator();
 		generator.setBeanFactory(mock(BeanFactory.class));

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests.java
@@ -106,9 +106,9 @@ public class FileOutboundChannelAdapterParserTests {
 		assertThat(actual, is(expected));
 		DefaultFileNameGenerator fileNameGenerator = (DefaultFileNameGenerator) handlerAccessor.getPropertyValue("fileNameGenerator");
 		assertNotNull(fileNameGenerator);
-		String expression = (String) TestUtils.getPropertyValue(fileNameGenerator, "expression");
+		Expression expression = TestUtils.getPropertyValue(fileNameGenerator, "expression", Expression.class);
 		assertNotNull(expression);
-		assertEquals("'foo.txt'", expression);
+		assertEquals("'foo.txt'", expression.getExpressionString());
 		assertEquals(Boolean.FALSE, handlerAccessor.getPropertyValue("deleteSourceFiles"));
 	}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests.java
@@ -26,6 +26,7 @@ import java.io.File;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -93,9 +94,9 @@ public class FileOutboundGatewayParserTests {
 		assertEquals(Boolean.TRUE, handlerAccessor.getPropertyValue("requiresReply"));
 		DefaultFileNameGenerator fileNameGenerator = (DefaultFileNameGenerator) handlerAccessor.getPropertyValue("fileNameGenerator");
 		assertNotNull(fileNameGenerator);
-		String expression = (String) TestUtils.getPropertyValue(fileNameGenerator, "expression");
+		Expression expression = TestUtils.getPropertyValue(fileNameGenerator, "expression", Expression.class);
 		assertNotNull(expression);
-		assertEquals("'foo.txt'", expression);
+		assertEquals("'foo.txt'", expression.getExpressionString());
 
 		Long sendTimeout = TestUtils.getPropertyValue(handler, "messagingTemplate.sendTimeout", Long.class);
 		assertEquals(Long.valueOf(777), sendTimeout);

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
@@ -105,8 +105,9 @@ public class OutboundChannelAdapterParserTests {
 		assertNotNull(remoteDirectoryExpression);
 		assertEquals("'foo' + '/' + 'bar'", remoteDirectoryExpression.getExpressionString());
 		FileNameGenerator generator = (FileNameGenerator) TestUtils.getPropertyValue(handler, "remoteFileTemplate.fileNameGenerator");
-		String fileNameGeneratorExpression = (String) TestUtils.getPropertyValue(generator, "expression");
-		assertEquals("payload.getName() + '-foo'", fileNameGeneratorExpression);
+		Expression fileNameGeneratorExpression = TestUtils.getPropertyValue(generator, "expression", Expression.class);
+		assertNotNull(fileNameGeneratorExpression);
+		assertEquals("payload.getName() + '-foo'", fileNameGeneratorExpression.getExpressionString());
 		assertEquals("UTF-8", TestUtils.getPropertyValue(handler, "remoteFileTemplate.charset"));
 		assertNull(TestUtils.getPropertyValue(handler, "remoteFileTemplate.temporaryDirectoryExpressionProcessor"));
 


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3209

Previously, the DefaultFileNameGenerator re-parsed the
SpEL expression for every message.

Compile the SpEL once (and if it is changed).

Change unit tests to match changes.
