### PR TITLE
INT-3319 Fix BeanFactory Propagation

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
@@ -99,7 +99,9 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 
 	@Override
 	protected AbstractDispatcher createDispatcher() {
-		return new BroadcastingDispatcher(true);
+		BroadcastingDispatcher broadcastingDispatcher = new BroadcastingDispatcher(true);
+		broadcastingDispatcher.setBeanFactory(this.getBeanFactory());
+		return broadcastingDispatcher;
 	}
 
 	@Override

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpChannelFactoryBean.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpChannelFactoryBean.java
@@ -318,6 +318,9 @@ public class AmqpChannelFactoryBean extends AbstractFactoryBean<AbstractAmqpChan
 				if (this.maxSubscribers != null) {
 					pubsub.setMaxSubscribers(this.maxSubscribers);
 				}
+				if (this.getBeanFactory() != null) {
+					pubsub.setBeanFactory(this.getBeanFactory());
+				}
 				this.channel = pubsub;
 			}
 			else {

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests-context.xml
@@ -19,4 +19,6 @@
 
 	<amqp:channel id="channelWithSubscriberLimit" max-subscribers="1" />
 
+	<amqp:publish-subscribe-channel id="pubSub" />
+
 </beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.amqp.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import java.util.List;
 
@@ -25,6 +26,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptorAdapter;
@@ -51,6 +53,10 @@ public class AmqpChannelParserTests {
 		assertEquals(TestInterceptor.class, interceptorList.get(0).getClass());
 		assertEquals(Integer.MAX_VALUE, TestUtils.getPropertyValue(
 				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers", Integer.class).intValue());
+		channel = context.getBean("pubSub", MessageChannel.class);
+		Object mbf = context.getBean(IntegrationContextUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
+		assertSame(mbf, TestUtils.getPropertyValue(channel, "dispatcher.messageBuilderFactory"));
+		assertSame(mbf, TestUtils.getPropertyValue(channel, "container.messageListener.messageBuilderFactory"));
 	}
 
 	@Test

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractAggregatingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractAggregatingMessageGroupProcessor.java
@@ -21,7 +21,11 @@ import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
@@ -39,15 +43,16 @@ import org.springframework.util.Assert;
  * @author Dave Syer
  * @since 2.0
  */
-public abstract class AbstractAggregatingMessageGroupProcessor implements MessageGroupProcessor {
+public abstract class AbstractAggregatingMessageGroupProcessor implements MessageGroupProcessor,
+		BeanFactoryAware {
 
 	private final Log logger = LogFactory.getLog(this.getClass());
 
 	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 
-	public void setMessageBuilderFactory(MessageBuilderFactory messageBuilderFactory) {
-		Assert.notNull(messageBuilderFactory, "'messageBuilderFactory' cannot be null");
-		this.messageBuilderFactory = messageBuilderFactory;
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.messageBuilderFactory = IntegrationContextUtils.getMessageBuilderFactory(beanFactory);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageGroupProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.integration.store.MessageGroup;
  *
  * @author Alex Peters
  * @author Dave Syer
+ * @author Gary Russell
  */
 public class ExpressionEvaluatingMessageGroupProcessor extends AbstractAggregatingMessageGroupProcessor implements BeanFactoryAware {
 
@@ -40,7 +41,9 @@ public class ExpressionEvaluatingMessageGroupProcessor extends AbstractAggregati
 		processor = new ExpressionEvaluatingMessageListProcessor(expression);
 	}
 
+	@Override
 	public void setBeanFactory(BeanFactory beanFactory) {
+		super.setBeanFactory(beanFactory);
 		processor.setBeanFactory(beanFactory);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,16 +22,17 @@ import java.util.Map;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.convert.ConversionService;
-import org.springframework.messaging.Message;
 import org.springframework.integration.annotation.Aggregator;
 import org.springframework.integration.store.MessageGroup;
+import org.springframework.messaging.Message;
 
 /**
  * MessageGroupProcessor that serves as an adapter for the invocation of a POJO method.
- * 
+ *
  * @author Iwein Fuld
  * @author Mark Fisher
  * @author Dave Syer
+ * @author Gary Russell
  * @since 2.0
  */
 public class MethodInvokingMessageGroupProcessor extends AbstractAggregatingMessageGroupProcessor {
@@ -41,7 +42,7 @@ public class MethodInvokingMessageGroupProcessor extends AbstractAggregatingMess
 	/**
 	 * Creates a wrapper around the object passed in. This constructor will look for a method that can process
 	 * a list of messages.
-	 * 
+	 *
 	 * @param target the object to wrap
 	 */
 	public MethodInvokingMessageGroupProcessor(Object target) {
@@ -51,7 +52,7 @@ public class MethodInvokingMessageGroupProcessor extends AbstractAggregatingMess
 	/**
 	 * Creates a wrapper around the object passed in. This constructor will look for a named method specifically and
 	 * fail when it cannot find a method with the given name.
-	 * 
+	 *
 	 * @param target the object to wrap
 	 * @param methodName the name of the method to invoke
 	 */
@@ -61,19 +62,21 @@ public class MethodInvokingMessageGroupProcessor extends AbstractAggregatingMess
 
 	/**
 	 * Creates a wrapper around the object passed in.
-	 * 
+	 *
 	 * @param target the object to wrap
 	 * @param method the method to invoke
 	 */
 	public MethodInvokingMessageGroupProcessor(Object target, Method method) {
 		this.processor = new MethodInvokingMessageListProcessor<Object>(target, method);
 	}
-	
+
 	public void setConversionService(ConversionService conversionService) {
 		processor.setConversionService(conversionService);
 	}
-	
+
+	@Override
 	public void setBeanFactory(BeanFactory beanFactory) {
+		super.setBeanFactory(beanFactory);
 		processor.setBeanFactory(beanFactory);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
@@ -164,6 +164,7 @@ public class PublishSubscribeChannel extends AbstractSubscribableChannel {
 			Integer maxSubscribers = this.getIntegrationProperty(IntegrationProperties.CHANNELS_MAX_BROADCAST_SUBSCRIBERS, Integer.class);
 			this.setMaxSubscribers(maxSubscribers);
 		}
+		this.dispatcher.setBeanFactory(this.getBeanFactory());
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AbstractDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AbstractDispatcher.java
@@ -23,8 +23,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
-import org.springframework.integration.support.DefaultMessageBuilderFactory;
-import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
@@ -55,7 +53,6 @@ public abstract class AbstractDispatcher implements MessageDispatcher {
 
 	private volatile MessageHandler theOneHandler;
 
-	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 	/**
 	 * Set the maximum subscribers allowed by this dispatcher.
 	 * @param maxSubscribers The maximum number of subscribers allowed.
@@ -72,15 +69,6 @@ public abstract class AbstractDispatcher implements MessageDispatcher {
 	 */
 	protected Set<MessageHandler> getHandlers() {
 		return handlers.asUnmodifiableSet();
-	}
-
-	protected MessageBuilderFactory getMessageBuilderFactory() {
-		return messageBuilderFactory;
-	}
-
-	public void setMessageBuilderFactory(MessageBuilderFactory messageBuilderFactory) {
-		Assert.notNull(messageBuilderFactory, "'messageBuilderFactory' cannot be null");
-		this.messageBuilderFactory = messageBuilderFactory;
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -180,6 +180,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint implement
 			if (this.requestMapper instanceof DefaultRequestMapper) {
 				((DefaultRequestMapper) this.requestMapper).setMessageBuilderFactory(this.getMessageBuilderFactory());
 			}
+			this.messageConverter.setBeanFactory(this.getBeanFactory());
 		}
 		this.initialized = true;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/converter/SimpleMessageConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/converter/SimpleMessageConverter.java
@@ -16,6 +16,10 @@
 
 package org.springframework.integration.support.converter;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.mapping.InboundMessageMapper;
 import org.springframework.integration.mapping.OutboundMessageMapper;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
@@ -31,7 +35,7 @@ import org.springframework.messaging.converter.MessageConverter;
  * @since 2.0
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class SimpleMessageConverter implements MessageConverter {
+public class SimpleMessageConverter implements MessageConverter, BeanFactoryAware {
 
 	private volatile InboundMessageMapper inboundMessageMapper;
 
@@ -67,8 +71,9 @@ public class SimpleMessageConverter implements MessageConverter {
 		this.outboundMessageMapper = (outboundMessageMapper != null) ? outboundMessageMapper : new DefaultOutboundMessageMapper();
 	}
 
-	public final void setMessageBuilderFactory(MessageBuilderFactory messageBuilderFactory) {
-		this.messageBuilderFactory = messageBuilderFactory;
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.messageBuilderFactory = IntegrationContextUtils.getMessageBuilderFactory(beanFactory);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/AbstractJacksonJsonMessageParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/AbstractJacksonJsonMessageParser.java
@@ -18,10 +18,13 @@ package org.springframework.integration.support.json;
 
 import java.lang.reflect.Type;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.messaging.Message;
-import org.springframework.util.Assert;
 
 /**
  * Base {@link JsonInboundMessageMapper.JsonMessageParser} implementation for Jackson processors.
@@ -30,7 +33,8 @@ import org.springframework.util.Assert;
  * @since 3.0
  *
  */
-abstract class AbstractJacksonJsonMessageParser<P> implements JsonInboundMessageMapper.JsonMessageParser<P> {
+abstract class AbstractJacksonJsonMessageParser<P> implements JsonInboundMessageMapper.JsonMessageParser<P>,
+		BeanFactoryAware {
 
 	private final JsonObjectMapper<?, P> objectMapper;
 
@@ -42,9 +46,9 @@ abstract class AbstractJacksonJsonMessageParser<P> implements JsonInboundMessage
 		this.objectMapper = objectMapper;
 	}
 
-	public void setMessageBuilderFactory(MessageBuilderFactory messageBuilderFactory) {
-		Assert.notNull(messageBuilderFactory, "'messageBuilderFactory' cannot be null");
-		this.messageBuilderFactory = messageBuilderFactory;
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.messageBuilderFactory = IntegrationContextUtils.getMessageBuilderFactory(beanFactory);
 	}
 
 	protected MessageBuilderFactory getMessageBuilderFactory() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/AbstractExpressionEvaluator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/AbstractExpressionEvaluator.java
@@ -32,7 +32,6 @@ import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
-import org.springframework.util.Assert;
 
 /**
  * @author Mark Fisher
@@ -60,6 +59,7 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 	/**
 	 * Specify a BeanFactory in order to enable resolution via <code>@beanName</code> in the expression.
 	 */
+	@Override
 	public void setBeanFactory(final BeanFactory beanFactory) {
 		if (beanFactory != null) {
 			this.beanFactory = beanFactory;
@@ -67,6 +67,7 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 			if (this.evaluationContext != null && this.evaluationContext.getBeanResolver() == null) {
 				this.evaluationContext.setBeanResolver(new BeanFactoryResolver(beanFactory));
 			}
+			this.messageBuilderFactory = IntegrationContextUtils.getMessageBuilderFactory(beanFactory);
 		}
 	}
 
@@ -74,11 +75,6 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 		if (conversionService != null) {
 			this.typeConverter.setConversionService(conversionService);
 		}
-	}
-
-	public void setMessageBuilderFactory(MessageBuilderFactory messageBuilderFactory) {
-		Assert.notNull(messageBuilderFactory, "'messageBuilderFactory' cannot be null");
-		this.messageBuilderFactory = messageBuilderFactory;
 	}
 
 	protected MessageBuilderFactory getMessageBuilderFactory() {
@@ -92,7 +88,7 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 	public void afterPropertiesSet() throws Exception {
 		getEvaluationContext();
 		if (this.messageBuilderFactory == null) {
-			this.messageBuilderFactory = IntegrationContextUtils.getMessageBuilderFactory(beanFactory);
+			this.messageBuilderFactory = IntegrationContextUtils.getMessageBuilderFactory(this.beanFactory);
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/PublishSubscribeChannelParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/PublishSubscribeChannelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.Executor;
@@ -29,12 +30,14 @@ import org.junit.Test;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.channel.PublishSubscribeChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.dispatcher.BroadcastingDispatcher;
 import org.springframework.integration.util.ErrorHandlingTaskExecutor;
 import org.springframework.util.ErrorHandler;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public class PublishSubscribeChannelParserTests {
 
@@ -51,6 +54,9 @@ public class PublishSubscribeChannelParserTests {
 		assertNull(dispatcherAccessor.getPropertyValue("executor"));
 		assertFalse((Boolean) dispatcherAccessor.getPropertyValue("ignoreFailures"));
 		assertFalse((Boolean) dispatcherAccessor.getPropertyValue("applySequence"));
+		Object mbf = context.getBean(IntegrationContextUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
+		assertSame(mbf, dispatcherAccessor.getPropertyValue("messageBuilderFactory"));
+		context.close();
 	}
 
 	@Test
@@ -63,6 +69,7 @@ public class PublishSubscribeChannelParserTests {
 		BroadcastingDispatcher dispatcher = (BroadcastingDispatcher)
 				accessor.getPropertyValue("dispatcher");
 		assertTrue((Boolean) new DirectFieldAccessor(dispatcher).getPropertyValue("ignoreFailures"));
+		context.close();
 	}
 
 	@Test
@@ -75,6 +82,7 @@ public class PublishSubscribeChannelParserTests {
 		BroadcastingDispatcher dispatcher = (BroadcastingDispatcher)
 				accessor.getPropertyValue("dispatcher");
 		assertTrue((Boolean) new DirectFieldAccessor(dispatcher).getPropertyValue("applySequence"));
+		context.close();
 	}
 
 	@Test
@@ -93,6 +101,7 @@ public class PublishSubscribeChannelParserTests {
 		DirectFieldAccessor executorAccessor = new DirectFieldAccessor(executor);
 		Executor innerExecutor = (Executor) executorAccessor.getPropertyValue("executor");
 		assertEquals(context.getBean("pool"), innerExecutor);
+		context.close();
 	}
 
 	@Test
@@ -112,6 +121,7 @@ public class PublishSubscribeChannelParserTests {
 		DirectFieldAccessor executorAccessor = new DirectFieldAccessor(executor);
 		Executor innerExecutor = (Executor) executorAccessor.getPropertyValue("executor");
 		assertEquals(context.getBean("pool"), innerExecutor);
+		context.close();
 	}
 
 	@Test
@@ -131,6 +141,7 @@ public class PublishSubscribeChannelParserTests {
 		DirectFieldAccessor executorAccessor = new DirectFieldAccessor(executor);
 		Executor innerExecutor = (Executor) executorAccessor.getPropertyValue("executor");
 		assertEquals(context.getBean("pool"), innerExecutor);
+		context.close();
 	}
 
 	@Test
@@ -143,6 +154,7 @@ public class PublishSubscribeChannelParserTests {
 		ErrorHandler errorHandler = (ErrorHandler) accessor.getPropertyValue("errorHandler");
 		assertNotNull(errorHandler);
 		assertEquals(context.getBean("testErrorHandler"), errorHandler);
+		context.close();
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Method;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.hamcrest.Matchers;
@@ -35,12 +37,14 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.annotation.Gateway;
 import org.springframework.integration.annotation.Header;
 import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
@@ -55,7 +59,7 @@ public class GatewayInterfaceTests {
 
 	@Test
 	public void testWithServiceSuperclassAnnotatedMethod() throws Exception {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
 		DirectChannel channel = ac.getBean("requestChannelFoo", DirectChannel.class);
 		final Method fooMethod = Foo.class.getMethod("foo", String.class);
 		final AtomicBoolean called = new AtomicBoolean();
@@ -76,11 +80,16 @@ public class GatewayInterfaceTests {
 		Bar bar = ac.getBean(Bar.class);
 		bar.foo("hello");
 		assertTrue(called.get());
+		Map<?,?> gateways = TestUtils.getPropertyValue(ac.getBean("&sampleGateway"), "gatewayMap", Map.class);
+		Object mbf = ac.getBean(IntegrationContextUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
+		assertSame(mbf, TestUtils.getPropertyValue(gateways.values().iterator().next(),
+				"messageConverter.messageBuilderFactory"));
+		ac.close();
 	}
 
 	@Test
 	public void testWithServiceSuperclassAnnotatedMethodOverridePE() throws Exception {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests2-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests2-context.xml", this.getClass());
 		DirectChannel channel = ac.getBean("requestChannelFoo", DirectChannel.class);
 		final Method fooMethod = Foo.class.getMethod("foo", String.class);
 		final AtomicBoolean called = new AtomicBoolean();
@@ -101,22 +110,24 @@ public class GatewayInterfaceTests {
 		Bar bar = ac.getBean(Bar.class);
 		bar.foo("hello");
 		assertTrue(called.get());
+		ac.close();
 	}
 
 	@Test
 	public void testWithServiceAnnotatedMethod() {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
 		DirectChannel channel = ac.getBean("requestChannelBar", DirectChannel.class);
 		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		bar.bar("hello");
 		verify(handler, times(1)).handleMessage(Mockito.any(Message.class));
+		ac.close();
 	}
 
 	@Test
 	public void testWithServiceSuperclassUnAnnotatedMethod() throws Exception {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
 		final Method bazMethod = Foo.class.getMethod("baz", String.class);
 		final AtomicBoolean called = new AtomicBoolean();
@@ -137,11 +148,12 @@ public class GatewayInterfaceTests {
 		Bar bar = ac.getBean(Bar.class);
 		bar.baz("hello");
 		assertTrue(called.get());
+		ac.close();
 	}
 
 	@Test
 	public void testWithServiceUnAnnotatedMethodGlobalHeaderDoesntOverride() throws Exception {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
 		final Method quxMethod = Bar.class.getMethod("qux", String.class, String.class);
 		final AtomicBoolean called = new AtomicBoolean();
@@ -162,55 +174,60 @@ public class GatewayInterfaceTests {
 		Bar bar = ac.getBean(Bar.class);
 		bar.qux("hello", "arg1");
 		assertTrue(called.get());
+		ac.close();
 	}
 
 	@Test
 	public void testWithServiceCastAsSuperclassAnnotatedMethod() {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
 		DirectChannel channel = ac.getBean("requestChannelFoo", DirectChannel.class);
 		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Foo foo = ac.getBean(Foo.class);
 		foo.foo("hello");
 		verify(handler, times(1)).handleMessage(Mockito.any(Message.class));
+		ac.close();
 	}
 
 	@Test
 	public void testWithServiceCastAsSuperclassUnAnnotatedMethod() {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
 		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Foo foo = ac.getBean(Foo.class);
 		foo.baz("hello");
 		verify(handler, times(1)).handleMessage(Mockito.any(Message.class));
+		ac.close();
 	}
 
 	@Test
 	public void testWithServiceHashcode() throws Exception {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
 		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		assertEquals(bar.hashCode(), ac.getBean(Bar.class).hashCode());
 		verify(handler, times(0)).handleMessage(Mockito.any(Message.class));
+		ac.close();
 	}
 
 	@Test
 	public void testWithServiceToString() {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
 		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		bar.toString();
 		verify(handler, times(0)).handleMessage(Mockito.any(Message.class));
+		ac.close();
 	}
 
 	@Test
 	public void testWithServiceEquals() throws Exception {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
 		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
@@ -225,17 +242,19 @@ public class GatewayInterfaceTests {
 		fb.afterPropertiesSet();
 		assertFalse(bar.equals(fb.getObject()));
 		verify(handler, times(0)).handleMessage(Mockito.any(Message.class));
+		ac.close();
 	}
 
 	@Test
 	public void testWithServiceGetClass() {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
 		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		bar.getClass();
 		verify(handler, times(0)).handleMessage(Mockito.any(Message.class));
+		ac.close();
 	}
 
 	@Test(expected=IllegalArgumentException.class)
@@ -245,7 +264,7 @@ public class GatewayInterfaceTests {
 
 	@Test
 	public void testWithCustomMapper() {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
 		final AtomicBoolean called = new AtomicBoolean();
 		MessageHandler handler = new MessageHandler() {
@@ -260,11 +279,12 @@ public class GatewayInterfaceTests {
 		Baz baz = ac.getBean(Baz.class);
 		baz.baz("hello");
 		assertTrue(called.get());
+		ac.close();
 	}
 
 	@Test
 	public void testLateReply() throws Exception {
-		ApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
+		ConfigurableApplicationContext ac = new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", this.getClass());
 		Bar baz = ac.getBean(Bar.class);
 		String reply = baz.lateReply("hello");
 		assertNull(reply);
@@ -273,6 +293,7 @@ public class GatewayInterfaceTests {
 		assertNotNull(receive);
 		MessagingException messagingException = (MessagingException) receive.getPayload();
 		assertThat(messagingException.getMessage(), Matchers.startsWith("Reply message received but the receiving thread has exited due to a timeout"));
+		ac.close();
 	}
 
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileToByteArrayTransformerParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileToByteArrayTransformerParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,19 @@
 
 package org.springframework.integration.file.config;
 
+import org.springframework.integration.file.transformer.FileToByteArrayTransformer;
+
 /**
  * Parser for the &lt;file-to-bytes-transformer&gt; element.
- * 
+ *
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public class FileToByteArrayTransformerParser extends AbstractFilePayloadTransformerParser {
 
 	@Override
 	protected String getTransformerClassName() {
-		return "org.springframework.integration.file.transformer.FileToByteArrayTransformer";
+		return FileToByteArrayTransformer.class.getName();
 	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileToStringTransformerParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileToStringTransformerParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,19 @@ import org.w3c.dom.Element;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.file.transformer.FileToStringTransformer;
 
 /**
  * Parser for the &lt;file-to-string-transformer&gt; element.
- * 
+ *
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public class FileToStringTransformerParser extends AbstractFilePayloadTransformerParser {
 
 	@Override
 	protected String getTransformerClassName() {
-		return "org.springframework.integration.file.transformer.FileToStringTransformer";
+		return FileToStringTransformer.class.getName();
 	}
 
 	@Override

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/transformer/AbstractFilePayloadTransformer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/transformer/AbstractFilePayloadTransformer.java
@@ -21,6 +21,10 @@ import java.io.File;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
@@ -34,7 +38,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Fisher
  */
-public abstract class AbstractFilePayloadTransformer<T> implements Transformer {
+public abstract class AbstractFilePayloadTransformer<T> implements Transformer, BeanFactoryAware {
 
 	private final Log logger = LogFactory.getLog(this.getClass());
 
@@ -52,9 +56,9 @@ public abstract class AbstractFilePayloadTransformer<T> implements Transformer {
 		this.deleteFiles = deleteFiles;
 	}
 
-	public void setMessageBuilderFactory(MessageBuilderFactory messageBuilderFactory) {
-		Assert.notNull(messageBuilderFactory, "'messageBuilderFactory' cannot be null");
-		this.messageBuilderFactory = messageBuilderFactory;
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.messageBuilderFactory = IntegrationContextUtils.getMessageBuilderFactory(beanFactory);
 	}
 
 	@Override

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileToStringTransformerParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileToStringTransformerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,25 @@
 
 package org.springframework.integration.file.config;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.file.transformer.FileToStringTransformer;
+import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.transformer.MessageTransformingHandler;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static org.junit.Assert.assertEquals;
-
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -39,6 +43,9 @@ public class FileToStringTransformerParserTests {
     @Autowired
     @Qualifier("transformer")
     EventDrivenConsumer endpoint;
+
+    @Autowired
+    MessageBuilderFactory messageBuilderFactory;
 
     @Test
     public void checkDeleteFilesValue() {
@@ -50,6 +57,7 @@ public class FileToStringTransformerParserTests {
                 handlerAccessor.getPropertyValue("transformer");
         DirectFieldAccessor transformerAccessor = new DirectFieldAccessor(transformer);
         assertEquals(Boolean.TRUE, transformerAccessor.getPropertyValue("deleteFiles"));
+        assertSame(this.messageBuilderFactory, transformerAccessor.getPropertyValue("messageBuilderFactory"));
     }
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
@@ -27,7 +27,6 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.core.serializer.Deserializer;
 import org.springframework.core.serializer.Serializer;
-import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.ip.tcp.connection.AbstractConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.DefaultTcpNetSSLSocketFactorySupport;
@@ -134,7 +133,7 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 	@Override
 	protected AbstractConnectionFactory createInstance() throws Exception {
 		if (!this.mapperSet) {
-			mapper.setMessageBuilderFactory(IntegrationContextUtils.getMessageBuilderFactory(this.beanFactory));
+			mapper.setBeanFactory(this.beanFactory);
 		}
 		if (this.usingNio) {
 			if ("server".equals(this.type)) {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -93,6 +93,8 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 
 	private volatile TcpMessageMapper mapper = new TcpMessageMapper();
 
+	private volatile boolean mapperSet;
+
 	private volatile boolean singleUse;
 
 	private volatile boolean active;
@@ -359,6 +361,7 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 	 */
 	public void setMapper(TcpMessageMapper mapper) {
 		this.mapper = mapper;
+		this.mapperSet = true;
 	}
 
 	/**
@@ -407,6 +410,14 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 	public void setNioHarvestInterval(int nioHarvestInterval) {
 		Assert.isTrue(nioHarvestInterval > 0, "NIO Harvest interval must be > 0");
 		this.nioHarvestInterval = nioHarvestInterval;
+	}
+
+	@Override
+	protected void onInit() throws Exception {
+		super.onInit();
+		if (!this.mapperSet) {
+			this.mapper.setBeanFactory(this.getBeanFactory());
+		}
 	}
 
 	@Override

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
@@ -21,6 +21,10 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.mapping.InboundMessageMapper;
 import org.springframework.integration.mapping.OutboundMessageMapper;
@@ -46,7 +50,8 @@ import org.springframework.messaging.MessageHandlingException;
  */
 public class TcpMessageMapper implements
 		InboundMessageMapper<TcpConnection>,
-		OutboundMessageMapper<Object> {
+		OutboundMessageMapper<Object>,
+		BeanFactoryAware {
 
 	protected final Log logger = LogFactory.getLog(this.getClass());
 
@@ -81,8 +86,9 @@ public class TcpMessageMapper implements
 		this.applySequence = applySequence;
 	}
 
-	public void setMessageBuilderFactory(MessageBuilderFactory messageBuilderFactory) {
-		this.messageBuilderFactory = messageBuilderFactory;
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.messageBuilderFactory = IntegrationContextUtils.getMessageBuilderFactory(beanFactory);
 	}
 
 	protected MessageBuilderFactory getMessageBuilderFactory() {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/DatagramPacketMessageMapper.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/DatagramPacketMessageMapper.java
@@ -23,6 +23,10 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.ip.util.RegexUtils;
 import org.springframework.integration.mapping.InboundMessageMapper;
@@ -57,7 +61,8 @@ import org.springframework.util.Assert;
  * @author Dave Syer
  * @since 2.0
  */
-public class DatagramPacketMessageMapper implements InboundMessageMapper<DatagramPacket>, OutboundMessageMapper<DatagramPacket> {
+public class DatagramPacketMessageMapper implements InboundMessageMapper<DatagramPacket>, OutboundMessageMapper<DatagramPacket>,
+		BeanFactoryAware {
 
 	private volatile String charset = "UTF-8";
 
@@ -76,10 +81,6 @@ public class DatagramPacketMessageMapper implements InboundMessageMapper<Datagra
 				"=" + "([^;]*);" +
 				RegexUtils.escapeRegexSpecials(MessageHeaders.ID) +
 				"=" + "([^;]*);");
-
-	public void setMessageBuilderFactory(MessageBuilderFactory messageBuilderFactory) {
-		this.messageBuilderFactory = messageBuilderFactory;
-	}
 
 	public void setCharset(String charset) {
 		this.charset = charset;
@@ -102,6 +103,11 @@ public class DatagramPacketMessageMapper implements InboundMessageMapper<Datagra
 	 */
 	public void setLookupHost(boolean lookupHost) {
 		this.lookupHost = lookupHost;
+	}
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.messageBuilderFactory = IntegrationContextUtils.getMessageBuilderFactory(beanFactory);
 	}
 
 	/**

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastReceivingChannelAdapter.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastReceivingChannelAdapter.java
@@ -75,7 +75,7 @@ public class UnicastReceivingChannelAdapter extends AbstractInternetProtocolRece
 	@Override
 	protected void onInit() {
 		super.onInit();
-		this.mapper.setMessageBuilderFactory(this.getMessageBuilderFactory());
+		this.mapper.setBeanFactory(this.getBeanFactory());
 	}
 
 	@Override

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastSendingMessageHandler.java
@@ -32,11 +32,11 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.integration.MessageRejectedException;
 import org.springframework.integration.ip.AbstractInternetProtocolSendingMessageHandler;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
 
@@ -298,6 +298,65 @@ public class UnicastSendingMessageHandler extends
 		return this.socket;
 	}
 
+	/**
+	 * @see java.net.Socket#setReceiveBufferSize(int)
+	 * @see DatagramSocket#setReceiveBufferSize(int)
+	 */
+	@Override
+	public void setSoReceiveBufferSize(int size) {
+		this.soReceiveBufferSize = size;
+	}
+
+	@Override
+	public void setLocalAddress(String localAddress) {
+		this.localAddress = localAddress;
+	}
+
+	public void setTaskExecutor(Executor taskExecutor) {
+		Assert.notNull(taskExecutor, "'taskExecutor' cannot be null");
+		this.taskExecutor = taskExecutor;
+		this.taskExecutorSet = true;
+	}
+
+	/**
+	 * @param ackCounter the ackCounter to set
+	 */
+	public void setAckCounter(int ackCounter) {
+		this.ackCounter = ackCounter;
+	}
+
+	@Override
+	public String getComponentType(){
+		return "ip:udp-outbound-channel-adapter";
+	}
+
+	/**
+	 * @return the acknowledge
+	 */
+	public boolean isAcknowledge() {
+		return acknowledge;
+	}
+
+	/**
+	 * @return the ackPort
+	 */
+	public int getAckPort() {
+		return ackPort;
+	}
+
+	/**
+	 * @return the soReceiveBufferSize
+	 */
+	public int getSoReceiveBufferSize() {
+		return soReceiveBufferSize;
+	}
+
+	@Override
+	protected void onInit() throws Exception {
+		super.onInit();
+		this.mapper.setBeanFactory(this.getBeanFactory());
+	}
+
 	protected void setSocketAttributes(DatagramSocket socket) throws SocketException {
 		if (this.getSoTimeout() >= 0) {
 			socket.setSoTimeout(this.getSoTimeout());
@@ -365,56 +424,4 @@ public class UnicastSendingMessageHandler extends
 		}
 	}
 
-	/**
-	 * @see java.net.Socket#setReceiveBufferSize(int)
-	 * @see DatagramSocket#setReceiveBufferSize(int)
-	 */
-	@Override
-	public void setSoReceiveBufferSize(int size) {
-		this.soReceiveBufferSize = size;
-	}
-
-	@Override
-	public void setLocalAddress(String localAddress) {
-		this.localAddress = localAddress;
-	}
-
-	public void setTaskExecutor(Executor taskExecutor) {
-		Assert.notNull(taskExecutor, "'taskExecutor' cannot be null");
-		this.taskExecutor = taskExecutor;
-		this.taskExecutorSet = true;
-	}
-
-	/**
-	 * @param ackCounter the ackCounter to set
-	 */
-	public void setAckCounter(int ackCounter) {
-		this.ackCounter = ackCounter;
-	}
-
-	@Override
-	public String getComponentType(){
-		return "ip:udp-outbound-channel-adapter";
-	}
-
-	/**
-	 * @return the acknowledge
-	 */
-	public boolean isAcknowledge() {
-		return acknowledge;
-	}
-
-	/**
-	 * @return the ackPort
-	 */
-	public int getAckPort() {
-		return ackPort;
-	}
-
-	/**
-	 * @return the soReceiveBufferSize
-	 */
-	public int getSoReceiveBufferSize() {
-		return soReceiveBufferSize;
-	}
 }

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
@@ -102,7 +102,9 @@ public class SubscribableJmsChannel extends AbstractJmsChannel implements Subscr
 
 	private void configureDispatcher(boolean isPubSub) {
 		if (isPubSub) {
-			this.dispatcher = new BroadcastingDispatcher(true);
+			BroadcastingDispatcher broadcastingDispatcher = new BroadcastingDispatcher(true);
+			broadcastingDispatcher.setBeanFactory(this.getBeanFactory());
+			this.dispatcher = broadcastingDispatcher;
 		}
 		else {
 			UnicastingDispatcher unicastingDispatcher = new UnicastingDispatcher();

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
@@ -337,6 +337,9 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 			this.container = this.createContainer();
 			SubscribableJmsChannel subscribableJmsChannel = new SubscribableJmsChannel(this.container, this.jmsTemplate);
 			subscribableJmsChannel.setMaxSubscribers(this.maxSubscribers);
+			if (this.getBeanFactory() != null) {
+				subscribableJmsChannel.setBeanFactory(this.getBeanFactory());
+			}
 			this.channel = subscribableJmsChannel;
 		}
 		else {

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.jms.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import java.util.List;
 
@@ -36,6 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.integration.jms.PollableJmsChannel;
 import org.springframework.integration.jms.SubscribableJmsChannel;
+import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
@@ -116,6 +118,9 @@ public class JmsChannelParserTests {
 	@Autowired
 	private AbstractApplicationContext context;
 
+	@Autowired
+	private MessageBuilderFactory messageBuilderFactory;
+
 
 	@After
 	public void closeContext() {
@@ -172,7 +177,11 @@ public class JmsChannelParserTests {
 		AbstractMessageListenerContainer container = (AbstractMessageListenerContainer) accessor.getPropertyValue("container");
 		assertEquals(topic, jmsTemplate.getDefaultDestination());
 		assertEquals(topic, container.getDestination());
+		assertSame(this.messageBuilderFactory, TestUtils.getPropertyValue(channel, "dispatcher.messageBuilderFactory"));
+		assertSame(this.messageBuilderFactory,
+				TestUtils.getPropertyValue(channel, "container.messageListener.messageBuilderFactory"));
 	}
+
 
 	@Test
 	public void topicNameChannel() {

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapter.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2013 the original author or authors
+ * Copyright 2007-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.redis.inbound;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.PatternTopic;
@@ -95,6 +96,9 @@ public class RedisInboundChannelAdapter extends MessageProducerSupport {
 		}
 		Assert.state(hasTopics || hasPatterns, "at least one topic or topic pattern is required for subscription.");
 
+		if (this.messageConverter instanceof BeanFactoryAware) {
+			((BeanFactoryAware) this.messageConverter).setBeanFactory(this.getBeanFactory());
+		}
 		MessageListenerDelegate delegate = new MessageListenerDelegate();
 		MessageListenerAdapter adapter = new MessageListenerAdapter(delegate);
 		adapter.setSerializer(this.serializer);

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisPublishingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisPublishingMessageHandler.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.redis.outbound;
 
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializer;
@@ -94,6 +95,9 @@ public class RedisPublishingMessageHandler extends AbstractMessageHandler implem
 	@Override
 	protected void onInit() throws Exception {
 		Assert.notNull(topicExpression, "'topicExpression' must not be null.");
+		if (this.messageConverter instanceof BeanFactoryAware) {
+			((BeanFactoryAware) this.messageConverter).setBeanFactory(this.getBeanFactory());
+		}
 	}
 
 	@Override

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.redis.inbound.RedisInboundChannelAdapter;
 import org.springframework.integration.redis.rules.RedisAvailable;
 import org.springframework.integration.redis.rules.RedisAvailableTests;
@@ -77,6 +78,8 @@ public class RedisInboundChannelAdapterParserTests extends RedisAvailableTests {
 		Object bean = context.getBean("withoutSerializer.adapter");
 		assertNotNull(bean);
 		assertNull(TestUtils.getPropertyValue(bean, "serializer"));
+		Object mbf = context.getBean(IntegrationContextUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
+		assertSame(mbf, TestUtils.getPropertyValue(bean, "messageConverter.messageBuilderFactory"));
 	}
 
 	@Test

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
@@ -18,6 +18,7 @@ package org.springframework.integration.redis.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +29,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.expression.Expression;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.redis.inbound.RedisInboundChannelAdapter;
 import org.springframework.integration.redis.outbound.RedisPublishingMessageHandler;
@@ -73,6 +75,8 @@ public class RedisOutboundChannelAdapterParserTests extends RedisAvailableTests 
 		Object converterBean = context.getBean("testConverter");
 		assertEquals(converterBean, accessor.getPropertyValue("messageConverter"));
 		assertEquals(context.getBean("serializer"), accessor.getPropertyValue("serializer"));
+		Object mbf = context.getBean(IntegrationContextUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
+		assertSame(mbf, TestUtils.getPropertyValue(handler, "messageConverter.messageBuilderFactory"));
 	}
 
 	@Test

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisStoreInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisStoreInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
@@ -70,7 +71,7 @@ public class RedisStoreInboundChannelAdapterParserTests {
 
 	@Test(expected=BeanDefinitionParsingException.class)
 	public void testTemplateAndCfMutualExclusivity(){
-		new ClassPathXmlApplicationContext("inbound-template-cf-fail.xml", this.getClass());
+		new ClassPathXmlApplicationContext("inbound-template-cf-fail.xml", this.getClass()).close();
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3319

The `MessageBuilderFactory` abstraction relies on the bean factory
being propagated to all classes that create messages.

Some classes were missed in the initial PR.
