### PR TITLE
INT-3316 BeanFactoryTypeConverter Concurrency

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/BeanFactoryTypeConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/BeanFactoryTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,7 +139,9 @@ public class BeanFactoryTypeConverter implements TypeConverter, BeanFactoryAware
 				return convertValue(text, TypeDescriptor.valueOf(String.class), targetType);
 			}
 		}
-		return delegate.convertIfNecessary(value, targetType.getType());
+		synchronized (this.delegate) {
+			return delegate.convertIfNecessary(value, targetType.getType());
+		}
 	}
 
 	private PropertyEditor getDefaultEditor(Class<?> sourceType) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3316

The `SimpleTypeConverter` delegate uses property editors
which are not thread safe. We protect against concurrent
access when the source is not a String, but when a String,
we delegate to the `STC`.

Synchronize access to the `STC.convertIfNecessary()` method.

**cherry-pick to 3.0.x, 2.2.x**
