### PR TITLE
INT-3266 (S)FTP Close Dirty Cached Sessions

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
@@ -33,7 +33,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.expression.Expression;
 import org.springframework.integration.file.DefaultFileNameGenerator;
 import org.springframework.integration.file.FileNameGenerator;
-import org.springframework.integration.file.remote.session.CachingSessionFactory.CachedSession;
+import org.springframework.integration.file.remote.session.CachingSessionFactory;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
@@ -292,7 +292,6 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 		});
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Override
 	public <T> T execute(SessionCallback<F, T> callback) {
 		Session<F> session = null;
@@ -302,8 +301,11 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 			return callback.doInSession(session);
 		}
 		catch (Exception e) {
-			if (session instanceof CachedSession) {
-				((CachedSession) session).dirty();
+			if (session instanceof CachingSessionFactory<?>.CachedSession) {
+				((CachingSessionFactory<?>.CachedSession) session).dirty();
+			}
+			if (e instanceof MessagingException) {
+				throw (MessagingException) e;
 			}
 			throw new MessagingException("Failed to execute on session", e);
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/session/CachingSessionFactory.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/session/CachingSessionFactory.java
@@ -152,11 +152,13 @@ public class CachingSessionFactory<F> implements SessionFactory<F>, DisposableBe
 		this.pool.removeAllIdleItems();
 	}
 
-	private class CachedSession implements Session<F> {
+	public class CachedSession implements Session<F> {
 
 		private final Session<F> targetSession;
 
-		private volatile boolean released;
+		private boolean released;
+
+		private boolean dirty;
 
 		/**
 		 * The epoch in which this session was created.
@@ -183,6 +185,9 @@ public class CachingSessionFactory<F> implements SessionFactory<F>, DisposableBe
 					if (logger.isDebugEnabled()){
 						logger.debug("Closing session " + targetSession + " after reset.");
 					}
+					this.targetSession.close();
+				}
+				else if (this.dirty) {
 					this.targetSession.close();
 				}
 				pool.releaseItem(targetSession);
@@ -243,6 +248,10 @@ public class CachingSessionFactory<F> implements SessionFactory<F>, DisposableBe
 		@Override
 		public boolean finalizeRaw() throws IOException {
 			return this.targetSession.finalizeRaw();
+		}
+
+		public void dirty() {
+			this.dirty = true;
 		}
 
 	}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -130,6 +130,8 @@ public class FtpServerOutboundTests {
 		}
 		catch (Exception e) {
 			Throwable cause = e.getCause();
+			assertNotNull(cause);
+			cause = cause.getCause();
 			assertThat(cause, Matchers.instanceOf(IllegalArgumentException.class));
 			assertThat(cause.getMessage(), Matchers.startsWith("Failed to make local directory"));
 		}

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
@@ -218,6 +218,8 @@ public class SftpServerOutboundTests {
 		}
 		catch (Exception e) {
 			Throwable cause = e.getCause();
+			assertNotNull(cause);
+			cause = cause.getCause();
 			assertThat(cause, Matchers.instanceOf(IllegalArgumentException.class));
 			assertThat(cause.getMessage(), Matchers.startsWith("Failed to make local directory"));
 		}


### PR DESCRIPTION
If an exception occurs on a session it should be physically closed
and not reused because its state is indeterminate and the next
operation might fail.

Note: The booleans within CachedSession do not need to be volatile
because it is a short-lived object only used by the current thread.

Also fixes the assertion message in RFT.get().

JIRA: https://jira.springsource.org/browse/INT-3266

**cherry-pick to 3.0.x**
