### PR TITLE
INT-2738 Add Missing `getComponentType()` Methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -312,6 +312,10 @@ project('spring-integration-http') {
 	dependencies {
 		compile project(":spring-integration-core")
 		compile "org.springframework:spring-webmvc:$springVersion"
+		compile("net.java.dev.rome:rome-fetcher:$romeVersion") {
+			optional
+			exclude group: 'junit'
+		}
 
 		compile("javax.servlet:javax.servlet-api:$servletApiVersion", provided)
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -67,8 +67,14 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 	}
 
 	@Override
+	public String getComponentType() {
+		return "amqp:inbound-channel-adapter";
+	}
+
+	@Override
 	protected void onInit() {
 		this.messageListenerContainer.setMessageListener(new MessageListener() {
+			@Override
 			public void onMessage(Message message) {
 				Object payload = messageConverter.fromMessage(message);
 				Map<String, ?> headers = headerMapper.toHeadersFromRequest(message.getMessageProperties());
@@ -95,6 +101,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 	 * <p>
 	 * Shuts down the listener container.
 	 */
+	@Override
 	public int beforeShutdown() {
 		this.stop();
 		return 0;
@@ -105,6 +112,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 	 * {@inheritDoc}
 	 * <p>No-op
 	 */
+	@Override
 	public int afterShutdown() {
 		return 0;
 	}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,8 +76,14 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 	}
 
 	@Override
+	public String getComponentType() {
+		return "amqp:inbound-gateway";
+	}
+
+	@Override
 	protected void onInit() throws Exception {
 		this.messageListenerContainer.setMessageListener(new MessageListener() {
+			@Override
 			public void onMessage(Message message) {
 				Object payload = amqpMessageConverter.fromMessage(message);
 				Map<String, ?> headers = headerMapper.toHeadersFromRequest(message.getMessageProperties());
@@ -91,6 +97,7 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 							"request Message being handled by the AMQP inbound gateway.");
 					amqpTemplate.convertAndSend(replyTo.getExchangeName(), replyTo.getRoutingKey(), reply.getPayload(),
 							new MessagePostProcessor() {
+								@Override
 								public Message postProcessMessage(Message message) throws AmqpException {
 									MessageProperties messageProperties = message.getMessageProperties();
 									String contentEncoding = messageProperties.getContentEncoding();

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonToObjectTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonToObjectTransformer.java
@@ -68,6 +68,11 @@ public class JsonToObjectTransformer extends AbstractTransformer implements Bean
 	}
 
 	@Override
+	public String getComponentType() {
+		return "json-to-object-transformer";
+	}
+
+	@Override
 	protected Object doTransform(Message<?> message) throws Exception {
 		if (this.targetClass != null) {
 			return this.jsonObjectMapper.fromJson(message.getPayload(), this.targetClass);

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/ObjectToJsonTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/ObjectToJsonTransformer.java
@@ -87,6 +87,11 @@ public class ObjectToJsonTransformer extends AbstractTransformer {
 	}
 
 	@Override
+	public String getComponentType() {
+		return "object-to-json-transformer";
+	}
+
+	@Override
 	protected Object doTransform(Message<?> message) throws Exception {
 		Object payload = ResultType.STRING.equals(this.resultType)
 				? this.jsonObjectMapper.toJson(message.getPayload())

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ClaimCheckInTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ClaimCheckInTransformer.java
@@ -43,6 +43,10 @@ public class ClaimCheckInTransformer extends AbstractTransformer {
 		this.messageStore = messageStore;
 	}
 
+	@Override
+	public String getComponentType() {
+		return "claim-check-in";
+	}
 
 	@Override
 	protected Object doTransform(Message<?> message) throws Exception {

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ClaimCheckOutTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ClaimCheckOutTransformer.java
@@ -55,6 +55,11 @@ public class ClaimCheckOutTransformer extends AbstractTransformer {
 	}
 
 	@Override
+	public String getComponentType() {
+		return "claim-check-out";
+	}
+
+	@Override
 	protected Object doTransform(Message<?> message) throws Exception {
 		Assert.notNull(message, "message must not be null");
 		Assert.isTrue(message.getPayload() instanceof UUID, "payload must be a UUID");

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
@@ -214,10 +214,15 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler implem
 		this.sourceEvaluationContext = evaluationContext;
 	}
 
-    /**
-     * Initializes the Content Enricher. Will instantiate an internal Gateway if
-     * the requestChannel is set.
-     */
+	@Override
+	public String getComponentType() {
+		return "enricher";
+	}
+
+	/**
+	 * Initializes the Content Enricher. Will instantiate an internal Gateway if
+	 * the requestChannel is set.
+	 */
 	@Override
 	protected void doInit() {
 		if (StringUtils.hasText(this.requestChannelName)) {
@@ -383,6 +388,12 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler implem
 		protected Message<?> sendAndReceiveMessage(Object object) {
 			return super.sendAndReceiveMessage(object);
 		}
+
+		@Override
+		public String getComponentType() {
+			return "enricher$gateway";
+		}
+
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/HeaderFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/HeaderFilter.java
@@ -46,6 +46,11 @@ public class HeaderFilter extends IntegrationObjectSupport implements Transforme
 	}
 
 	@Override
+	public String getComponentType() {
+		return "header-filter";
+	}
+
+	@Override
 	public Message<?> transform(Message<?> message) {
 		AbstractIntegrationMessageBuilder<?> builder = this.getMessageBuilderFactory().fromMessage(message);
 		if (this.patternMatch){

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/MapToObjectTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/MapToObjectTransformer.java
@@ -63,6 +63,19 @@ public class MapToObjectTransformer extends AbstractPayloadTransformer<Map<?, ?>
 	}
 
 	@Override
+	public String getComponentType() {
+		return "map-to-object-transformer";
+	}
+
+	@Override
+	protected void onInit() {
+		if (StringUtils.hasText(this.targetBeanName)) {
+			Assert.isTrue(this.getBeanFactory().isPrototype(this.targetBeanName),
+					"target bean [" + targetBeanName + "] must have 'prototype' scope");
+		}
+	}
+
+	@Override
 	protected Object transformPayload(Map<?, ?> payload) throws Exception {
 		Object target = (this.targetClass != null)
 				? BeanUtils.instantiate(this.targetClass)
@@ -77,14 +90,6 @@ public class MapToObjectTransformer extends AbstractPayloadTransformer<Map<?, ?>
 		binder.bind(new MutablePropertyValues(payload));
 
 		return target;
-	}
-
-	@Override
-	protected void onInit() {
-		if (StringUtils.hasText(this.targetBeanName)) {
-			Assert.isTrue(this.getBeanFactory().isPrototype(this.targetBeanName),
-					"target bean [" + targetBeanName + "] must have 'prototype' scope");
-		}
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ObjectToMapTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ObjectToMapTransformer.java
@@ -62,6 +62,7 @@ public class ObjectToMapTransformer extends AbstractPayloadTransformer<Object, M
 		this.shouldFlattenKeys = shouldFlattenKeys;
 	}
 
+	@Override
 	@SuppressWarnings("unchecked")
 	protected Map<String, Object> transformPayload(Object payload) throws Exception {
 		Map<String,Object> result = this.jsonObjectMapper.fromJson(this.jsonObjectMapper.toJson(payload), Map.class);
@@ -69,6 +70,28 @@ public class ObjectToMapTransformer extends AbstractPayloadTransformer<Object, M
 			result = this.flattenMap(result);
 		}
 		return result;
+	}
+
+	@Override
+	public String getComponentType() {
+		return "object-to-map-transformer";
+	}
+
+	@SuppressWarnings("unchecked")
+	private void doProcessElement(String propertyPrefix, Object element, Map<String, Object> resultMap) {
+		if (element instanceof Map) {
+			this.doFlatten(propertyPrefix, (Map<String, Object>) element, resultMap);
+		}
+		else if (element instanceof Collection) {
+			this.doProcessCollection(propertyPrefix, (Collection<?>) element, resultMap);
+		}
+		else if (element != null && element.getClass().isArray()) {
+			Collection<?> collection =  CollectionUtils.arrayToList(element);
+			this.doProcessCollection(propertyPrefix, collection, resultMap);
+		}
+		else {
+			resultMap.put(propertyPrefix, element);
+		}
 	}
 
 	private Map<String, Object> flattenMap(Map<String,Object> result){
@@ -92,23 +115,6 @@ public class ObjectToMapTransformer extends AbstractPayloadTransformer<Object, M
 		for (Object element : list) {
 			this.doProcessElement(propertyPrefix + "[" + counter + "]", element, resultMap);
 			counter ++;
-		}
-	}
-
-	@SuppressWarnings("unchecked")
-	private void doProcessElement(String propertyPrefix, Object element, Map<String, Object> resultMap) {
-		if (element instanceof Map) {
-			this.doFlatten(propertyPrefix, (Map<String, Object>) element, resultMap);
-		}
-		else if (element instanceof Collection) {
-			this.doProcessCollection(propertyPrefix, (Collection<?>) element, resultMap);
-		}
-		else if (element != null && element.getClass().isArray()) {
-			Collection<?> collection =  CollectionUtils.arrayToList(element);
-			this.doProcessCollection(propertyPrefix, collection, resultMap);
-		}
-		else {
-			resultMap.put(propertyPrefix, element);
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ObjectToStringTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ObjectToStringTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,11 @@ public class ObjectToStringTransformer extends AbstractPayloadTransformer<Object
 	public ObjectToStringTransformer(String charset) {
 		Assert.notNull(charset, "'charset' cannot be null");
 		this.charset = charset;
+	}
+
+	@Override
+	public String getComponentType() {
+		return "object-to-string-transformer";
 	}
 
 	@Override

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,10 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 		super(remoteFileTemplate, command, expression);
 	}
 
+	@Override
+	public String getComponentType() {
+		return "ftp:outbound-gateway";
+	}
 
 	@Override
 	protected boolean isDirectory(FTPFile file) {

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/config/xml/GemfireCqInboundChannelAdapterParser.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/config/xml/GemfireCqInboundChannelAdapterParser.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2011 the original author or authors.
- * 
+ * Copyright 2002-2014 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -19,62 +19,62 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.gemfire.inbound.ContinuousQueryMessageProducer;
 
 /**
  * @author David Turanski
  * @author Dan Oxlade
+ * @author Gary Russell
  * @since 2.1
  *
  */
 public class GemfireCqInboundChannelAdapterParser extends AbstractChannelAdapterParser {
 
-	 
+
 	private static final String ERROR_CHANNEL_ATTRIBUTE = "error-channel";
-	 
+
 	private static final String OUTPUT_CHANNEL_PROPERTY = "outputChannel";
- 
+
 	private static final String QUERY_LISTENER_CONTAINER_ATTRIBUTE = "cq-listener-container";
-	
+
 	private static final String DURABLE_ATTRIBUTE = "durable";
-	
+
 	private static final String QUERY_NAME_ATTRIBUTE = "query-name";
-	
+
 	private static final String QUERY_ATTRIBUTE = "query";
-	 
+
 	private static final String PAYLOAD_EXPRESSION_PROPERTY = "payloadExpression";
- 
+
 	private static final String EXPRESSION_ATTRIBUTE = "expression";
- 
-	private static final String GEMFIRE_INBOUND_CONTINUOUS_QUERY_MESSAGE_PRODUCER = "org.springframework.integration.gemfire.inbound.ContinuousQueryMessageProducer";
 
 	private static final String SUPPORTED_EVENT_TYPES_PROPERTY = "supportedEventTypes";
-	
+
 	private static final String QUERY_EVENTS_ATTRIBUTE = "query-events";
 
-	
+
 	@Override
 	protected AbstractBeanDefinition doParse(Element element, ParserContext parserContext, String channelName) {
-		BeanDefinitionBuilder continuousQueryMesageProducer = BeanDefinitionBuilder.genericBeanDefinition(GEMFIRE_INBOUND_CONTINUOUS_QUERY_MESSAGE_PRODUCER);
+		BeanDefinitionBuilder continuousQueryMesageProducer = BeanDefinitionBuilder.genericBeanDefinition(ContinuousQueryMessageProducer.class);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(continuousQueryMesageProducer, element, EXPRESSION_ATTRIBUTE,PAYLOAD_EXPRESSION_PROPERTY);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(continuousQueryMesageProducer, element, QUERY_EVENTS_ATTRIBUTE, SUPPORTED_EVENT_TYPES_PROPERTY);
-	 	
+
 		if (!element.hasAttribute(QUERY_LISTENER_CONTAINER_ATTRIBUTE)){
 			parserContext.getReaderContext().error("'" + QUERY_LISTENER_CONTAINER_ATTRIBUTE + "' attribute is required.",element);
 		}
-		
+
 		if (!element.hasAttribute(QUERY_ATTRIBUTE)){
 			parserContext.getReaderContext().error("'" + QUERY_ATTRIBUTE + "' attribute is required.",element);
 		}
-		 
+
 		continuousQueryMesageProducer.addConstructorArgReference(element.getAttribute(QUERY_LISTENER_CONTAINER_ATTRIBUTE));
 		continuousQueryMesageProducer.addConstructorArgValue(element.getAttribute(QUERY_ATTRIBUTE));
-		 
+
 		continuousQueryMesageProducer.addPropertyReference(OUTPUT_CHANNEL_PROPERTY, channelName);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(continuousQueryMesageProducer, element, ERROR_CHANNEL_ATTRIBUTE);
-		
+
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(continuousQueryMesageProducer, element, QUERY_NAME_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(continuousQueryMesageProducer, element, DURABLE_ATTRIBUTE);
-		
+
 		return continuousQueryMesageProducer.getBeanDefinition();
 	}
 

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/config/xml/GemfireInboundChannelAdapterParser.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/config/xml/GemfireInboundChannelAdapterParser.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2011 the original author or authors.
- * 
+ * Copyright 2002-2014 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -20,47 +20,44 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.gemfire.inbound.CacheListeningMessageProducer;
 
 /**
  * @author David Turanski
+ * @author Gary Russell
  * @since 2.1
  */
 public class GemfireInboundChannelAdapterParser extends AbstractChannelAdapterParser {
-	 
+
 	private static final String ERROR_CHANNEL_ATTRIBUTE = "error-channel";
-	 
+
 	private static final String OUTPUT_CHANNEL_PROPERTY = "outputChannel";
- 
+
 	private static final String REGION_ATTRIBUTE = "region";
-	 
+
 	private static final String PAYLOAD_EXPRESSION_PROPERTY = "payloadExpression";
- 
+
 	private static final String EXPRESSION_ATTRIBUTE = "expression";
- 
-	private static final String GEMFIRE_INBOUND_CACHE_LISTENING_MESSAGE_PRODUCER = "org.springframework.integration.gemfire.inbound.CacheListeningMessageProducer";
 
 	private static final String SUPPORTED_EVENT_TYPES_PROPERTY = "supportedEventTypes";
-	
+
 	private static final String CACHE_EVENTS_ATTRIBUTE = "cache-events";
 
-	/* (non-Javadoc)
-	 * @see org.springframework.integration.config.xml.AbstractChannelAdapterParser#doParse(org.w3c.dom.Element, org.springframework.beans.factory.xml.ParserContext, java.lang.String)
-	 */
 	@Override
 	protected AbstractBeanDefinition doParse(Element element, ParserContext parserContext, String channelName) {
-		BeanDefinitionBuilder listeningMessageProducer = BeanDefinitionBuilder.genericBeanDefinition(GEMFIRE_INBOUND_CACHE_LISTENING_MESSAGE_PRODUCER);
+		BeanDefinitionBuilder listeningMessageProducer = BeanDefinitionBuilder.genericBeanDefinition(CacheListeningMessageProducer.class);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(listeningMessageProducer, element, EXPRESSION_ATTRIBUTE,PAYLOAD_EXPRESSION_PROPERTY);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(listeningMessageProducer, element, CACHE_EVENTS_ATTRIBUTE, SUPPORTED_EVENT_TYPES_PROPERTY);
-	 	
+
 		if (!element.hasAttribute(REGION_ATTRIBUTE)){
 			parserContext.getReaderContext().error("'region' attribute is required.",element);
 		}
-		 
+
 		listeningMessageProducer.addConstructorArgReference(element.getAttribute(REGION_ATTRIBUTE));
-		 
+
 		listeningMessageProducer.addPropertyReference(OUTPUT_CHANNEL_PROPERTY, channelName);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(listeningMessageProducer, element, ERROR_CHANNEL_ATTRIBUTE);
-		
+
 		return listeningMessageProducer.getBeanDefinition();
 	}
 

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/config/xml/GemfireOutboundChannelAdapterParser.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/config/xml/GemfireOutboundChannelAdapterParser.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2011 the original author or authors.
- * 
+ * Copyright 2002-2014 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -21,21 +21,21 @@ import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractOutboundChannelAdapterParser;
+import org.springframework.integration.gemfire.outbound.CacheWritingMessageHandler;
 import org.springframework.util.xml.DomUtils;
 
 /**
  * @author David Turanski
+ * @author Gary Russell
  * @since 2.1
  */
 public class GemfireOutboundChannelAdapterParser extends AbstractOutboundChannelAdapterParser {
-	 
+
 	private static final String CACHE_ENTRIES_PROPERTY = "cacheEntries";
 
 	private static final String CACHE_ENTRIES_ELEMENT = "cache-entries";
 
 	private static final String REGION_ATTRIBUTE = "region";
-	
-	private static final String GEMFIRE_OUTBOUND_CACHE_WRITING_MESSAGE_HANDLER = "org.springframework.integration.gemfire.outbound.CacheWritingMessageHandler";
 
 	/* (non-Javadoc)
 	 * @see org.springframework.integration.config.xml.AbstractOutboundChannelAdapterParser#parseConsumer(org.w3c.dom.Element, org.springframework.beans.factory.xml.ParserContext)
@@ -43,19 +43,19 @@ public class GemfireOutboundChannelAdapterParser extends AbstractOutboundChannel
 	@Override
 	protected AbstractBeanDefinition parseConsumer(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder cacheWritingMessageHandler = BeanDefinitionBuilder.genericBeanDefinition(
-				GEMFIRE_OUTBOUND_CACHE_WRITING_MESSAGE_HANDLER);
+				CacheWritingMessageHandler.class);
 		if (!element.hasAttribute(REGION_ATTRIBUTE)){
 			parserContext.getReaderContext().error("'region' attribute is required.",element);
 		}
-		 
+
 		cacheWritingMessageHandler.addConstructorArgReference(element.getAttribute(REGION_ATTRIBUTE));
-		
+
 		Element cacheEntries = DomUtils.getChildElementByTagName(element,CACHE_ENTRIES_ELEMENT);
 		if (cacheEntries != null) {
 			Map<?,?> map = parserContext.getDelegate().parseMapElement(cacheEntries,cacheWritingMessageHandler.getBeanDefinition());
 			cacheWritingMessageHandler.addPropertyValue(CACHE_ENTRIES_PROPERTY, map);
 		}
-		
+
 		return cacheWritingMessageHandler.getBeanDefinition();
 	}
 }

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/CacheListeningMessageProducer.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/CacheListeningMessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,10 @@ public class CacheListeningMessageProducer extends ExpressionMessageProducerSupp
 		this.supportedEventTypes = new HashSet<EventType>(Arrays.asList(eventTypes));
 	}
 
+	@Override
+	public String getComponentType() {
+		return "gemfire:inbound-channel-adapter";
+	}
 
 	@Override
 	protected void doStart() {

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/ContinuousQueryMessageProducer.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/inbound/ContinuousQueryMessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,11 @@ public class ContinuousQueryMessageProducer extends ExpressionMessageProducerSup
 	}
 
 	@Override
+	public String getComponentType() {
+		return "gemfire:cq-inbound-channel-adapter";
+	}
+
+	@Override
 	protected void onInit() {
 		super.onInit();
 		if (queryName == null) {
@@ -108,6 +113,7 @@ public class ContinuousQueryMessageProducer extends ExpressionMessageProducerSup
 	 * org.springframework.data.gemfire.listener.QueryListener#onEvent(com.gemstone
 	 * .gemfire.cache.query.CqEvent)
 	 */
+	@Override
 	public void onEvent(CqEvent event) {
 		if (isEventSupported(event)) {
 			if (logger.isDebugEnabled()) {

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/outbound/CacheWritingMessageHandler.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/outbound/CacheWritingMessageHandler.java
@@ -25,9 +25,9 @@ import org.springframework.data.gemfire.GemfireCallback;
 import org.springframework.data.gemfire.GemfireTemplate;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
-import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.util.Assert;
 
 import com.gemstone.gemfire.GemFireCheckedException;
@@ -37,7 +37,7 @@ import com.gemstone.gemfire.cache.Region;
 /**
  * A {@link MessageHandler} implementation that writes to a GemFire Region. The
  * Message's payload must be an instance of java.util.Map.
- * 
+ *
  * @author Mark Fisher
  * @author David Turanski
  * @since 2.1
@@ -51,22 +51,28 @@ public class CacheWritingMessageHandler extends AbstractMessageHandler {
 	public CacheWritingMessageHandler(Region region) {
 		Assert.notNull(region, "region must not be null");
 		this.gemfireTemplate.setRegion(region);
-		this.gemfireTemplate.afterPropertiesSet(); 
+		this.gemfireTemplate.afterPropertiesSet();
 	}
-	
+
+	@Override
+	public String getComponentType() {
+		return "gemfire:outbound-channel-adapter";
+	}
+
 	@Override
 	public void handleMessageInternal(Message<?> message) {
 		Object payload = message.getPayload();
 		Map<?, ?> cacheValues = (cacheEntryExpressions.size() > 0)?parseCacheEntries(message):null;
-		
+
 		if (cacheValues == null) {
 			Assert.isTrue(payload instanceof Map, "If cache entry expressions are not configured, then payload must be a Map");
 			cacheValues = (Map<?, ?>) payload;
 		}
 
 		final Map<?, ?> map = cacheValues;
-		
+
 		this.gemfireTemplate.execute(new GemfireCallback<Object>() {
+			@Override
 			@SuppressWarnings({ "rawtypes", "unchecked" })
 			public Object doInGemfire(Region region) throws GemFireCheckedException, GemFireException {
 				region.putAll(map);
@@ -89,11 +95,11 @@ public class CacheWritingMessageHandler extends AbstractMessageHandler {
 	}
 
 	public void setCacheEntries(Map<String, String> cacheEntries) {
-		
+
 		if (cacheEntryExpressions.size() > 0) {
 			cacheEntryExpressions.clear();
 		}
-		
+
 		for (Entry<String, String> cacheEntry : cacheEntries.entrySet()) {
 			this.cacheEntryExpressions.put(new SpelExpressionParser().parseExpression(cacheEntry.getKey()),
 					new SpelExpressionParser().parseExpression(cacheEntry.getValue()));

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -343,6 +343,11 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 	}
 
 	@Override
+	public String getComponentType() {
+		return (this.expectReply ? "http:outbound-gateway" : "http:outbound-channel-adapter");
+	}
+
+	@Override
 	protected void doInit() {
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionEventListeningMessageProducer.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionEventListeningMessageProducer.java
@@ -54,6 +54,11 @@ public class TcpConnectionEventListeningMessageProducer extends MessageProducerS
 	}
 
 	@Override
+	public String getComponentType() {
+		return "ip:tcp-connection-event-inbound-channel-adapter";
+	}
+
+	@Override
 	public void onApplicationEvent(TcpConnectionEvent event) {
 		if (this.isRunning()) {
 			if (CollectionUtils.isEmpty(this.eventTypes)) {

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageHandler.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.integration.MessageRejectedException;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -31,6 +30,7 @@ import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.util.LinkedCaseInsensitiveMap;
 
 /**
@@ -96,6 +96,11 @@ public class JdbcMessageHandler extends AbstractMessageHandler {
 
 	public void setSqlParameterSourceFactory(SqlParameterSourceFactory sqlParameterSourceFactory) {
 		this.sqlParameterSourceFactory = sqlParameterSourceFactory;
+	}
+
+	@Override
+	public String getComponentType() {
+		return "jdbc:outbound-channel-adapter";
 	}
 
 	/**

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcOutboundGateway.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcOutboundGateway.java
@@ -106,6 +106,11 @@ public class JdbcOutboundGateway extends AbstractReplyProducingMessageHandler im
 	}
 
 	@Override
+	public String getComponentType() {
+		return "jdbc:outbound-gateway";
+	}
+
+	@Override
 	protected void doInit() {
 		if (this.maxRowsPerPoll != null) {
 			Assert.notNull(poller, "If you want to set 'maxRowsPerPoll', then you must provide a 'selectQuery'.");

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/StoredProcMessageHandler.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/StoredProcMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -59,6 +59,11 @@ public class StoredProcMessageHandler extends AbstractMessageHandler implements 
 		Assert.notNull(storedProcExecutor, "storedProcExecutor must not be null.");
 		this.executor = storedProcExecutor;
 
+	}
+
+	@Override
+	public String getComponentType() {
+		return "jdbc:stored-proc-outbound-channel-adapter";
 	}
 
 	/**

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/StoredProcOutboundGateway.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/StoredProcOutboundGateway.java
@@ -50,6 +50,11 @@ public class StoredProcOutboundGateway extends AbstractReplyProducingMessageHand
 	}
 
 	@Override
+	public String getComponentType() {
+		return "jdbc:stored-proc-outbound-gateway";
+	}
+
+	@Override
 	protected Object handleRequestMessage(Message<?> requestMessage) {
 
 		Map<String, Object> resultMap = executor.executeStoredProcedure(requestMessage);

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/NotificationPublishingMessageHandler.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/NotificationPublishingMessageHandler.java
@@ -94,6 +94,11 @@ public class NotificationPublishingMessageHandler extends AbstractMessageHandler
 	}
 
 	@Override
+	public String getComponentType() {
+		return "jmx:notification-publishing-channel-adapter";
+	}
+
+	@Override
 	public final void onInit() throws Exception {
 		Assert.isTrue(this.getBeanFactory() instanceof ListableBeanFactory, "A ListableBeanFactory is required.");
 		Map<String, MBeanExporter> exporters = BeanFactoryUtils.beansOfTypeIncludingAncestors(

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
@@ -107,6 +107,11 @@ public class OperationInvokingMessageHandler extends AbstractReplyProducingMessa
 	}
 
 	@Override
+	public String getComponentType() {
+		return "jmx:operation-invoking-channel-adapter";
+	}
+
+	@Override
 	protected void doInit() {
 		Assert.notNull(this.server, "MBeanServer is required.");
 	}

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGateway.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGateway.java
@@ -62,6 +62,11 @@ public class JpaOutboundGateway extends AbstractReplyProducingMessageHandler {
 	}
 
 	@Override
+	public String getComponentType() {
+		return "jpa:outbound-gateway";
+	}
+
+	@Override
 	protected void doInit() {
 		this.jpaExecutor.setBeanFactory(this.getBeanFactory());
 	}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailSendingMessageHandler.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailSendingMessageHandler.java
@@ -20,7 +20,6 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.mapping.MessageMappingException;
 import org.springframework.mail.MailMessage;
@@ -30,6 +29,7 @@ import org.springframework.mail.javamail.MimeMailMessage;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -66,6 +66,10 @@ public class MailSendingMessageHandler extends AbstractMessageHandler {
 		this.mailSender = mailSender;
 	}
 
+	@Override
+	public String getComponentType() {
+		return "mail:outbound-channel-adapter";
+	}
 
 	@Override
 	protected final void handleMessageInternal(Message<?> message) {

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSource.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSource.java
@@ -166,6 +166,11 @@ public class MongoDbMessageSource extends IntegrationObjectSupport
 	}
 
 	@Override
+	public String getComponentType() {
+		return "mongo:inbound-channel-adapter";
+	}
+
+	@Override
 	protected void onInit() throws Exception {
 		this.evaluationContext =
 					ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandler.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandler.java
@@ -98,6 +98,11 @@ public class MongoDbStoringMessageHandler extends AbstractMessageHandler {
 	}
 
 	@Override
+	public String getComponentType() {
+		return "mongo:outbound-channel-adapter";
+	}
+
+	@Override
 	protected void onInit() throws Exception {
 		this.evaluationContext =
 					ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -70,16 +70,16 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter extends MessagePro
 	}
 
 	@Override
+	public String getComponentType(){
+		return "mqtt:inbound-channel-adapter";
+	}
+
+	@Override
 	protected void onInit() {
 		super.onInit();
 		if (this.converter == null) {
 			this.converter = new DefaultPahoMessageConverter();
 		}
-	}
-
-	@Override
-	public String getComponentType(){
-		return "mqtt:inbound-channel-adapter";
 	}
 
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/AbstractMqttMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/AbstractMqttMessageHandler.java
@@ -87,6 +87,11 @@ public abstract class AbstractMqttMessageHandler extends AbstractMessageHandler 
 	}
 
 	@Override
+	public String getComponentType() {
+		return "mqtt:outbound-channel-adapter";
+	}
+
+	@Override
 	protected void onInit() throws Exception {
 		super.onInit();
 		if (this.converter == null) {
@@ -152,10 +157,5 @@ public abstract class AbstractMqttMessageHandler extends AbstractMessageHandler 
 	protected abstract void connectIfNeeded();
 
 	protected abstract void publish(String topic, Object mqttMessage) throws Exception;
-
-	@Override
-	public String getComponentType() {
-		return "mqtt:outbound-channel-adapter";
-	}
 
 }

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisStoreMessageSource.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisStoreMessageSource.java
@@ -141,6 +141,11 @@ public class RedisStoreMessageSource extends IntegrationObjectSupport
 	}
 
 	@Override
+	public String getComponentType() {
+		return "redis:store-inbound-channel-adapter";
+	}
+
+	@Override
 	protected void onInit() throws Exception {
 		this.evaluationContext =
 					ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisOutboundGateway.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisOutboundGateway.java
@@ -88,6 +88,11 @@ public class RedisOutboundGateway extends AbstractReplyProducingMessageHandler
 	}
 
 	@Override
+	public String getComponentType() {
+		return "redis:outbound-gateway";
+	}
+
+	@Override
 	protected Object handleRequestMessage(Message<?> requestMessage) {
 		final String command = this.commandExpression.getValue(this.evaluationContext, requestMessage, String.class);
 		Assert.notNull(command, "The 'command' must not evaluate to 'null'.");

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisPublishingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisPublishingMessageHandler.java
@@ -93,6 +93,11 @@ public class RedisPublishingMessageHandler extends AbstractMessageHandler implem
 	}
 
 	@Override
+	public String getComponentType() {
+		return "redis:outbound-channel-adapter";
+	}
+
+	@Override
 	protected void onInit() throws Exception {
 		Assert.notNull(topicExpression, "'topicExpression' must not be null.");
 		if (this.messageConverter instanceof BeanFactoryAware) {

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisQueueOutboundChannelAdapter.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisQueueOutboundChannelAdapter.java
@@ -84,7 +84,7 @@ public class RedisQueueOutboundChannelAdapter extends AbstractMessageHandler imp
 
 	@Override
 	public String getComponentType() {
-		return "redis:outbound-channel-adapter";
+		return "redis:queue-outbound-channel-adapter";
 	}
 
 	@Override

--- a/spring-integration-rmi/src/main/java/org/springframework/integration/rmi/RmiOutboundGateway.java
+++ b/spring-integration-rmi/src/main/java/org/springframework/integration/rmi/RmiOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,11 @@ public class RmiOutboundGateway extends AbstractReplyProducingMessageHandler {
 
 	public void setReplyChannel(MessageChannel replyChannel) {
 		this.setOutputChannel(replyChannel);
+	}
+
+	@Override
+	public String getComponentType() {
+		return "rmi:outbound-gateway";
 	}
 
 	@Override

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/gateway/SftpOutboundGateway.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/gateway/SftpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,11 @@ public class SftpOutboundGateway extends AbstractRemoteFileOutboundGateway<LsEnt
 		DirectFieldAccessor accessor = new DirectFieldAccessor(file);
 		accessor.setPropertyValue("filename", directory + file.getFilename());
 		return file;
+	}
+
+	@Override
+	public String getComponentType() {
+		return "sftp:outbound-gateway";
 	}
 
 }

--- a/spring-integration-stream/src/main/java/org/springframework/integration/stream/ByteStreamWritingMessageHandler.java
+++ b/spring-integration-stream/src/main/java/org/springframework/integration/stream/ByteStreamWritingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,14 +23,14 @@ import java.io.OutputStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessagingException;
-import org.springframework.messaging.MessageHandler;
 import org.springframework.integration.handler.AbstractMessageHandler;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
 
 /**
  * A {@link MessageHandler} that writes a byte array to an {@link OutputStream}.
- * 
+ *
  * @author Mark Fisher
  */
 public class ByteStreamWritingMessageHandler extends AbstractMessageHandler {
@@ -53,7 +53,12 @@ public class ByteStreamWritingMessageHandler extends AbstractMessageHandler {
 		}
 	}
 
+	@Override
+	public String getComponentType() {
+		return "stream:outbound-channel-adapter";
+	}
 
+	@Override
 	protected void handleMessageInternal(Message<?> message) {
 		Object payload = message.getPayload();
 		if (payload == null) {

--- a/spring-integration-stream/src/main/java/org/springframework/integration/stream/CharacterStreamWritingMessageHandler.java
+++ b/spring-integration-stream/src/main/java/org/springframework/integration/stream/CharacterStreamWritingMessageHandler.java
@@ -129,6 +129,11 @@ public class CharacterStreamWritingMessageHandler extends AbstractMessageHandler
 	}
 
 	@Override
+	public String getComponentType() {
+		return "stream:outbound-channel-adapter";
+	}
+
+	@Override
 	protected void handleMessageInternal(Message<?> message) {
 		Object payload = message.getPayload();
 		if (payload == null) {

--- a/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/TcpSyslogReceivingChannelAdapter.java
+++ b/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/TcpSyslogReceivingChannelAdapter.java
@@ -51,6 +51,11 @@ public class TcpSyslogReceivingChannelAdapter extends SyslogReceivingChannelAdap
 	}
 
 	@Override
+	public String getComponentType() {
+		return "syslog:inbound-channel-adapter(tcp)";
+	}
+
+	@Override
 	protected void onInit() {
 		super.onInit();
 		if (this.connectionFactory == null) {

--- a/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/UdpSyslogReceivingChannelAdapter.java
+++ b/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/UdpSyslogReceivingChannelAdapter.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.integration.syslog.inbound;
 
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessagingException;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.messaging.MessageHandler;
 import org.springframework.integration.ip.udp.UnicastReceivingChannelAdapter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
 
 /**
  * UDP implementation of a syslog inbound channel adapter.
@@ -34,6 +34,11 @@ public class UdpSyslogReceivingChannelAdapter extends SyslogReceivingChannelAdap
 
 	public void setUdpAdapter(UnicastReceivingChannelAdapter udpAdpter) {
 		this.udpAdapter = udpAdpter;
+	}
+
+	@Override
+	public String getComponentType() {
+		return "syslog:inbound-channel-adapter(udp)";
 	}
 
 	@Override

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/outbound/DirectMessageSendingMessageHandler.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/outbound/DirectMessageSendingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors
+ * Copyright 2002-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.twitter.outbound;
 
-import org.springframework.messaging.Message;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.twitter.core.TwitterHeaders;
+import org.springframework.messaging.Message;
 import org.springframework.social.twitter.api.Twitter;
 import org.springframework.util.Assert;
 
@@ -40,6 +40,10 @@ public class DirectMessageSendingMessageHandler extends AbstractMessageHandler {
 		this.twitter = twitter;
 	}
 
+	@Override
+	public String getComponentType() {
+		return "twitter:dm-outbound-channel-adapter";
+	}
 
 	@Override
 	protected void handleMessageInternal(Message<?> message) throws Exception {
@@ -47,12 +51,12 @@ public class DirectMessageSendingMessageHandler extends AbstractMessageHandler {
 				"Consider adding a transformer to the message flow in front of this adapter.");
 		Object toUser = message.getHeaders().get(TwitterHeaders.DM_TARGET_USER_ID);
 		Assert.isTrue(toUser instanceof String || toUser instanceof Number,
-				"the header '" + TwitterHeaders.DM_TARGET_USER_ID + 
+				"the header '" + TwitterHeaders.DM_TARGET_USER_ID +
 				"' must contain either a String (a screenname) or an number (a user ID)");
 		String payload = (String) message.getPayload();
 		if (toUser instanceof Number) {
 			this.twitter.directMessageOperations().sendDirectMessage(((Number) toUser).longValue(), payload);
-		} 
+		}
 		else if (toUser instanceof String) {
 			this.twitter.directMessageOperations().sendDirectMessage((String) toUser, payload);
 		}

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/outbound/StatusUpdatingMessageHandler.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/outbound/StatusUpdatingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors
+ * Copyright 2002-2014 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.twitter.outbound;
 
+import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
-import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.social.twitter.api.Tweet;
 import org.springframework.social.twitter.api.Twitter;
 import org.springframework.util.Assert;
@@ -40,6 +40,10 @@ public class StatusUpdatingMessageHandler extends AbstractMessageHandler {
 		this.twitter = twitter;
 	}
 
+	@Override
+	public String getComponentType() {
+		return "twitter:outbound-channel-adapter";
+	}
 
 	@Override
 	protected void handleMessageInternal(Message<?> message) throws Exception {

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
@@ -76,6 +76,17 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 		this(uri, marshaller, (WebServiceMessageFactory) null);
 	}
 
+	@Override
+	protected Object doHandle(String uri, Message<?> requestMessage, WebServiceMessageCallback requestCallback) {
+		Object reply = this.getWebServiceTemplate().sendAndReceive(uri,
+				new MarshallingRequestMessageCallback(requestCallback, requestMessage), new MarshallingResponseMessageExtractor());
+		return reply;
+	}
+
+	@Override
+	public String getComponentType() {
+		return "ws:outbound-gateway";
+	}
 
 	/**
 	 * Sets the provided Marshaller and Unmarshaller on this gateway's WebServiceTemplate.
@@ -97,13 +108,6 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 		Assert.notNull(unmarshaller, "unmarshaller must not be null");
 		this.marshaller = marshaller;
 		this.unmarshaller = unmarshaller;
-	}
-
-	@Override
-	protected Object doHandle(String uri, Message<?> requestMessage, WebServiceMessageCallback requestCallback) {
-		Object reply = this.getWebServiceTemplate().sendAndReceive(uri,
-				new MarshallingRequestMessageCallback(requestCallback, requestMessage), new MarshallingResponseMessageExtractor());
-		return reply;
 	}
 
 	private class MarshallingRequestMessageCallback extends RequestMessageCallback {

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,10 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 		this.sourceExtractor = (sourceExtractor != null) ? sourceExtractor : new DefaultSourceExtractor();
 	}
 
+	@Override
+	public String getComponentType() {
+		return "ws:outbound-gateway";
+	}
 
 	@Override
 	protected Object doHandle(String uri, final Message<?> requestMessage, final WebServiceMessageCallback requestCallback) {
@@ -163,6 +167,7 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 
 	private static class DefaultSourceExtractor extends TransformerObjectSupport implements SourceExtractor<DOMSource> {
 
+		@Override
 		public DOMSource extractData(Source source) throws IOException, TransformerException {
 			if (source instanceof DOMSource) {
 				return (DOMSource)source;

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/MarshallingTransformer.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/MarshallingTransformer.java
@@ -75,6 +75,11 @@ public class MarshallingTransformer extends AbstractTransformer {
 	}
 
 	@Override
+	public String getComponentType() {
+		return "xml:marshalling-transformer";
+	}
+
+	@Override
 	public Object doTransform(Message<?> message) {
 		Object source = (this.extractPayload) ? message.getPayload() : message;
 		Object transformedPayload = null;

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/UnmarshallingTransformer.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/UnmarshallingTransformer.java
@@ -81,6 +81,10 @@ public class UnmarshallingTransformer extends AbstractPayloadTransformer<Object,
 		this.alwaysUseSourceFactory = alwaysUseSourceFactory;
 	}
 
+	@Override
+	public String getComponentType() {
+		return "xml:unmarshalling-transformer";
+	}
 
 	@Override
 	public Object transformPayload(Object payload) {

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/XPathTransformer.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/XPathTransformer.java
@@ -107,6 +107,11 @@ public class XPathTransformer extends AbstractTransformer {
 	}
 
 	@Override
+	public String getComponentType() {
+		return "xml:xpath-transformer";
+	}
+
+	@Override
 	protected Object doTransform(Message<?> message) throws Exception {
 		Node node = this.converter.convertToNode(message.getPayload());
 		Object result = null;

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/outbound/ChatMessageSendingMessageHandler.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/outbound/ChatMessageSendingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,12 @@ package org.springframework.integration.xmpp.outbound;
 
 import org.jivesoftware.smack.XMPPConnection;
 
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.integration.xmpp.XmppHeaders;
 import org.springframework.integration.xmpp.core.AbstractXmppConnectionAwareMessageHandler;
 import org.springframework.integration.xmpp.support.DefaultXmppHeaderMapper;
 import org.springframework.integration.xmpp.support.XmppHeaderMapper;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -52,6 +52,11 @@ public class ChatMessageSendingMessageHandler extends AbstractXmppConnectionAwar
 	public void setHeaderMapper(XmppHeaderMapper headerMapper) {
 		Assert.notNull(headerMapper, "headerMapper must not be null");
 		this.headerMapper = headerMapper;
+	}
+
+	@Override
+	public String getComponentType() {
+		return "xmpp:outbound-channel-adapter";
 	}
 
 	@Override

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/outbound/PresenceSendingMessageHandler.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/outbound/PresenceSendingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@ package org.springframework.integration.xmpp.outbound;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.Presence;
 
-import org.springframework.messaging.Message;
 import org.springframework.integration.xmpp.core.AbstractXmppConnectionAwareMessageHandler;
+import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
 /**
- * MessageHandler that publishes updated Presence values for a given XMPP connection. 
+ * MessageHandler that publishes updated Presence values for a given XMPP connection.
  *
  * @author Josh Long
  * @author Oleg Zhurakousky
@@ -40,6 +40,10 @@ public class PresenceSendingMessageHandler extends AbstractXmppConnectionAwareMe
 		super(xmppConnection);
 	}
 
+	@Override
+	public String getComponentType() {
+		return "xmpp:presence-outbound-channel-adapter";
+	}
 
 	@Override
 	protected void handleMessageInternal(Message<?> message) throws Exception {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-2738

Add a `getComponentType()` method for all handlers,
message producers, and message sources that implement
`NamedComponent` (see `SPCA.getComponentType()`).
