### PR TITLE
INT-3431-4.0.x: Fix `RecipientListRouter.onInit()`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
@@ -54,6 +54,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  */
 public class RecipientListRouter extends AbstractMessageRouter implements InitializingBean {
 
@@ -64,7 +65,6 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 	 * Set the channels for this router. Either call this method or
 	 * {@link #setRecipients(List)} but not both. If MessageSelectors should be
 	 * considered, then use {@link #setRecipients(List)}.
-	 *
 	 * @param channels The channels.
 	 */
 	public void setChannels(List<MessageChannel> channels) {
@@ -78,7 +78,6 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 
 	/**
 	 * Set the recipients for this router.
-	 *
 	 * @param recipients The recipients.
 	 */
 	public void setRecipients(List<Recipient> recipients) {
@@ -92,8 +91,9 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 	}
 
 	@Override
-	public void onInit() {
+	public void onInit() throws Exception {
 		Assert.notEmpty(this.recipients, "recipient list must not be empty");
+		super.onInit();
 	}
 
 	@Override
@@ -131,7 +131,7 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 		}
 
 		public boolean accept(Message<?> message) {
-			return (this.selector != null ? this.selector.accept(message) : true);
+			return (this.selector == null || this.selector.accept(message));
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3431

The introduced `late channel resolution by name` via https://jira.spring.io/browse/INT-3324
has lost `onInit()` propagation from `RecipientListRouter.onInit()`
