### PR TITLE
INT-3433 NIO Thread Starvation with Fixed Pool

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -696,7 +696,7 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 			if (logger.isDebugEnabled()) {
 				logger.debug("No threads available, delaying read for " + connection.getConnectionId());
 			}
-			// wake the selector; he might we waiting on a long (or infinite) select().
+			// wake the selector in case it is currently blocked, and waiting for longer than readDelay
 			selector.wakeup();
 		}
 	}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -34,9 +34,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -60,6 +63,10 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 		implements ConnectionFactory, SmartLifecycle, ApplicationEventPublisherAware {
 
 	protected static final int DEFAULT_REPLY_TIMEOUT = 10000;
+
+	private static final int DEFAULT_NIO_HARVEST_INTERVAL = 2000;
+
+	private static final int DEFAULT_READ_DELAY = 100;
 
 	private volatile String host;
 
@@ -117,7 +124,9 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 
 	private volatile ApplicationEventPublisher applicationEventPublisher;
 
-	private static final int DEFAULT_NIO_HARVEST_INTERVAL = 2000;
+	private final BlockingQueue<PendingIO> delayedReads = new LinkedBlockingQueue<AbstractConnectionFactory.PendingIO>();
+
+	private volatile long readDelay = DEFAULT_READ_DELAY;
 
 	public AbstractConnectionFactory(int port) {
 		this.port = port;
@@ -419,6 +428,25 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 		this.nioHarvestInterval = nioHarvestInterval;
 	}
 
+	protected BlockingQueue<PendingIO> getDelayedReads() {
+		return delayedReads;
+	}
+
+	protected long getReadDelay() {
+		return readDelay;
+	}
+
+	// TODO: Expose on the namespace in 4.1 ?
+	/**
+	 * The delay (in milliseconds) before retrying a read after the previous attempt
+	 * failed due to insufficient threads. Default 100.
+	 * @param readDelay the readDelay to set.
+	 */
+	public void setReadDelay(long readDelay) {
+		Assert.isTrue(readDelay > 0, "'readDelay' must be positive");
+		this.readDelay = readDelay;
+	}
+
 	@Override
 	protected void onInit() throws Exception {
 		super.onInit();
@@ -533,7 +561,8 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 	 */
 	protected void processNioSelections(int selectionCount, final Selector selector, ServerSocketChannel server,
 			Map<SocketChannel, TcpNioConnection> connections) throws IOException {
-		long now = System.currentTimeMillis();
+		final long now = System.currentTimeMillis();
+		rescheduleDelayedReads(selector, now);
 		if (this.soTimeout > 0 ||
 				now >= this.nextCheckForClosedNioConnections ||
 				selectionCount == 0) {
@@ -596,31 +625,43 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 						final TcpNioConnection connection;
 						connection = (TcpNioConnection) key.attachment();
 						connection.setLastRead(System.currentTimeMillis());
-						this.taskExecutor.execute(new Runnable() {
-							@Override
-							public void run() {
-								try {
-									connection.readPacket();
-								}
-								catch (Exception e) {
-									if (connection.isOpen()) {
-										logger.error("Exception on read " +
-												connection.getConnectionId() + " " +
-												e.getMessage());
-										connection.close();
+						try {
+							this.taskExecutor.execute(new Runnable() {
+								@Override
+								public void run() {
+									boolean delayed = false;
+									try {
+										connection.readPacket();
 									}
-									else {
-										logger.debug("Connection closed");
+									catch (RejectedExecutionException e) {
+										delayRead(selector, now, key);
+										delayed = true;
 									}
-								}
-								if (key.channel().isOpen()) {
-									key.interestOps(SelectionKey.OP_READ);
-									selector.wakeup();
-								}
-								else {
-									connection.sendExceptionToListener(new EOFException("Connection is closed"));
-								}
-							}});
+									catch (Exception e) {
+										if (connection.isOpen()) {
+											logger.error("Exception on read " +
+													connection.getConnectionId() + " " +
+													e.getMessage());
+											connection.close();
+										}
+										else {
+											logger.debug("Connection closed");
+										}
+									}
+									if (!delayed) {
+										if (key.channel().isOpen()) {
+											key.interestOps(SelectionKey.OP_READ);
+											selector.wakeup();
+										}
+										else {
+											connection.sendExceptionToListener(new EOFException("Connection is closed"));
+										}
+									}
+								}});
+						}
+						catch (RejectedExecutionException e) {
+							delayRead(selector, now, key);
+						}
 					}
 					else if (key.isAcceptable()) {
 						try {
@@ -632,13 +673,69 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 					else {
 						logger.error("Unexpected key: " + key);
 					}
-				} catch (CancelledKeyException e) {
+				}
+				catch (CancelledKeyException e) {
 					if (logger.isDebugEnabled()) {
 						logger.debug("Selection key " + key + " cancelled");
 					}
-				} catch (Exception e) {
+				}
+				catch (Exception e) {
 					logger.error("Exception on selection key " + key, e);
 				}
+			}
+		}
+	}
+
+	protected void delayRead(Selector selector, long now, final SelectionKey key) {
+		TcpNioConnection connection = (TcpNioConnection) key.attachment();
+		if (!this.delayedReads.add(new PendingIO(now, key))) { // should never happen - unbounded queue
+			logger.error("Failed to delay read; closing " + connection.getConnectionId());
+			connection.close();
+		}
+		else {
+			if (logger.isDebugEnabled()) {
+				logger.debug("No threads available, delaying read for " + connection.getConnectionId());
+			}
+			// wake the selector; he might we waiting on a long (or infinite) select().
+			selector.wakeup();
+		}
+	}
+
+	/**
+	 * If any reads were delayed due to insufficient threads, reschedule them if
+	 * the readDelay has passed.
+	 * @param selector the selector to wake if necessary.
+	 * @param now the current time.
+	 */
+	private void rescheduleDelayedReads(Selector selector, long now) {
+		boolean wakeSelector = false;
+		try {
+			while (this.delayedReads.size() > 0) {
+				if (this.delayedReads.peek().failedAt + this.readDelay < now) {
+					PendingIO pendingRead = this.delayedReads.take();
+					if (pendingRead.key.channel().isOpen()) {
+						pendingRead.key.interestOps(SelectionKey.OP_READ);
+						wakeSelector = true;
+						if (logger.isDebugEnabled()) {
+							logger.debug("Rescheduling delayed read for " + ((TcpNioConnection) pendingRead.key.attachment()).getConnectionId());
+						}
+					}
+					else {
+						((TcpNioConnection) pendingRead.key.attachment()).sendExceptionToListener(new EOFException("Connection is closed"));
+					}
+				}
+				else {
+					// remaining delayed reads have not expired yet.
+					break;
+				}
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		finally {
+			if (wakeSelector) {
+				selector.wakeup();
 			}
 		}
 	}
@@ -781,4 +878,18 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 			return closed;
 		}
 	}
+
+	private class PendingIO {
+
+		private final long failedAt;
+
+		private final SelectionKey key;
+
+		private PendingIO(long failedAt, SelectionKey key) {
+			this.failedAt = failedAt;
+			this.key = key;
+		}
+
+	}
+
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
@@ -149,7 +149,11 @@ public class TcpNioClientConnectionFactory extends
 				int soTimeout = this.getSoTimeout();
 				int selectionCount = 0;
 				try {
-					selectionCount = selector.select(soTimeout < 0 ? 0 : soTimeout);
+					long timeout = soTimeout < 0 ? 0 : soTimeout;
+					if (getDelayedReads().size() > 0 && (timeout == 0 || getReadDelay() < timeout)) {
+						timeout = getReadDelay();
+					}
+					selectionCount = selector.select(timeout);
 				}
 				catch (CancelledKeyException cke) {
 					if (logger.isDebugEnabled()) {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -45,6 +45,7 @@ import org.springframework.util.Assert;
  * A TcpConnection that uses and underlying {@link SocketChannel}.
  *
  * @author Gary Russell
+ * @author John Anderson
  * @since 2.0
  *
  */
@@ -266,7 +267,6 @@ public class TcpNioConnection extends TcpConnectionSupport {
 						}
 					}
 					if (moreDataAvailable) {
-						Thread.yield();
 						if (logger.isTraceEnabled()) {
 							logger.trace(this.getConnectionId() + " Nio message assembler continuing...");
 						}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -26,11 +26,11 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -39,7 +39,6 @@ import org.springframework.core.serializer.Serializer;
 import org.springframework.integration.ip.tcp.serializer.SoftEndOfStreamException;
 import org.springframework.integration.util.CompositeExecutor;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
 
 /**
@@ -189,67 +188,97 @@ public class TcpNioConnection extends TcpConnectionSupport {
 		if (logger.isTraceEnabled()) {
 			logger.trace(this.getConnectionId() + " Nio message assembler running...");
 		}
-		try {
-			if (this.getListener() == null && !this.isSingleUse()) {
-				logger.debug("TcpListener exiting - no listener and not single use");
-				return;
-			}
+		boolean moreDataAvailable = true;
+		while(moreDataAvailable) {
 			try {
-				if (dataAvailable()) {
-					Message<?> message = convert();
+				if (this.getListener() == null && !this.isSingleUse()) {
+					logger.debug("TcpListener exiting - no listener and not single use");
+					return;
+				}
+				try {
 					if (dataAvailable()) {
-						// there is more data in the pipe; run another assembler
-						// to assemble the next message, while we send ours
-						this.executionControl.incrementAndGet();
-						this.taskExecutor.execute(this);
+						Message<?> message = convert();
+						if (dataAvailable()) {
+							// there is more data in the pipe; run another assembler
+							// to assemble the next message, while we send ours
+							this.executionControl.incrementAndGet();
+							try {
+								this.taskExecutor.execute2(this);
+							}
+							catch (RejectedExecutionException e) {
+								this.executionControl.decrementAndGet();
+								if (logger.isInfoEnabled()) {
+									logger.info("Insufficient threads in the assembler fixed thread pool; consider " +
+											"increasing this task executor pool size");
+								}
+							}
+						}
+						this.executionControl.decrementAndGet();
+						if (message != null) {
+							sendToChannel(message);
+						}
 					}
-					this.executionControl.decrementAndGet();
-					if (message != null) {
-						sendToChannel(message);
+					else {
+						this.executionControl.decrementAndGet();
 					}
 				}
-				else {
-					this.executionControl.decrementAndGet();
-				}
-			}
-			catch (Exception e) {
-				if (logger.isTraceEnabled()) {
-					logger.error("Read exception " +
-							 this.getConnectionId(), e);
-				}
-				else if (!this.isNoReadErrorOnClose()) {
-					logger.error("Read exception " +
-								 this.getConnectionId() + " " +
-								 e.getClass().getSimpleName() +
-							     ":" + e.getCause() + ":" + e.getMessage());
-				}
-				else {
-					if (logger.isDebugEnabled()) {
-						logger.debug("Read exception " +
+				catch (Exception e) {
+					if (logger.isTraceEnabled()) {
+						logger.error("Read exception " +
+								 this.getConnectionId(), e);
+					}
+					else if (!this.isNoReadErrorOnClose()) {
+						logger.error("Read exception " +
 									 this.getConnectionId() + " " +
 									 e.getClass().getSimpleName() +
 								     ":" + e.getCause() + ":" + e.getMessage());
 					}
-				}
-				this.closeConnection(true);
-				this.sendExceptionToListener(e);
-				return;
-			}
-		}
-		finally {
-			if (logger.isTraceEnabled()) {
-				logger.trace(this.getConnectionId() + " Nio message assembler exiting...");
-			}
-			// Final check in case new data came in and the
-			// timing was such that we were the last assembler and
-			// a new one wasn't run
-			try {
-				if (this.isOpen() && dataAvailable()) {
-					checkForAssembler();
+					else {
+						if (logger.isDebugEnabled()) {
+							logger.debug("Read exception " +
+										 this.getConnectionId() + " " +
+										 e.getClass().getSimpleName() +
+									     ":" + e.getCause() + ":" + e.getMessage());
+						}
+					}
+					this.closeConnection(true);
+					this.sendExceptionToListener(e);
+					return;
 				}
 			}
-			catch (IOException e) {
-				logger.error("Exception when checking for assembler", e);
+			finally {
+				moreDataAvailable = false;
+				// Final check in case new data came in and the
+				// timing was such that we were the last assembler and
+				// a new one wasn't run
+				try {
+					if (this.isOpen() && dataAvailable()) {
+						synchronized(this.executionControl) {
+							if (this.executionControl.incrementAndGet() <= 1) {
+								// only continue if we don't already have another assembler running
+								this.executionControl.set(1);
+								moreDataAvailable = true;
+								
+							} else {
+								this.executionControl.decrementAndGet();
+							}
+						}
+					}
+					if (moreDataAvailable) {
+						Thread.yield();
+						if (logger.isTraceEnabled()) {
+							logger.trace(this.getConnectionId() + " Nio message assembler continuing...");
+						}
+					}
+					else {
+						if (logger.isTraceEnabled()) {
+							logger.trace(this.getConnectionId() + " Nio message assembler exiting...");
+						}
+					}
+				}
+				catch (IOException e) {
+					logger.error("Exception when checking for assembler", e);
+				}
 			}
 		}
 	}
@@ -333,48 +362,26 @@ public class TcpNioConnection extends TcpConnectionSupport {
 				this.taskExecutor = new CompositeExecutor(executor, executor);
 			}
 			// If there is no assembler running, start one
-			checkForAssembler();
-			if (logger.isTraceEnabled()) {
-				logger.trace("Before read:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
-			}
-			int len = this.socketChannel.read(this.rawBuffer);
-			if (len < 0) {
-				this.writingToPipe = false;
-				this.closeConnection(true);
-			}
-			if (logger.isTraceEnabled()) {
-				logger.trace("After read:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
-			}
-			this.rawBuffer.flip();
-			if (logger.isTraceEnabled()) {
-				logger.trace("After flip:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
-			}
-			if (logger.isDebugEnabled()) {
-				logger.debug("Read " + rawBuffer.limit() + " into raw buffer");
-			}
-			final CountDownLatch latch = new CountDownLatch(1);
-			/*
-			 * If there are insufficient threads, either to run the
-			 * write to the pipe, or to assemble the data, we need
-			 * avoid a deadlock (block on the write to the pipe).
-			 * Hence the count down latch.
-			 */
-			this.taskExecutor.execute2(new Runnable() {
-				@Override
-				public void run() {
-					try {
-						TcpNioConnection.this.sendToPipe(rawBuffer);
-						latch.countDown();
-					}
-					catch (Exception e) {
-						logger.error(getConnectionId() + " Failed to write to pipe", e);
-					}
+			if (checkForAssembler()) {
+				if (logger.isTraceEnabled()) {
+					logger.trace("Before read:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
 				}
-			});
-			if (!latch.await(this.pipeTimeout , TimeUnit.MILLISECONDS)) {
-				this.close();
-				throw new MessagingException("Timed out writing to ChannelInputStream, probably due to insufficient threads in " +
-						"a fixed thread pool; consider increasing this task executor pool size");
+				int len = this.socketChannel.read(this.rawBuffer);
+				if (len < 0) {
+					this.writingToPipe = false;
+					this.closeConnection(true);
+				}
+				if (logger.isTraceEnabled()) {
+					logger.trace("After read:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
+				}
+				this.rawBuffer.flip();
+				if (logger.isTraceEnabled()) {
+					logger.trace("After flip:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
+				}
+				if (logger.isDebugEnabled()) {
+					logger.debug("Read " + rawBuffer.limit() + " into raw buffer");
+				}
+				this.sendToPipe(rawBuffer);
 			}
 		}
 		catch (Exception e) {
@@ -395,7 +402,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 		rawBuffer.clear();
 	}
 
-	private void checkForAssembler() {
+	private boolean checkForAssembler() {
 		synchronized(this.executionControl) {
 			if (this.executionControl.incrementAndGet() <= 1) {
 				// only execute run() if we don't already have one running
@@ -403,11 +410,22 @@ public class TcpNioConnection extends TcpConnectionSupport {
 				if (logger.isDebugEnabled()) {
 					logger.debug(this.getConnectionId() + " Running an assembler");
 				}
-				this.taskExecutor.execute2(this);
+				try {
+					this.taskExecutor.execute2(this);
+				}
+				catch (RejectedExecutionException e) {
+					this.executionControl.decrementAndGet();
+					if (logger.isInfoEnabled()) {
+						logger.info("Insufficient threads in the assembler fixed thread pool; consider increasing " +
+								"this task executor pool size");
+					}
+					return false;
+				}
 			} else {
 				this.executionControl.decrementAndGet();
 			}
 		}
+		return true;
 	}
 
 	/**

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
@@ -128,7 +128,14 @@ public class TcpNioServerConnectionFactory extends AbstractServerConnectionFacto
 			int soTimeout = this.getSoTimeout();
 			int selectionCount = 0;
 			try {
-				selectionCount = selector.select(soTimeout < 0 ? 0 : soTimeout);
+				long timeout = soTimeout < 0 ? 0 : soTimeout;
+				if (getDelayedReads().size() > 0 && (timeout == 0 || getReadDelay() < timeout)) {
+					timeout = getReadDelay();
+				}
+				if (logger.isTraceEnabled()) {
+					logger.trace("Delayed reads:" + getDelayedReads().size() + " timeout " + timeout);
+				}
+				selectionCount = selector.select(timeout);
 				this.processNioSelections(selectionCount, selector, server, this.channelMap);
 			}
 			catch (CancelledKeyException cke) {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -73,7 +73,6 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.converter.MapMessageConverter;
 import org.springframework.integration.test.util.SocketUtils;
 import org.springframework.integration.test.util.TestUtils;
-import org.springframework.integration.util.CallerBlocksPolicy;
 import org.springframework.integration.util.CompositeExecutor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.ErrorMessage;
@@ -608,7 +607,7 @@ public class TcpNioConnectionTests {
 
 	@Test
 	public void testAllMessagesDelivered() throws Exception {
-		final int numberOfSockets = 25;
+		final int numberOfSockets = 100;
 		final int port = SocketUtils.findAvailableServerSocket();
 		TcpNioServerConnectionFactory factory = new TcpNioServerConnectionFactory(port);
 		factory.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
@@ -616,7 +615,7 @@ public class TcpNioConnectionTests {
 		CompositeExecutor compositeExec = compositeExecutor();
 
 		factory.setTaskExecutor(compositeExec);
-		final CountDownLatch latch = new CountDownLatch(numberOfSockets);
+		final CountDownLatch latch = new CountDownLatch(numberOfSockets * 4);
 		factory.registerListener(new TcpListener() {
 
 			@Override
@@ -629,7 +628,7 @@ public class TcpNioConnectionTests {
 
 		});
 		factory.start();
-		
+
 		Socket[] sockets = new Socket[numberOfSockets];
 		for (int i = 0; i < numberOfSockets; i++) {
 			Socket socket = null;
@@ -651,11 +650,28 @@ public class TcpNioConnectionTests {
 		}
 		Thread.sleep(100);
 		for (int i = 0; i < numberOfSockets; i++) {
-			sockets[i].getOutputStream().write(("...foo2\r\n").getBytes());
+			sockets[i].getOutputStream().write(("...foo2\r\nbar1 and...").getBytes());
+			sockets[i].getOutputStream().flush();
+		}
+		for (int i = 0; i < numberOfSockets; i++) {
+			sockets[i].getOutputStream().write(("...bar2\r\n").getBytes());
+			sockets[i].getOutputStream().flush();
+		}
+		for (int i = 0; i < numberOfSockets; i++) {
+			sockets[i].getOutputStream().write("foo3 and...".getBytes());
+			sockets[i].getOutputStream().flush();
+		}
+		Thread.sleep(100);
+		for (int i = 0; i < numberOfSockets; i++) {
+			sockets[i].getOutputStream().write(("...foo4\r\nbar3 and...").getBytes());
+			sockets[i].getOutputStream().flush();
+		}
+		for (int i = 0; i < numberOfSockets; i++) {
+			sockets[i].getOutputStream().write(("...bar4\r\n").getBytes());
 			sockets[i].close();
 		}
-		
-		assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+		assertTrue("latch is still " + latch.getCount(), latch.await(60, TimeUnit.SECONDS));
 
 		factory.stop();
 	}
@@ -666,7 +682,7 @@ public class TcpNioConnectionTests {
 		ioExec.setMaxPoolSize(4);
 		ioExec.setQueueCapacity(0);
 		ioExec.setThreadNamePrefix("io-");
-		ioExec.setRejectedExecutionHandler(new CallerBlocksPolicy(5000));
+		ioExec.setRejectedExecutionHandler(new AbortPolicy());
 		ioExec.initialize();
 		ThreadPoolTaskExecutor assemblerExec = new ThreadPoolTaskExecutor();
 		assemblerExec.setCorePoolSize(2);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -335,9 +336,7 @@ public class TcpNioConnectionTests {
 			fail("Expected exception, got " + o);
 		}
 		catch (ExecutionException e) {
-			assertEquals("Timed out writing to ChannelInputStream, probably due to insufficient threads in " +
-					"a fixed thread pool; consider increasing this task executor pool size", e.getCause()
-					.getMessage());
+			assertEquals("Timed out waiting for buffer space", e.getCause().getMessage());
 		}
 	}
 
@@ -607,18 +606,74 @@ public class TcpNioConnectionTests {
 		factory.stop();
 	}
 
+	@Test
+	public void testAllMessagesDelivered() throws Exception {
+		final int numberOfSockets = 25;
+		final int port = SocketUtils.findAvailableServerSocket();
+		TcpNioServerConnectionFactory factory = new TcpNioServerConnectionFactory(port);
+		factory.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
+
+		CompositeExecutor compositeExec = compositeExecutor();
+
+		factory.setTaskExecutor(compositeExec);
+		final CountDownLatch latch = new CountDownLatch(numberOfSockets);
+		factory.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				if (!(message instanceof ErrorMessage)) {
+					latch.countDown();
+				}
+				return false;
+			}
+
+		});
+		factory.start();
+		
+		Socket[] sockets = new Socket[numberOfSockets];
+		for (int i = 0; i < numberOfSockets; i++) {
+			Socket socket = null;
+			int n = 0;
+			while (n++ < 100) {
+				try {
+					socket = SocketFactory.getDefault().createSocket("localhost", port);
+					break;
+				}
+				catch (ConnectException e) {}
+				Thread.sleep(100);
+			}
+			assertTrue("Could not open socket to localhost:" + port, n < 100);
+			sockets[i] = socket;
+		}
+		for (int i = 0; i < numberOfSockets; i++) {
+			sockets[i].getOutputStream().write("foo1 and...".getBytes());
+			sockets[i].getOutputStream().flush();
+		}
+		Thread.sleep(100);
+		for (int i = 0; i < numberOfSockets; i++) {
+			sockets[i].getOutputStream().write(("...foo2\r\n").getBytes());
+			sockets[i].close();
+		}
+		
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+		factory.stop();
+	}
+
 	private CompositeExecutor compositeExecutor() {
 		ThreadPoolTaskExecutor ioExec = new ThreadPoolTaskExecutor();
 		ioExec.setCorePoolSize(2);
-		ioExec.setQueueCapacity(10);
+		ioExec.setMaxPoolSize(4);
+		ioExec.setQueueCapacity(0);
 		ioExec.setThreadNamePrefix("io-");
-		ioExec.setRejectedExecutionHandler(new CallerBlocksPolicy(10000));
+		ioExec.setRejectedExecutionHandler(new CallerBlocksPolicy(5000));
 		ioExec.initialize();
 		ThreadPoolTaskExecutor assemblerExec = new ThreadPoolTaskExecutor();
 		assemblerExec.setCorePoolSize(2);
-		assemblerExec.setQueueCapacity(10);
+		assemblerExec.setMaxPoolSize(5);
+		assemblerExec.setQueueCapacity(0);
 		assemblerExec.setThreadNamePrefix("assembler-");
-		assemblerExec.setRejectedExecutionHandler(new CallerBlocksPolicy(10000));
+		assemblerExec.setRejectedExecutionHandler(new AbortPolicy());
 		assemblerExec.initialize();
 		return new CompositeExecutor(ioExec, assemblerExec);
 	}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -84,6 +84,7 @@ import org.springframework.util.ReflectionUtils.FieldFilter;
 
 /**
  * @author Gary Russell
+ * @author John Anderson
  * @since 2.0
  *
  */

--- a/src/reference/docbook/ip.xml
+++ b/src/reference/docbook/ip.xml
@@ -1035,7 +1035,7 @@
       <classname>CompositeExecutor</classname> allows the configuration
       of two distinct executors; one for performing IO operations, and
       one for message assembly. The <classname>CallerBlocksPolicy</classname>
-      (which should be configured for both task executors) will suspend
+      (which should be configured for the first task executors) will suspend
       the IO operation until an assembler thread is available (or a timeout
       occurs). In this environment, an IO thread can never
       become an assembler thread, and the deadlock cannot occur.
@@ -1049,16 +1049,16 @@ private CompositeExecutor compositeExecutor() {
     ThreadPoolTaskExecutor ioExec = new ThreadPoolTaskExecutor();
     ioExec.setCorePoolSize(4);
     ioExec.setMaxPoolSize(8);
-    ioExec.setQueueCapacity(10);
+    ioExec.setQueueCapacity(0);
     ioExec.setThreadNamePrefix("io-");
     ioExec.setRejectedExecutionHandler(new CallerRunsPolicy());
     ioExec.initialize();
     ThreadPoolTaskExecutor assemblerExec = new ThreadPoolTaskExecutor();
-    assemblerExec.setCorePoolSize(2);
+    assemblerExec.setCorePoolSize(4);
     assemblerExec.setMaxPoolSize(10);
-    assemblerExec.setQueueCapacity(12);
+    assemblerExec.setQueueCapacity(0);
     assemblerExec.setThreadNamePrefix("assembler-");
-    assemblerExec.setRejectedExecutionHandler(new CallerBlocksPolicy(10000));
+    assemblerExec.setRejectedExecutionHandler(new AbortPolicy());
     assemblerExec.initialize();
     return new CompositeExecutor(ioExec, assemblerExec);
 }]]></programlisting>
@@ -1068,7 +1068,7 @@ private CompositeExecutor compositeExecutor() {
             <property name="threadNamePrefix" value="io-" />
             <property name="corePoolSize" value="4" />
             <property name="maxPoolSize" value="8" />
-            <property name="queueCapacity" value="10" />
+            <property name="queueCapacity" value="0" />
             <property name="rejectedExecutionHandler">
                 <bean class="org.springframework.integration.util.CallerBlocksPolicy">
                     <constructor-arg value="10000" />
@@ -1081,11 +1081,9 @@ private CompositeExecutor compositeExecutor() {
             <property name="threadNamePrefix" value="assembler-" />
             <property name="corePoolSize" value="4" />
             <property name="maxPoolSize" value="10" />
-            <property name="queueCapacity" value="10" />
+            <property name="queueCapacity" value="0" />
             <property name="rejectedExecutionHandler">
-                <bean class="org.springframework.integration.util.CallerBlocksPolicy">
-                    <constructor-arg value="10000" />
-                </bean>
+                <bean class="java.util.concurrent.ThreadPoolExecutor.AbortPolicy" />
             </property>
         </bean>
     </constructor-arg>

--- a/src/reference/docbook/ip.xml
+++ b/src/reference/docbook/ip.xml
@@ -1002,6 +1002,9 @@
       using the <code>&lt;task/&gt;</code> namespace) and the queue capacity is small.
      </para>
      <para>
+      The following does not apply if you are not using a fixed thread pool.
+     </para>
+     <para>
       With NIO connections there are 3 distinct task types; the IO Selector processing
       is performed on one dedicated thread - detecting events, accepting new connections,
       and dispatching the IO read operations to other threads, using the task
@@ -1028,30 +1031,34 @@
      </para>
      <para>
       We must avoid the selector (or reader) threads performing the
-      assembly task to avoid this deadlock.
+      assembly task to avoid this deadlock. It is desirable to use seperate
+      pools for the IO and assembly operations.
      </para>
      <para>
-      Two classes are provided by the framework to avoid this problem. The
-      <classname>CompositeExecutor</classname> allows the configuration
+      The framework providers a
+      <classname>CompositeExecutor</classname>, which allows the configuration
       of two distinct executors; one for performing IO operations, and
-      one for message assembly. The <classname>CallerBlocksPolicy</classname>
-      (which should be configured for the first task executors) will suspend
-      the IO operation until an assembler thread is available (or a timeout
-      occurs). In this environment, an IO thread can never
+      one for message assembly. In this environment, an IO thread can never
       become an assembler thread, and the deadlock cannot occur.
-      Example configuration of the composite executor is shown below. The
-      <code>maxPoolSize</code> (or <code>queueCapacity</code>)
-      of the assembler executor should be slightly
-      larger than those on the IO executor.
+     </para>
+     <para>
+      In addition, the task executors should be configured to use a
+      <classname>AbortPolicy</classname> (ABORT when using <code>&lt;task&gt;</code>).
+      When an IO cannot be completed, it is deferred for a short time and
+      retried continually until it can be completed and an assembler
+      allocated.
+     </para>
+     <para>
+      Example configuration of the composite executor is shown below.
      </para>
      <programlisting language="java"><![CDATA[@Bean
 private CompositeExecutor compositeExecutor() {
     ThreadPoolTaskExecutor ioExec = new ThreadPoolTaskExecutor();
     ioExec.setCorePoolSize(4);
-    ioExec.setMaxPoolSize(8);
+    ioExec.setMaxPoolSize(10);
     ioExec.setQueueCapacity(0);
     ioExec.setThreadNamePrefix("io-");
-    ioExec.setRejectedExecutionHandler(new CallerRunsPolicy());
+    ioExec.setRejectedExecutionHandler(new AbortPolicy());
     ioExec.initialize();
     ThreadPoolTaskExecutor assemblerExec = new ThreadPoolTaskExecutor();
     assemblerExec.setCorePoolSize(4);
@@ -1063,6 +1070,14 @@ private CompositeExecutor compositeExecutor() {
     return new CompositeExecutor(ioExec, assemblerExec);
 }]]></programlisting>
 <programlisting language="xml"><![CDATA[<bean id="myTaskExecutor" class="org.springframework.integration.util.CompositeExecutor">
+    <constructor-arg ref="io"/>
+    <constructor-arg ref="assembler"/>
+</bean>
+
+<task:executor id="io" pool-size="4-10" queue-capacity="0" rejection-policy="ABORT" />
+<task:executor id="assembler" pool-size="4-10" queue-capacity="0" rejection-policy="ABORT" />]]></programlisting>
+
+<programlisting language="xml"><![CDATA[<bean id="myTaskExecutor" class="org.springframework.integration.util.CompositeExecutor">
     <constructor-arg>
         <bean class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
             <property name="threadNamePrefix" value="io-" />
@@ -1070,9 +1085,7 @@ private CompositeExecutor compositeExecutor() {
             <property name="maxPoolSize" value="8" />
             <property name="queueCapacity" value="0" />
             <property name="rejectedExecutionHandler">
-                <bean class="org.springframework.integration.util.CallerBlocksPolicy">
-                    <constructor-arg value="10000" />
-                </bean>
+                <bean class="java.util.concurrent.ThreadPoolExecutor.AbortPolicy" />
             </property>
         </bean>
     </constructor-arg>


### PR DESCRIPTION
Replaces #1171

Squashed @john2A 's commits into one; squashed my delayed IO commits; added doc changes.

Artem - after review, please squash my 2 commits and leave John's separate (adding 2 commits to master); thanks.

JIRA: https://jira.spring.io/browse/INT-3433

INT-3433 added the test-case

INT-3433 Delay Failed IOs

JIRA: https://jira.spring.io/browse/INT-3433`

If a read fails due to insufficient threads, delay the read
for (default 100ms) - do not re-enable OP_READ until that
time has elapsed. Avoids spinning the CPU.

INT-3433 More Polishing

If the assembler couldn't execute a new assembler after assembling
the current message (when it detected there is more data), in the
finally block it would "continue" only if the socket was still
open.

The test case closes the socket after sending 4 messages so when
this condition occurred, the assembler failed to continue and
data was left in the buffer.

Remove the `isOpen()` check in the finally block and always continue
if there's not another assembler running and there's data available.

INT-3433 More Polishing

We can still get starvation if the selector is in a long
wait (in select()) when a read is delayed.

Whenever a read is delayed, wake the selector so its next
select will use the readDelay timeout.

INT-3433 Reference Docs

Also remove Thread.yield().
