### PR TITLE
Update JavaMail dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -415,8 +415,10 @@ project('spring-integration-mail') {
 	dependencies {
 		compile project(":spring-integration-core")
 		compile "org.springframework:spring-context-support:$springVersion"
-		compile("javax.mail:mail:$javaxMailVersion", provided)
+		compile("javax.mail:javax.mail-api:$javaxMailVersion", provided)
+		compile("com.sun.mail:imap:$javaxMailVersion", provided)
 		compile("javax.activation:activation:$javaxActivationVersion", optional)
+		testRuntime "com.sun.mail:mailapi:$javaxMailVersion"
 	}
 
 	// suppress javax.activation path warnings
@@ -572,7 +574,8 @@ project('spring-integration-ws') {
 		testCompile "javax.jms:jms-api:$jmsApiVersion"
 		testCompile "org.igniterealtime.smack:smack:$smackVersion"
 		testCompile "org.igniterealtime.smack:smackx:$smackVersion"
-		testCompile "javax.mail:mail:$javaxMailVersion"
+		testCompile "javax.mail:javax.mail-api:$javaxMailVersion"
+		testRuntime "com.sun.mail:mailapi:$javaxMailVersion"
 	}
 
 	// suppress saaj path warnings


### PR DESCRIPTION
This PR updates the JavaMail dependency to use the new coordinates, although the version that's being used remains unchanged. This brings the dependency into line with other javax dependencies. It also paves the way for moving to 1.5 at some point in the future as 1.5 no longer publishes the javax.mail:mail artifact
