### PR TITLE
INT-3299 Remove Unneeded Dependency From IP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -325,7 +325,7 @@ project('spring-integration-ip') {
 	dependencies {
 		compile project(":spring-integration-core")
 		compile "org.springframework:spring-context:$springVersion"
-		runtime project(":spring-integration-stream")
+		testCompile project(":spring-integration-stream")
 	}
 
 	// suppress deprecation warnings (@SuppressWarnings("deprecation") is not enough for javac)


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-3299

The IP module incorrectly has s-i-stream as a transitive dependency.

It is only used in a test case.
