### PR TITLE
INT-3235 Make GatewayMethodMetadata Public

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GatewayParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GatewayParser.java
@@ -27,6 +27,9 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.factory.xml.AbstractSimpleBeanDefinitionParser;
+import org.springframework.expression.common.LiteralExpression;
+import org.springframework.integration.config.ExpressionFactoryBean;
+import org.springframework.integration.gateway.GatewayMethodMetadata;
 import org.springframework.integration.gateway.GatewayProxyFactoryBean;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -105,7 +108,7 @@ public class GatewayParser extends AbstractSimpleBeanDefinitionParser {
 
 		if (hasDefaultHeaders || hasDefaultPayloadExpression) {
 			BeanDefinitionBuilder methodMetadataBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-					"org.springframework.integration.gateway.GatewayMethodMetadata");
+					GatewayMethodMetadata.class);
 			this.setMethodInvocationHeaders(methodMetadataBuilder, invocationHeaders);
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(methodMetadataBuilder, element,
 					"default-payload-expression", "payloadExpression");
@@ -120,7 +123,7 @@ public class GatewayParser extends AbstractSimpleBeanDefinitionParser {
 		for (Element methodElement : elements) {
 			String methodName = methodElement.getAttribute("name");
 			BeanDefinitionBuilder methodMetadataBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-					"org.springframework.integration.gateway.GatewayMethodMetadata");
+					GatewayMethodMetadata.class);
 			methodMetadataBuilder.addPropertyValue("requestChannelName", methodElement.getAttribute("request-channel"));
 			methodMetadataBuilder.addPropertyValue("replyChannelName", methodElement.getAttribute("reply-channel"));
 			methodMetadataBuilder.addPropertyValue("requestTimeout", methodElement.getAttribute("request-timeout"));
@@ -151,11 +154,11 @@ public class GatewayParser extends AbstractSimpleBeanDefinitionParser {
 			}
 			RootBeanDefinition expressionDef = null;
 			if (hasValue) {
-				expressionDef = new RootBeanDefinition("org.springframework.expression.common.LiteralExpression");
+				expressionDef = new RootBeanDefinition(LiteralExpression.class);
 				expressionDef.getConstructorArgumentValues().addGenericArgumentValue(headerValue);
 			}
 			else if (hasExpression) {
-				expressionDef = new RootBeanDefinition("org.springframework.integration.config.ExpressionFactoryBean");
+				expressionDef = new RootBeanDefinition(ExpressionFactoryBean.class);
 				expressionDef.getConstructorArgumentValues().addGenericArgumentValue(headerExpression);
 			}
 			if (expressionDef != null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,12 @@ import org.springframework.expression.Expression;
  * <p>
  * The sub-element of a &lt;gateway&gt; element would look like this:
  * &lt;method name="echo" request-channel="inputA" reply-timeout="2" request-timeout="200"/&gt;
- * 
+ *
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.0
  */
-class GatewayMethodMetadata {
+public class GatewayMethodMetadata {
 
 	private volatile String payloadExpression;
 


### PR DESCRIPTION
Unable to programmatically wire header expressions or method-specific
properties into a GatewayProxyFactoryBean.

The GPFB has public methods that take arguments of
this type.

Make the class public instead of package-protected.

Add a test case.
