### PR TITLE
INT-3233 NIO, Windows 7 and Java 7/8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,9 +295,11 @@ project('spring-integration-http') {
 		compile ("net.java.dev.rome:rome:1.0.0", optional)
 		testCompile project(":spring-integration-test")
 
-		// suppress deprecation warnings (@SuppressWarnings("deprecation") is not enough for javac)
-		compileJava.options.compilerArgs = ["${xLintArg},-deprecation"]
 	}
+
+	// suppress deprecation warnings (@SuppressWarnings("deprecation") is not enough for javac)
+	compileJava.options.compilerArgs = ["${xLintArg},-deprecation"]
+
 }
 
 project('spring-integration-ip') {
@@ -308,6 +310,10 @@ project('spring-integration-ip') {
 		runtime project(":spring-integration-stream")
 		testCompile project(":spring-integration-test")
 	}
+
+	// suppress deprecation warnings (@SuppressWarnings("deprecation") is not enough for javac)
+	compileJava.options.compilerArgs = ["${xLintArg},-deprecation"]
+
 }
 
 project('spring-integration-jdbc') {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/AbstractInternetProtocolSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/AbstractInternetProtocolSendingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 
+import org.springframework.context.Lifecycle;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.util.Assert;
 
@@ -30,7 +31,8 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @since 2.0
  */
-public abstract class AbstractInternetProtocolSendingMessageHandler extends AbstractMessageHandler implements CommonSocketOptions {
+public abstract class AbstractInternetProtocolSendingMessageHandler extends AbstractMessageHandler implements CommonSocketOptions,
+		Lifecycle {
 
 	private final SocketAddress destinationAddress;
 
@@ -41,6 +43,8 @@ public abstract class AbstractInternetProtocolSendingMessageHandler extends Abst
 	private volatile int soSendBufferSize = -1;
 
 	private volatile int soTimeout = -1;
+
+	private volatile boolean running;
 
 	public AbstractInternetProtocolSendingMessageHandler(String host, int port) {
 		Assert.notNull(host, "host must not be null");
@@ -55,6 +59,7 @@ public abstract class AbstractInternetProtocolSendingMessageHandler extends Abst
 	 * @see DatagramSocket#setSoTimeout(int)
 	 * @param timeout
 	 */
+	@Override
 	public void setSoTimeout(int timeout) {
 		this.soTimeout = timeout;
 	}
@@ -64,6 +69,7 @@ public abstract class AbstractInternetProtocolSendingMessageHandler extends Abst
 	 * @see DatagramSocket#setReceiveBufferSize(int)
 	 * @param size
 	 */
+	@Override
 	public void setSoReceiveBufferSize(int size) {
 	}
 
@@ -72,6 +78,7 @@ public abstract class AbstractInternetProtocolSendingMessageHandler extends Abst
 	 * @see DatagramSocket#setSendBufferSize(int)
 	 * @param size
 	 */
+	@Override
 	public void setSoSendBufferSize(int size) {
 		this.soSendBufferSize = size;
 	}
@@ -114,5 +121,32 @@ public abstract class AbstractInternetProtocolSendingMessageHandler extends Abst
 	public int getSoSendBufferSize() {
 		return soSendBufferSize;
 	}
+
+
+	@Override
+	public synchronized void start() {
+		if (!this.running) {
+			this.doStart();
+			this.running = true;
+		}
+	}
+
+	protected abstract void doStart();
+
+	@Override
+	public synchronized void stop() {
+		if (this.running) {
+			this.doStop();
+			this.running = false;
+		}
+	}
+
+	protected abstract void doStop();
+
+	@Override
+	public boolean isRunning() {
+		return this.running;
+	}
+
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -410,8 +410,10 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 	}
 
 	/**
-	 * Closes the server.
+	 * Closes the factory.
+	 * @deprecated As of 3.0; use {@link #stop()}.
 	 */
+	@Deprecated
 	public abstract void close();
 
 	@Override

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactory.java
@@ -44,6 +44,7 @@ public class CachingClientConnectionFactory extends AbstractClientConnectionFact
 		this.targetConnectionFactory = target;
 		pool = new SimplePool<TcpConnectionSupport>(poolSize, new SimplePool.PoolItemCallback<TcpConnectionSupport>() {
 
+			@Override
 			public TcpConnectionSupport createForPool() {
 				try {
 					return targetConnectionFactory.getConnection();
@@ -52,10 +53,12 @@ public class CachingClientConnectionFactory extends AbstractClientConnectionFact
 				}
 			}
 
+			@Override
 			public boolean isStale(TcpConnectionSupport connection) {
 				return !connection.isOpen();
 			}
 
+			@Override
 			public void removedFromPool(TcpConnectionSupport connection) {
 				connection.close();
 			}
@@ -167,6 +170,7 @@ public class CachingClientConnectionFactory extends AbstractClientConnectionFact
 		return targetConnectionFactory.isRunning();
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void close() {
 		targetConnectionFactory.close();
@@ -317,6 +321,7 @@ public class CachingClientConnectionFactory extends AbstractClientConnectionFact
 	public void registerListener(TcpListener listener) {
 		super.registerListener(listener);
 		targetConnectionFactory.registerListener(new TcpListener() {
+			@Override
 			public boolean onMessage(Message<?> message) {
 				if (!(message instanceof ErrorMessage)) {
 					throw new UnsupportedOperationException("This should never be called");

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
@@ -82,6 +82,7 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 		super.registerListener(listener);
 		for (AbstractClientConnectionFactory factory : this.factories) {
 			factory.registerListener(new TcpListener() {
+				@Override
 				public boolean onMessage(Message<?> message) {
 					if (!(message instanceof ErrorMessage)) {
 						throw new UnsupportedOperationException("This should never be called");
@@ -112,6 +113,7 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 		return failoverTcpConnection;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void close() {
 		for (AbstractClientConnectionFactory factory : this.factories) {
@@ -229,6 +231,7 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 			this.open = false;
 		}
 
+		@Override
 		public boolean isOpen() {
 			return this.open;
 		}
@@ -238,6 +241,7 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 		 * send to a new connection obtained from {@link #findAConnection()}.
 		 * If send fails on a connection from every factory, we give up.
 		 */
+		@Override
 		public synchronized void send(Message<?> message) throws Exception {
 			boolean success = false;
 			AbstractClientConnectionFactory lastFactoryToTry = this.currentFactory;
@@ -268,10 +272,12 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 			}
 		}
 
+		@Override
 		public Object getPayload() throws Exception {
 			return this.delegate.getPayload();
 		}
 
+		@Override
 		public void run() {
 			throw new UnsupportedOperationException("Not supported on FailoverTcpConnection");
 		}
@@ -286,10 +292,12 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 			return this.delegate.getHostAddress();
 		}
 
+		@Override
 		public int getPort() {
 			return this.delegate.getPort();
 		}
 
+		@Override
 		public Object getDeserializerStateKey() {
 			return this.delegate.getDeserializerStateKey();
 		}
@@ -350,6 +358,7 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 		 * the actual connectionId in another header for convenience and tracing
 		 * purposes.
 		 */
+		@Override
 		public boolean onMessage(Message<?> message) {
 			if (this.delegate.getConnectionId().equals(message.getHeaders().get(IpHeaders.CONNECTION_ID))) {
 				MessageBuilder<?> messageBuilder = MessageBuilder.fromMessage(message)

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
@@ -21,6 +21,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.CancelledKeyException;
 import java.nio.channels.ClosedChannelException;
+import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
@@ -114,7 +115,12 @@ public class TcpNioClientConnectionFactory extends
 	@Override
 	public void close() {
 		if (this.selector != null) {
-			this.selector.wakeup();
+			try {
+				this.selector.close();
+			}
+			catch (IOException e) {
+				logger.error("Error closing selector", e);
+			}
 		}
 	}
 
@@ -129,6 +135,7 @@ public class TcpNioClientConnectionFactory extends
 		super.start();
 	}
 
+	@Override
 	public void run() {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Read selector running for connections to " + this.getHost() + ":" + this.getPort());
@@ -141,23 +148,37 @@ public class TcpNioClientConnectionFactory extends
 				int selectionCount = 0;
 				try {
 					selectionCount = selector.select(soTimeout < 0 ? 0 : soTimeout);
-				} catch (CancelledKeyException cke) {
+				}
+				catch (CancelledKeyException cke) {
 					if (logger.isDebugEnabled()) {
 						logger.debug("CancelledKeyException during Selector.select()");
 					}
 				}
+				catch (ClosedSelectorException cse) {
+					throw cse;
+				}
 				while ((newChannel = newChannels.poll()) != null) {
 					try {
 						newChannel.register(this.selector, SelectionKey.OP_READ, channelMap.get(newChannel));
-					} catch (ClosedChannelException cce) {
+					}
+					catch (ClosedChannelException cce) {
 						if (logger.isDebugEnabled()) {
 							logger.debug("Channel closed before registering with selector for reading");
 						}
 					}
+					catch (ClosedSelectorException cse) {
+						throw cse;
+					}
 				}
 				this.processNioSelections(selectionCount, selector, null, this.channelMap);
 			}
-		} catch (Exception e) {
+		}
+		catch (ClosedSelectorException cse) {
+			if (this.isActive()) {
+				logger.error("Selector closed", cse);
+			}
+		}
+		catch (Exception e) {
 			logger.error("Exception in read selector thread", e);
 			this.setActive(false);
 		}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
@@ -112,6 +112,7 @@ public class TcpNioClientConnectionFactory extends
 		this.tcpNioConnectionSupport = tcpNioSupport;
 	}
 
+	@Deprecated
 	@Override
 	public void close() {
 		if (this.selector != null) {
@@ -154,9 +155,6 @@ public class TcpNioClientConnectionFactory extends
 						logger.debug("CancelledKeyException during Selector.select()");
 					}
 				}
-				catch (ClosedSelectorException cse) {
-					throw cse;
-				}
 				while ((newChannel = newChannels.poll()) != null) {
 					try {
 						newChannel.register(this.selector, SelectionKey.OP_READ, channelMap.get(newChannel));
@@ -165,9 +163,6 @@ public class TcpNioClientConnectionFactory extends
 						if (logger.isDebugEnabled()) {
 							logger.debug("Channel closed before registering with selector for reading");
 						}
-					}
-					catch (ClosedSelectorException cse) {
-						throw cse;
 					}
 				}
 				this.processNioSelections(selectionCount, selector, null, this.channelMap);

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastReceivingChannelAdapter.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastReceivingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,7 @@ public class UnicastReceivingChannelAdapter extends AbstractInternetProtocolRece
 	}
 
 
+	@Override
 	public void run() {
 		if (logger.isDebugEnabled()) {
 			logger.debug("UDP Receiver running on port:" + this.getPort());
@@ -90,7 +91,7 @@ public class UnicastReceivingChannelAdapter extends AbstractInternetProtocolRece
 				// continue
 			}
 			catch (SocketException e) {
-				doStop();
+				this.stop();
 			}
 			catch (Exception e) {
 				if (e instanceof MessagingException) {
@@ -133,6 +134,7 @@ public class UnicastReceivingChannelAdapter extends AbstractInternetProtocolRece
 
 	protected boolean asyncSendMessage(final DatagramPacket packet) {
 		this.getTaskExecutor().execute(new Runnable(){
+			@Override
 			public void run() {
 				Message<byte[]> message = null;
 				try {
@@ -222,6 +224,7 @@ public class UnicastReceivingChannelAdapter extends AbstractInternetProtocolRece
 		}
 	}
 
+	@Override
 	public void setSoSendBufferSize(int soSendBufferSize) {
 		this.soSendBufferSize = soSendBufferSize;
 	}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastSendingMessageHandler.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.springframework.context.Lifecycle;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageDeliveryException;
 import org.springframework.integration.MessageHandlingException;
@@ -53,7 +52,7 @@ import org.springframework.util.Assert;
  * @since 2.0
  */
 public class UnicastSendingMessageHandler extends
-		AbstractInternetProtocolSendingMessageHandler implements Runnable, Lifecycle {
+		AbstractInternetProtocolSendingMessageHandler implements Runnable {
 
 	private final DatagramPacketMessageMapper mapper = new DatagramPacketMessageMapper();
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastSendingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2011 the original author or authors.
+ * Copyright 2001-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,11 +26,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.springframework.context.Lifecycle;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageDeliveryException;
 import org.springframework.integration.MessageHandlingException;
@@ -51,7 +53,7 @@ import org.springframework.util.Assert;
  * @since 2.0
  */
 public class UnicastSendingMessageHandler extends
-		AbstractInternetProtocolSendingMessageHandler implements Runnable{
+		AbstractInternetProtocolSendingMessageHandler implements Runnable, Lifecycle {
 
 	private final DatagramPacketMessageMapper mapper = new DatagramPacketMessageMapper();
 
@@ -85,6 +87,8 @@ public class UnicastSendingMessageHandler extends
 	private volatile boolean ackThreadRunning;
 
 	private volatile Executor taskExecutor;
+
+	private volatile boolean taskExecutorSet;
 
 	/**
 	 * Basic constructor; no reliability; no acknowledgment.
@@ -167,12 +171,14 @@ public class UnicastSendingMessageHandler extends
 		}
 	}
 
-	public void onInit() {
+	@Override
+	public void doStart() {
 		if (this.acknowledge) {
 			if (this.taskExecutor == null) {
 				Executor executor = Executors
 						.newSingleThreadExecutor(new ThreadFactory() {
-							private AtomicInteger n = new AtomicInteger();
+							private final AtomicInteger n = new AtomicInteger();
+							@Override
 							public Thread newThread(Runnable runner) {
 								Thread thread = new Thread(runner);
 								thread.setName("UDP-Ack-Handler-" + n.getAndIncrement());
@@ -185,10 +191,21 @@ public class UnicastSendingMessageHandler extends
 		}
 	}
 
+	@Override
+	protected void doStop() {
+		this.closeSocketIfNeeded();
+		if (!this.taskExecutorSet && this.taskExecutor != null) {
+			((ExecutorService) this.taskExecutor).shutdown();
+			this.taskExecutor = null;
+		}
+	}
+
+	@Override
 	public void handleMessageInternal(Message<?> message)
 			throws MessageRejectedException, MessageHandlingException,
 			MessageDeliveryException {
 		if (this.acknowledge) {
+			Assert.state(this.isRunning(), "When 'acknowlege' is enabled, adapter must be running");
 			if (!this.ackThreadRunning) {
 				synchronized(this) {
 					if (!this.ackThreadRunning) {
@@ -294,6 +311,7 @@ public class UnicastSendingMessageHandler extends
 	/**
 	 * Process acknowledgments, if requested.
 	 */
+	@Override
 	public void run() {
 		try {
 			this.ackThreadRunning = true;
@@ -333,7 +351,15 @@ public class UnicastSendingMessageHandler extends
 		this.taskExecutor.execute(this);
 	}
 
+	/**
+	 * @deprecated Use stop() instead.
+	 */
+	@Deprecated
 	public void shutDown() {
+		this.stop();
+	}
+
+	private void closeSocketIfNeeded() {
 		if (socket != null) {
 			socket.close();
 			socket = null;
@@ -344,16 +370,20 @@ public class UnicastSendingMessageHandler extends
 	 * @see java.net.Socket#setReceiveBufferSize(int)
 	 * @see DatagramSocket#setReceiveBufferSize(int)
 	 */
+	@Override
 	public void setSoReceiveBufferSize(int size) {
 		this.soReceiveBufferSize = size;
 	}
 
+	@Override
 	public void setLocalAddress(String localAddress) {
 		this.localAddress = localAddress;
 	}
 
 	public void setTaskExecutor(Executor taskExecutor) {
+		Assert.notNull(taskExecutor, "'taskExecutor' cannot be null");
 		this.taskExecutor = taskExecutor;
+		this.taskExecutorSet = true;
 	}
 
 	/**
@@ -363,6 +393,7 @@ public class UnicastSendingMessageHandler extends
 		this.ackCounter = ackCounter;
 	}
 
+	@Override
 	public String getComponentType(){
 		return "ip:udp-outbound-channel-adapter";
 	}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,10 +86,13 @@ public class TcpOutboundGatewayTests {
 		AbstractConnectionFactory ccf = new TcpNetClientConnectionFactory("localhost", port);
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port, 100);
+					serverSocket.set(server);
 					latch.countDown();
 					List<Socket> sockets = new ArrayList<Socket>();
 					int i = 0;
@@ -101,7 +104,8 @@ public class TcpOutboundGatewayTests {
 						oos.writeObject("Reply" + (i++));
 						sockets.add(socket);
 					}
-				} catch (Exception e) {
+				}
+				catch (Exception e) {
 					if (!done.get()) {
 						e.printStackTrace();
 					}
@@ -141,6 +145,8 @@ public class TcpOutboundGatewayTests {
 		for (int i = 0; i < 100; i++) {
 			assertTrue(replies.remove("Reply" + i));
 		}
+		done.set(true);
+		serverSocket.get().close();
 	}
 
 	@Test
@@ -149,6 +155,7 @@ public class TcpOutboundGatewayTests {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port, 10);
@@ -202,6 +209,7 @@ public class TcpOutboundGatewayTests {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
@@ -240,6 +248,7 @@ public class TcpOutboundGatewayTests {
 		for (int i = 0; i < 2; i++) {
 			final int j = i;
 			results[j] = (Executors.newSingleThreadExecutor().submit(new Callable<Integer>(){
+				@Override
 				public Integer call() throws Exception {
 					gateway.handleMessage(MessageBuilder.withPayload("Test" + j).build());
 					return 0;
@@ -319,6 +328,7 @@ public class TcpOutboundGatewayTests {
 
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
 
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
@@ -368,6 +378,7 @@ public class TcpOutboundGatewayTests {
 		for (int i = 0; i < 2; i++) {
 			final int j = i;
 			results[j] = (Executors.newSingleThreadExecutor().submit(new Callable<Integer>() {
+				@Override
 				public Integer call() throws Exception {
 					// increase the timeout after the first send
 					if (j > 0) {
@@ -419,6 +430,7 @@ public class TcpOutboundGatewayTests {
 
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
 
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
@@ -498,6 +510,7 @@ public class TcpOutboundGatewayTests {
 
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
 
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
@@ -633,14 +646,13 @@ public class TcpOutboundGatewayTests {
 
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
 
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
 					latch.countDown();
-					int i = 0;
 					while (!done.get()) {
 						Socket socket = server.accept();
-						i++;
 						while (!socket.isClosed()) {
 							try {
 								ObjectInputStream ois = new ObjectInputStream(socket.getInputStream());

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryShutDownTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryShutDownTests.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
+
 import org.springframework.integration.MessagingException;
 import org.springframework.util.StopWatch;
 
@@ -36,13 +37,16 @@ public class ConnectionFactoryShutDownTests {
 	public void testShutdownDoesntDeadlock() throws Exception {
 		final AbstractConnectionFactory factory = new AbstractConnectionFactory(0) {
 
+			@Override
 			public TcpConnection getConnection() throws Exception {
 				return null;
 			}
 
 			@Override
+			@Deprecated
 			public void close() {
 			}
+
 		};
 		factory.setActive(true);
 		Executor executor = factory.getTaskExecutor();
@@ -50,6 +54,7 @@ public class ConnectionFactoryShutDownTests {
 		final CountDownLatch latch2 = new CountDownLatch(1);
 		executor.execute(new Runnable() {
 
+			@Override
 			public void run() {
 				latch1.countDown();
 				try {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
@@ -20,9 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
 import java.net.Socket;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -69,9 +67,6 @@ public class TcpNioConnectionReadTests {
 		return scf;
 	}
 
-	/**
-	 * Test method for {@link org.springframework.integration.ip.tcp.NioSocketReader}.
-	 */
 	@Test
 	public void testReadLength() throws Exception {
 		int port = SocketUtils.findAvailableServerSocket();
@@ -98,7 +93,7 @@ public class TcpNioConnectionReadTests {
 				new String((byte[]) responses.get(0).getPayload()));
 		assertEquals("Data", SocketTestUtils.TEST_STRING + SocketTestUtils.TEST_STRING,
 		         new String((byte[]) responses.get(1).getPayload()));
-		scf.close();
+		scf.stop();
 		done.countDown();
 	}
 
@@ -117,7 +112,10 @@ public class TcpNioConnectionReadTests {
 				responses.add(message);
 				try {
 					Thread.sleep(1000);
-				} catch (InterruptedException e) { }
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
 				semaphore.release();
 				return false;
 			}
@@ -133,13 +131,10 @@ public class TcpNioConnectionReadTests {
 			assertEquals("Data", "xx",
 				new String(((Message<byte[]>) responses.get(0)).getPayload()));
 		}
-		scf.close();
+		scf.stop();
 		done.countDown();
 	}
 
-	/**
-	 * Test method for {@link org.springframework.integration.ip.tcp.NioSocketReader}.
-	 */
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testReadStxEtx() throws Exception {
@@ -167,7 +162,7 @@ public class TcpNioConnectionReadTests {
 						         new String(((Message<byte[]>) responses.get(0)).getPayload()));
 		assertEquals("Data", SocketTestUtils.TEST_STRING + SocketTestUtils.TEST_STRING,
 		         new String(((Message<byte[]>) responses.get(1)).getPayload()));
-		scf.close();
+		scf.stop();
 		done.countDown();
 	}
 
@@ -201,25 +196,20 @@ public class TcpNioConnectionReadTests {
 						         new String(((Message<byte[]>) responses.get(0)).getPayload()));
 		assertEquals("Data", SocketTestUtils.TEST_STRING + SocketTestUtils.TEST_STRING,
 		         new String(((Message<byte[]>) responses.get(1)).getPayload()));
-		scf.close();
+		scf.stop();
 		done.countDown();
 	}
 
-	/**
-	 * Test method for {@link org.springframework.integration.ip.tcp.NioSocketReader}.
-	 */
 	@Test
 	public void testReadLengthOverflow() throws Exception {
 		int port = SocketUtils.findAvailableServerSocket();
 		ByteArrayLengthHeaderSerializer serializer = new ByteArrayLengthHeaderSerializer();
-		final List<Message<?>> responses = new ArrayList<Message<?>>();
 		final Semaphore semaphore = new Semaphore(0);
 		final List<TcpConnection> added = new ArrayList<TcpConnection>();
 		final List<TcpConnection> removed = new ArrayList<TcpConnection>();
 		AbstractServerConnectionFactory scf = getConnectionFactory(port, serializer,new TcpListener() {
 			@Override
 			public boolean onMessage(Message<?> message) {
-				responses.add(message);
 				semaphore.release();
 				return false;
 			}
@@ -243,26 +233,21 @@ public class TcpNioConnectionReadTests {
 		assertEquals(1, added.size());
 		assertTrue(semaphore.tryAcquire(10000, TimeUnit.MILLISECONDS));
 		assertTrue(removed.size() > 0);
-		scf.close();
+		scf.stop();
 		done.countDown();
 	}
 
-	/**
-	 * Test method for {@link org.springframework.integration.ip.tcp.NioSocketReader}.
-	 */
 	@Test
 	public void testReadStxEtxOverflow() throws Exception {
 		int port = SocketUtils.findAvailableServerSocket();
 		ByteArrayStxEtxSerializer serializer = new ByteArrayStxEtxSerializer();
 		serializer.setMaxMessageSize(1024);
-		final List<Message<?>> responses = new ArrayList<Message<?>>();
 		final Semaphore semaphore = new Semaphore(0);
 		final List<TcpConnection> added = new ArrayList<TcpConnection>();
 		final List<TcpConnection> removed = new ArrayList<TcpConnection>();
 		AbstractServerConnectionFactory scf = getConnectionFactory(port, serializer,new TcpListener() {
 			@Override
 			public boolean onMessage(Message<?> message) {
-				responses.add(message);
 				semaphore.release();
 				return false;
 			}
@@ -286,26 +271,21 @@ public class TcpNioConnectionReadTests {
 		assertEquals(1, added.size());
 		assertTrue(semaphore.tryAcquire(10000, TimeUnit.MILLISECONDS));
 		assertTrue(removed.size() > 0);
-		scf.close();
+		scf.stop();
 		done.countDown();
 	}
 
-	/**
-	 * Test method for {@link org.springframework.integration.ip.tcp.NioSocketReader}.
-	 */
 	@Test
 	public void testReadCrLfOverflow() throws Exception {
 		int port = SocketUtils.findAvailableServerSocket();
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		serializer.setMaxMessageSize(1024);
-		final List<Message<?>> responses = new ArrayList<Message<?>>();
 		final Semaphore semaphore = new Semaphore(0);
 		final List<TcpConnection> added = new ArrayList<TcpConnection>();
 		final List<TcpConnection> removed = new ArrayList<TcpConnection>();
 		AbstractServerConnectionFactory scf = getConnectionFactory(port, serializer,new TcpListener() {
 			@Override
 			public boolean onMessage(Message<?> message) {
-				responses.add(message);
 				semaphore.release();
 				return false;
 			}
@@ -329,7 +309,7 @@ public class TcpNioConnectionReadTests {
 		assertEquals(1, added.size());
 		assertTrue(semaphore.tryAcquire(10000, TimeUnit.MILLISECONDS));
 		assertTrue(removed.size() > 0);
-		scf.close();
+		scf.stop();
 		done.countDown();
 	}
 
@@ -343,14 +323,12 @@ public class TcpNioConnectionReadTests {
 		int port = SocketUtils.findAvailableServerSocket();
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		serializer.setMaxMessageSize(1024);
-		final List<Message<?>> responses = new ArrayList<Message<?>>();
 		final Semaphore semaphore = new Semaphore(0);
 		final List<TcpConnection> added = new ArrayList<TcpConnection>();
 		final List<TcpConnection> removed = new ArrayList<TcpConnection>();
 		AbstractServerConnectionFactory scf = getConnectionFactory(port, serializer,new TcpListener() {
 			@Override
 			public boolean onMessage(Message<?> message) {
-				responses.add(message);
 				semaphore.release();
 				return false;
 			}
@@ -372,7 +350,7 @@ public class TcpNioConnectionReadTests {
 		assertEquals(1, added.size());
 		assertTrue(semaphore.tryAcquire(10000, TimeUnit.MILLISECONDS));
 		assertTrue(removed.size() > 0);
-		scf.close();
+		scf.stop();
 	}
 
 	/**
@@ -385,14 +363,12 @@ public class TcpNioConnectionReadTests {
 		int port = SocketUtils.findAvailableServerSocket();
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		serializer.setMaxMessageSize(1024);
-		final List<Message<?>> responses = new ArrayList<Message<?>>();
 		final Semaphore semaphore = new Semaphore(0);
 		final List<TcpConnection> added = new ArrayList<TcpConnection>();
 		final List<TcpConnection> removed = new ArrayList<TcpConnection>();
 		AbstractServerConnectionFactory scf = getConnectionFactory(port, serializer,new TcpListener() {
 			@Override
 			public boolean onMessage(Message<?> message) {
-				responses.add(message);
 				semaphore.release();
 				return false;
 			}
@@ -415,7 +391,7 @@ public class TcpNioConnectionReadTests {
 		assertEquals(1, added.size());
 		assertTrue(semaphore.tryAcquire(10000, TimeUnit.MILLISECONDS));
 		assertTrue(removed.size() > 0);
-		scf.close();
+		scf.stop();
 	}
 
 	/**
@@ -454,8 +430,7 @@ public class TcpNioConnectionReadTests {
 	}
 
 	private void testClosureMidMessageGuts(AbstractByteArraySerializer serializer, String shortMessage)
-			throws Exception, IOException, UnknownHostException,
-			InterruptedException {
+			throws Exception {
 		final int port = SocketUtils.findAvailableServerSocket();
 		final List<Message<?>> responses = new ArrayList<Message<?>>();
 		final Semaphore semaphore = new Semaphore(0);
@@ -486,7 +461,7 @@ public class TcpNioConnectionReadTests {
 		assertEquals(1, added.size());
 		assertTrue(semaphore.tryAcquire(10000, TimeUnit.MILLISECONDS));
 		assertTrue(removed.size() > 0);
-		scf.close();
+		scf.stop();
 	}
 
 	private void whileOpen(Semaphore semaphore, final List<TcpConnection> added)

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -50,6 +50,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
 import javax.net.ServerSocketFactory;
 
 import org.junit.Test;
@@ -81,6 +82,7 @@ import org.springframework.util.ReflectionUtils.FieldFilter;
 public class TcpNioConnectionTests {
 
 	private final ApplicationEventPublisher nullPublisher = new ApplicationEventPublisher() {
+		@Override
 		public void publishEvent(ApplicationEvent event) {
 		}
 	};
@@ -92,7 +94,9 @@ public class TcpNioConnectionTests {
 		factory.setSoTimeout(1000);
 		factory.start();
 		final CountDownLatch latch = new CountDownLatch(1);
+		final CountDownLatch done = new CountDownLatch(1);
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
+			@Override
 			@SuppressWarnings("unused")
 			public void run() {
 				try {
@@ -100,8 +104,9 @@ public class TcpNioConnectionTests {
 					latch.countDown();
 					Socket s = server.accept();
 					// block so we fill the buffer
-					server.accept();
-				} catch (Exception e) {
+					done.await(10, TimeUnit.SECONDS);
+				}
+				catch (Exception e) {
 					e.printStackTrace();
 				}
 			}
@@ -110,10 +115,12 @@ public class TcpNioConnectionTests {
 		try {
 			TcpConnection connection = factory.getConnection();
 			connection.send(MessageBuilder.withPayload(new byte[1000000]).build());
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			assertTrue("Expected SocketTimeoutException, got " + e.getClass().getSimpleName() +
 					   ":" + e.getMessage(), e instanceof SocketTimeoutException);
 		}
+		done.countDown();
 	}
 
 	@Test
@@ -123,7 +130,9 @@ public class TcpNioConnectionTests {
 		factory.setSoTimeout(1000);
 		factory.start();
 		final CountDownLatch latch = new CountDownLatch(1);
+		final CountDownLatch done = new CountDownLatch(1);
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
@@ -132,8 +141,9 @@ public class TcpNioConnectionTests {
 					byte[] b = new byte[6];
 					readFully(socket.getInputStream(), b);
 					// block to cause timeout on read.
-					server.accept();
-				} catch (Exception e) {
+					done.await(10, TimeUnit.SECONDS);
+				}
+				catch (Exception e) {
 					e.printStackTrace();
 				}
 			}
@@ -150,9 +160,11 @@ public class TcpNioConnectionTests {
 				}
 			}
 			assertTrue(!connection.isOpen());
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			fail("Unexpected exception " + e);
 		}
+		done.countDown();
 	}
 
 	@Test
@@ -163,6 +175,7 @@ public class TcpNioConnectionTests {
 		factory.start();
 		final CountDownLatch latch = new CountDownLatch(1);
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
@@ -170,7 +183,8 @@ public class TcpNioConnectionTests {
 					Socket socket = server.accept();
 					byte[] b = new byte[6];
 					readFully(socket.getInputStream(), b);
-				} catch (Exception e) {
+				}
+				catch (Exception e) {
 					e.printStackTrace();
 				}
 			}
@@ -182,8 +196,7 @@ public class TcpNioConnectionTests {
 			assertEquals(1, connections.size());
 			connection.close();
 			assertTrue(!connection.isOpen());
-			// force a wakeup of the selector
-			factory.close();
+			TestUtils.getPropertyValue(factory, "selector", Selector.class).wakeup();
 			int n = 0;
 			while (connections.size() > 0) {
 				Thread.sleep(100);
@@ -192,7 +205,8 @@ public class TcpNioConnectionTests {
 				}
 			}
 			assertEquals(0, connections.size());
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			e.printStackTrace();
 			fail("Unexpected exception " + e);
 		}
@@ -216,6 +230,7 @@ public class TcpNioConnectionTests {
 		final List<Field> fields = new ArrayList<Field>();
 		ReflectionUtils.doWithFields(SocketChannel.class, new FieldCallback() {
 
+			@Override
 			public void doWith(Field field) throws IllegalArgumentException,
 					IllegalAccessException {
 				field.setAccessible(true);
@@ -223,6 +238,7 @@ public class TcpNioConnectionTests {
 			}
 		}, new FieldFilter() {
 
+			@Override
 			public boolean matches(Field field) {
 				return field.getName().equals("open");
 			}});
@@ -265,11 +281,13 @@ public class TcpNioConnectionTests {
 	public void testInsufficientThreads() throws Exception {
 		final ExecutorService exec = Executors.newFixedThreadPool(2);
 		Future<Object> future = exec.submit(new Callable<Object>() {
+			@Override
 			public Object call() throws Exception {
 				SocketChannel channel = mock(SocketChannel.class);
 				Socket socket = mock(Socket.class);
 				Mockito.when(channel.socket()).thenReturn(socket);
 				doAnswer(new Answer<Integer>() {
+					@Override
 					public Integer answer(InvocationOnMock invocation) throws Throwable {
 						ByteBuffer buffer = (ByteBuffer) invocation.getArguments()[0];
 						buffer.position(1);
@@ -311,11 +329,13 @@ public class TcpNioConnectionTests {
 		final ExecutorService exec = Executors.newFixedThreadPool(3);
 		final CountDownLatch messageLatch = new CountDownLatch(1);
 		Future<Object> future = exec.submit(new Callable<Object>() {
+			@Override
 			public Object call() throws Exception {
 				SocketChannel channel = mock(SocketChannel.class);
 				Socket socket = mock(Socket.class);
 				Mockito.when(channel.socket()).thenReturn(socket);
 				doAnswer(new Answer<Integer>() {
+					@Override
 					public Integer answer(InvocationOnMock invocation) throws Throwable {
 						ByteBuffer buffer = (ByteBuffer) invocation.getArguments()[0];
 						buffer.position(1025);
@@ -327,6 +347,7 @@ public class TcpNioConnectionTests {
 				final TcpNioConnection connection = new TcpNioConnection(channel, false, false, null, null);
 				connection.setTaskExecutor(exec);
 				connection.registerListener(new TcpListener(){
+					@Override
 					public boolean onMessage(Message<?> message) {
 						messageLatch.countDown();
 						return false;
@@ -438,6 +459,7 @@ public class TcpNioConnectionTests {
 		final byte[] out = new byte[4];
 		ExecutorService exec = Executors.newSingleThreadExecutor();
 		exec.execute(new Runnable(){
+			@Override
 			public void run() {
 				try {
 					stream.read(out);
@@ -468,6 +490,7 @@ public class TcpNioConnectionTests {
 		inboundConnection.setMapper(inMapper);
 		final ByteArrayOutputStream written = new ByteArrayOutputStream();
 		doAnswer(new Answer<Integer>() {
+			@Override
 			public Integer answer(InvocationOnMock invocation) throws Throwable {
 				ByteBuffer buff = (ByteBuffer) invocation.getArguments()[0];
 				byte[] bytes = written.toByteArray();
@@ -481,6 +504,7 @@ public class TcpNioConnectionTests {
 		when(outChannel.socket()).thenReturn(outSocket);
 		TcpNioConnection outboundConnection = new TcpNioConnection(outChannel, true, false, nullPublisher, null);
 		doAnswer(new Answer<Object>() {
+			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				ByteBuffer buff = (ByteBuffer) invocation.getArguments()[0];
 				byte[] bytes = new byte[buff.limit()];
@@ -505,6 +529,7 @@ public class TcpNioConnectionTests {
 		final CountDownLatch latch = new CountDownLatch(1);
 		TcpListener listener = new TcpListener() {
 
+			@Override
 			public boolean onMessage(Message<?> message) {
 				inboundMessage.set(message);
 				latch.countDown();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -95,12 +95,14 @@ public class TcpNioConnectionTests {
 		factory.start();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final CountDownLatch done = new CountDownLatch(1);
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
 			@Override
 			@SuppressWarnings("unused")
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+					serverSocket.set(server);
 					latch.countDown();
 					Socket s = server.accept();
 					// block so we fill the buffer
@@ -121,6 +123,7 @@ public class TcpNioConnectionTests {
 					   ":" + e.getMessage(), e instanceof SocketTimeoutException);
 		}
 		done.countDown();
+		serverSocket.get().close();
 	}
 
 	@Test
@@ -131,11 +134,13 @@ public class TcpNioConnectionTests {
 		factory.start();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final CountDownLatch done = new CountDownLatch(1);
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
 			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+					serverSocket.set(server);
 					latch.countDown();
 					Socket socket = server.accept();
 					byte[] b = new byte[6];
@@ -165,6 +170,7 @@ public class TcpNioConnectionTests {
 			fail("Unexpected exception " + e);
 		}
 		done.countDown();
+		serverSocket.get().close();
 	}
 
 	@Test
@@ -174,11 +180,13 @@ public class TcpNioConnectionTests {
 		factory.setNioHarvestInterval(100);
 		factory.start();
 		final CountDownLatch latch = new CountDownLatch(1);
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
 			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+					serverSocket.set(server);
 					latch.countDown();
 					Socket socket = server.accept();
 					byte[] b = new byte[6];
@@ -211,6 +219,7 @@ public class TcpNioConnectionTests {
 			fail("Unexpected exception " + e);
 		}
 		factory.stop();
+		serverSocket.get().close();
 	}
 
 	@Test

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionWriteTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionWriteTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,13 @@ import java.io.InputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ServerSocketFactory;
 
 import org.junit.Test;
+
 import org.springframework.integration.ip.tcp.serializer.AbstractByteArraySerializer;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayLengthHeaderSerializer;
@@ -58,15 +61,18 @@ public class TcpNioConnectionWriteTests {
 		ServerSocket server = ServerSocketFactory.getDefault()
 				.createServerSocket(port);
 		server.setSoTimeout(10000);
+		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ByteArrayLengthHeaderSerializer serializer = new ByteArrayLengthHeaderSerializer();
 					AbstractConnectionFactory ccf = getClientConnectionFactory(false, port, serializer);
 					TcpConnection connection = ccf.getConnection();
 					connection.send(MessageBuilder.withPayload(testString.getBytes()).build());
-					Thread.sleep(1000000000L);
-				} catch (Exception e) {
+					latch.await(10, TimeUnit.SECONDS);
+				}
+				catch (Exception e) {
 					e.printStackTrace();
 				}
 			}
@@ -82,6 +88,7 @@ public class TcpNioConnectionWriteTests {
 		assertEquals(testString.length(), buffer.getInt());
 		assertEquals(testString, new String(buff, 4, testString.length()));
 		server.close();
+		latch.countDown();
 	}
 
 	@Test
@@ -91,15 +98,18 @@ public class TcpNioConnectionWriteTests {
 		ServerSocket server = ServerSocketFactory.getDefault()
 				.createServerSocket(port);
 		server.setSoTimeout(10000);
+		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ByteArrayStxEtxSerializer serializer = new ByteArrayStxEtxSerializer();
 					AbstractConnectionFactory ccf = getClientConnectionFactory(false, port, serializer);
 					TcpConnection connection = ccf.getConnection();
 					connection.send(MessageBuilder.withPayload(testString.getBytes()).build());
-					Thread.sleep(1000000000L);
-				} catch (Exception e) {
+					latch.await(10, TimeUnit.SECONDS);
+				}
+				catch (Exception e) {
 					e.printStackTrace();
 				}
 			}
@@ -115,6 +125,7 @@ public class TcpNioConnectionWriteTests {
 		assertEquals(testString, new String(buff, 1, testString.length()));
 		assertEquals(ByteArrayStxEtxSerializer.ETX, buff[testString.length() + 1]);
 		server.close();
+		latch.countDown();
 	}
 
 	@Test
@@ -124,15 +135,18 @@ public class TcpNioConnectionWriteTests {
 		ServerSocket server = ServerSocketFactory.getDefault()
 				.createServerSocket(port);
 		server.setSoTimeout(10000);
+		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 					AbstractConnectionFactory ccf = getClientConnectionFactory(false, port, serializer);
 					TcpConnection connection = ccf.getConnection();
 					connection.send(MessageBuilder.withPayload(testString.getBytes()).build());
-					Thread.sleep(1000000000L);
-				} catch (Exception e) {
+					latch.await(10, TimeUnit.SECONDS);
+				}
+				catch (Exception e) {
 					e.printStackTrace();
 				}
 			}
@@ -148,6 +162,7 @@ public class TcpNioConnectionWriteTests {
 		assertEquals('\r', buff[testString.length()]);
 		assertEquals('\n', buff[testString.length() + 1]);
 		server.close();
+		latch.countDown();
 	}
 
 	@Test
@@ -157,15 +172,18 @@ public class TcpNioConnectionWriteTests {
 		ServerSocket server = ServerSocketFactory.getDefault()
 				.createServerSocket(port);
 		server.setSoTimeout(10000);
+		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ByteArrayLengthHeaderSerializer serializer = new ByteArrayLengthHeaderSerializer();
 					AbstractConnectionFactory ccf = getClientConnectionFactory(true, port, serializer);
 					TcpConnection connection = ccf.getConnection();
 					connection.send(MessageBuilder.withPayload(testString.getBytes()).build());
-					Thread.sleep(1000000000L);
-				} catch (Exception e) {
+					latch.await(10, TimeUnit.SECONDS);
+				}
+				catch (Exception e) {
 					e.printStackTrace();
 				}
 			}
@@ -181,6 +199,7 @@ public class TcpNioConnectionWriteTests {
 		assertEquals(testString.length(), buffer.getInt());
 		assertEquals(testString, new String(buff, 4, testString.length()));
 		server.close();
+		latch.countDown();
 	}
 
 	@Test
@@ -190,16 +209,18 @@ public class TcpNioConnectionWriteTests {
 		ServerSocket server = ServerSocketFactory.getDefault()
 				.createServerSocket(port);
 		server.setSoTimeout(10000);
+		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ByteArrayStxEtxSerializer serializer = new ByteArrayStxEtxSerializer();
 					AbstractConnectionFactory ccf = getClientConnectionFactory(true, port, serializer);
 					TcpConnection connection = ccf.getConnection();
 					connection.send(MessageBuilder.withPayload(testString.getBytes()).build());
-					Thread.sleep(1000000000L);
-					Thread.sleep(1000000000L);
-				} catch (Exception e) {
+					latch.await(10, TimeUnit.SECONDS);
+				}
+				catch (Exception e) {
 					e.printStackTrace();
 				}
 			}
@@ -215,6 +236,7 @@ public class TcpNioConnectionWriteTests {
 		assertEquals(testString, new String(buff, 1, testString.length()));
 		assertEquals(ByteArrayStxEtxSerializer.ETX, buff[testString.length() + 1]);
 		server.close();
+		latch.countDown();
 	}
 
 	@Test
@@ -224,16 +246,18 @@ public class TcpNioConnectionWriteTests {
 		ServerSocket server = ServerSocketFactory.getDefault()
 				.createServerSocket(port);
 		server.setSoTimeout(10000);
+		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 					AbstractConnectionFactory ccf = getClientConnectionFactory(true, port, serializer);
 					TcpConnection connection = ccf.getConnection();
 					connection.send(MessageBuilder.withPayload(testString.getBytes()).build());
-					Thread.sleep(1000000000L);
-					Thread.sleep(1000000000L);
-				} catch (Exception e) {
+					latch.await(10, TimeUnit.SECONDS);
+				}
+				catch (Exception e) {
 					e.printStackTrace();
 				}
 			}
@@ -249,6 +273,7 @@ public class TcpNioConnectionWriteTests {
 		assertEquals('\r', buff[testString.length()]);
 		assertEquals('\n', buff[testString.length() + 1]);
 		server.close();
+		latch.countDown();
 	}
 
 	/**

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/DeserializationTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/DeserializationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,12 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.CountDownLatch;
 
 import javax.net.ServerSocketFactory;
 
 import org.junit.Test;
+
 import org.springframework.core.serializer.DefaultDeserializer;
 import org.springframework.integration.ip.util.SocketTestUtils;
 import org.springframework.integration.test.util.SocketUtils;
@@ -41,7 +43,7 @@ public class DeserializationTests {
 		int port = SocketUtils.findAvailableServerSocket();
 		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
 		server.setSoTimeout(10000);
-		SocketTestUtils.testSendLength(port, null);
+		CountDownLatch done = SocketTestUtils.testSendLength(port, null);
 		Socket socket = server.accept();
 		socket.setSoTimeout(5000);
 		ByteArrayLengthHeaderSerializer serializer = new ByteArrayLengthHeaderSerializer();
@@ -52,6 +54,7 @@ public class DeserializationTests {
 		assertEquals("Data", SocketTestUtils.TEST_STRING + SocketTestUtils.TEST_STRING,
 				 new String(out));
 		server.close();
+		done.countDown();
 	}
 
 	@Test
@@ -59,7 +62,7 @@ public class DeserializationTests {
 		int port = SocketUtils.findAvailableServerSocket();
 		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
 		server.setSoTimeout(10000);
-		SocketTestUtils.testSendStxEtx(port, null);
+		CountDownLatch done = SocketTestUtils.testSendStxEtx(port, null);
 		Socket socket = server.accept();
 		socket.setSoTimeout(5000);
 		ByteArrayStxEtxSerializer serializer = new ByteArrayStxEtxSerializer();
@@ -70,6 +73,7 @@ public class DeserializationTests {
 		assertEquals("Data", SocketTestUtils.TEST_STRING + SocketTestUtils.TEST_STRING,
 				 new String(out));
 		server.close();
+		done.countDown();
 	}
 
 	@Test
@@ -77,7 +81,7 @@ public class DeserializationTests {
 		int port = SocketUtils.findAvailableServerSocket();
 		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
 		server.setSoTimeout(10000);
-		SocketTestUtils.testSendCrLf(port, null);
+		CountDownLatch done = SocketTestUtils.testSendCrLf(port, null);
 		Socket socket = server.accept();
 		socket.setSoTimeout(5000);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
@@ -88,6 +92,7 @@ public class DeserializationTests {
 		assertEquals("Data", SocketTestUtils.TEST_STRING + SocketTestUtils.TEST_STRING,
 				 new String(out));
 		server.close();
+		done.countDown();
 	}
 
 	@Test
@@ -110,7 +115,7 @@ public class DeserializationTests {
 		int port = SocketUtils.findAvailableServerSocket();
 		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
 		server.setSoTimeout(10000);
-		SocketTestUtils.testSendSerialized(port);
+		CountDownLatch done = SocketTestUtils.testSendSerialized(port);
 		Socket socket = server.accept();
 		socket.setSoTimeout(5000);
 		DefaultDeserializer deserializer = new DefaultDeserializer();
@@ -119,6 +124,7 @@ public class DeserializationTests {
 		out = deserializer.deserialize(socket.getInputStream());
 		assertEquals("Data", SocketTestUtils.TEST_STRING, out);
 		server.close();
+		done.countDown();
 	}
 
 	@Test
@@ -126,7 +132,7 @@ public class DeserializationTests {
 		int port = SocketUtils.findAvailableServerSocket();
 		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
 		server.setSoTimeout(10000);
-		SocketTestUtils.testSendLengthOverflow(port);
+		CountDownLatch done = SocketTestUtils.testSendLengthOverflow(port);
 		Socket socket = server.accept();
 		socket.setSoTimeout(5000);
 		ByteArrayLengthHeaderSerializer serializer = new ByteArrayLengthHeaderSerializer();
@@ -140,6 +146,7 @@ public class DeserializationTests {
 			}
 		}
 		server.close();
+		done.countDown();
 	}
 
 	@Test
@@ -147,7 +154,7 @@ public class DeserializationTests {
 		int port = SocketUtils.findAvailableServerSocket();
 		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
 		server.setSoTimeout(10000);
-		SocketTestUtils.testSendStxEtxOverflow(port);
+		CountDownLatch done = SocketTestUtils.testSendStxEtxOverflow(port);
 		Socket socket = server.accept();
 		socket.setSoTimeout(500);
 		ByteArrayStxEtxSerializer serializer = new ByteArrayStxEtxSerializer();
@@ -161,6 +168,7 @@ public class DeserializationTests {
 			}
 		}
 		server.close();
+		done.countDown();
 	}
 
 	@Test
@@ -168,7 +176,7 @@ public class DeserializationTests {
 		int port = SocketUtils.findAvailableServerSocket();
 		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
 		server.setSoTimeout(10000);
-		SocketTestUtils.testSendStxEtxOverflow(port);
+		CountDownLatch done = SocketTestUtils.testSendStxEtxOverflow(port);
 		Socket socket = server.accept();
 		socket.setSoTimeout(5000);
 		ByteArrayStxEtxSerializer serializer = new ByteArrayStxEtxSerializer();
@@ -183,6 +191,7 @@ public class DeserializationTests {
 			}
 		}
 		server.close();
+		done.countDown();
 	}
 
 	@Test
@@ -190,7 +199,7 @@ public class DeserializationTests {
 		int port = SocketUtils.findAvailableServerSocket();
 		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
 		server.setSoTimeout(10000);
-		SocketTestUtils.testSendCrLfOverflow(port);
+		CountDownLatch latch = SocketTestUtils.testSendCrLfOverflow(port);
 		Socket socket = server.accept();
 		socket.setSoTimeout(500);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
@@ -204,6 +213,7 @@ public class DeserializationTests {
 			}
 		}
 		server.close();
+		latch.countDown();
 	}
 
 	@Test
@@ -211,7 +221,7 @@ public class DeserializationTests {
 		int port = SocketUtils.findAvailableServerSocket();
 		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
 		server.setSoTimeout(10000);
-		SocketTestUtils.testSendCrLfOverflow(port);
+		CountDownLatch latch = SocketTestUtils.testSendCrLfOverflow(port);
 		Socket socket = server.accept();
 		socket.setSoTimeout(5000);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
@@ -219,13 +229,15 @@ public class DeserializationTests {
 		try {
 			serializer.deserialize(socket.getInputStream());
 	    	fail("Expected message length exceeded exception");
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			if (!e.getMessage().startsWith("CRLF not found")) {
 				e.printStackTrace();
 				fail("Unexpected IO Error:" + e.getMessage());
 			}
 		}
 		server.close();
+		latch.countDown();
 	}
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketSendingHandlerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketSendingHandlerTests.java
@@ -255,6 +255,8 @@ public class DatagramPacketSendingHandlerTests {
 			new MulticastSendingMessageHandler(multicastAddress, testPort, true,
                     							true, "localhost", ackPort, 500000);
 		handler.setMinAcksForSuccess(2);
+		handler.afterPropertiesSet();
+		handler.start();
 		handler.handleMessage(MessageBuilder.withPayload(payload).build());
 		assertTrue(latch2.await(10000, TimeUnit.MILLISECONDS));
 		handler.stop();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketSendingHandlerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketSendingHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.springframework.integration.Message;
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.support.MessageBuilder;
@@ -54,6 +55,7 @@ public class DatagramPacketSendingHandlerTests {
 		final DatagramPacket receivedPacket = new DatagramPacket(buffer, buffer.length);
 		final CountDownLatch latch = new CountDownLatch(1);
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					DatagramSocket socket = new DatagramSocket(testPort);
@@ -78,7 +80,7 @@ public class DatagramPacketSendingHandlerTests {
 		byte[] dest = new byte[length];
 		System.arraycopy(src, offset, dest, 0, length);
 		assertEquals(payload, new String(dest));
-		handler.shutDown();
+		handler.stop();
 	}
 
 	@Test
@@ -97,7 +99,9 @@ public class DatagramPacketSendingHandlerTests {
 				new UnicastSendingMessageHandler("localhost", testPort, true,
 						true, "localhost", ackPort, 5000);
 		handler.afterPropertiesSet();
+		handler.start();
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					DatagramSocket socket = new DatagramSocket(testPort);
@@ -132,7 +136,7 @@ public class DatagramPacketSendingHandlerTests {
 		byte[] dest = new byte[6];
 		System.arraycopy(src, offset+length-6, dest, 0, 6);
 		assertEquals(payload, new String(dest));
-		handler.shutDown();
+		handler.stop();
 	}
 
 	@Test
@@ -144,6 +148,7 @@ public class DatagramPacketSendingHandlerTests {
 		final CountDownLatch latch1 = new CountDownLatch(2);
 		final CountDownLatch latch2 = new CountDownLatch(2);
 		Runnable catcher = new Runnable() {
+			@Override
 			public void run() {
 				try {
 					byte[] buffer = new byte[8];
@@ -183,7 +188,7 @@ public class DatagramPacketSendingHandlerTests {
 		MulticastSendingMessageHandler handler = new MulticastSendingMessageHandler(multicastAddress, testPort);
 		handler.handleMessage(MessageBuilder.withPayload(payload).build());
 		assertTrue(latch2.await(3000, TimeUnit.MILLISECONDS));
-		handler.shutDown();
+		handler.stop();
 	}
 
 	@Test
@@ -200,6 +205,7 @@ public class DatagramPacketSendingHandlerTests {
 		final CountDownLatch latch1 = new CountDownLatch(2);
 		final CountDownLatch latch2 = new CountDownLatch(2);
 		Runnable catcher = new Runnable() {
+			@Override
 			public void run() {
 				try {
 					byte[] buffer = new byte[1000];
@@ -251,7 +257,7 @@ public class DatagramPacketSendingHandlerTests {
 		handler.setMinAcksForSuccess(2);
 		handler.handleMessage(MessageBuilder.withPayload(payload).build());
 		assertTrue(latch2.await(10000, TimeUnit.MILLISECONDS));
-		handler.shutDown();
+		handler.stop();
 	}
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/MultiClientTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/MultiClientTests.java
@@ -16,10 +16,13 @@
 package org.springframework.integration.ip.udp;
 
 import static org.junit.Assert.assertNotNull;
-import org.junit.Assert;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.springframework.integration.Message;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.ip.util.SocketTestUtils;
@@ -45,7 +48,8 @@ import org.springframework.integration.test.util.SocketUtils;
 public class MultiClientTests {
 
 	@SuppressWarnings("unchecked")
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testNoAck() throws Exception {
 		final String payload = largePayload(1000);
 		final UnicastReceivingChannelAdapter adapter =
@@ -57,15 +61,24 @@ public class MultiClientTests {
 		adapter.start();
 		final QueueChannel queueIn = new QueueChannel(1000);
 		SocketTestUtils.waitListening(adapter);
+
+		final AtomicBoolean done = new AtomicBoolean();
+
 		for (int i = 0; i < drivers; i++) {
 			Thread t = new Thread( new Runnable() {
+				@Override
 				public void run() {
 					UnicastSendingMessageHandler sender = new UnicastSendingMessageHandler(
 							"localhost", adapter.getPort());
+					sender.start();
 					while (true) {
 						Message<?> message = queueIn.receive();
 						sender.handleMessage(message);
+						if (done.get()) {
+							break;
+						}
 					}
+					sender.stop();
 				}});
 			t.setDaemon(true);
 			t.start();
@@ -79,12 +92,13 @@ public class MultiClientTests {
 			Assert.assertEquals(payload, new String(messageOut.getPayload()));
 		}
 		adapter.stop();
+		done.set(true);
 	}
 
 	@SuppressWarnings("unchecked")
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testAck() throws Exception {
-		Thread.sleep(1000);
 		final String payload = largePayload(1000);
 		final UnicastReceivingChannelAdapter adapter =
 			new UnicastReceivingChannelAdapter(SocketUtils.findAvailableUdpSocket(), false);
@@ -95,19 +109,28 @@ public class MultiClientTests {
 		adapter.start();
 		final QueueChannel queueIn = new QueueChannel(1000);
 		SocketTestUtils.waitListening(adapter);
+
+		final AtomicBoolean done = new AtomicBoolean();
+
 		for (int i = 0; i < drivers; i++) {
 			final int j = i;
 			Thread t = new Thread( new Runnable() {
+				@Override
 				public void run() {
 					UnicastSendingMessageHandler sender = new UnicastSendingMessageHandler(
 							"localhost", adapter.getPort(),
 							false, true, "localhost",
 							SocketUtils.findAvailableUdpSocket(adapter.getPort() + j + 1000),
 							10000);
+					sender.start();
 					while (true) {
 						Message<?> message = queueIn.receive();
 						sender.handleMessage(message);
+						if (done.get()) {
+							break;
+						}
 					}
+					sender.stop();
 				}});
 			t.setDaemon(true);
 			t.start();
@@ -121,12 +144,13 @@ public class MultiClientTests {
 			Assert.assertEquals(payload, new String(messageOut.getPayload()));
 		}
 		adapter.stop();
+		done.set(true);
 	}
 
 	@SuppressWarnings("unchecked")
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testAckWithLength() throws Exception {
-		Thread.sleep(1000);
 		final String payload = largePayload(1000);
 		final UnicastReceivingChannelAdapter adapter =
 			new UnicastReceivingChannelAdapter(SocketUtils.findAvailableUdpSocket(), true);
@@ -137,19 +161,28 @@ public class MultiClientTests {
 		adapter.start();
 		final QueueChannel queueIn = new QueueChannel(1000);
 		SocketTestUtils.waitListening(adapter);
+
+		final AtomicBoolean done = new AtomicBoolean();
+
 		for (int i = 0; i < drivers; i++) {
 			final int j = i;
 			Thread t = new Thread( new Runnable() {
+				@Override
 				public void run() {
 					UnicastSendingMessageHandler sender = new UnicastSendingMessageHandler(
 							"localhost", adapter.getPort(),
 							true, true, "localhost",
 							SocketUtils.findAvailableUdpSocket(adapter.getPort() + j + 1100),
 							10000);
+					sender.start();
 					while (true) {
 						Message<?> message = queueIn.receive();
 						sender.handleMessage(message);
+						if (done.get()) {
+							break;
+						}
 					}
+					sender.stop();
 				}});
 			t.setDaemon(true);
 			t.start();
@@ -163,6 +196,7 @@ public class MultiClientTests {
 			Assert.assertEquals(payload, new String(messageOut.getPayload()));
 		}
 		adapter.stop();
+		done.set(true);
 	}
 
 	private String largePayload(int n) {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/SyslogdTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/SyslogdTests.java
@@ -30,6 +30,5 @@ public class SyslogdTests {
 		System.out.println("Hit enter to terminate");
 		System.in.read();
 		ctx.close();
-		ctx.destroy();
 	}
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/SyslogdTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/SyslogdTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ public class SyslogdTests {
 		AbstractApplicationContext ctx = new ClassPathXmlApplicationContext("SyslogdTests-context.xml", SyslogdTests.class);
 		System.out.println("Hit enter to terminate");
 		System.in.read();
+		ctx.close();
 		ctx.destroy();
 	}
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.springframework.integration.Message;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
@@ -65,9 +66,12 @@ public class UdpChannelAdapterTests {
 		DatagramPacketMessageMapper mapper = new DatagramPacketMessageMapper();
 		DatagramPacket packet = mapper.fromMessage(message);
 		packet.setSocketAddress(new InetSocketAddress("localhost", port));
-		new DatagramSocket(SocketUtils.findAvailableUdpSocket()).send(packet);
+		DatagramSocket datagramSocket = new DatagramSocket(SocketUtils.findAvailableUdpSocket());
+		datagramSocket.send(packet);
+		datagramSocket.close();
 		Message<byte[]> receivedMessage = (Message<byte[]>) channel.receive(2000);
 		assertEquals(new String(message.getPayload()), new String(receivedMessage.getPayload()));
+		adapter.stop();
 	}
 
 	@SuppressWarnings("unchecked")
@@ -91,6 +95,7 @@ public class UdpChannelAdapterTests {
 		final CountDownLatch replyReceivedLatch = new CountDownLatch(1);
 		//main thread sends the reply using the headers, this thread will receive it
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
+			@Override
 			public void run() {
 				DatagramPacket answer = new DatagramPacket(new byte[2000], 2000);
 				try {
@@ -112,11 +117,15 @@ public class UdpChannelAdapterTests {
 				(String) receivedMessage.getHeaders().get(IpHeaders.IP_ADDRESS),
 				(Integer) receivedMessage.getHeaders().get(IpHeaders.PORT)));
 		assertTrue(receiverReadyLatch.await(10, TimeUnit.SECONDS));
-		new DatagramSocket().send(reply);
+		DatagramSocket datagramSocket = new DatagramSocket();
+		datagramSocket.send(reply);
 		assertTrue(replyReceivedLatch.await(10, TimeUnit.SECONDS));
 		DatagramPacket answerPacket = theAnswer.get();
 		assertNotNull(answerPacket);
 		assertEquals(replyString, new String(answerPacket.getData(), 0, answerPacket.getLength()));
+		datagramSocket.close();
+		socket.close();
+		adapter.stop();
 	}
 
 	@SuppressWarnings("unchecked")
@@ -139,10 +148,13 @@ public class UdpChannelAdapterTests {
 				SocketUtils.findAvailableUdpSocket(), 5000);
 //		handler.setLocalAddress(whichNic);
 		handler.afterPropertiesSet();
+		handler.start();
 		Message<byte[]> message = MessageBuilder.withPayload("ABCD".getBytes()).build();
 		handler.handleMessage(message);
 		Message<byte[]> receivedMessage = (Message<byte[]>) channel.receive(2000);
 		assertEquals(new String(message.getPayload()), new String(receivedMessage.getPayload()));
+		adapter.stop();
+		handler.stop();
 	}
 
 	@SuppressWarnings("unchecked")
@@ -165,11 +177,14 @@ public class UdpChannelAdapterTests {
 		DatagramPacketMessageMapper mapper = new DatagramPacketMessageMapper();
 		DatagramPacket packet = mapper.fromMessage(message);
 		packet.setSocketAddress(new InetSocketAddress("225.6.7.8", port));
-		new DatagramSocket(0, Inet4Address.getByName(nic)).send(packet);
+		DatagramSocket datagramSocket = new DatagramSocket(0, Inet4Address.getByName(nic));
+		datagramSocket.send(packet);
+		datagramSocket.close();
 
 		Message<byte[]> receivedMessage = (Message<byte[]>) channel.receive(2000);
 		assertNotNull(receivedMessage);
 		assertEquals(new String(message.getPayload()), new String(receivedMessage.getPayload()));
+		adapter.stop();
 	}
 
 	@SuppressWarnings("unchecked")
@@ -196,6 +211,7 @@ public class UdpChannelAdapterTests {
 		Message<byte[]> receivedMessage = (Message<byte[]>) channel.receive(2000);
 		assertNotNull(receivedMessage);
 		assertEquals(new String(message.getPayload()), new String(receivedMessage.getPayload()));
+		adapter.stop();
 	}
 
 	@Test
@@ -217,10 +233,13 @@ public class UdpChannelAdapterTests {
 		DatagramPacketMessageMapper mapper = new DatagramPacketMessageMapper();
 		DatagramPacket packet = mapper.fromMessage(message);
 		packet.setSocketAddress(new InetSocketAddress("localhost", port));
-		new DatagramSocket(SocketUtils.findAvailableUdpSocket()).send(packet);
+		DatagramSocket datagramSocket = new DatagramSocket(SocketUtils.findAvailableUdpSocket());
+		datagramSocket.send(packet);
+		datagramSocket.close();
 		Message<?> receivedMessage = errorChannel.receive(2000);
 		assertNotNull(receivedMessage);
 		assertEquals("Failed", ((Exception) receivedMessage.getPayload()).getCause().getMessage());
+		adapter.stop();
 	}
 
 	private class FailingService {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpMulticastEndToEndTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpMulticastEndToEndTests.java
@@ -148,7 +148,6 @@ public class UdpMulticastEndToEndTests implements Runnable {
 		}
 		ctx.stop();
 		ctx.close();
-		ctx.destroy();
 	}
 
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpMulticastEndToEndTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpMulticastEndToEndTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,12 +41,12 @@ import org.springframework.integration.support.channel.ChannelResolver;
 /**
  * Sends and receives a simple message through to the Udp channel adapters.
  * If run as a JUnit just sends one message and terminates (see console).
- * 
- * If run from main(),  
+ *
+ * If run from main(),
  * hangs around for a couple of minutes to allow console interaction (enter a message on the
- * console and you should see it go through the outbound context, over UDP, and 
+ * console and you should see it go through the outbound context, over UDP, and
  * received in the other context (and written back to the console).
- *  
+ *
  * @author Gary Russell
  * @since 2.0
  */
@@ -58,13 +58,13 @@ public class UdpMulticastEndToEndTests implements Runnable {
 
 	private CountDownLatch sentFirst = new CountDownLatch(1);
 
-	private CountDownLatch firstReceived = new CountDownLatch(1);
+	private final CountDownLatch firstReceived = new CountDownLatch(1);
 
-	private CountDownLatch doneProcessing = new CountDownLatch(1);
+	private final CountDownLatch doneProcessing = new CountDownLatch(1);
 
 	private boolean okToRun = true;
 
-	private CountDownLatch readyToReceive = new CountDownLatch(1);
+	private final CountDownLatch readyToReceive = new CountDownLatch(1);
 
 	private static long hangAroundFor = 0;
 
@@ -77,7 +77,7 @@ public class UdpMulticastEndToEndTests implements Runnable {
 		t.start(); // launch the receiver
 		AbstractApplicationContext applicationContext = new ClassPathXmlApplicationContext(
 				"testIp-out-multicast-context.xml",
-				UdpMulticastEndToEndTests.class);	
+				UdpMulticastEndToEndTests.class);
 		launcher.launchSender(applicationContext);
 		applicationContext.stop();
 	}
@@ -122,6 +122,7 @@ public class UdpMulticastEndToEndTests implements Runnable {
 	/**
 	 * Instantiate the receiving context
 	 */
+	@Override
 	@SuppressWarnings("unchecked")
 	public void run() {
 		AbstractApplicationContext ctx = new ClassPathXmlApplicationContext(
@@ -129,7 +130,7 @@ public class UdpMulticastEndToEndTests implements Runnable {
 				UdpMulticastEndToEndTests.class);
 		while (okToRun) {
 			try {
-				readyToReceive.countDown();				
+				readyToReceive.countDown();
 				sentFirst.await();
 			}
 			catch (InterruptedException e) {
@@ -146,6 +147,8 @@ public class UdpMulticastEndToEndTests implements Runnable {
 			}
 		}
 		ctx.stop();
+		ctx.close();
+		ctx.destroy();
 	}
 
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpUnicastEndToEndTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpUnicastEndToEndTests.java
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.ip.udp;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -142,7 +143,9 @@ public class UdpUnicastEndToEndTests implements Runnable {
 	 * Instantiate the receiving context
 	 */
 	@SuppressWarnings("unchecked")
+	@Override
 	public void run() {
+		@SuppressWarnings("resource")
 		AbstractApplicationContext ctx = new ClassPathXmlApplicationContext(
 				"testIp-in-context.xml", UdpUnicastEndToEndTests.class);
 		UnicastReceivingChannelAdapter inbound = ctx.getBean(UnicastReceivingChannelAdapter.class);
@@ -154,7 +157,8 @@ public class UdpUnicastEndToEndTests implements Runnable {
 					throw new RuntimeException("Failed to start listening");
 				}
 			}
-		} catch (Exception e) { }
+		}
+		catch (Exception e) { }
 		while (okToRun) {
 			try {
 				readyToReceive.countDown();
@@ -178,6 +182,8 @@ public class UdpUnicastEndToEndTests implements Runnable {
 			}
 		}
 		ctx.stop();
+		ctx.close();
+		ctx.destroy();
 	}
 
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpUnicastEndToEndTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpUnicastEndToEndTests.java
@@ -183,7 +183,6 @@ public class UdpUnicastEndToEndTests implements Runnable {
 		}
 		ctx.stop();
 		ctx.close();
-		ctx.destroy();
 	}
 
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/testIp-out-multicast-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/testIp-out-multicast-context.xml
@@ -14,9 +14,7 @@
 			http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd">
 
 	<stream:stdin-channel-adapter id="stdin" channel="mcOutputChannel" >
-		<poller>
-			<interval-trigger interval="100" time-unit="MILLISECONDS"/>
-		</poller>
+		<poller fixed-delay="100" />
 	</stream:stdin-channel-adapter>
 
 	<channel id="mcInputChannel"/>


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3233

With Windows 7 and Java 7/8 closing a server channel does
not close the underlying socket. Closing the Selector does
close the socket.

It is not clear why this is needed, given that a selector can
be used for multiple sockets.

However, we only use the server side selector for a single
server socket so there is no detriment in closing it.

Also close the selector on the client side (even though it is
used for multiple sockets, because we are stopping the factory
anyway and all sockets will be closed).

However, closing the selector opens us up to 'ClosedSelectorException's
in several places. Add catch blocks to deal with this exception, and only
log an error if the factory is active.

While debugging this issue, I found that a number of (older) tests
left threads running, sockets open etc.
