### PR TITLE
INT-3268 Add Simple RemoteFileOperations.get()

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileOperations.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileOperations.java
@@ -46,9 +46,18 @@ public interface RemoteFileOperations<F> {
 	String send(Message<?> message, String subDirectory);
 
 	/**
+	 * Retrieve a remote file as an InputStream.
+	 *
+	 * @param remotePath The remote path to the file.
+	 * @param callback the callback.
+	 * @return true if the operation was successful.
+	 */
+	boolean get(String remotePath, InputStreamCallback callback);
+
+	/**
 	 * Retrieve a remote file as an InputStream, based on information in a message.
 	 *
-	 * @param message The message.
+	 * @param message The message which will be evaluated to generate the remote path.
 	 * @param callback the callback.
 	 * @return true if the operation was successful.
 	 */

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
@@ -269,15 +269,20 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 		});
 	}
 
+	@Override
+	public boolean get(Message<?> message, InputStreamCallback callback) {
+		Assert.notNull(this.fileNameProcessor, "A 'fileNameExpression' is needed to use get");
+		String remotePath = RemoteFileTemplate.this.fileNameProcessor.processMessage(message);
+		return this.get(remotePath, callback);
+	}
 
 	@Override
-	public boolean get(final Message<?> message, final InputStreamCallback callback) {
-		Assert.notNull(this.fileNameProcessor, "'fileNameProcessor' needed to use get");
+	public boolean get(final String remotePath, final InputStreamCallback callback) {
+		Assert.notNull(remotePath, "'remotePath' cannot be null");
 		return this.execute(new SessionCallback<F, Boolean>() {
 
 			@Override
 			public Boolean doInSession(Session<F> session) throws IOException {
-				final String remotePath = RemoteFileTemplate.this.fileNameProcessor.processMessage(message);
 				InputStream inputStream = session.readRaw(remotePath);
 				callback.doWithInputStream(inputStream);
 				inputStream.close();


### PR DESCRIPTION
Requires a simple `remotePath` arg instead of
a Message<?>.

JIRA: https://jira.springsource.org/browse/INT-3268
