### PR TITLE
INT-3240: i-c-a-parser: Fix gen. MessageSource id

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractPollingInboundChannelAdapterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractPollingInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,13 +42,13 @@ public abstract class AbstractPollingInboundChannelAdapterParser extends Abstrac
 		if (source == null) {
 			parserContext.getReaderContext().error("failed to parse source", element);
 		}
+		BeanDefinitionBuilder adapterBuilder = BeanDefinitionBuilder
+				.genericBeanDefinition(SourcePollingChannelAdapterFactoryBean.class);
 
-		String channelAdapterId = this.resolveId(element, (AbstractBeanDefinition) source, parserContext);
+		String channelAdapterId = this.resolveId(element, adapterBuilder.getRawBeanDefinition(), parserContext);
 		String sourceBeanName = channelAdapterId + ".source";
 		parserContext.getRegistry().registerBeanDefinition(sourceBeanName, (BeanDefinition) source);
 
-		BeanDefinitionBuilder adapterBuilder = BeanDefinitionBuilder
-				.genericBeanDefinition(SourcePollingChannelAdapterFactoryBean.class);
 		adapterBuilder.addPropertyReference("source", sourceBeanName);
 		adapterBuilder.addPropertyReference("outputChannel", channelName);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(adapterBuilder, element, "send-timeout");

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChannelAdapterParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChannelAdapterParserTests-context.xml
@@ -46,4 +46,23 @@
 
 	<beans:bean id="testBean" class="org.springframework.integration.config.TestBean"/>
 
+
+	<poller default="true" max-messages-per-poll="1" fixed-delay="100"/>
+
+	<channel id="channelAdapter1Channel">
+		<queue/>
+	</channel>
+
+	<channel id="channelAdapter2Channel">
+		<queue/>
+	</channel>
+
+	<beans:bean id="counter1" class="java.util.concurrent.atomic.AtomicInteger"/>
+
+	<beans:bean id="counter2" parent="counter1"/>
+
+	<inbound-channel-adapter channel="channelAdapter1Channel" ref="counter1" method="incrementAndGet"/>
+
+	<inbound-channel-adapter channel="channelAdapter2Channel"  ref="counter2" method="incrementAndGet"/>
+
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChannelAdapterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -278,6 +278,17 @@ public class ChannelAdapterParserTests {
 	@Test(expected = BeanDefinitionParsingException.class)
 	public void innerBeanAndExpressionFail() throws Exception {
 		new ClassPathXmlApplicationContext("InboundChannelAdapterInnerBeanWithExpression-fail-context.xml", this.getClass());
+	}
+
+	@Test
+	public void testMessageSourceUniqueIds() {
+		PollableChannel channel1 = this.applicationContext.getBean("channelAdapter1Channel", PollableChannel.class);
+		PollableChannel channel2 = this.applicationContext.getBean("channelAdapter2Channel", PollableChannel.class);
+
+		for (int i = 0; i < 10; i++) {
+			assertEquals(i + 1, channel1.receive(500).getPayload());
+			assertEquals(i + 1, channel2.receive(500).getPayload());
+		}
 	}
 
 	public static class SampleBean {


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3240

Spring Integration 3.0 introduced registration `MessageSource` as beans
with `id` based on the adapter `id` or as fallback to generation from
`MessageSource` class name and the suffix `.source`.
But as far as that bean wasn't registered as bean with generated name (because suffix),
usage several anonymous `inbound-channel-adapter` with the same type (`file:`, `ftp:`, `twitter:` etc.)
caused an issue, when the same `MessageSource` bean was used by several `SourcePollingChannelAdapter` beans.

Fix the issue using for fallback generation a `SourcePollingChannelAdapterFactoryBean` class name.

**Cherry-pick to 3.0.1**
