### PR TITLE
INT-3160: IRMHM: use protected method from super

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/IntegrationRequestMappingHandlerMapping.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/IntegrationRequestMappingHandlerMapping.java
@@ -44,10 +44,10 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  * {@link RequestMappingHandlerMapping}. It is recommended to have only one similar bean in the application context
  * using the 'id' {@link org.springframework.integration.http.support.HttpContextUtils#HANDLER_MAPPING_BEAN_NAME}.
  * <p/>
- * In most cases Spring MVC offers to configure Request Mapping via {@link org.springframework.stereotype.Controller}
+ * In most cases Spring MVC offers to configure Request Mapping via {@code org.springframework.stereotype.Controller}
  * and {@link org.springframework.web.bind.annotation.RequestMapping}.
  * That's why Spring MVC's Handler Mapping infrastructure relies on {@link org.springframework.web.method.HandlerMethod},
- * as different methods at the same {@link org.springframework.stereotype.Controller} user-class may have their own
+ * as different methods at the same {@code org.springframework.stereotype.Controller} user-class may have their own
  * {@link org.springframework.web.bind.annotation.RequestMapping}. On the other side, all Spring Integration HTTP Inbound
  * Endpoints are configured on the basis of the same {@link HttpRequestHandlingEndpointSupport} class and there is no
  * single {@link RequestMappingInfo} configuration without {@link org.springframework.web.method.HandlerMethod} in Spring MVC.
@@ -64,18 +64,6 @@ public final class IntegrationRequestMappingHandlerMapping extends RequestMappin
 
 	private static final Method HANDLE_REQUEST_METHOD = ReflectionUtils.findMethod(HttpRequestHandler.class,
 			"handleRequest", HttpServletRequest.class, HttpServletResponse.class);
-
-	private static final Method CREATE_REQUEST_MAPPING_INFO_METHOD;
-
-	static {
-		/**
-		 * Need for full reuse {@link RequestMappingHandlerMapping}'s logic
-		 * and makes this class Spring MVC version independent.
-		 */
-		CREATE_REQUEST_MAPPING_INFO_METHOD = ReflectionUtils.findMethod(RequestMappingHandlerMapping.class,
-				"createRequestMappingInfo", org.springframework.web.bind.annotation.RequestMapping.class, RequestCondition.class);
-		ReflectionUtils.makeAccessible(CREATE_REQUEST_MAPPING_INFO_METHOD);
-	}
 
 	@Override
 	protected final boolean isHandler(Class<?> beanType) {
@@ -152,8 +140,7 @@ public final class IntegrationRequestMappingHandlerMapping extends RequestMappin
 					}
 				};
 
-		Object[] createRequestMappingInfoParams = new Object[]{requestMappingAnnotation, this.getCustomTypeCondition(endpoint.getClass())};
-		return (RequestMappingInfo) ReflectionUtils.invokeMethod(CREATE_REQUEST_MAPPING_INFO_METHOD, this, createRequestMappingInfoParams);
+        return this.createRequestMappingInfo(requestMappingAnnotation, this.getCustomTypeCondition(endpoint.getClass()));
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3160

Prior to SPR 4.0 `RequestMappingHandlerMapping#createRequestMappingInfo` was `private`.
So, there was reason to to use reflection in the `IntegrationRequestMappingHandlerMapping`
