### PR TITLE
INT-3355 Improve Redis Tests 3.0.x Backport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ target
 vf.gf.dmn-*
 /atlassian-ide-plugin.xml
 hostkey.ser
+.springBeans

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisStoreInboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisStoreInboundChannelAdapterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,21 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.support.collections.RedisList;
 import org.springframework.data.redis.support.collections.RedisZSet;
 import org.springframework.integration.Message;
+import org.springframework.integration.MessagingException;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.core.MessageHandler;
+import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.redis.rules.RedisAvailable;
 import org.springframework.integration.redis.rules.RedisAvailableTests;
@@ -36,6 +43,7 @@ import org.springframework.integration.redis.rules.RedisAvailableTests;
 /**
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 2.2
  */
 public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvailableTests {
@@ -59,14 +67,18 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
 		assertNotNull(message);
 		assertEquals(13, message.getPayload().size());
+		this.deletePresidents(jcf);
 		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	@SuppressWarnings("unchecked")
+	// synchronization commit renames the list
 	public void testListInboundConfigurationWithSynchronization() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		StringRedisTemplate template = this.createStringRedisTemplate(jcf);
+		template.delete("bar");
 		this.prepareList(jcf);
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml", this.getClass());
 		SourcePollingChannelAdapter spca = context.getBean("listAdapterWithSynchronization", SourcePollingChannelAdapter.class);
@@ -80,6 +92,44 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 		//poll again, should get nothing since the collection was removed during synchronization
 		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
 		assertNull(message);
+		assertEquals(Long.valueOf(13), template.boundListOps("bar").size());
+		template.delete("bar");
+
+		spca.stop();
+		context.close();
+	}
+
+	@Test
+	@RedisAvailable
+	// synchronization rollback renames the list
+	public void testListInboundConfigurationWithSynchronizationAndRollback() throws Exception{
+		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		StringRedisTemplate template = this.createStringRedisTemplate(jcf);
+		template.delete("baz");
+		this.prepareList(jcf);
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml",
+				this.getClass());
+		SubscribableChannel fail = context.getBean("redisFailChannel", SubscribableChannel.class);
+		final CountDownLatch latch = new CountDownLatch(1);
+		fail.subscribe(new MessageHandler() {
+
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+				latch.countDown();
+				throw new RuntimeException("Test Rollback");
+			}
+		});
+		SourcePollingChannelAdapter spca = context.getBean("listAdapterWithSynchronizationAndRollback",
+				SourcePollingChannelAdapter.class);
+		spca.start();
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+		int n = 0;
+		while (n++ < 100 && template.keys("baz").size() == 0) {
+			Thread.sleep(100);
+		}
+		assertTrue("Rename didn't occcur", n < 100);
+		assertEquals(Long.valueOf(13), template.boundListOps("baz").size());
+		template.delete("baz");
 
 		spca.stop();
 		context.close();
@@ -88,8 +138,11 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 	@Test
 	@RedisAvailable
 	@SuppressWarnings("unchecked")
+	// synchronization commit renames the list
 	public void testListInboundConfigurationWithSynchronizationAndTemplate() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		StringRedisTemplate template = this.createStringRedisTemplate(jcf);
+		template.delete("bar");
 		this.prepareList(jcf);
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml", this.getClass());
 		SourcePollingChannelAdapter spca = context.getBean("listAdapterWithSynchronizationAndRedisTemplate", SourcePollingChannelAdapter.class);
@@ -103,6 +156,8 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 		//poll again, should get nothing since the collection was removed during synchronization
 		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
 		assertNull(message);
+		assertEquals(Long.valueOf(13), template.boundListOps("bar").size());
+		template.delete("bar");
 
 		spca.stop();
 		context.close();
@@ -201,6 +256,7 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 
 		zsetAdapterNoScore.stop();
 		zsetAdapterWithSingleScoreAndSynchronization.stop();
+		this.deletePresidents(jcf);
 
 		context.close();
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/list-inbound-adapter.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/list-inbound-adapter.xml
@@ -49,7 +49,7 @@
 	</int-redis:store-inbound-channel-adapter>
 
 	<int:transaction-synchronization-factory id="syncFactory">
-		<int:after-commit expression="#resource.attributes['store'].rename('bar')"/>
+		<int:after-commit expression="#store.rename('bar')"/>
 		<int:after-rollback expression="#store.rename('baz')"/>
 	</int:transaction-synchronization-factory>
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/metadata/RedisMetadataStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/metadata/RedisMetadataStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors
+ * Copyright 2013-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -30,10 +32,17 @@ import org.springframework.integration.redis.rules.RedisAvailableTests;
 /**
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 3.0
  *
  */
 public class RedisMetadataStoreTests extends RedisAvailableTests {
+
+	@Before
+	@After
+	public void setUpTearDown() {
+		this.createStringRedisTemplate(this.getConnectionFactoryForTest()).delete("testMetadata");
+	}
 
 	@Test
 	@RedisAvailable
@@ -48,11 +57,11 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	@RedisAvailable
 	public void testPersistKeyValue() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "foo");
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 		metadataStore.put("RedisMetadataStoreTests-Spring", "Integration");
 
 		StringRedisTemplate redisTemplate = new StringRedisTemplate(jcf);
-		BoundHashOperations<String,Object,Object> ops = redisTemplate.boundHashOps("foo");
+		BoundHashOperations<String,Object,Object> ops = redisTemplate.boundHashOps("testMetadata");
 
 		assertEquals("Integration", ops.get("RedisMetadataStoreTests-Spring"));
 	}
@@ -62,7 +71,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	public void testGetValueFromMetadataStore() {
 
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 		metadataStore.put("RedisMetadataStoreTests-GetValue", "Hello Redis");
 
 		String retrievedValue = metadataStore.get("RedisMetadataStoreTests-GetValue");
@@ -74,7 +83,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	public void testPersistEmptyStringToMetadataStore() {
 
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 		metadataStore.put("RedisMetadataStoreTests-PersistEmpty", "");
 
 		String retrievedValue = metadataStore.get("RedisMetadataStoreTests-PersistEmpty");
@@ -86,7 +95,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	public void testPersistNullStringToMetadataStore() {
 
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 
 		try {
 			metadataStore.put("RedisMetadataStoreTests-PersistEmpty", null);
@@ -104,7 +113,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	@RedisAvailable
 	public void testPersistWithEmptyKeyToMetadataStore() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 		metadataStore.put("", "PersistWithEmptyKey");
 
 		String retrievedValue = metadataStore.get("");
@@ -115,7 +124,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	@RedisAvailable
 	public void testPersistWithNullKeyToMetadataStore() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 
 		try {
 			metadataStore.put(null, "something");
@@ -132,7 +141,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	@RedisAvailable
 	public void testGetValueWithNullKeyFromMetadataStore() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 
 		try {
 			metadataStore.get(null);
@@ -149,7 +158,7 @@ public class RedisMetadataStoreTests extends RedisAvailableTests {
 	@RedisAvailable
 	public void testRemoveFromMetadataStore() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
-		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf);
+		RedisMetadataStore metadataStore = new RedisMetadataStore(jcf, "testMetadata");
 
 		String testKey = "RedisMetadataStoreTests-Remove";
 		String testValue = "Integration";

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreOutboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreOutboundChannelAdapterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2013 the original author or authors
+ * Copyright 2007-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ import org.springframework.integration.test.util.TestUtils;
 /**
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.2
  */
 public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvailableTests {
@@ -65,6 +66,7 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 	public void testListWithKeyAsHeader(){
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 
+		this.deleteKey(jcf, "pepboys");
 		RedisList<String> redisList =
 				new DefaultRedisList<String>("pepboys", this.initTemplate(jcf, new StringRedisTemplate()));
 		assertEquals(0, redisList.size());
@@ -79,6 +81,8 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		redisChannel.send(message);
 
 		assertEquals(3, redisList.size());
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
@@ -98,12 +102,14 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 
 		assertEquals(1, redisList.size());
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testListWithProvidedKey(){
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisList<String> redisList =
 				new DefaultRedisList<String>("pepboys", this.initTemplate(jcf, new StringRedisTemplate()));
 		assertEquals(0, redisList.size());
@@ -118,6 +124,8 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		redisChannel.send(message);
 
 		assertEquals(3, redisList.size());
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
@@ -143,6 +151,7 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals(1, redisZSet.size());
 		assertEquals(Double.valueOf(2), redisZSet.score("bar"));
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	@Test
@@ -171,6 +180,7 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals(1, redisZSet.size());
 		assertEquals(Double.valueOf(1), redisZSet.score("bar"));
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	@Test
@@ -199,6 +209,7 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals(1, redisZSet.size());
 		assertEquals(Double.valueOf(4), redisZSet.score("bar"));
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	@Test
@@ -228,12 +239,14 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals(1, redisZSet.size());
 		assertEquals(Double.valueOf(15), redisZSet.score("bar"));
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testMapToZsetWithProvidedKey(){
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deletePresidents(jcf);
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>("presidents", this.initTemplate(jcf, new StringRedisTemplate()));
 		assertEquals(0, redisZset.size());
@@ -274,12 +287,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals(1, redisZset.rangeByScore(18, 18).size());
 		assertEquals(4, redisZset.rangeByScore(18, 19).size());
 		assertEquals(1, redisZset.rangeByScore(31, 31).size());
+		this.deletePresidents(jcf);
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testMapToMapWithProvidedKey(){
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisMap<String, String> redisMap =
 				new DefaultRedisMap<String, String>("pepboys",
 						this.initTemplate(jcf, new StringRedisTemplate()));
@@ -303,12 +319,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 				RedisStoreWritingMessageHandler.class);
 		assertEquals("pepboys", TestUtils.getPropertyValue(handler, "keyExpression", LiteralExpression.class).getExpressionString());
 		assertEquals("'foo'", TestUtils.getPropertyValue(handler, "mapKeyExpression", SpelExpression.class).getExpressionString());
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test(expected=MessageHandlingException.class) // map key is not provided
 	@RedisAvailable
 	public void testMapToMapAsSingleEntryWithKeyAsHeaderFail(){
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisMap<String, Map<String, String>> redisMap =
 				new DefaultRedisMap<String, Map<String, String>>("pepboys",
 						this.initTemplate(jcf, new RedisTemplate<String, Map<String, Map<String, String>>>()));
@@ -325,12 +344,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		Message<Map<String, String>> message = MessageBuilder.withPayload(pepboys).
 				setHeader(RedisHeaders.KEY, "pepboys").build();
 		redisChannel.send(message);
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test(expected=MessageHandlingException.class) // key is not provided
 	@RedisAvailable
 	public void testMapToMapNoKey(){
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisTemplate<String, Map<String, Map<String, String>>> redisTemplate = new RedisTemplate<String, Map<String, Map<String, String>>>();
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
@@ -349,12 +371,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 
 		Message<Map<String, String>> message = MessageBuilder.withPayload(pepboys).build();
 		redisChannel.send(message);
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testMapToMapAsSingleEntryWithKeyAsHeader(){
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisTemplate<String, Map<String, Map<String, String>>> redisTemplate = new RedisTemplate<String, Map<String, Map<String, String>>>();
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
@@ -379,12 +404,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals("Manny", pepboyz.get("1"));
 		assertEquals("Moe", pepboyz.get("2"));
 		assertEquals("Jack", pepboyz.get("3"));
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testStoreSimpleStringInMap(){
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "bar");
 		StringRedisTemplate redisTemplate = new StringRedisTemplate();
 		RedisMap<String, String> redisMap =
 				new DefaultRedisMap<String, String>("bar",
@@ -401,12 +429,14 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		String hello = redisMap.get("foo");
 
 		assertEquals("hello, world!", hello);
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testSetWithKeyAsHeader(){
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisSet<String> redisSet =
 				new DefaultRedisSet<String>("pepboys", this.initTemplate(jcf, new StringRedisTemplate()));
 		assertEquals(0, redisSet.size());
@@ -421,6 +451,8 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		redisChannel.send(message);
 
 		assertEquals(3, redisSet.size());
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
@@ -440,12 +472,14 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 
 		assertEquals(1, redisSet.size());
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testSetWithKeyAsHeaderNotParsed(){
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisTemplate<String, String> redisTemplate = new RedisTemplate<String, String>();
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
@@ -463,12 +497,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		redisChannel.send(message);
 
 		assertEquals(1, redisSet.size());
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testPojoIntoSet(){
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisSet<String> redisSet =
 				new DefaultRedisSet<String>("pepboys", this.initTemplate(jcf, new StringRedisTemplate()));
 		assertEquals(0, redisSet.size());
@@ -480,12 +517,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		redisChannel.send(message);
 
 		assertEquals(1, redisSet.size());
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testProperties(){
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisProperties redisProperties =
 				new RedisProperties("pepboys", this.initTemplate(jcf, new StringRedisTemplate()));
 
@@ -503,6 +543,8 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals("Manny", redisProperties.get("1"));
 		assertEquals("Moe", redisProperties.get("2"));
 		assertEquals("Jack", redisProperties.get("3"));
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
@@ -525,6 +567,7 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 
 		assertEquals("bar", redisProperties.get("qux"));
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	private <K,V> RedisTemplate<K,V> initTemplate(RedisConnectionFactory rcf, RedisTemplate<K,V> redisTemplate){

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandlerTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandlerTests.java
@@ -33,6 +33,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.data.redis.support.collections.DefaultRedisList;
 import org.springframework.data.redis.support.collections.DefaultRedisZSet;
 import org.springframework.data.redis.support.collections.RedisCollectionFactoryBean.CollectionType;
@@ -58,6 +59,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 	@RedisAvailable
 	public void testListWithListPayloadParsedAndProvidedKey() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisList<String> redisList =
 				new DefaultRedisList<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -80,12 +82,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		assertEquals("Manny", redisList.get(0));
 		assertEquals("Moe", redisList.get(1));
 		assertEquals("Jack", redisList.get(2));
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testListWithListPayloadParsedAndProvidedKeyAsHeader() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisList<String> redisList =
 				new DefaultRedisList<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -108,12 +112,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		assertEquals("Manny", redisList.get(0));
 		assertEquals("Moe", redisList.get(1));
 		assertEquals("Jack", redisList.get(2));
+		this.deleteKey(jcf, "foo");
 	}
 
 	@RedisAvailable
 	@Test(expected=MessageHandlingException.class)
 	public void testListWithListPayloadParsedAndNoKey() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisList<String> redisList =
 				new DefaultRedisList<String>(key, this.initTemplate(jcf, new RedisTemplate<String, String>()));
@@ -130,12 +136,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		list.add("Jack");
 		Message<List<String>> message = MessageBuilder.withPayload(list).build();
 		handler.handleMessage(message);
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testListWithListPayloadAsSingleEntry() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisList<List<String>> redisList =
 				new DefaultRedisList<List<String>>(key, this.initTemplate(jcf, new RedisTemplate<String, List<String>>()));
@@ -161,12 +169,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		assertEquals("Manny", resultList.get(0));
 		assertEquals("Moe", resultList.get(1));
 		assertEquals("Jack", resultList.get(2));
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithListPayloadParsedAndProvidedKeyDefault() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -199,12 +209,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		for (TypedTuple<String> pepboy : pepboys) {
 			assertEquals(Double.valueOf(2), pepboy.getScore());
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithListPayloadParsedAndProvidedKeyScoreIncrement() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -240,12 +252,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		for (TypedTuple<String> pepboy : pepboys) {
 			assertTrue(pepboy.getScore() == 2);
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithListPayloadParsedAndProvidedKeyScoreIncrementAsStringHeader() {// see INT-2775
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -281,12 +295,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		for (TypedTuple<String> pepboy : pepboys) {
 			assertTrue(pepboy.getScore() == 2);
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithListPayloadAsSingleEntryAndHeaderKeyHeaderScore() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisZSet<List<String>> redisZset =
 				new DefaultRedisZSet<List<String>>(key, this.initTemplate(jcf, new RedisTemplate<String, List<String>>()));
@@ -314,12 +330,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		for (TypedTuple<List<String>> pepboys : entries) {
 			assertTrue(pepboys.getScore() == 4);
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithMapPayloadParsedHeaderKey() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deletePresidents(jcf);
 		String key = "presidents";
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -356,12 +374,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 
 		Set<TypedTuple<String>> entries = redisZset.rangeByScoreWithScores(18, 19);
 		assertEquals(6, entries.size());
+		this.deletePresidents(jcf);
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithMapPayloadPojoParsedHeaderKey() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deletePresidents(jcf);
 		String key = "presidents";
 		RedisZSet<President> redisZset =
 				new DefaultRedisZSet<President>(key, this.initTemplate(jcf, new RedisTemplate<String, President>()));
@@ -399,12 +419,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 
 		Set<TypedTuple<President>> entries = redisZset.rangeByScoreWithScores(18, 19);
 		assertEquals(6, entries.size());
+		this.deletePresidents(jcf);
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithMapPayloadPojoAsSingleEntryHeaderKey() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deletePresidents(jcf);
 		String key = "presidents";
 		RedisZSet<Map<President, Double>> redisZset =
 				new DefaultRedisZSet<Map<President, Double>>(key, this.initTemplate(jcf, new RedisTemplate<String, Map<President, Double>>()));
@@ -429,6 +451,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		handler.handleMessage(message);
 
 		assertEquals(1, redisZset.size());
+		this.deletePresidents(jcf);
 	}
 
 	@Test(expected=IllegalStateException.class)
@@ -473,6 +496,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 	@RedisAvailable
 	public void testMapWithMapKeyExpression() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisStoreWritingMessageHandler handler =
 				new RedisStoreWritingMessageHandler(jcf);
@@ -485,12 +509,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		catch (Exception e) {
 			fail("No exception expected:" + e.getMessage());
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testPropertiesWithMapKeyExpression() {
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisStoreWritingMessageHandler handler =
 				new RedisStoreWritingMessageHandler(jcf);
@@ -503,10 +529,12 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		catch (Exception e) {
 			fail("No exception expected:" + e.getMessage());
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	private <K,V> RedisTemplate<K,V> initTemplate(RedisConnectionFactory rcf, RedisTemplate<K,V> redisTemplate) {
 		redisTemplate.setConnectionFactory(rcf);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.afterPropertiesSet();
 		return redisTemplate;
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 
 import java.util.concurrent.TimeUnit;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,6 +45,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 3.0
  */
 public class DelayerHandlerRescheduleIntegrationTests extends RedisAvailableTests {
@@ -62,6 +64,7 @@ public class DelayerHandlerRescheduleIntegrationTests extends RedisAvailableTest
 		connectionFactory.afterPropertiesSet();
 	}
 
+	@AfterClass
 	public static void tearDown() {
 		connectionFactory.destroy();
 	}
@@ -126,6 +129,8 @@ public class DelayerHandlerRescheduleIntegrationTests extends RedisAvailableTest
 
 		assertEquals(1, messageStore.getMessageGroupCount());
 		assertEquals(0, messageStore.messageGroupSize(delayerMessageGroupId));
+
+		messageStore.removeMessageGroup(delayerMessageGroupId);
 
 	}
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2013 the original author or authors
+ * Copyright 2007-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -24,9 +24,12 @@ import java.io.Serializable;
 import java.util.Properties;
 import java.util.UUID;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.integration.Message;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.history.MessageHistory;
@@ -39,6 +42,13 @@ import org.springframework.integration.redis.rules.RedisAvailableTests;
  *
  */
 public class RedisMessageStoreTests extends RedisAvailableTests {
+
+	@Before
+	@After
+	public void setUpTearDown() {
+		StringRedisTemplate template = this.createStringRedisTemplate(this.getConnectionFactoryForTest());
+		template.delete(template.keys("MESSAGE_*"));
+	}
 
 	@Test
 	@RedisAvailable


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3355

Previously, the RedisAvailableTests unconditionally
flushed Redis; this is not appropriate and could affect
other builds on the CI server (as well as wiping out the
developer's Redis DB).

Change the tests to clean up their own redis data.

Conflicts:

```
spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisStoreInboundChannelAdapterIntegrationTests.java
spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreOutboundChannelAdapterIntegrationTests.java
spring-integration-redis/src/test/java/org/springframework/integration/redis/rules/RedisAvailableTests.java
spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageStoreTests.java
```

Resolved.
