### PR TITLE
Update tests to be compatible with Spring Web Services 2.2

### DIFF
--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/StubClientInterceptor.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/StubClientInterceptor.java
@@ -37,4 +37,8 @@ public class StubClientInterceptor implements ClientInterceptor {
 		return false;
 	}
 
+	public void afterCompletion(MessageContext messageContext, Exception ex) throws WebServiceClientException {
+
+	}
+
 }

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests.java
@@ -259,6 +259,10 @@ public class UriVariableTests {
 		public boolean handleFault(MessageContext messageContext) throws WebServiceClientException {
 			return false;
 		}
+
+		public void afterCompletion(MessageContext messageContext, Exception ex) throws WebServiceClientException {
+
+		}
 	}
 
 	private static class Int2720EmailTestClientInterceptor extends TestClientInterceptor {


### PR DESCRIPTION
Spring Web Services 2.2 added a new method, afterCompletion, to ClientInterceptor. To allow Spring Integration's tests to be run successfully against Spring Web Services 2.2, this PR adds empty implementations of this method to two test implementations of the ClientInterceptor interface.
