### PR TITLE
INT-3386 Improve Aggregator Performance

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -142,7 +142,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageH
 	}
 
 	public AbstractCorrelatingMessageHandler(MessageGroupProcessor processor) {
-		this(processor, new SimpleMessageStore(0), null, null);
+		this(processor, SimpleMessageStore.fastMessageStore(0), null, null);
 	}
 
 	public void setLockRegistry(LockRegistry lockRegistry) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -110,10 +110,24 @@ public abstract class AbstractMessageGroupStore implements MessageGroupStore, It
 
 			if (timestamp <= threshold) {
 				count++;
-				expire(group);
+				expire(copy(group));
 			}
 		}
 		return count;
+	}
+
+	/**
+	 * Used by expireMessageGroups. We need to return a snapshot of the group
+	 * at the time the reaper runs, so we can properly detect if the
+	 * group changed between now and the attempt to expire the group.
+	 * Not necessary for persistent stores, so the default behavior is
+	 * to just return the group.
+	 * @param group The group.
+	 * @return The group, or a copy.
+	 * @since 4.0.1
+	 */
+	protected MessageGroup copy(MessageGroup group) {
+		return group;
 	}
 
 	@Override

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandlerTests.java
@@ -36,15 +36,16 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Gary Russell
@@ -349,7 +350,7 @@ public class AbstractCorrelatingMessageHandlerTests {
 		handler.setOutputChannel(outputChannel);
 		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore", MessageGroupStore.class);
 		mgs.addMessageToGroup("foo", new GenericMessage<String>("foo"));
-		MessageGroup group = mgs.getMessageGroup("foo");
+		MessageGroup group = new SimpleMessageGroup(mgs.getMessageGroup("foo"));
 		mgs.completeGroup("foo");
 		mgs = spy(mgs);
 		new DirectFieldAccessor(handler).setPropertyValue("messageStore", mgs);
@@ -383,7 +384,7 @@ public class AbstractCorrelatingMessageHandlerTests {
 		handler.setOutputChannel(outputChannel);
 		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore", MessageGroupStore.class);
 		mgs.addMessageToGroup("foo", new GenericMessage<String>("foo"));
-		MessageGroup group = mgs.getMessageGroup("foo");
+		MessageGroup group = new SimpleMessageGroup(mgs.getMessageGroup("foo"));
 		mgs = spy(mgs);
 		new DirectFieldAccessor(handler).setPropertyValue("messageStore", mgs);
 		Method forceComplete = AbstractCorrelatingMessageHandler.class.getDeclaredMethod("forceComplete", MessageGroup.class);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3386

Eliminate unnecessary group copy during retrieval in the
aggregator. This is expensive with large groups.

Ensure that the reaper uses a snapshot of the group at the
time it is considered for reaping.

AggregatorTests.testAggPerf() -  before:

```
AggregatorTests [main] : Sent 0 in 0.0 (10k in 0ms)
AggregatorTests [main] : Sent 10000 in 4.872 (10k in 4872ms)
AggregatorTests [main] : Sent 20000 in 16.86 (10k in 11988ms)
AggregatorTests [main] : Sent 30000 in 36.809 (10k in 19949ms)
AggregatorTests [main] : Sent 40000 in 65.045 (10k in 28236ms)
AggregatorTests [main] : Sent 50000 in 100.329 (10k in 35284ms)
AggregatorTests [main] : Received 60000
AggregatorTests [main] : Sent 60000 in 143.106 (10k in 42777ms)
AggregatorTests [main] : Sent 70000 in 147.027 (10k in 3921ms)
AggregatorTests [main] : Sent 80000 in 158.664 (10k in 11637ms)
AggregatorTests [main] : Sent 90000 in 177.956 (10k in 19292ms)
AggregatorTests [main] : Sent 100000 in 205.045 (10k in 27089ms)
AggregatorTests [main] : Sent 110000 in 240.005 (10k in 34960ms)
AggregatorTests [main] : Received 60000
AggregatorTests [main] : Sent 120000 in 282.566 (10k in 42561ms)
```

After:

```
AggregatorTests [main] : Sent 0 in 0.0 (10k in 0ms)
AggregatorTests [main] : Sent 10000 in 0.612 (10k in 612ms)
AggregatorTests [main] : Sent 20000 in 0.925 (10k in 313ms)
AggregatorTests [main] : Sent 30000 in 1.131 (10k in 206ms)
AggregatorTests [main] : Sent 40000 in 1.288 (10k in 157ms)
AggregatorTests [main] : Sent 50000 in 1.361 (10k in 73ms)
AggregatorTests [main] : Received 60000
AggregatorTests [main] : Sent 60000 in 1.522 (10k in 161ms)
AggregatorTests [main] : Sent 70000 in 1.619 (10k in 97ms)
AggregatorTests [main] : Sent 80000 in 1.696 (10k in 77ms)
AggregatorTests [main] : Sent 90000 in 1.75 (10k in 54ms)
AggregatorTests [main] : Sent 100000 in 1.81 (10k in 60ms)
AggregatorTests [main] : Sent 110000 in 1.851 (10k in 41ms)
AggregatorTests [main] : Received 60000
AggregatorTests [main] : Sent 120000 in 1.918 (10k in 67ms)
```
