### PR TITLE
INT-3052 RestTemplate with TypeReference for HTTP

### DIFF
--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context.xml
@@ -36,6 +36,11 @@
 							   message-converters="stringAndSerializingConverters"
 							   expected-response-type-expression="payload"/>
 
+	<int-http:outbound-gateway url="http://localhost:#{portBean.port}/testApps/outboundResponse"
+							   request-channel="invalidResponseTypeChannel"
+							   expected-response-type-expression="new java.util.Date()"/>
+
+
 	<util:list id="stringAndSerializingConverters">
 		<bean class="org.springframework.integration.http.converter.SerializingHttpMessageConverter" />
 		<bean class="org.springframework.http.converter.StringHttpMessageConverter" />

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpOutboundWithinChainTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpOutboundWithinChainTests-context.xml
@@ -22,7 +22,7 @@
 		<outbound-gateway url="http://localhost:51235/%2f/testApps?param={param}"
 						  rest-template="restTemplate"
 						  encode-uri="false"
-						  expected-response-type="java.lang.String">
+						  expected-response-type-expression="T (org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandlerTests).testParameterizedTypeReference()">
 			<uri-variable name="param" expression="T(org.apache.commons.httpclient.util.URIUtil).encodeWithinQuery('http Outbound Gateway Within Chain')"/>
 						  </outbound-gateway>
 	</si:chain>


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3052

Add support of `ParameterizedTypeReference` as a result of
`expectedResponseTypeExpression` evaluation for
`RestTemplate.exchange` with `ParameterizedTypeReference` parameter
