### PR TITLE
INT-3381: Messaging Annotations on `@Bean` method

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Filter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Filter.java
@@ -54,7 +54,7 @@ public @interface Filter {
 
 	String[] adviceChain() default {};
 
-	String discardWithinAdvice() default "true";
+	boolean discardWithinAdvice() default true;
 
 	/*
 	 {@code SmartLifecycle} options.

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Filter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Filter.java
@@ -48,9 +48,13 @@ public @interface Filter {
 
 	String outputChannel() default "";
 
+	String discardChannel() default "";
+
+	String throwExceptionOnRejection() default "";
+
 	String[] adviceChain() default {};
 
-	boolean discardWithinAdvice() default true;
+	String discardWithinAdvice() default "true";
 
 	/*
 	 {@code SmartLifecycle} options.

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Router.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Router.java
@@ -38,7 +38,8 @@ import java.lang.annotation.Target;
  * whose elements are either
  * {@link org.springframework.messaging.MessageChannel channels} or
  * Strings. In the latter case, the endpoint hosting this router will attempt
- * to resolve each channel name with the Channel Registry.
+ * to resolve each channel name with the Channel Registry or with
+ * {@link #channelMappings()}, if provided.
  *
  * @author Mark Fisher
  * @author Artem Bilan
@@ -52,6 +53,23 @@ public @interface Router {
 	String inputChannel() default "";
 
 	String defaultOutputChannel() default "";
+
+	/**
+	 * The 'key=value' pairs to represent channelMapping entries
+	 * @return the channelMappings
+	 * @see org.springframework.integration.router.AbstractMappingMessageRouter#setChannelMapping(String, String)
+	 */
+	String[] channelMappings() default {};
+
+	String prefix() default "";
+
+	String suffix() default "";
+
+	String resolutionRequired() default "";
+
+	String applySequence() default "";
+
+	String ignoreSendFailures() default "";
 
 	/*
 	 {@code SmartLifecycle} options.

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/ServiceActivator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/ServiceActivator.java
@@ -51,6 +51,8 @@ public @interface ServiceActivator {
 
 	String outputChannel() default "";
 
+	String requiresReply() default "";
+
 	String[] adviceChain() default {};
 
 	/*

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Splitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Splitter.java
@@ -50,6 +50,8 @@ public @interface Splitter {
 
 	String outputChannel() default "";
 
+	String applySequence() default "";
+
 	String[] adviceChain() default {};
 
 	/*

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
@@ -83,13 +83,16 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 				return (MessageHandler) targetObject;
 			}
 			router = this.createMethodInvokingRouter(targetObject, targetMethodName);
-
+			this.configureRouter(router);
 		}
 		else {
 			Assert.isTrue(!StringUtils.hasText(targetMethodName), "target method should not be provided when the target "
 					+ "object is an implementation of AbstractMessageRouter");
+			this.configureRouter(router);
+			if (targetObject instanceof MessageHandler) {
+				return (MessageHandler) targetObject;
+			}
 		}
-		this.configureRouter(router);
 		return router;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
@@ -83,16 +83,13 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 				return (MessageHandler) targetObject;
 			}
 			router = this.createMethodInvokingRouter(targetObject, targetMethodName);
-			this.configureRouter(router);
+
 		}
 		else {
 			Assert.isTrue(!StringUtils.hasText(targetMethodName), "target method should not be provided when the target "
 					+ "object is an implementation of AbstractMessageRouter");
-			this.configureRouter(router);
-			if (targetObject instanceof MessageHandler) {
-				return (MessageHandler) targetObject;
-			}
 		}
+		this.configureRouter(router);
 		return router;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/SplitterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/SplitterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Iwein Fuld
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class SplitterFactoryBean extends AbstractStandardMessageHandlerFactoryBean {
 
@@ -71,17 +72,13 @@ public class SplitterFactoryBean extends AbstractStandardMessageHandlerFactoryBe
 		if (splitter == null) {
 			this.checkForIllegalTarget(targetObject, targetMethodName);
 			splitter = this.createMethodInvokingSplitter(targetObject, targetMethodName);
-			this.configureSplitter(splitter);
 		}
 		else {
 			Assert.isTrue(!StringUtils.hasText(targetMethodName), "target method should not be provided when the target "
 					+ "object is an implementation of AbstractMessageSplitter");
-			this.configureSplitter(splitter);
-			if (targetObject instanceof MessageHandler) {
-				return (MessageHandler) targetObject;
-			}
+
 		}
-		return splitter;
+		return this.configureSplitter(splitter);
 	}
 
 	private AbstractMessageSplitter createMethodInvokingSplitter(Object targetObject, String targetMethodName) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/SplitterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/SplitterFactoryBean.java
@@ -32,7 +32,6 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Iwein Fuld
  * @author Gary Russell
- * @author Artem Bilan
  */
 public class SplitterFactoryBean extends AbstractStandardMessageHandlerFactoryBean {
 
@@ -72,13 +71,17 @@ public class SplitterFactoryBean extends AbstractStandardMessageHandlerFactoryBe
 		if (splitter == null) {
 			this.checkForIllegalTarget(targetObject, targetMethodName);
 			splitter = this.createMethodInvokingSplitter(targetObject, targetMethodName);
+			this.configureSplitter(splitter);
 		}
 		else {
 			Assert.isTrue(!StringUtils.hasText(targetMethodName), "target method should not be provided when the target "
 					+ "object is an implementation of AbstractMessageSplitter");
-
+			this.configureSplitter(splitter);
+			if (targetObject instanceof MessageHandler) {
+				return (MessageHandler) targetObject;
+			}
 		}
-		return this.configureSplitter(splitter);
+		return splitter;
 	}
 
 	private AbstractMessageSplitter createMethodInvokingSplitter(Object targetObject, String targetMethodName) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -144,8 +144,8 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 		boolean createEndpoint = StringUtils.hasText(inputChannel);
 		if (!createEndpoint && beanAnnotationAware()) {
 			boolean isBean = AnnotatedElementUtils.isAnnotated(method, Bean.class.getName());
-			Assert.isTrue(!isBean, "The '" + getInputChannelAttribute() + "' is required, when " + this.annotationType +
-					" is used on '@Bean' methods level");
+			Assert.isTrue(!isBean, "A channel name in '" + getInputChannelAttribute() + "' is required when " + this.annotationType +
+					" is used on '@Bean' methods.");
 		}
 		return createEndpoint;
 	}
@@ -336,12 +336,12 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 	}
 
 	@SuppressWarnings("unchecked")
-	<T> T extractTypeIfPossible(Object targetObject, Class<T> expectedType) {
+	<H> H extractTypeIfPossible(Object targetObject, Class<H> expectedType) {
 		if (targetObject == null) {
 			return null;
 		}
 		if (expectedType.isAssignableFrom(targetObject.getClass())) {
-			return (T) targetObject;
+			return (H) targetObject;
 		}
 		if (targetObject instanceof Advised) {
 			TargetSource targetSource = ((Advised) targetObject).getTargetSource();
@@ -362,6 +362,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 	 *
 	 * @param bean The bean.
 	 * @param method The method.
+	 * @param annotations The messaging annotation (or meta-annotation hierarchy) on the method.
 	 * @return The MessageHandler.
 	 */
 	protected abstract MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -118,9 +118,17 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 			}
 		}
 
-		String handlerBeanName = generateHandlerBeanName(beanName, method);
-		this.beanFactory.registerSingleton(handlerBeanName, handler);
-		handler = (MessageHandler) this.beanFactory.initializeBean(handler, handlerBeanName);
+		boolean handlerExists = false;
+		if (this.beanAnnotationAware() && AnnotatedElementUtils.isAnnotated(method, Bean.class.getName())) {
+			Object handlerBean = this.resolveTargetBeanFromMethodWithBeanAnnotation(method);
+			handlerExists = handlerBean != null && handler == handlerBean;
+		}
+
+		if (!handlerExists) {
+			String handlerBeanName = generateHandlerBeanName(beanName, method);
+			this.beanFactory.registerSingleton(handlerBeanName, handler);
+			handler = (MessageHandler) this.beanFactory.initializeBean(handler, handlerBeanName);
+		}
 
 		AbstractEndpoint endpoint = createEndpoint(handler, method, annotations);
 		if (endpoint != null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AggregatorAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AggregatorAnnotationPostProcessor.java
@@ -94,4 +94,8 @@ public class AggregatorAnnotationPostProcessor extends AbstractMethodAnnotationP
 		return handler;
 	}
 
+	protected boolean beanAnnotationAware() {
+		return false;
+	}
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/BridgeFromAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/BridgeFromAnnotationPostProcessor.java
@@ -31,7 +31,6 @@ import org.springframework.integration.handler.BridgeHandler;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.util.Assert;
-import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -74,15 +73,9 @@ public class BridgeFromAnnotationPostProcessor extends AbstractMethodAnnotationP
 	@Override
 	protected MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations) {
 		BridgeHandler handler = new BridgeHandler();
-		String outputChannelName = null;
-		String[] names = AnnotationUtils.getAnnotation(method, Bean.class).name();
-		if (!ObjectUtils.isEmpty(names)) {
-			outputChannelName = names[0];
-		}
-		if (!StringUtils.hasText(outputChannelName)) {
-			outputChannelName = method.getName();
-		}
-		handler.setOutputChannelName(outputChannelName);
+		Object outputChannel = resolveTargetBeanFromMethodWithBeanAnnotation(method);
+		Assert.isInstanceOf(MessageChannel.class, outputChannel);
+		handler.setOutputChannel((MessageChannel) outputChannel);
 		return handler;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/BridgeToAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/BridgeToAnnotationPostProcessor.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.AnnotatedElementUtils;
-import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.env.Environment;
 import org.springframework.integration.annotation.BridgeFrom;
 import org.springframework.integration.annotation.BridgeTo;
@@ -32,8 +31,6 @@ import org.springframework.integration.handler.BridgeHandler;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.util.Assert;
-import org.springframework.util.ObjectUtils;
-import org.springframework.util.StringUtils;
 
 /**
  * Post-processor for the {@link BridgeTo @BridgeTo} annotation.
@@ -73,18 +70,9 @@ public class BridgeToAnnotationPostProcessor extends AbstractMethodAnnotationPos
 
 	@Override
 	protected AbstractEndpoint createEndpoint(MessageHandler handler, Method method, List<Annotation> annotations) {
-		String inputChannelName = null;
-		String[] names = AnnotationUtils.getAnnotation(method, Bean.class).name();
-		if (!ObjectUtils.isEmpty(names)) {
-			inputChannelName = names[0];
-		}
-		if (!StringUtils.hasText(inputChannelName)) {
-			inputChannelName = method.getName();
-		}
-
-		MessageChannel inputChannel = this.beanFactory.getBean(inputChannelName, MessageChannel.class);
-
-		return doCreateEndpoint(handler, inputChannel, annotations);
+		Object inputChannel = this.resolveTargetBeanFromMethodWithBeanAnnotation(method);
+		Assert.isInstanceOf(MessageChannel.class, inputChannel);
+		return doCreateEndpoint(handler, (MessageChannel) inputChannel, annotations);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessor.java
@@ -70,6 +70,7 @@ public class FilterAnnotationPostProcessor extends AbstractMethodAnnotationPostP
 
 		MessageFilter filter = new MessageFilter(selector);
 
+		/* TODO will be revised in the future
 		String discardWithinAdvice = MessagingAnnotationUtils.resolveAttribute(annotations, "discardWithinAdvice",
 				String.class);
 		if (StringUtils.hasText(discardWithinAdvice)) {
@@ -77,7 +78,10 @@ public class FilterAnnotationPostProcessor extends AbstractMethodAnnotationPostP
 			if (StringUtils.hasText(discardWithinAdviceValue)) {
 				filter.setDiscardWithinAdvice(Boolean.parseBoolean(discardWithinAdviceValue));
 			}
-		}
+		}*/
+
+		filter.setDiscardWithinAdvice(MessagingAnnotationUtils.resolveAttribute(annotations, "discardWithinAdvice",
+				Boolean.class));
 
 		String throwExceptionOnRejection = MessagingAnnotationUtils.resolveAttribute(annotations,
 				"throwExceptionOnRejection", String.class);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/MessagingAnnotationUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/MessagingAnnotationUtils.java
@@ -48,6 +48,7 @@ public final class MessagingAnnotationUtils {
 	 * @param annotations The meta-annotations in order (closest first).
 	 * @param name The attribute name.
 	 * @param requiredType The expected type.
+	 * @param <T> The type.
 	 * @return The value.
 	 */
 	@SuppressWarnings("unchecked")

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessor.java
@@ -19,14 +19,20 @@ package org.springframework.integration.config.annotation;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Properties;
 
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.env.Environment;
 import org.springframework.integration.annotation.Router;
+import org.springframework.integration.router.AbstractMappingMessageRouter;
+import org.springframework.integration.router.AbstractMessageRouter;
 import org.springframework.integration.router.MethodInvokingRouter;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -34,6 +40,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class RouterAnnotationPostProcessor extends AbstractMethodAnnotationPostProcessor<Router> {
 
@@ -43,18 +50,94 @@ public class RouterAnnotationPostProcessor extends AbstractMethodAnnotationPostP
 
 
 	@Override
-	protected MessageHandler createHandler(Object bean, Method method,
-			List<Annotation> annotations) {
-		MethodInvokingRouter router = new MethodInvokingRouter(bean, method);
-		router.setBeanFactory(this.beanFactory);
-		String defaultOutputChannelName = MessagingAnnotationUtils.resolveAttribute(annotations, "defaultOutputChannel",
-				String.class);
-		if (StringUtils.hasText(defaultOutputChannelName)) {
-			MessageChannel defaultOutputChannel = this.channelResolver.resolveDestination(defaultOutputChannelName);
-			Assert.notNull(defaultOutputChannel, "unable to resolve defaultOutputChannel '" + defaultOutputChannelName + "'");
-			router.setDefaultOutputChannel(defaultOutputChannel);
+	protected MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations) {
+		AbstractMessageRouter router;
+		if (AnnotatedElementUtils.isAnnotated(method, Bean.class.getName())) {
+			Object target = this.resolveTargetBeanFromMethodWithBeanAnnotation(method);
+			router = this.extractTypeIfPossible(target, AbstractMessageRouter.class);
+			if (router == null) {
+				if (target instanceof MessageHandler) {
+					Assert.isTrue(!this.noRouterAttributesProvided(annotations), "'defaultOutputChannel', "
+							+ "'applySequence', 'ignoreSendFailures', 'resolutionRequired' and 'channelMappings' "
+							+ "can be applied to 'AbstractMessageRouter' implementations, but target handler is: "
+							+ target.getClass());
+					return (MessageHandler) target;
+				}
+				else {
+					router = new MethodInvokingRouter(target);
+				}
+			}
 		}
+		else {
+			router = new MethodInvokingRouter(bean, method);
+		}
+		String defaultOutputChannelName = MessagingAnnotationUtils.resolveAttribute(annotations,
+				"defaultOutputChannel", String.class);
+		router.setDefaultOutputChannelName(defaultOutputChannelName);
+
+		String applySequence = MessagingAnnotationUtils.resolveAttribute(annotations, "applySequence", String.class);
+		if (StringUtils.hasText(applySequence)) {
+			router.setApplySequence(Boolean.parseBoolean(this.environment.resolvePlaceholders(applySequence)));
+		}
+
+		String ignoreSendFailures = MessagingAnnotationUtils.resolveAttribute(annotations, "ignoreSendFailures",
+				String.class);
+		if (StringUtils.hasText(ignoreSendFailures)) {
+			router.setIgnoreSendFailures(Boolean.parseBoolean(this.environment.resolvePlaceholders(ignoreSendFailures)));
+		}
+
+		if (!(router instanceof AbstractMappingMessageRouter) && !this.noRouterAttributesProvided(annotations)) {
+			throw new IllegalArgumentException("''resolutionRequired'', 'prefix', suffix and 'channelMappings' "
+					+ "can be applied to 'AbstractMessageRouter' implementations, but target handler is: "
+					+ router.getClass());
+		}
+		else {
+			AbstractMappingMessageRouter mappingMessageRouter = (AbstractMappingMessageRouter) router;
+
+			String resolutionRequired = MessagingAnnotationUtils.resolveAttribute(annotations, "resolutionRequired",
+					String.class);
+			if (StringUtils.hasText(resolutionRequired)) {
+				String resolutionRequiredValue = this.environment.resolvePlaceholders(resolutionRequired);
+				if (StringUtils.hasText(resolutionRequiredValue)) {
+					mappingMessageRouter.setResolutionRequired(Boolean.parseBoolean(resolutionRequiredValue));
+				}
+			}
+
+			String prefix = MessagingAnnotationUtils.resolveAttribute(annotations, "prefix", String.class);
+			if (StringUtils.hasText(prefix)) {
+				mappingMessageRouter.setPrefix(this.environment.resolvePlaceholders(prefix));
+			}
+
+			String suffix = MessagingAnnotationUtils.resolveAttribute(annotations, "suffix", String.class);
+			if (StringUtils.hasText(suffix)) {
+				mappingMessageRouter.setSuffix(this.environment.resolvePlaceholders(suffix));
+			}
+
+			String[] channelMappings = MessagingAnnotationUtils.resolveAttribute(annotations, "channelMappings",
+					String[].class);
+			if (!ObjectUtils.isEmpty(channelMappings)) {
+				StringBuilder mappings = new StringBuilder();
+				for (String channelMapping : channelMappings) {
+					mappings.append(channelMapping).append("\n");
+				}
+				Properties properties = (Properties) this.conversionService.convert(mappings.toString(),
+						TypeDescriptor.valueOf(String.class), TypeDescriptor.valueOf(Properties.class));
+				mappingMessageRouter.replaceChannelMappings(properties);
+			}
+
+		}
+
 		return router;
+	}
+
+	private boolean noRouterAttributesProvided(List<Annotation> annotations) {
+		return MessagingAnnotationUtils.resolveAttribute(annotations, "defaultOutputChannel", String.class) == null
+				&& MessagingAnnotationUtils.resolveAttribute(annotations, "channelMappings", String[].class) == null
+				&& MessagingAnnotationUtils.resolveAttribute(annotations, "prefix", String.class) == null
+				&& MessagingAnnotationUtils.resolveAttribute(annotations, "suffix", String.class) == null
+				&& MessagingAnnotationUtils.resolveAttribute(annotations, "resolutionRequired", String.class) == null
+				&& MessagingAnnotationUtils.resolveAttribute(annotations, "applySequence", String.class) == null
+				&& MessagingAnnotationUtils.resolveAttribute(annotations, "ignoreSendFailures", String.class) == null;
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessor.java
@@ -27,7 +27,6 @@ import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.env.Environment;
 import org.springframework.integration.annotation.Router;
-import org.springframework.integration.router.AbstractMappingMessageRouter;
 import org.springframework.integration.router.AbstractMessageRouter;
 import org.springframework.integration.router.MethodInvokingRouter;
 import org.springframework.messaging.MessageHandler;
@@ -90,29 +89,26 @@ public class RouterAnnotationPostProcessor extends AbstractMethodAnnotationPostP
 		}
 
 		if (this.routerAttributesProvided(annotations)) {
-			Assert.isInstanceOf(AbstractMappingMessageRouter.class, router, "''resolutionRequired'', 'prefix', " +
-					"suffix and 'channelMappings' can be applied to 'AbstractMessageRouter' implementations, " +
-					"but target handler is: " + router.getClass());
 
-			AbstractMappingMessageRouter mappingMessageRouter = (AbstractMappingMessageRouter) router;
+			MethodInvokingRouter methodInvokingRouter = (MethodInvokingRouter) router;
 
 			String resolutionRequired = MessagingAnnotationUtils.resolveAttribute(annotations, "resolutionRequired",
 					String.class);
 			if (StringUtils.hasText(resolutionRequired)) {
 				String resolutionRequiredValue = this.environment.resolvePlaceholders(resolutionRequired);
 				if (StringUtils.hasText(resolutionRequiredValue)) {
-					mappingMessageRouter.setResolutionRequired(Boolean.parseBoolean(resolutionRequiredValue));
+					methodInvokingRouter.setResolutionRequired(Boolean.parseBoolean(resolutionRequiredValue));
 				}
 			}
 
 			String prefix = MessagingAnnotationUtils.resolveAttribute(annotations, "prefix", String.class);
 			if (StringUtils.hasText(prefix)) {
-				mappingMessageRouter.setPrefix(this.environment.resolvePlaceholders(prefix));
+				methodInvokingRouter.setPrefix(this.environment.resolvePlaceholders(prefix));
 			}
 
 			String suffix = MessagingAnnotationUtils.resolveAttribute(annotations, "suffix", String.class);
 			if (StringUtils.hasText(suffix)) {
-				mappingMessageRouter.setSuffix(this.environment.resolvePlaceholders(suffix));
+				methodInvokingRouter.setSuffix(this.environment.resolvePlaceholders(suffix));
 			}
 
 			String[] channelMappings = MessagingAnnotationUtils.resolveAttribute(annotations, "channelMappings",
@@ -124,7 +120,7 @@ public class RouterAnnotationPostProcessor extends AbstractMethodAnnotationPostP
 				}
 				Properties properties = (Properties) this.conversionService.convert(mappings.toString(),
 						TypeDescriptor.valueOf(String.class), TypeDescriptor.valueOf(Properties.class));
-				mappingMessageRouter.replaceChannelMappings(properties);
+				methodInvokingRouter.replaceChannelMappings(properties);
 			}
 
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/ServiceActivatorAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/ServiceActivatorAnnotationPostProcessor.java
@@ -21,16 +21,22 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.env.Environment;
 import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.ServiceActivatingHandler;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.util.StringUtils;
 
 /**
  * Post-processor for Methods annotated with {@link ServiceActivator @ServiceActivator}.
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class ServiceActivatorAnnotationPostProcessor extends AbstractMethodAnnotationPostProcessor<ServiceActivator> {
 
@@ -41,7 +47,43 @@ public class ServiceActivatorAnnotationPostProcessor extends AbstractMethodAnnot
 
 	@Override
 	protected MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations) {
-		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(bean, method);
+		AbstractReplyProducingMessageHandler serviceActivator;
+		if (AnnotatedElementUtils.isAnnotated(method, Bean.class.getName())) {
+			final Object target = this.resolveTargetBeanFromMethodWithBeanAnnotation(method);
+			serviceActivator = this.extractTypeIfPossible(target, AbstractReplyProducingMessageHandler.class);
+			if (serviceActivator == null) {
+				if (target instanceof MessageHandler) {
+					/*
+			 		 * Return a reply-producing message handler so that we still get 'produced no reply' messages
+			 		 * and the super class will inject the advice chain to advise the handler method if needed.
+			 		 */
+					return new AbstractReplyProducingMessageHandler() {
+
+						@Override
+						protected Object handleRequestMessage(Message<?> requestMessage) {
+
+							((MessageHandler) target).handleMessage(requestMessage);
+							return null;
+						}
+					};
+				}
+				else {
+					serviceActivator = new ServiceActivatingHandler(target);
+				}
+			}
+			else {
+				return (MessageHandler) target;
+			}
+		}
+		else {
+			serviceActivator = new ServiceActivatingHandler(bean, method);
+		}
+
+		String requiresReply = MessagingAnnotationUtils.resolveAttribute(annotations, "requiresReply", String.class);
+		if (StringUtils.hasText(requiresReply)) {
+			serviceActivator.setRequiresReply(Boolean.parseBoolean(this.environment.resolvePlaceholders(requiresReply)));
+		}
+
 		this.setOutputChannelIfPresent(annotations, serviceActivator);
 		return serviceActivator;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/SplitterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/SplitterAnnotationPostProcessor.java
@@ -63,6 +63,9 @@ public class SplitterAnnotationPostProcessor extends AbstractMethodAnnotationPos
 					splitter = new MethodInvokingSplitter(target);
 				}
 			}
+			else {
+				return splitter;
+			}
 		}
 		else {
 			splitter = new MethodInvokingSplitter(bean, method);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/SplitterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/SplitterAnnotationPostProcessor.java
@@ -21,16 +21,22 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.env.Environment;
 import org.springframework.integration.annotation.Splitter;
+import org.springframework.integration.splitter.AbstractMessageSplitter;
 import org.springframework.integration.splitter.MethodInvokingSplitter;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Post-processor for Methods annotated with {@link Splitter @Splitter}.
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class SplitterAnnotationPostProcessor extends AbstractMethodAnnotationPostProcessor<Splitter> {
 
@@ -41,7 +47,34 @@ public class SplitterAnnotationPostProcessor extends AbstractMethodAnnotationPos
 
 	@Override
 	protected MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations) {
-		MethodInvokingSplitter splitter = new MethodInvokingSplitter(bean, method);
+		String applySequence = MessagingAnnotationUtils.resolveAttribute(annotations, "applySequence", String.class);
+
+		AbstractMessageSplitter splitter;
+		if (AnnotatedElementUtils.isAnnotated(method, Bean.class.getName())) {
+			Object target = this.resolveTargetBeanFromMethodWithBeanAnnotation(method);
+			splitter = this.extractTypeIfPossible(target, AbstractMessageSplitter.class);
+			if (splitter == null) {
+				if (target instanceof MessageHandler) {
+					Assert.hasText(applySequence, "'applySequence' can be applied to 'AbstractMessageSplitter', but " +
+							"target handler is: " + target.getClass());
+					return (MessageHandler) target;
+				}
+				else {
+					splitter = new MethodInvokingSplitter(target);
+				}
+			}
+		}
+		else {
+			splitter = new MethodInvokingSplitter(bean, method);
+		}
+
+		if (StringUtils.hasText(applySequence)) {
+			String applySequenceValue = this.environment.resolvePlaceholders(applySequence);
+			if (StringUtils.hasText(applySequenceValue)) {
+				splitter.setApplySequence(Boolean.parseBoolean(applySequenceValue));
+			}
+		}
+
 		this.setOutputChannelIfPresent(annotations, splitter);
 		return splitter;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/TransformerAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/TransformerAnnotationPostProcessor.java
@@ -21,8 +21,11 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.env.Environment;
 import org.springframework.integration.annotation.Transformer;
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.transformer.MessageTransformingHandler;
 import org.springframework.integration.transformer.MethodInvokingTransformer;
 import org.springframework.messaging.MessageHandler;
@@ -32,6 +35,7 @@ import org.springframework.messaging.MessageHandler;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class TransformerAnnotationPostProcessor extends AbstractMethodAnnotationPostProcessor<Transformer> {
 
@@ -42,7 +46,21 @@ public class TransformerAnnotationPostProcessor extends AbstractMethodAnnotation
 
 	@Override
 	protected MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations) {
-		MethodInvokingTransformer transformer = new MethodInvokingTransformer(bean, method);
+		org.springframework.integration.transformer.Transformer transformer;
+		if (AnnotatedElementUtils.isAnnotated(method, Bean.class.getName())) {
+			Object target = this.resolveTargetBeanFromMethodWithBeanAnnotation(method);
+			transformer = this.extractTypeIfPossible(target, org.springframework.integration.transformer.Transformer.class);
+			if (transformer == null) {
+				if (target instanceof AbstractReplyProducingMessageHandler) {
+					return (MessageHandler) target;
+				}
+				transformer = new MethodInvokingTransformer(target);
+			}
+		}
+		else {
+			transformer = new MethodInvokingTransformer(bean, method);
+		}
+
 		MessageTransformingHandler handler = new MessageTransformingHandler(transformer);
 		this.setOutputChannelIfPresent(annotations, handler);
 		return handler;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/TransformerAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/TransformerAnnotationPostProcessor.java
@@ -51,7 +51,7 @@ public class TransformerAnnotationPostProcessor extends AbstractMethodAnnotation
 			Object target = this.resolveTargetBeanFromMethodWithBeanAnnotation(method);
 			transformer = this.extractTypeIfPossible(target, org.springframework.integration.transformer.Transformer.class);
 			if (transformer == null) {
-				if (target instanceof AbstractReplyProducingMessageHandler) {
+				if (this.extractTypeIfPossible(target, AbstractReplyProducingMessageHandler.class) != null) {
 					return (MessageHandler) target;
 				}
 				transformer = new MethodInvokingTransformer(target);

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
@@ -154,6 +154,12 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 
 	@Override
 	public void onInit() {
+		try {
+			super.onInit();
+		}
+		catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
 		BeanFactory beanFactory = this.getBeanFactory();
 		if (this.channelResolver == null && beanFactory != null) {
 			this.channelResolver = new BeanFactoryChannelResolver(beanFactory);

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,10 +39,12 @@ import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvi
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.test.util.TestUtils.TestApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
 
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.0
  */
 public class FilterAnnotationPostProcessorTests {
@@ -60,6 +62,7 @@ public class FilterAnnotationPostProcessorTests {
 		context.registerChannel("input", inputChannel);
 		context.registerChannel("output", outputChannel);
 		postProcessor.setBeanFactory(context.getBeanFactory());
+		postProcessor.setEnvironment(new MockEnvironment());
 		postProcessor.afterPropertiesSet();
 	}
 
@@ -223,7 +226,7 @@ public class FilterAnnotationPostProcessorTests {
 	private static class TestFilterWithAdviceDiscardWithout {
 
 		@Filter(inputChannel="input", outputChannel="output",
-				adviceChain="adviceChain", discardWithinAdvice=false)
+				adviceChain="adviceChain", discardWithinAdvice="false")
 		public boolean filter(String s) {
 			return !s.contains("bad");
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessorTests.java
@@ -226,7 +226,7 @@ public class FilterAnnotationPostProcessorTests {
 	private static class TestFilterWithAdviceDiscardWithout {
 
 		@Filter(inputChannel="input", outputChannel="output",
-				adviceChain="adviceChain", discardWithinAdvice="false")
+				adviceChain="adviceChain", discardWithinAdvice=false)
 		public boolean filter(String s) {
 			return !s.contains("bad");
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -139,14 +139,19 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 
 		@Bean
 		@Router(inputChannel = "routerChannel", channelMappings = {"true=odd", "false=filter"}, suffix = "Channel")
-		public MessageHandler router() {
-			return new ExpressionEvaluatingRouter(PARSER.parseExpression("payload % 2 == 0"));
+		public MessageSelector router() {
+			return new ExpressionEvaluatingSelector("payload % 2 == 0");
 		}
 
 		@Bean
 		@Transformer(inputChannel = "oddChannel", outputChannel = "filterChannel")
 		public ExpressionEvaluatingTransformer oddTransformer() {
 			return new ExpressionEvaluatingTransformer(PARSER.parseExpression("payload / 2"));
+		}
+
+		@Bean
+		public MessageChannel filterChannel() {
+			return new DirectChannel();
 		}
 
 		@Bean
@@ -176,9 +181,11 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 		}
 
 		@Bean
-		@Splitter(inputChannel = "splitterChannel", outputChannel = "serviceChannel")
+		@Splitter(inputChannel = "splitterChannel")
 		public MessageHandler splitter() {
-			return new DefaultMessageSplitter();
+			DefaultMessageSplitter defaultMessageSplitter = new DefaultMessageSplitter();
+			defaultMessageSplitter.setOutputChannelName("serviceChannel");
+			return defaultMessageSplitter;
 		}
 
 		@Bean
@@ -189,6 +196,11 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 		@Bean
 		public List<Message<?>> collector() {
 			return new ArrayList<Message<?>>();
+		}
+
+		@Bean
+		public MessageChannel serviceChannel() {
+			return new DirectChannel();
 		}
 
 		@Bean

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.config.annotation;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Resource;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.integration.aggregator.AggregatingMessageHandler;
+import org.springframework.integration.aggregator.ExpressionEvaluatingCorrelationStrategy;
+import org.springframework.integration.aggregator.ExpressionEvaluatingReleaseStrategy;
+import org.springframework.integration.aggregator.PassThroughMessageGroupProcessor;
+import org.springframework.integration.annotation.Filter;
+import org.springframework.integration.annotation.InboundChannelAdapter;
+import org.springframework.integration.annotation.Poller;
+import org.springframework.integration.annotation.Router;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.annotation.Splitter;
+import org.springframework.integration.annotation.Transformer;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.config.EnableMessageHistory;
+import org.springframework.integration.core.MessageSelector;
+import org.springframework.integration.core.MessageSource;
+import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
+import org.springframework.integration.filter.ExpressionEvaluatingSelector;
+import org.springframework.integration.history.MessageHistory;
+import org.springframework.integration.router.ExpressionEvaluatingRouter;
+import org.springframework.integration.splitter.DefaultMessageSplitter;
+import org.springframework.integration.transformer.ExpressionEvaluatingTransformer;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+/**
+ * @author Artem Bilan
+ * @since 4.0
+ */
+@ContextConfiguration(loader = AnnotationConfigContextLoader.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
+public class MessagingAnnotationsWithBeanAnnotationTests {
+
+	@Autowired
+	private SourcePollingChannelAdapter sourcePollingChannelAdapter;
+
+	@Autowired
+	private PollableChannel discardChannel;
+
+	@Resource(name="collector")
+	private List<Message<?>> collector;
+
+	@Test
+	public void testMessagingAnnotationsFlow() {
+		this.sourcePollingChannelAdapter.start();
+		for (int i = 0; i < 10; i++) {
+			Message<?> receive = this.discardChannel.receive(1000);
+			assertNotNull(receive);
+			assertTrue(((Integer) receive.getPayload()) % 2 == 0);
+		}
+		for (Message<?> message : collector) {
+			assertFalse(((Integer) message.getPayload()) % 2 == 0);
+			MessageHistory messageHistory = MessageHistory.read(message);
+			assertNotNull(messageHistory);
+			String messageHistoryString = messageHistory.toString();
+			assertThat(messageHistoryString, Matchers.containsString("routerChannel"));
+			assertThat(messageHistoryString, Matchers.containsString("filterChannel"));
+			assertThat(messageHistoryString, Matchers.containsString("aggregatorChannel"));
+			assertThat(messageHistoryString, Matchers.containsString("splitterChannel"));
+			assertThat(messageHistoryString, Matchers.containsString("serviceChannel"));
+			assertThat(messageHistoryString, Matchers.not(Matchers.containsString("discardChannel")));
+		}
+	}
+
+	@Configuration
+	@EnableIntegration
+	@EnableMessageHistory
+	public static class ContextConfiguration {
+
+		private static final ExpressionParser PARSER = new SpelExpressionParser();
+
+		@Bean
+		public AtomicInteger counter() {
+			return new AtomicInteger();
+		}
+
+		@Bean
+		@InboundChannelAdapter(value = "routerChannel", autoStartup = "false",
+				poller = @Poller(fixedRate = "10", maxMessagesPerPoll = "1"))
+		public MessageSource<Integer> counterMessageSource(final AtomicInteger counter) {
+			return new MessageSource<Integer>() {
+
+				@Override
+				public Message<Integer> receive() {
+					return new GenericMessage<Integer>(counter.incrementAndGet());
+				}
+			};
+		}
+
+		@Bean
+		public MessageChannel routerChannel() {
+			return new DirectChannel();
+		}
+
+		@Bean
+		@Router(inputChannel = "routerChannel", channelMappings = {"true=odd", "false=filter"}, suffix = "Channel")
+		public MessageHandler router() {
+			return new ExpressionEvaluatingRouter(PARSER.parseExpression("payload % 2 == 0"));
+		}
+
+		@Bean
+		@Transformer(inputChannel = "oddChannel", outputChannel = "filterChannel")
+		public ExpressionEvaluatingTransformer oddTransformer() {
+			return new ExpressionEvaluatingTransformer(PARSER.parseExpression("payload / 2"));
+		}
+
+		@Bean
+		@Filter(inputChannel = "filterChannel", outputChannel = "aggregatorChannel", discardChannel = "discardChannel")
+		public MessageSelector filter() {
+			return new ExpressionEvaluatingSelector("payload % 2 != 0");
+		}
+
+		@Bean
+		public MessageChannel aggregatorChannel() {
+			return new DirectChannel();
+		}
+
+		@Bean
+		@ServiceActivator(inputChannel = "aggregatorChannel")
+		public MessageHandler aggregator() {
+			AggregatingMessageHandler handler = new AggregatingMessageHandler(new PassThroughMessageGroupProcessor());
+			handler.setCorrelationStrategy(new ExpressionEvaluatingCorrelationStrategy("1"));
+			handler.setReleaseStrategy(new ExpressionEvaluatingReleaseStrategy("size() == 10"));
+			handler.setOutputChannelName("splitterChannel");
+			return handler;
+		}
+
+		@Bean
+		public MessageChannel splitterChannel() {
+			return new DirectChannel();
+		}
+
+		@Bean
+		@Splitter(inputChannel = "splitterChannel", outputChannel = "serviceChannel")
+		public MessageHandler splitter() {
+			return new DefaultMessageSplitter();
+		}
+
+		@Bean
+		public PollableChannel discardChannel() {
+			return new QueueChannel();
+		}
+
+		@Bean
+		public List<Message<?>> collector() {
+			return new ArrayList<Message<?>>();
+		}
+
+		@Bean
+		@ServiceActivator(inputChannel = "serviceChannel")
+		public MessageHandler service() {
+			final List<Message<?>> collector = this.collector();
+			return new MessageHandler() {
+
+				@Override
+				public void handleMessage(Message<?> message) throws MessagingException {
+					collector.add(message);
+				}
+			};
+		}
+
+	}
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -16,7 +16,10 @@
 
 package org.springframework.integration.config.annotation;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +56,6 @@ import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.filter.ExpressionEvaluatingSelector;
 import org.springframework.integration.history.MessageHistory;
-import org.springframework.integration.router.ExpressionEvaluatingRouter;
 import org.springframework.integration.splitter.DefaultMessageSplitter;
 import org.springframework.integration.transformer.ExpressionEvaluatingTransformer;
 import org.springframework.messaging.Message;

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
@@ -15,11 +15,7 @@
  */
 package org.springframework.integration.gemfire.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -29,8 +25,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import com.gemstone.gemfire.cache.Cache;
 import junit.framework.AssertionFailedError;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -39,19 +35,17 @@ import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.data.gemfire.CacheFactoryBean;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.history.MessageHistory;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.support.LongRunningIntegrationTest;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.Assert;
-
-import com.gemstone.gemfire.cache.Cache;
 
 /**
  * @author Oleg Zhurakousky
@@ -356,7 +350,7 @@ public class GemfireGroupStoreTests {
 			Thread.sleep(1);
 		}
 		for (int i = 0; i < 20; i++) {
-			assertNotNull(outputQueue.receive(1));
+			assertNotNull(outputQueue.receive(1000));
 		}
 		assertNull(outputQueue.receive(1));
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3381
- Add support to mark `@Bean` methods with `Messaging Annotations`
- Addition attributes for `Messaging Annotations`
- Some refactoring and fixing
- Fix `AbstractMappingMessageRouter#onInit()` propagation
- Fix `GemfireGroupStoreTests` (https://build.spring.io/browse/INT-MASTERSPRING40-JOB1-246/test/case/135235772)

There is still some side effect: we need define `MessageChannel` beans explicitly. Since methods are processed within `BPP`,
not all beans with `Messaging Annotations` might be processes.
