### PR TITLE
INT-3265 Stored Proc Debug Logging

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/StoredProcExecutor.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/StoredProcExecutor.java
@@ -232,6 +232,13 @@ public class StoredProcExecutor implements BeanFactoryAware, InitializingBean {
 
 		final SimpleJdbcCall simpleJdbcCall = new SimpleJdbcCall(this.dataSource);
 
+		if (this.isFunction) {
+			simpleJdbcCall.withFunctionName(storedProcedureName);
+		}
+		else {
+			simpleJdbcCall.withProcedureName(storedProcedureName);
+		}
+
 		if (this.ignoreColumnMetaData) {
 			simpleJdbcCall.withoutProcedureColumnMetaDataAccess();
 		}
@@ -248,13 +255,6 @@ public class StoredProcExecutor implements BeanFactoryAware, InitializingBean {
 
 		if (this.returnValueRequired) {
 			simpleJdbcCall.withReturnValue();
-		}
-
-		if (this.isFunction) {
-			simpleJdbcCall.withFunctionName(storedProcedureName);
-		}
-		else {
-			simpleJdbcCall.withProcedureName(storedProcedureName);
 		}
 
 		simpleJdbcCall.getJdbcTemplate().setSkipUndeclaredResults(this.skipUndeclaredResults);


### PR DESCRIPTION
Set up stored procedure name in `SimpleJdbcCall` before setting
up row mappers; previously the debug logg showed `[null]` for
the procedure name.

JIRA: https://jira.springsource.org/browse/INT-3265

**cherry-pick to 3.0.x**
