### PR TITLE
INT-3386: Add `GroupMetadataAggregator`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/GroupMetadataAggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/GroupMetadataAggregatingMessageHandler.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.aggregator;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.UUID;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.locks.Lock;
+
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.store.MessageGroup;
+import org.springframework.integration.store.MessageGroupMetadata;
+import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.integration.util.UUIDConverter;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+
+/**
+ * @author Artem Bilan
+ * @since 4.0
+ */
+public class GroupMetadataAggregatingMessageHandler extends AggregatingMessageHandler {
+
+	public GroupMetadataAggregatingMessageHandler(MessageGroupProcessor processor, MessageGroupStore store,
+			CorrelationStrategy correlationStrategy, ReleaseStrategy releaseStrategy) {
+		super(processor, store, correlationStrategy, releaseStrategy);
+	}
+
+	public GroupMetadataAggregatingMessageHandler(MessageGroupProcessor processor, MessageGroupStore store) {
+		super(processor, store);
+	}
+
+	public GroupMetadataAggregatingMessageHandler(MessageGroupProcessor processor) {
+		super(processor);
+	}
+
+	@Override
+	protected void handleMessageInternal(Message<?> message) throws Exception {
+		Object correlationKey = getCorrelationStrategy().getCorrelationKey(message);
+		Assert.state(correlationKey != null, "Null correlation not allowed.  Maybe the CorrelationStrategy is failing?");
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("Handling message with correlationKey [" + correlationKey + "]: " + message);
+		}
+
+		UUID groupIdUuid = UUIDConverter.getUUID(correlationKey);
+		Lock lock = getLockRegistry().obtain(groupIdUuid.toString());
+
+		lock.lockInterruptibly();
+		try {
+			ScheduledFuture<?> scheduledFuture = this.expireGroupScheduledFutures.remove(groupIdUuid);
+			if (scheduledFuture != null) {
+				boolean canceled = scheduledFuture.cancel(true);
+				if (canceled && logger.isDebugEnabled()) {
+					logger.debug("Cancel 'forceComplete' scheduling for MessageGroup with Correlation Key [ "
+							+ correlationKey + "].");
+				}
+			}
+			MessageGroupMetadata messageGroup = messageStore.getGroupMetadata(correlationKey);
+
+			if (!messageGroup.isComplete()) {
+				if (logger.isTraceEnabled()) {
+					logger.trace("Adding message to group [ " + messageGroup + "]");
+				}
+				messageGroup = this.messageStore.addMessageToGroupMetadata(correlationKey, message);
+
+				MessageGroup groupProxy = new MessageGroupProxy(messageGroup, this.messageStore);
+
+				if (getReleaseStrategy().canRelease(groupProxy)) {
+					MessageGroup group = this.messageStore.getMessageGroup(correlationKey);
+					Collection<Message<?>> completedMessages = null;
+					try {
+						completedMessages = this.completeGroup(message, correlationKey, group);
+					}
+					finally {
+						// Always clean up even if there was an exception
+						// processing messages
+						this.afterRelease(group, completedMessages);
+					}
+				}
+				else {
+					Long groupTimeout = this.obtainGroupTimeout(groupProxy);
+					if (groupTimeout != null && groupTimeout >= 0) {
+						if (groupTimeout > 0) {
+							final MessageGroup messageGroupToSchedule = groupProxy;
+
+							scheduledFuture = this.getTaskScheduler()
+									.schedule(new Runnable() {
+
+										@Override
+										public void run() {
+											forceComplete(messageGroupToSchedule);
+										}
+									}, new Date(System.currentTimeMillis() + groupTimeout));
+
+							if (logger.isDebugEnabled()) {
+								logger.debug("Schedule MessageGroup [ " + messageGroup + "] to 'forceComplete'.");
+							}
+							this.expireGroupScheduledFutures.put(groupIdUuid, scheduledFuture);
+						}
+						else {
+							this.forceComplete(groupProxy);
+						}
+					}
+				}
+			}
+			else {
+				getDiscardChannel().send(message);
+			}
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	protected void forceComplete(MessageGroup group) {
+		Object correlationKey = group.getGroupId();
+		// UUIDConverter is no-op if already converted
+		Lock lock = getLockRegistry().obtain(UUIDConverter.getUUID(correlationKey).toString());
+		boolean removeGroup = true;
+		try {
+			lock.lockInterruptibly();
+			try {
+				ScheduledFuture<?> scheduledFuture =
+						this.expireGroupScheduledFutures.remove(UUIDConverter.getUUID(correlationKey));
+				if (scheduledFuture != null) {
+					boolean canceled = scheduledFuture.cancel(false);
+					if (canceled && logger.isDebugEnabled()) {
+						logger.debug("Cancel 'forceComplete' scheduling for MessageGroup [ " + group + "].");
+					}
+				}
+				MessageGroup groupNow = group;
+				/*
+				 * If the group argument is not already complete,
+				 * re-fetch it because it might have changed while we were waiting on
+				 * its lock. If the last modified timestamp changed, defer the completion
+				 * because the selection condition may have changed such that the group
+				 * would no longer be eligible. If the timestamp changed, it's a completely new
+				 * group and should not be reaped on this cycle.
+				 *
+				 * If the group argument is already complete, do not re-fetch.
+				 * Note: not all message stores provide a direct reference to its internal
+				 * group so the initial 'isComplete()` will only return true for those stores if
+				 * the group was already complete at the time of its selection as a candidate.
+				 *
+				 * If the group is marked complete, only consider it
+				 * for reaping if it's empty (and both timestamps are unaltered).
+				 */
+				if (!group.isComplete()) {
+					groupNow = new MessageGroupProxy(this.messageStore.getGroupMetadata(correlationKey),
+							this.messageStore);
+				}
+				long lastModifiedNow = groupNow.getLastModified();
+				int groupSize = groupNow.size();
+				if ((!groupNow.isComplete() || groupSize == 0)
+						&& group.getLastModified() == lastModifiedNow
+						&& group.getTimestamp() == groupNow.getTimestamp()) {
+					if (groupSize > 0) {
+						if (getReleaseStrategy().canRelease(groupNow)) {
+							this.completeGroup(correlationKey, groupNow);
+						}
+						else {
+							this.expireGroup(correlationKey, groupNow);
+						}
+					}
+					else {
+						/*
+						 * By default empty groups are removed on the same schedule as non-empty
+						 * groups. A longer timeout for empty groups can be enabled by
+						 * setting minimumTimeoutForEmptyGroups.
+						 */
+						removeGroup = lastModifiedNow <= (System.currentTimeMillis() - getMinimumTimeoutForEmptyGroups());
+						if (removeGroup && logger.isDebugEnabled()) {
+							logger.debug("Removing empty group: " + correlationKey);
+						}
+					}
+				}
+				else {
+					removeGroup = false;
+					if (logger.isDebugEnabled()) {
+						logger.debug("Group expiry candidate (" + correlationKey +
+								") has changed - it may be reconsidered for a future expiration");
+					}
+				}
+			}
+			finally {
+				if (removeGroup) {
+					this.remove(group);
+				}
+				lock.unlock();
+			}
+		}
+		catch (InterruptedException ie) {
+			Thread.currentThread().interrupt();
+			logger.debug("Thread was interrupted while trying to obtain lock");
+		}
+	}
+
+	private static class MessageGroupProxy implements MessageGroup, Collection<Message<?>> {
+
+		private final MessageGroupMetadata metadata;
+
+		private final MessageGroupStore store;
+
+		private final Object oneMonitor = new Object();
+
+		private final Object messagesMonitor = new Object();
+
+		private volatile Message<?> one;
+
+		private volatile Collection<Message<?>> messages;
+
+		MessageGroupProxy(MessageGroupMetadata metadata, MessageGroupStore store) {
+			this.metadata = metadata;
+			this.store = store;
+		}
+
+		@Override
+		public boolean canAdd(Message<?> message) {
+			return true;
+		}
+
+		@Override
+		public Collection<Message<?>> getMessages() {
+			if (this.messages == null) {
+				synchronized (this.messagesMonitor) {
+					if (this.messages == null) {
+						this.messages = this.store.getMessageGroup(this.metadata.getGroupId()).getMessages();
+					}
+				}
+			}
+
+			return this.messages;
+		}
+
+		@Override
+		public Iterator<Message<?>> iterator() {
+			return getMessages().iterator();
+		}
+
+		@Override
+		public Object getGroupId() {
+			return this.metadata.getGroupId();
+		}
+
+		@Override
+		public int getLastReleasedMessageSequenceNumber() {
+			return this.metadata.getLastReleasedMessageSequenceNumber();
+		}
+
+		@Override
+		public boolean isComplete() {
+			return this.metadata.isComplete();
+		}
+
+		@Override
+		public void complete() {
+			 this.store.completeGroup(this.metadata.getGroupId());
+		}
+
+		@Override
+		public int getSequenceSize() {
+			if (size() == 0) {
+				return 0;
+			}
+			return new IntegrationMessageHeaderAccessor(getOne()).getSequenceSize();
+		}
+
+		@Override
+		public int size() {
+			return this.metadata.size();
+		}
+
+		@Override
+		public Message<?> getOne() {
+			if (this.one == null) {
+				synchronized (this.oneMonitor) {
+					if (this.one == null) {
+						this.one = this.store.getOneMessageFromGroup(this.metadata.getGroupId());
+					}
+				}
+			}
+			return this.one;
+		}
+
+		@Override
+		public long getTimestamp() {
+			return this.metadata.getTimestamp();
+		}
+
+		@Override
+		public long getLastModified() {
+			return this.metadata.getLastModified();
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return this.metadata.size() == 0;
+		}
+
+		@Override
+		public Object[] toArray() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public <T> T[] toArray(T[] a) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean add(Message<?> message) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean remove(Object o) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean containsAll(Collection<?> c) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean contains(Object o) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean addAll(Collection<? extends Message<?>> c) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean removeAll(Collection<?> c) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean retainAll(Collection<?> c) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void clear() {
+			throw new UnsupportedOperationException();
+		}
+
+	}
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MessageGroupExpressionReleaseStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MessageGroupExpressionReleaseStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.aggregator;
+
+import org.springframework.expression.Expression;
+import org.springframework.integration.store.MessageGroup;
+import org.springframework.integration.util.AbstractExpressionEvaluator;
+
+
+/**
+ * @author Artem Bilan
+ * @since 4.0
+ */
+public class MessageGroupExpressionReleaseStrategy extends AbstractExpressionEvaluator implements ReleaseStrategy {
+
+	private final Expression expression;
+
+	public MessageGroupExpressionReleaseStrategy(Expression expression) {
+		this.expression = expression;
+	}
+
+	@Override
+	public boolean canRelease(MessageGroup group) {
+		return evaluateExpression(this.expression, group, Boolean.class);
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -26,7 +26,6 @@ import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
-import org.springframework.messaging.Message;
 
 /**
  * @author Dave Syer
@@ -134,16 +133,6 @@ public abstract class AbstractMessageGroupStore implements MessageGroupStore, It
 			count ++;
 		}
 		return count;
-	}
-
-	@Override
-	public MessageGroupMetadata getGroupMetadata(Object groupId) {
-		throw new UnsupportedOperationException("Not yet implemented for this store");
-	}
-
-	@Override
-	public Message<?> getOneMessageFromGroup(Object groupId) {
-		throw new UnsupportedOperationException("Not yet implemented for this store");
 	}
 
 	private void expire(MessageGroup group) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -39,6 +39,8 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	@ManagedAttribute
 	int getMessageCountForAllMessageGroups();
 
+	MessageGroupMetadata addMessageToGroupMetadata(Object groupId, Message<?> message);
+
 	/**
 	 * Optional attribute giving the number of  message groups. Implementations may decline
 	 * to respond by throwing an exception.

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
@@ -187,6 +187,11 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 	}
 
 	@Override
+	public MessageGroupMetadata addMessageToGroupMetadata(Object groupId, Message<?> message) {
+		return new MessageGroupMetadata(addMessageToGroup(groupId, message));
+	}
+
+	@Override
 	public void removeMessageGroup(Object groupId) {
 		Lock lock = this.lockRegistry.obtain(groupId);
 		try {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/expression-evaluating-correlation-with-bf.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/expression-evaluating-correlation-with-bf.xml
@@ -5,6 +5,8 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator input-channel="inputChannel" output-channel="outputChannel"
 		correlation-strategy-expression="@correlator.correlate(payload)"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorExpressionIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorExpressionIntegrationTests-context.xml
@@ -7,6 +7,8 @@
 		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<beans:bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<channel id="input"/>
 
 	<aggregator expression="new java.util.ArrayList(#root).![payload].toString()" input-channel="input"

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
@@ -7,6 +7,8 @@
 		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<beans:bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<channel id="input">
 		<queue capacity="5" />
 	</channel>

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AnnotationAggregatorTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AnnotationAggregatorTests-context.xml
@@ -7,6 +7,8 @@
 			http://www.springframework.org/schema/integration
 			http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<beans:bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<channel id="output">
 		<queue/>
 	</channel>

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/DefaultMessageAggregatorIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/DefaultMessageAggregatorIntegrationTests-context.xml
@@ -7,6 +7,8 @@
 		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<beans:bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<annotation-config />
 
 	<channel id="input">

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/MethodInvokingAggregatorReturningMessageTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/MethodInvokingAggregatorReturningMessageTests-context.xml
@@ -7,6 +7,8 @@
 			http://www.springframework.org/schema/integration
 			http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<beans:bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<channel id="pojoOutput">
 		<queue/>
 	</channel>

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/scenarios/AggregationResendTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/scenarios/AggregationResendTests-context.xml
@@ -7,6 +7,8 @@
             http://www.springframework.org/schema/integration
             http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<beans:bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<channel id="input_for_aggregator_with_explicit_timeout"/>
 	<channel id="input_for_aggregator_without_explicit_timeout"/>
 	<channel id="aggregator_with_explicit_timeout_channel"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/scenarios/AggregatorReplyChannelTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/scenarios/AggregatorReplyChannelTests-context.xml
@@ -5,6 +5,8 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<beans:bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<channel id="input"/>
 
 	<channel id="output">

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/scenarios/NestedAggregationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/scenarios/NestedAggregationTests-context.xml
@@ -6,6 +6,8 @@
             http://www.springframework.org/schema/integration
             http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<beans:bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<channel id="splitter" />
 
 	<splitter id="upstream-splitter" input-channel="splitter" output-channel="upstream-splits" />

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/scenarios/aggregator-with-custom-release-strategy.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/scenarios/aggregator-with-custom-release-strategy.xml
@@ -5,6 +5,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
 
 	<int:splitter input-channel="in" output-channel="aggregationChannelFromSplitter"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/history/messageHistoryWithHistoryWriter.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/history/messageHistoryWithHistoryWriter.xml
@@ -30,6 +30,8 @@
 
 	<int:splitter id="testSplitter" input-channel="splitterChannel" output-channel="aggregatorChannel"/>
 
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator id="testAggregator" input-channel="aggregatorChannel" output-channel="endOfThePipeChannel"/>
 
 	<int:channel id="endOfThePipeChannel"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/history/messageHistoryWithHistoryWriterNamespace.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/history/messageHistoryWithHistoryWriterNamespace.xml
@@ -5,37 +5,39 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<int:gateway id="sampleGateway" 
+	<int:gateway id="sampleGateway"
 	             service-interface="org.springframework.integration.history.MessageHistoryIntegrationTests.SampleGateway"
 	             default-request-channel="bridgeInChannel"/>
-	             
+
 	<int:channel id="bridgeInChannel">
 		<int:queue/>
 	</int:channel>
-	             
+
 	<int:bridge id="testBridge" input-channel="bridgeInChannel" output-channel="headerEnricherChannel">
 		<int:poller max-messages-per-poll="1" fixed-delay="100"/>
 	</int:bridge>
-	
+
 	<int:header-enricher id="testHeaderEnricher" input-channel="headerEnricherChannel" output-channel="chainChannel">
 		<int:header name="foo" value="foo"/>
 	</int:header-enricher>
-	
+
 	<int:chain id="sampleChain" input-channel="chainChannel" output-channel="filterChannel">
 		<int:header-enricher>
 			<int:header name="baz" value="baz"/>
 		</int:header-enricher>
 	</int:chain>
-	
-	<int:filter id="testFilter" input-channel="filterChannel" 
+
+	<int:filter id="testFilter" input-channel="filterChannel"
 				output-channel="splitterChannel" expression="payload.equals('hello')"/>
-				
+
 	<int:splitter id="testSplitter" input-channel="splitterChannel" output-channel="aggregatorChannel"/>
-	
+
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator id="testAggregator" input-channel="aggregatorChannel" output-channel="endOfThePipeChannel"/>
-	
+
 	<int:channel id="endOfThePipeChannel"/>
-	
+
 	<int:message-history/>
 
 </beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/history/messageHistoryWithHistoryWriterNamespaceAndPatterns.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/history/messageHistoryWithHistoryWriterNamespaceAndPatterns.xml
@@ -5,31 +5,33 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<int:gateway id="sampleGateway" 
+	<int:gateway id="sampleGateway"
 	             service-interface="org.springframework.integration.history.MessageHistoryIntegrationTests.SampleGateway"
 	             default-request-channel="bridgeInChannel"/>
-	             
+
 	<int:bridge id="testBridge" input-channel="bridgeInChannel" output-channel="headerEnricherChannel"/>
-	
+
 	<int:header-enricher id="testHeaderEnricher" input-channel="headerEnricherChannel" output-channel="chainChannel">
 		<int:header name="foo" value="foo"/>
 	</int:header-enricher>
-	
+
 	<int:chain id="sampleChain" input-channel="chainChannel" output-channel="filterChannel">
 		<int:header-enricher>
 			<int:header name="baz" value="baz"/>
 		</int:header-enricher>
 	</int:chain>
-	
-	<int:filter id="testFilter" input-channel="filterChannel" 
+
+	<int:filter id="testFilter" input-channel="filterChannel"
 				output-channel="splitterChannel" expression="payload.equals('hello')"/>
-				
+
 	<int:splitter id="testSplitter" input-channel="splitterChannel" output-channel="aggregatorChannel"/>
-	
+
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator id="testAggregator" input-channel="aggregatorChannel" output-channel="endOfThePipeChannel"/>
-	
+
 	<int:channel id="endOfThePipeChannel"/>
-	
+
 	<int:message-history tracked-components="*Gateway, sample*"/>
 
 </beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/history/messageHistoryWithoutHistoryWriter.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/history/messageHistoryWithoutHistoryWriter.xml
@@ -5,28 +5,30 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<int:gateway id="sampleGateway" 
+	<int:gateway id="sampleGateway"
 	             service-interface="org.springframework.integration.history.MessageHistoryIntegrationTests.SampleGateway"
 	             default-request-channel="bridgeInChannel"/>
-	             
+
 	<int:bridge id="testBridge" input-channel="bridgeInChannel" output-channel="headerEnricherChannel"/>
-	
+
 	<int:header-enricher id="testHeaderEnricher" input-channel="headerEnricherChannel" output-channel="chainChannel">
 		<int:header name="foo" value="foo"/>
 	</int:header-enricher>
-	
+
 	<int:chain id="sampleChain" input-channel="chainChannel" output-channel="filterChannel">
 		<int:header-enricher>
 			<int:header name="baz" value="baz"/>
 		</int:header-enricher>
 	</int:chain>
-	
-	<int:filter id="testFilter" input-channel="filterChannel" 
+
+	<int:filter id="testFilter" input-channel="filterChannel"
 				output-channel="splitterChannel" expression="payload.equals('hello')"/>
-				
+
 	<int:splitter id="testSplitter" input-channel="splitterChannel" output-channel="aggregatorChannel"/>
-	
+
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator id="testAggregator" input-channel="aggregatorChannel" output-channel="endOfThePipeChannel"/>
-	
+
 	<int:channel id="endOfThePipeChannel"/>
 </beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/history/perfWithMessageHistory.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/history/perfWithMessageHistory.xml
@@ -5,34 +5,36 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<int:gateway id="sampleGateway" 
+	<int:gateway id="sampleGateway"
 	             service-interface="org.springframework.integration.history.MessageHistoryIntegrationTests.SampleGateway"
 	             default-request-channel="bridgeInChannel"/>
-	             
+
 	<int:channel id="bridgeInChannel"/>
-	
+
 	<int:bridge id="testBridge" input-channel="bridgeInChannel" output-channel="headerEnricherChannel"/>
-	
-	
+
+
 	<int:header-enricher id="testHeaderEnricher" input-channel="headerEnricherChannel" output-channel="chainChannel">
 		<int:header name="foo" value="foo"/>
 	</int:header-enricher>
-	
+
 	<int:chain id="sampleChain" input-channel="chainChannel" output-channel="filterChannel">
 		<int:header-enricher>
 			<int:header name="baz" value="baz"/>
 		</int:header-enricher>
 	</int:chain>
-	
-	<int:filter id="testFilter" input-channel="filterChannel" 
+
+	<int:filter id="testFilter" input-channel="filterChannel"
 				output-channel="splitterChannel" expression="payload.equals('hello')"/>
-				
+
 	<int:splitter id="testSplitter" input-channel="splitterChannel" output-channel="aggregatorChannel"/>
-	
+
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator id="testAggregator" input-channel="aggregatorChannel" output-channel="endOfThePipeChannel"/>
-	
+
 	<int:channel id="endOfThePipeChannel"/>
-	
+
 	<int:message-history/>
 
 </beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/history/perfWithoutMessageHistory.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/history/perfWithoutMessageHistory.xml
@@ -5,32 +5,34 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<int:gateway id="sampleGateway" 
+	<int:gateway id="sampleGateway"
 	             service-interface="org.springframework.integration.history.MessageHistoryIntegrationTests.SampleGateway"
 	             default-request-channel="bridgeInChannel"/>
-	             
+
 	<int:channel id="bridgeInChannel"/>
-	
+
 	<int:bridge id="testBridge" input-channel="bridgeInChannel" output-channel="headerEnricherChannel"/>
-	
-	
+
+
 	<int:header-enricher id="testHeaderEnricher" input-channel="headerEnricherChannel" output-channel="chainChannel">
 		<int:header name="foo" value="foo"/>
 	</int:header-enricher>
-	
+
 	<int:chain id="sampleChain" input-channel="chainChannel" output-channel="filterChannel">
 		<int:header-enricher>
 			<int:header name="baz" value="baz"/>
 		</int:header-enricher>
 	</int:chain>
-	
-	<int:filter id="testFilter" input-channel="filterChannel" 
+
+	<int:filter id="testFilter" input-channel="filterChannel"
 				output-channel="splitterChannel" expression="payload.equals('hello')"/>
-				
+
 	<int:splitter id="testSplitter" input-channel="splitterChannel" output-channel="aggregatorChannel"/>
-	
+
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator id="testAggregator" input-channel="aggregatorChannel" output-channel="endOfThePipeChannel"/>
-	
+
 	<int:channel id="endOfThePipeChannel"/>
 
 </beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/splitterAggregatorTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/splitterAggregatorTests.xml
@@ -7,6 +7,8 @@
 			http://www.springframework.org/schema/integration
 			http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<beans:bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<channel id="numbers"/>
 	<channel id="splits"/>
 	<channel id="results">
@@ -14,6 +16,7 @@
 	</channel>
 
 	<splitter ref="splitter" method="split" input-channel="numbers" output-channel="splits"/>
+
 	<aggregator ref="aggregator" method="sum" input-channel="splits" output-channel="results"/>
 
 	<beans:bean id="splitter" class="org.springframework.integration.router.config.NumberSplitter"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,6 +121,21 @@ public class MessageStoreTests {
 
 		public int messageGroupSize(Object groupId) {
 			return 0;
+		}
+
+		@Override
+		public MessageGroupMetadata addMessageToGroupMetadata(Object groupId, Message<?> message) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public MessageGroupMetadata getGroupMetadata(Object groupId) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Message<?> getOneMessageFromGroup(Object groupId) {
+			throw new UnsupportedOperationException();
 		}
 
 	}

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStore-context.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStore-context.xml
@@ -13,10 +13,12 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:property-placeholder location="org/springframework/integration/gemfire/inbound/cq/common.properties"/>
-    
+
     <context:component-scan base-package="org.springframework.integration.gemfire.store"/>
 
     <int:channel id="i"/>
+
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
 
     <int:aggregator  release-strategy="releaseStrategy" correlation-strategy="correlationStrategy" message-store="gemfireMessageGroupStore" input-channel="i" output-channel="o"  />
 

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-aggregator-config-a.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-aggregator-config-a.xml
@@ -4,17 +4,19 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
-	
+
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="gemfireStore"/>
-	
+
 	<int:channel id="outputChannel">
 		<int:queue/>
 	</int:channel>
-	
+
 	<bean id="gemfireStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
 		<constructor-arg ref="cache"/>
 	</bean>
-	
+
 	<bean id="cache" class="org.springframework.data.gemfire.CacheFactoryBean"/>
 
 </beans>

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-aggregator-config.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-aggregator-config.xml
@@ -4,17 +4,19 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
-	
+
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="gemfireStore"/>
-	
+
 	<int:channel id="outputChannel">
 		<int:queue/>
 	</int:channel>
-	
+
 	<bean id="gemfireStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
 		<constructor-arg ref="myCache"/>
 	</bean>
-	
+
 	<bean id="myCache" class="org.springframework.data.gemfire.CacheFactoryBean"/>
 
 </beans>

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/util/AggregatorWithGemfireLocksTests-context.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/util/AggregatorWithGemfireLocksTests-context.xml
@@ -22,6 +22,8 @@
 
 	<bean id="sms" class="org.springframework.integration.store.SimpleMessageStore"/>
 
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator input-channel="in" release-strategy="latching" output-channel="out"
 					message-store="sms"
 					expire-groups-upon-completion="true" lock-registry="lockRegistry"/>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-config.xml
@@ -5,6 +5,8 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="mongoStore"/>
 
 	<int:channel id="outputChannel">

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-confugurable-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-confugurable-config.xml
@@ -5,6 +5,8 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="mongoStore"/>
 
 	<int:channel id="outputChannel">

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/redis-aggregator-config.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/redis-aggregator-config.xml
@@ -5,6 +5,8 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="redisStore"/>
 
 	<int:channel id="outputChannel">

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/AggregatorWithRedisLocksTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/AggregatorWithRedisLocksTests-context.xml
@@ -5,6 +5,8 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<bean id="$useGroupMetadataAggregatorHandler$" class="java.lang.Object"/>
+
 	<int:aggregator input-channel="in" release-strategy="latching" output-channel="out"
 		message-store="sms"
 		expire-groups-upon-completion="true" lock-registry="redisLockRegistry" />


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3386
- Add `GroupMetadataAggregatingMessageHandler` and `MessageGroupExpressionReleaseStrategy`
- Introduce internal `MessageGroupProxy` with Lazy-Load for `messages` and `Collection` implementation to get deal with SpEL projections
- Change `AggregatorParser` to get deal with `$useGroupMetadataAggregatorHandler$` fake bean,
  to replace `AggregatingMessageHandler` with `GroupMetadataAggregatingMessageHandler`
  and `ExpressionEvaluatingReleaseStrategy` with `MessageGroupExpressionReleaseStrategy`
- Add to test configs `$useGroupMetadataAggregatorHandler$` fake bean
- Implement for `MGS`s methods: `getGroupMetadata`, `getOneMessageFromGroup`, `addMessageToGroupMetadata`

TODO
- There is still need to invent how to get deal with `MethodInvokingReleaseStrategy`, because `MessagingMethodInvokerHelper` can process only
  `Message<?>` or `Collection<Message<?>>`, but avoid eager `messages` fetching we should have something for `MessageGroup`
