### PR TITLE
INT-3130: Add result-type to <o-to-j-transformer>

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ObjectToJsonTransformerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ObjectToJsonTransformerParser.java
@@ -16,12 +16,12 @@
 
 package org.springframework.integration.config.xml;
 
-import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.json.ObjectToJsonTransformer;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Mark Fisher
@@ -42,11 +42,13 @@ public class ObjectToJsonTransformerParser extends AbstractTransformerParser {
 		if (StringUtils.hasText(objectMapper)) {
 			builder.addConstructorArgReference(objectMapper);
 		}
+		String resultType = element.getAttribute("result-type");
+		if (StringUtils.hasText(resultType)) {
+			builder.addConstructorArgValue(resultType);
+		}
 		if (element.hasAttribute("content-type")){
 			builder.addPropertyValue("contentType", element.getAttribute("content-type"));
 		}
-
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "result-type");
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ObjectToJsonTransformerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ObjectToJsonTransformerParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,8 @@ public class ObjectToJsonTransformerParser extends AbstractTransformerParser {
 		if (element.hasAttribute("content-type")){
 			builder.addPropertyValue("contentType", element.getAttribute("content-type"));
 		}
+
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "result-type");
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonToObjectTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonToObjectTransformer.java
@@ -43,7 +43,7 @@ public class JsonToObjectTransformer extends AbstractTransformer implements Bean
 
 	private final Class<?> targetClass;
 
-	private final JsonObjectMapper<?> jsonObjectMapper;
+	private final JsonObjectMapper<?, ?> jsonObjectMapper;
 
 	public JsonToObjectTransformer() {
 		this((Class<?>) null);
@@ -82,11 +82,11 @@ public class JsonToObjectTransformer extends AbstractTransformer implements Bean
 		}
 	}
 
-	public JsonToObjectTransformer(JsonObjectMapper<?> jsonObjectMapper) {
+	public JsonToObjectTransformer(JsonObjectMapper<?, ?> jsonObjectMapper) {
 		this(null, jsonObjectMapper);
 	}
 
-	public JsonToObjectTransformer(Class<?> targetClass, JsonObjectMapper<?> jsonObjectMapper) {
+	public JsonToObjectTransformer(Class<?> targetClass, JsonObjectMapper<?, ?> jsonObjectMapper) {
 		this.targetClass = targetClass;
 		this.jsonObjectMapper = (jsonObjectMapper != null) ? jsonObjectMapper : JacksonJsonObjectMapperProvider.newInstance();
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonToObjectTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonToObjectTransformer.java
@@ -23,8 +23,6 @@ import org.springframework.integration.support.json.JacksonJsonObjectMapperProvi
 import org.springframework.integration.support.json.JsonObjectMapper;
 import org.springframework.integration.transformer.AbstractTransformer;
 import org.springframework.messaging.Message;
-import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 
 /**
  * Transformer implementation that converts a JSON string payload into an instance of the provided target Class.
@@ -51,35 +49,6 @@ public class JsonToObjectTransformer extends AbstractTransformer implements Bean
 
 	public JsonToObjectTransformer(Class<?> targetClass) {
 		this(targetClass, null);
-	}
-
-	/**
-	 * Backward compatibility - allows existing configurations using Jackson 1.x to inject
-	 * an ObjectMapper directly.
-	 *
-	 * @param targetClass The target class.
-	 * @param objectMapper The object mapper.
-	 * @throws ClassNotFoundException When the target class is not found.
-	 *
-	 * @deprecated in favor of {@link #JsonToObjectTransformer(Class, JsonObjectMapper)}
-	 */
-	@Deprecated
-	public JsonToObjectTransformer(Class<?> targetClass, Object objectMapper) throws ClassNotFoundException {
-		this.targetClass = targetClass;
-		if (objectMapper != null) {
-			try {
-				Class<?> objectMapperClass = ClassUtils.forName("org.codehaus.jackson.map.ObjectMapper", ClassUtils.getDefaultClassLoader());
-				Assert.isTrue(objectMapperClass.isAssignableFrom(objectMapper.getClass()));
-				this.jsonObjectMapper = new org.springframework.integration.support.json.JacksonJsonObjectMapper(
-						(org.codehaus.jackson.map.ObjectMapper) objectMapper);
-			}
-			catch (ClassNotFoundException e) {
-				throw new IllegalArgumentException(e);
-			}
-		}
-		else {
-			this.jsonObjectMapper = JacksonJsonObjectMapperProvider.newInstance();
-		}
 	}
 
 	public JsonToObjectTransformer(JsonObjectMapper<?, ?> jsonObjectMapper) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/AbstractJacksonJsonMessageParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/AbstractJacksonJsonMessageParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,11 +30,11 @@ import org.springframework.messaging.Message;
  */
 abstract class AbstractJacksonJsonMessageParser<P> implements JsonInboundMessageMapper.JsonMessageParser<P> {
 
-	private final JsonObjectMapper<P> objectMapper;
+	private final JsonObjectMapper<?, P> objectMapper;
 
 	private volatile JsonInboundMessageMapper messageMapper;
 
-	protected AbstractJacksonJsonMessageParser(JsonObjectMapper<P> objectMapper) {
+	protected AbstractJacksonJsonMessageParser(JsonObjectMapper<?, P> objectMapper) {
 		this.objectMapper = objectMapper;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/AbstractJacksonJsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/AbstractJacksonJsonObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.springframework.util.ClassUtils;
  * @author Artem Bilan
  * @since 3.0
  */
-public abstract class AbstractJacksonJsonObjectMapper<P, J> implements JsonObjectMapper<P>, BeanClassLoaderAware {
+public abstract class AbstractJacksonJsonObjectMapper<N, P, J> implements JsonObjectMapper<N, P>, BeanClassLoaderAware {
 
 	protected static final Collection<Class<?>> supportedJsonTypes =
 			Arrays.<Class<?>> asList(String.class, byte[].class, File.class, URL.class, InputStream.class, Reader.class);

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/AbstractJacksonJsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/AbstractJacksonJsonObjectMapper.java
@@ -31,6 +31,10 @@ import org.springframework.util.ClassUtils;
 /**
  * Base class for Jackson {@link JsonObjectMapper} implementations.
  *
+ * @param <N> - The expected type of JSON Node.
+ * @param <P> - The expected type of JSON Parser.
+ * @param <J> - The expected type of Java Type representation.
+ *
  * @author Artem Bilan
  * @since 3.0
  */

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -40,7 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Artem Bilan
  * @since 3.0
  */
-public class Jackson2JsonObjectMapper extends AbstractJacksonJsonObjectMapper<JsonParser, JavaType> {
+public class Jackson2JsonObjectMapper extends AbstractJacksonJsonObjectMapper<JsonNode, JsonParser, JavaType> {
 
 	private final ObjectMapper objectMapper;
 
@@ -61,6 +62,11 @@ public class Jackson2JsonObjectMapper extends AbstractJacksonJsonObjectMapper<Js
 	@Override
 	public void toJson(Object value, Writer writer) throws Exception {
 		this.objectMapper.writeValue(writer, value);
+	}
+
+	@Override
+	public JsonNode toJsonNode(Object value) throws Exception {
+		return this.objectMapper.valueToTree(value);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.Map;
 
+import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.JavaType;
@@ -43,7 +44,7 @@ import org.springframework.util.Assert;
  * @since 3.0
  */
 @Deprecated
-public class JacksonJsonObjectMapper extends AbstractJacksonJsonObjectMapper<JsonParser, JavaType> {
+public class JacksonJsonObjectMapper extends AbstractJacksonJsonObjectMapper<JsonNode, JsonParser, JavaType> {
 
 	private final ObjectMapper objectMapper;
 
@@ -64,6 +65,11 @@ public class JacksonJsonObjectMapper extends AbstractJacksonJsonObjectMapper<Jso
 	@Override
 	public void toJson(Object value, Writer writer) throws Exception {
 		this.objectMapper.writeValue(writer, value);
+	}
+
+	@Override
+	public JsonNode toJsonNode(Object value) throws Exception {
+		return this.objectMapper.valueToTree(value);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonObjectMapperProvider.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonObjectMapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ package org.springframework.integration.support.json;
 public final class JacksonJsonObjectMapperProvider {
 
 	@SuppressWarnings("deprecation")
-	public static JsonObjectMapper<?> newInstance() {
+	public static JsonObjectMapper<?, ?> newInstance() {
 		if (JacksonJsonUtils.isJackson2Present()) {
 			return new Jackson2JsonObjectMapper();
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapper.java
@@ -23,6 +23,9 @@ import java.util.Map;
 /**
  * Strategy interface to convert an Object to/from the JSON representation.
  *
+ * @param <N> - The expected type of JSON Node.
+ * @param <P> - The expected type of JSON Parser.
+ *
  * @author Artem Bilan
  * @since 3.0
  *

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,13 @@ import java.util.Map;
  * @since 3.0
  *
  */
-public interface JsonObjectMapper<P> {
+public interface JsonObjectMapper<N, P> {
 
 	String toJson(Object value) throws Exception;
 
 	void toJson(Object value, Writer writer) throws Exception;
+
+	N toJsonNode(Object value) throws Exception;
 
 	<T> T fromJson(Object json, Class<T> valueType) throws Exception;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapperAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapperAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import java.util.Map;
  * @author Artem Bilan
  * @since 3.0
  */
-public abstract class JsonObjectMapperAdapter<P> implements JsonObjectMapper<P> {
+public abstract class JsonObjectMapperAdapter<N, P> implements JsonObjectMapper<N, P> {
 
 	@Override
 	public String toJson(Object value) throws Exception {
@@ -36,6 +36,11 @@ public abstract class JsonObjectMapperAdapter<P> implements JsonObjectMapper<P> 
 
 	@Override
 	public void toJson(Object value, Writer writer) throws Exception {
+	}
+
+	@Override
+	public N toJsonNode(Object value) throws Exception {
+		return null;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonOutboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonOutboundMessageMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,13 +32,13 @@ public class JsonOutboundMessageMapper implements OutboundMessageMapper<String> 
 
 	private volatile boolean shouldExtractPayload = false;
 
-	private volatile JsonObjectMapper<?> jsonObjectMapper;
+	private volatile JsonObjectMapper<?, ?> jsonObjectMapper;
 
 	public JsonOutboundMessageMapper() {
 		this(JacksonJsonObjectMapperProvider.newInstance());
 	}
 
-	public JsonOutboundMessageMapper(JsonObjectMapper<?> jsonObjectMapper) {
+	public JsonOutboundMessageMapper(JsonObjectMapper<?, ?> jsonObjectMapper) {
 		Assert.notNull(jsonObjectMapper, "jsonObjectMapper must not be null");
 		this.jsonObjectMapper = jsonObjectMapper;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ObjectToMapTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ObjectToMapTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ import org.springframework.util.StringUtils;
  */
 public class ObjectToMapTransformer extends AbstractPayloadTransformer<Object, Map<?,?>> {
 
-	private final JsonObjectMapper<?> jsonObjectMapper = JacksonJsonObjectMapperProvider.newInstance();
+	private final JsonObjectMapper<?, ?> jsonObjectMapper = JacksonJsonObjectMapperProvider.newInstance();
 
 	private volatile boolean shouldFlattenKeys = true;
 

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
@@ -2271,8 +2271,29 @@
 				</xsd:appinfo>-->
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="result-type" default="STRING">
+			<xsd:annotation>
+				<xsd:documentation>
+					The type for representation of result JSON. Can apply 'STRING' and 'NODE' values.
+					If 'NODE' is provided the result JSON tree depends on provided implementation of
+					'org.springframework.integration.support.json.JsonObjectMapper'.
+					Default value is 'STRING'.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="jsonResultTypeEnumeration xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
 		<xsd:attribute name="id" type="xsd:string" />
 	</xsd:complexType>
+
+	<xsd:simpleType name="jsonResultTypeEnumeration">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="STRING" />
+			<xsd:enumeration value="NODE" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
 
 	<xsd:element name="json-to-object-transformer">
 		<xsd:annotation>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
@@ -2263,12 +2263,11 @@
 					This Jackson 1 ObjectMapper backward compatibility is deprecated
 					and will be removed in the Spring Integration 3.1 or above.
 				</xsd:documentation>
-				<!-- TODO: Revert in the Spring Integration 3.1 or above after removing Jackson 1 backward compatibility
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
 						<tool:expected-type type="org.springframework.integration.support.json.JsonObjectMapper" />
 					</tool:annotation>
-				</xsd:appinfo>-->
+				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="result-type" default="STRING">
@@ -2331,12 +2330,11 @@
 					This Jackson 1 ObjectMapper backward compatibility is deprecated
 					and will be removed in the Spring Integration 3.1 or above.
 				</xsd:documentation>
-				<!-- TODO: Revert in the Spring Integration 3.1 or above after removing Jackson 1 backward compatibility
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
 						<tool:expected-type type="org.springframework.integration.support.json.JsonObjectMapper" />
 					</tool:annotation>
-				</xsd:appinfo>-->
+				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="id" type="xsd:string" />

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/AbstractJsonInboundMessageMapperTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/AbstractJsonInboundMessageMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ import org.springframework.messaging.Message;
  */
 public abstract class AbstractJsonInboundMessageMapperTests {
 
-	private final JsonObjectMapper<?> mapper = JacksonJsonObjectMapperProvider.newInstance();
+	private final JsonObjectMapper<?, ?> mapper = JacksonJsonObjectMapperProvider.newInstance();
 
 	@Factory
     public static Matcher<Message<?>> sameExceptImmutableHeaders(Message<?> operand) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/JsonToObjectTransformerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/JsonToObjectTransformerParserTests-context.xml
@@ -10,12 +10,6 @@
 	<json-to-object-transformer id="defaultJacksonMapperTransformer" input-channel="defaultObjectMapperInput"
 			type="org.springframework.integration.json.TestPerson"/>
 
-	<json-to-object-transformer id="customJacksonMapperTransformer" input-channel="customObjectMapperInput"
-			type="org.springframework.integration.json.TestPerson"
-			object-mapper="customObjectMapper"/>
-
-	<beans:bean id="customObjectMapper" class="org.springframework.integration.json.JsonToObjectTransformerParserTests$CustomObjectMapper"/>
-
 	<json-to-object-transformer id="customJsonMapperTransformer" input-channel="customJsonObjectMapperInput"
 			type="org.springframework.integration.json.TestPerson"
 			object-mapper="customJsonObjectMapper"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/JsonToObjectTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/JsonToObjectTransformerParserTests.java
@@ -20,8 +20,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 
-import org.codehaus.jackson.JsonParser.Feature;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,9 +50,6 @@ public class JsonToObjectTransformerParserTests {
 	private volatile MessageChannel defaultObjectMapperInput;
 
 	@Autowired
-	private volatile MessageChannel customObjectMapperInput;
-
-	@Autowired
 	private volatile MessageChannel customJsonObjectMapperInput;
 
 	@Autowired
@@ -62,15 +57,8 @@ public class JsonToObjectTransformerParserTests {
 	private MessageHandler defaultJacksonMapperTransformer;
 
 	@Autowired
-	@Qualifier("customJacksonMapperTransformer.handler")
-	private MessageHandler customJacksonMapperTransformer;
-
-	@Autowired
 	@Qualifier("customJsonMapperTransformer.handler")
 	private MessageHandler customJsonMapperTransformer;
-
-	@Autowired
-	private ObjectMapper customObjectMapper;
 
 	@Autowired
 	private JsonObjectMapper<?, ?> jsonObjectMapper;
@@ -84,27 +72,6 @@ public class JsonToObjectTransformerParserTests {
 		QueueChannel replyChannel = new QueueChannel();
 		Message<String> message = MessageBuilder.withPayload(jsonString).setReplyChannel(replyChannel).build();
 		this.defaultObjectMapperInput.send(message);
-		Message<?> reply = replyChannel.receive(0);
-		assertNotNull(reply);
-		assertNotNull(reply.getPayload());
-		assertEquals(TestPerson.class, reply.getPayload().getClass());
-		TestPerson person = (TestPerson) reply.getPayload();
-		assertEquals("John", person.getFirstName());
-		assertEquals("Doe", person.getLastName());
-		assertEquals(42, person.getAge());
-		assertEquals("123 Main Street", person.getAddress().toString());
-	}
-
-	@Test
-	public void customObjectMapper() {
-		Object jsonToObjectTransformer = TestUtils.getPropertyValue(this.customJacksonMapperTransformer, "transformer");
-		JsonObjectMapper<?, ?> jsonObjectMapper = TestUtils.getPropertyValue(jsonToObjectTransformer, "jsonObjectMapper", JsonObjectMapper.class);
-		assertSame(this.customObjectMapper, TestUtils.getPropertyValue(jsonObjectMapper, "objectMapper"));
-
-		String jsonString = "{firstName:'John', lastName:'Doe', age:42, address:{number:123, street:'Main Street'}}";
-		QueueChannel replyChannel = new QueueChannel();
-		Message<String> message = MessageBuilder.withPayload(jsonString).setReplyChannel(replyChannel).build();
-		this.customObjectMapperInput.send(message);
 		Message<?> reply = replyChannel.receive(0);
 		assertNotNull(reply);
 		assertNotNull(reply.getPayload());
@@ -131,15 +98,6 @@ public class JsonToObjectTransformerParserTests {
 		assertEquals(TestJsonContainer.class, reply.getPayload().getClass());
 		TestJsonContainer result = (TestJsonContainer) reply.getPayload();
 		assertEquals(jsonString, result.getJson());
-	}
-
-
-	static class CustomObjectMapper extends ObjectMapper {
-
-		public CustomObjectMapper() {
-			this.configure(Feature.ALLOW_UNQUOTED_FIELD_NAMES, Boolean.TRUE);
-			this.configure(Feature.ALLOW_SINGLE_QUOTES, Boolean.TRUE);
-		}
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/JsonToObjectTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/JsonToObjectTransformerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ public class JsonToObjectTransformerParserTests {
 	private ObjectMapper customObjectMapper;
 
 	@Autowired
-	private JsonObjectMapper<?> jsonObjectMapper;
+	private JsonObjectMapper<?, ?> jsonObjectMapper;
 
 	@Test
 	public void defaultObjectMapper() {
@@ -98,7 +98,7 @@ public class JsonToObjectTransformerParserTests {
 	@Test
 	public void customObjectMapper() {
 		Object jsonToObjectTransformer = TestUtils.getPropertyValue(this.customJacksonMapperTransformer, "transformer");
-		JsonObjectMapper<?> jsonObjectMapper = TestUtils.getPropertyValue(jsonToObjectTransformer, "jsonObjectMapper", JsonObjectMapper.class);
+		JsonObjectMapper<?, ?> jsonObjectMapper = TestUtils.getPropertyValue(jsonToObjectTransformer, "jsonObjectMapper", JsonObjectMapper.class);
 		assertSame(this.customObjectMapper, TestUtils.getPropertyValue(jsonObjectMapper, "objectMapper"));
 
 		String jsonString = "{firstName:'John', lastName:'Doe', age:42, address:{number:123, street:'Main Street'}}";

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests-context.xml
@@ -20,6 +20,8 @@
 	<object-to-json-transformer id="customJsonObjectMapperTransformer" input-channel="customJsonObjectMapperInput"
 								object-mapper="customJsonObjectMapper"/>
 
+	<object-to-json-transformer id="jsonNodeTransformer" input-channel="jsonNodeInput" result-type="NODE"/>
+
 	<beans:bean id="customJsonObjectMapper" class="org.springframework.integration.json.ObjectToJsonTransformerParserTests$CustomJsonObjectMapper"/>
 
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests-context.xml
@@ -9,13 +9,9 @@
 
 	<object-to-json-transformer id="defaultTransformer" input-channel="defaultObjectMapperInput"/>
 
-	<object-to-json-transformer id="customTransformer" input-channel="customObjectMapperInput" object-mapper="customObjectMapper"/>
-
 	<object-to-json-transformer id="emptyContentTypeTransformer" input-channel="customObjectMapperInput" content-type=""/>
 
 	<object-to-json-transformer id="overridenContentTypeTransformer" input-channel="customObjectMapperInput" content-type="text/xml"/>
-
-	<beans:bean id="customObjectMapper" class="org.springframework.integration.json.ObjectToJsonTransformerParserTests$CustomObjectMapper"/>
 
 	<object-to-json-transformer id="customJsonObjectMapperTransformer" input-channel="customJsonObjectMapperInput"
 								object-mapper="customJsonObjectMapper"/>

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/MapJsonSerializer.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/MapJsonSerializer.java
@@ -48,7 +48,7 @@ import org.springframework.util.Assert;
  */
 public class MapJsonSerializer implements Serializer<Map<?, ?>>, Deserializer<Map<?, ?>> {
 
-	private volatile JsonObjectMapper<?> jsonObjectMapper = JacksonJsonObjectMapperProvider.newInstance();
+	private volatile JsonObjectMapper<?, ?> jsonObjectMapper = JacksonJsonObjectMapperProvider.newInstance();
 
 	private volatile Deserializer<byte[]> packetDeserializer = new ByteArrayLfSerializer();
 
@@ -59,7 +59,7 @@ public class MapJsonSerializer implements Serializer<Map<?, ?>>, Deserializer<Ma
 	 * JSON. Use this if you wish to set additional {@link JsonObjectMapper} implementation features.
 	 * @param jsonObjectMapper the jsonObjectMapper.
 	 */
-	public void setJsonObjectMapper(JsonObjectMapper<?> jsonObjectMapper) {
+	public void setJsonObjectMapper(JsonObjectMapper<?, ?> jsonObjectMapper) {
 		Assert.notNull(jsonObjectMapper, "'jsonObjectMapper' cannot be null");
 		this.jsonObjectMapper = jsonObjectMapper;
 	}

--- a/src/reference/docbook/transformer.xml
+++ b/src/reference/docbook/transformer.xml
@@ -368,6 +368,15 @@ public class Foo {
 	 Since version <emphasis>3.0</emphasis>, Spring Integration also provides a built-in <emphasis>#xpath</emphasis>
 	 SpEL function for use in expressions. For more information see <xref linkend="xpath-spel-function"/>.
 	</para>
+	<para>
+		Beginning with <emphasis>version 4.0</emphasis>, the <classname>ObjectToJsonTransformer</classname>
+		supports the <code>resultType</code> option, to allow get the <emphasis>node</emphasis> JSON representation.
+		The result node tree presentation depends on the implementation of provided <interfacename>JsonObjectMapper</interfacename>.
+		By default <classname>ObjectToJsonTransformer</classname> uses <classname>Jackson2JsonObjectMapper</classname>
+		and delegates the conversion of the object to the node tree to the <classname>ObjectMapper#valueToTree</classname> method.
+		The node JSON representation provides efficiency for <classname>JsonPropertyAccessor</classname>, when the
+		downstream message flow uses SpEL expressions with access to the properties of the JSON data.
+	</para>
   </section>
 
   <section id="transformer-annotation">

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -32,12 +32,21 @@
 			<ulink url="https://github.com/spring-projects/spring-integration/wiki/Spring-Integration-3.0-to-4.0-Migration-Guide"
 			>Migration Guide</ulink>.
 		</para>
-		<section id="3.0-xpath-header-enricher-header-type">
+		<section id="4.0-xpath-header-enricher-header-type">
 			<title>Header Type for XPath Header Enricher</title>
 			<para>
 				The <code>header-type</code> attribute has been introduced for the <code>header</code> sub-element of the
 				<code>&lt;int-xml:xpath-header-enricher&gt;</code>. This attribute provides the target type for
 				the header value to which the result of the XPath expression evaluation will be converted.
+				For more information see <xref linkend="xml-xpath-header-enricher"/>.
+			</para>
+		</section>
+		<section id="4.0-object-to-json-transformer-result-type">
+			<title>Object To Json Transformer: Node Result</title>
+			<para>
+				The <code>result-type</code> attribute has been introduced for the  <code>&lt;int:object-to-json-transformer&gt;</code>.
+				This attribute provides the target type for the result of object mapping to the JSON.
+				Supports <code>STRING</code> (default) and <code>NODE</code>.
 				For more information see <xref linkend="xml-xpath-header-enricher"/>.
 			</para>
 		</section>


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3130
- add `result-type` attribute to the `<object-to-json-transformer>`
  based on enumeration values: `STRING`, `NODE`
- Provide implementations for methods to convert value to the node representation
- Refactoring according new generic option in the `JsonObjectMapper`
- Add tests and documentation

Need Migration Guide note according this refactoring
