### PR TITLE
INT-3292: Add support for Boot AutoConfiguration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ subprojects { subproject ->
 		springSocialTwitterVersion = '1.0.5.RELEASE'
 		springWsVersion = '2.1.1.RELEASE'
 		springRetryVersion = '1.0.3.RELEASE'
+		springBootVersion = '1.0.0.RC1'
 	}
 
 	eclipse {
@@ -205,7 +206,11 @@ project('spring-integration-core') {
 		compile("org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion", optional)
 		compile("com.fasterxml.jackson.core:jackson-databind:$jackson2Version", optional)
 		compile('com.jayway.jsonpath:json-path:0.9.0', optional)
+
 		testCompile ("org.aspectj:aspectjweaver:$aspectjVersion")
+		testCompile ("org.springframework.boot:spring-boot-autoconfigure:$springBootVersion") {
+			exclude group: 'org.springframework'
+		}
 	}
 }
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/boot/IntegrationAutoConfiguration.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/boot/IntegrationAutoConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.config.boot;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.config.EnableIntegration;
+
+/**
+ * @author Artem Bilan
+ * @since 4.0
+ */
+@Configuration
+@EnableIntegration
+interface IntegrationAutoConfiguration {
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/boot/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/boot/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains components for Spring Boot configuration.
+ */
+package org.springframework.integration.config.boot;

--- a/spring-integration-core/src/main/resources/META-INF/spring.factories
+++ b/spring-integration-core/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.springframework.integration.config.boot.IntegrationAutoConfiguration

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/boot/IntegrationAutoConfigurationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/boot/IntegrationAutoConfigurationTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.configuration.boot;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.integration.context.IntegrationContextUtils;
+
+/**
+ * @author Artem Bilan
+ * @since 4.0
+ */
+public class IntegrationAutoConfigurationTests {
+
+	@Test
+	public void testIntegrationAutoConfiguration() {
+		ConfigurableApplicationContext applicationContext = SpringApplication.run(Configuration.class);
+		assertTrue(applicationContext.containsBean(IntegrationContextUtils.CHANNEL_INITIALIZER_BEAN_NAME));
+		assertTrue(applicationContext.containsBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME));
+		assertTrue(applicationContext.containsBean(IntegrationContextUtils.MESSAGING_ANNOTATION_POSTPROCESSOR_NAME));
+		assertTrue(applicationContext.containsBean("jsonPath"));
+		assertFalse(applicationContext.containsBean("xpath"));
+	}
+
+	@EnableAutoConfiguration
+	public static class Configuration {
+	}
+
+}

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -36,11 +36,20 @@
 			</para>
 		</section>
 		<section>
-			<title>@EnableConfiguration</title>
+			<title>@EnableIntegration</title>
 			<para>
 				The <code>@EnableIntegration</code> annotation has been added, to permit declaration of
 				standard Spring Integration beans when using <code>@Configuration</code> classes. See
 				<xref linkend="enable-integration"/> for more information.
+			</para>
+		</section>
+		<section>
+			<title>Spring Boot @EnableAutoConfiguration</title>
+			<para>
+				Together with <code>@EnableIntegration</code> annotation has been introduced a hook to allow
+				Spring Integration infrastructure via Spring Boot <code>@EnableAutoConfiguration</code>.
+				For more information see
+				<ulink url="http://projects.spring.io/spring-boot/docs/spring-boot-autoconfigure/README.html">Spring Boot - AutoConfigure</ulink>.
 			</para>
 		</section>
 		<section id="4.0-xpath-header-enricher-header-type">


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3292

As far as Spring Boot reads `spring.factories` for key
`org.springframework.boot.autoconfigure.EnableAutoConfiguration`,
there is no difficulties to provide a hook to enable Spring Integration
via just Boot `@EnableAutoConfiguration`
