### PR TITLE
Update preface docs for Java 8 compatibility

### DIFF
--- a/src/reference/docbook/preface.xml
+++ b/src/reference/docbook/preface.xml
@@ -20,7 +20,7 @@
 			<para>
 				<emphasis>Spring Integration</emphasis> <emphasis role="strong">3.0.x</emphasis>
 				is also compatible with <emphasis role="strong">Java SE 7</emphasis> as well
-				as <emphasis role="strong">Java SE 8</emphasis> (once released).
+				as <emphasis role="strong">Java SE 8</emphasis>.
 			</para>
 			<note>
 				<emphasis>Spring Integration</emphasis> <emphasis role="strong">2.2.x</emphasis>


### PR DESCRIPTION
Reference docs in preface mention Spring Integration compatibility with
Java 8, once it's released. Since Java 8 is released, the extra note is
no longer relevant and should be removed.

This patch removes no longer relevant note of pending Java 8 release.

Issue: INT-3400
