### PR TITLE
INT-2595: Add time-based `ReleaseStrategy` option

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -308,7 +308,6 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageH
 			logger.debug("Handling message with correlationKey [" + correlationKey + "]: " + message);
 		}
 
-		// TODO: INT-1117 - make the lock global?
 		UUID groupIdUuid = UUIDConverter.getUUID(correlationKey);
 		Lock lock = this.lockRegistry.obtain(groupIdUuid.toString());
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
@@ -69,6 +69,7 @@ public abstract class AbstractCorrelatingMessageHandlerParser extends AbstractCo
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, MESSAGE_STORE_ATTRIBUTE);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "scheduler", "taskScheduler");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, DISCARD_CHANNEL_ATTRIBUTE);
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "lock-registry");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, SEND_TIMEOUT_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, SEND_PARTIAL_RESULT_ON_EXPIRY_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "empty-group-min-timeout", "minimumTimeoutForEmptyGroups");

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractCorrelatingMessageHandlerParser.java
@@ -15,6 +15,7 @@ package org.springframework.integration.config.xml;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.BeanMetadataElement;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
@@ -66,10 +67,16 @@ public abstract class AbstractCorrelatingMessageHandlerParser extends AbstractCo
 				element, builder, processor, parserContext);
 
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, MESSAGE_STORE_ATTRIBUTE);
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "scheduler", "taskScheduler");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, DISCARD_CHANNEL_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, SEND_TIMEOUT_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, SEND_PARTIAL_RESULT_ON_EXPIRY_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "empty-group-min-timeout", "minimumTimeoutForEmptyGroups");
+
+		BeanDefinition expressionDef =
+				IntegrationNamespaceUtils.createExpressionDefinitionFromValueOrExpression("group-timeout", "group-timeout-expression",
+						parserContext, element, false);
+		builder.addPropertyValue("groupTimeoutExpression", expressionDef);
 	}
 
 	protected void injectPropertyWithAdapter(String beanRefAttribute, String methodRefAttribute,

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
@@ -3438,7 +3438,7 @@
 						<xsd:documentation>
 							The schedule timeout in milliseconds to 'forceComplete' the MessageGroup,
 							when the 'ReleaseStrategy' can't 'release' on the current arrived Message.
-							If 'group-timeout' less than or equal '0' the MessageGroup won't be scheduled to 'forceComplete'.
+							If 'group-timeout' is 'null' or less than '0' the MessageGroup won't be scheduled to 'forceComplete'.
 							Mutually exclusive with 'group-timeout-expression' attribute.
 						</xsd:documentation>
 					</xsd:annotation>
@@ -3449,7 +3449,7 @@
 							The SpEL expression to evaluate 'group-timeout' against the MessageGroup as root evaluation context object
 							for scheduling the MessageGroup to 'forceComplete',
 							when the 'ReleaseStrategy' can't 'release' on the current arrived Message.
-							If 'group-timeout' less than or equal '0' the MessageGroup won't be scheduled to 'forceComplete'.
+							If 'group-timeout' is 'null' or less than '0' the MessageGroup won't be scheduled to 'forceComplete'.
 							Mutually exclusive with 'group-timeout' attribute.
 						</xsd:documentation>
 					</xsd:annotation>
@@ -3463,7 +3463,7 @@
 						</xsd:appinfo>
 						<xsd:documentation>
 							Provide a reference to the TaskScheduler instance to schedule 'forceComplete' the MessageGroup
-							when there is no new message arrives for the MessageGroup. If not
+							when there is no new message arrives for the MessageGroup. If isn't
 							provided, the default scheduler 'taskScheduler',
 							registered in the ApplicationContext {ThreadPoolTaskScheduler} will be
 							used. This attribute doesn't have value if 'group-timeout' or

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
@@ -3436,21 +3436,27 @@
 				<xsd:attribute name="group-timeout" type="xsd:string">
 					<xsd:annotation>
 						<xsd:documentation>
-							The schedule timeout in milliseconds to 'forceComplete' the MessageGroup,
-							when the 'ReleaseStrategy' can't 'release' on the current arrived Message.
-							If 'group-timeout' is 'null' or less than '0' the MessageGroup won't be scheduled to 'forceComplete'.
-							Mutually exclusive with 'group-timeout-expression' attribute.
+							A timeout in milliseconds to force the MessageGroup complete,
+							when the 'ReleaseStrategy' does not 'release' the group when the current Message arrives.
+							If 'group-timeout' is not provided or is less than '0' the MessageGroup won't be scheduled
+							to be forced complete.
+							The action taken when the group is forced complete depends on the
+							'send-partial-result-on-expiry' attribute.
+							Mutually exclusive with the 'group-timeout-expression' attribute.
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 				<xsd:attribute name="group-timeout-expression" type="xsd:string">
 					<xsd:annotation>
 						<xsd:documentation>
-							The SpEL expression to evaluate 'group-timeout' against the MessageGroup as root evaluation context object
-							for scheduling the MessageGroup to 'forceComplete',
-							when the 'ReleaseStrategy' can't 'release' on the current arrived Message.
-							If 'group-timeout' is 'null' or less than '0' the MessageGroup won't be scheduled to 'forceComplete'.
-							Mutually exclusive with 'group-timeout' attribute.
+							A SpEL expression to evaluate a 'group-timeout' with the MessageGroup as the #root evaluation
+							context object for scheduling the MessageGroup forced completion,
+							when the 'ReleaseStrategy' does not 'release' the group when the current Message arrives.
+							If 'group-timeout-expression' evaluates to 'null' or less than '0',
+							the MessageGroup won't be scheduled to be forced complete.
+							The action taken when the group is forced complete depends on the
+							'send-partial-result-on-expiry' attribute.
+							Mutually exclusive with the 'group-timeout' attribute.
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
@@ -3462,12 +3468,14 @@
 							</tool:annotation>
 						</xsd:appinfo>
 						<xsd:documentation>
-							Provide a reference to the TaskScheduler instance to schedule 'forceComplete' the MessageGroup
-							when there is no new message arrives for the MessageGroup. If isn't
+							Provide a reference to the TaskScheduler instance to schedule 'forceComplete' on
+							the MessageGroup
+							when no new message arrives for the MessageGroup within the
+							'group-timeout' or 'group-timeout-expression'. If it isn't
 							provided, the default scheduler 'taskScheduler',
 							registered in the ApplicationContext {ThreadPoolTaskScheduler} will be
-							used. This attribute doesn't have value if 'group-timeout' or
-							'group-timeout-expression' isn't specified.
+							used. This attribute only applies if 'group-timeout' or
+							'group-timeout-expression' is specified.
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
@@ -3479,9 +3487,9 @@
 							</tool:annotation>
 						</xsd:appinfo>
 						<xsd:documentation>
-							The reference to the 'org.springframework.integration.util.LockRegistry' bean
-							to obtain 'java.util.concurrent.locks.Lock' by 'groupId' for concurrent operation around each
-							MessageGroup. By default it is an internal 'DefaultLockRegistry'.
+							A reference to a 'org.springframework.integration.util.LockRegistry' bean
+							to obtain 'java.util.concurrent.locks.Lock' by 'groupId'. Used for concurrent operations on
+							MessageGroups. By default an internal 'DefaultLockRegistry' is used.
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
@@ -3433,6 +3433,44 @@
 						<xsd:documentation>A SpEL expression to evaluate against a root object that is the Collection of messages within the message group (e.g, size() > 6)</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
+				<xsd:attribute name="group-timeout" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							The schedule timeout in milliseconds to 'forceComplete' the MessageGroup,
+							when the 'ReleaseStrategy' can't 'release' on the current arrived Message.
+							If 'group-timeout' less than or equal '0' the MessageGroup won't be scheduled to 'forceComplete'.
+							Mutually exclusive with 'group-timeout-expression' attribute.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="group-timeout-expression" type="xsd:string">
+					<xsd:annotation>
+						<xsd:documentation>
+							The SpEL expression to evaluate 'group-timeout' against the MessageGroup as root evaluation context object
+							for scheduling the MessageGroup to 'forceComplete',
+							when the 'ReleaseStrategy' can't 'release' on the current arrived Message.
+							If 'group-timeout' less than or equal '0' the MessageGroup won't be scheduled to 'forceComplete'.
+							Mutually exclusive with 'group-timeout' attribute.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="scheduler" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.scheduling.TaskScheduler" />
+							</tool:annotation>
+						</xsd:appinfo>
+						<xsd:documentation>
+							Provide a reference to the TaskScheduler instance to schedule 'forceComplete' the MessageGroup
+							when there is no new message arrives for the MessageGroup. If not
+							provided, the default scheduler 'taskScheduler',
+							registered in the ApplicationContext {ThreadPoolTaskScheduler} will be
+							used. This attribute doesn't have value if 'group-timeout' or
+							'group-timeout-expression' isn't specified.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 				<xsd:attribute name="discard-channel" type="xsd:string">
 					<xsd:annotation>
 						<xsd:appinfo>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.0.xsd
@@ -3471,6 +3471,20 @@
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
+				<xsd:attribute name="lock-registry" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo>
+							<tool:annotation kind="ref">
+								<tool:expected-type type="org.springframework.integration.util.LockRegistry" />
+							</tool:annotation>
+						</xsd:appinfo>
+						<xsd:documentation>
+							The reference to the 'org.springframework.integration.util.LockRegistry' bean
+							to obtain 'java.util.concurrent.locks.Lock' by 'groupId' for concurrent operation around each
+							MessageGroup. By default it is an internal 'DefaultLockRegistry'.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 				<xsd:attribute name="discard-channel" type="xsd:string">
 					<xsd:annotation>
 						<xsd:appinfo>

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
@@ -34,7 +34,8 @@
 	<aggregator id="nonExpiringAggregator" input-channel="nonExpiringAggregatorInput" output-channel="output"
 				expire-groups-upon-completion="false" discard-channel="discard"/>
 
-	<aggregator input-channel="groupTimeoutAggregatorInput" output-channel="output" discard-channel="discard"
+	<aggregator id="gta"
+				input-channel="groupTimeoutAggregatorInput" output-channel="output" discard-channel="discard"
 				send-partial-result-on-expiry="true"
 				group-timeout="100"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
@@ -40,7 +40,7 @@
 
 	<aggregator input-channel="groupTimeoutExpressionAggregatorInput" output-channel="output" discard-channel="discard"
 				send-partial-result-on-expiry="true"
-				group-timeout-expression="size() == 2 ? 100 : 0"
+				group-timeout-expression="size() ge 2 ? 100 : -1"
 			    release-strategy-expression="[0].headers.sequenceNumber == [0].headers.sequenceSize"/>
 
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
@@ -34,5 +34,14 @@
 	<aggregator id="nonExpiringAggregator" input-channel="nonExpiringAggregatorInput" output-channel="output"
 				expire-groups-upon-completion="false" discard-channel="discard"/>
 
+	<aggregator input-channel="groupTimeoutAggregatorInput" output-channel="output" discard-channel="discard"
+				send-partial-result-on-expiry="true"
+				group-timeout="100"/>
+
+	<aggregator input-channel="groupTimeoutExpressionAggregatorInput" output-channel="output" discard-channel="discard"
+				send-partial-result-on-expiry="true"
+				group-timeout-expression="size() == 2 ? 100 : 0"
+			    release-strategy-expression="[0].headers.sequenceNumber == [0].headers.sequenceSize"/>
+
 
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
@@ -74,7 +76,7 @@ public class AggregatorIntegrationTests {
 			Map<String, Object> headers = stubHeaders(i, 5, 1);
 			input.send(new GenericMessage<Integer>(i, headers));
 		}
-		assertEquals(0 + 1 + 2 + 3 + 4, output.receive().getPayload());
+		assertEquals(0 + 1 + 2 + 3 + 4, output.receive(1000).getPayload());
 	}
 
 	@Test
@@ -135,28 +137,40 @@ public class AggregatorIntegrationTests {
 
 	@Test
 	public void testGroupTimeoutExpressionScheduling() throws Exception {
-		// Since group-timeout-expression="size() == 2 ? 100 : 0". The first message won't be scheduled to 'forceComplete'
-		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(1, stubHeaders(1, 5, 1)));
-		assertNull(this.output.receive(500));
+		// Since group-timeout-expression="size() >= 2 ? 100 : -1". The first message won't be scheduled to 'forceComplete'
+		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(1, stubHeaders(1, 6, 1)));
+		assertNull(this.output.receive(0));
 		assertNull(this.discard.receive(0));
 
-		// As far as 'group.size() == 2' it will be scheduled to 'forceComplete'
-		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(2, stubHeaders(2, 5, 1)));
-		assertNotNull(this.output.receive(500));
+		// As far as 'group.size() >= 2' it will be scheduled to 'forceComplete'
+		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(2, stubHeaders(2, 6, 1)));
+		assertNull(this.output.receive(0));
+		Message<?> receive = this.output.receive(500);
+		assertNotNull(receive);
+		assertEquals(2, ((Collection) receive.getPayload()).size());
 		assertNull(this.discard.receive(0));
 
-		// The same with these two messages
-		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(3, stubHeaders(3, 5, 1)));
-		assertNull(this.output.receive(500));
+		// The same with these three messages
+		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(3, stubHeaders(3, 6, 1)));
+		assertNull(this.output.receive(0));
 		assertNull(this.discard.receive(0));
 
-		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(4, stubHeaders(4, 5, 1)));
-		assertNotNull(this.output.receive(500));
+		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(4, stubHeaders(4, 6, 1)));
+		assertNull(this.output.receive(0));
+		assertNull(this.discard.receive(0));
+
+		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(5, stubHeaders(5, 6, 1)));
+		assertNull(this.output.receive(0));
+		receive = this.output.receive(500);
+		assertNotNull(receive);
+		assertEquals(3, ((Collection) receive.getPayload()).size());
 		assertNull(this.discard.receive(0));
 
 		// The last message in the sequence - normal release by provided 'ReleaseStrategy'
-		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(5, stubHeaders(5, 5, 1)));
-		assertNotNull(this.output.receive(10));
+		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(6, stubHeaders(6, 6, 1)));
+		receive = this.output.receive(0);
+		assertNotNull(receive);
+		assertEquals(1, ((Collection) receive.getPayload()).size());
 		assertNull(this.discard.receive(0));
 	}
 
@@ -172,11 +186,11 @@ public class AggregatorIntegrationTests {
 		}
 	}
 
-	private Map<String, Object> stubHeaders(int sequenceNumber, int sequenceSize, int correllationId) {
+	private Map<String, Object> stubHeaders(int sequenceNumber, int sequenceSize, int correlationId) {
 		Map<String, Object> headers = new HashMap<String, Object>();
 		headers.put(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, sequenceNumber);
 		headers.put(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, sequenceSize);
-		headers.put(IntegrationMessageHeaderAccessor.CORRELATION_ID, correllationId);
+		headers.put(IntegrationMessageHeaderAccessor.CORRELATION_ID, correlationId);
 		return headers;
 	}
 

--- a/spring-integration-core/src/test/resources/log4j.properties
+++ b/spring-integration-core/src/test/resources/log4j.properties
@@ -2,6 +2,6 @@ log4j.rootCategory=WARN, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%c{1}: %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d %c{1} [%t] : %m%n
 
 log4j.category.org.springframework.integration=WARN

--- a/src/reference/docbook/aggregator.xml
+++ b/src/reference/docbook/aggregator.xml
@@ -370,6 +370,8 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 		expire-groups-upon-completion="false" ]]><co id="aggxml18" /><![CDATA[
 		empty-group-min-timeout="60000" ]]><co id="aggxml19" /><![CDATA[
 
+        lock-registry="lockRegistry" ]]><co id="aggxml191" /><![CDATA[
+
 		group-timeout="60000" ]]><co id="aggxml20" /><![CDATA[
 		group-timeout-expression="size() ge 2 ? 100 : -1" ]]><co id="aggxml21" /><![CDATA[
 		scheduler="taskScheduler" /> ]]><co id="aggxml22" /><![CDATA[
@@ -439,8 +441,7 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 		or by simply invoking that method if you have a reference to the <classname>MessageGroupStore</classname> instance.
 		Otherwise by itself this attribute has no behavior. It only serves as an indicator of what to do (discard or send to the output/reply
 		channel) with Messages that are still in the <classname>MessageGroup</classname> that is about to be expired.
-        <emphasis>Optional</emphasis>.</para>
-        <para><emphasis>Default - 'false'</emphasis>.</para>
+        <emphasis>Optional</emphasis>. <emphasis>Default - 'false'</emphasis>.</para>
       </callout>
 
        <callout arearefs="aggxml09">
@@ -528,6 +529,14 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
         property and it could be as much as this value plus the timeout.</para>
       </callout>
 
+	  <callout arearefs="aggxml191">
+        <para>
+			The reference for the <interfacename>org.springframework.integration.util.LockRegistry</interfacename> bean
+			to obtain <interfacename>Lock</interfacename> by <code>groupId</code> for concurrent operation around each
+			<code>MessageGroup</code>. By default it is and internal <classname>DefaultLockRegistry</classname>.
+        </para>
+      </callout>
+
 	  <callout arearefs="aggxml20">
         <para>
 			The schedule timeout in milliseconds to <emphasis>forceComplete</emphasis> the <code>MessageGroup</code>,
@@ -555,7 +564,7 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 				The <interfacename>TaskScheduler</interfacename> bean reference to schedule <emphasis>forceComplete</emphasis>
 				the <code>MessageGroup</code> when there is no new message arrives for the <code>MessageGroup</code>.
 				If isn't provided, the default scheduler <code>taskScheduler</code>,
-				registered in the <interfacename>ApplicationContext</interfacename> {<classname>ThreadPoolTaskScheduler</classname>}
+				registered in the <interfacename>ApplicationContext</interfacename> (<classname>ThreadPoolTaskScheduler</classname>)
 				will be used. This attribute doesn't have value if <code>group-timeout</code> or <code>group-timeout-expression</code>
 				isn't specified.
 			</para>
@@ -701,7 +710,11 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
     that as soon as there are more than 5 messages in this group, it should be released.
     </para>
 
-    <para>
+	<para>
+		<emphasis>Aggregators and Group Timeout</emphasis>
+	</para>
+
+	<para>
 		Starting with <emphasis>version 4.0</emphasis> two new mutually exclusive attributes have been introduced:
 		<code>group-timeout</code> and <code>group-timeout-expression</code> (see the description above). There are some
 		cases where it is needed to emit the aggregator result, even if <interfacename>ReleaseStrategy</interfacename>
@@ -716,6 +729,17 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 		to schedule <code>forceComplete</code> partial result or not: the <code>group-timeout-expression</code> says, that group
 		should be <code>forceCompleted</code> after 10 seconds and only, if the group contains at least 2 Messages.
     </para>
+    <para>
+		The <code>forceComplete</code> result depends of the <code>send-partial-result-on-expiry</code>. If it is <code>true</code>
+		existing messages in the <code>MessageGroup</code> will be released as normal aggregator reply Message to the
+		<code>output-channel</code>, otherwise they will be discarded.
+    </para>
+	<para>
+		There is a difference between <code>groupTimeout</code> behaviour and <classname>MessageGroupStoreReaper</classname>
+		(see <xref linkend="aggregator-config"/>). The last one initiate <code>forceComplete</code> for all <code>MessageGroup</code>s
+		in the <code>MessageGroupStore</code> periodically. The <code>groupTimeout</code> does it only for one <code>MessageGroup</code>
+		and only once, and if the new Message isn't arrived during <code>groupTimeout</code>.
+	</para>
   </section>
 
   <section id="aggregator-annotations">

--- a/src/reference/docbook/aggregator.xml
+++ b/src/reference/docbook/aggregator.xml
@@ -370,7 +370,7 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 		expire-groups-upon-completion="false" ]]><co id="aggxml18" /><![CDATA[
 		empty-group-min-timeout="60000" ]]><co id="aggxml19" /><![CDATA[
 
-        lock-registry="lockRegistry" ]]><co id="aggxml191" /><![CDATA[
+		lock-registry="lockRegistry" ]]><co id="aggxml191" /><![CDATA[
 
 		group-timeout="60000" ]]><co id="aggxml20" /><![CDATA[
 		group-timeout-expression="size() ge 2 ? 100 : -1" ]]><co id="aggxml21" /><![CDATA[
@@ -531,42 +531,55 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 
 	  <callout arearefs="aggxml191">
         <para>
-			The reference for the <interfacename>org.springframework.integration.util.LockRegistry</interfacename> bean
-			to obtain <interfacename>Lock</interfacename> by <code>groupId</code> for concurrent operation around each
-			<code>MessageGroup</code>. By default it is and internal <classname>DefaultLockRegistry</classname>.
+			A reference to a <interfacename>org.springframework.integration.util.LockRegistry</interfacename> bean;
+			used to obtain a <interfacename>Lock</interfacename> based on the <code>groupId</code> for
+			concurrent operations on the
+			<code>MessageGroup</code>. By default, an internal <classname>DefaultLockRegistry</classname> is used.
         </para>
       </callout>
 
 	  <callout arearefs="aggxml20">
         <para>
-			The schedule timeout in milliseconds to <emphasis>forceComplete</emphasis> the <code>MessageGroup</code>,
-			when the <interfacename>ReleaseStrategy</interfacename> can't <emphasis>release</emphasis> on the current arrived Message.
-			This attribute provides some built-in <emphasis>Time-base Release Strategy</emphasis> for the aggregator,
-			when there is need to emit some partial result, if a new Message for the <code>MessageGroup</code> isn't arrived during some time or at all.
-			When the new Message comes to the aggregator, the <interfacename>ScheduledFuture&lt;?&gt;</interfacename>
-			for its <code>MessageGroup</code> is canceled and new one will be scheduled, if <interfacename>ReleaseStrategy</interfacename>
-			returns <code>false</code> and <code>groupTimeout != null &amp;&amp; groupTimeout &gt; 0</code>.
-			Note, if <code>groupTimeout == 0</code>, the <code>MessageGroup</code> is <emphasis>forceCompleted</emphasis> immediately
-			within the current Thread.
+			A timeout in milliseconds to force the <code>MessageGroup</code> complete,
+			when the <interfacename>ReleaseStrategy</interfacename> doesn't <emphasis>release</emphasis>
+			the group when the current Message arrives.
+			This attribute provides a built-in <emphasis>Time-base Release Strategy</emphasis> for the aggregator,
+			when there is a need to emit a partial result (or discard the group), if a new Message does not arrive
+			for the <code>MessageGroup</code> within the timeout.
+			When a new Message arrives at the aggregator, any existing <interfacename>ScheduledFuture&lt;?&gt;</interfacename>
+			for its <code>MessageGroup</code> is canceled. If the
+			<interfacename>ReleaseStrategy</interfacename>
+			returns <code>false</code> (don't release) and the <code>groupTimeout &gt; 0</code> a new task will be
+			scheduled to expire the group.
+			Setting this attribute to zero is not advised because it will effectively disable the aggregator because every
+			message group will be immediately completed. It is possible, however to conditionally set it to zero using an
+			expression; see <code>group-timeout-expressoin</code> for information.
+			The action taken during the completion depends on the release strategy and the
+			<code>send-partial-group-on-expiry</code> attribute. See <xref linkend="agg-and-group-to"/> for
+			more information.
 			Mutually exclusive with 'group-timeout-expression' attribute.
         </para>
       </callout>
 	  <callout arearefs="aggxml21">
 			<para>
-				The SpEL expression to evaluate <code>groupTimeout</code> against the <code>MessageGroup</code>
-				as root evaluation context object for scheduling the <code>MessageGroup</code> to <emphasis>forceComplete</emphasis>,
-				when the <interfacename>ReleaseStrategy</interfacename> can't <emphasis>release</emphasis> on the current arrived Message.
+				The SpEL expression that evaluates to a <code>groupTimeout</code> with the <code>MessageGroup</code>
+				as the <code>#root</code> evaluation context object. Used for scheduling the <code>MessageGroup</code> to
+				<emphasis>forceComplete()</emphasis>. If the expression evaluates to null or <code>&lt; 0</code>, the
+				completion is not scheduled. If it evaluates to zero, the group is completed immediately on
+				the current thread. In effect, this provides a dynamic <code>group-timeout</code> property.
+				See <code>group-timeout</code> for more information.
 				Mutually exclusive with 'group-timeout' attribute.
 			</para>
 	  </callout>
 	  <callout arearefs="aggxml22">
 			<para>
-				The <interfacename>TaskScheduler</interfacename> bean reference to schedule <emphasis>forceComplete</emphasis>
-				the <code>MessageGroup</code> when there is no new message arrives for the <code>MessageGroup</code>.
-				If isn't provided, the default scheduler <code>taskScheduler</code>,
+				A <interfacename>TaskScheduler</interfacename> bean reference to schedule <emphasis>forceComplete()</emphasis>
+				for the <code>MessageGroup</code> when there no new message arrives for the <code>MessageGroup</code>
+				within the <code>groupTimeout</code>.
+				If not provided, the default scheduler <code>taskScheduler</code>,
 				registered in the <interfacename>ApplicationContext</interfacename> (<classname>ThreadPoolTaskScheduler</classname>)
-				will be used. This attribute doesn't have value if <code>group-timeout</code> or <code>group-timeout-expression</code>
-				isn't specified.
+				will be used. This attribute does not apply if <code>group-timeout</code> or
+				<code>group-timeout-expression</code> is not specified.
 			</para>
 	  </callout>
 
@@ -710,36 +723,44 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
     that as soon as there are more than 5 messages in this group, it should be released.
     </para>
 
-	<para>
-		<emphasis>Aggregators and Group Timeout</emphasis>
-	</para>
+	<section id="agg-and-group-to">
+		<title>Aggregators and Group Timeout</title>
 
 	<para>
-		Starting with <emphasis>version 4.0</emphasis> two new mutually exclusive attributes have been introduced:
+		Starting with <emphasis>version 4.0</emphasis>, two new mutually exclusive attributes have been introduced:
 		<code>group-timeout</code> and <code>group-timeout-expression</code> (see the description above). There are some
-		cases where it is needed to emit the aggregator result, even if <interfacename>ReleaseStrategy</interfacename>
-		can't <emphasis>release</emphasis> on the current arrived Message and there is no arrived new messages for the group.
-		For this purpose the <code>groupTimeout</code> option allows to schedule the <code>MessageGroup</code> to <code>forceComplete</code>:
+		cases where it is needed to emit the aggregator result (or discard the group) after a timeout
+		if the <interfacename>ReleaseStrategy</interfacename>
+		doesn't <emphasis>release</emphasis> when the current Message arrives.
+		For this purpose the <code>groupTimeout</code> option allows scheduling the <code>MessageGroup</code> to
+		<code>forceComplete()</code>:
 		<programlisting language="xml"><![CDATA[<aggregator input-channel="input" output-channel="output"
 		send-partial-result-on-expiry="true"
 		group-timeout-expression="size() ge 2 ? 10000 : -1"
 		release-strategy-expression="[0].headers.sequenceNumber == [0].headers.sequenceSize"/>]]></programlisting>
-		With this sample the normal <emphasis>release</emphasis> will be possible, if the aggregator receives the last message
-		in sequence. It is presented by <code>release-strategy-expression</code>. All other cases are up to the <code>groupTimeout</code>
-		to schedule <code>forceComplete</code> partial result or not: the <code>group-timeout-expression</code> says, that group
-		should be <code>forceCompleted</code> after 10 seconds and only, if the group contains at least 2 Messages.
+		With this example, the normal <emphasis>release</emphasis> will be possible if the aggregator receives the last message
+		in sequence as defined by the <code>release-strategy-expression</code>. If that specific message does not arrive,
+		the <code>groupTimeout</code> will force the group complete after 10 seconds as long a the group contains at least 2 Messages.
     </para>
     <para>
-		The <code>forceComplete</code> result depends of the <code>send-partial-result-on-expiry</code>. If it is <code>true</code>
-		existing messages in the <code>MessageGroup</code> will be released as normal aggregator reply Message to the
-		<code>output-channel</code>, otherwise they will be discarded.
+		The results of the <code>forceComplete()</code> depends on the release strategy and
+		the <code>send-partial-result-on-expiry</code>.
+		First, the release strategy is again consulted to see if a "normal" release is to be made - while the
+		group won't have changed, the release strategy can decide to release the group at this time. If the
+		release strategy still does not release the group, it will be expired.
+		If <code>send-partial-result-on-expiry</code> is <code>true</code>,
+		existing messages in the (partial) <code>MessageGroup</code> will be released as a normal aggregator reply Message to the
+		<code>output-channel</code>, otherwise it will be discarded.
     </para>
 	<para>
-		There is a difference between <code>groupTimeout</code> behaviour and <classname>MessageGroupStoreReaper</classname>
-		(see <xref linkend="aggregator-config"/>). The last one initiate <code>forceComplete</code> for all <code>MessageGroup</code>s
-		in the <code>MessageGroupStore</code> periodically. The <code>groupTimeout</code> does it only for one <code>MessageGroup</code>
-		and only once, and if the new Message isn't arrived during <code>groupTimeout</code>.
+		There is a difference between <code>groupTimeout</code> behavior and <classname>MessageGroupStoreReaper</classname>
+		(see <xref linkend="aggregator-config"/>). The reaper initiate <code>forceComplete</code> for all <code>MessageGroup</code>s
+		in the <code>MessageGroupStore</code> periodically. The <code>groupTimeout</code> does it for each <code>MessageGroup</code>
+		individually, if the new Message isn't arrived during <code>groupTimeout</code>. Also, the reaper can be used to
+		remove empty groups (empty groups are retained in order to discard late messages,
+		if <code>expire-groups-upon-completion</code> is false).
 	</para>
+	</section>
   </section>
 
   <section id="aggregator-annotations">

--- a/src/reference/docbook/aggregator.xml
+++ b/src/reference/docbook/aggregator.xml
@@ -553,8 +553,8 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 			scheduled to expire the group.
 			Setting this attribute to zero is not advised because it will effectively disable the aggregator because every
 			message group will be immediately completed. It is possible, however to conditionally set it to zero using an
-			expression; see <code>group-timeout-expressoin</code> for information.
-			The action taken during the completion depends on the release strategy and the
+			expression; see <code>group-timeout-expression</code> for information.
+			The action taken during the completion depends on the <interfacename>ReleaseStrategy</interfacename> and the
 			<code>send-partial-group-on-expiry</code> attribute. See <xref linkend="agg-and-group-to"/> for
 			more information.
 			Mutually exclusive with 'group-timeout-expression' attribute.
@@ -724,7 +724,7 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
     </para>
 
 	<section id="agg-and-group-to">
-		<title>Aggregators and Group Timeout</title>
+		<title>Aggregator and Group Timeout</title>
 
 	<para>
 		Starting with <emphasis>version 4.0</emphasis>, two new mutually exclusive attributes have been introduced:
@@ -740,13 +740,13 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 		release-strategy-expression="[0].headers.sequenceNumber == [0].headers.sequenceSize"/>]]></programlisting>
 		With this example, the normal <emphasis>release</emphasis> will be possible if the aggregator receives the last message
 		in sequence as defined by the <code>release-strategy-expression</code>. If that specific message does not arrive,
-		the <code>groupTimeout</code> will force the group complete after 10 seconds as long a the group contains at least 2 Messages.
+		the <code>groupTimeout</code> will force the group complete after 10 seconds as long as the group contains at least 2 Messages.
     </para>
     <para>
-		The results of the <code>forceComplete()</code> depends on the release strategy and
+		The results of the <code>forceComplete()</code> depends on the <interfacename>ReleaseStrategy</interfacename> and
 		the <code>send-partial-result-on-expiry</code>.
-		First, the release strategy is again consulted to see if a "normal" release is to be made - while the
-		group won't have changed, the release strategy can decide to release the group at this time. If the
+		First, the release strategy is again consulted to see if a <emphasis>normal</emphasis> release is to be made - while the
+		group won't have changed, the <interfacename>ReleaseStrategy</interfacename> can decide to release the group at this time. If the
 		release strategy still does not release the group, it will be expired.
 		If <code>send-partial-result-on-expiry</code> is <code>true</code>,
 		existing messages in the (partial) <code>MessageGroup</code> will be released as a normal aggregator reply Message to the
@@ -754,7 +754,7 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
     </para>
 	<para>
 		There is a difference between <code>groupTimeout</code> behavior and <classname>MessageGroupStoreReaper</classname>
-		(see <xref linkend="aggregator-config"/>). The reaper initiate <code>forceComplete</code> for all <code>MessageGroup</code>s
+		(see <xref linkend="aggregator-config"/>). The reaper initiates <code>forceComplete</code> for all <code>MessageGroup</code>s
 		in the <code>MessageGroupStore</code> periodically. The <code>groupTimeout</code> does it for each <code>MessageGroup</code>
 		individually, if the new Message isn't arrived during <code>groupTimeout</code>. Also, the reaper can be used to
 		remove empty groups (empty groups are retained in order to discard late messages,

--- a/src/reference/docbook/aggregator.xml
+++ b/src/reference/docbook/aggregator.xml
@@ -368,7 +368,11 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 		release-strategy-expression="size() == 5" ]]><co id="aggxml17" /><![CDATA[
 
 		expire-groups-upon-completion="false" ]]><co id="aggxml18" /><![CDATA[
-		empty-group-min-timeout="60000" /> ]]><co id="aggxml19" /><![CDATA[
+		empty-group-min-timeout="60000" ]]><co id="aggxml19" /><![CDATA[
+
+		group-timeout="60000" ]]><co id="aggxml20" /><![CDATA[
+		group-timeout-expression="size() ge 2 ? 100 : -1" ]]><co id="aggxml21" /><![CDATA[
+		scheduler="taskScheduler" /> ]]><co id="aggxml22" /><![CDATA[
 
 <int:channel id="outputChannel"/>
 
@@ -524,6 +528,39 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
         property and it could be as much as this value plus the timeout.</para>
       </callout>
 
+	  <callout arearefs="aggxml20">
+        <para>
+			The schedule timeout in milliseconds to <emphasis>forceComplete</emphasis> the <code>MessageGroup</code>,
+			when the <interfacename>ReleaseStrategy</interfacename> can't <emphasis>release</emphasis> on the current arrived Message.
+			This attribute provides some built-in <emphasis>Time-base Release Strategy</emphasis> for the aggregator,
+			when there is need to emit some partial result, if a new Message for the <code>MessageGroup</code> isn't arrived during some time or at all.
+			When the new Message comes to the aggregator, the <interfacename>ScheduledFuture&lt;?&gt;</interfacename>
+			for its <code>MessageGroup</code> is canceled and new one will be scheduled, if <interfacename>ReleaseStrategy</interfacename>
+			returns <code>false</code> and <code>groupTimeout != null &amp;&amp; groupTimeout &gt; 0</code>.
+			Note, if <code>groupTimeout == 0</code>, the <code>MessageGroup</code> is <emphasis>forceCompleted</emphasis> immediately
+			within the current Thread.
+			Mutually exclusive with 'group-timeout-expression' attribute.
+        </para>
+      </callout>
+	  <callout arearefs="aggxml21">
+			<para>
+				The SpEL expression to evaluate <code>groupTimeout</code> against the <code>MessageGroup</code>
+				as root evaluation context object for scheduling the <code>MessageGroup</code> to <emphasis>forceComplete</emphasis>,
+				when the <interfacename>ReleaseStrategy</interfacename> can't <emphasis>release</emphasis> on the current arrived Message.
+				Mutually exclusive with 'group-timeout' attribute.
+			</para>
+	  </callout>
+	  <callout arearefs="aggxml22">
+			<para>
+				The <interfacename>TaskScheduler</interfacename> bean reference to schedule <emphasis>forceComplete</emphasis>
+				the <code>MessageGroup</code> when there is no new message arrives for the <code>MessageGroup</code>.
+				If isn't provided, the default scheduler <code>taskScheduler</code>,
+				registered in the <interfacename>ApplicationContext</interfacename> {<classname>ThreadPoolTaskScheduler</classname>}
+				will be used. This attribute doesn't have value if <code>group-timeout</code> or <code>group-timeout-expression</code>
+				isn't specified.
+			</para>
+	  </callout>
+
     </calloutlist>
 
     <para>Using a <code>ref</code> attribute is generally recommended if a custom
@@ -662,6 +699,22 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 	In this example the root object of the SpEL Evaluation Context is the
     <interfacename>MessageGroup</interfacename> itself, and you are simply stating
     that as soon as there are more than 5 messages in this group, it should be released.
+    </para>
+
+    <para>
+		Starting with <emphasis>version 4.0</emphasis> two new mutually exclusive attributes have been introduced:
+		<code>group-timeout</code> and <code>group-timeout-expression</code> (see the description above). There are some
+		cases where it is needed to emit the aggregator result, even if <interfacename>ReleaseStrategy</interfacename>
+		can't <emphasis>release</emphasis> on the current arrived Message and there is no arrived new messages for the group.
+		For this purpose the <code>groupTimeout</code> option allows to schedule the <code>MessageGroup</code> to <code>forceComplete</code>:
+		<programlisting language="xml"><![CDATA[<aggregator input-channel="input" output-channel="output"
+		send-partial-result-on-expiry="true"
+		group-timeout-expression="size() ge 2 ? 10000 : -1"
+		release-strategy-expression="[0].headers.sequenceNumber == [0].headers.sequenceSize"/>]]></programlisting>
+		With this sample the normal <emphasis>release</emphasis> will be possible, if the aggregator receives the last message
+		in sequence. It is presented by <code>release-strategy-expression</code>. All other cases are up to the <code>groupTimeout</code>
+		to schedule <code>forceComplete</code> partial result or not: the <code>group-timeout-expression</code> says, that group
+		should be <code>forceCompleted</code> after 10 seconds and only, if the group contains at least 2 Messages.
     </para>
   </section>
 

--- a/src/reference/docbook/resequencer.xml
+++ b/src/reference/docbook/resequencer.xml
@@ -52,8 +52,13 @@
   release-strategy="releaseStrategyBean" ]]><co id="resxml14-co" linkends="resxml14" /><![CDATA[
   release-strategy-method="release" ]]><co id="resxml15-co" linkends="resxml15" /><![CDATA[
   release-strategy-expression="size() == 10" ]]><co id="resxml16-co" linkends="resxml16" /><![CDATA[
-  empty-group-min-timeout="60000" />]]><co id="resxml17-co" linkends="resxml17" /></programlisting>
+  empty-group-min-timeout="60000" ]]><co id="resxml17-co" linkends="resxml17" /><![CDATA[
 
+  lock-registry="lockRegistry" ]]><co id="resxml18" /><![CDATA[
+
+		group-timeout="60000" ]]><co id="resxml19" /><![CDATA[
+		group-timeout-expression="size() ge 2 ? 100 : -1" ]]><co id="resxml20" /><![CDATA[
+		scheduler="taskScheduler" /> ]]><co id="resxml21" /></programlisting>
     <para><calloutlist>
         <callout arearefs="resxml1-co" id="resxml1">
           <para>The id of the resequencer is
@@ -160,7 +165,27 @@
           empty group will also be affected by the reaper's <emphasis>timeout</emphasis>
           property and it could be as much as this value plus the timeout.</para>
         </callout>
+		<callout arearefs="resxml18">
+			<para>
+				See <xref linkend="aggregator-xml"/>.
+			</para>
+		</callout>
 
+		<callout arearefs="resxml19">
+			<para>
+				See <xref linkend="aggregator-xml"/>.
+			</para>
+		</callout>
+		<callout arearefs="resxml20">
+			<para>
+				See <xref linkend="aggregator-xml"/>.
+			</para>
+		</callout>
+		<callout arearefs="resxml21">
+			<para>
+				See <xref linkend="aggregator-xml"/>.
+			</para>
+		</callout>
       </calloutlist></para>
 
     <note>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -212,12 +212,12 @@
 		<section id="4.0-release-strategy-group-timeout">
 			<title>Correlation Endpoint: Time-based Release Strategy</title>
 			<para>
-				New mutually exclusive <code>group-timeout</code> and <code>group-timeout-expression</code>
-				attributes have been added for the <code>&lt;int:aggregator&gt;</code> and <code>&lt;int:resequencer&gt;</code>.
-				The <code>group-timeout</code> option makes the Correlation Endpoint as active and allow to
-				<emphasis>forceComplete</emphasis> the <code>MessageGroup</code>, if <interfacename>ReleaseStrategy</interfacename>
-				returns <code>false</code>, but it is needed to emit result after some period, if the new Message for group
-				isn't arrived. For more information see <xref linkend="aggregator-config"/>.
+				The mutually exclusive <code>group-timeout</code> and <code>group-timeout-expression</code>
+				attributes have been added to the <code>&lt;int:aggregator&gt;</code> and <code>&lt;int:resequencer&gt;</code>.
+				These attributes allow forced completion of a partial <code>MessageGroup</code>,
+				if the <interfacename>ReleaseStrategy</interfacename> does not release a group and no
+				further messages arrive within the time specified.
+				For more information see <xref linkend="aggregator-config"/>.
 			</para>
 		</section>
 	</section>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -209,5 +209,16 @@
 				For more information see <xref linkend="retry-config"/>.
 			</para>
 		</section>
+		<section id="4.0-release-strategy-group-timeout">
+			<title>Correlation Endpoint: Time-based Release Strategy</title>
+			<para>
+				New mutually exclusive <code>group-timeout</code> and <code>group-timeout-expression</code>
+				attributes have been added for the <code>&lt;int:aggregator&gt;</code> and <code>&lt;int:resequencer&gt;</code>.
+				The <code>group-timeout</code> option makes the Correlation Endpoint as active and allow to
+				<emphasis>forceComplete</emphasis> the <code>MessageGroup</code>, if <interfacename>ReleaseStrategy</interfacename>
+				returns <code>false</code>, but it is needed to emit result after some period, if the new Message for group
+				isn't arrived. For more information see <xref linkend="aggregator-config"/>.
+			</para>
+		</section>
 	</section>
 </chapter>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-2595
- Add `group-timeout` and `group-timeout-expression` to the Correlation Endpoint
- Add logic to the `AbstractCorrelatingMessageHandler` to schedule group for `forceComplete`,
  when the target `ReleaseStrategy` returns `false`
