### PR TITLE
INT-3305 SFTP Close Session on Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ spring-integration-samples/loanshark/application.log*
 target
 vf.gf.dmn-*
 /atlassian-ide-plugin.xml
+hostkey.ser

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
 		if (version.endsWith('BUILD-SNAPSHOT')) {
 			maven { url 'http://repo.spring.io/libs-snapshot' }
 		}
-		maven { url 'http://repo.springsource.org/libs-milestone' }
+		maven { url 'http://repo.spring.io/libs-milestone' }
 		maven { url 'http://repo.spring.io/plugins-release' }
 		mavenCentral()
 	}
@@ -60,6 +60,7 @@ subprojects { subproject ->
 	ext {
 		activeMqVersion = '5.9.0'
 		aspectjVersion = '1.7.4'
+		apacheSshdVersion = '0.10.0'
 		commonsDbcpVersion = '1.4'
 		commonsIoVersion = '2.4'
 		commonsNetVersion = '3.3'
@@ -507,6 +508,7 @@ project('spring-integration-sftp') {
 		compile "com.jcraft:jsch:$jschVersion"
 		compile "org.springframework:spring-context-support:$springVersion"
 		compile("javax.activation:activation:$javaxActivationVersion", optional)
+		testCompile "org.apache.sshd:sshd-core:$apacheSshdVersion"
 	}
 }
 

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -244,6 +244,7 @@ class SftpSession implements Session<LsEntry> {
 			}
 		}
 		catch (JSchException e) {
+			this.close();
 			throw new IllegalStateException("failed to connect", e);
 		}
 	}

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/INT3305Tests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/INT3305Tests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.sftp.session;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import org.apache.sshd.SshServer;
+import org.apache.sshd.common.session.AbstractSession;
+import org.apache.sshd.server.PasswordAuthenticator;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.session.ServerSession;
+import org.junit.Test;
+
+import org.springframework.integration.test.util.SocketUtils;
+
+/**
+ * @author Gary Russell
+ * @since 3.0.2
+ *
+ */
+public class INT3305Tests {
+
+	/*
+	 * Verify the socket is closed if the channel.connect() fails.
+	 */
+	@Test
+	public void testConnectFailSocketOpen() throws Exception {
+		final int port = SocketUtils.findAvailableServerSocket();
+		SshServer server = SshServer.setUpDefaultServer();
+		try {
+			server.setPasswordAuthenticator(new PasswordAuthenticator() {
+
+				@Override
+				public boolean authenticate(String arg0, String arg1, ServerSession arg2) {
+					return true;
+				}
+			});
+			server.setPort(port);
+			server.setKeyPairProvider(new SimpleGeneratorHostKeyProvider("hostkey.ser"));
+			server.start();
+
+			DefaultSftpSessionFactory f = new DefaultSftpSessionFactory();
+			f.setHost("localhost");
+			f.setPort(port);
+			f.setUser("user");
+			f.setPassword("pass");
+			try {
+				f.getSession();
+				fail("Expected Exception");
+			}
+			catch (Exception e) {
+				assertThat(e, instanceOf(IllegalStateException.class));
+				assertThat(e.getCause(), instanceOf(IllegalStateException.class));
+				assertThat(e.getCause().getMessage(), equalTo("failed to connect"));
+			}
+			List<AbstractSession> sessions = server.getActiveSessions();
+
+			assertEquals(0, sessions.size());
+		}
+		finally {
+			server.stop(true);
+		}
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3305

Previously, if the channel can't be connected (e.g. if the server
does not support SFTP), the connection to the server remained open.

Close the session in the event of a failure.

Add test with the Apache SSHD server.

**cherry-pick to 3.0.x**
