### PR TITLE
INT-3187 Uncomment JMX Test Case

### DIFF
--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingOutboundGatewayTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingOutboundGatewayTests.java
@@ -126,13 +126,13 @@ public class OperationInvokingOutboundGatewayTests {
 			assertThat(e, Matchers.instanceOf(MessagingException.class));
 			assertThat(e.getMessage(), Matchers.containsString("failed to find JMX operation"));
 		}
-		// TODO: Uncomment when Spring Framework minimum is 3.2.3
-//		argMap = new HashMap<String, Object>();
-//		argMap.put("bool", true);
-//		argMap.put("time", 0L);
-//		argMap.put("foo", 42);
-//		primitiveChannel.send(new GenericMessage<Map<String, Object>>(argMap));
-//		assertEquals(4, testBean.messages.size());
+		// Args are named starting with Spring 3.2.3
+		argMap = new HashMap<String, Object>();
+		argMap.put("bool", true);
+		argMap.put("time", 0L);
+		argMap.put("foo", 42);
+		primitiveChannel.send(new GenericMessage<Map<String, Object>>(argMap));
+		assertEquals(4, testBean.messages.size());
 	}
 
 	@Test


### PR DESCRIPTION
Since 3.2.3, the operation invoking message handler can take a
map containing arguments named for their equivalent parameters.

This test was commented out because the 3.x stream supports
older versions of Spring.

JIRA: https://jira.springsource.org/browse/INT-3187
