### PR TITLE
INT-3431: Fix `RecipientListRouter.onInit()`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ subprojects { subproject ->
 		derbyVersion = '10.10.1.1'
 		eclipseLinkVersion = '2.4.2'
 		ftpServerVersion = '1.0.6'
-		groovyVersion = '2.3.0'
+		groovyVersion = '2.3.1'
 		guavaVersion = '16.0.1'
 		hamcrestVersion = '1.3'
 		hibernateVersion = '4.2.11.Final'
@@ -107,7 +107,7 @@ subprojects { subproject ->
 		servletApiVersion = '3.1.0'
 		slf4jVersion = "1.7.6"
 		smackVersion = '3.2.1'
-		springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '1.3.3.RELEASE'
+		springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '1.3.4.RELEASE'
 		springDataMongoVersion = '1.5.0.RELEASE'
 		springDataRedisVersion = '1.3.0.RELEASE'
 		springGemfireVersion = '1.4.0.RELEASE'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=4.0.2.BUILD-SNAPSHOT
+version=4.0.2.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=4.0.2.RELEASE
+version=4.0.3.BUILD-SNAPSHOT

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/ChannelTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/ChannelTests-context.xml
@@ -11,6 +11,6 @@
 
 	<int-amqp:publish-subscribe-channel id="foo" />
 
-	<rabbit:connection-factory id="rabbitConnectionFactory" />
+	<rabbit:connection-factory id="rabbitConnectionFactory" host="localhost" />
 
 </beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/OutboundGatewayIntegrationTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/OutboundGatewayIntegrationTests-context.xml
@@ -40,6 +40,6 @@
 
 	<rabbit:template id="amqpTemplate" connection-factory="connectionFactory"/>
 
-	<rabbit:connection-factory id="connectionFactory"/>
+	<rabbit:connection-factory id="connectionFactory" host="localhost" />
 
 </beans:beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/ManualAckTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/ManualAckTests.java
@@ -128,7 +128,9 @@ public class ManualAckTests {
 
 		@Bean
 		public CachingConnectionFactory connectionFactory() {
-			return new CachingConnectionFactory();
+			CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+			connectionFactory.setHost("localhost");
+			return connectionFactory;
 		}
 
 		@Bean

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/rule/BrokerRunning.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/rule/BrokerRunning.java
@@ -99,6 +99,7 @@ public class BrokerRunning extends TestWatcher {
 	@Override
 	public Statement apply(Statement base, Description description) {
 		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		connectionFactory.setHost("localhost");
 
 		try {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
@@ -54,6 +54,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  */
 public class RecipientListRouter extends AbstractMessageRouter implements InitializingBean {
 
@@ -64,7 +65,6 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 	 * Set the channels for this router. Either call this method or
 	 * {@link #setRecipients(List)} but not both. If MessageSelectors should be
 	 * considered, then use {@link #setRecipients(List)}.
-	 *
 	 * @param channels The channels.
 	 */
 	public void setChannels(List<MessageChannel> channels) {
@@ -78,7 +78,6 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 
 	/**
 	 * Set the recipients for this router.
-	 *
 	 * @param recipients The recipients.
 	 */
 	public void setRecipients(List<Recipient> recipients) {
@@ -92,8 +91,9 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 	}
 
 	@Override
-	public void onInit() {
+	public void onInit() throws Exception {
 		Assert.notEmpty(this.recipients, "recipient list must not be empty");
+		super.onInit();
 	}
 
 	@Override
@@ -131,7 +131,7 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 		}
 
 		public boolean accept(Message<?> message) {
-			return (this.selector != null ? this.selector.accept(message) : true);
+			return (this.selector == null || this.selector.accept(message));
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3431

The introduced `late channel resolution by name` via https://jira.spring.io/browse/INT-3431
has lost `onInit()` propagation from `RecipientListRouter.onInit()`
