### PR TITLE
INT-3404: Get rid of `MProducer` from `AIFileSMS`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MethodInvokingMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MethodInvokingMessageSource.java
@@ -65,7 +65,8 @@ public class MethodInvokingMessageSource extends AbstractMessageSource<Object> i
 	}
 
 	@Override
-	public void afterPropertiesSet() {
+	public void afterPropertiesSet() throws Exception {
+		super.afterPropertiesSet();
 		synchronized (this.initializationMonitor) {
 			if (this.initialized) {
 				return;

--- a/spring-integration-core/src/main/java/org/springframework/integration/resource/ResourceRetrievingMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/resource/ResourceRetrievingMessageSource.java
@@ -41,7 +41,8 @@ import org.springframework.util.ObjectUtils;
  * @author Gary Russell
  * @since 2.1
  */
-public class ResourceRetrievingMessageSource extends AbstractMessageSource<Resource[]> implements ApplicationContextAware, InitializingBean {
+public class ResourceRetrievingMessageSource extends AbstractMessageSource<Resource[]>
+		implements ApplicationContextAware, InitializingBean {
 
 	private final String pattern;
 
@@ -78,11 +79,10 @@ public class ResourceRetrievingMessageSource extends AbstractMessageSource<Resou
 
 
 	@Override
-	public void afterPropertiesSet() {
+	public void afterPropertiesSet() throws Exception {
+		super.afterPropertiesSet();
 		if (this.patternResolver == null) {
-			if (this.applicationContext instanceof ResourcePatternResolver) {
-				this.patternResolver = this.applicationContext;
-			}
+			this.patternResolver = this.applicationContext;
 		}
 		Assert.notNull(this.patternResolver, "no 'patternResolver' available");
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/AbstractExpressionEvaluator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/AbstractExpressionEvaluator.java
@@ -44,7 +44,7 @@ import org.springframework.messaging.MessageHandlingException;
  */
 public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, InitializingBean {
 
-	private final Log logger = LogFactory.getLog(this.getClass());
+	protected final Log logger = LogFactory.getLog(this.getClass());
 
 	private volatile StandardEvaluationContext evaluationContext;
 
@@ -69,6 +69,10 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 			}
 			this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(beanFactory);
 		}
+	}
+
+	protected BeanFactory getBeanFactory() {
+		return beanFactory;
 	}
 
 	public void setConversionService(ConversionService conversionService) {
@@ -136,15 +140,16 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 	}
 
 	protected Object evaluateExpression(String expression, Object input) {
-		return this.evaluateExpression(expression, input, (Class<?>) null);
+		return this.evaluateExpression(expression, input, null);
 	}
 
 	protected <T> T evaluateExpression(String expression, Object input, Class<T> expectedType) {
-		return this.expressionParser.parseExpression(expression).getValue(this.getEvaluationContext(), input, expectedType);
+		return this.expressionParser.parseExpression(expression)
+				.getValue(this.getEvaluationContext(), input, expectedType);
 	}
 
 	protected Object evaluateExpression(Expression expression, Object input) {
-		return this.evaluateExpression(expression, input, (Class<?>) null);
+		return this.evaluateExpression(expression, input, null);
 	}
 
 	protected <T> T evaluateExpression(Expression expression, Class<T> expectedType) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
@@ -22,8 +22,10 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.regex.Pattern;
 
-import org.springframework.integration.core.MessageSource;
-import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.integration.endpoint.AbstractMessageSource;
 import org.springframework.integration.file.FileReadingMessageSource;
 import org.springframework.integration.file.filters.AcceptOnceFileListFilter;
 import org.springframework.integration.file.filters.CompositeFileListFilter;
@@ -55,8 +57,7 @@ import org.springframework.util.Assert;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  */
-public abstract class AbstractInboundFileSynchronizingMessageSource<F> extends MessageProducerSupport
-	implements MessageSource<File> {
+public abstract class AbstractInboundFileSynchronizingMessageSource<F> extends AbstractMessageSource<File> {
 
 	/**
 	 * Should the endpoint attempt to create the local directory? True by default.
@@ -86,7 +87,8 @@ public abstract class AbstractInboundFileSynchronizingMessageSource<F> extends M
 		this(synchronizer, null);
 	}
 
-	public AbstractInboundFileSynchronizingMessageSource(AbstractInboundFileSynchronizer<F> synchronizer, Comparator<File> comparator) {
+	public AbstractInboundFileSynchronizingMessageSource(AbstractInboundFileSynchronizer<F> synchronizer,
+			Comparator<File> comparator) {
 		Assert.notNull(synchronizer, "synchronizer must not be null");
 		this.synchronizer = synchronizer;
 		if (comparator == null){
@@ -122,7 +124,8 @@ public abstract class AbstractInboundFileSynchronizingMessageSource<F> extends M
 	}
 
 	@Override
-	protected void onInit() {
+	public void afterPropertiesSet() throws Exception {
+		super.afterPropertiesSet();
 		Assert.notNull(this.localDirectory, "localDirectory must not be null");
 		try {
 			if (!this.localDirectory.exists()) {
@@ -149,7 +152,7 @@ public abstract class AbstractInboundFileSynchronizingMessageSource<F> extends M
 		}
 		catch (Exception e) {
 			throw new MessagingException(
-					"Failure during initialization of MessageSource for: " + this.getComponentType(), e);
+					"Failure during initialization of MessageSource for: " + this.getClass(), e);
 		}
 	}
 
@@ -159,9 +162,9 @@ public abstract class AbstractInboundFileSynchronizingMessageSource<F> extends M
 	 * Then, it polls the file source again and returns the result, whether or not it is null.
 	 */
 	@Override
-	public final Message<File> receive() {
-		Assert.state(this.fileSource != null, "fileSource must not be null");
-		Assert.state(this.synchronizer != null, "synchronizer must not be null");
+	protected final Message<File> doReceive() {
+		Assert.notNull(this.fileSource, "fileSource must not be null");
+		Assert.notNull(this.synchronizer, "synchronizer must not be null");
 		Message<File> message = this.fileSource.receive();
 		if (message == null) {
 			this.synchronizer.synchronizeToLocalDirectory(this.localDirectory);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3404

Before `AbstractInboundFileSynchronizingMessageSource` implemented both `MessageProducer` and `MessageSource`.
The `MessageProducer` is really redundant and confused stuff here.
From other side it might produce some side-effects from JavaConfig.

Provide some other simple but important fix for all `AbstractMessageSource` implementation to get deal with `super.afterPropertiesSet()`
