### PR TITLE
INT-3322 JDBC i-c-a SpEL Select ParameterSource

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/ExpressionEvaluatingSqlParameterSourceFactory.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/ExpressionEvaluatingSqlParameterSourceFactory.java
@@ -125,7 +125,17 @@ public class ExpressionEvaluatingSqlParameterSourceFactory extends AbstractExpre
 
 	@Override
 	public SqlParameterSource createParameterSource(final Object input) {
-		return new ExpressionEvaluatingSqlParameterSource(input, this.staticParameters, this.parameterExpressions);
+		return new ExpressionEvaluatingSqlParameterSource(input, this.staticParameters, this.parameterExpressions, true);
+	}
+
+	/**
+	 * Create an expression evaluating parameter source the does not cache it's results. Useful for cases
+	 * where the source is used multiple times, for example in an i-c-a for the select parameter source.
+	 * @param input The root object for the evaluation.
+	 * @return The parameter source.
+	 */
+	public SqlParameterSource createParameterSourceNoCache(final Object input) {
+		return new ExpressionEvaluatingSqlParameterSource(input, this.staticParameters, this.parameterExpressions, false);
 	}
 
 	@Override
@@ -138,21 +148,32 @@ public class ExpressionEvaluatingSqlParameterSourceFactory extends AbstractExpre
 
 		private final Object input;
 
-		private volatile Map<String, Object> values = new HashMap<String, Object>();
+		private final Map<String, Object> values = new HashMap<String, Object>();
 
 		private final Map<String, Expression[]> parameterExpressions;
 
+		private final boolean cache;
+
 		private ExpressionEvaluatingSqlParameterSource(Object input, Map<String, ?> staticParameters,
-				Map<String, Expression[]> parameterExpressions) {
+				Map<String, Expression[]> parameterExpressions, boolean cache) {
 			this.input = input;
 			this.parameterExpressions = parameterExpressions;
 			this.values.putAll(staticParameters);
+			this.cache = cache;
 		}
 
 		@Override
 		public Object getValue(String paramName) throws IllegalArgumentException {
+			return this.doGetValue(paramName, false);
+		}
+
+		public Object doGetValue(String paramName, boolean calledFromHasValue) throws IllegalArgumentException {
 			if (values.containsKey(paramName)) {
-				return values.get(paramName);
+				Object cachedByHasValue = values.get(paramName);
+				if (!this.cache) {
+					values.remove(paramName);
+				}
+				return cachedByHasValue;
 			}
 
 			if (!parameterExpressions.containsKey(paramName)) {
@@ -174,7 +195,9 @@ public class ExpressionEvaluatingSqlParameterSourceFactory extends AbstractExpre
 			}
 
 			Object value = evaluateExpression(expression, input);
-			values.put(paramName, value);
+			if (this.cache || calledFromHasValue) {
+				values.put(paramName, value);
+			}
 			if (logger.isDebugEnabled()) {
 				logger.debug("Resolved expression " + expression + " to " + value);
 			}
@@ -184,7 +207,7 @@ public class ExpressionEvaluatingSqlParameterSourceFactory extends AbstractExpre
 		@Override
 		public boolean hasValue(String paramName) {
 			try {
-				Object value = getValue(paramName);
+				Object value = doGetValue(paramName, true);
 				if (value == ERROR) {
 					return false;
 				}
@@ -193,7 +216,9 @@ public class ExpressionEvaluatingSqlParameterSourceFactory extends AbstractExpre
 				if (logger.isDebugEnabled()) {
 					logger.debug("Could not evaluate expression", e);
 				}
-				values.put(paramName, ERROR);
+				if (this.cache) {
+					values.put(paramName, ERROR);
+				}
 				return false;
 			}
 			return true;

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/ExpressionEvaluatingSqlParameterSourceFactory.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/ExpressionEvaluatingSqlParameterSourceFactory.java
@@ -129,8 +129,9 @@ public class ExpressionEvaluatingSqlParameterSourceFactory extends AbstractExpre
 	}
 
 	/**
-	 * Create an expression evaluating parameter source the does not cache it's results. Useful for cases
-	 * where the source is used multiple times, for example in an i-c-a for the select parameter source.
+	 * Create an expression evaluating {@link SqlParameterSource} that does not cache it's results. Useful for cases
+	 * where the source is used multiple times, for example in a {@code <int-jdbc:inbound-channel-adapter} for the
+	 * {@code select-sql-parameter-source}.
 	 * @param input The root object for the evaluation.
 	 * @return The parameter source.
 	 */

--- a/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-4.0.xsd
+++ b/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-4.0.xsd
@@ -202,6 +202,10 @@
 									that query has
 									placeholders (e.g. "SELECT * from FOO where KEY=:key") they
 									will be bound from this source by name.
+									Note: if you use the framework's 'ExpressionEvaluatingSqlParameterSourceFactory'
+									to create a SpEL-based parameter source, be sure to use the 'createParameterSourceNoCache'
+									method so that the expression will be re-evaluated on each poll. See the reference
+									documentation for more information.
 								</xsd:documentation>
 								<tool:annotation kind="ref">
 									<tool:expected-type type="org.springframework.jdbc.core.namedparam.SqlParameterSource" />

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/pollingWithSelectParameterSourceJdbcInboundChannelAdapterTest.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/pollingWithSelectParameterSourceJdbcInboundChannelAdapterTest.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration/jdbc"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:si="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+			http://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/integration
+			http://www.springframework.org/schema/integration/spring-integration.xsd
+			http://www.springframework.org/schema/integration/jdbc
+			http://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd">
+	
+	<inbound-channel-adapter query="select * from item where status=:status" channel="target" 
+			data-source="dataSource" select-sql-parameter-source="parameterSource"
+			update="delete from item" />
+		
+	<beans:import  resource="jdbcInboundChannelAdapterCommonConfig.xml" />
+	
+	<beans:bean id="parameterSource" factory-bean="parameterSourceFactory" factory-method="createParameterSourceNoCache">
+		<beans:constructor-arg value="" />
+	</beans:bean>
+	
+	<beans:bean id="parameterSourceFactory" class="org.springframework.integration.jdbc.ExpressionEvaluatingSqlParameterSourceFactory">
+		<beans:property name="parameterExpressions">
+			<beans:map>
+				<beans:entry key="status" value="@statusBean.which()" />
+			</beans:map>
+		</beans:property>
+	</beans:bean>
+
+	<beans:bean id="statusBean" class="org.springframework.integration.jdbc.config.JdbcPollingChannelAdapterParserTests$Status" />
+
+</beans:beans>

--- a/src/reference/docbook/jdbc.xml
+++ b/src/reference/docbook/jdbc.xml
@@ -82,7 +82,8 @@
     provides a <classname>ExpressionEvaluatingSqlParameterSourceFactory</classname> which
     will create a SpEL-based parameter source, with the results of the query as the
     <code>#root</code> object. (If <code>update-per-row</code> is true, the root object
-    is the row).
+    is the row). If the same parameter name appears multiple times in the update query, it
+    is evaluated only one time, and its result is cached.
     </para>
 
 	<para>
@@ -119,7 +120,9 @@
 	</para>
 	<important>
 		Use the <code>createParameterSourceNoCache</code> factory method; otherwise the parameter source will
-		cache the result of the evaluation.
+		cache the result of the evaluation. Also note that, because caching is disabled, if the same
+		parameter name appears in the select query multiple times, it will be re-evaluated for each
+		occurrence.
 	</important>
     <section>
       <title>Polling and Transactions</title>

--- a/src/reference/docbook/jdbc.xml
+++ b/src/reference/docbook/jdbc.xml
@@ -78,8 +78,49 @@
       </note> To change the parameter generation strategy you can inject a
     <classname>SqlParameterSourceFactory</classname> into the adapter to
     override the default behavior (the adapter has a
-    <code>sql-parameter-source-factory</code> attribute).</para>
+    <code>sql-parameter-source-factory</code> attribute). Spring Integration
+    provides a <classname>ExpressionEvaluatingSqlParameterSourceFactory</classname> which
+    will create a SpEL-based parameter source, with the results of the query as the
+    <code>#root</code> object. (If <code>update-per-row</code> is true, the root object
+    is the row).
+    </para>
 
+	<para>
+		You can also use a parameter source for the select query. In this case, since there is no "result"
+		object to evaluate against, a single parameter source is used each time (rather than using a 
+		parameter source factory). Starting with <emphasis>version 4.0</emphasis>, you can use Spring
+		to create a SpEL based parameter source as follows:
+	</para>
+	<programlisting language="xml"><![CDATA[<int-jdbc:inbound-channel-adapter query="select * from item where status=:status"
+	channel="target" data-source="dataSource"
+	select-sql-parameter-source="parameterSource" />
+
+<bean id="parameterSource" factory-bean="parameterSourceFactory"
+			factory-method="createParameterSourceNoCache">
+	<constructor-arg value="" />
+</bean>
+
+<bean id="parameterSourceFactory"
+		class="o.s.integration.jdbc.ExpressionEvaluatingSqlParameterSourceFactory">
+	<property name="parameterExpressions">
+		<map>
+			<entry key="status" value="@statusBean.which()" />
+		</map>
+	</property>
+</bean>
+
+<bean id="statusBean" class="foo.StatusDetermination" />]]></programlisting>
+
+	<para>
+		The <code>value</code> in each parameter expression can be any valid SpEL expression.
+		The <code>#root</code> object for the expression evaluation is the
+		constructor argument defined on the <code>parameterSource</code> bean. It is static
+		for all evaluations (in this case, an empty String).
+	</para>
+	<important>
+		Use the <code>createParameterSourceNoCache</code> factory method; otherwise the parameter source will
+		cache the result of the evaluation.
+	</important>
     <section>
       <title>Polling and Transactions</title>
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3322

Support the use of an ExpressionEvaluatingSqlParameterSource
from the ExpressionEvaluatingSqlParameterSourceFactory as the
`select-sql-parameter-source` for an inbound channel adapter.

Add documentation showing how to construct the bean.

Add a mechanism to disable caching so that the expression is
re-evaluated each time. However, the value should still be
cached between the `hasValue()` and `getValue()` calls.
