### PR TITLE
INT-3431: Fix `RecipientListRouter.onInit()`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
@@ -153,13 +153,7 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 	}
 
 	@Override
-	public void onInit() {
-		try {
-			super.onInit();
-		}
-		catch (Exception e) {
-			throw new IllegalStateException(e);
-		}
+	protected void doInit() {
 		BeanFactory beanFactory = this.getBeanFactory();
 		if (this.channelResolver == null && beanFactory != null) {
 			this.channelResolver = new BeanFactoryChannelResolver(beanFactory);
@@ -219,7 +213,7 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 
 	private MessageChannel resolveChannelForName(String channelName, Message<?> message) {
 		if (this.channelResolver == null) {
-			this.onInit();
+			doInit();
 		}
 		Assert.state(this.channelResolver != null, "unable to resolve channel names, no ChannelResolver available");
 		MessageChannel channel = null;

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,8 @@ class AbstractMessageProcessingRouter extends AbstractMappingMessageRouter {
 
 
 	@Override
-	public final void onInit() {
-		super.onInit();
+	protected void doInit() {
+		super.doInit();
 		if (this.messageProcessor instanceof AbstractMessageProcessor) {
 			((AbstractMessageProcessor<?>) this.messageProcessor).setConversionService(this.getConversionService());
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageRouter.java
@@ -134,8 +134,8 @@ public abstract class AbstractMessageRouter extends AbstractMessageHandler {
 	}
 
 	@Override
-	protected void onInit() throws Exception {
-		super.onInit();
+	protected final void onInit() {
+		doInit();
 		if (this.getBeanFactory() != null) {
 			this.messagingTemplate.setBeanFactory(this.getBeanFactory());
 			if (StringUtils.hasText(this.defaultOutputChannelName)) {
@@ -150,6 +150,8 @@ public abstract class AbstractMessageRouter extends AbstractMessageHandler {
 			}
 		}
 	}
+
+	protected abstract void doInit();
 
 	/**
 	 * Subclasses must implement this method to return a Collection of zero or more

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
@@ -54,6 +54,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  */
 public class RecipientListRouter extends AbstractMessageRouter implements InitializingBean {
 
@@ -64,7 +65,6 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 	 * Set the channels for this router. Either call this method or
 	 * {@link #setRecipients(List)} but not both. If MessageSelectors should be
 	 * considered, then use {@link #setRecipients(List)}.
-	 *
 	 * @param channels The channels.
 	 */
 	public void setChannels(List<MessageChannel> channels) {
@@ -78,7 +78,6 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 
 	/**
 	 * Set the recipients for this router.
-	 *
 	 * @param recipients The recipients.
 	 */
 	public void setRecipients(List<Recipient> recipients) {
@@ -92,7 +91,7 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 	}
 
 	@Override
-	public void onInit() {
+	protected void doInit() {
 		Assert.notEmpty(this.recipients, "recipient list must not be empty");
 	}
 
@@ -131,7 +130,7 @@ public class RecipientListRouter extends AbstractMessageRouter implements Initia
 		}
 
 		public boolean accept(Message<?> message) {
-			return (this.selector != null ? this.selector.accept(message) : true);
+			return (this.selector == null || this.selector.accept(message));
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelegatingConsumerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelegatingConsumerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.config.xml;
 
 import static org.junit.Assert.assertEquals;
@@ -235,6 +236,8 @@ public class DelegatingConsumerParserTests {
 			return channels;
 		}
 
+		@Override
+		protected void doInit() {}
 	}
 
 	public static class MyRouterMH implements MessageHandler {

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/RouterConcurrencyTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/RouterConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.router;
 
 import static org.junit.Assert.assertEquals;
@@ -72,6 +73,8 @@ public class RouterConcurrencyTest {
 				}
 			}
 
+			@Override
+			protected void doInit() {}
 		};
 
 		final AtomicInteger beanCounter = new AtomicInteger();

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RfbFixRouter.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RfbFixRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,12 @@ import org.springframework.integration.router.AbstractMessageRouter;
  * @author Oleg Zhurakousky
  */
 public class RfbFixRouter extends AbstractMessageRouter {
-	
+
 	@Override
 	protected Collection<MessageChannel> determineTargetChannels(Message<?> message) {
 		return null;
 	}
+
+	@Override
+	protected void doInit() {}
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3431

The introduced `late channel resolution by name` via https://jira.spring.io/browse/INT-3324
has lost `onInit()` propagation from `RecipientListRouter.onInit()`
