### PR TITLE
Add the Spring IO Platform plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 		maven { url 'http://repo.spring.io/plugins-snapshot' }
 	}
 	dependencies {
-		classpath 'org.springframework.build.gradle:springio-platform-plugin:0.0.3.BUILD-SNAPSHOT'
+		classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.BUILD-SNAPSHOT'
 		classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.2.8'
 	}
 }
@@ -26,7 +26,7 @@ ext {
 allprojects {
 	group = 'org.springframework.integration'
 
-	apply plugin: 'springio-platform'
+	apply plugin: 'spring-io'
 
 	repositories {
 		if (version.endsWith('BUILD-SNAPSHOT')) {
@@ -150,6 +150,8 @@ subprojects { subproject ->
 			testCompile project(":spring-integration-test")
 		}
 		jacoco group: "org.jacoco", name: "org.jacoco.agent", version: "0.5.6.201201232323", classifier: "runtime"
+
+		springIoVersions 'io.spring.platform:platform-versions:1.0.0.BUILD-SNAPSHOT@properties'
 	}
 
 	// enable all compiler warnings; individual projects may customize further
@@ -188,7 +190,7 @@ subprojects { subproject ->
 		logging.captureStandardOutput(LogLevel.INFO)
 		dependsOn checkTestConfigs
 
-		if (name ==~ /(springio.*)|(testAll)/) {
+		if (name ==~ /(springIo.*)|(testAll)/) {
 			systemProperty 'RUN_LONG_INTEGRATION_TESTS', 'true'
 		}
 	}
@@ -291,7 +293,7 @@ project('spring-integration-ftp') {
 
 project('spring-integration-gemfire') {
 	description = 'Spring Integration GemFire Support'
-	tasks.withType(Test).matching {it.name ==~ /(springio.+)|(test)|(testAll)/}.all {
+	tasks.withType(Test).matching {it.name ==~ /(springIo.+)|(test)|(testAll)/}.all {
 		forkEvery = 1
 		systemProperties['gemfire.disableShutdownHook'] = 'true'
 	}
@@ -428,7 +430,7 @@ project('spring-integration-jpa') {
 	//Suppress openjpa annotation processor warnings
 	compileTestJava.options.compilerArgs = ["${xLintArg},-processing"]
 
-	tasks.withType(Test).matching {it.name ==~ /(springio.+)|(test)|(testAll)/}.all {
+	tasks.withType(Test).matching {it.name ==~ /(springIo.+)|(test)|(testAll)/}.all {
 		jvmArgs classpath.files.findAll{it.name ==~ /(spring-instrument.+)|(openjpa.+)/}.collect{"-javaagent:$it"}
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,10 @@ apply plugin: 'idea'
 
 buildscript {
 	repositories {
-		maven { url 'http://repo.spring.io/plugins-release' }
+		maven { url 'http://repo.spring.io/plugins-snapshot' }
 	}
 	dependencies {
+		classpath 'org.springframework.build.gradle:springio-platform-plugin:0.0.3.BUILD-SNAPSHOT'
 		classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.2.8'
 	}
 }
@@ -23,6 +24,8 @@ ext {
 
 allprojects {
 	group = 'org.springframework.integration'
+
+	apply plugin: 'springio-platform'
 
 	repositories {
 		if (version.endsWith('BUILD-SNAPSHOT')) {
@@ -152,9 +155,12 @@ subprojects { subproject ->
 	ext.xLintArg = '-Xlint:all,-options'
 	[compileJava, compileTestJava]*.options*.compilerArgs = [xLintArg]
 
-	test {
+	tasks.withType(Test).all {
 		// suppress all console output during testing unless running `gradle -i`
 		logging.captureStandardOutput(LogLevel.INFO)
+	}
+
+	test {
 		jvmArgs "-javaagent:${configurations.jacoco.asPath}=destfile=${buildDir}/jacoco.exec,includes=org.springframework.integration.*"
 	}
 
@@ -285,7 +291,7 @@ project('spring-integration-ftp') {
 
 project('spring-integration-gemfire') {
 	description = 'Spring Integration GemFire Support'
-	test {
+	tasks.withType(Test).all {
 		forkEvery = 1
 		systemProperties['gemfire.disableShutdownHook'] = 'true'
 	}
@@ -422,11 +428,13 @@ project('spring-integration-jpa') {
 	//Suppress openjpa annotation processor warnings
 	compileTestJava.options.compilerArgs = ["${xLintArg},-processing"]
 
-	test.doFirst {
-		def javaAgents = configurations.testRuntime.resolvedConfiguration.resolvedArtifacts
-				.findAll { it.name in ['spring-instrument', 'openjpa'] }
-				.collect { "-javaagent:${it.file}" }
-		jvmArgs javaAgents
+	tasks.withType(Test).all {
+		doFirst {
+			def javaAgents = classpath.files
+					.findAll { it.name.contains('spring-instrument') || it.name.contains('openjpa')}
+					.collect { "-javaagent:$it" }
+			jvmArgs javaAgents
+		}
 	}
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 		maven { url 'http://repo.spring.io/plugins-snapshot' }
 	}
 	dependencies {
-		classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.BUILD-SNAPSHOT'
+		classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE'
 		classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.2.8'
 	}
 }
@@ -25,8 +25,6 @@ ext {
 
 allprojects {
 	group = 'org.springframework.integration'
-
-	apply plugin: 'spring-io'
 
 	repositories {
 		if (version.endsWith('BUILD-SNAPSHOT')) {
@@ -57,6 +55,18 @@ subprojects { subproject ->
 	apply from:   "${rootProject.projectDir}/publish-maven.gradle"
 	apply plugin: 'eclipse'
 	apply plugin: 'idea'
+
+	if (project.hasProperty('platformVersion')) {
+		apply plugin: 'spring-io'
+
+		repositories {
+			maven { url "https://repo.spring.io/libs-snapshot" }
+		}
+
+		dependencies {
+			springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+		}
+	}
 
 	sourceCompatibility=1.6
 	targetCompatibility=1.6

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'idea'
 
 buildscript {
 	repositories {
+		maven { url 'http://repo.spring.io/plugins-release' }
 		maven { url 'http://repo.spring.io/plugins-snapshot' }
 	}
 	dependencies {
@@ -155,32 +156,6 @@ subprojects { subproject ->
 	ext.xLintArg = '-Xlint:all,-options'
 	[compileJava, compileTestJava]*.options*.compilerArgs = [xLintArg]
 
-	tasks.withType(Test).all {
-		// suppress all console output during testing unless running `gradle -i`
-		logging.captureStandardOutput(LogLevel.INFO)
-	}
-
-	test {
-		jvmArgs "-javaagent:${configurations.jacoco.asPath}=destfile=${buildDir}/jacoco.exec,includes=org.springframework.integration.*"
-	}
-
-	task testAll() {
-		doFirst {
-			tasks.test.systemProperty 'RUN_LONG_INTEGRATION_TESTS', 'true'
-		}
-		finalizedBy test
-	}
-
-	task sourcesJar(type: Jar) {
-		classifier = 'sources'
-		from sourceSets.main.allJava
-	}
-
-	task javadocJar(type: Jar) {
-		classifier = 'javadoc'
-		from javadoc
-	}
-
 	task checkTestConfigs {
 		doLast {
 			def configFiles = []
@@ -196,12 +171,37 @@ subprojects { subproject ->
 			if (configFiles) {
 				throw new InvalidUserDataException('Hardcoded XSD version in the config files:\n' +
 						configFiles.collect {relativePath(it)}.join('\n') +
-						'\nPlease, use versionless schemaLocations for Spring XSDs to avoid issues with builds on different versions of dependencies.')
+						'\nPlease, use versionless schemaLocations for Spring XSDs to avoid issues with builds ' +
+						'on different versions of dependencies.')
 			}
 		}
 	}
 
-	test.dependsOn checkTestConfigs
+	test {
+		jvmArgs "-javaagent:${configurations.jacoco.asPath}=destfile=${buildDir}/jacoco.exec,includes=org.springframework.integration.*"
+	}
+
+	task testAll(type: Test)
+
+	tasks.withType(Test).all {
+		// suppress all console output during testing unless running `gradle -i`
+		logging.captureStandardOutput(LogLevel.INFO)
+		dependsOn checkTestConfigs
+
+		if (name ==~ /(springio.*)|(testAll)/) {
+			systemProperty 'RUN_LONG_INTEGRATION_TESTS', 'true'
+		}
+	}
+
+	task sourcesJar(type: Jar) {
+		classifier = 'sources'
+		from sourceSets.main.allJava
+	}
+
+	task javadocJar(type: Jar) {
+		classifier = 'javadoc'
+		from javadoc
+	}
 
 	artifacts {
 		archives sourcesJar
@@ -291,7 +291,7 @@ project('spring-integration-ftp') {
 
 project('spring-integration-gemfire') {
 	description = 'Spring Integration GemFire Support'
-	tasks.withType(Test).all {
+	tasks.withType(Test).matching {it.name ==~ /(springio.+)|(test)|(testAll)/}.all {
 		forkEvery = 1
 		systemProperties['gemfire.disableShutdownHook'] = 'true'
 	}
@@ -428,13 +428,8 @@ project('spring-integration-jpa') {
 	//Suppress openjpa annotation processor warnings
 	compileTestJava.options.compilerArgs = ["${xLintArg},-processing"]
 
-	tasks.withType(Test).all {
-		doFirst {
-			def javaAgents = classpath.files
-					.findAll { it.name.contains('spring-instrument') || it.name.contains('openjpa')}
-					.collect { "-javaagent:$it" }
-			jvmArgs javaAgents
-		}
+	tasks.withType(Test).matching {it.name ==~ /(springio.+)|(test)|(testAll)/}.all {
+		jvmArgs classpath.files.findAll{it.name ==~ /(spring-instrument.+)|(openjpa.+)/}.collect{"-javaagent:$it"}
 	}
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'idea'
 buildscript {
 	repositories {
 		maven { url 'http://repo.spring.io/plugins-release' }
-		maven { url 'http://repo.spring.io/plugins-snapshot' }
 	}
 	dependencies {
 		classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE'
@@ -160,8 +159,6 @@ subprojects { subproject ->
 			testCompile project(":spring-integration-test")
 		}
 		jacoco group: "org.jacoco", name: "org.jacoco.agent", version: "0.5.6.201201232323", classifier: "runtime"
-
-		springIoVersions 'io.spring.platform:platform-versions:1.0.0.BUILD-SNAPSHOT@properties'
 	}
 
 	// enable all compiler warnings; individual projects may customize further

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 	group = 'org.springframework.integration'
 
 	repositories {
-		if (version.endsWith('BUILD-SNAPSHOT')) {
+		if (version.endsWith('BUILD-SNAPSHOT') || project.hasProperty('platformVersion')) {
 			maven { url 'http://repo.spring.io/libs-snapshot' }
 		}
 		maven { url 'http://repo.spring.io/libs-milestone' }
@@ -57,10 +57,6 @@ subprojects { subproject ->
 
 	if (project.hasProperty('platformVersion')) {
 		apply plugin: 'spring-io'
-
-		repositories {
-			maven { url "https://repo.spring.io/libs-snapshot" }
-		}
 
 		dependencies {
 			springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"


### PR DESCRIPTION
With thanks to the pointers from Artem, the `spring-integration-jpa` and `spring-integration-gemfire` tests now pass when run with the Spring IO versions: note the changes to apply the javaagents and forkEvery to every Test task. However, I'm seeing failures in `spring-integration-core` and `spring-integration-twitter` due to a `MalformedParameterizedTypeException`. Given that it's using a snapshot, I'm not sure that you'll want to merge this PR yet, but I thought it would be a reasonable way to share what I've done and discuss the test failures.

In both cases the failures seem to be related to retry advice. I _think_ these failures are legitimate problems, rather than due to the plugin. You can reproduce the failure by running `/gradlew springioCheck -PJDK7_HOME=/Library/Java/JavaVirtualMachines/jdk7/Contents/Home/` (updating JDK7_HOME as appropriate for your OS). You should see a single failure in `spring-integration-core`:

```
org.springframework.integration.config.xml.RetryAdviceParserTests > testAll:

java.lang.IllegalStateException: Failed to load ApplicationContext
    at org.springframework.test.context.CacheAwareContextLoaderDelegate.loadContext(CacheAwareContextLoaderDelegate.java:99)
    at org.springframework.test.context.DefaultTestContext.getApplicationContext(DefaultTestContext.java:101)
    at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.injectDependencies(DependencyInjectionTestExecutionListener.java:109)
    at org.springframework.test.context.support.DependencyInjectionTestExecutionListener.prepareTestInstance(DependencyInjectionTestExecutionListener.java:75)
    at org.springframework.test.context.TestContextManager.prepareTestInstance(TestContextManager.java:324)
    at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.createTest(SpringJUnit4ClassRunner.java:213)
    at org.springframework.test.context.junit4.SpringJUnit4ClassRunner$1.runReflectiveCall(SpringJUnit4ClassRunner.java:290)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.methodBlock(SpringJUnit4ClassRunner.java:292)
    at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:233)
    at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.runChild(SpringJUnit4ClassRunner.java:87)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.springframework.test.context.junit4.statements.RunBeforeTestClassCallbacks.evaluate(RunBeforeTestClassCallbacks.java:61)
    at org.springframework.test.context.junit4.statements.RunAfterTestClassCallbacks.evaluate(RunAfterTestClassCallbacks.java:71)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.springframework.test.context.junit4.SpringJUnit4ClassRunner.run(SpringJUnit4ClassRunner.java:176)
    at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.runTestClass(JUnitTestClassExecuter.java:86)
    at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.execute(JUnitTestClassExecuter.java:49)
    at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassProcessor.processTestClass(JUnitTestClassProcessor.java:69)
    at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:50)
    at sun.reflect.GeneratedMethodAccessor18.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.gradle.messaging.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
    at org.gradle.messaging.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
    at org.gradle.messaging.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
    at org.gradle.messaging.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
    at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
    at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:103)
    at sun.reflect.GeneratedMethodAccessor17.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.gradle.messaging.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
    at org.gradle.messaging.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
    at org.gradle.messaging.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:355)
    at org.gradle.internal.concurrent.DefaultExecutorFactory$StoppableExecutorImpl$1.run(DefaultExecutorFactory.java:64)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:744)
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'a1': Initialization of bean failed; nested exception is java.lang.reflect.MalformedParameterizedTypeException
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:547)
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:475)
    at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:304)
    at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:228)
    at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:300)
    at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:195)
    at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:703)
    at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:760)
    at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:482)
    at org.springframework.test.context.support.AbstractGenericContextLoader.loadContext(AbstractGenericContextLoader.java:125)
    at org.springframework.test.context.support.AbstractGenericContextLoader.loadContext(AbstractGenericContextLoader.java:60)
    at org.springframework.test.context.support.AbstractDelegatingSmartContextLoader.delegateLoading(AbstractDelegatingSmartContextLoader.java:100)
    at org.springframework.test.context.support.AbstractDelegatingSmartContextLoader.loadContext(AbstractDelegatingSmartContextLoader.java:250)
    at org.springframework.test.context.CacheAwareContextLoaderDelegate.loadContextInternal(CacheAwareContextLoaderDelegate.java:64)
    at org.springframework.test.context.CacheAwareContextLoaderDelegate.loadContext(CacheAwareContextLoaderDelegate.java:91)
    ... 42 more
Caused by: java.lang.reflect.MalformedParameterizedTypeException
    at sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl.validateConstructorArguments(ParameterizedTypeImpl.java:60)
    at sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl.<init>(ParameterizedTypeImpl.java:53)
    at sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl.make(ParameterizedTypeImpl.java:95)
    at sun.reflect.generics.factory.CoreReflectionFactory.makeParameterizedType(CoreReflectionFactory.java:105)
    at sun.reflect.generics.visitor.Reifier.visitClassTypeSignature(Reifier.java:140)
    at sun.reflect.generics.tree.ClassTypeSignature.accept(ClassTypeSignature.java:49)
    at sun.reflect.generics.repository.ConstructorRepository.getParameterTypes(ConstructorRepository.java:94)
    at java.lang.reflect.Method.getGenericParameterTypes(Method.java:292)
    at java.beans.FeatureDescriptor.getParameterTypes(FeatureDescriptor.java:387)
    at java.beans.MethodDescriptor.setMethod(MethodDescriptor.java:114)
    at java.beans.MethodDescriptor.<init>(MethodDescriptor.java:72)
    at java.beans.MethodDescriptor.<init>(MethodDescriptor.java:56)
    at java.beans.Introspector.getTargetMethodInfo(Introspector.java:1149)
    at java.beans.Introspector.getBeanInfo(Introspector.java:416)
    at java.beans.Introspector.getBeanInfo(Introspector.java:163)
    at org.springframework.beans.CachedIntrospectionResults.<init>(CachedIntrospectionResults.java:284)
    at org.springframework.beans.CachedIntrospectionResults.forClass(CachedIntrospectionResults.java:188)
    at org.springframework.beans.BeanWrapperImpl.getCachedIntrospectionResults(BeanWrapperImpl.java:327)
    at org.springframework.beans.BeanWrapperImpl.getPropertyDescriptors(BeanWrapperImpl.java:335)
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.filterPropertyDescriptorsForDependencyCheck(AbstractAutowireCapableBeanFactory.java:1343)
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.filterPropertyDescriptorsForDependencyCheck(AbstractAutowireCapableBeanFactory.java:1322)
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1180)
    at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:537)
    ... 56 more
```

I've you run with `--continue` you'll also see very similar failures in `spring-integration-twitter`.

If you'd like to see the versions of the dependencies that the tests are being run against use `./gradlew ./gradlew spring-integration-core:dependencies --configuration springioTestRuntime`

Please let me know if there's anything I can do to help
