### PR TITLE
INT-3355 Improve Redis Tests 2.2.x Backport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ spring-integration-jms/activemq-data/
 spring-integration-samples/loanshark/application.log*
 target
 vf.gf.dmn-*
+/atlassian-ide-plugin.xml
+hostkey.ser
+.springBeans

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisStoreInboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisStoreInboundChannelAdapterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,21 +19,31 @@ package org.springframework.integration.redis.inbound;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.support.collections.RedisList;
 import org.springframework.data.redis.support.collections.RedisZSet;
 import org.springframework.integration.Message;
+import org.springframework.integration.MessagingException;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.core.MessageHandler;
+import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.redis.rules.RedisAvailable;
 import org.springframework.integration.redis.rules.RedisAvailableTests;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
+ * @author Gary Russell
  * @since 2.2
  */
 public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvailableTests{
@@ -57,14 +67,18 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
 		assertNotNull(message);
 		assertEquals(13, message.getPayload().size());
+		this.deletePresidents(jcf);
 		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	@SuppressWarnings("unchecked")
+	// synchronization commit renames the list
 	public void testListInboundConfigurationWithSynchronization() throws Exception{
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		StringRedisTemplate template = this.createStringRedisTemplate(jcf);
+		template.delete("bar");
 		this.prepareList(jcf);
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml", this.getClass());
 		SourcePollingChannelAdapter spca = context.getBean("listAdapterWithSynchronization", SourcePollingChannelAdapter.class);
@@ -78,6 +92,44 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 		//poll again, should get nothing since the collection was removed during synchronization
 		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
 		assertNull(message);
+		assertEquals(Long.valueOf(13), template.boundListOps("bar").size());
+		template.delete("bar");
+
+		spca.stop();
+		context.close();
+	}
+
+	@Test
+	@RedisAvailable
+	// synchronization rollback renames the list
+	public void testListInboundConfigurationWithSynchronizationAndRollback() throws Exception{
+		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		StringRedisTemplate template = this.createStringRedisTemplate(jcf);
+		template.delete("baz");
+		this.prepareList(jcf);
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml",
+				this.getClass());
+		SubscribableChannel fail = context.getBean("redisFailChannel", SubscribableChannel.class);
+		final CountDownLatch latch = new CountDownLatch(1);
+		fail.subscribe(new MessageHandler() {
+
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+				latch.countDown();
+				throw new RuntimeException("Test Rollback");
+			}
+		});
+		SourcePollingChannelAdapter spca = context.getBean("listAdapterWithSynchronizationAndRollback",
+				SourcePollingChannelAdapter.class);
+		spca.start();
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+		int n = 0;
+		while (n++ < 100 && template.keys("baz").size() == 0) {
+			Thread.sleep(100);
+		}
+		assertTrue("Rename didn't occcur", n < 100);
+		assertEquals(Long.valueOf(13), template.boundListOps("baz").size());
+		template.delete("baz");
 
 		spca.stop();
 		context.close();
@@ -86,8 +138,11 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 	@Test
 	@RedisAvailable
 	@SuppressWarnings("unchecked")
+	// synchronization commit renames the list
 	public void testListInboundConfigurationWithSynchronizationAndTemplate() throws Exception{
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		StringRedisTemplate template = this.createStringRedisTemplate(jcf);
+		template.delete("bar");
 		this.prepareList(jcf);
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("list-inbound-adapter.xml", this.getClass());
 		SourcePollingChannelAdapter spca = context.getBean("listAdapterWithSynchronizationAndRedisTemplate", SourcePollingChannelAdapter.class);
@@ -101,6 +156,8 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 		//poll again, should get nothing since the collection was removed during synchronization
 		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
 		assertNull(message);
+		assertEquals(Long.valueOf(13), template.boundListOps("bar").size());
+		template.delete("bar");
 
 		spca.stop();
 		context.close();
@@ -224,6 +281,9 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 		assertEquals(11, message.getPayload().size());
 
 		zsetAdapterNoScore.stop();
+		zsetAdapterWithSingleScoreAndSynchronization.stop();
+		this.deletePresidents(jcf);
+
 		context.close();
 	}
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/list-inbound-adapter.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/list-inbound-adapter.xml
@@ -49,7 +49,7 @@
 	</int-redis:store-inbound-channel-adapter>
 	
 	<int:transaction-synchronization-factory id="syncFactory">
-		<int:after-commit expression="#resource.attributes['store'].rename('bar')"/>
+		<int:after-commit expression="#store.rename('bar')"/>
 		<int:after-rollback expression="#store.rename('baz')"/>
 	</int:transaction-synchronization-factory>
 	

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreOutboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreOutboundChannelAdapterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2012 the original author or authors
+ * Copyright 2007-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.junit.Test;
+
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
@@ -56,6 +57,7 @@ import org.springframework.integration.test.util.TestUtils;
 /**
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.2
  */
 public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvailableTests {
@@ -65,6 +67,7 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 	public void testListWithKeyAsHeader(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 
+		this.deleteKey(jcf, "pepboys");
 		RedisList<String> redisList =
 				new DefaultRedisList<String>("pepboys", this.initTemplate(jcf, new StringRedisTemplate()));
 		assertEquals(0, redisList.size());
@@ -79,6 +82,8 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		redisChannel.send(message);
 
 		assertEquals(3, redisList.size());
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
@@ -98,12 +103,14 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 
 		assertEquals(1, redisList.size());
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testListWithProvidedKey(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisList<String> redisList =
 				new DefaultRedisList<String>("pepboys", this.initTemplate(jcf, new StringRedisTemplate()));
 		assertEquals(0, redisList.size());
@@ -118,6 +125,8 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		redisChannel.send(message);
 
 		assertEquals(3, redisList.size());
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
@@ -143,6 +152,7 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals(1, redisZSet.size());
 		assertEquals(Double.valueOf(2), redisZSet.score("bar"));
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	@Test
@@ -171,6 +181,7 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals(1, redisZSet.size());
 		assertEquals(Double.valueOf(1), redisZSet.score("bar"));
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	@Test
@@ -199,6 +210,7 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals(1, redisZSet.size());
 		assertEquals(Double.valueOf(4), redisZSet.score("bar"));
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	@Test
@@ -228,12 +240,14 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals(1, redisZSet.size());
 		assertEquals(Double.valueOf(15), redisZSet.score("bar"));
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testMapToZsetWithProvidedKey(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deletePresidents(jcf);
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>("presidents", this.initTemplate(jcf, new StringRedisTemplate()));
 		assertEquals(0, redisZset.size());
@@ -274,12 +288,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals(1, redisZset.rangeByScore(18, 18).size());
 		assertEquals(4, redisZset.rangeByScore(18, 19).size());
 		assertEquals(1, redisZset.rangeByScore(31, 31).size());
+		this.deletePresidents(jcf);
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testMapToMapWithProvidedKey(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisMap<String, String> redisMap =
 				new DefaultRedisMap<String, String>("pepboys",
 						this.initTemplate(jcf, new StringRedisTemplate()));
@@ -303,12 +320,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 				RedisStoreWritingMessageHandler.class);
 		assertEquals("pepboys", TestUtils.getPropertyValue(handler, "keyExpression", LiteralExpression.class).getExpressionString());
 		assertEquals("'foo'", TestUtils.getPropertyValue(handler, "mapKeyExpression", SpelExpression.class).getExpressionString());
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test(expected=MessageHandlingException.class) // map key is not provided
 	@RedisAvailable
 	public void testMapToMapAsSingleEntryWithKeyAsHeaderFail(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisMap<String, Map<String, String>> redisMap =
 				new DefaultRedisMap<String, Map<String, String>>("pepboys",
 						this.initTemplate(jcf, new RedisTemplate<String, Map<String, Map<String, String>>>()));
@@ -325,12 +345,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		Message<Map<String, String>> message = MessageBuilder.withPayload(pepboys).
 				setHeader(RedisHeaders.KEY, "pepboys").build();
 		redisChannel.send(message);
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test(expected=MessageHandlingException.class) // key is not provided
 	@RedisAvailable
 	public void testMapToMapNoKey(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisTemplate<String, Map<String, Map<String, String>>> redisTemplate = new RedisTemplate<String, Map<String, Map<String, String>>>();
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
@@ -349,12 +372,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 
 		Message<Map<String, String>> message = MessageBuilder.withPayload(pepboys).build();
 		redisChannel.send(message);
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testMapToMapAsSingleEntryWithKeyAsHeader(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisTemplate<String, Map<String, Map<String, String>>> redisTemplate = new RedisTemplate<String, Map<String, Map<String, String>>>();
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
@@ -379,12 +405,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals("Manny", pepboyz.get("1"));
 		assertEquals("Moe", pepboyz.get("2"));
 		assertEquals("Jack", pepboyz.get("3"));
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testStoreSimpleStringInMap(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "bar");
 		StringRedisTemplate redisTemplate = new StringRedisTemplate();
 		RedisMap<String, String> redisMap =
 				new DefaultRedisMap<String, String>("bar",
@@ -401,12 +430,14 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		String hello = redisMap.get("foo");
 
 		assertEquals("hello, world!", hello);
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testSetWithKeyAsHeader(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisSet<String> redisSet =
 				new DefaultRedisSet<String>("pepboys", this.initTemplate(jcf, new StringRedisTemplate()));
 		assertEquals(0, redisSet.size());
@@ -421,6 +452,8 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		redisChannel.send(message);
 
 		assertEquals(3, redisSet.size());
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
@@ -440,12 +473,14 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 
 		assertEquals(1, redisSet.size());
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testSetWithKeyAsHeaderNotParsed(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisTemplate<String, String> redisTemplate = new RedisTemplate<String, String>();
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
@@ -463,12 +498,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		redisChannel.send(message);
 
 		assertEquals(1, redisSet.size());
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testPojoIntoSet(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisSet<String> redisSet =
 				new DefaultRedisSet<String>("pepboys", this.initTemplate(jcf, new StringRedisTemplate()));
 		assertEquals(0, redisSet.size());
@@ -480,12 +518,15 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		redisChannel.send(message);
 
 		assertEquals(1, redisSet.size());
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testProperties(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "pepboys");
 		RedisProperties redisProperties =
 				new RedisProperties("pepboys", this.initTemplate(jcf, new StringRedisTemplate()));
 
@@ -503,6 +544,8 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 		assertEquals("Manny", redisProperties.get("1"));
 		assertEquals("Moe", redisProperties.get("2"));
 		assertEquals("Jack", redisProperties.get("3"));
+		this.deleteKey(jcf, "pepboys");
+		context.close();
 	}
 
 	@Test
@@ -525,6 +568,7 @@ public class RedisStoreOutboundChannelAdapterIntegrationTests extends RedisAvail
 
 		assertEquals("bar", redisProperties.get("qux"));
 		redisTemplate.delete("foo");
+		context.close();
 	}
 
 	private <K,V> RedisTemplate<K,V> initTemplate(RedisConnectionFactory rcf, RedisTemplate<K,V> redisTemplate){

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandlerTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandlerTests.java
@@ -34,6 +34,7 @@ import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.data.redis.support.collections.DefaultRedisList;
 import org.springframework.data.redis.support.collections.DefaultRedisZSet;
 import org.springframework.data.redis.support.collections.RedisCollectionFactoryBean.CollectionType;
@@ -59,6 +60,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 	@RedisAvailable
 	public void testListWithListPayloadParsedAndProvidedKey() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisList<String> redisList =
 				new DefaultRedisList<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -81,12 +83,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		assertEquals("Manny", redisList.get(0));
 		assertEquals("Moe", redisList.get(1));
 		assertEquals("Jack", redisList.get(2));
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testListWithListPayloadParsedAndProvidedKeyAsHeader() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisList<String> redisList =
 				new DefaultRedisList<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -109,12 +113,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		assertEquals("Manny", redisList.get(0));
 		assertEquals("Moe", redisList.get(1));
 		assertEquals("Jack", redisList.get(2));
+		this.deleteKey(jcf, "foo");
 	}
 
 	@RedisAvailable
 	@Test(expected=MessageHandlingException.class)
 	public void testListWithListPayloadParsedAndNoKey() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisList<String> redisList =
 				new DefaultRedisList<String>(key, this.initTemplate(jcf, new RedisTemplate<String, String>()));
@@ -131,12 +137,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		list.add("Jack");
 		Message<List<String>> message = MessageBuilder.withPayload(list).build();
 		handler.handleMessage(message);
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testListWithListPayloadAsSingleEntry() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisList<List<String>> redisList =
 				new DefaultRedisList<List<String>>(key, this.initTemplate(jcf, new RedisTemplate<String, List<String>>()));
@@ -162,12 +170,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		assertEquals("Manny", resultList.get(0));
 		assertEquals("Moe", resultList.get(1));
 		assertEquals("Jack", resultList.get(2));
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithListPayloadParsedAndProvidedKeyDefault() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -200,12 +210,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		for (TypedTuple<String> pepboy : pepboys) {
 			assertEquals(Double.valueOf(2), pepboy.getScore());
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithListPayloadParsedAndProvidedKeyScoreIncrement() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -241,12 +253,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		for (TypedTuple<String> pepboy : pepboys) {
 			assertTrue(pepboy.getScore() == 2);
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithListPayloadParsedAndProvidedKeyScoreIncrementAsStringHeader() {// see INT-2775
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -282,12 +296,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		for (TypedTuple<String> pepboy : pepboys) {
 			assertTrue(pepboy.getScore() == 2);
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithListPayloadAsSingleEntryAndHeaderKeyHeaderScore() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisZSet<List<String>> redisZset =
 				new DefaultRedisZSet<List<String>>(key, this.initTemplate(jcf, new RedisTemplate<String, List<String>>()));
@@ -315,12 +331,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		for (TypedTuple<List<String>> pepboys : entries) {
 			assertTrue(pepboys.getScore() == 4);
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithMapPayloadParsedHeaderKey() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deletePresidents(jcf);
 		String key = "presidents";
 		RedisZSet<String> redisZset =
 				new DefaultRedisZSet<String>(key, this.initTemplate(jcf, new StringRedisTemplate()));
@@ -357,12 +375,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 
 		Set<TypedTuple<String>> entries = redisZset.rangeByScoreWithScores(18, 19);
 		assertEquals(6, entries.size());
+		this.deletePresidents(jcf);
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithMapPayloadPojoParsedHeaderKey() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deletePresidents(jcf);
 		String key = "presidents";
 		RedisZSet<President> redisZset =
 				new DefaultRedisZSet<President>(key, this.initTemplate(jcf, new RedisTemplate<String, President>()));
@@ -400,12 +420,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 
 		Set<TypedTuple<President>> entries = redisZset.rangeByScoreWithScores(18, 19);
 		assertEquals(6, entries.size());
+		this.deletePresidents(jcf);
 	}
 
 	@Test
 	@RedisAvailable
 	public void testZsetWithMapPayloadPojoAsSingleEntryHeaderKey() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deletePresidents(jcf);
 		String key = "presidents";
 		RedisZSet<Map<President, Double>> redisZset =
 				new DefaultRedisZSet<Map<President, Double>>(key, this.initTemplate(jcf, new RedisTemplate<String, Map<President, Double>>()));
@@ -430,6 +452,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		handler.handleMessage(message);
 
 		assertEquals(1, redisZset.size());
+		this.deletePresidents(jcf);
 	}
 
 	@Test(expected=IllegalStateException.class)
@@ -474,6 +497,7 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 	@RedisAvailable
 	public void testMapWithMapKeyExpression() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisStoreWritingMessageHandler handler =
 				new RedisStoreWritingMessageHandler(jcf);
@@ -486,12 +510,14 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		catch (Exception e) {
 			fail("No exception expected:" + e.getMessage());
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	@Test
 	@RedisAvailable
 	public void testPropertiesWithMapKeyExpression() {
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		this.deleteKey(jcf, "foo");
 		String key = "foo";
 		RedisStoreWritingMessageHandler handler =
 				new RedisStoreWritingMessageHandler(jcf);
@@ -504,10 +530,12 @@ public class RedisStoreWritingMessageHandlerTests extends RedisAvailableTests{
 		catch (Exception e) {
 			fail("No exception expected:" + e.getMessage());
 		}
+		this.deleteKey(jcf, "foo");
 	}
 
 	private <K,V> RedisTemplate<K,V> initTemplate(RedisConnectionFactory rcf, RedisTemplate<K,V> redisTemplate) {
 		redisTemplate.setConnectionFactory(rcf);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.afterPropertiesSet();
 		return redisTemplate;
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
@@ -31,11 +31,14 @@ import java.util.concurrent.TimeUnit;
 
 import junit.framework.AssertionFailedError;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.channel.DirectChannel;
@@ -50,9 +53,20 @@ import org.springframework.integration.support.MessageBuilder;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
+ * @author Gary Russell
  *
  */
 public class RedisMessageGroupStoreTests extends RedisAvailableTests {
+
+	@Before
+	@After
+	public void setUpTearDown() {
+		StringRedisTemplate template = this.createStringRedisTemplate(this.getConnectionFactoryForTest());
+		template.delete("MESSAGE_GROUP_1");
+		template.delete("MESSAGE_GROUP_2");
+		template.delete("MESSAGE_GROUP_3");
+	}
 
 	@Test
 	@RedisAvailable
@@ -317,6 +331,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 			executor = Executors.newCachedThreadPool();
 
 			executor.execute(new Runnable() {
+				@Override
 				public void run() {
 					MessageGroup group = store1.addMessageToGroup(1, message);
 					if (group.getMessages().size() != 1){
@@ -326,6 +341,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 				}
 			});
 			executor.execute(new Runnable() {
+				@Override
 				public void run() {
 					MessageGroup group = store2.removeMessageFromGroup(1, message);
 					if (group.getMessages().size() != 0){
@@ -344,9 +360,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 
 	@Test
 	@RedisAvailable
-	public void testWithAggregatorWithShutdown(){
-		this.getConnectionFactoryForTest(); // for this test it only ensures that DB was flushed before test
-
+	public void testWithAggregatorWithShutdown() {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("redis-aggregator-config.xml", this.getClass());
 		MessageChannel input = context.getBean("inputChannel", MessageChannel.class);
 		QueueChannel output = context.getBean("outputChannel", QueueChannel.class);
@@ -366,6 +380,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 		Message<?> m3 = MessageBuilder.withPayload("3").setSequenceNumber(3).setSequenceSize(3).setCorrelationId(1).build();
 		input.send(m3);
 		assertNotNull(output.receive(1000));
+		context.close();
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2011 the original author or authors
+ * Copyright 2007-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -15,13 +15,21 @@
  */
 package org.springframework.integration.redis.store;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+
 import java.io.Serializable;
 import java.util.Properties;
 import java.util.UUID;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.integration.Message;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.history.MessageHistory;
@@ -29,37 +37,39 @@ import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.redis.rules.RedisAvailable;
 import org.springframework.integration.redis.rules.RedisAvailableTests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-
 /**
  * @author Oleg Zhurakousky
  *
  */
 public class RedisMessageStoreTests extends RedisAvailableTests {
 
+	@Before
+	@After
+	public void setUpTearDown() {
+		StringRedisTemplate template = this.createStringRedisTemplate(this.getConnectionFactoryForTest());
+		template.delete(template.keys("MESSAGE_*"));
+	}
+
 	@Test
 	@RedisAvailable
-	public void testGetNonExistingMessage(){	
+	public void testGetNonExistingMessage(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 		Message<?> message = store.getMessage(UUID.randomUUID());
 		assertNull(message);
 	}
-	
+
 	@Test
 	@RedisAvailable
-	public void testGetMessageCountWhenEmpty(){	
+	public void testGetMessageCountWhenEmpty(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 		assertEquals(0, store.getMessageCount());
 	}
-	
+
 	@Test
 	@RedisAvailable
-	public void testAddStringMessage(){	
+	public void testAddStringMessage(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 		Message<String> stringMessage = new GenericMessage<String>("Hello Redis");
@@ -67,36 +77,36 @@ public class RedisMessageStoreTests extends RedisAvailableTests {
 		assertNotSame(stringMessage, storedMessage);
 		assertEquals("Hello Redis", storedMessage.getPayload());
 	}
-	
+
 	@Test
 	@RedisAvailable
-	public void testAddSerializableObjectMessage(){	
+	public void testAddSerializableObjectMessage(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 		Address address = new Address();
 		address.setAddress("1600 Pennsylvania Av, Washington, DC");
 		Person person = new Person(address, "Barak Obama");
-		
+
 		Message<Person> objectMessage = new GenericMessage<Person>(person);
 		Message<Person> storedMessage =  store.addMessage(objectMessage);
 		assertNotSame(objectMessage, storedMessage);
 		assertEquals("Barak Obama", storedMessage.getPayload().getName());
 	}
-	
+
 	@Test(expected=IllegalArgumentException.class)
 	@RedisAvailable
-	public void testAddNonSerializableObjectMessage(){	
+	public void testAddNonSerializableObjectMessage(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
-		
+
 		Message<Foo> objectMessage = new GenericMessage<Foo>(new Foo());
 		store.addMessage(objectMessage);
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	@Test
 	@RedisAvailable
-	public void testAddAndGetStringMessage(){	
+	public void testAddAndGetStringMessage(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 		Message<String> stringMessage = new GenericMessage<String>("Hello Redis");
@@ -108,7 +118,7 @@ public class RedisMessageStoreTests extends RedisAvailableTests {
 	@SuppressWarnings("unchecked")
 	@Test
 	@RedisAvailable
-	public void testAddAndRemoveStringMessage(){	
+	public void testAddAndRemoveStringMessage(){
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 		Message<String> stringMessage = new GenericMessage<String>("Hello Redis");
@@ -118,19 +128,19 @@ public class RedisMessageStoreTests extends RedisAvailableTests {
 		assertEquals("Hello Redis", retrievedMessage.getPayload());
 		assertNull(store.getMessage(stringMessage.getHeaders().getId()));
 	}
-	
+
 	@Test
 	@RedisAvailable
-	public void testWithMessageHistory() throws Exception{	
+	public void testWithMessageHistory() throws Exception{
 		JedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
-		
+
 		Message<?> message = new GenericMessage<String>("Hello");
 		DirectChannel fooChannel = new DirectChannel();
 		fooChannel.setBeanName("fooChannel");
 		DirectChannel barChannel = new DirectChannel();
 		barChannel.setBeanName("barChannel");
-		
+
 		message = MessageHistory.write(message, fooChannel);
 		message = MessageHistory.write(message, barChannel);
 		store.addMessage(message);
@@ -142,7 +152,7 @@ public class RedisMessageStoreTests extends RedisAvailableTests {
 		assertEquals("fooChannel", fooChannelHistory.get("name"));
 		assertEquals("channel", fooChannelHistory.get("type"));
 	}
-	
+
 	@SuppressWarnings("serial")
 	public static class Person implements Serializable{
 		private Address address;
@@ -176,8 +186,8 @@ public class RedisMessageStoreTests extends RedisAvailableTests {
 			this.address = address;
 		}
 	}
-	
+
 	public static class Foo{
-		
+
 	}
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3355

Previously, the RedisAvailableTests unconditionally
flushed Redis; this is not appropriate and could affect
other builds on the CI server (as well as wiping out the
developer's Redis DB).

Change the tests to clean up their own redis data.

Conflicts:

```
.gitignore
spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisStoreInboundChannelAdapterIntegrationTests.java
spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreOutboundChannelAdapterIntegrationTests.java
spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandlerTests.java
spring-integration-redis/src/test/java/org/springframework/integration/redis/rules/RedisAvailableTests.java
spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests.java
spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageStoreTests.java
```

Resolved.
