### PR TITLE
Poller element in http outbound adapter and gateway

### DIFF
--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-4.0.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-4.0.xsd
@@ -317,7 +317,7 @@
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
-			<xsd:choice minOccurs="0" maxOccurs="2">
+			<xsd:choice minOccurs="0" maxOccurs="3">
 				<xsd:element name="uri-variable" type="uriVariableType" minOccurs="0" maxOccurs="unbounded">
 					<xsd:annotation>
 						<xsd:documentation>
@@ -327,6 +327,7 @@
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="request-handler-advice-chain" type="integration:handlerAdviceChainType" minOccurs="0" maxOccurs="1" />
+				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
 			</xsd:choice>
 			<xsd:attributeGroup ref="integration:channelAdapterAttributes"/>
 			<xsd:attributeGroup ref="httpOutboundCommonAttributes"/>
@@ -352,7 +353,7 @@
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="gatewayType">
-					<xsd:choice minOccurs="0" maxOccurs="2">
+					<xsd:choice minOccurs="0" maxOccurs="3">
 						<xsd:element name="uri-variable" type="uriVariableType" minOccurs="0" maxOccurs="unbounded">
 							<xsd:annotation>
 								<xsd:documentation>
@@ -361,6 +362,7 @@
 							</xsd:annotation>
 						</xsd:element>
 						<xsd:element name="request-handler-advice-chain" type="integration:handlerAdviceChainType" minOccurs="0" maxOccurs="1" />
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
 					</xsd:choice>
 					<xsd:attribute name="request-channel" type="xsd:string">
 						<xsd:annotation>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests-context.xml
@@ -32,6 +32,7 @@
 			order="77"
 			auto-startup="false">
 		<uri-variable name="foo" expression="headers.bar"/>
+
 	</outbound-channel-adapter>
 
 	<util:map id="uriVariables">
@@ -55,6 +56,41 @@
 	<outbound-channel-adapter id="withUrlExpressionAndTemplate"
 		url-expression="'http://localhost/test1'" channel="requests"
 		rest-template="customRestTemplate"/>
+
+	<si:channel id="queueChannel">
+		<si:queue capacity="10"/>
+	</si:channel>
+	<outbound-channel-adapter id="withPoller1" url="http://localhost/test1" channel="queueChannel">
+		<si:poller fixed-delay="5000"/>
+	</outbound-channel-adapter>
+
+	<outbound-channel-adapter id="withPoller2" url="http://localhost/test1" channel="queueChannel">
+		<request-handler-advice-chain/>
+		<uri-variable name="foo" expression="headers.bar"/>
+		<uri-variable name="bar" expression="headers.bar"/>
+		<si:poller fixed-delay="5000"/>
+	</outbound-channel-adapter>
+
+	<outbound-channel-adapter id="withPoller3" url="http://localhost/test1" channel="queueChannel">
+		<uri-variable name="foo" expression="headers.bar"/>
+		<uri-variable name="bar" expression="headers.bar"/>
+		<request-handler-advice-chain/>
+		<si:poller fixed-delay="5000"/>
+	</outbound-channel-adapter>
+
+	<outbound-channel-adapter id="withPoller4" url="http://localhost/test1" channel="queueChannel">
+		<si:poller fixed-delay="5000"/>
+		<uri-variable name="foo" expression="headers.bar"/>
+		<uri-variable name="bar" expression="headers.bar"/>
+		<request-handler-advice-chain/>
+	</outbound-channel-adapter>
+
+	<outbound-channel-adapter id="withPoller5" url="http://localhost/test1" channel="queueChannel">
+		<si:poller fixed-delay="5000"/>
+		<request-handler-advice-chain/>
+		<uri-variable name="foo" expression="headers.bar"/>
+		<uri-variable name="bar" expression="headers.bar"/>
+	</outbound-channel-adapter>
 
 	<beans:bean id="testRequestFactory" class="org.springframework.http.client.SimpleClientHttpRequestFactory"/>
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
@@ -16,16 +16,10 @@
 
 package org.springframework.integration.http.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.util.Map;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,6 +35,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.integration.endpoint.PollingConsumer;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.integration.endpoint.AbstractEndpoint;
@@ -54,11 +49,14 @@ import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
+import static org.junit.Assert.*;
+
 /**
  * @author Mark Fisher
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Biju Kunjummen
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -87,6 +85,9 @@ public class HttpOutboundChannelAdapterParserTests {
 
 	@Autowired @Qualifier("withUrlExpressionAndTemplate")
 	private AbstractEndpoint withUrlExpressionAndTemplate;
+
+	@Autowired @Qualifier("withPoller1")
+	private AbstractEndpoint withPoller1;
 
 	@Autowired
 	private ApplicationContext applicationContext;
@@ -248,6 +249,11 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertEquals(HttpMethod.POST.name(), TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString());
 		assertEquals("UTF-8", handlerAccessor.getPropertyValue("charset"));
 		assertEquals(true, handlerAccessor.getPropertyValue("extractPayload"));
+	}
+
+	@Test
+	public void withPoller() {
+		assertThat(this.withPoller1, Matchers.instanceOf(PollingConsumer.class));
 	}
 
 	@Test(expected=BeanDefinitionParsingException.class)

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests-context.xml
@@ -40,6 +40,7 @@
 		<uri-variable name="foo" expression="headers.bar"/>
 	</outbound-gateway>
 
+
 	<util:map id="uriVariables">
 		<beans:entry key="foo1" value="bar1"/>
 		<beans:entry key="foo2" value="bar2"/>
@@ -52,6 +53,42 @@
 		<request-handler-advice-chain>
 			<beans:bean class="org.springframework.integration.http.config.HttpOutboundGatewayParserTests$FooAdvice" />
 		</request-handler-advice-chain>
+	</outbound-gateway>
+
+	<si:channel id="queueChannel">
+		<si:queue capacity="10"/>
+	</si:channel>
+
+	<outbound-gateway id="withPoller1" request-channel="queueChannel" url="http://localhost/test1">
+		<si:poller fixed-delay="5000"/>
+	</outbound-gateway>
+
+	<outbound-gateway id="withPoller2" url="http://localhost/test1" request-channel="queueChannel">
+		<request-handler-advice-chain/>
+		<uri-variable name="foo" expression="headers.bar"/>
+		<uri-variable name="bar" expression="headers.bar"/>
+		<si:poller fixed-delay="5000"/>
+	</outbound-gateway>
+
+	<outbound-gateway id="withPoller3" url="http://localhost/test1" request-channel="queueChannel">
+		<uri-variable name="foo" expression="headers.bar"/>
+		<uri-variable name="bar" expression="headers.bar"/>
+		<request-handler-advice-chain/>
+		<si:poller fixed-delay="5000"/>
+	</outbound-gateway>
+
+	<outbound-gateway id="withPoller4" url="http://localhost/test1" request-channel="queueChannel">
+		<si:poller fixed-delay="5000"/>
+		<uri-variable name="foo" expression="headers.bar"/>
+		<uri-variable name="bar" expression="headers.bar"/>
+		<request-handler-advice-chain/>
+	</outbound-gateway>
+
+	<outbound-gateway id="withPoller5" url="http://localhost/test1" request-channel="queueChannel">
+		<si:poller fixed-delay="5000"/>
+		<request-handler-advice-chain/>
+		<uri-variable name="foo" expression="headers.bar"/>
+		<uri-variable name="bar" expression="headers.bar"/>
 	</outbound-gateway>
 
 	<beans:bean id="testRequestFactory" class="org.springframework.http.client.SimpleClientHttpRequestFactory"/>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
@@ -16,15 +16,10 @@
 
 package org.springframework.integration.http.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.util.Map;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.BeansException;
@@ -40,6 +35,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.integration.endpoint.PollingConsumer;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.integration.endpoint.AbstractEndpoint;
@@ -52,10 +48,13 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 
+import static org.junit.Assert.*;
+
 /**
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Biju Kunjummen
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -72,6 +71,9 @@ public class HttpOutboundGatewayParserTests {
 
 	@Autowired @Qualifier("withAdvice")
 	private AbstractEndpoint withAdvice;
+
+	@Autowired @Qualifier("withPoller1")
+	private AbstractEndpoint withPoller1;
 
 	@Autowired
 	private ApplicationContext applicationContext;
@@ -198,6 +200,11 @@ public class HttpOutboundGatewayParserTests {
 			assertTrue(e instanceof BeanDefinitionParsingException);
 			assertTrue(e.getMessage().contains("'request-channel' attribute isn't allowed for a nested"));
 		}
+	}
+
+	@Test
+	public void withPoller() {
+		assertThat(this.withPoller1, Matchers.instanceOf(PollingConsumer.class));
 	}
 
 


### PR DESCRIPTION
This is just a proposal for a change. I searched around but did not see a JIRA issue for this, but felt that this is a good change just to ensure consistent behavior.

The proposal is to add a poller element to both http gateway and outbound adapter in their schema. Currently poller is supported at the level of http gateway and outbound adapter bean definition but not by their schema. This change attempts to fix the schema.
- Added in schema element for base poller, in both outbound adapter and outbound gateway
- Added in tests to ensure that a PollingConsumer is the instance type

Please review, if it looks okay I can open a jira and clean it much more based on any feedback.
