### PR TITLE
INT-3453 Fix NIO Connection Race Condition

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -288,6 +288,10 @@ public class TcpNioConnection extends TcpConnectionSupport {
 	}
 
 	private boolean dataAvailable() throws IOException {
+		if (logger.isTraceEnabled()) {
+			logger.trace(getConnectionId() + " checking data avail: " + this.channelInputStream.available() +
+					" pending: " + (this.writingToPipe));
+		}
 		return writingToPipe || this.channelInputStream.available() > 0;
 	}
 
@@ -298,6 +302,10 @@ public class TcpNioConnection extends TcpConnectionSupport {
 	 * @throws IOException
 	 */
 	private synchronized Message<?> convert() throws Exception {
+		if (logger.isTraceEnabled()) {
+			logger.trace(getConnectionId() + " checking data avail (convert): " + this.channelInputStream.available() +
+					" pending: " + (this.writingToPipe));
+		}
 		if (this.channelInputStream.available() <= 0) {
 			try {
 				if (this.writingLatch.await(60, TimeUnit.SECONDS)) {
@@ -306,8 +314,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 					}
 				}
 				else { // should never happen
-					logger.error(this.getConnectionId() + " timed out waiting for IO");
-					return null;
+					throw new IOException("Timed out waiting for IO");
 				}
 			}
 			catch (InterruptedException e) {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -26,6 +26,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -74,6 +75,8 @@ public class TcpNioConnection extends TcpConnectionSupport {
 	private final AtomicInteger executionControl = new AtomicInteger();
 
 	private volatile boolean writingToPipe;
+
+	private volatile CountDownLatch writingLatch;
 
 	private volatile long pipeTimeout = DEFAULT_PIPE_TIMEOUT;
 
@@ -285,7 +288,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 	}
 
 	private boolean dataAvailable() throws IOException {
-		return this.channelInputStream.available() > 0 || writingToPipe;
+		return writingToPipe || this.channelInputStream.available() > 0;
 	}
 
 	/**
@@ -295,8 +298,22 @@ public class TcpNioConnection extends TcpConnectionSupport {
 	 * @throws IOException
 	 */
 	private synchronized Message<?> convert() throws Exception {
-		if (!dataAvailable()) {
-			return null;
+		if (this.channelInputStream.available() <= 0) {
+			try {
+				if (this.writingLatch.await(60, TimeUnit.SECONDS)) {
+					if (this.channelInputStream.available() <= 0) {
+						return null;
+					}
+				}
+				else { // should never happen
+					logger.error(this.getConnectionId() + " timed out waiting for IO");
+					return null;
+				}
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new IOException("Interrupted waiting for IO");
+			}
 		}
 		Message<?> message = null;
 		try {
@@ -356,6 +373,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 			this.rawBuffer = allocate(maxMessageSize);
 		}
 
+		this.writingLatch = new CountDownLatch(1);
 		this.writingToPipe = true;
 		try {
 			if (this.taskExecutor == null) {
@@ -394,6 +412,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 		}
 		finally {
 			this.writingToPipe = false;
+			this.writingLatch.countDown();
 		}
 	}
 
@@ -682,6 +701,9 @@ public class TcpNioConnection extends TcpConnectionSupport {
 				byte[] buffer = new byte[bytesToWrite];
 				System.arraycopy(array, 0, buffer, 0, bytesToWrite);
 				this.available.addAndGet(bytesToWrite);
+				if (TcpNioConnection.this.writingLatch != null) {
+					TcpNioConnection.this.writingLatch.countDown();
+				}
 				try {
 					if (!this.buffers.offer(buffer, pipeTimeout, TimeUnit.MILLISECONDS)) {
 						throw new IOException("Timed out waiting for buffer space");
@@ -690,6 +712,9 @@ public class TcpNioConnection extends TcpConnectionSupport {
 				catch (InterruptedException e) {
 					Thread.currentThread().interrupt();
 					throw new IOException("Interrupted while waiting for buffer space", e);
+				}
+				if (TcpNioConnection.this.writingLatch != null) {
+					TcpNioConnection.this.writingLatch = new CountDownLatch(1);
 				}
 			}
 		}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3453

A race condition in the TcpNioConnection can leave
an assembler thread blocked when there is no data coming.

This can happen because `writingToPipe` might not be reset
before the assembler consumed the IO data.

Change it to a semaphore so that the assembler will wait
until the data is actually written to the pipe
and will not block again in `convert()` unless the message is not
fully assembled. As soon as the write completes the semaphore is
released so that an assembler won't block once the write for the
current IO has completed.

SSL can be call `write` multiple times for each IO so only one
permit is released on each write to keep the assembler processing
until `doRead()` completes.

The finally block in `doRead()` makes the semaphore wide open.
However, during normal processing, the permits are not acquired
(only if the assembler detects there are no permits) so this
is not strictly necessary, but for safety only.

INT-3453 Test Case

Exposes the race condition when `writingToPipe` is not reset in time
and we end up tying up an assembler thread on a socket with no data.

Examines the assembler thread's stack trace to ensure it does not
contain `ChannelInputStream.getNextBuffer()`.

**cherry-pick to 4.0.x, 3.0.x**
