### PR TITLE
INT-3442 `RedisQMDE` delay `stop` until last read

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.endpoint;
 
+import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.springframework.context.SmartLifecycle;
@@ -24,14 +25,14 @@ import org.springframework.scheduling.TaskScheduler;
 
 /**
  * The base class for Message Endpoint implementations.
- * 
+ *
  * <p>This class implements Lifecycle and provides an {@link #autoStartup}
  * property. If <code>true</code>, the endpoint will start automatically upon
  * initialization. Otherwise, it will require an explicit invocation of its
  * {@link #start()} method. The default value is <code>true</code>.
  * To require explicit startup, provide a value of <code>false</code>
  * to the {@link #setAutoStartup(boolean)} method.
- * 
+ *
  * @author Mark Fisher
  */
 public abstract class AbstractEndpoint extends IntegrationObjectSupport implements SmartLifecycle {
@@ -42,7 +43,9 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport implemen
 
 	private volatile boolean running;
 
-	private final ReentrantLock lifecycleLock = new ReentrantLock();
+	protected final ReentrantLock lifecycleLock = new ReentrantLock();
+
+	protected final Condition lifecycleCondition = this.lifecycleLock.newCondition();
 
 
 	public void setAutoStartup(boolean autoStartup) {

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
@@ -131,7 +131,7 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport impl
 	/**
 	 * @param stopTimeout the timeout to block {@link #doStop()} until the last message will be processed
 	 * or this timeout is reached. Should be less then or equal to {@link #receiveTimeout}
-	 * @since 4.1
+	 * @since 4.0.3
 	 */
 	public void setStopTimeout(long stopTimeout) {
 		this.stopTimeout = stopTimeout;
@@ -269,11 +269,13 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport impl
 		try {
 			this.active = false;
 			this.lifecycleCondition.await(Math.min(this.stopTimeout, this.receiveTimeout), TimeUnit.MICROSECONDS);
-			this.listening = false;
 		}
 		catch (InterruptedException e) {
 			logger.debug("Thread interrupted while stopping the endpoint");
 			Thread.currentThread().interrupt();
+		}
+		finally {
+			this.listening = false;
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3442

Previously `RedisQueueMessageDrivenEndpoint.stop()` returned immediately.
It caused an issue when one more `message` might be read and processed to stopped app.
- Introduce `AbstractEndpoint#lifecycleCondition` and wait on it from `RedisQueueMessageDrivenEndpoint.doStop()`
  and `signal()` it from `ListenerTask`.
- Since everything is done around `lifecycleLock` the `RedisQueueMessageDrivenEndpoint.stop()` waits for the proper
  'last' message process.
- Add tiny `Thread.sleep(1)` to the `popMessageAndSend` cycle to free `lifecycleLock` for other Threads, e.g. `stop()`

**Cherry-pick to 4.0.x**
