### PR TITLE
INT-3355 Improve Redis Tests, RedisLockReg.list()

### DIFF
--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/list-inbound-adapter.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/list-inbound-adapter.xml
@@ -49,7 +49,7 @@
 	</int-redis:store-inbound-channel-adapter>
 
 	<int:transaction-synchronization-factory id="syncFactory">
-		<int:after-commit expression="#resource.attributes['store'].rename('bar')"/>
+		<int:after-commit expression="#store.rename('bar')"/>
 		<int:after-rollback expression="#store.rename('baz')"/>
 	</int:transaction-synchronization-factory>
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/metadata/RedisMetadataStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/metadata/RedisMetadataStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors
+ * Copyright 2013-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -30,10 +32,17 @@ import org.springframework.integration.redis.rules.RedisAvailableTests;
 /**
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 3.0
  *
  */
 public class RedisMetadataStoreTests extends RedisAvailableTests {
+
+	@Before
+	@After
+	public void setUpTearDown() {
+		this.createStringRedisTemplate(this.getConnectionFactoryForTest()).delete("testMetadata");
+	}
 
 	@Test
 	@RedisAvailable
@@ -48,11 +57,11 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	@RedisAvailable
 	public void testPersistKeyValue() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "foo");
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 		metadataStore.put("RedisMetadataStoreTests-Spring", "Integration");
 
 		StringRedisTemplate redisTemplate = new StringRedisTemplate(jcf);
-		BoundHashOperations<String,Object,Object> ops = redisTemplate.boundHashOps("foo");
+		BoundHashOperations<String,Object,Object> ops = redisTemplate.boundHashOps("testMetadata");
 
 		assertEquals("Integration", ops.get("RedisMetadataStoreTests-Spring"));
 	}
@@ -62,7 +71,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	public void testGetValueFromMetadataStore() {
 
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 		metadataStore.put("RedisMetadataStoreTests-GetValue", "Hello Redis");
 
 		String retrievedValue = metadataStore.get("RedisMetadataStoreTests-GetValue");
@@ -74,7 +83,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	public void testPersistEmptyStringToMetadataStore() {
 
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 		metadataStore.put("RedisMetadataStoreTests-PersistEmpty", "");
 
 		String retrievedValue = metadataStore.get("RedisMetadataStoreTests-PersistEmpty");
@@ -86,7 +95,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	public void testPersistNullStringToMetadataStore() {
 
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 
 		try {
 			metadataStore.put("RedisMetadataStoreTests-PersistEmpty", null);
@@ -104,7 +113,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	@RedisAvailable
 	public void testPersistWithEmptyKeyToMetadataStore() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 		metadataStore.put("", "PersistWithEmptyKey");
 
 		String retrievedValue = metadataStore.get("");
@@ -115,7 +124,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	@RedisAvailable
 	public void testPersistWithNullKeyToMetadataStore() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 
 		try {
 			metadataStore.put(null, "something");
@@ -132,7 +141,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	@RedisAvailable
 	public void testGetValueWithNullKeyFromMetadataStore() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 
 		try {
 			metadataStore.get(null);
@@ -149,7 +158,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	@RedisAvailable
 	public void testRemoveFromMetadataStore() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 
 		String testKey = "RedisMetadataStoreTests-Remove";
 		String testValue = "Integration";

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisOutboundGatewayTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisOutboundGatewayTests.java
@@ -47,6 +47,7 @@ import com.lambdaworks.redis.protocol.CommandType;
 
 /**
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 4.0
  */
 @ContextConfiguration
@@ -121,6 +122,7 @@ public class RedisOutboundGatewayTests extends RedisAvailableTests {
 		receive = this.replyChannel.receive(1000);
 		assertNotNull(receive);
 		assertEquals("11", new String((byte[]) receive.getPayload()));
+		this.createStringRedisTemplate(this.getConnectionFactoryForTest()).delete("si.test.RedisAtomicInteger");
 	}
 
 	@Test
@@ -163,6 +165,7 @@ public class RedisOutboundGatewayTests extends RedisAvailableTests {
 		Message<?> receive = this.replyChannel.receive(1000);
 		assertNotNull(receive);
 		assertThat((List<byte[]>) receive.getPayload(), Matchers.contains(value1, value2));
+		connection.del("foo1".getBytes(), "foo2".getBytes());
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandlerTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandlerTests.java
@@ -35,6 +35,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.data.redis.support.collections.DefaultRedisList;
 import org.springframework.data.redis.support.collections.DefaultRedisZSet;
 import org.springframework.data.redis.support.collections.RedisCollectionFactoryBean.CollectionType;
@@ -61,6 +62,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 	@RedisAvailable
 	public void testListWithListPayloadParsedAndProvidedKey() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisList<String> redisList =
 				new DefaultRedisList<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -84,12 +86,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		assertEquals("Manny", redisList.get(0));
 		assertEquals("Moe", redisList.get(1));
 		assertEquals("Jack", redisList.get(2));
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testListWithListPayloadParsedAndProvidedKeyAsHeader() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisList<String> redisList =
 				new DefaultRedisList<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -113,12 +117,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		assertEquals("Manny", redisList.get(0));
 		assertEquals("Moe", redisList.get(1));
 		assertEquals("Jack", redisList.get(2));
+		this.deleteKey(jcf, "foo");
 	}
 
 	@RedisAvailable
 	@Test(expected=MessageHandlingException.class)
 	public void testListWithListPayloadParsedAndNoKey() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisList<String> redisList =
 				new DefaultRedisList<String>(key, this.initTemplate(jcf, new RedisTemplate<String, String>()));
@@ -136,12 +142,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		list.add("Jack");
 		Message<List<String>> message = MessageBuilder.withPayload(list).build();
 		handler.handleMessage(message);
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testListWithListPayloadAsSingleEntry() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisList<List<String>> redisList =
 				new DefaultRedisList<List<String>>(key, this.initTemplate(jcf, new RedisTemplate<String, List<String>>()));
@@ -168,12 +176,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		assertEquals("Manny", resultList.get(0));
 		assertEquals("Moe", resultList.get(1));
 		assertEquals("Jack", resultList.get(2));
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithListPayloadParsedAndProvidedKeyDefault() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -207,12 +217,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		for (TypedTuple<String> pepboy : pepboys) {
 			assertEquals(Double.valueOf(2), pepboy.getScore());
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithListPayloadParsedAndProvidedKeyScoreIncrement() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -249,12 +261,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		for (TypedTuple<String> pepboy : pepboys) {
 			assertTrue(pepboy.getScore() == 2);
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithListPayloadParsedAndProvidedKeyScoreIncrementAsStringHeader() {// see INT-2775
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -291,12 +305,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		for (TypedTuple<String> pepboy : pepboys) {
 			assertTrue(pepboy.getScore() == 2);
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithListPayloadAsSingleEntryAndHeaderKeyHeaderScore() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisZSet<List<String>> redisZset =
 				new DefaultRedisZSet<List<String>>(key, this.initTemplate(jcf, new RedisTemplate<String, List<String>>()));
@@ -325,12 +341,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		for (TypedTuple<List<String>> pepboys : entries) {
 			assertTrue(pepboys.getScore() == 4);
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithMapPayloadParsedHeaderKey() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deletePresidents(jcf);
 		String key = "presidents";
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -368,12 +386,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 
 		Set<TypedTuple<String>> entries = redisZset.rangeByScoreWithScores(18, 19);
 		assertEquals(6, entries.size());
+		this.deletePresidents(jcf);
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithMapPayloadPojoParsedHeaderKey() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deletePresidents(jcf);
 		String key = "presidents";
 		RedisZSet<President> redisZset =
 				new DefaultRedisZSet<President>(key, this.initTemplate(jcf, new RedisTemplate<String, President>()));
@@ -412,12 +432,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 
 		Set<TypedTuple<President>> entries = redisZset.rangeByScoreWithScores(18, 19);
 		assertEquals(6, entries.size());
+		this.deletePresidents(jcf);
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithMapPayloadPojoAsSingleEntryHeaderKey() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deletePresidents(jcf);
 		String key = "presidents";
 		RedisZSet<Map<President, Double>> redisZset =
 				new DefaultRedisZSet<Map<President, Double>>(key, this.initTemplate(jcf, new RedisTemplate<String, Map<President, Double>>()));
@@ -443,6 +465,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		handler.handleMessage(message);
 
 		assertEquals(1, redisZset.size());
+		this.deletePresidents(jcf);
 	}
 
 	@Test(expected=IllegalStateException.class)
@@ -490,6 +513,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 	@RedisAvailable
 	public void testMapWithMapKeyExpression() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisStoreWritingMessageHandler handler =
 				new RedisStoreWritingMessageHandler(jcf);
@@ -503,12 +527,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		catch (Exception e) {
 			fail("No exception expected:" + e.getMessage());
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testPropertiesWithMapKeyExpression() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisStoreWritingMessageHandler handler =
 				new RedisStoreWritingMessageHandler(jcf);
@@ -522,10 +548,12 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		catch (Exception e) {
 			fail("No exception expected:" + e.getMessage());
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	private <K,V> RedisTemplate<K,V> initTemplate(RedisConnectionFactory rcf, RedisTemplate<K,V> redisTemplate) {
 		redisTemplate.setConnectionFactory(rcf);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.afterPropertiesSet();
 		return redisTemplate;
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/rules/RedisAvailableTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/rules/RedisAvailableTests.java
@@ -17,18 +17,13 @@ package org.springframework.integration.redis.rules;
 
 import static org.junit.Assert.assertTrue;
 
-import java.util.UUID;
-
 import org.junit.Rule;
 
-import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.BoundListOperations;
 import org.springframework.data.redis.core.BoundZSetOperations;
-import org.springframework.data.redis.core.RedisCallback;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.integration.test.util.TestUtils;
@@ -44,20 +39,14 @@ public class RedisAvailableTests {
 	@Rule
 	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
 
-	protected RedisConnectionFactory getConnectionFactoryForTest() {
-		LettuceConnectionFactory connectionFactory =  RedisAvailableRule.connectionFactoryResource.get();
-		RedisTemplate<UUID, Object> rt = new RedisTemplate<UUID, Object>();
-		rt.setConnectionFactory(connectionFactory);
-		rt.afterPropertiesSet();
-		rt.execute(new RedisCallback<Object>() {
+	private RedisConnectionFactory connectionFactory;
 
-			@Override
-			public Object doInRedis(RedisConnection connection)
-					throws DataAccessException {
-				connection.flushDb();
-				return null;
-			}
-		});
+	protected RedisConnectionFactory getConnectionFactoryForTest() {
+		if (this.connectionFactory != null) {
+			return this.connectionFactory;
+		}
+		LettuceConnectionFactory connectionFactory =  RedisAvailableRule.connectionFactoryResource.get();
+		this.connectionFactory = connectionFactory;
 		return connectionFactory;
 	}
 
@@ -90,9 +79,8 @@ public class RedisAvailableTests {
 
 	protected void prepareList(RedisConnectionFactory connectionFactory){
 
-		StringRedisTemplate redisTemplate = new StringRedisTemplate();
-		redisTemplate.setConnectionFactory(connectionFactory);
-		redisTemplate.afterPropertiesSet();
+		StringRedisTemplate redisTemplate = createStringRedisTemplate(connectionFactory);
+		redisTemplate.delete("presidents");
 		BoundListOperations<String, String> ops = redisTemplate.boundListOps("presidents");
 
 		ops.rightPush("John Adams");
@@ -114,10 +102,9 @@ public class RedisAvailableTests {
 
 	protected void prepareZset(RedisConnectionFactory connectionFactory){
 
-		StringRedisTemplate redisTemplate = new StringRedisTemplate();
-		redisTemplate.setConnectionFactory(connectionFactory);
-		redisTemplate.afterPropertiesSet();
+		StringRedisTemplate redisTemplate = createStringRedisTemplate(connectionFactory);
 
+		redisTemplate.delete("presidents");
 		BoundZSetOperations<String, String> ops = redisTemplate.boundZSetOps("presidents");
 
 		ops.add("John Adams", 18);
@@ -134,7 +121,23 @@ public class RedisAvailableTests {
 		ops.add("Ronald Reagan", 20);
 		ops.add("William J. Clinton", 20);
 		ops.add("Abraham Lincoln", 19);
-		ops.add("George Washington", 18);
+		ops.add("George Wahington", 18);
+	}
+
+	protected void deletePresidents(RedisConnectionFactory connectionFactory){
+		this.deleteKey(connectionFactory, "presidents");
+	}
+
+	protected void deleteKey(RedisConnectionFactory connectionFactory, String key) {
+		StringRedisTemplate redisTemplate = createStringRedisTemplate(connectionFactory);
+		redisTemplate.delete(key);
+	}
+
+	protected StringRedisTemplate createStringRedisTemplate(RedisConnectionFactory connectionFactory) {
+		StringRedisTemplate redisTemplate = new StringRedisTemplate();
+		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.afterPropertiesSet();
+		return redisTemplate;
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 
 import java.util.concurrent.TimeUnit;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,6 +45,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 3.0
  */
 public class DelayerHandlerRescheduleIntegrationTests extends RedisAvailableTests {
@@ -62,6 +64,7 @@ public class DelayerHandlerRescheduleIntegrationTests extends RedisAvailableTest
 		connectionFactory.afterPropertiesSet();
 	}
 
+	@AfterClass
 	public static void tearDown() {
 		connectionFactory.destroy();
 	}
@@ -126,6 +129,8 @@ public class DelayerHandlerRescheduleIntegrationTests extends RedisAvailableTest
 
 		assertEquals(1, messageStore.getMessageGroupCount());
 		assertEquals(0, messageStore.messageGroupSize(delayerMessageGroupId));
+
+		messageStore.removeMessageGroup(delayerMessageGroupId);
 
 	}
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisChannelMessageStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisChannelMessageStoreTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import org.hamcrest.Matchers;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -65,7 +66,8 @@ public class RedisChannelMessageStoreTests extends RedisAvailableTests {
 	private RedisChannelMessageStore priorityCms;
 
 	@Before
-	public void setup() {
+	@After
+	public void setUpTearDown() {
 		this.cms.removeMessageGroup("cms:testChannel1");
 		this.cms.removeMessageGroup("cms:testChannel2");
 		this.priorityCms.removeMessageGroup("priorityCms:testChannel3");

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
@@ -31,11 +31,14 @@ import java.util.concurrent.TimeUnit;
 
 import junit.framework.AssertionFailedError;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.history.MessageHistory;
@@ -51,9 +54,19 @@ import org.springframework.messaging.support.GenericMessage;
 /**
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Gary Russell
  *
  */
 public class RedisMessageGroupStoreTests extends RedisAvailableTests {
+
+	@Before
+	@After
+	public void setUpTearDown() {
+		StringRedisTemplate template = this.createStringRedisTemplate(this.getConnectionFactoryForTest());
+		template.delete("MESSAGE_GROUP_1");
+		template.delete("MESSAGE_GROUP_2");
+		template.delete("MESSAGE_GROUP_3");
+	}
 
 	@Test
 	@RedisAvailable

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageStoreTests.java
@@ -24,21 +24,31 @@ import java.io.Serializable;
 import java.util.Properties;
 import java.util.UUID;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.history.MessageHistory;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.redis.rules.RedisAvailable;
 import org.springframework.integration.redis.rules.RedisAvailableTests;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Oleg Zhurakousky
  *
  */
 public class RedisMessageStoreTests extends RedisAvailableTests {
+
+	@Before
+	@After
+	public void setUpTearDown() {
+		StringRedisTemplate template = this.createStringRedisTemplate(this.getConnectionFactoryForTest());
+		template.delete(template.keys("MESSAGE_*"));
+	}
 
 	@Test
 	@RedisAvailable


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3355

Previously, the RedisAvailableTests unconditionally
flushed Redis; this is not appropriate and could affect
other builds on the CI server (as well as wiping out the
developer's Redis DB).

Change the tests to clean up their own redis data.

Also, improve `RedisLockRegistry.listLocks()` to use mget.
