### PR TITLE
INT-3289 FileWMH - Improve Exception Message

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -250,7 +250,8 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 	private void validateDestinationDirectory(File destinationDirectory, boolean autoCreateDirectory) {
 
 		if (!destinationDirectory.exists() && autoCreateDirectory) {
-			destinationDirectory.mkdirs();
+			Assert.isTrue(destinationDirectory.mkdirs(),
+				"Destination directory [" + destinationDirectory + "] could not be created.");
 		}
 
 		Assert.isTrue(destinationDirectory.exists(),


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3289

Emit '...could not be created.' instead of 'does not exist.'
if the `mkDirs` fails on auto-create.
