### PR TITLE
INT-3312: Add support for `outputChannelName`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBean.java
@@ -24,11 +24,10 @@ import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.SmartLifecycle;
-import org.springframework.integration.core.MessageProducer;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.scheduling.PollerMetadata;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -40,7 +39,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  */
 public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<SourcePollingChannelAdapter>,
-		BeanFactoryAware, BeanNameAware, BeanClassLoaderAware, InitializingBean, SmartLifecycle, MessageProducer {
+		BeanFactoryAware, BeanNameAware, BeanClassLoaderAware, InitializingBean, SmartLifecycle {
 
 	private volatile MessageSource<?> source;
 
@@ -76,7 +75,6 @@ public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<Sourc
 		this.sendTimeout = sendTimeout;
 	}
 
-	@Override
 	public void setOutputChannel(MessageChannel outputChannel) {
 		this.outputChannel = outputChannel;
 	}
@@ -136,13 +134,15 @@ public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<Sourc
 				return;
 			}
 			Assert.notNull(this.source, "source is required");
-			Assert.notNull(this.outputChannel, "outputChannel is required");
-			SourcePollingChannelAdapter spca = new SourcePollingChannelAdapter();
-			spca.setSource(this.source);
+
 			if (StringUtils.hasText(this.outputChannelName)) {
 				Assert.isNull(this.outputChannel, "'outputChannelName' and 'outputChannel' are mutually exclusive.");
 				this.outputChannel = this.beanFactory.getBean(this.outputChannelName, MessageChannel.class);
 			}
+
+			Assert.notNull(this.outputChannel, "outputChannel is required");
+			SourcePollingChannelAdapter spca = new SourcePollingChannelAdapter();
+			spca.setSource(this.source);
 			spca.setOutputChannel(this.outputChannel);
 			if (this.pollerMetadata == null) {
 				this.pollerMetadata = PollerMetadata.getDefaultPollerMetadata(this.beanFactory);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBean.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.config;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -28,6 +29,7 @@ import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -137,7 +139,13 @@ public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<Sourc
 
 			if (StringUtils.hasText(this.outputChannelName)) {
 				Assert.isNull(this.outputChannel, "'outputChannelName' and 'outputChannel' are mutually exclusive.");
-				this.outputChannel = this.beanFactory.getBean(this.outputChannelName, MessageChannel.class);
+				try {
+					this.outputChannel = this.beanFactory.getBean(this.outputChannelName, MessageChannel.class);
+				}
+				catch (BeansException e) {
+					throw new DestinationResolutionException("Failed to look up MessageChannel with name '"
+							+ this.outputChannelName + "' in the BeanFactory.");
+				}
 			}
 
 			Assert.notNull(this.outputChannel, "outputChannel is required");

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/EnricherParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/EnricherParser.java
@@ -25,8 +25,8 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.ExpressionFactoryBean;
-import org.springframework.integration.config.IntegrationConfigUtils;
 import org.springframework.integration.transformer.ContentEnricher;
+import org.springframework.integration.transformer.support.ExpressionEvaluatingHeaderValueMessageProcessor;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
@@ -69,8 +69,7 @@ public class EnricherParser extends AbstractConsumerEndpointParser {
 				String name = subElement.getAttribute("name");
 				BeanDefinition expressionDefinition = IntegrationNamespaceUtils.createExpressionDefinitionFromValueOrExpression("value",
 						"expression", parserContext, subElement, true);
-				BeanDefinitionBuilder valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-						IntegrationConfigUtils.BASE_PACKAGE + ".transformer.support.ExpressionEvaluatingHeaderValueMessageProcessor");
+				BeanDefinitionBuilder valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(ExpressionEvaluatingHeaderValueMessageProcessor.class);
 				valueProcessorBuilder.addConstructorArgValue(expressionDefinition)
 						.addConstructorArgValue(subElement.getAttribute("type"));
 				IntegrationNamespaceUtils.setValueIfAttributeDefined(valueProcessorBuilder, subElement, "overwrite");

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/HeaderEnricherParserSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/HeaderEnricherParserSupport.java
@@ -29,10 +29,12 @@ import org.springframework.beans.factory.config.TypedStringValue;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.springframework.integration.config.IntegrationConfigUtils;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.expression.DynamicExpression;
 import org.springframework.integration.transformer.HeaderEnricher;
+import org.springframework.integration.transformer.support.ExpressionEvaluatingHeaderValueMessageProcessor;
+import org.springframework.integration.transformer.support.MessageProcessingHeaderValueMessageProcessor;
+import org.springframework.integration.transformer.support.StaticHeaderValueMessageProcessor;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
@@ -216,8 +218,7 @@ public abstract class HeaderEnricherParserSupport extends AbstractTransformerPar
 			}
 			Object headerValue = (headerType != null) ?
 					new TypedStringValue(value, headerType) : value;
-			valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-					IntegrationConfigUtils.BASE_PACKAGE + ".transformer.support.StaticHeaderValueMessageProcessor");
+			valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(StaticHeaderValueMessageProcessor.class);
 			valueProcessorBuilder.addConstructorArgValue(headerValue);
 		}
 		else if (isExpression) {
@@ -225,8 +226,7 @@ public abstract class HeaderEnricherParserSupport extends AbstractTransformerPar
 				parserContext.getReaderContext().error(
 						"The 'method' attribute cannot be used with the 'expression' attribute.", element);
 			}
-			valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-					IntegrationConfigUtils.BASE_PACKAGE + ".transformer.support.ExpressionEvaluatingHeaderValueMessageProcessor");
+			valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(ExpressionEvaluatingHeaderValueMessageProcessor.class);
 			if (expressionElement != null) {
 				BeanDefinitionBuilder dynamicExpressionBuilder = BeanDefinitionBuilder.genericBeanDefinition(DynamicExpression.class);
 				dynamicExpressionBuilder.addConstructorArgValue(expressionElement.getAttribute("key"));
@@ -244,16 +244,14 @@ public abstract class HeaderEnricherParserSupport extends AbstractTransformerPar
 						"The 'type' attribute cannot be used with an inner bean.", element);
 			}
 			if (hasMethod || isScript) {
-				valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-						IntegrationConfigUtils.BASE_PACKAGE + ".transformer.support.MessageProcessingHeaderValueMessageProcessor");
+				valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(MessageProcessingHeaderValueMessageProcessor.class);
 				valueProcessorBuilder.addConstructorArgValue(innerComponentDefinition);
 				if (hasMethod) {
 					valueProcessorBuilder.addConstructorArgValue(method);
 				}
 			}
 			else {
-				valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-						IntegrationConfigUtils.BASE_PACKAGE + ".transformer.support.StaticHeaderValueMessageProcessor");
+				valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(StaticHeaderValueMessageProcessor.class);
 				valueProcessorBuilder.addConstructorArgValue(innerComponentDefinition);
 			}
 		}
@@ -263,14 +261,12 @@ public abstract class HeaderEnricherParserSupport extends AbstractTransformerPar
 						"The 'type' attribute cannot be used with the 'ref' attribute.", element);
 			}
 			if (hasMethod) {
-				valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-						IntegrationConfigUtils.BASE_PACKAGE + ".transformer.support.MessageProcessingHeaderValueMessageProcessor");
+				valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(MessageProcessingHeaderValueMessageProcessor.class);
 				valueProcessorBuilder.addConstructorArgReference(ref);
 				valueProcessorBuilder.addConstructorArgValue(method);
 			}
 			else {
-				valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-						IntegrationConfigUtils.BASE_PACKAGE + ".transformer.support.StaticHeaderValueMessageProcessor");
+				valueProcessorBuilder = BeanDefinitionBuilder.genericBeanDefinition(StaticHeaderValueMessageProcessor.class);
 				valueProcessorBuilder.addConstructorArgReference(ref);
 			}
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.aopalliance.aop.Advice;
 
 import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.core.MessagingTemplate;
@@ -137,7 +138,13 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 			this.messagingTemplate.setBeanFactory(getBeanFactory());
 			if (StringUtils.hasText(this.outputChannelName)) {
 				Assert.isNull(this.outputChannel, "'outputChannelName' and 'outputChannel' are mutually exclusive.");
-				this.outputChannel = this.getBeanFactory().getBean(this.outputChannelName, MessageChannel.class);
+				try {
+					this.outputChannel = this.getBeanFactory().getBean(this.outputChannelName, MessageChannel.class);
+				}
+				catch (BeansException e) {
+					throw new DestinationResolutionException("Failed to look up MessageChannel with name '"
+							+ this.outputChannelName + "' in the BeanFactory.");
+				}
 			}
 		}
 		if (!CollectionUtils.isEmpty(this.adviceChain)) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
@@ -226,7 +226,7 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 	 * @param replyMessage the reply Message to send
 	 * @param replyChannelHeaderValue the 'replyChannel' header value from the original request
 	 */
-	private final void sendReplyMessage(Message<?> replyMessage, final Object replyChannelHeaderValue) {
+	private void sendReplyMessage(Message<?> replyMessage, final Object replyChannelHeaderValue) {
 		if (logger.isDebugEnabled()) {
 			logger.debug("handler '" + this + "' sending reply Message: " + replyMessage);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
@@ -34,6 +34,7 @@ import org.springframework.messaging.core.DestinationResolver;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Base class for MessageHandlers that are capable of producing replies.
@@ -47,6 +48,8 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 		implements MessageProducer, BeanClassLoaderAware {
 
 	private MessageChannel outputChannel;
+
+	private String outputChannelName;
 
 	private volatile boolean requiresReply = false;
 
@@ -68,6 +71,10 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 	@Override
 	public void setOutputChannel(MessageChannel outputChannel) {
 		this.outputChannel = outputChannel;
+	}
+
+	public void setOutputChannelName(String outputChannelName) {
+		this.outputChannelName = outputChannelName;
 	}
 
 	/**
@@ -128,6 +135,10 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 	protected final void onInit() {
 		if (this.getBeanFactory() != null) {
 			this.messagingTemplate.setBeanFactory(getBeanFactory());
+			if (StringUtils.hasText(this.outputChannelName)) {
+				Assert.isNull(this.outputChannel, "'outputChannelName' and 'outputChannel' are mutually exclusive.");
+				this.outputChannel = this.getBeanFactory().getBean(this.outputChannelName, MessageChannel.class);
+			}
 		}
 		if (!CollectionUtils.isEmpty(this.adviceChain)) {
 			ProxyFactory proxyFactory = new ProxyFactory(new AdvisedRequestHandler());

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
@@ -37,6 +37,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Content Enricher is a Message Transformer that can augment a message's payload
@@ -68,7 +69,11 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler implem
 
 	private volatile MessageChannel requestChannel;
 
+	private volatile String requestChannelName;
+
 	private volatile MessageChannel replyChannel;
+
+	private volatile String replyChannelName;
 
 	private volatile Gateway gateway = null;
 
@@ -123,6 +128,10 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler implem
 		this.requestChannel = requestChannel;
 	}
 
+	public void setRequestChannelName(String requestChannelName) {
+		this.requestChannelName = requestChannelName;
+	}
+
 	/**
 	 * Sets the content enricher's reply channel. If not specified, yet the request
 	 * channel is set, an anonymous reply channel will automatically created
@@ -132,6 +141,10 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler implem
 	 */
 	public void setReplyChannel(MessageChannel replyChannel) {
 		this.replyChannel = replyChannel;
+	}
+
+	public void setReplyChannelName(String replyChannelName) {
+		this.replyChannelName = replyChannelName;
 	}
 
 	/**
@@ -207,6 +220,16 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler implem
      */
 	@Override
 	protected void doInit() {
+		if (StringUtils.hasText(this.requestChannelName)) {
+			Assert.isNull(this.requestChannel, "'requestChannelName' and 'requestChannel' are mutually exclusive.");
+			this.requestChannel = this.getBeanFactory().getBean(this.requestChannelName, MessageChannel.class);
+		}
+
+		if (StringUtils.hasText(this.replyChannelName)) {
+			Assert.isNull(this.replyChannel, "'replyChannelName' and 'replyChannel' are mutually exclusive.");
+			this.replyChannel = this.getBeanFactory().getBean(this.replyChannelName, MessageChannel.class);
+		}
+
 		if (this.replyChannel != null) {
 			Assert.notNull(this.requestChannel, "If the replyChannel is set, then the requestChannel must not be null");
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/AbstractHeaderValueMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/AbstractHeaderValueMessageProcessor.java
@@ -21,7 +21,7 @@ package org.springframework.integration.transformer.support;
  * @author Artem Bilan
  * @since 3.0
  */
-abstract class AbstractHeaderValueMessageProcessor<T> implements HeaderValueMessageProcessor<T> {
+public abstract class AbstractHeaderValueMessageProcessor<T> implements HeaderValueMessageProcessor<T> {
 
 	// null indicates no explicit setting
 	private volatile Boolean overwrite = null;

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/ExpressionEvaluatingHeaderValueMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/ExpressionEvaluatingHeaderValueMessageProcessor.java
@@ -30,7 +30,7 @@ import org.springframework.messaging.Message;
  * @author Artem Bilan
  * @since 3.0
  */
-class ExpressionEvaluatingHeaderValueMessageProcessor<T> extends AbstractHeaderValueMessageProcessor<T>
+public class ExpressionEvaluatingHeaderValueMessageProcessor<T> extends AbstractHeaderValueMessageProcessor<T>
 		implements BeanFactoryAware {
 
 	private static final ExpressionParser expressionParser = new SpelExpressionParser(new SpelParserConfiguration(

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/MessageProcessingHeaderValueMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/MessageProcessingHeaderValueMessageProcessor.java
@@ -25,7 +25,7 @@ import org.springframework.messaging.Message;
  * @author Artem Bilan
  * @since 3.0
  */
-class MessageProcessingHeaderValueMessageProcessor extends AbstractHeaderValueMessageProcessor<Object> {
+public class MessageProcessingHeaderValueMessageProcessor extends AbstractHeaderValueMessageProcessor<Object> {
 
 	private final MessageProcessor<?> targetProcessor;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/StaticHeaderValueMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/StaticHeaderValueMessageProcessor.java
@@ -23,7 +23,7 @@ import org.springframework.messaging.Message;
  * @author Artem Bilan
  * @since 3.0
  */
-class StaticHeaderValueMessageProcessor<T> extends AbstractHeaderValueMessageProcessor<T> {
+public class StaticHeaderValueMessageProcessor<T> extends AbstractHeaderValueMessageProcessor<T> {
 
 	private final T value;
 


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3312
- Add `setOutputChannelName` to `AbstractReplyProducingMessageHandler` and `SourcePollingChannelAdapterFactoryBean`
  to allow to have 'late binding' and resolve the real channel from `AC` on component initialization, not create phase
- Add `setRequestChannelName` and `setReplyChannelName` to `ContentEnricher` for the same purpose as before
- Make `HeaderValueMessageProcessor` implementation as `public`. It is useful from JavaConfig and DSL
- Polishing parsers to use classes, not their strings
