### PR TITLE
INT-3297: Add `@MessagingGateway` support

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Gateway.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Gateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import java.lang.annotation.Target;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -58,5 +59,9 @@ public @interface Gateway {
 	long requestTimeout() default Long.MIN_VALUE;
 
 	long replyTimeout() default Long.MIN_VALUE;
+
+	String payloadExpression() default "";
+
+	GatewayHeader[] headers() default {};
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/GatewayHeader.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/GatewayHeader.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Provides the message header {@code value} or {@code expression}.
+ *
+ * @author Artem Bilan
+ * @since 4.0
+ */
+@Target({ })
+@Retention(RUNTIME)
+public @interface GatewayHeader {
+
+	/**
+	 * @return The name of the header.
+	 */
+	String name();
+
+	/**
+	 * @return The value for the header.
+	 */
+	String value() default "";
+
+	/**
+	 * @return The {@code Expression} to be evaluated to produce a value for the header.
+	 */
+	String expression() default "";
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/IntegrationComponentScan.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/IntegrationComponentScan.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.integration.config.IntegrationComponentsRegistrar;
+
+/**
+ * Configures component scanning directives for use with @{@link org.springframework.context.annotation.Configuration} classes.
+ * Scan Spring Integration specific components.
+ *
+ * @author Artem Bilan
+ * @since 4.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+@Import(IntegrationComponentsRegistrar.class)
+public @interface IntegrationComponentScan {
+
+	/**
+	 * Alias for the {@link #basePackages()} attribute.
+	 * Allows for more concise annotation declarations e.g.:
+	 * {@code @ComponentScan("org.my.pkg")} instead of
+	 * {@code @ComponentScan(basePackages="org.my.pkg")}.
+	 */
+	String[] value() default {};
+
+	/**
+	 * Base packages to scan for annotated components.
+	 * <p>{@link #value()} is an alias for (and mutually exclusive with) this attribute.
+	 * <p>Use {@link #basePackageClasses()} for a type-safe alternative to String-based package names.
+	 */
+	String[] basePackages() default {};
+
+	/**
+	 * Type-safe alternative to {@link #basePackages()} for specifying the packages
+	 * to scan for annotated components. The package of each class specified will be scanned.
+	 * <p>Consider creating a special no-op marker class or interface in each package
+	 * that serves no purpose other than being referenced by this attribute.
+	 */
+	Class<?>[] basePackageClasses() default {};
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/IntegrationComponentScan.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/IntegrationComponentScan.java
@@ -23,7 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.context.annotation.Import;
-import org.springframework.integration.config.IntegrationComponentsRegistrar;
+import org.springframework.integration.config.IntegrationComponentScanRegistrar;
 
 /**
  * Configures component scanning directives for use with @{@link org.springframework.context.annotation.Configuration} classes.
@@ -35,7 +35,7 @@ import org.springframework.integration.config.IntegrationComponentsRegistrar;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Documented
-@Import(IntegrationComponentsRegistrar.class)
+@Import(IntegrationComponentScanRegistrar.class)
 public @interface IntegrationComponentScan {
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The stereotype annotation to provide the Integration Messaging Gateway Proxy ({@code <gateway/>}).
+ *
+ * @author Artem Bilan
+ * @since 4.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MessagingGateway {
+
+	/**
+	 * The value may indicate a suggestion for a logical component name,
+	 * to be turned into a Spring bean in case of an autodetected component.
+	 *
+	 * @return the suggested component name, if any
+	 */
+	String value() default "";
+
+	/**
+	 * Identifies default channel the messages will be sent to upon invocation of methods of the gateway proxy.
+	 *
+	 * @return the suggested channel name, if any
+	 */
+	String defaultRequestChannel() default "";
+
+	/**
+	 * Identifies default channel the gateway proxy will subscribe to to receive reply {@code Message}s, which will then be
+	 * converted to the return type of the method signature.
+	 *
+	 * @return the suggested channel name, if any
+	 */
+	String defaultReplyChannel() default "";
+
+	/**
+	 * Identifies a channel that error messages will be sent to if a failure occurs in the
+	 * gateway's proxy invocation. If no {@code errorChannel} reference is provided, the gateway will
+	 * propagate {@code Exception}s to the caller. To completely suppress {@code Exception}s, provide a
+	 * reference to the {@code nullChannel} here.
+	 *
+	 * @return the suggested channel name, if any
+	 */
+	String errorChannel() default "";
+
+	/**
+	 * Provides the amount of time dispatcher would wait to send a {@code Message}.
+	 * This timeout would only apply if there is a potential to block in the send call.
+	 * For example if this gateway is hooked up to a {@code QueueChannel}. 
+	 *
+	 * @return the suggested timeout in milliseconds, if any
+	 */
+	long defaultRequestTimeout() default Long.MIN_VALUE;
+
+	/**
+	 * Allows to specify how long this gateway will wait for the reply {@code Message}
+	 * before returning. By default it will wait indefinitely. {@code null} is returned
+	 if the gateway times out.
+	 *
+	 * @return the suggested timeout in milliseconds, if any
+	 */
+	long defaultReplyTimeout() default Long.MIN_VALUE;
+
+	/**
+	 * Provide a reference to an implementation of {@link java.util.concurrent.Executor}
+	 * to use for any of the interface methods that have a {@link java.util.concurrent.Future} return type.
+	 * This {@code Executor} will only be used for those async methods; the sync methods
+	 * will be invoked in the caller's thread.
+	 *
+	 * @return the suggested executor bean name, if any
+	 */
+	String asyncExecutor() default "";
+
+	/**
+	 * An expression that will be used to generate the {@code payload} for all methods in the service interface
+	 * unless explicitly overridden by a method declaration. Variables include {@code #args}, {@code #methodName},
+	 * {@code #methodString} and {@code #methodObject};
+	 * a bean resolver is also available, enabling expressions like {@code @someBean(#args)}.
+	 *
+	 * @return the suggested payload expression, if any
+	 */
+	String defaultPayloadExpression() default "";
+
+	/**
+	 * Provides custom message headers. These default headers are created for
+	 * all methods on the service-interface (unless overridden by a specific method).
+	 *
+	 * @return the suggested payload expression, if any
+	 */
+	GatewayHeader[] defaultHeaders() default {};
+
+	/**
+	 * An {@link org.springframework.integration.gateway.MethodArgsMessageMapper}
+	 * to map the method arguments to a {@link org.springframework.messaging.Message}. When this
+	 * is provided, no {@code payload-expression}s or {@code header}s are allowed; the custom mapper is
+	 * responsible for creating the message.
+	 *
+	 * @return the suggested mapper bean name, if any
+	 */
+	String mapper() default "";
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
@@ -39,7 +39,7 @@ public @interface MessagingGateway {
 	 *
 	 * @return the suggested component name, if any
 	 */
-	String value() default "";
+	String name() default "";
 
 	/**
 	 * Identifies default channel the messages will be sent to upon invocation of methods of the gateway proxy.

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationComponentsRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationComponentsRegistrar.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.config;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.integration.annotation.MessagingGateway;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link ImportBeanDefinitionRegistrar} implementation to scan and register Integration specific components.
+ *
+ * @author Artem Bilan
+ * @since 4.0
+ */
+public class IntegrationComponentsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLoaderAware {
+
+	private ResourceLoader resourceLoader;
+
+	@Override
+	public void setResourceLoader(ResourceLoader resourceLoader) {
+		this.resourceLoader = resourceLoader;
+	}
+
+	@Override
+	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+		Map<String, Object> componentScan = importingClassMetadata.getAnnotationAttributes("org.springframework.integration.annotation.IntegrationComponentScan");
+
+		Set<String> basePackages = new HashSet<String>();
+		for (String pkg : (String[]) componentScan.get("value")) {
+			if (StringUtils.hasText(pkg)) {
+				basePackages.add(pkg);
+			}
+		}
+		for (String pkg : (String[]) componentScan.get("basePackages")) {
+			if (StringUtils.hasText(pkg)) {
+				basePackages.add(pkg);
+			}
+		}
+		for (Class<?> clazz : (Class[]) componentScan.get("basePackageClasses")) {
+			basePackages.add(ClassUtils.getPackageName(clazz));
+		}
+
+		if (basePackages.isEmpty()) {
+			basePackages.add(ClassUtils.getPackageName(importingClassMetadata.getClassName()));
+		}
+
+		ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false) {
+
+			@Override
+			protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
+				return beanDefinition.getMetadata().isIndependent();
+			}
+		};
+		scanner.addIncludeFilter(new AnnotationTypeFilter(MessagingGateway.class));
+		scanner.setResourceLoader(resourceLoader);
+
+		for (String basePackage : basePackages) {
+			Set<BeanDefinition> candidateComponents = scanner.findCandidateComponents(basePackage);
+			for (BeanDefinition candidateComponent : candidateComponents) {
+				if (candidateComponent instanceof AnnotatedBeanDefinition &&
+						((AnnotatedBeanDefinition) candidateComponent).getMetadata().hasAnnotation(MessagingGateway.class.getName())) {
+					new MessagingGatewayRegistrar().registerBeanDefinitions(((AnnotatedBeanDefinition) candidateComponent).getMetadata(), registry);
+				}
+			}
+		}
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.config;
+
+import java.beans.Introspector;
+import java.util.Map;
+
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.ManagedMap;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.expression.common.LiteralExpression;
+import org.springframework.integration.annotation.MessagingGateway;
+import org.springframework.integration.gateway.GatewayMethodMetadata;
+import org.springframework.integration.gateway.GatewayProxyFactoryBean;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * The {@link ImportBeanDefinitionRegistrar} to parse {@link MessagingGateway} and its service-interface
+ * and registers {@link GatewayProxyFactoryBean} {@link org.springframework.beans.factory.config.BeanDefinition}.
+ *
+ * @author Artem Bilan
+ * @since 4.0
+ */
+public class MessagingGatewayRegistrar implements ImportBeanDefinitionRegistrar {
+
+	@Override
+	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+		Map<String, Object> annotationAttributes = importingClassMetadata.getAnnotationAttributes(MessagingGateway.class.getName());
+		String id = (String) annotationAttributes.get("value");
+		String defaultPayloadExpression = (String) annotationAttributes.get("defaultPayloadExpression");
+		AnnotationAttributes[] defaultHeaders = (AnnotationAttributes[]) annotationAttributes.get("defaultHeaders");
+		String defaultRequestChannel = (String) annotationAttributes.get("defaultRequestChannel");
+		String defaultReplyChannel = (String) annotationAttributes.get("defaultReplyChannel");
+		String errorChannel = (String) annotationAttributes.get("errorChannel");
+		Long defaultRequestTimeout = (Long) annotationAttributes.get("defaultRequestTimeout");
+		Long defaultReplyTimeout = (Long) annotationAttributes.get("defaultReplyTimeout");
+		String asyncExecutor = (String) annotationAttributes.get("asyncExecutor");
+		String mapper = (String) annotationAttributes.get("mapper");
+
+		boolean hasMapper = StringUtils.hasText(mapper);
+		boolean hasDefaultPayloadExpression = StringUtils.hasText(defaultPayloadExpression);
+		Assert.state(!hasMapper || !hasDefaultPayloadExpression, "'defaultPayloadExpression' is not allowed when a 'mapper' is provided");
+
+		boolean hasDefaultHeaders = !ObjectUtils.isEmpty(defaultHeaders);
+		Assert.state(!hasMapper || !hasDefaultHeaders, "'defaultHeaders' are not allowed when a 'mapper' is provided");
+
+		BeanDefinitionBuilder gatewayProxyBuilder = BeanDefinitionBuilder.genericBeanDefinition(GatewayProxyFactoryBean.class);
+
+
+		if (hasDefaultHeaders || hasDefaultPayloadExpression) {
+			BeanDefinitionBuilder methodMetadataBuilder = BeanDefinitionBuilder.genericBeanDefinition(GatewayMethodMetadata.class);
+			if (hasDefaultPayloadExpression) {
+				methodMetadataBuilder.addPropertyValue("payloadExpression", defaultPayloadExpression);
+			}
+			this.setMethodInvocationHeaders(methodMetadataBuilder, defaultHeaders);
+			gatewayProxyBuilder.addPropertyValue("globalMethodMetadata", methodMetadataBuilder.getBeanDefinition());
+		}
+
+
+		if (StringUtils.hasText(defaultRequestChannel)) {
+			gatewayProxyBuilder.addPropertyReference("defaultRequestChannel", defaultRequestChannel);
+		}
+		if (StringUtils.hasText(defaultReplyChannel)) {
+			gatewayProxyBuilder.addPropertyReference("defaultReplyChannel", defaultReplyChannel);
+		}
+		if (StringUtils.hasText(errorChannel)) {
+			gatewayProxyBuilder.addPropertyReference("errorChannel", errorChannel);
+		}
+		if (StringUtils.hasText(asyncExecutor)) {
+			gatewayProxyBuilder.addPropertyReference("asyncExecutor", asyncExecutor);
+		}
+		if (StringUtils.hasText(mapper)) {
+			gatewayProxyBuilder.addPropertyReference("mapper", mapper);
+		}
+		gatewayProxyBuilder.addPropertyValue("defaultRequestTimeout", defaultRequestTimeout);
+		gatewayProxyBuilder.addPropertyValue("defaultReplyTimeout", defaultReplyTimeout);
+
+		String serviceInterface = importingClassMetadata.getClassName();
+		gatewayProxyBuilder.addConstructorArgValue(serviceInterface);
+
+		if (!StringUtils.hasText(id)) {
+			id = Introspector.decapitalize(serviceInterface.substring(serviceInterface.lastIndexOf(".") + 1));
+		}
+
+		registry.registerBeanDefinition(id, gatewayProxyBuilder.getBeanDefinition());
+	}
+
+	private void setMethodInvocationHeaders(BeanDefinitionBuilder methodMetadataBuilder, AnnotationAttributes[] headerAnnotations) {
+		Map<String, Object> headerExpressions = new ManagedMap<String, Object>();
+		for (AnnotationAttributes headerAnnotation : headerAnnotations) {
+			String headerName = (String) headerAnnotation.get("name");
+			Assert.state(StringUtils.hasText(headerName), "The 'name' attribute is is required for gateway's header.");
+
+			String headerValue = (String) headerAnnotation.get("value");
+			String headerExpression = (String) headerAnnotation.get("expression");
+			boolean hasValue = StringUtils.hasText(headerValue);
+			boolean hasExpression = StringUtils.hasText(headerExpression);
+			if (!(hasValue ^ hasExpression)) {
+				throw new BeanDefinitionStoreException("exactly one of 'value' or 'expression' is required on a gateway's header.");
+			}
+			RootBeanDefinition expressionDef = null;
+			if (hasValue) {
+				expressionDef = new RootBeanDefinition(LiteralExpression.class);
+				expressionDef.getConstructorArgumentValues().addGenericArgumentValue(headerValue);
+			}
+			else {
+				expressionDef = new RootBeanDefinition(ExpressionFactoryBean.class);
+				expressionDef.getConstructorArgumentValues().addGenericArgumentValue(headerExpression);
+			}
+
+			headerExpressions.put(headerName, expressionDef);
+		}
+		methodMetadataBuilder.addPropertyValue("headerExpressions", headerExpressions);
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
@@ -56,7 +56,7 @@ public class MessagingGatewayRegistrar implements ImportBeanDefinitionRegistrar 
 
 		BeanDefinition gatewayBeanDefinition = this.parse(importingClassMetadata);
 
-		String id = (String) annotationAttributes.get("value");
+		String id = (String) annotationAttributes.get("name");
 		if (!StringUtils.hasText(id)) {
 			String serviceInterface = gatewayBeanDefinition.getConstructorArgumentValues().getIndexedArgumentValue(0, Class.class).getValue().toString();
 			id = Introspector.decapitalize(serviceInterface.substring(serviceInterface.lastIndexOf(".") + 1));

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GatewayParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GatewayParser.java
@@ -57,7 +57,7 @@ public class GatewayParser implements BeanDefinitionParser {
 		boolean isNested = parserContext.isNested();
 
 		final Map<String, Object> gatewayAttributes = new HashMap<String, Object>();
-		gatewayAttributes.put("value", element.getAttribute(AbstractBeanDefinitionParser.ID_ATTRIBUTE));
+		gatewayAttributes.put("name", element.getAttribute(AbstractBeanDefinitionParser.ID_ATTRIBUTE));
 		gatewayAttributes.put("defaultPayloadExpression", element.getAttribute("default-payload-expression"));
 		gatewayAttributes.put("defaultRequestChannel", element.getAttribute(isNested ? "request-channel" : "default-request-channel"));
 		gatewayAttributes.put("defaultReplyChannel", element.getAttribute(isNested ? "reply-channel" : "default-reply-channel"));

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
@@ -651,7 +651,7 @@
 					<xsd:documentation>
 										<![CDATA[
 				An expression that will be used to generate the payload for all methods in the service interface
-				unless explicitly overriden by a method declaration. Variables include #args, #methodName, #methodString
+				unless explicitly overridden by a method declaration. Variables include #args, #methodName, #methodString
 				and #methodObject; a bean resolver is also available, enabling expressions like "@someBean(#args)".
 										]]>
 					</xsd:documentation>

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyFactoryBeanTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyFactoryBeanTests.java
@@ -336,7 +336,7 @@ public class GatewayProxyFactoryBeanTests {
 		gpfb.setServiceInterface(TestEchoService.class);
 		QueueChannel drc = new QueueChannel();
 		gpfb.setDefaultRequestChannel(drc);
-		gpfb.setDefaultReplyTimeout(0);
+		gpfb.setDefaultReplyTimeout(0L);
 		GatewayMethodMetadata meta = new GatewayMethodMetadata();
 		meta.setHeaderExpressions(Collections. <String, Expression> singletonMap("foo", new LiteralExpression("bar")));
 		gpfb.setGlobalMethodMetadata(meta);

--- a/src/reference/docbook/gateway.xml
+++ b/src/reference/docbook/gateway.xml
@@ -241,8 +241,9 @@ public String send2(Map foo, Map bar);
   <int:method name="echoViaDefault"/>
 </int:gateway>]]></programlisting>
 	<programlisting language="java"><![CDATA[
-@MessagingGateway(value = "myGateway", defaultRequestChannel = "inputC",
-		defaultHeaders = @GatewayHeader(name = "calledMethod", expression="#gatewayMethod.name"))
+@MessagingGateway(name = "myGateway", defaultRequestChannel = "inputC",
+		   defaultHeaders = @GatewayHeader(name = "calledMethod",
+		                           expression="#gatewayMethod.name"))
 public interface TestGateway {
 
    @Gateway(requestChannel = "inputA", replyTimeout = 2, requestTimeout = 200)

--- a/src/reference/docbook/gateway.xml
+++ b/src/reference/docbook/gateway.xml
@@ -224,6 +224,45 @@ public String send2(Map foo, Map bar);
       </para>
     </section>
 
+	<section id="messaging-gateway-annotation">
+		<title>@MessagingGateway annotation</title>
+		<para>
+			Starting with <emphasis>version 4.0</emphasis> gateway service interfaces can be marked with
+			<code>@MessagingGateway</code> annotation to replace the <code>&lt;gateway&gt;</code> xml element configuration.
+			Just to compare:
+		</para>
+		<programlisting language="xml"><![CDATA[<int:gateway id="myGateway" service-interface="org.foo.bar.TestGateway"
+      default-request-channel="inputC">
+  <int:default-header name="calledMethod" expression="#gatewayMethod.name"/>
+  <int:method name="echo" request-channel="inputA" reply-timeout="2" request-timeout="200"/>
+  <int:method name="echoUpperCase" request-channel="inputB">
+  		<int:header name="foo" value="bar"/>
+  </int:method>
+  <int:method name="echoViaDefault"/>
+</int:gateway>]]></programlisting>
+	<programlisting language="java"><![CDATA[
+@MessagingGateway(value = "myGateway", defaultRequestChannel = "inputC",
+		defaultHeaders = @GatewayHeader(name = "calledMethod", expression="#gatewayMethod.name"))
+public interface TestGateway {
+
+   @Gateway(requestChannel = "inputA", replyTimeout = 2, requestTimeout = 200)
+   String echo(String payload);
+
+   @Gateway(requestChannel = "inputB, headers = @GatewayHeader(name = "foo", value="bar"))
+   String echoUpperCase(String payload);
+
+   String echoViaDefault(String payload);
+
+}]]></programlisting>
+		<para>
+			As far as it is an interface and Spring Integration produces the <code>proxy</code> for it
+			by its messaging infrastructure, there is no standard process to parse that annotation and
+			register <interfacename>BeanDefinition</interfacename> in the application context. So, be sure to use
+			the <code>@IntegrationComponentScan</code> annotation together with the <code>@Configuration</code> -
+			<xref linkend="enable-integration"/>.
+		</para>
+	</section>
+
     <section id="gateway-calling-no-argument-methods">
       <title>Invoking No-Argument Methods</title>
       <para>

--- a/src/reference/docbook/overview.xml
+++ b/src/reference/docbook/overview.xml
@@ -19,7 +19,7 @@
       enterprise applications. Developers benefit from the consistency of this model and especially the fact that it is
       based upon well-established best practices such as programming to interfaces and favoring composition over
       inheritance. Spring's simplified abstractions and powerful support libraries boost developer productivity while
-      simultaneously increasing the level of testability and portability. 
+      simultaneously increasing the level of testability and portability.
     </para>
     <para>
       Spring Integration is motivated by these same goals and principles. It
@@ -343,6 +343,12 @@
       <code>@EnableIntegration</code> is also useful when you have a parent context with no Spring Integration
       components and 2 or more child contexts that do use Spring Integration. It would enable these common
       components to be declared once only, in the parent context.
+    </para>
+	<para>
+      <code>@IntegrationComponentScan</code> annotation has been also introduced to permit classpath
+		scanning. This annotation plays similar role as standard Spring Framework <code>@ComponentScan</code> annotation,
+		but it is restricted just to Spring Integration specific components and annotations,
+		which aren't reachable by standard component scan mechanism. For example <xref linkend="messaging-gateway-annotation"/>.
     </para>
   </section>
 

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -19,22 +19,6 @@
 				See <xref linkend="mqtt"/>
 			</para>
 		</section>
-	</section>
-
-	<section id="4.0-general">
-		<title>General Changes</title>
-		<section>
-			<title>Requires Spring Framework 4.0</title>
-			<para>
-				Core messaging abstractions (<interfacename>Message</interfacename>,
-				<interfacename>MessageChannel</interfacename> etc) have moved to the Spring
-				Framework <code>spring-messaging</code> module. Users who reference these
-				classes directly in their code will need to make changes as described in
-				the first section of the
-				<ulink url="https://github.com/spring-projects/spring-integration/wiki/Spring-Integration-3.0-to-4.0-Migration-Guide"
-				>Migration Guide</ulink>.
-			</para>
-		</section>
 		<section id="4.0-enable-configuration">
 			<title>@EnableIntegration</title>
 			<para>
@@ -76,7 +60,23 @@
 				<code>@EnableAutoConfiguration</code>.
 				For more information see
 				<ulink url="http://projects.spring.io/spring-boot/docs/spring-boot-autoconfigure/README.html"
-				>Spring Boot - AutoConfigure</ulink>.
+						>Spring Boot - AutoConfigure</ulink>.
+			</para>
+		</section>
+	</section>
+
+	<section id="4.0-general">
+		<title>General Changes</title>
+		<section>
+			<title>Requires Spring Framework 4.0</title>
+			<para>
+				Core messaging abstractions (<interfacename>Message</interfacename>,
+				<interfacename>MessageChannel</interfacename> etc) have moved to the Spring
+				Framework <code>spring-messaging</code> module. Users who reference these
+				classes directly in their code will need to make changes as described in
+				the first section of the
+				<ulink url="https://github.com/spring-projects/spring-integration/wiki/Spring-Integration-3.0-to-4.0-Migration-Guide"
+				>Migration Guide</ulink>.
 			</para>
 		</section>
 		<section id="4.0-xpath-header-enricher-header-type">

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -39,8 +39,16 @@
 			<title>@EnableIntegration</title>
 			<para>
 				The <code>@EnableIntegration</code> annotation has been added, to permit declaration of
-				standard Spring Integration beans when using <code>@Configuration</code> classes. See
-				<xref linkend="enable-integration"/> for more information.
+				standard Spring Integration beans when using <code>@Configuration</code> classes.
+				See <xref linkend="enable-integration"/> for more information.
+			</para>
+		</section>
+		<section id="4.0-component-scan">
+			<title>@IntegrationComponentScan</title>
+			<para>
+				The <code>@IntegrationComponentScan</code> annotation has been added, to permit classpath
+				scanning for Spring Integration specific components.
+				See <xref linkend="enable-integration"/> for more information.
 			</para>
 		</section>
 		<section id="4.0-message-history">
@@ -49,6 +57,14 @@
 				Message history can now be enabled with the <code>@EnableMessageHistory</code> annotation in a
 				<code>@Configuration</code> class; in addition the message history settings can be modified
 				by a JMX MBean. For more information, see <xref linkend="message-history"/>.
+			</para>
+		</section>
+		<section id="4.0-messaging-gateway">
+			<title>@MessagingGateway</title>
+			<para>
+				Messaging gateway interfaces can now be configured with the <code>@MessagingGateway</code> annotation.
+				It is an analogue of <code>&lt;gateway&gt;</code> xml element.
+				For more information, see <xref linkend="messaging-gateway-annotation"/>.
 			</para>
 		</section>
 		<section id="4.0-boot">


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3297
- Add `<gateway>` annotation analogue and its `MessagingGatewayRegistrar` to register `GatewayProxyFactoryBean` based on annotation attributes
- Add `@IntegrationComponentScan` and its `IntegrationComponentsRegistrar` to scan packages for integration components
- Add implementation to scan `@MessagingGateway`
- Add simple `@MessagingGateway` test

**REVIEW ONLY**
There is need:
- to improve `IntegrationComponentsRegistrar`, to make it more generic and independent of cocreate `Registrar` implementation - Visitor pattern
- Conver `GatewayParser` to use `MessagingGatewayRegistrar`. It's allow to check existing tests that everything is correct in the implementation of latest
- Add more test
- Add docs
