### PR TITLE
INT-3232: RedisQMDE: Polish log Exceptions

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
@@ -178,9 +178,14 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport impl
 			value = this.boundListOperations.rightPop(this.receiveTimeout, TimeUnit.MILLISECONDS);
 		}
 		catch (Exception e) {
-			logger.error("Failed to execute listening task. Will attempt to resubmit in " + this.recoveryInterval + " milliseconds.", e);
 			this.listening = false;
-			this.sleepBeforeRecoveryAttempt();
+			if (this.active) {
+				logger.error("Failed to execute listening task. Will attempt to resubmit in " + this.recoveryInterval + " milliseconds.", e);
+				this.sleepBeforeRecoveryAttempt();
+			}
+			else {
+				logger.debug("Failed to execute listening task. " + e.getClass() + ": " + e.getMessage());
+			}
 			this.publishException(e);
 			return;
 		}


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3232

Previously, in the `RedisQueueMessageDrivenEndpoint` all `Exceptions` on `rightPop` operation
were logged with `error` level independently of state of Endpoint.

Add `if...else` and log with `debug`, if Endpoint isn't active
