### PR TITLE
INT-3349 BeanFactory Propagation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ services:
   - rabbitmq
   - redis-server
 env:
-  - TERM=dumb
+  - TERM=dumb SI_FATAL_WHEN_NO_BEANFACTORY=true GRADLE_OPTS='-XX:MaxPermSize=512M -Xmx1024M'

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpChannelFactoryBean.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpChannelFactoryBean.java
@@ -318,9 +318,6 @@ public class AmqpChannelFactoryBean extends AbstractFactoryBean<AbstractAmqpChan
 				if (this.maxSubscribers != null) {
 					pubsub.setMaxSubscribers(this.maxSubscribers);
 				}
-				if (this.getBeanFactory() != null) {
-					pubsub.setBeanFactory(this.getBeanFactory());
-				}
 				this.channel = pubsub;
 			}
 			else {
@@ -350,8 +347,11 @@ public class AmqpChannelFactoryBean extends AbstractFactoryBean<AbstractAmqpChan
 		if (!CollectionUtils.isEmpty(this.interceptors)) {
 			this.channel.setInterceptors(this.interceptors);
 		}
-		this.channel.afterPropertiesSet();
 		this.channel.setBeanName(this.beanName);
+		if (this.getBeanFactory() != null) {
+			this.channel.setBeanFactory(this.getBeanFactory());
+		}
+		this.channel.afterPropertiesSet();
 		return this.channel;
 	}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
@@ -44,6 +44,7 @@ import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.MessageDeliveryException;
 
@@ -80,6 +81,7 @@ public class DispatcherHasNoSubscribersTests {
 		PointToPointSubscribableAmqpChannel amqpChannel = new PointToPointSubscribableAmqpChannel("noSubscribersChannel",
 				container, amqpTemplate);
 		amqpChannel.setBeanName("noSubscribersChannel");
+		amqpChannel.setBeanFactory(mock(BeanFactory.class));
 		amqpChannel.afterPropertiesSet();
 
 		MessageListener listener = (MessageListener) container.getMessageListener();
@@ -115,6 +117,7 @@ public class DispatcherHasNoSubscribersTests {
 						return queue;
 					}};
 		amqpChannel.setBeanName("noSubscribersChannel");
+		amqpChannel.setBeanFactory(mock(BeanFactory.class));
 		amqpChannel.afterPropertiesSet();
 
 		List<String> logList = insertMockLoggerInListener(amqpChannel);

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import org.springframework.amqp.rabbit.support.CorrelationData;
 import org.springframework.amqp.support.converter.JsonMessageConverter;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
@@ -60,6 +61,7 @@ import com.rabbitmq.client.Channel;
 
 /**
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 3.0
  */
 public class InboundEndpointTests {
@@ -84,6 +86,7 @@ public class InboundEndpointTests {
 		PollableChannel channel = new QueueChannel();
 
 		adapter.setOutputChannel(channel);
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 
 		Object payload = new Foo("bar1");
@@ -122,6 +125,7 @@ public class InboundEndpointTests {
 		PollableChannel channel = new QueueChannel();
 
 		adapter.setOutputChannel(channel);
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 
 		Object payload = new Foo("bar1");
@@ -171,6 +175,7 @@ public class InboundEndpointTests {
 		gateway.setMessageConverter(new JsonMessageConverter());
 
 		gateway.setRequestChannel(channel);
+		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.afterPropertiesSet();
 
 		RabbitTemplate rabbitTemplate = Mockito.spy(TestUtils.getPropertyValue(gateway, "amqpTemplate", RabbitTemplate.class));

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
@@ -87,6 +87,11 @@ public abstract class IntegrationContextUtils {
 	public static final String GLOBAL_CHANNEL_INTERCEPTOR_PROCESSOR_BEAN_NAME = "globalChannelInterceptorProcessor";
 
 	/**
+	 * Should be set to TRUE on CI plans and framework developer systems.
+	 */
+	public static final boolean fatalWhenNoBeanFactory = Boolean.valueOf(System.getenv("SI_FATAL_WHEN_NO_BEANFACTORY"));
+
+	/**
 	 * @param beanFactory BeanFactory for lookup, must not be null.
 	 * @return The {@link MetadataStore} bean whose name is "metadataStore".
 	 */
@@ -194,6 +199,9 @@ public abstract class IntegrationContextUtils {
 			if (logger.isWarnEnabled()) {
 				logger.warn("No 'beanFactory' supplied; cannot find MessageBuilderFactory"
 							+ ", using default.");
+			}
+			if (fatalWhenNoBeanFactory) {
+				throw new RuntimeException("All Message creators need a BeanFactory");
 			}
 		}
 		if (messageBuilderFactory == null) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -18,11 +18,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageStore;
@@ -36,6 +38,7 @@ import org.springframework.messaging.MessageHeaders;
  * @author Mark Fisher
  * @author Marius Bogoevici
  * @author Iwein Fuld
+ * @author Gary Russell
  */
 public class AggregatorTests {
 
@@ -47,6 +50,7 @@ public class AggregatorTests {
 	@Before
 	public void configureAggregator() {
 		this.aggregator = new AggregatingMessageHandler(new MultiplyingProcessor(), store);
+		this.aggregator.setBeanFactory(mock(BeanFactory.class));
 		this.aggregator.afterPropertiesSet();
 	}
 
@@ -218,6 +222,7 @@ public class AggregatorTests {
 
 
 	private class MultiplyingProcessor implements MessageGroupProcessor {
+		@Override
 		public Object processMessageGroup(MessageGroup group) {
 			Integer product = 1;
 			for (Message<?> message : group.getMessages()) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelatingMessageHandlerIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelatingMessageHandlerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.integration.support.MessageBuilder;
@@ -33,19 +34,20 @@ import org.springframework.messaging.MessageChannel;
 
 public class CorrelatingMessageHandlerIntegrationTests {
 
-	private MessageGroupStore store = new SimpleMessageStore(100);
+	private final MessageGroupStore store = new SimpleMessageStore(100);
 
-	private MessageChannel outputChannel = mock(MessageChannel.class);
+	private final MessageChannel outputChannel = mock(MessageChannel.class);
 
-	private MessageGroupProcessor processor = new PassThroughMessageGroupProcessor();
+	private final MessageGroupProcessor processor = new PassThroughMessageGroupProcessor();
 
-	private AggregatingMessageHandler defaultHandler = new AggregatingMessageHandler(processor, store);
+	private final AggregatingMessageHandler defaultHandler = new AggregatingMessageHandler(processor, store);
 
 	@Before
 	public void setupHandler() {
 		when(outputChannel.send(isA(Message.class))).thenReturn(true);
 		defaultHandler.setOutputChannel(outputChannel);
 		defaultHandler.setSendTimeout(-1);
+		defaultHandler.setBeanFactory(mock(BeanFactory.class));
 		defaultHandler.afterPropertiesSet();
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,6 +29,8 @@ import java.util.Collections;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.store.MessageGroupStore;
@@ -42,6 +45,7 @@ import org.springframework.messaging.MessageChannel;
  * @author Dave Syer
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
 public class ResequencerTests {
 
@@ -54,6 +58,7 @@ public class ResequencerTests {
 	@Before
 	public void configureResequencer() {
 		this.resequencer = new ResequencingMessageHandler(processor, store, null, null);
+		this.resequencer.setBeanFactory(mock(BeanFactory.class));
 		this.resequencer.afterPropertiesSet();
 	}
 
@@ -82,6 +87,7 @@ public class ResequencerTests {
 		SequenceSizeReleaseStrategy releaseStrategy = new SequenceSizeReleaseStrategy();
 		releaseStrategy.setReleasePartialSequences(true);
 		this.resequencer = new ResequencingMessageHandler(processor, store, null, releaseStrategy);
+		this.resequencer.setBeanFactory(mock(BeanFactory.class));
 		this.resequencer.afterPropertiesSet();
 
 		QueueChannel replyChannel = new QueueChannel();
@@ -102,10 +108,12 @@ public class ResequencerTests {
 		this.resequencer = new ResequencingMessageHandler(processor, store, null, releaseStrategy);
 		QueueChannel replyChannel = new QueueChannel();
 		this.resequencer.setCorrelationStrategy(new CorrelationStrategy() {
+			@Override
 			public Object getCorrelationKey(Message<?> message) {
 				return "A";
 			}
 		});
+		this.resequencer.setBeanFactory(mock(BeanFactory.class));
 		this.resequencer.afterPropertiesSet();
 
 		//Message<?> message0 = MessageBuilder.withPayload("0").setSequenceNumber(0).build();

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/MessageProducerSupportTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/MessageProducerSupportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,23 +17,26 @@
 package org.springframework.integration.endpoint;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.handler.ServiceActivatingHandler;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.0.1
  */
 public class MessageProducerSupportTests {
@@ -43,6 +46,7 @@ public class MessageProducerSupportTests {
 		DirectChannel outChannel = new DirectChannel();
 
 		outChannel.subscribe(new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) throws MessagingException {
 				throw new RuntimeException("problems");
 			}
@@ -59,12 +63,14 @@ public class MessageProducerSupportTests {
 	public void validateExceptionIfSendToErrorChannelFails() {
 		DirectChannel outChannel = new DirectChannel();
 		outChannel.subscribe(new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) throws MessagingException {
 				throw new RuntimeException("problems");
 			}
 		});
 		PublishSubscribeChannel errorChannel = new PublishSubscribeChannel();
 		errorChannel.subscribe(new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) throws MessagingException {
 				throw new RuntimeException("ooops");
 			}
@@ -82,6 +88,7 @@ public class MessageProducerSupportTests {
 	public void validateSuccessfulErrorFlowDoesNotThrowErrors() {
 		DirectChannel outChannel = new DirectChannel();
 		outChannel.subscribe(new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) throws MessagingException {
 				throw new RuntimeException("problems");
 			}
@@ -89,6 +96,7 @@ public class MessageProducerSupportTests {
 		PublishSubscribeChannel errorChannel = new PublishSubscribeChannel();
 		SuccessfulErrorService errorService = new SuccessfulErrorService();
 		ServiceActivatingHandler handler  = new ServiceActivatingHandler(errorService);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		errorChannel.subscribe(handler);
 		MessageProducerSupport mps = new MessageProducerSupport() {};

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyFactoryBeanTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,6 +129,7 @@ public class GatewayProxyFactoryBeanTests {
 		proxyFactory.setDefaultRequestChannel(new DirectChannel());
 		proxyFactory.setDefaultReplyChannel(replyChannel);
 		proxyFactory.setBeanName("testGateway");
+		proxyFactory.setBeanFactory(mock(BeanFactory.class));
 		proxyFactory.afterPropertiesSet();
 		TestService service = (TestService) proxyFactory.getObject();
 		String result = service.solicitResponse();

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/MessagingGatewayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/MessagingGatewayTests.java
@@ -19,18 +19,19 @@ package org.springframework.integration.gateway;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.handler.ServiceActivatingHandler;
@@ -48,6 +49,7 @@ import org.springframework.messaging.PollableChannel;
  * @author Iwein Fuld
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Gary Russell
  */
 @SuppressWarnings("unchecked")
 public class MessagingGatewayTests {
@@ -249,12 +251,14 @@ public class MessagingGatewayTests {
 	public void validateErroMessageCanNotBeReplyMessage() {
 		DirectChannel reqChannel = new DirectChannel();
 		reqChannel.subscribe(new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) throws MessagingException {
 				throw new RuntimeException("ooops");
 			}
 		});
 		PublishSubscribeChannel errorChannel = new PublishSubscribeChannel();
 		ServiceActivatingHandler handler  = new ServiceActivatingHandler(new MyErrorService());
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		errorChannel.subscribe(handler);
 
@@ -263,6 +267,7 @@ public class MessagingGatewayTests {
 		this.messagingGateway.setRequestChannel(reqChannel);
 		this.messagingGateway.setErrorChannel(errorChannel);
 		this.messagingGateway.setReplyChannel(null);
+		this.messagingGateway.setBeanFactory(mock(BeanFactory.class));
 		this.messagingGateway.afterPropertiesSet();
 		this.messagingGateway.start();
 
@@ -274,12 +279,14 @@ public class MessagingGatewayTests {
 	public void validateErrorChannelWithSuccessfulReply() {
 		DirectChannel reqChannel = new DirectChannel();
 		reqChannel.subscribe(new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) throws MessagingException {
 				throw new RuntimeException("ooops");
 			}
 		});
 		PublishSubscribeChannel errorChannel = new PublishSubscribeChannel();
 		ServiceActivatingHandler handler  = new ServiceActivatingHandler(new MyOneWayErrorService());
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		errorChannel.subscribe(handler);
 
@@ -288,6 +295,7 @@ public class MessagingGatewayTests {
 		this.messagingGateway.setRequestChannel(reqChannel);
 		this.messagingGateway.setErrorChannel(errorChannel);
 		this.messagingGateway.setReplyChannel(null);
+		this.messagingGateway.setBeanFactory(mock(BeanFactory.class));
 		this.messagingGateway.afterPropertiesSet();
 		this.messagingGateway.start();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/NestedGatewayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/NestedGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,19 @@
 package org.springframework.integration.gateway;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 
-import org.springframework.messaging.Message;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public class NestedGatewayTests {
 
@@ -42,6 +45,7 @@ public class NestedGatewayTests {
 		});
 		final MessagingGatewaySupport innerGateway = new MessagingGatewaySupport() {};
 		innerGateway.setRequestChannel(innerChannel);
+		innerGateway.setBeanFactory(mock(BeanFactory.class));
 		innerGateway.afterPropertiesSet();
 		outerChannel.subscribe(new AbstractReplyProducingMessageHandler() {
 			@Override
@@ -52,6 +56,7 @@ public class NestedGatewayTests {
 		});
 		MessagingGatewaySupport outerGateway = new MessagingGatewaySupport() {};
 		outerGateway.setRequestChannel(outerChannel);
+		outerGateway.setBeanFactory(mock(BeanFactory.class));
 		outerGateway.afterPropertiesSet();
 		Message<?> reply = outerGateway.sendAndReceiveMessage("test");
 		assertEquals("pre-test-reply-post", reply.getPayload());
@@ -69,6 +74,7 @@ public class NestedGatewayTests {
 		});
 		MessagingGatewaySupport gateway = new MessagingGatewaySupport() {};
 		gateway.setRequestChannel(requestChannel);
+		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.afterPropertiesSet();
 		Message<?> message = MessageBuilder.withPayload("test")
 				.setReplyChannel(replyChannel).build();
@@ -89,6 +95,7 @@ public class NestedGatewayTests {
 		});
 		MessagingGatewaySupport gateway = new MessagingGatewaySupport() {};
 		gateway.setRequestChannel(requestChannel);
+		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.afterPropertiesSet();
 		Message<?> message = MessageBuilder.withPayload("test")
 				.setErrorChannel(errorChannel).build();

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/HeaderAnnotationTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/HeaderAnnotationTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,11 @@ package org.springframework.integration.handler;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
+
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.annotation.Header;
 import org.springframework.integration.channel.QueueChannel;
@@ -30,6 +33,7 @@ import org.springframework.messaging.Message;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.0
  */
 public class HeaderAnnotationTransformerTests {
@@ -39,6 +43,7 @@ public class HeaderAnnotationTransformerTests {
 		Object target = new TestTransformer();
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(target, "appendCorrelationId");
 		MessageTransformingHandler handler = new MessageTransformingHandler(transformer);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		QueueChannel outputChannel = new QueueChannel();
 		handler.setOutputChannel(outputChannel);
@@ -54,6 +59,7 @@ public class HeaderAnnotationTransformerTests {
 		Object target = new TestTransformer();
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(target, "evalCorrelationId");
 		MessageTransformingHandler handler = new MessageTransformingHandler(transformer);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		QueueChannel outputChannel = new QueueChannel();
 		handler.setOutputChannel(outputChannel);
@@ -69,6 +75,7 @@ public class HeaderAnnotationTransformerTests {
 		Object target = new TestTransformer();
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(target, "appendFoo");
 		MessageTransformingHandler handler = new MessageTransformingHandler(transformer);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		QueueChannel outputChannel = new QueueChannel();
 		handler.setOutputChannel(outputChannel);
@@ -84,6 +91,7 @@ public class HeaderAnnotationTransformerTests {
 		Object target = new TestTransformer();
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(target, "evalFoo");
 		MessageTransformingHandler handler = new MessageTransformingHandler(transformer);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		QueueChannel outputChannel = new QueueChannel();
 		handler.setOutputChannel(outputChannel);

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MessageHandlerChainTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MessageHandlerChainTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.handler;
 
+import static org.mockito.Mockito.mock;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.core.MessageProducer;
@@ -96,6 +99,7 @@ public class MessageHandlerChainTests {
 		chain.setBeanName("testChain");
 		chain.setHandlers(handlers);
 		chain.setOutputChannel(outputChannel);
+		chain.setBeanFactory(mock(BeanFactory.class));
 		chain.afterPropertiesSet();
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 
 package org.springframework.integration.handler;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
 import java.util.Date;
@@ -37,16 +37,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.expression.spel.SpelEvaluationException;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.integration.annotation.Header;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.gateway.GatewayProxyFactoryBean;
 import org.springframework.integration.gateway.RequestReplyExchanger;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.util.MessagingMethodInvokerHelper;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.support.GenericMessage;
+
 
 /**
  * @author Mark Fisher
@@ -349,6 +351,7 @@ public class MethodInvokingMessageProcessorTests {
 	@Test
 	public void gatewayTest() throws Exception {
 		GatewayProxyFactoryBean gwFactoryBean = new GatewayProxyFactoryBean();
+		gwFactoryBean.setBeanFactory(mock(BeanFactory.class));
 		gwFactoryBean.afterPropertiesSet();
 		Object target = gwFactoryBean.getObject();
 		// just instantiate a helper with a simple target; we're going to invoke getTargetClass with reflection
@@ -365,14 +368,17 @@ public class MethodInvokingMessageProcessorTests {
 
 		class Foo {
 
+			@SuppressWarnings("unused")
 			public String handleMessage(Message<Number> message) {
 				return "" + (message.getPayload().intValue() * 2);
 			}
 
+			@SuppressWarnings("unused")
 			public String objectMethod(Integer foo) {
 				return foo.toString();
 			}
 
+			@SuppressWarnings("unused")
 			public String voidMethod() {
 				return "foo";
 			}
@@ -390,10 +396,12 @@ public class MethodInvokingMessageProcessorTests {
 
 		class Foo {
 
+			@SuppressWarnings("unused")
 			public String getFoo() {
 				return "foo";
 			}
 
+			@SuppressWarnings("unused")
 			public String getBar() {
 				return "foo";
 			}
@@ -414,14 +422,17 @@ public class MethodInvokingMessageProcessorTests {
 
 		class Foo {
 
+			@SuppressWarnings("unused")
 			public String m1(Message<String> message) {
 				return message.getPayload();
 			}
 
+			@SuppressWarnings("unused")
 			public Integer m2(Message<Integer> message) {
 				return message.getPayload();
 			}
 
+			@SuppressWarnings("unused")
 			public Object m3(Message<?> message) {
 				return message.getPayload();
 			}
@@ -441,14 +452,17 @@ public class MethodInvokingMessageProcessorTests {
 
 		class Foo {
 
+			@SuppressWarnings("unused")
 			public String m1(String payload) {
 				return payload;
 			}
 
+			@SuppressWarnings("unused")
 			public Integer m2(Integer payload) {
 				return payload;
 			}
 
+			@SuppressWarnings("unused")
 			public Object m3(Object payload) {
 				return payload;
 			}
@@ -468,15 +482,18 @@ public class MethodInvokingMessageProcessorTests {
 
 		class Foo {
 
+			@SuppressWarnings("unused")
 			public Object m1(Message<String> message) {
 				fail("This method must not be invoked");
 				return message;
 			}
 
+			@SuppressWarnings("unused")
 			public Object m2(String payload) {
 				return payload;
 			}
 
+			@SuppressWarnings("unused")
 			public Object m3() {
 				return "FOO";
 			}
@@ -506,6 +523,7 @@ public class MethodInvokingMessageProcessorTests {
 			return type.isAssignableFrom(cause.getClass());
 		}
 
+		@Override
 		public void describeTo(Description description) {
 			description.appendText("cause to be ").appendValue(type).appendText("but was ").appendValue(cause);
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/RecipientListRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/RecipientListRouterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,24 +19,28 @@ package org.springframework.integration.router;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
+
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.core.MessageSelector;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.router.RecipientListRouter.Recipient;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public class RecipientListRouterTests {
 
@@ -50,6 +54,7 @@ public class RecipientListRouterTests {
 		channels.add(channel2);
 		RecipientListRouter router = new RecipientListRouter();
 		router.setChannels(channels);
+		router.setBeanFactory(mock(BeanFactory.class));
 		router.afterPropertiesSet();
 		List<Recipient> recipients = (List<Recipient>)
 				new DirectFieldAccessor(router).getPropertyValue("recipients");
@@ -67,6 +72,7 @@ public class RecipientListRouterTests {
 		channels.add(channel2);
 		RecipientListRouter router = new RecipientListRouter();
 		router.setChannels(channels);
+		router.setBeanFactory(mock(BeanFactory.class));
 		router.afterPropertiesSet();
 		Message<String> message = new GenericMessage<String>("test");
 		router.handleMessage(message);
@@ -350,6 +356,7 @@ public class RecipientListRouterTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void noChannelListFailsInitialization() {
 		RecipientListRouter router = new RecipientListRouter();
+		router.setBeanFactory(mock(BeanFactory.class));
 		router.afterPropertiesSet();
 	}
 
@@ -404,6 +411,7 @@ public class RecipientListRouterTests {
 
 	private static class AlwaysTrueSelector implements MessageSelector {
 
+		@Override
 		public boolean accept(Message<?> message) {
 			return true;
 		}
@@ -412,6 +420,7 @@ public class RecipientListRouterTests {
 
 	private static class AlwaysFalseSelector implements MessageSelector {
 
+		@Override
 		public boolean accept(Message<?> message) {
 			return false;
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/ContentEnricherTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/ContentEnricherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.channel.QueueChannel;
@@ -47,6 +46,7 @@ import org.springframework.integration.handler.ReplyRequiredException;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.support.PeriodicTrigger;
 
@@ -124,6 +124,7 @@ public class ContentEnricherTests {
 
 		};
 
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		final PollingConsumer consumer = new PollingConsumer(requestChannel, handler);

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/HeaderFilterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/HeaderFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,20 +19,21 @@ package org.springframework.integration.transformer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 
 import java.util.UUID;
 
 import org.junit.Test;
 
-import org.springframework.messaging.Message;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.transformer.HeaderFilter;
-import org.springframework.integration.transformer.MessageTransformingHandler;
+import org.springframework.messaging.Message;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.0
  */
 public class HeaderFilterTests {
@@ -62,6 +63,7 @@ public class HeaderFilterTests {
 				.build();
 		HeaderFilter filter = new HeaderFilter("x", "z");
 		MessageTransformingHandler handler = new MessageTransformingHandler(filter);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		handler.handleMessage(message);
 		Message<?> result = replyChannel.receive(0);

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FeedEntryMessageSourceTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FeedEntryMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.feed.inbound;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.net.URL;
@@ -26,6 +27,7 @@ import java.net.URL;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.metadata.PropertiesPersistingMetadataStore;
 import org.springframework.messaging.Message;
 
@@ -35,6 +37,7 @@ import com.sun.syndication.fetcher.FeedFetcher;
 /**
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.0
  */
 public class FeedEntryMessageSourceTests {
@@ -62,6 +65,7 @@ public class FeedEntryMessageSourceTests {
 		URL url = new URL("file:src/test/java/org/springframework/integration/feed/empty.rss");
 		FeedEntryMessageSource feedEntrySource = new FeedEntryMessageSource(url, "foo", this.feedFetcher);
 		feedEntrySource.setBeanName("feedReader");
+		feedEntrySource.setBeanFactory(mock(BeanFactory.class));
 		feedEntrySource.afterPropertiesSet();
 		assertNull(feedEntrySource.receive());
 	}
@@ -71,6 +75,7 @@ public class FeedEntryMessageSourceTests {
 		URL url = new URL("file:src/test/java/org/springframework/integration/feed/sample.rss");
 		FeedEntryMessageSource source = new FeedEntryMessageSource(url, "foo", this.feedFetcher);
 		source.setComponentName("feedReader");
+		source.setBeanFactory(mock(BeanFactory.class));
 		source.afterPropertiesSet();
 		Message<SyndEntry> message1 = source.receive();
 		Message<SyndEntry> message2 = source.receive();
@@ -93,6 +98,7 @@ public class FeedEntryMessageSourceTests {
 		PropertiesPersistingMetadataStore metadataStore = new PropertiesPersistingMetadataStore();
 		metadataStore.afterPropertiesSet();
 		feedEntrySource.setMetadataStore(metadataStore);
+		feedEntrySource.setBeanFactory(mock(BeanFactory.class));
 		feedEntrySource.afterPropertiesSet();
 		SyndEntry entry1 = feedEntrySource.receive().getPayload();
 		SyndEntry entry2 = feedEntrySource.receive().getPayload();
@@ -117,6 +123,7 @@ public class FeedEntryMessageSourceTests {
 		metadataStore = new PropertiesPersistingMetadataStore();
 		metadataStore.afterPropertiesSet();
 		feedEntrySource.setMetadataStore(metadataStore);
+		feedEntrySource.setBeanFactory(mock(BeanFactory.class));
 		feedEntrySource.afterPropertiesSet();
 		assertNull(feedEntrySource.receive());
 		assertNull(feedEntrySource.receive());
@@ -130,6 +137,7 @@ public class FeedEntryMessageSourceTests {
 		URL url = new URL("file:src/test/java/org/springframework/integration/feed/sample.rss");
 		FeedEntryMessageSource feedEntrySource = new FeedEntryMessageSource(url, "foo", this.feedFetcher);
 		feedEntrySource.setBeanName("feedReader");
+		feedEntrySource.setBeanFactory(mock(BeanFactory.class));
 		feedEntrySource.afterPropertiesSet();
 		SyndEntry entry1 = feedEntrySource.receive().getPayload();
 		SyndEntry entry2 = feedEntrySource.receive().getPayload();
@@ -149,6 +157,7 @@ public class FeedEntryMessageSourceTests {
 		// now test that what's been read is read AGAIN
 		feedEntrySource = new FeedEntryMessageSource(url, "foo", this.feedFetcher);
 		feedEntrySource.setBeanName("feedReader");
+		feedEntrySource.setBeanFactory(mock(BeanFactory.class));
 		feedEntrySource.afterPropertiesSet();
 		entry1 = feedEntrySource.receive().getPayload();
 		entry2 = feedEntrySource.receive().getPayload();

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileReadingMessageSourceFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileReadingMessageSourceFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,9 @@ import java.util.Comparator;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.integration.file.DirectoryScanner;
 import org.springframework.integration.file.FileReadingMessageSource;
@@ -31,9 +34,11 @@ import org.springframework.integration.file.locking.AbstractFileLockerFilter;
 /**
  * @author Mark Fisher
  * @author Iwein Fuld
+ * @author Gary Russell
  * @since 1.0.3
  */
-public class FileReadingMessageSourceFactoryBean implements FactoryBean<FileReadingMessageSource> {
+public class FileReadingMessageSourceFactoryBean implements FactoryBean<FileReadingMessageSource>,
+		BeanFactoryAware {
 
 	private static Log logger = LogFactory.getLog(FileReadingMessageSourceFactoryBean.class);
 
@@ -54,6 +59,8 @@ public class FileReadingMessageSourceFactoryBean implements FactoryBean<FileRead
 	private volatile Boolean autoCreateDirectory;
 
 	private volatile Integer queueSize;
+
+	private volatile BeanFactory beanFactory;
 
 	private final Object initializationMonitor = new Object();
 
@@ -93,6 +100,12 @@ public class FileReadingMessageSourceFactoryBean implements FactoryBean<FileRead
 		this.locker = locker;
 	}
 
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) {
+		this.beanFactory = beanFactory;
+	}
+
+	@Override
 	public FileReadingMessageSource getObject() throws Exception {
 		if (this.source == null) {
 			initSource();
@@ -100,10 +113,12 @@ public class FileReadingMessageSourceFactoryBean implements FactoryBean<FileRead
 		return this.source;
 	}
 
+	@Override
 	public Class<?> getObjectType() {
 		return FileReadingMessageSource.class;
 	}
 
+	@Override
 	public boolean isSingleton() {
 		return true;
 	}
@@ -148,6 +163,9 @@ public class FileReadingMessageSourceFactoryBean implements FactoryBean<FileRead
 			}
 			if (this.autoCreateDirectory != null) {
 				this.source.setAutoCreateDirectory(this.autoCreateDirectory);
+			}
+			if (this.beanFactory != null) {
+				this.source.setBeanFactory(this.beanFactory);
 			}
 			this.source.afterPropertiesSet();
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.core.task.TaskExecutor;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.integration.file.tail.ApacheCommonsFileTailingMessageProducer;
 import org.springframework.integration.file.tail.FileTailingMessageProducerSupport;
 import org.springframework.integration.file.tail.OSDelegatingFileTailingMessageProducer;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -216,6 +216,9 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 		}
 		if (this.applicationEventPublisher != null) {
 			adapter.setApplicationEventPublisher(this.applicationEventPublisher);
+		}
+		if (this.getBeanFactory() != null) {
+			adapter.setBeanFactory(this.getBeanFactory());
 		}
 		adapter.afterPropertiesSet();
 		this.adapter = adapter;

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
@@ -138,6 +138,9 @@ public abstract class AbstractInboundFileSynchronizingMessageSource<F> extends M
 			}
 			this.fileSource.setDirectory(this.localDirectory);
 			this.fileSource.setFilter(this.buildFilter());
+			if (this.getBeanFactory() != null) {
+				this.fileSource.setBeanFactory(this.getBeanFactory());
+			}
 			this.fileSource.afterPropertiesSet();
 			this.synchronizer.afterPropertiesSet();
 		}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/tail/FileTailingMessageProducerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/tail/FileTailingMessageProducerTests.java
@@ -18,6 +18,7 @@ package org.springframework.integration.file.tail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -32,11 +33,12 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.messaging.Message;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.file.tail.FileTailingMessageProducerSupport.FileTailingEvent;
+import org.springframework.messaging.Message;
 
 /**
  * @author Gary Russell
@@ -104,6 +106,7 @@ public class FileTailingMessageProducerTests {
 		QueueChannel outputChannel = new QueueChannel();
 		adapter.setOutputChannel(outputChannel);
 		adapter.setTailAttemptsDelay(500);
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 		File file = new File(testDir, "foo");
 		File renamed = new File(testDir, "bar");

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpInboundRemoteFileSystemSynchronizerTests.java
@@ -44,6 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.SpelParserConfiguration;
@@ -117,6 +118,7 @@ public class FtpInboundRemoteFileSystemSynchronizerTests {
 		ms.setAutoCreateLocalDirectory(true);
 
 		ms.setLocalDirectory(localDirectoy);
+		ms.setBeanFactory(mock(BeanFactory.class));
 		ms.afterPropertiesSet();
 		Message<File> atestFile =  ms.receive();
 		assertNotNull(atestFile);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,10 +53,10 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.serializer.DefaultDeserializer;
 import org.springframework.core.serializer.DefaultSerializer;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.PollableChannel;
 import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.ip.tcp.connection.AbstractClientConnectionFactory;
@@ -66,10 +66,12 @@ import org.springframework.integration.ip.tcp.connection.FailoverClientConnectio
 import org.springframework.integration.ip.tcp.connection.TcpConnectionSupport;
 import org.springframework.integration.ip.tcp.connection.TcpNetClientConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.TcpNioClientConnectionFactory;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.SocketUtils;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Gary Russell
@@ -487,6 +489,7 @@ public class TcpOutboundGatewayTests {
 		gateway.setConnectionFactory(cachingFactory);
 		PollableChannel outputChannel = new QueueChannel();
 		gateway.setOutputChannel(outputChannel);
+		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.afterPropertiesSet();
 		gateway.start();
 
@@ -567,6 +570,7 @@ public class TcpOutboundGatewayTests {
 		gateway.setConnectionFactory(failoverFactory);
 		PollableChannel outputChannel = new QueueChannel();
 		gateway.setOutputChannel(outputChannel);
+		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.afterPropertiesSet();
 		gateway.start();
 
@@ -682,6 +686,7 @@ public class TcpOutboundGatewayTests {
 		gateway.setRequiresReply(true);
 		gateway.setOutputChannel(replyChannel);
 		gateway.setRemoteTimeout(5000);
+		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.afterPropertiesSet();
 		gateway.start();
 		try {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.ip.tcp;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,12 +42,11 @@ import javax.net.SocketFactory;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.serializer.DefaultDeserializer;
 import org.springframework.core.serializer.DefaultSerializer;
-import org.springframework.messaging.Message;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.messaging.SubscribableChannel;
 import org.springframework.integration.handler.ServiceActivatingHandler;
 import org.springframework.integration.ip.tcp.connection.AbstractClientConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory;
@@ -58,6 +58,8 @@ import org.springframework.integration.ip.tcp.connection.TcpNioServerConnectionF
 import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer;
 import org.springframework.integration.ip.util.TestingUtilities;
 import org.springframework.integration.test.util.SocketUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.SubscribableChannel;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
@@ -79,6 +81,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		TestingUtilities.waitListening(scf, null);
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 		Socket socket = SocketFactory.getDefault().createSocket("localhost", port);
 		socket.getOutputStream().write("Test1\r\n".getBytes());
@@ -128,6 +131,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		adapter.setClientMode(true);
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 		assertTrue(latch1.await(10, TimeUnit.SECONDS));
 		adapter.setRetryInterval(10000);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandlerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,15 +50,12 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.core.serializer.DefaultDeserializer;
 import org.springframework.core.serializer.DefaultSerializer;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.MessagingException;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.messaging.PollableChannel;
 import org.springframework.integration.ip.tcp.connection.AbstractClientConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.AbstractConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory;
@@ -70,9 +67,13 @@ import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer
 import org.springframework.integration.ip.tcp.serializer.ByteArrayLengthHeaderSerializer;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayStxEtxSerializer;
 import org.springframework.integration.ip.util.TestingUtilities;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.SocketUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 
@@ -187,6 +188,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		assertTrue(latch.await(10, TimeUnit.SECONDS));
 		handler.setClientMode(true);
 		handler.setRetryInterval(10000);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 		taskScheduler.setPoolSize(1);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpConnectionEventListenerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpConnectionEventListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ package org.springframework.integration.ip.tcp.connection;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.messaging.Message;
 
@@ -37,6 +39,7 @@ public class TcpConnectionEventListenerTests {
 		TcpConnectionEventListeningMessageProducer eventProducer = new TcpConnectionEventListeningMessageProducer();
 		QueueChannel outputChannel = new QueueChannel();
 		eventProducer.setOutputChannel(outputChannel);
+		eventProducer.setBeanFactory(mock(BeanFactory.class));
 		eventProducer.afterPropertiesSet();
 		eventProducer.start();
 		TcpConnectionSupport connection = Mockito.mock(TcpConnectionSupport.class);
@@ -67,6 +70,7 @@ public class TcpConnectionEventListenerTests {
 		eventProducer.setOutputChannel(outputChannel);
 		Class<?>[] eventTypes = new Class<?>[]{FooEvent.class, BarEvent.class};
 		eventProducer.setEventTypes((Class<? extends TcpConnectionEvent>[]) eventTypes);
+		eventProducer.setBeanFactory(mock(BeanFactory.class));
 		eventProducer.afterPropertiesSet();
 		eventProducer.start();
 		TcpConnectionSupport connection = Mockito.mock(TcpConnectionSupport.class);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketSendingHandlerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketSendingHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.ip.udp;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
@@ -34,6 +35,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.SocketUtils;
@@ -98,6 +100,7 @@ public class DatagramPacketSendingHandlerTests {
 		UnicastSendingMessageHandler handler =
 				new UnicastSendingMessageHandler("localhost", testPort, true,
 						true, "localhost", ackPort, 5000);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		handler.start();
 		Executors.newSingleThreadExecutor().execute(new Runnable() {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.ip.udp;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -33,6 +34,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.handler.ServiceActivatingHandler;
@@ -147,6 +149,7 @@ public class UdpChannelAdapterTests {
 //				whichNic,
 				SocketUtils.findAvailableUdpSocket(), 5000);
 //		handler.setLocalAddress(whichNic);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		handler.start();
 		Message<byte[]> message = MessageBuilder.withPayload("ABCD".getBytes()).build();

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcOutboundGatewayTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,18 +14,21 @@ package org.springframework.integration.jdbc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import javax.sql.DataSource;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
 /**
  *
  * @author Gunnar Hillert
+ * @author Gary Russell
  * @since 2.1
  *
  */
@@ -41,6 +44,7 @@ public class JdbcOutboundGatewayTests {
 
 		try {
 			jdbcOutboundGateway.setMaxRowsPerPoll(10);
+			jdbcOutboundGateway.setBeanFactory(mock(BeanFactory.class));
 			jdbcOutboundGateway.afterPropertiesSet();
 
 		} catch (IllegalArgumentException e) {

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/StoredProcMessageHandlerDerbyIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/StoredProcMessageHandlerDerbyIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,7 @@ public class StoredProcMessageHandlerDerbyIntegrationTests {
 		storedProcExecutor.setBeanFactory(mock(BeanFactory.class));
 
 		storedProcExecutor.afterPropertiesSet();
+		messageHandler.setBeanFactory(mock(BeanFactory.class));
 		messageHandler.afterPropertiesSet();
 
 		MessageBuilder<User> message = MessageBuilder.withPayload(new User("username", "password", "email"));
@@ -100,6 +101,7 @@ public class StoredProcMessageHandlerDerbyIntegrationTests {
 		storedProcExecutor.setBeanFactory(mock(BeanFactory.class));
 
 		storedProcExecutor.afterPropertiesSet();
+		messageHandler.setBeanFactory(mock(BeanFactory.class));
 		messageHandler.afterPropertiesSet();
 
 		MessageBuilder<User> message = MessageBuilder.withPayload(new User("username", "password", "email"));
@@ -128,6 +130,7 @@ public class StoredProcMessageHandlerDerbyIntegrationTests {
 		storedProcExecutor.setBeanFactory(mock(BeanFactory.class));
 
 		storedProcExecutor.afterPropertiesSet();
+		messageHandler.setBeanFactory(mock(BeanFactory.class));
 		messageHandler.afterPropertiesSet();
 
 		MessageBuilder<User> message = MessageBuilder.withPayload(new User("username", "password", "email"));
@@ -159,6 +162,7 @@ public class StoredProcMessageHandlerDerbyIntegrationTests {
 		storedProcExecutor.setBeanFactory(mock(BeanFactory.class));
 
 		storedProcExecutor.afterPropertiesSet();
+		messageHandler.setBeanFactory(mock(BeanFactory.class));
 		messageHandler.afterPropertiesSet();
 
 		MessageBuilder<User> message = MessageBuilder.withPayload(new User("Eric.Cartman", "c4rtm4n", "eric@cartman.com"));
@@ -191,6 +195,7 @@ public class StoredProcMessageHandlerDerbyIntegrationTests {
 		storedProcExecutor.setBeanFactory(mock(BeanFactory.class));
 
 		storedProcExecutor.afterPropertiesSet();
+		messageHandler.setBeanFactory(mock(BeanFactory.class));
 		messageHandler.afterPropertiesSet();
 
 		MessageBuilder<User> message = MessageBuilder.withPayload(new User("Eric.Cartman", "c4rtm4n", "eric@cartman.com"));

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -337,9 +337,6 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 			this.container = this.createContainer();
 			SubscribableJmsChannel subscribableJmsChannel = new SubscribableJmsChannel(this.container, this.jmsTemplate);
 			subscribableJmsChannel.setMaxSubscribers(this.maxSubscribers);
-			if (this.getBeanFactory() != null) {
-				subscribableJmsChannel.setBeanFactory(this.getBeanFactory());
-			}
 			this.channel = subscribableJmsChannel;
 		}
 		else {
@@ -355,6 +352,9 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 			this.channel.setInterceptors(this.interceptors);
 		}
 		this.channel.setBeanName(this.beanName);
+		if (this.getBeanFactory() != null) {
+			this.channel.setBeanFactory(this.getBeanFactory());
+		}
 		this.channel.afterPropertiesSet();
 		return this.channel;
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsOutboundGatewayTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsOutboundGatewayTests.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.integration.jms.JmsOutboundGateway.ReplyContainerProperties;
 import org.springframework.integration.test.util.TestUtils;
@@ -68,6 +69,7 @@ public class JmsOutboundGatewayTests {
 		gateway.setRequestDestinationName("foo");
 		gateway.setUseReplyContainer(true);
 		gateway.setReplyContainerProperties(new ReplyContainerProperties());
+		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.afterPropertiesSet();
 		assertEquals("JMS_OutboundGateway@" + ObjectUtils.getIdentityHexString(gateway) +
 				".replyListener",

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/PollableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/PollableJmsChannelTests.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -41,6 +42,7 @@ import org.apache.activemq.command.ActiveMQQueue;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.jms.config.JmsChannelFactoryBean;
 import org.springframework.integration.support.MessageBuilder;
@@ -75,6 +77,7 @@ public class PollableJmsChannelTests {
 		ccf.setCacheConsumers(false);
 		factoryBean.setConnectionFactory(ccf);
 		factoryBean.setDestination(this.queue);
+		factoryBean.setBeanFactory(mock(BeanFactory.class));
 		factoryBean.afterPropertiesSet();
 		PollableJmsChannel channel = (PollableJmsChannel) factoryBean.getObject();
 		boolean sent1 = channel.send(new GenericMessage<String>("foo"));
@@ -101,6 +104,7 @@ public class PollableJmsChannelTests {
 		factoryBean.setConnectionFactory(ccf);
 		factoryBean.setDestinationName("someDynamicQueue");
 		factoryBean.setPubSubDomain(false);
+		factoryBean.setBeanFactory(mock(BeanFactory.class));
 		factoryBean.afterPropertiesSet();
 		PollableJmsChannel channel = (PollableJmsChannel) factoryBean.getObject();
 		boolean sent1 = channel.send(new GenericMessage<String>("foo"));
@@ -131,6 +135,7 @@ public class PollableJmsChannelTests {
 		ChannelInterceptor interceptor = spy(new SampleInterceptor(false));
 		interceptorList.add(interceptor);
 		factoryBean.setInterceptors(interceptorList);
+		factoryBean.setBeanFactory(mock(BeanFactory.class));
 		factoryBean.afterPropertiesSet();
 		PollableJmsChannel channel = (PollableJmsChannel) factoryBean.getObject();
 		boolean sent1 = channel.send(new GenericMessage<String>("foo"));
@@ -157,6 +162,7 @@ public class PollableJmsChannelTests {
 		ChannelInterceptor interceptor = spy(new SampleInterceptor(true));
 		interceptorList.add(interceptor);
 		factoryBean.setInterceptors(interceptorList);
+		factoryBean.setBeanFactory(mock(BeanFactory.class));
 		factoryBean.afterPropertiesSet();
 		PollableJmsChannel channel = (PollableJmsChannel) factoryBean.getObject();
 		boolean sent1 = channel.send(new GenericMessage<String>("foo"));
@@ -184,6 +190,7 @@ public class PollableJmsChannelTests {
 		int ttl = 10000;
 		factoryBean.setTimeToLive(ttl);
 		factoryBean.setDeliveryPersistent(false);
+		factoryBean.setBeanFactory(mock(BeanFactory.class));
 		factoryBean.afterPropertiesSet();
 		PollableJmsChannel channel = (PollableJmsChannel) factoryBean.getObject();
 		final JmsTemplate receiver = new JmsTemplate(this.connectionFactory);
@@ -234,6 +241,7 @@ public class PollableJmsChannelTests {
 
 		factoryBean.setMessageSelector("baz='qux'");
 
+		factoryBean.setBeanFactory(mock(BeanFactory.class));
 		factoryBean.afterPropertiesSet();
 		PollableJmsChannel channel = (PollableJmsChannel) factoryBean.getObject();
 		boolean sent1 = channel.send(new GenericMessage<String>("foo"));

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/SubscribableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/SubscribableJmsChannelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,11 +45,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.integration.jms.config.JmsChannelFactoryBean;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.jms.connection.CachingConnectionFactory;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
@@ -57,6 +58,7 @@ import org.springframework.jms.listener.DefaultMessageListenerContainer;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Mark Fisher
@@ -93,6 +95,7 @@ public class SubscribableJmsChannelTests {
 		final CountDownLatch latch = new CountDownLatch(2);
 		final List<Message<?>> receivedList1 = Collections.synchronizedList( new ArrayList<Message<?>>());
 		MessageHandler handler1 = new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) {
 				receivedList1.add(message);
 				latch.countDown();
@@ -100,6 +103,7 @@ public class SubscribableJmsChannelTests {
 		};
 		final List<Message<?>> receivedList2 = Collections.synchronizedList( new ArrayList<Message<?>>());
 		MessageHandler handler2 = new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) {
 				receivedList2.add(message);
 				latch.countDown();
@@ -108,6 +112,7 @@ public class SubscribableJmsChannelTests {
 		JmsChannelFactoryBean factoryBean = new JmsChannelFactoryBean(true);
 		factoryBean.setConnectionFactory(this.connectionFactory);
 		factoryBean.setDestination(this.queue);
+		factoryBean.setBeanFactory(mock(BeanFactory.class));
 		factoryBean.afterPropertiesSet();
 		SubscribableJmsChannel channel = (SubscribableJmsChannel) factoryBean.getObject();
 		channel.afterPropertiesSet();
@@ -131,6 +136,7 @@ public class SubscribableJmsChannelTests {
 		final CountDownLatch latch = new CountDownLatch(4);
 		final List<Message<?>> receivedList1 = Collections.synchronizedList( new ArrayList<Message<?>>());
 		MessageHandler handler1 = new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) {
 				receivedList1.add(message);
 				latch.countDown();
@@ -138,6 +144,7 @@ public class SubscribableJmsChannelTests {
 		};
 		final List<Message<?>> receivedList2 = Collections.synchronizedList( new ArrayList<Message<?>>());
 		MessageHandler handler2 = new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) {
 				receivedList2.add(message);
 				latch.countDown();
@@ -146,6 +153,7 @@ public class SubscribableJmsChannelTests {
 		JmsChannelFactoryBean factoryBean = new JmsChannelFactoryBean(true);
 		factoryBean.setConnectionFactory(this.connectionFactory);
 		factoryBean.setDestination(this.topic);
+		factoryBean.setBeanFactory(mock(BeanFactory.class));
 		factoryBean.afterPropertiesSet();
 		SubscribableJmsChannel channel = (SubscribableJmsChannel) factoryBean.getObject();
 		channel.afterPropertiesSet();
@@ -173,6 +181,7 @@ public class SubscribableJmsChannelTests {
 		final List<Message<?>> receivedList1 = Collections.synchronizedList( new ArrayList<Message<?>>());
 		MessageHandler handler1 = new MessageHandler() {
 
+			@Override
 			public void handleMessage(Message<?> message) {
 				receivedList1.add(message);
 				latch.countDown();
@@ -181,6 +190,7 @@ public class SubscribableJmsChannelTests {
 		final List<Message<?>> receivedList2 = Collections.synchronizedList( new ArrayList<Message<?>>());
 		MessageHandler handler2 = new MessageHandler() {
 
+			@Override
 			public void handleMessage(Message<?> message) {
 				receivedList2.add(message);
 				latch.countDown();
@@ -190,6 +200,7 @@ public class SubscribableJmsChannelTests {
 		factoryBean.setConnectionFactory(this.connectionFactory);
 		factoryBean.setDestinationName("dynamicQueue");
 		factoryBean.setPubSubDomain(false);
+		factoryBean.setBeanFactory(mock(BeanFactory.class));
 		factoryBean.afterPropertiesSet();
 
 		SubscribableJmsChannel channel = (SubscribableJmsChannel) factoryBean.getObject();
@@ -217,6 +228,7 @@ public class SubscribableJmsChannelTests {
 		final CountDownLatch latch = new CountDownLatch(4);
 		final List<Message<?>> receivedList1 = Collections.synchronizedList( new ArrayList<Message<?>>());
 		MessageHandler handler1 = new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) {
 				receivedList1.add(message);
 				latch.countDown();
@@ -224,6 +236,7 @@ public class SubscribableJmsChannelTests {
 		};
 		final List<Message<?>> receivedList2 = Collections.synchronizedList( new ArrayList<Message<?>>());
 		MessageHandler handler2 = new MessageHandler() {
+			@Override
 			public void handleMessage(Message<?> message) {
 				receivedList2.add(message);
 				latch.countDown();
@@ -234,6 +247,7 @@ public class SubscribableJmsChannelTests {
 		factoryBean.setConnectionFactory(this.connectionFactory);
 		factoryBean.setDestinationName("dynamicTopic");
 		factoryBean.setPubSubDomain(true);
+		factoryBean.setBeanFactory(mock(BeanFactory.class));
 		factoryBean.afterPropertiesSet();
 		SubscribableJmsChannel channel = (SubscribableJmsChannel) factoryBean.getObject();
 		channel.afterPropertiesSet();
@@ -279,6 +293,7 @@ public class SubscribableJmsChannelTests {
 		factoryBean.setConnectionFactory(this.connectionFactory);
 		factoryBean.setDestinationName("noSubscribersQueue");
 		factoryBean.setBeanName("noSubscribersChannel");
+		factoryBean.setBeanFactory(mock(BeanFactory.class));
 		factoryBean.afterPropertiesSet();
 		SubscribableJmsChannel channel = (SubscribableJmsChannel) factoryBean.getObject();
 		channel.afterPropertiesSet();
@@ -303,6 +318,7 @@ public class SubscribableJmsChannelTests {
 		factoryBean.setDestinationName("noSubscribersTopic");
 		factoryBean.setBeanName("noSubscribersChannel");
 		factoryBean.setPubSubDomain(true);
+		factoryBean.setBeanFactory(mock(BeanFactory.class));
 		factoryBean.afterPropertiesSet();
 		SubscribableJmsChannel channel = (SubscribableJmsChannel) factoryBean.getObject();
 		channel.afterPropertiesSet();
@@ -323,6 +339,7 @@ public class SubscribableJmsChannelTests {
 		Log logger = mock(Log.class);
 		final ArrayList<String> logList = new ArrayList<String>();
 		doAnswer(new Answer<Object>() {
+			@Override
 			public Object answer(InvocationOnMock invocation)
 					throws Throwable {
 				String message = (String) invocation.getArguments()[0];

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/NotificationListeningMessageProducerTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/NotificationListeningMessageProducerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -32,13 +33,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.springframework.messaging.Message;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.jmx.export.MBeanExporter;
 import org.springframework.jmx.export.notification.NotificationPublisher;
 import org.springframework.jmx.export.notification.NotificationPublisherAware;
 import org.springframework.jmx.support.MBeanServerFactoryBean;
 import org.springframework.jmx.support.ObjectNameManager;
+import org.springframework.messaging.Message;
 
 /**
  * @author Mark Fisher
@@ -78,6 +80,7 @@ public class NotificationListeningMessageProducerTests {
 		adapter.setServer(this.server);
 		adapter.setObjectName(this.objectName);
 		adapter.setOutputChannel(outputChannel);
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 		adapter.start();
 		this.numberHolder.publish("foo");
@@ -99,6 +102,7 @@ public class NotificationListeningMessageProducerTests {
 		adapter.setOutputChannel(outputChannel);
 		Integer handback = new Integer(123);
 		adapter.setHandback(handback);
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 		adapter.start();
 		this.numberHolder.publish("foo");
@@ -120,10 +124,12 @@ public class NotificationListeningMessageProducerTests {
 		adapter.setObjectName(this.objectName);
 		adapter.setOutputChannel(outputChannel);
 		adapter.setFilter(new NotificationFilter() {
+			@Override
 			public boolean isNotificationEnabled(Notification notification) {
 				return !notification.getMessage().equals("bad");
 			}
 		});
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 		adapter.start();
 		this.numberHolder.publish("bad");
@@ -154,6 +160,7 @@ public class NotificationListeningMessageProducerTests {
 			this.number.set(value);
 		}
 
+		@Override
 		public void setNotificationPublisher(NotificationPublisher notificationPublisher) {
 			this.notificationPublisher = notificationPublisher;
 		}

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/OperationInvokingMessageHandlerTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/OperationInvokingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.jmx;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -30,19 +31,21 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessagingException;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.jmx.config.DynamicRouterTests;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.jmx.support.MBeanServerFactoryBean;
 import org.springframework.jmx.support.ObjectNameManager;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 
 /**
  * See DynamicRouterTests for additional tests where the MBean is registered by the Spring exporter.
  * @see DynamicRouterTests
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.0
  */
 public class OperationInvokingMessageHandlerTests {
@@ -75,6 +78,7 @@ public class OperationInvokingMessageHandlerTests {
 		handler.setObjectName(this.objectName);
 		handler.setOutputChannel(outputChannel);
 		handler.setOperationName("x");
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		Map<String, Object> params = new HashMap<String, Object>();
 		params.put("p1", "foo");
@@ -94,6 +98,7 @@ public class OperationInvokingMessageHandlerTests {
 		handler.setObjectName(this.objectName);
 		handler.setOutputChannel(outputChannel);
 		handler.setOperationName("y");
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		Message<?> message = MessageBuilder.withPayload("foo").build();
 		handler.handleMessage(message);
@@ -107,6 +112,7 @@ public class OperationInvokingMessageHandlerTests {
 		handler.setObjectName(this.objectName);
 		handler.setOutputChannel(outputChannel);
 		handler.setOperationName("x");
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		Map<String, Object> params = new HashMap<String, Object>();
 		params.put("p1", "foo");
@@ -125,6 +131,7 @@ public class OperationInvokingMessageHandlerTests {
 		handler.setObjectName(this.objectName);
 		handler.setOutputChannel(outputChannel);
 		handler.setOperationName("x");
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		List<Object> params = Arrays.asList(new Object[] { "foo", new Integer(123) });
 		Message<?> message = MessageBuilder.withPayload(params).build();
@@ -146,14 +153,17 @@ public class OperationInvokingMessageHandlerTests {
 
 	public static class TestOps implements TestOpsMBean {
 
+		@Override
 		public String x(String s1, String s2) {
 			return s1 + s2;
 		}
 
+		@Override
 		public String x(String s, Integer i) {
 			return s + i;
 		}
 
+		@Override
 		public void y(String s){}
 	}
 

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundChannelAdapterTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -12,24 +12,27 @@
  */
 package org.springframework.integration.jpa.outbound;
 
+import static org.mockito.Mockito.mock;
+
 import java.util.List;
 
 import javax.persistence.EntityManager;
 
-import org.junit.Assert;
-
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.integration.jpa.core.JpaExecutor;
 import org.springframework.integration.jpa.support.PersistMode;
 import org.springframework.integration.jpa.test.JpaTestUtils;
 import org.springframework.integration.jpa.test.entity.StudentDomain;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.transaction.TransactionConfiguration;
@@ -42,6 +45,7 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
  *
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 2.2
  *
  */
@@ -155,6 +159,7 @@ public class JpaOutboundChannelAdapterTests {
 
 		Message<StudentDomain> message = MessageBuilder.withPayload(testStudent).build();
 
+		jpaOutboundChannelAdapter.setBeanFactory(mock(BeanFactory.class));
 		jpaOutboundChannelAdapter.afterPropertiesSet();
 
 		DefaultTransactionDefinition def = new DefaultTransactionDefinition();

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSourceTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2012 the original author or authors
+ * Copyright 2007-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import java.util.List;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -42,6 +44,7 @@ import com.mongodb.util.JSON;
 /**
  * @author Amol Nayak
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  *
  * @since 2.2
  *
@@ -80,6 +83,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 
 		Expression queryExpression = new LiteralExpression("{'name' : 'Oleg'}");
 		MongoDbMessageSource messageSource = new MongoDbMessageSource(mongoDbFactory, queryExpression);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
 		messageSource.afterPropertiesSet();
 		@SuppressWarnings("unchecked")
 		List<DBObject> results = ((List<DBObject>)messageSource.receive().getPayload());
@@ -101,6 +105,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 		Expression queryExpression = new LiteralExpression("{'name' : 'Oleg'}");
 		MongoDbMessageSource messageSource = new MongoDbMessageSource(mongoDbFactory, queryExpression);
 		messageSource.setEntityClass(Object.class);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
 		messageSource.afterPropertiesSet();
 		@SuppressWarnings("unchecked")
 		List<Person> results = ((List<Person>)messageSource.receive().getPayload());
@@ -123,6 +128,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 		MongoDbMessageSource messageSource = new MongoDbMessageSource(mongoDbFactory, queryExpression);
 		messageSource.setEntityClass(Object.class);
 		messageSource.setExpectSingleResult(true);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
 		messageSource.afterPropertiesSet();
 		Person person = (Person)messageSource.receive().getPayload();
 
@@ -143,6 +149,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 		Expression queryExpression = new LiteralExpression("{'address.state' : 'PA'}");
 		MongoDbMessageSource messageSource = new MongoDbMessageSource(mongoDbFactory, queryExpression);
 		messageSource.setEntityClass(Object.class);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
 		messageSource.afterPropertiesSet();
 		@SuppressWarnings("unchecked")
 		List<Person> results = ((List<Person>)messageSource.receive().getPayload());
@@ -164,6 +171,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 
 		Expression queryExpression = new LiteralExpression("{'address.state' : 'PA'}");
 		MongoDbMessageSource messageSource = new MongoDbMessageSource(mongoDbFactory, queryExpression);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
 		messageSource.afterPropertiesSet();
 		@SuppressWarnings("unchecked")
 		List<Person> persons = (List<Person>) messageSource.receive().getPayload();
@@ -183,6 +191,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 
 		Expression queryExpression = new LiteralExpression("{'address.state' : 'NJ'}");
 		MongoDbMessageSource messageSource = new MongoDbMessageSource(mongoDbFactory, queryExpression);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
 		messageSource.afterPropertiesSet();
 		assertNull(messageSource.receive());
 	}
@@ -202,6 +211,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 		Expression queryExpression = new LiteralExpression("{'address.state' : 'PA'}");
 		MongoDbMessageSource messageSource = new MongoDbMessageSource(mongoDbFactory, queryExpression);
 		MappingMongoConverter converter = new TestMongoConverter(mongoDbFactory, new MongoMappingContext());
+		messageSource.setBeanFactory(mock(BeanFactory.class));
 		converter.afterPropertiesSet();
 		converter = spy(converter);
 		messageSource.setMongoConverter(converter);
@@ -226,6 +236,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 		MongoTemplate template = new MongoTemplate(mongoDbFactory, converter);
 		Expression queryExpression = new LiteralExpression("{'address.state' : 'PA'}");
 		MongoDbMessageSource messageSource = new MongoDbMessageSource(template, queryExpression);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
 		messageSource.afterPropertiesSet();
 
 		MongoTemplate writingTemplate = new MongoTemplate(mongoDbFactory, converter);
@@ -247,15 +258,16 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 
 		template.save(JSON.parse("{'name' : 'Manny', 'id' : 1}"), "data");
-		
+
 		Expression queryExpression = new LiteralExpression("{'name' : 'Manny'}");
 		MongoDbMessageSource messageSource = new MongoDbMessageSource(mongoDbFactory, queryExpression);
 		messageSource.setExpectSingleResult(true);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
 		messageSource.afterPropertiesSet();
 		DBObject result = (DBObject) messageSource.receive().getPayload();
 		Object id = result.get("_id");
 		result.put("company","PepBoys");
-		template.save(result, "data"); 
+		template.save(result, "data");
 		result = (DBObject) messageSource.receive().getPayload();
 		assertEquals(id, result.get("_id"));
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandlerTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2012 the original author or authors
+ * Copyright 2007-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
 package org.springframework.integration.mongodb.outbound;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -30,16 +33,17 @@ import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.expression.common.LiteralExpression;
-import org.springframework.messaging.Message;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
 import org.springframework.integration.mongodb.rules.MongoDbAvailableTests;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
 
 import com.mongodb.DBObject;
 
 /**
  * @author Amol Nayak
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  *
  * @since 2.2
  */
@@ -62,6 +66,7 @@ public class MongoDbStoringMessageHandlerTests extends MongoDbAvailableTests {
 
 		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoDbStoringMessageHandler handler = new MongoDbStoringMessageHandler(mongoDbFactory);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob")).build();
 		handler.handleMessage(message);
@@ -81,6 +86,7 @@ public class MongoDbStoringMessageHandlerTests extends MongoDbAvailableTests {
 		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoDbStoringMessageHandler handler = new MongoDbStoringMessageHandler(mongoDbFactory);
 		handler.setCollectionNameExpression(new LiteralExpression("foo"));
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob")).build();
 		handler.handleMessage(message);
@@ -104,6 +110,7 @@ public class MongoDbStoringMessageHandlerTests extends MongoDbAvailableTests {
 		converter.afterPropertiesSet();
 		converter = spy(converter);
 		handler.setMongoConverter(converter);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob")).build();
 		handler.handleMessage(message);
@@ -129,6 +136,7 @@ public class MongoDbStoringMessageHandlerTests extends MongoDbAvailableTests {
 
 		MongoDbStoringMessageHandler handler = new MongoDbStoringMessageHandler(template);
 		handler.setCollectionNameExpression(new LiteralExpression("foo"));
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob")).build();
 		handler.handleMessage(message);

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/BackTobackAdapterTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/BackTobackAdapterTests.java
@@ -17,10 +17,12 @@ package org.springframework.integration.mqtt;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.mqtt.inbound.MqttPahoMessageDrivenChannelAdapter;
 import org.springframework.integration.mqtt.outbound.MqttPahoMessageHandler;
@@ -44,6 +46,7 @@ public class BackTobackAdapterTests {
 	public void testSingleTopic() {
 		MqttPahoMessageHandler adapter = new MqttPahoMessageHandler("tcp://localhost:1883", "si-test-out");
 		adapter.setDefaultTopic("mqtt-foo");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 		adapter.start();
 		MqttPahoMessageDrivenChannelAdapter inbound = new MqttPahoMessageDrivenChannelAdapter("tcp://localhost:1883", "si-test-in", "mqtt-foo");
@@ -52,6 +55,7 @@ public class BackTobackAdapterTests {
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 		taskScheduler.initialize();
 		inbound.setTaskScheduler(taskScheduler);
+		inbound.setBeanFactory(mock(BeanFactory.class));
 		inbound.afterPropertiesSet();
 		inbound.start();
 		adapter.handleMessage(new GenericMessage<String>("foo"));
@@ -68,6 +72,7 @@ public class BackTobackAdapterTests {
 	public void testTwoTopics() {
 		MqttPahoMessageHandler adapter = new MqttPahoMessageHandler("tcp://localhost:1883", "si-test-out");
 		adapter.setDefaultTopic("mqtt-foo");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 		adapter.start();
 		MqttPahoMessageDrivenChannelAdapter inbound = new MqttPahoMessageDrivenChannelAdapter("tcp://localhost:1883", "si-test-in", "mqtt-foo", "mqtt-bar");
@@ -76,6 +81,7 @@ public class BackTobackAdapterTests {
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 		taskScheduler.initialize();
 		inbound.setTaskScheduler(taskScheduler);
+		inbound.setBeanFactory(mock(BeanFactory.class));
 		inbound.afterPropertiesSet();
 		inbound.start();
 		adapter.handleMessage(new GenericMessage<String>("foo"));

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/DownstreamExceptionTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/DownstreamExceptionTests.java
@@ -22,6 +22,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.contains;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -37,6 +38,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.mqtt.inbound.MqttPahoMessageDrivenChannelAdapter;
 import org.springframework.integration.mqtt.outbound.MqttPahoMessageHandler;
@@ -90,6 +92,7 @@ public class DownstreamExceptionTests {
 		new DirectFieldAccessor(noErrorChannel).setPropertyValue("logger", logger);
 		MqttPahoMessageHandler adapter = new MqttPahoMessageHandler("tcp://localhost:1883", "si-test-out");
 		adapter.setDefaultTopic("mqtt-fooEx1");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 		adapter.start();
 		adapter.handleMessage(new GenericMessage<String>("foo"));
@@ -109,6 +112,7 @@ public class DownstreamExceptionTests {
 		service.n = 0;
 		MqttPahoMessageHandler adapter = new MqttPahoMessageHandler("tcp://localhost:1883", "si-test-out");
 		adapter.setDefaultTopic("mqtt-fooEx2");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 		adapter.start();
 		adapter.handleMessage(new GenericMessage<String>("foo"));

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.mqtt.core.DefaultMqttPahoClientFactory;
 import org.springframework.integration.mqtt.core.DefaultMqttPahoClientFactory.Will;
@@ -117,6 +118,7 @@ public class MqttAdapterTests {
 
 		MqttPahoMessageHandler handler = new MqttPahoMessageHandler("foo", "bar", factory);
 		handler.setDefaultTopic("mqtt-foo");
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		handler.start();
 		final AtomicBoolean connectCalled = new AtomicBoolean();
@@ -222,6 +224,7 @@ public class MqttAdapterTests {
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 		taskScheduler.initialize();
 		adapter.setTaskScheduler(taskScheduler);
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 		adapter.start();
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/channel/SubscribableRedisChannelTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/channel/SubscribableRedisChannelTests.java
@@ -75,7 +75,7 @@ public class SubscribableRedisChannelTests extends RedisAvailableTests {
 		channel.send(new GenericMessage<String>("1"));
 		channel.send(new GenericMessage<String>("2"));
 		channel.send(new GenericMessage<String>("3"));
-		assertTrue(latch.await(5, TimeUnit.SECONDS));
+		assertTrue(latch.await(20, TimeUnit.SECONDS));
 	}
 
 	@Test

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapterTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2013 the original author or authors
+ * Copyright 2007-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -20,19 +20,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.messaging.Message;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.redis.rules.RedisAvailable;
 import org.springframework.integration.redis.rules.RedisAvailableTests;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.messaging.Message;
 
 /**
  * @author Mark Fisher
@@ -59,6 +61,7 @@ public class RedisInboundChannelAdapterTests extends RedisAvailableTests{
 		RedisInboundChannelAdapter adapter = new RedisInboundChannelAdapter(connectionFactory);
 		adapter.setTopics(redisChannelName);
 		adapter.setOutputChannel(channel);
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
 		adapter.start();
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandlerTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.redis.outbound;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -39,18 +41,19 @@ import org.springframework.data.redis.support.collections.RedisCollectionFactory
 import org.springframework.data.redis.support.collections.RedisList;
 import org.springframework.data.redis.support.collections.RedisZSet;
 import org.springframework.expression.common.LiteralExpression;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.redis.rules.RedisAvailable;
 import org.springframework.integration.redis.rules.RedisAvailableTests;
 import org.springframework.integration.redis.support.RedisHeaders;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 
@@ -67,6 +70,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		RedisStoreWritingMessageHandler handler =
 				new RedisStoreWritingMessageHandler(jcf);
 		handler.setKey(key);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		List<String> list = new ArrayList<String>();
@@ -95,6 +99,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		RedisStoreWritingMessageHandler handler =
 				new RedisStoreWritingMessageHandler(jcf);
 
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		List<String> list = new ArrayList<String>();
@@ -122,6 +127,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 
 		RedisStoreWritingMessageHandler handler =
 				new RedisStoreWritingMessageHandler(jcf);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		List<String> list = new ArrayList<String>();
@@ -147,6 +153,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 				new RedisStoreWritingMessageHandler(template);
 		handler.setKey(key);
 		handler.setExtractPayloadElements(false);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		List<String> list = new ArrayList<String>();
@@ -177,6 +184,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 				new RedisStoreWritingMessageHandler(jcf);
 		handler.setKey(key);
 		handler.setCollectionType(CollectionType.ZSET);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		List<String> list = new ArrayList<String>();
@@ -215,6 +223,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 				new RedisStoreWritingMessageHandler(jcf);
 		handler.setKey(key);
 		handler.setCollectionType(CollectionType.ZSET);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		List<String> list = new ArrayList<String>();
@@ -256,6 +265,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 				new RedisStoreWritingMessageHandler(jcf);
 		handler.setKey(key);
 		handler.setCollectionType(CollectionType.ZSET);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		List<String> list = new ArrayList<String>();
@@ -299,6 +309,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 
 		handler.setCollectionType(CollectionType.ZSET);
 		handler.setExtractPayloadElements(false);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		List<String> list = new ArrayList<String>();
@@ -330,6 +341,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 				new RedisStoreWritingMessageHandler(jcf);
 		handler.setKey(key);
 		handler.setCollectionType(CollectionType.ZSET);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		Map<String, Double> presidents = new HashMap<String, Double>();
@@ -373,6 +385,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 				new RedisStoreWritingMessageHandler(template);
 		handler.setKey(key);
 		handler.setCollectionType(CollectionType.ZSET);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		Map<President, Double> presidents = new HashMap<President, Double>();
@@ -417,6 +430,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		handler.setKey(key);
 		handler.setCollectionType(CollectionType.ZSET);
 		handler.setExtractPayloadElements(false);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		Map<President, Double> presidents = new HashMap<President, Double>();
@@ -440,6 +454,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 				new RedisStoreWritingMessageHandler(jcf);
 		handler.setKey(key);
 		handler.setMapKeyExpression(new LiteralExpression(key));
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 	}
 
@@ -453,6 +468,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		handler.setKey(key);
 		handler.setCollectionType(CollectionType.SET);
 		handler.setMapKeyExpression(new LiteralExpression(key));
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 	}
 
@@ -466,6 +482,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		handler.setKey(key);
 		handler.setCollectionType(CollectionType.ZSET);
 		handler.setMapKeyExpression(new LiteralExpression(key));
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 	}
 
@@ -479,6 +496,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		handler.setKey(key);
 		handler.setCollectionType(CollectionType.MAP);
 		handler.setMapKeyExpression(new LiteralExpression(key));
+		handler.setBeanFactory(mock(BeanFactory.class));
 		try {
 			handler.afterPropertiesSet();
 		}
@@ -497,6 +515,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		handler.setKey(key);
 		handler.setCollectionType(CollectionType.PROPERTIES);
 		handler.setMapKeyExpression(new LiteralExpression(key));
+		handler.setBeanFactory(mock(BeanFactory.class));
 		try {
 			handler.afterPropertiesSet();
 		}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/rules/RedisAvailableTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/rules/RedisAvailableTests.java
@@ -51,6 +51,7 @@ public class RedisAvailableTests {
 		rt.afterPropertiesSet();
 		rt.execute(new RedisCallback<Object>() {
 
+			@Override
 			public Object doInRedis(RedisConnection connection)
 					throws DataAccessException {
 				connection.flushDb();
@@ -69,6 +70,8 @@ public class RedisAvailableTests {
 			Thread.sleep(100);
 		}
 		assertTrue("RedisMessageListenerContainer Failed to Subscribe", n < 100);
+		// wait another second because of race condition in Lettuce
+		Thread.sleep(1000);
 	}
 
 	protected void awaitContainerSubscribedWithPatterns(RedisMessageListenerContainer container) throws Exception {
@@ -81,6 +84,8 @@ public class RedisAvailableTests {
 			Thread.sleep(100);
 		}
 		assertTrue("RedisMessageListenerContainer Failed to Subscribe with patterns", n < 100);
+		// wait another second because of race condition in Lettuce
+		Thread.sleep(1000);
 	}
 
 	protected void prepareList(RedisConnectionFactory connectionFactory){

--- a/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/config/RmiOutboundGatewayParserTests.java
+++ b/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/config/RmiOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,21 +20,24 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.context.ApplicationContext;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.messaging.PollableChannel;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.rmi.RmiInboundGateway;
 import org.springframework.integration.rmi.RmiOutboundGateway;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Mark Fisher
@@ -53,21 +56,23 @@ public class RmiOutboundGatewayParserTests {
 		RmiInboundGateway gateway = new RmiInboundGateway();
 		gateway.setRequestChannel(testChannel);
 		gateway.setExpectReply(false);
+		gateway.setBeanFactory(mock(BeanFactory.class));
 		gateway.afterPropertiesSet();
 	}
 
 	@Test
 	public void testOrder() {
-		ApplicationContext context = new ClassPathXmlApplicationContext(
+		ConfigurableApplicationContext context = new ClassPathXmlApplicationContext(
 				"rmiOutboundGatewayParserTests.xml", this.getClass());
 		RmiOutboundGateway gateway = context.getBean("gateway.handler", RmiOutboundGateway.class);
 		assertEquals(23, TestUtils.getPropertyValue(gateway, "order"));
 		assertTrue(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));
+		context.close();
 	}
 
 	@Test
 	public void directInvocation() {
-		ApplicationContext context = new ClassPathXmlApplicationContext(
+		ConfigurableApplicationContext context = new ClassPathXmlApplicationContext(
 				"rmiOutboundGatewayParserTests.xml", this.getClass());
 		MessageChannel localChannel = (MessageChannel) context.getBean("advisedChannel");
 		RmiOutboundGateway gateway = context.getBean("advised.handler", RmiOutboundGateway.class);
@@ -78,22 +83,24 @@ public class RmiOutboundGatewayParserTests {
 		assertNotNull(result);
 		assertEquals("test", result.getPayload());
 		assertEquals(1, adviceCalled);
+		context.close();
 	}
 
 	@Test //INT-1029
 	public void testRmiOutboundGatewayInsideChain() {
-		ApplicationContext context = new ClassPathXmlApplicationContext(
+		ConfigurableApplicationContext context = new ClassPathXmlApplicationContext(
 				"rmiOutboundGatewayParserTests.xml", this.getClass());
 		MessageChannel localChannel = context.getBean("rmiOutboundGatewayInsideChain", MessageChannel.class);
 		localChannel.send(MessageBuilder.withPayload("test").build());
 		Message<?> result = testChannel.receive(1000);
 		assertNotNull(result);
 		assertEquals("test", result.getPayload());
+		context.close();
 	}
 
 	@Test //INT-1029
 	public void testRmiRequestReplyWithinChain() {
-		ApplicationContext context = new ClassPathXmlApplicationContext(
+		ConfigurableApplicationContext context = new ClassPathXmlApplicationContext(
 				"rmiOutboundGatewayParserTests.xml", this.getClass());
 		MessageChannel localChannel = context.getBean("requestReplyRmiWithChainChannel", MessageChannel.class);
 		localChannel.send(MessageBuilder.withPayload("test").build());
@@ -101,6 +108,7 @@ public class RmiOutboundGatewayParserTests {
 		Message<?> result = replyChannel.receive();
 		assertNotNull(result);
 		assertEquals("TEST", result.getPayload());
+		context.close();
 	}
 
 	public static class FooAdvice extends AbstractRequestHandlerAdvice {

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpInboundRemoteFileSystemSynchronizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.file.filters.CompositeFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
@@ -113,6 +114,7 @@ public class SftpInboundRemoteFileSystemSynchronizerTests {
 				new SftpInboundFileSynchronizingMessageSource(synchronizer);
 		ms.setAutoCreateLocalDirectory(true);
 		ms.setLocalDirectory(localDirectoy);
+		ms.setBeanFactory(mock(BeanFactory.class));
 		ms.afterPropertiesSet();
 		Message<File> atestFile =  ms.receive();
 		assertNotNull(atestFile);

--- a/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/config/SyslogReceivingChannelAdapterFactoryBean.java
+++ b/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/config/SyslogReceivingChannelAdapterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.SmartLifecycle;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory;
 import org.springframework.integration.ip.udp.UnicastReceivingChannelAdapter;
 import org.springframework.integration.syslog.MessageConverter;
 import org.springframework.integration.syslog.inbound.SyslogReceivingChannelAdapterSupport;
 import org.springframework.integration.syslog.inbound.TcpSyslogReceivingChannelAdapter;
 import org.springframework.integration.syslog.inbound.UdpSyslogReceivingChannelAdapter;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 
 /**
@@ -212,6 +212,9 @@ public class SyslogReceivingChannelAdapterFactoryBean extends AbstractFactoryBea
 		}
 		if (this.beanName != null) {
 			adapter.setBeanName(this.beanName);
+		}
+		if (this.getBeanFactory() != null) {
+			adapter.setBeanFactory(this.getBeanFactory());
 		}
 		adapter.afterPropertiesSet();
 		this.adapter = adapter;

--- a/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/inbound/SyslogReceivingChannelAdapterTests.java
+++ b/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/inbound/SyslogReceivingChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.integration.channel.QueueChannel;
@@ -64,6 +65,7 @@ public class SyslogReceivingChannelAdapterTests {
 		factory.setPort(port);
 		PollableChannel outputChannel = new QueueChannel();
 		factory.setOutputChannel(outputChannel);
+		factory.setBeanFactory(mock(BeanFactory.class));
 		factory.afterPropertiesSet();
 		factory.start();
 		UdpSyslogReceivingChannelAdapter adapter = (UdpSyslogReceivingChannelAdapter) factory.getObject();
@@ -98,6 +100,7 @@ public class SyslogReceivingChannelAdapterTests {
 			}
 		}).when(publisher).publishEvent(any(ApplicationEvent.class));
 		factory.setApplicationEventPublisher(publisher);
+		factory.setBeanFactory(mock(BeanFactory.class));
 		factory.afterPropertiesSet();
 		factory.start();
 		TcpSyslogReceivingChannelAdapter adapter = (TcpSyslogReceivingChannelAdapter) factory.getObject();

--- a/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceTests.java
+++ b/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceTests.java
@@ -32,6 +32,7 @@ import java.util.Properties;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.PropertiesFactoryBean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.integration.metadata.SimpleMetadataStore;
@@ -39,16 +40,17 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.social.twitter.api.SearchMetadata;
 import org.springframework.social.twitter.api.SearchOperations;
+import org.springframework.social.twitter.api.SearchParameters;
 import org.springframework.social.twitter.api.SearchResults;
 import org.springframework.social.twitter.api.Tweet;
 import org.springframework.social.twitter.api.Twitter;
-import org.springframework.social.twitter.api.SearchParameters;
 import org.springframework.social.twitter.api.impl.TwitterTemplate;
 
 
 /**
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
+ * @author Gary Russell
  */
 public class SearchReceivingMessageSourceTests {
 
@@ -93,6 +95,7 @@ public class SearchReceivingMessageSourceTests {
 		assertNull(metadataStore);
 		assertNotNull(metadataKey);
 
+		messageSource.setBeanFactory(mock(BeanFactory.class));
 		messageSource.afterPropertiesSet();
 
 		final Object metadataStoreInitialized = TestUtils.getPropertyValue(messageSource, "metadataStore");

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpointTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpointTests.java
@@ -35,15 +35,16 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.messaging.MessagingException;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.messaging.MessageHandler;
-import org.springframework.messaging.PollableChannel;
-import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.xmpp.core.XmppContextUtils;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.ErrorMessage;
 
 /**
  * @author Oleg Zhurakousky
@@ -63,6 +64,7 @@ public class ChatMessageListeningEndpointTests {
 		ChatMessageListeningEndpoint endpoint = new ChatMessageListeningEndpoint(connection);
 
 		doAnswer(new Answer<Object>() {
+			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				packetListSet.add((PacketListener) invocation.getArguments()[0]);
 				return null;
@@ -70,6 +72,7 @@ public class ChatMessageListeningEndpointTests {
 		}).when(connection).addPacketListener(Mockito.any(PacketListener.class), (PacketFilter) Mockito.any());
 
 		doAnswer(new Answer<Object>() {
+			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				packetListSet.remove(invocation.getArguments()[0]);
 				return null;
@@ -78,6 +81,7 @@ public class ChatMessageListeningEndpointTests {
 
 		assertEquals(0, packetListSet.size());
 		endpoint.setOutputChannel(new QueueChannel());
+		endpoint.setBeanFactory(mock(BeanFactory.class));
 		endpoint.afterPropertiesSet();
 		endpoint.start();
 		assertEquals(1, packetListSet.size());
@@ -105,6 +109,7 @@ public class ChatMessageListeningEndpointTests {
 	@Test(expected=IllegalArgumentException.class)
 	public void testNoXmppConnection(){
 		ChatMessageListeningEndpoint endpoint = new ChatMessageListeningEndpoint();
+		endpoint.setBeanFactory(mock(BeanFactory.class));
 		endpoint.afterPropertiesSet();
 	}
 
@@ -123,6 +128,7 @@ public class ChatMessageListeningEndpointTests {
 
 		DirectChannel outChannel = new DirectChannel();
 		outChannel.subscribe(new MessageHandler() {
+			@Override
 			public void handleMessage(org.springframework.messaging.Message<?> message)
 					throws MessagingException {
 				throw new RuntimeException("ooops");

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpointTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,20 +38,22 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessagingException;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.messaging.MessageHandler;
-import org.springframework.messaging.PollableChannel;
-import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.xmpp.core.XmppContextUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.ErrorMessage;
 
 /**
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
+ * @author Gary Russell
  */
 public class PresenceListeningEndpointTests {
 
@@ -63,6 +65,7 @@ public class PresenceListeningEndpointTests {
 		when(connection.getRoster()).thenReturn(roster);
 
 		doAnswer(new Answer<Object>() {
+			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				rosterSet.add((RosterListener) invocation.getArguments()[0]);
 				return null;
@@ -70,6 +73,7 @@ public class PresenceListeningEndpointTests {
 		}).when(roster).addRosterListener(Mockito.any(RosterListener.class));
 
 		doAnswer(new Answer<Object>() {
+			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				rosterSet.remove(invocation.getArguments()[0]);
 				return null;
@@ -77,6 +81,7 @@ public class PresenceListeningEndpointTests {
 		}).when(roster).removeRosterListener(Mockito.any(RosterListener.class));
 		PresenceListeningEndpoint rosterEndpoint = new PresenceListeningEndpoint(connection);
 		rosterEndpoint.setOutputChannel(new QueueChannel());
+		rosterEndpoint.setBeanFactory(mock(BeanFactory.class));
 		rosterEndpoint.afterPropertiesSet();
 		assertEquals(0, rosterSet.size());
 		rosterEndpoint.start();
@@ -99,6 +104,7 @@ public class PresenceListeningEndpointTests {
 		PresenceListeningEndpoint rosterEndpoint = new PresenceListeningEndpoint(connection);
 		QueueChannel channel = new QueueChannel();
 		rosterEndpoint.setOutputChannel(channel);
+		rosterEndpoint.setBeanFactory(mock(BeanFactory.class));
 		rosterEndpoint.afterPropertiesSet();
 		rosterEndpoint.start();
 		RosterListener rosterListener = (RosterListener) TestUtils.getPropertyValue(rosterEndpoint, "rosterListener");
@@ -122,6 +128,7 @@ public class PresenceListeningEndpointTests {
 	@Test(expected=IllegalArgumentException.class)
 	public void testNoXmppConnection() {
 		PresenceListeningEndpoint handler = new PresenceListeningEndpoint();
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 	}
 
@@ -140,6 +147,7 @@ public class PresenceListeningEndpointTests {
 
 		DirectChannel outChannel = new DirectChannel();
 		outChannel.subscribe(new MessageHandler() {
+			@Override
 			public void handleMessage(org.springframework.messaging.Message<?> message)
 					throws MessagingException {
 				throw new RuntimeException("ooops");

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/outbound/ChatMessageSendingMessageHandlerTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/outbound/ChatMessageSendingMessageHandlerTests.java
@@ -27,14 +27,15 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.xmpp.XmppHeaders;
 import org.springframework.integration.xmpp.core.XmppContextUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Oleg Zhurakousky
@@ -48,6 +49,7 @@ public class ChatMessageSendingMessageHandlerTests {
 	public void validateMessagePostAsString() throws Exception{
 		XMPPConnection connection = mock(XMPPConnection.class);
 		ChatMessageSendingMessageHandler handler = new ChatMessageSendingMessageHandler(connection);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		Message<?> message = MessageBuilder.withPayload("Test Message").
 					setHeader(XmppHeaders.TO, "kermit@frog.com").
@@ -56,7 +58,8 @@ public class ChatMessageSendingMessageHandlerTests {
 		handler.handleMessage(message);
 
 		class EqualSmackMessage extends ArgumentMatcher<org.jivesoftware.smack.packet.Message> {
-		      public boolean matches(Object msg) {
+		      @Override
+			public boolean matches(Object msg) {
 		    	  org.jivesoftware.smack.packet.Message smackMessage = (org.jivesoftware.smack.packet.Message) msg;
 		    	  boolean bodyMatches = smackMessage.getBody().equals("Test Message");
 		    	  boolean toMatches = smackMessage.getTo().equals("kermit@frog.com");
@@ -73,7 +76,8 @@ public class ChatMessageSendingMessageHandlerTests {
 			build();
 
 		class EqualSmackMessageWithThreadId extends ArgumentMatcher<org.jivesoftware.smack.packet.Message> {
-		      public boolean matches(Object msg) {
+		      @Override
+			public boolean matches(Object msg) {
 		    	  org.jivesoftware.smack.packet.Message smackMessage = (org.jivesoftware.smack.packet.Message) msg;
 		    	  boolean bodyMatches = smackMessage.getBody().equals("Hello Kitty");
 		    	  boolean toMatches = smackMessage.getTo().equals("kermit@frog.com");
@@ -92,6 +96,7 @@ public class ChatMessageSendingMessageHandlerTests {
 	public void validateMessagePostAsSmackMessage() throws Exception{
 		XMPPConnection connection = mock(XMPPConnection.class);
 		ChatMessageSendingMessageHandler handler = new ChatMessageSendingMessageHandler(connection);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		org.jivesoftware.smack.packet.Message smackMessage = new org.jivesoftware.smack.packet.Message("kermit@frog.com");
@@ -141,6 +146,7 @@ public class ChatMessageSendingMessageHandlerTests {
 	@Test(expected=IllegalArgumentException.class)
 	public void testNoXmppConnection(){
 		ChatMessageSendingMessageHandler handler = new ChatMessageSendingMessageHandler();
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 	}
 }

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/outbound/PresenceSendingMessageHandlerTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/outbound/PresenceSendingMessageHandlerTests.java
@@ -22,12 +22,13 @@ import static org.mockito.Mockito.mock;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.Presence;
 import org.junit.Test;
+
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.messaging.MessageHandlingException;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.xmpp.core.XmppContextUtils;
-import org.springframework.integration.xmpp.outbound.PresenceSendingMessageHandler;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Oleg Zhurakousky
@@ -40,6 +41,7 @@ public class PresenceSendingMessageHandlerTests {
 	@Test
 	public void testPresencePayload(){
 		PresenceSendingMessageHandler handler = new PresenceSendingMessageHandler(mock(XMPPConnection.class));
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		handler.handleMessage(new GenericMessage(mock(Presence.class)));
 	}
@@ -48,6 +50,7 @@ public class PresenceSendingMessageHandlerTests {
 	@Test(expected=MessageHandlingException.class)
 	public void testWrongPayload(){
 		PresenceSendingMessageHandler handler = new PresenceSendingMessageHandler(mock(XMPPConnection.class));
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		handler.handleMessage(new GenericMessage(new Object()));
 	}
@@ -65,6 +68,7 @@ public class PresenceSendingMessageHandlerTests {
 	@Test(expected=IllegalArgumentException.class)
 	public void testNoXmppConnection(){
 		PresenceSendingMessageHandler handler = new PresenceSendingMessageHandler();
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 	}
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3349

Several FactoryBeans did not propagate the BeanFactory
to their created object(s). Beans that create messages
must have access to a bean factory to get the
message builder factory.

Fix the FactoryBeans and add a mock FB to all tests that
need one.

Add a runtime environment variable to make any infractions
fatal. This should be set to `true` on CI builds and on
framework developer environments.
