### PR TITLE
INT-3248 Suppress HeaderChannelRegistry Warning

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/channel/BeanFactoryChannelResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/channel/BeanFactoryChannelResolver.java
@@ -88,7 +88,7 @@ public class BeanFactoryChannelResolver implements DestinationResolver<MessageCh
 					HeaderChannelRegistry.class);
 		}
 		catch (Exception e) {
-			logger.warn("No HeaderChannelRegistry found", e);
+			logger.debug("No HeaderChannelRegistry found");
 		}
 	}
 
@@ -106,7 +106,8 @@ public class BeanFactoryChannelResolver implements DestinationResolver<MessageCh
 				}
 			}
 			throw new DestinationResolutionException(
-					"failed to look up MessageChannel bean with name '" + name + "'", e);
+					"failed to look up MessageChannel with name '" + name + "' in the BeanFactory"
+					+ (this.replyChannelRegistry == null ? " (and there is no HeaderChannelRegistry present)." : "."), e);
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
@@ -22,21 +22,32 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.channel.DefaultHeaderChannelRegistry;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
+import org.springframework.integration.support.channel.HeaderChannelRegistry;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.integration.core.MessagingTemplate;
+import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.TaskScheduler;
@@ -141,6 +152,53 @@ public class HeaderChannelRegistryTests {
 		Thread.sleep(300);
 		assertNull(registry.channelNameToChannel(id));
 		registry.stop();
+	}
+
+	@Test
+	public void testBFCRWithRegistry() {
+		BeanFactoryChannelResolver resolver = new BeanFactoryChannelResolver();
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		when(beanFactory.getBean(IntegrationContextUtils.INTEGRATION_HEADER_CHANNEL_REGISTRY_BEAN_NAME,
+						HeaderChannelRegistry.class))
+			.thenReturn(mock(HeaderChannelRegistry.class));
+		doAnswer(new Answer<Object>(){
+
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				throw new NoSuchBeanDefinitionException("bar");
+			}
+		}).when(beanFactory).getBean("foo", MessageChannel.class);
+		resolver.setBeanFactory(beanFactory);
+		try {
+			resolver.resolveDestination("foo");
+			fail("Expected exception");
+		}
+		catch (DestinationResolutionException e){
+			assertThat(e.getMessage(),
+				Matchers.equalTo("failed to look up MessageChannel with name 'foo' in the BeanFactory."));
+		}
+	}
+
+	@Test
+	public void testBFCRNoRegistry() {
+		BeanFactoryChannelResolver resolver = new BeanFactoryChannelResolver();
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		doAnswer(new Answer<Object>(){
+
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				throw new NoSuchBeanDefinitionException("bar");
+			}
+		}).when(beanFactory).getBean("foo", MessageChannel.class);
+		resolver.setBeanFactory(beanFactory);
+		try {
+			resolver.resolveDestination("foo");
+			fail("Expected exception");
+		}
+		catch (DestinationResolutionException e){
+			assertThat(e.getMessage(),
+				Matchers.equalTo("failed to look up MessageChannel with name 'foo' in the BeanFactory (and there is no HeaderChannelRegistry present)."));
+		}
 	}
 
 	public static class Foo extends AbstractReplyProducingMessageHandler {


### PR DESCRIPTION
Remove warning from BFCR if there is no HeaderChannelRegistry in
the bean factory. Change the log to DEBUG and remove the stack
trace.

Instead, update the Exception message when a channel name can't be
resolved to a channel to indicate that there is no registry.

JIRA: https://jira.springsource.org/browse/INT-3248

**cherry-pick to 3.0.x** (will require fixup of `DestinationResolutionException` to `ChanneResolutionException` in test case.
