### PR TITLE
INT-3271 Revert MessageHandlingException Ctor Use

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ subprojects { subproject ->
 		h2Version = '1.3.172'
 		activeMqVersion = '5.8.0'
 
-		springVersionDefault = '4.0.0.RELEASE'
+		springVersionDefault = '4.0.1.BUILD-SNAPSHOT'
 		springVersion = project.hasProperty('springVersion') ? getProperty('springVersion') : springVersionDefault
 
 		springAmqpVersion = '1.3.0.BUILD-SNAPSHOT'

--- a/spring-integration-core/src/main/java/org/springframework/integration/MessageRejectedException.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/MessageRejectedException.java
@@ -27,13 +27,8 @@ import org.springframework.messaging.MessageHandlingException;
 @SuppressWarnings("serial")
 public class MessageRejectedException extends MessageHandlingException {
 
-	/**
-	 * @param failedMessage The failed message.
-	 * @deprecated since 4.0 in favor of {@code MessageRejectedException(Message, String)}
-	 */
-	@Deprecated
 	public MessageRejectedException(Message<?> failedMessage) {
-		super(failedMessage, null);
+		super(failedMessage);
 	}
 
 	public MessageRejectedException(Message<?> failedMessage, String description) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
@@ -21,9 +21,9 @@ import java.lang.reflect.Method;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.convert.ConversionService;
+import org.springframework.integration.util.MessagingMethodInvokerHelper;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
-import org.springframework.integration.util.MessagingMethodInvokerHelper;
 
 /**
  * A MessageProcessor implementation that invokes a method on a target Object. The Method instance or method name may be
@@ -69,12 +69,13 @@ public class MethodInvokingMessageProcessor<T> extends AbstractMessageProcessor<
 		delegate.setBeanFactory(beanFactory);
 	}
 
+	@Override
 	public T processMessage(Message<?> message) {
 		try {
 			return delegate.process(message);
 		}
 		catch (Exception e) {
-			throw new MessageHandlingException(message, this.delegate + " failed to process Message.", e);
+			throw new MessageHandlingException(message, e);
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInvokingMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInvokingMessageHandlerTests.java
@@ -17,18 +17,17 @@
 package org.springframework.integration.gateway;
 
 import org.junit.Assert;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.integration.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
@@ -71,6 +70,7 @@ public class GatewayInvokingMessageHandlerTests {
 	@Test
 	public void validateGatewayInTheChainViaChannel() {
 		output.subscribe(new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) {
 				Assert.assertEquals("echo:echo:echo:hello", message.getPayload());
 				Assert.assertEquals("foo", message.getHeaders().get("foo"));
@@ -83,6 +83,7 @@ public class GatewayInvokingMessageHandlerTests {
 	@Test
 	public void validateGatewayInTheChainViaAnotherGateway() {
 		output.subscribe(new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) {
 				Assert.assertEquals("echo:echo:echo:hello", message.getPayload());
 				Assert.assertEquals("foo", message.getHeaders().get("foo"));
@@ -178,7 +179,7 @@ public class GatewayInvokingMessageHandlerTests {
 		}
 
 		public String echoWithMessagingException(String value) {
-			throw new MessageHandlingException(new GenericMessage<String>(value), null);
+			throw new MessageHandlingException(new GenericMessage<String>(value));
 		}
 
 		public String echoWithErrorAsync(String value) {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
@@ -125,7 +125,7 @@ public class TcpMessageMapper implements
 				bytes = ((String) payload).getBytes(this.charset);
 			}
 			catch (UnsupportedEncodingException e) {
-				throw new MessageHandlingException(message, null, e);
+				throw new MessageHandlingException(message, e);
 			}
 		}
 		else {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/DatagramPacketMessageMapper.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/DatagramPacketMessageMapper.java
@@ -23,15 +23,15 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.ip.util.RegexUtils;
 import org.springframework.integration.mapping.InboundMessageMapper;
 import org.springframework.integration.mapping.MessageMappingException;
 import org.springframework.integration.mapping.OutboundMessageMapper;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
 
 /**
@@ -101,6 +101,7 @@ public class DatagramPacketMessageMapper implements InboundMessageMapper<Datagra
 	/**
 	 * Raw byte[] from message, possibly with a length field up front.
 	 */
+	@Override
 	public DatagramPacket fromMessage(Message<?> message) throws Exception {
 		if (this.acknowledge) {
 			return fromMessageWithAck(message);
@@ -156,7 +157,7 @@ public class DatagramPacketMessageMapper implements InboundMessageMapper<Datagra
 				bytes = ((String) payload).getBytes(this.charset);
 			}
 			catch (UnsupportedEncodingException e) {
-				throw new MessageHandlingException(message, null, e);
+				throw new MessageHandlingException(message, e);
 			}
 		}
 		else {
@@ -166,6 +167,7 @@ public class DatagramPacketMessageMapper implements InboundMessageMapper<Datagra
 		return bytes;
 	}
 
+	@Override
 	public Message<byte[]> toMessage(DatagramPacket packet) throws Exception {
 		int offset = packet.getOffset();
 		int length = packet.getLength();

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsOutboundGateway.java
@@ -673,7 +673,7 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler imp
 			return replyMessage;
 		}
 		catch (JMSException e) {
-			throw new MessageHandlingException(requestMessage, this.getComponentName() + " failed to handle request Message.", e);
+			throw new MessageHandlingException(requestMessage, e);
 		}
 	}
 

--- a/spring-integration-rmi/src/main/java/org/springframework/integration/rmi/RmiOutboundGateway.java
+++ b/spring-integration-rmi/src/main/java/org/springframework/integration/rmi/RmiOutboundGateway.java
@@ -18,13 +18,13 @@ package org.springframework.integration.rmi;
 
 import java.io.Serializable;
 
+import org.springframework.integration.gateway.RequestReplyExchanger;
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessagingException;
-import org.springframework.integration.gateway.RequestReplyExchanger;
-import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
-import org.springframework.integration.support.MessageBuilder;
 import org.springframework.remoting.RemoteAccessException;
 import org.springframework.remoting.rmi.RmiProxyFactoryBean;
 
@@ -65,7 +65,7 @@ public class RmiOutboundGateway extends AbstractReplyProducingMessageHandler {
 			return reply;
 		}
 		catch (MessagingException e) {
-			throw new MessageHandlingException(message, this.getComponentName() + " failed to handle request Message.", e);
+			throw new MessageHandlingException(message, e);
 		}
 		catch (RemoteAccessException e) {
 			throw new MessageHandlingException(message, "Remote failure in RmiOutboundGateway: " + this.getComponentName(), e);

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/selector/XmlValidatingMessageSelector.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/selector/XmlValidatingMessageSelector.java
@@ -99,7 +99,7 @@ public class XmlValidatingMessageSelector implements MessageSelector {
 			validationExceptions = this.xmlValidator.validate(this.converter.convertToSource(message.getPayload()));
 		}
 		catch (Exception e) {
-			throw new MessageHandlingException(message, "XML validation error.", e);
+			throw new MessageHandlingException(message, e);
 		}
 		boolean validationSuccess = ObjectUtils.isEmpty(validationExceptions);
 		if (!validationSuccess) {


### PR DESCRIPTION
When `MHE` was moved to spring-messaging, 2 constructors were
dropped. INT-3246 worked around it but it had undesirable
side-effects. Constructors have been added back in
spring-messaging so this commit reverts to using those
constructors.

JIRA: https://jira.springsource.org/browse/INT-3271
