### PR TITLE
INT-3342 Allow Custom TypeLocator for SpEL

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationEvaluationContextFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationEvaluationContextFactoryBean.java
@@ -34,6 +34,7 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.expression.BeanResolver;
 import org.springframework.expression.PropertyAccessor;
 import org.springframework.expression.TypeConverter;
+import org.springframework.expression.TypeLocator;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.expression.spel.support.StandardTypeConverter;
 import org.springframework.integration.context.IntegrationContextUtils;
@@ -78,6 +79,8 @@ public class IntegrationEvaluationContextFactoryBean implements FactoryBean<Stan
 
 	private TypeConverter typeConverter = new StandardTypeConverter();
 
+	private volatile TypeLocator typeLocator;
+
 	private BeanResolver beanResolver;
 
 	private ApplicationContext applicationContext;
@@ -105,6 +108,10 @@ public class IntegrationEvaluationContextFactoryBean implements FactoryBean<Stan
 		Assert.notNull(functionsArg, "'functions' must not be null.");
 		Assert.noNullElements(functionsArg.values().toArray(), "'functions' cannot have null values.");
 		this.functions = new LinkedHashMap<String, Method>(functionsArg);
+	}
+
+	public void setTypeLocator(TypeLocator typeLocator) {
+		this.typeLocator = typeLocator;
 	}
 
 
@@ -158,6 +165,9 @@ public class IntegrationEvaluationContextFactoryBean implements FactoryBean<Stan
 	@Override
 	public StandardEvaluationContext getObject() throws Exception {
 		StandardEvaluationContext evaluationContext = new StandardEvaluationContext();
+		if (this.typeLocator != null) {
+			evaluationContext.setTypeLocator(this.typeLocator);
+		}
 
 		evaluationContext.setBeanResolver(this.beanResolver);
 		evaluationContext.setTypeConverter(this.typeConverter);

--- a/spring-integration-core/src/test/java/org/springframework/integration/expression/ForeignClassloaderTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/expression/ForeignClassloaderTests-context.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<int:service-activator input-channel="foo" output-channel="bar"
+		expression="new org.springframework.integration.expression.ForeignClassloaderTests$Foo()" />
+
+	<int:channel id="bar">
+		<int:queue />
+	</int:channel>
+
+	<bean id="integrationEvaluationContext" class="org.springframework.integration.config.IntegrationEvaluationContextFactoryBean">
+		<property name="typeLocator">
+			<bean class="org.springframework.expression.spel.support.StandardTypeLocator">
+				<constructor-arg value="#{beanFactory.beanClassLoader}"/>
+			</bean>
+		</property>
+	</bean>
+
+</beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/expression/ForeignClassloaderTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/expression/ForeignClassloaderTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.expression;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 3.0.2
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
+public class ForeignClassloaderTests {
+
+	@Autowired
+	private MessageChannel foo;
+
+	@Autowired
+	private PollableChannel bar;
+
+	/**
+	 * Sends a message on a thread that has a ClassLoader that doesn't have visibility to Foo.
+	 * Fails without a custom TypeLocator in the evaluation context factory bean.
+	 */
+	@Test
+	public void testThreadHasWrongClassLoader() {
+		Thread t = new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+				try {
+					foo.send(new GenericMessage<String>("foo"));
+				}
+				catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+
+		});
+		t.setContextClassLoader(new ClassLoader() {
+
+			@Override
+			public Class<?> loadClass(String name) throws ClassNotFoundException {
+				throw new ClassNotFoundException("Foo not found");
+			}
+		});
+		t.start();
+		Message<?> reply = bar.receive(10000);
+		assertThat(reply.getPayload(), instanceOf(Foo.class));
+	}
+
+	public static class Foo {
+
+	}
+
+}

--- a/src/reference/docbook/spel.xml
+++ b/src/reference/docbook/spel.xml
@@ -53,13 +53,13 @@
 			described in the following sections, and the framework will automatically configure
 			the factory bean on your behalf.
 		</para>
-		<programlisting language="xml"><![CDATA[<beans:bean id="integrationEvaluationContext"
+		<programlisting language="xml"><![CDATA[<bean id="integrationEvaluationContext"
 			class="org.springframework.integration.config.IntegrationEvaluationContextFactoryBean">
 	<property name="propertyAccessors">
 		<util:map>
-			<beans:entry key="foo">
-				<beans:bean class="<bean class="foo.MyCustomPropertyAccessor"/>"/>
-			</beans:entry>
+			<entry key="foo">
+				<bean class="foo.MyCustomPropertyAccessor"/>
+			</entry>
 		</util:map>
 	</property>
 	<property name="functions">
@@ -89,6 +89,20 @@
 			and configure a custom property accessor to do so. So, your final expression might be
 			<code>"#barcalc(payload.myBar)"</code>.
 		</para>
+		<para>
+			The factory bean has another property <code>typeLocator</code> which allows you to customize
+			the <interfacename>TypeLocator</interfacename> used during SpEL evaluation. This might be
+			necessary when running in some environments that use a non-standard <classname>ClassLoader</classname>.
+			In the following example, SpEL expressions will always use the bean factory's class loader:
+		</para>
+		<programlisting language="xml"><![CDATA[<bean id="integrationEvaluationContext"
+		class="org.springframework.integration.config.IntegrationEvaluationContextFactoryBean">
+	<property name="typeLocator">
+		<bean class="org.springframework.expression.spel.support.StandardTypeLocator">
+			<constructor-arg value="#{beanFactory.beanClassLoader}"/>
+		</bean>
+	</property>
+</bean>]]></programlisting>
 	</section>
 	<section id="spel-functions">
 		<title>SpEL Functions</title>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3342

Allow customization of the `TypeLocator` used by SpEL
`EvaluationContext`s throughout the framework.

**cherry-pick to 3.0.x**
