### PR TITLE
INT-3423 Fix Expression-Based Splitter

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/splitter/ExpressionEvaluatingSplitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/splitter/ExpressionEvaluatingSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.splitter;
 
-import java.util.Collection;
+import java.util.List;
 
 import org.springframework.expression.Expression;
 import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
@@ -26,15 +26,16 @@ import org.springframework.integration.handler.ExpressionEvaluatingMessageProces
  * expression. The result of evaluation will typically be a Collection or
  * Array. If the result is not a Collection or Array, then the single Object
  * will be returned as the payload of a single reply Message.
- * 
+ *
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.0
  */
 public class ExpressionEvaluatingSplitter extends AbstractMessageProcessingSplitter {
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	public ExpressionEvaluatingSplitter(Expression expression) {
-		super(new ExpressionEvaluatingMessageProcessor(expression, Collection.class));
+		super(new ExpressionEvaluatingMessageProcessor(expression, List.class));
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/splitter/SpelSplitterIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/splitter/SpelSplitterIntegrationTests-context.xml
@@ -13,6 +13,8 @@
 
 	<splitter input-channel="simpleInput" expression="payload.numbers.?[#this&lt;5]" output-channel="output"/>
 
+	<splitter input-channel="dups" expression="payload.split(' ')" output-channel="output"/>
+
 	<splitter input-channel="beanResolvingInput" expression="@testBean.split(payload)" output-channel="output"/>
 
 	<beans:bean id="testBean" class="org.springframework.integration.splitter.SpelSplitterIntegrationTests$TestBean"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/splitter/SpelSplitterIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/splitter/SpelSplitterIntegrationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.splitter;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
@@ -26,10 +27,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
-import org.springframework.integration.support.MessageBuilder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -44,11 +45,25 @@ public class SpelSplitterIntegrationTests {
 	private MessageChannel simpleInput;
 
 	@Autowired
+	private MessageChannel dups;
+
+	@Autowired
 	private MessageChannel beanResolvingInput;
 
 	@Autowired
 	private PollableChannel output;
 
+	@Test
+	public void dups() {
+		Message<?> message = MessageBuilder.withPayload("one one").build();
+		this.dups.send(message);
+		Message<?> one = output.receive(0);
+		Message<?> two = output.receive(0);
+		assertNotNull(one);
+		assertNotNull(two);
+		assertEquals("one", one.getPayload());
+		assertEquals("one", two.getPayload());
+	}
 
 	@Test
 	public void simple() {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3423

Consider a message containing "one one" and a splitter
with expression "payload.split(' ')", only one message
is emitted.

The default Collection created by SpEL is a HashSet.

Change the ExpressionEvaluatingSplitter to expect a
List instead of a Collection.
