### PR TITLE
INT-3310 Fix Syslog Error on Socket Close

### DIFF
--- a/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/SyslogReceivingChannelAdapterSupport.java
+++ b/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/SyslogReceivingChannelAdapterSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,13 @@ package org.springframework.integration.syslog.inbound;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessagingException;
+
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.syslog.DefaultMessageConverter;
 import org.springframework.integration.syslog.MessageConverter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.ErrorMessage;
 
 /**
  * Base support class for inbound channel adapters. The default port is 514.
@@ -70,7 +72,14 @@ public abstract class SyslogReceivingChannelAdapterSupport extends MessageProduc
 
 	protected void convertAndSend(Message<?> message) {
 		try {
-			this.sendMessage(this.converter.fromSyslog(message));
+			if (message instanceof ErrorMessage) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Error on syslog socket:" + ((ErrorMessage) message).getPayload().getMessage());
+				}
+			}
+			else {
+				this.sendMessage(this.converter.fromSyslog(message));
+			}
 		}
 		catch (Exception e) {
 			throw new MessagingException(message, e);


### PR DESCRIPTION
https://jira.springsource.org/browse/INT-3310

Previously, the syslog adapter tried to convert the ErrorMessage
that results from a socket error to a syslog packet, resulting
in a stack trace on stderr.

Test for the ErrorMessage and log at DEBUG.

**cherry-pick to 3.0.x**
