### PR TITLE
INT-3382: Add MG `LazyLoadMessagesInterceptor`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -320,7 +320,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageH
 					logger.debug("Cancel 'forceComplete' scheduling for MessageGroup with Correlation Key [ " + correlationKey + "].");
 				}
 			}
-			MessageGroup messageGroup = messageStore.getMessageGroup(correlationKey);
+			MessageGroup messageGroup = messageStore.getMessageGroupMetadata(correlationKey);
 			if (this.sequenceAware){
 				messageGroup = new SequenceAwareMessageGroup(messageGroup);
 			}
@@ -418,7 +418,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageH
 				 * for reaping if it's empty (and both timestamps are unaltered).
 				 */
 				if (!group.isComplete()) {
-					groupNow = this.messageStore.getMessageGroup(correlationKey);
+					groupNow = this.messageStore.getMessageGroupMetadata(correlationKey);
 				}
 				long lastModifiedNow = groupNow.getLastModified();
 				int groupSize = groupNow.size();

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -15,16 +15,16 @@ package org.springframework.integration.aggregator;
 
 import java.util.Collection;
 
-import org.springframework.messaging.Message;
-import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.messaging.Message;
 
 /**
  * Resequencer specific implementation of {@link AbstractCorrelatingMessageHandler}.
  * Will remove {@link MessageGroup}s only if 'sequenceSize' is provided and reached.
  *
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  * @since 2.1
  */
 public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandler {
@@ -49,12 +49,9 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 	@Override
 	protected void afterRelease(MessageGroup messageGroup, Collection<Message<?>> completedMessages) {
 
-		int size = messageGroup.getMessages().size();
-		int sequenceSize = 0;
-		Message<?> message = messageGroup.getOne();
-		if (message != null){
-			sequenceSize = new IntegrationMessageHeaderAccessor(message).getSequenceSize();
-		}
+		int size = messageGroup.size();
+		int sequenceSize = messageGroup.getSequenceSize();
+
 		// If there is no sequence then it must be incomplete or unbounded
 		if (sequenceSize > 0 && sequenceSize == size){
 			remove(messageGroup);

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/SequenceSizeReleaseStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/SequenceSizeReleaseStrategy.java
@@ -38,6 +38,7 @@ import org.springframework.messaging.Message;
  * @author Dave Syer
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  */
 public class SequenceSizeReleaseStrategy implements ReleaseStrategy {
 
@@ -70,13 +71,14 @@ public class SequenceSizeReleaseStrategy implements ReleaseStrategy {
 
 		boolean canRelease = false;
 
-		Collection<Message<?>> messages = messageGroup.getMessages();
-
-		if (releasePartialSequences && !messages.isEmpty()) {
+		int size = messageGroup.size();
+		if (releasePartialSequences && size > 0) {
 
 			if (logger.isTraceEnabled()) {
 				logger.trace("Considering partial release of group [" + messageGroup + "]");
 			}
+
+			Collection<Message<?>> messages = messageGroup.getMessages();
 			List<Message<?>> sorted = new ArrayList<Message<?>>(messages);
 			Collections.sort(sorted, comparator);
 
@@ -84,17 +86,15 @@ public class SequenceSizeReleaseStrategy implements ReleaseStrategy {
 			int lastReleasedMessageSequence = messageGroup.getLastReleasedMessageSequenceNumber();
 
 			if (nextSequenceNumber - lastReleasedMessageSequence == 1){
-				canRelease = true;;
+				canRelease = true;
 			}
 		}
 		else {
-			int size = messages.size();
-
 			if (size == 0){
 				canRelease = true;
 			}
 			else {
-				int sequenceSize = new IntegrationMessageHeaderAccessor(messageGroup.getOne()).getSequenceSize();
+				int sequenceSize = messageGroup.getSequenceSize();
 				// If there is no sequence then it must be incomplete....
 				if (sequenceSize == size){
 					canRelease = true;

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/BasicMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/BasicMessageGroupStore.java
@@ -22,6 +22,7 @@ import org.springframework.messaging.Message;
  * Defines a minimal message group store with basic capabilities.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 4.0
  *
  */
@@ -29,7 +30,6 @@ public interface BasicMessageGroupStore {
 
 	/**
 	 * Returns the size of this MessageGroup.
-	 *
 	 * @param groupId The group identifier.
 	 * @return The size.
 	 */
@@ -39,15 +39,20 @@ public interface BasicMessageGroupStore {
 	/**
 	 * Return all Messages currently in the MessageStore that were stored using
 	 * {@link #addMessageToGroup(Object, Message)} with this group id.
-	 *
 	 * @param groupId The group identifier.
 	 * @return A group of messages, empty if none exists for this key.
 	 */
 	MessageGroup getMessageGroup(Object groupId);
 
 	/**
+	 * Return the {@link MessageGroup} with its basic info, but without messages.
+	 * @param groupId The group identifier.
+	 * @return the {@link MessageGroup}.
+	 */
+	MessageGroup getMessageGroupMetadata(Object groupId);
+
+	/**
 	 * Store a message with an association to a group id. This can be used to group messages together.
-	 *
 	 * @param groupId The group id to store the message under.
 	 * @param message A message.
 	 * @return The message group.
@@ -57,7 +62,6 @@ public interface BasicMessageGroupStore {
 	/**
 	 * Polls Message from this {@link MessageGroup} (in FIFO style if supported by the implementation)
 	 * while also removing the polled {@link Message}
-	 *
 	 * @param groupId The group identifier.
 	 * @return The message.
 	 */
@@ -65,8 +69,8 @@ public interface BasicMessageGroupStore {
 
 	/**
 	 * Remove the message group with this id.
-	 *
 	 * @param groupId The id of the group to remove.
 	 */
 	void removeMessageGroup(Object groupId);
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/LazyLoadMessagesInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/LazyLoadMessagesInterceptor.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.store;
+
+import java.util.Collection;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.NameMatchMethodPointcutAdvisor;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.messaging.Message;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * @author Artem Bilan
+ * @since 4.0
+ */
+public class LazyLoadMessagesInterceptor implements MethodInterceptor {
+
+	private final static Log logger = LogFactory.getLog(LazyLoadMessagesInterceptor.class);
+
+	private final MessageGroupStore messageGroupStore;
+
+	private final SimpleMessageGroup messageGroup;
+
+	private final Object groupId;
+
+	private volatile Message<?> oneMessage;
+
+	private LazyLoadMessagesInterceptor(MessageGroupStore messageGroupStore, SimpleMessageGroup messageGroup) {
+		this.messageGroupStore = messageGroupStore;
+		this.messageGroup = messageGroup;
+		this.groupId = messageGroup.getGroupId();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Object invoke(MethodInvocation invocation) throws Throwable {
+		Object result = invocation.proceed();
+		String methodName = invocation.getMethod().getName();
+		if ("getMessages".equals(methodName)) {
+			Collection<Message<?>> messages = (Collection<Message<?>>) result;
+			if (CollectionUtils.isEmpty(messages)) {
+				logger.debug("Lazy loading of messages for messageGroup: " + this.groupId);
+				MessageGroup messageGroup = this.messageGroupStore.getMessageGroup(this.groupId);
+				messages = messageGroup.getMessages();
+				for (Message<?> message : messages) {
+					this.messageGroup.add(message);
+				}
+				this.oneMessage = null;
+				return messages;
+			}
+		}
+		else if ("getOne".equals(methodName)) {
+			if (result == null) {
+				if (this.oneMessage == null) {
+					logger.debug("Lazy loading of one message for messageGroup: " + this.groupId);
+					this.oneMessage = this.messageGroupStore.getOneMessageFromGroup(this.groupId);
+				}
+				return this.oneMessage;
+			}
+		}
+		else if ("getSequenceSize".equals(methodName)) {
+			if (0 == (Integer) result) {
+				if (this.oneMessage == null) {
+					logger.debug("Lazy loading of one message for messageGroup: " + this.groupId);
+					this.oneMessage = this.messageGroupStore.getOneMessageFromGroup(this.groupId);
+				}
+				if (this.oneMessage != null) {
+					return new IntegrationMessageHeaderAccessor(this.oneMessage).getSequenceSize();
+				}
+			}
+		}
+		else {
+			if (0 == (Integer) result) {
+				return this.messageGroupStore.messageGroupSize(this.groupId);
+			}
+		}
+		return result;
+	}
+
+
+	public static MessageGroup proxyMessageGroup(SimpleMessageGroup messageGroup, MessageGroupStore messageGroupStore,
+			ClassLoader classLoader) {
+		MethodInterceptor messagesInterceptor = new LazyLoadMessagesInterceptor(messageGroupStore, messageGroup);
+		NameMatchMethodPointcutAdvisor advisor = new NameMatchMethodPointcutAdvisor(messagesInterceptor);
+		advisor.setMappedNames(new String[] {"getMessages", "size", "getOne", "getSequenceSize"});
+		ProxyFactory proxyFactory = new ProxyFactory(messageGroup);
+		proxyFactory.addAdvisor(advisor);
+		return (MessageGroup) proxyFactory.getProxy(classLoader);
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -23,6 +23,7 @@ import org.springframework.messaging.Message;
  * @author Dave Syer
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 2.0
  *
@@ -100,6 +101,14 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	 * @param groupId The group identifier.
 	 */
 	void completeGroup(Object groupId);
+
+	/**
+	 * Return the one {@link org.springframework.messaging.Message} from {@link org.springframework.integration.store.MessageGroup}.
+	 * @param groupId The group identifier.
+	 * @return the {@link org.springframework.messaging.Message}.
+	 * @since 4.0
+	 */
+	Message<?> getOneMessageFromGroup(Object groupId);
 
 	/**
 	 * Invoked when a MessageGroupStore expires a group.

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
@@ -158,6 +158,16 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 	}
 
 	@Override
+	public MessageGroup getMessageGroupMetadata(Object groupId) {
+		return getMessageGroup(groupId);
+	}
+
+	@Override
+	public Message<?> getOneMessageFromGroup(Object groupId) {
+		return getMessageGroup(groupId).getOne();
+	}
+
+	@Override
 	public MessageGroup addMessageToGroup(Object groupId, Message<?> message) {
 		if (!groupUpperBound.tryAcquire(0)) {
 			throw new MessagingException(this.getClass().getSimpleName()

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 /**
  * @author Dave Syer
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class MessageStoreTests {
 
@@ -96,7 +97,17 @@ public class MessageStoreTests {
 			return removed ? new SimpleMessageGroup(correlationKey) : testMessages;
 		}
 
+		@Override
+		public MessageGroup getMessageGroupMetadata(Object groupId) {
+			return getMessageGroup(groupId);
+		}
+
 		public MessageGroup removeMessageFromGroup(Object key, Message<?> messageToRemove) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Message<?> getOneMessageFromGroup(Object groupId) {
 			throw new UnsupportedOperationException();
 		}
 

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -465,6 +465,11 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 		return new SimpleMessageGroup(groupId);
 	}
 
+	@Override
+	public MessageGroup getMessageGroupMetadata(Object groupId) {
+		return getMessageGroup(groupId);
+	}
+
 	/**
 	 * Method not implemented.
 	 *

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
@@ -13,11 +13,7 @@
 
 package org.springframework.integration.jdbc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -105,7 +101,7 @@ public class DelayerHandlerRescheduleIntegrationTests {
 		String delayerMessageGroupId = UUIDConverter.getUUID(DELAYER_ID + ".messageGroupId").toString();
 
 		assertEquals(1, messageStore.getMessageGroupCount());
-		assertEquals(delayerMessageGroupId, messageStore.iterator().next().getGroupId());
+		assertEquals(delayerMessageGroupId, messageStore.iterator().next().getGroupId().toString());
 		assertEquals(2, messageStore.messageGroupSize(delayerMessageGroupId));
 		assertEquals(2, messageStore.getMessageCountForAllMessageGroups());
 		MessageGroup messageGroup = messageStore.getMessageGroup(delayerMessageGroupId);

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreRegionTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreRegionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
 /**
  * @author Gunnar Hillert
+ * @author Artem Bilan
  */
 public class JdbcMessageStoreRegionTests {
 
@@ -63,10 +64,12 @@ public class JdbcMessageStoreRegionTests {
 	public void beforeTest() {
 		this.jdbcTemplate = new JdbcTemplate(dataSource);
 		this.messageStore1 = new JdbcMessageStore(dataSource);
-		messageStore1.setRegion("region1");
+		this.messageStore1.setRegion("region1");
+		this.messageStore1.setBeanClassLoader(this.getClass().getClassLoader());
 
 		this.messageStore2 = new JdbcMessageStore(dataSource);
 		this.messageStore2.setRegion("region2");
+		this.messageStore2.setBeanClassLoader(this.getClass().getClassLoader());
 	}
 
 	@After

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreTests.java
@@ -83,7 +83,8 @@ public class JdbcMessageStoreTests {
 
 	@Before
 	public void init() {
-		messageStore = new JdbcMessageStore(dataSource);
+		this.messageStore = new JdbcMessageStore(this.dataSource);
+		this.messageStore.setBeanClassLoader(this.getClass().getClassLoader());
 	}
 
 	@Test
@@ -447,9 +448,11 @@ public class JdbcMessageStoreTests {
 
 		final JdbcMessageStore messageStore1 = new JdbcMessageStore(dataSource);
 		messageStore1.setRegion(region1);
+		messageStore1.setBeanClassLoader(this.getClass().getClassLoader());
 
 		final JdbcMessageStore messageStore2 = new JdbcMessageStore(dataSource);
-		messageStore1.setRegion(region2);
+		messageStore2.setRegion(region2);
+		messageStore2.setBeanClassLoader(this.getClass().getClassLoader());
 
 		final Message<String> message = MessageBuilder.withPayload("foo").build();
 
@@ -474,8 +477,8 @@ public class JdbcMessageStoreTests {
 		LOG.info("messageFromRegion1: " + messageFromRegion1.getHeaders().getId() + "; Sequence #: " + new IntegrationMessageHeaderAccessor(messageFromRegion1).getSequenceNumber());
 		LOG.info("messageFromRegion2: " + messageFromRegion2.getHeaders().getId() + "; Sequence #: " + new IntegrationMessageHeaderAccessor(messageFromRegion1).getSequenceNumber());
 
-		assertEquals(Integer.valueOf(1), messageFromRegion1.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER));
-		assertEquals(Integer.valueOf(2), messageFromRegion2.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER));
+		assertEquals(1, messageFromRegion1.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER));
+		assertEquals(2, messageFromRegion2.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER));
 
 	}
 
@@ -494,6 +497,7 @@ public class JdbcMessageStoreTests {
 		 * (discard behavior performed by the AbstractCorrelatingMessageHandler.handleMessageInternal)
 		 */
 		final JdbcMessageStore messageStore = new JdbcMessageStore(dataSource);
+		messageStore.setBeanClassLoader(this.getClass().getClassLoader());
 		//init
 		String groupId = "group";
 		//build the messages

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
@@ -74,7 +74,8 @@ public class MongoDbChannelMessageStore extends AbstractConfigurableMongoDbMessa
 		this(mongoDbFactory, null, collectionName);
 	}
 
-	public MongoDbChannelMessageStore(MongoDbFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter, String collectionName) {
+	public MongoDbChannelMessageStore(MongoDbFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter,
+			String collectionName) {
 		super(mongoDbFactory, mappingMongoConverter, collectionName);
 	}
 
@@ -121,6 +122,11 @@ public class MongoDbChannelMessageStore extends AbstractConfigurableMongoDbMessa
 	@Override
 	public MessageGroup getMessageGroup(Object groupId) {
 		return new SimpleMessageGroup(groupId);
+	}
+
+	@Override
+	public MessageGroup getMessageGroupMetadata(Object groupId) {
+		return getMessageGroup(groupId);
 	}
 
 	@Override

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
@@ -123,6 +123,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 	public void testPollMessages() throws Exception{
 		this.cleanupCollections(new SimpleMongoDbFactory(new Mongo(), "test"));
 		MessageGroupStore store = this.getMessageGroupStore();
+
 		Message<?> messageA = new GenericMessage<String>("A");
 		Message<?> messageB = new GenericMessage<String>("B");
 		store.addMessageToGroup(1, messageA);

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
@@ -55,6 +55,7 @@ public class ConfigurableMongoDbMessageGroupStoreTests extends AbstractMongoDbMe
 		GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
 		testApplicationContext.refresh();
 		mongoDbMessageStore.setApplicationContext(testApplicationContext);
+		mongoDbMessageStore.setBeanClassLoader(this.getClass().getClassLoader());
 		mongoDbMessageStore.afterPropertiesSet();
 		return mongoDbMessageStore;
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageGroupStoreTests.java
@@ -33,6 +33,7 @@ public class MongoDbMessageGroupStoreTests extends AbstractMongoDbMessageGroupSt
 	@Override
 	protected MongoDbMessageStore getMessageGroupStore() throws Exception {
 		MongoDbMessageStore mongoDbMessageStore = new MongoDbMessageStore( new SimpleMongoDbFactory(new Mongo(), "test"));
+		mongoDbMessageStore.setBeanClassLoader(this.getClass().getClassLoader());
 		mongoDbMessageStore.afterPropertiesSet();
 		return mongoDbMessageStore;
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageStoreTests.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.integration.mongodb.store;
 
+import com.mongodb.Mongo;
+
 import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
 import org.springframework.integration.store.MessageStore;
-
-import com.mongodb.Mongo;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
@@ -30,6 +30,7 @@ public class MongoDbMessageStoreTests extends AbstractMongoDbMessageStoreTests {
 	@Override
 	protected MessageStore getMessageStore() throws Exception {
 		MongoDbMessageStore mongoDbMessageStore = new MongoDbMessageStore(new SimpleMongoDbFactory(new Mongo(), "test"));
+		mongoDbMessageStore.setBeanClassLoader(this.getClass().getClassLoader());
 		mongoDbMessageStore.afterPropertiesSet();
 		return mongoDbMessageStore;
 	}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelMessageStore.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelMessageStore.java
@@ -103,9 +103,14 @@ public class RedisChannelMessageStore implements ChannelMessageStore, BeanNameAw
 	}
 
 	@Override
+	public MessageGroup getMessageGroupMetadata(Object groupId) {
+		return new SimpleMessageGroup(groupId);
+	}
+
+	@Override
 	public MessageGroup addMessageToGroup(Object groupId, Message<?> message) {
 		this.redisTemplate.boundListOps(groupId).leftPush(message);
-		return null;
+		return new SimpleMessageGroup(groupId);
 	}
 
 	public void removeMessageGroup(Object groupId) {

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
@@ -85,6 +85,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	public void testMessageGroupUpdatedDateChangesWithEachAddedMessage() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
+		store.setBeanClassLoader(this.getClass().getClassLoader());
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("Hello");
@@ -112,7 +113,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	public void testMessageGroupWithAddedMessage() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
-
+		store.setBeanClassLoader(this.getClass().getClassLoader());
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("Hello");
 		messageGroup = store.addMessageToGroup(1, message);
@@ -130,6 +131,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	public void testRemoveMessageGroup() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
+		store.setBeanClassLoader(this.getClass().getClassLoader());
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("Hello");
@@ -157,6 +159,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	public void testCompleteMessageGroup() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
+		store.setBeanClassLoader(this.getClass().getClassLoader());
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("Hello");
@@ -171,6 +174,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	public void testLastReleasedSequenceNumber() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
+		store.setBeanClassLoader(this.getClass().getClassLoader());
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("Hello");
@@ -185,6 +189,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	public void testRemoveMessageFromTheGroup() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
+		store.setBeanClassLoader(this.getClass().getClassLoader());
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("2");
@@ -208,6 +213,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	public void testWithMessageHistory() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
+		store.setBeanClassLoader(this.getClass().getClassLoader());
 
 		store.getMessageGroup(1);
 
@@ -235,6 +241,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	public void testRemoveNonExistingMessageFromTheGroup() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
+		store.setBeanClassLoader(this.getClass().getClassLoader());
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		store.addMessageToGroup(messageGroup.getGroupId(), new GenericMessage<String>("1"));
@@ -246,6 +253,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	public void testRemoveNonExistingMessageFromNonExistingTheGroup() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
+		store.setBeanClassLoader(this.getClass().getClassLoader());
 		store.removeMessageFromGroup(1, new GenericMessage<String>("2"));
 	}
 
@@ -256,8 +264,10 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	public void testMultipleInstancesOfGroupStore() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store1 = new RedisMessageStore(jcf);
+		store1.setBeanClassLoader(this.getClass().getClassLoader());
 
 		RedisMessageStore store2 = new RedisMessageStore(jcf);
+		store2.setBeanClassLoader(this.getClass().getClassLoader());
 
 		Message<?> message = new GenericMessage<String>("1");
 		store1.addMessageToGroup(1, message);
@@ -266,6 +276,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 		assertEquals(2, messageGroup.getMessages().size());
 
 		RedisMessageStore store3 = new RedisMessageStore(jcf);
+		store3.setBeanClassLoader(this.getClass().getClassLoader());
 
 		messageGroup = store3.removeMessageFromGroup(1, message);
 
@@ -277,8 +288,10 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	public void testIteratorOfMessageGroups() throws Exception{
 		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
 		RedisMessageStore store1 = new RedisMessageStore(jcf);
-		RedisMessageStore store2 = new RedisMessageStore(jcf);
+		store1.setBeanClassLoader(this.getClass().getClassLoader());
 
+		RedisMessageStore store2 = new RedisMessageStore(jcf);
+		store2.setBeanClassLoader(this.getClass().getClassLoader());
 
 		store1.addMessageToGroup(1, new GenericMessage<String>("1"));
 		store2.addMessageToGroup(2, new GenericMessage<String>("2"));


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3382
- Add `BasicMessageGroupStore#getMessageGroupMetadata` to return `MessageGroup` without messages and just with common info
- Add `MessageGroupStore#getOneMessageFromGroup` to return just only one message to cover `MessageGroup#getOne()`
- Provide correct optimal implementation for all `BasicMessageGroupStore` and `MessageGroupStore`
- Proxy `MessageGroup` with new `LazyLoadMessagesInterceptor` from `BasicMessageGroupStore#getMessageGroupMetadata` to allow to get deal with real messages on demand
- Change `AbstractCorrelatingMessageHandler` to use new `BasicMessageGroupStore#getMessageGroupMetadata`

To have good performance for persistent `CorrelationHandler` with that `MessageGroup` proxy there is need to use custom `ReleaseStrategy` and don't use
`ExpressionEvaluatingReleaseStrategy` or `MethodInvokingReleaseStrategy`, which load `Collection<Message<?>>` immediately
