### PR TITLE
INT-3469 MQTT - Set Callback Before Subscribing

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
@@ -97,6 +97,7 @@ public class MqttPahoMessageDrivenChannelAdapter extends AbstractMqttMessageDriv
 
 	private void connectAndSubscribe() throws MqttException {
 		this.client = this.clientFactory.getClientInstance(this.getUrl(), this.getClientId());
+		this.client.setCallback(this);
 		this.client.connect(this.clientFactory.getConnectionOptions());
 		try {
 			this.client.subscribe(this.getTopic());
@@ -106,7 +107,6 @@ public class MqttPahoMessageDrivenChannelAdapter extends AbstractMqttMessageDriv
 			throw e;
 		}
 		if (this.client.isConnected()) {
-			this.client.setCallback(this);
 			this.connected = true;
 			if (this.reconnectFuture != null) {
 				this.cancelReconnect();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3469

Previously, the callback was set immediately after
subscribing which caused a small possibility of
message loss.

Set the callback before subscribing.

**cherry-pick to 4.0.x**
