### PR TITLE
INT-3457: Backport commits to 2.2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ target
 vf.gf.dmn-*
 /atlassian-ide-plugin.xml
 hostkey.ser
-.springBeans

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ subprojects { subproject ->
 		aspectjVersion = '1.6.8'
 		cglibVersion = '2.2'
 		commonsNetVersion = '3.0.1'
+		apacheSshdVersion = '0.10.0'
+		commonsIoVersion = '2.4'
+		derbyVersion = '10.9.1.0'
 		easymockVersion = '2.3'
 		groovyVersion = '1.8.5'
 		jacksonVersion = '1.9.2'
@@ -778,6 +781,7 @@ project('spring-integration-sftp') {
 		compile "org.springframework:spring-context-support:$springVersion"
 		compile("javax.activation:activation:$javaxActivationVersion", optional)
 		testCompile project(":spring-integration-test")
+		testCompile "org.apache.sshd:sshd-core:$apacheSshdVersion"
 	}
 	bundlor {
 		bundleSymbolicName = 'org.springframework.integration.sftp'

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CallerBlocksPolicy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CallerBlocksPolicy.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.util;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * A {@link RejectedExecutionHandler} that blocks the caller until
+ * the executor has room in its queue, or a timeout occurs (in which
+ * case a {@link RejectedExecutionException} is thrown.
+ *
+ * @author Gary Russell
+ * @since 3.0.3
+ *
+ */
+public class CallerBlocksPolicy implements RejectedExecutionHandler {
+
+	private static final Log logger = LogFactory.getLog(CallerBlocksPolicy.class);
+
+	private final long maxWait;
+
+	/**
+	 * @param maxWait The maximum time to wait for a queue slot to be
+	 * available, in milliseconds.
+	 */
+	public CallerBlocksPolicy(long maxWait) {
+		this.maxWait = maxWait;
+	}
+
+	@Override
+	public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+		if (!executor.isShutdown()) {
+			try {
+				BlockingQueue<Runnable> queue = executor.getQueue();
+				if (logger.isDebugEnabled()) {
+					logger.debug("Attempting to queue task execution for " + this.maxWait + " milliseconds");
+				}
+				if (!queue.offer(r, this.maxWait, TimeUnit.MILLISECONDS)) {
+					throw new RejectedExecutionException("Max wait time expired to queue task");
+				}
+				if (logger.isDebugEnabled()) {
+					logger.debug("Task execution queued");
+				}
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new RejectedExecutionException("Interrupted", e);
+			}
+		}
+		else {
+			throw new RejectedExecutionException("Executor has been shut down");
+		}
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CompositeExecutor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CompositeExecutor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.util;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.util.Assert;
+
+/**
+ * An {@link Executor} that encapsulates two underlying executors. Used in cases
+ * where two distinct operation types are being used where sharing threads could
+ * adversely affect the operation of the system. For example, NIO event processing
+ * threads being used for other blocking operations (such as assembling messages).
+ * If a {@code CallerRunsPolicy} rejected execution policy is used, the NIO event thread
+ * might deadlock, and stop processing events.
+ * <p>
+ * In order to work in such an environment, the secondary executor must <b>not</b>
+ * have a {@code CallerRunsPolicy} rejected execution policy.
+ * <p>
+ * It is generally recommended to use a {@code CallerBlocksPolicy} on both
+ * executors.
+ *
+ * @author Gary Russell
+ * @since 3.0.3
+ *
+ */
+public class CompositeExecutor implements Executor {
+
+	private final Executor primaryTaskExecutor;
+
+	private final Executor secondaryTaskExecutor;
+
+	public CompositeExecutor(Executor primaryTaskExecutor, Executor secondaryTaskExecutor) {
+		Assert.notNull(primaryTaskExecutor, "'primaryTaskExecutor' cannot be null");
+		Assert.notNull(primaryTaskExecutor, "'secondaryTaskExecutor' cannot be null");
+		this.primaryTaskExecutor = primaryTaskExecutor;
+		this.secondaryTaskExecutor = secondaryTaskExecutor;
+	}
+
+	/**
+	 * Execute using the primary executor.
+	 * @param task the task to run.
+	 */
+	@Override
+	public void execute(Runnable task) {
+		this.primaryTaskExecutor.execute(task);
+	}
+
+	/**
+	 * Execute using the secondary executor.
+	 * @param task the task to run.
+	 */
+	public void execute2(Runnable task) {
+		this.secondaryTaskExecutor.execute(task);
+	}
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ThreadLocalChannelParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ThreadLocalChannelParserTests.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.config.TestChannelInterceptor;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.message.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -43,6 +44,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
+@DirtiesContext(classMode= DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class ThreadLocalChannelParserTests {
 
 	@Autowired @Qualifier("simpleChannel")

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInvokingMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInvokingMessageHandlerTests.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.gateway;
 
 import junit.framework.Assert;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -29,6 +28,7 @@ import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -38,20 +38,21 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode= DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class GatewayInvokingMessageHandlerTests {
 
 	@Autowired
 	@Qualifier("inputA")
 	SubscribableChannel channel;
-	
+
 	@Autowired
 	@Qualifier("simpleGateway")
 	SimpleGateway gateway;
-	
+
 	@Autowired
 	@Qualifier("gatewayWithError")
 	SimpleGateway gatewayWithError;
-	
+
 	@Autowired
 	@Qualifier("gatewayWithErrorAsync")
 	SimpleGateway gatewayWithErrorAsync;
@@ -77,7 +78,7 @@ public class GatewayInvokingMessageHandlerTests {
 	}
 
 	@Test
-	public void validateGatewayInTheChainViaAnotherGateway() {	
+	public void validateGatewayInTheChainViaAnotherGateway() {
 		output.subscribe(new MessageHandler() {
 			public void handleMessage(Message<?> message) {
 				Assert.assertEquals("echo:echo:echo:hello", message.getPayload());
@@ -88,9 +89,9 @@ public class GatewayInvokingMessageHandlerTests {
 		String result = gateway.process("hello");
 		Assert.assertEquals("echo:echo:echo:hello", result);
 	}
-	
+
 	@Test
-	public void validateGatewayWithErrorMessageReturned() {	
+	public void validateGatewayWithErrorMessageReturned() {
 		try {
 			String result = gatewayWithErrorChannelAndTransformer.process("echoWithRuntimeExceptionChannel");
 			Assert.assertNotNull(result);
@@ -99,7 +100,7 @@ public class GatewayInvokingMessageHandlerTests {
 		catch (Exception e) {
 			Assert.fail();
 		}
-		
+
 		try {
 			gatewayWithError.process("echoWithRuntimeExceptionChannel");
 			Assert.fail();
@@ -107,7 +108,7 @@ public class GatewayInvokingMessageHandlerTests {
 		catch (SampleRuntimeException e) {
 			Assert.assertEquals("echoWithRuntimeExceptionChannel", e.getMessage());
 		}
-		
+
 		try {
 			gatewayWithError.process("echoWithMessagingExceptionChannel");
 			Assert.fail();
@@ -115,7 +116,7 @@ public class GatewayInvokingMessageHandlerTests {
 		catch (MessageHandlingException e) {
 			Assert.assertEquals("echoWithMessagingExceptionChannel", e.getFailedMessage().getPayload());
 		}
-		
+
 		try {
 			String result = gatewayWithErrorChannelAndTransformer.process("echoWithMessagingExceptionChannel");
 			Assert.assertNotNull(result);
@@ -125,9 +126,9 @@ public class GatewayInvokingMessageHandlerTests {
 			Assert.fail();
 		}
 	}
-	
+
 	@Test
-	public void validateGatewayWithErrorAsync() {	
+	public void validateGatewayWithErrorAsync() {
 		try {
 			gatewayWithErrorAsync.process("echoWithErrorAsyncChannel");
 			Assert.fail();
@@ -136,9 +137,9 @@ public class GatewayInvokingMessageHandlerTests {
 			Assert.assertEquals(SampleRuntimeException.class, e.getClass());
 		}
 	}
-	
+
 	@Test
-	public void validateGatewayWithErrorFlowReturningMessage() {	
+	public void validateGatewayWithErrorFlowReturningMessage() {
 		try {
 			Object result = gatewayWithErrorChannelAndTransformer.process("echoWithErrorAsyncChannel");
 			Assert.assertEquals("Error happened in message: echoWithErrorAsyncChannel", result);
@@ -151,10 +152,10 @@ public class GatewayInvokingMessageHandlerTests {
 
 	public static class SampleErrorTransformer {
 		public Message<?> toMessage(Throwable object) throws Exception {
-			MessageHandlingException ex = (MessageHandlingException) object;		
+			MessageHandlingException ex = (MessageHandlingException) object;
 			return MessageBuilder.withPayload("Error happened in message: " + ex.getFailedMessage().getPayload()).build();
 		}
-		
+
 	}
 
 
@@ -195,7 +196,7 @@ public class GatewayInvokingMessageHandlerTests {
 	public static class SampleRuntimeException extends RuntimeException {
 		public SampleRuntimeException(String message) {
 			super(message);
-		}		
+		}
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/splitter/SplitterIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/splitter/SplitterIntegrationTests.java
@@ -37,6 +37,7 @@ import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.annotation.Splitter;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -47,6 +48,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode= DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class SplitterIntegrationTests {
 
 	@Autowired

--- a/spring-integration-core/src/test/java/org/springframework/integration/util/CallerBlocksPolicyTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/util/CallerBlocksPolicyTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.util;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import org.springframework.core.task.TaskRejectedException;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * @author Gary Russell
+ * @since 3.0.3
+ *
+ */
+public class CallerBlocksPolicyTests {
+
+	@Test
+	public void test0() throws Exception {
+		final ThreadPoolTaskExecutor te = new ThreadPoolTaskExecutor();
+		te.setCorePoolSize(1);
+		te.setMaxPoolSize(1);
+		te.setQueueCapacity(0);
+		te.setRejectedExecutionHandler(new CallerBlocksPolicy(1000));
+		te.initialize();
+		final AtomicReference<Throwable> e = new AtomicReference<Throwable>();
+		final CountDownLatch latch = new CountDownLatch(1);
+		te.execute(new Runnable() {
+
+			@Override
+			public void run() {
+				try {
+					te.execute(this);
+				}
+				catch (TaskRejectedException tre) {
+					e.set(tre.getCause());
+				}
+				latch.countDown();
+			}
+		});
+		assertTrue(latch.await(10,  TimeUnit.SECONDS));
+		assertThat(e.get(), instanceOf(RejectedExecutionException.class));
+		assertEquals("Max wait time expired to queue task", e.get().getMessage());
+	}
+
+	@Test
+	public void test1() throws Exception {
+		final ThreadPoolTaskExecutor te = new ThreadPoolTaskExecutor();
+		te.setCorePoolSize(2);
+		te.setMaxPoolSize(2);
+		te.setQueueCapacity(1);
+		te.setRejectedExecutionHandler(new CallerBlocksPolicy(10000));
+		te.initialize();
+		final AtomicReference<Throwable> e = new AtomicReference<Throwable>();
+		final CountDownLatch latch = new CountDownLatch(3);
+		te.execute(new Runnable() {
+
+			@Override
+			public void run() {
+				try {
+					Runnable foo = new Runnable() {
+
+						@Override
+						public void run() {
+							try {
+								Thread.sleep(1000);
+							}
+							catch (InterruptedException e) {
+								Thread.currentThread().interrupt();
+								throw new RuntimeException();
+							}
+							latch.countDown();
+						}
+					};
+					te.execute(foo);
+					te.execute(foo); // this one will be queued
+					te.execute(foo); // this one will be blocked and successful later
+				}
+				catch (TaskRejectedException tre) {
+					e.set(tre.getCause());
+				}
+			}
+		});
+		assertTrue(latch.await(10,  TimeUnit.SECONDS));
+		assertNull(e.get());
+	}
+
+}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileInboundTransactionTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileInboundTransactionTests.java
@@ -35,6 +35,7 @@ import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.PollableChannel;
 import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.TransactionDefinition;
@@ -49,6 +50,7 @@ import org.springframework.transaction.support.DefaultTransactionStatus;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class FileInboundTransactionTests {
 
 	@Autowired

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileToChannelIntegrationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileToChannelIntegrationTests.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.Message;
 import org.springframework.integration.core.PollableChannel;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -37,6 +38,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode= DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class FileToChannelIntegrationTests {
 
 	@Autowired File inputDirectory;

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParserTests.java
@@ -21,11 +21,8 @@ import static junit.framework.Assert.assertNotNull;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-import java.io.File;
-import java.util.Comparator;
 import java.util.Map;
 
 import org.junit.Test;
@@ -57,8 +54,6 @@ public class FtpInboundChannelAdapterParserTests {
 			new ClassPathXmlApplicationContext("FtpInboundChannelAdapterParserTests-context.xml", this.getClass());
 		SourcePollingChannelAdapter adapter = ac.getBean("ftpInbound", SourcePollingChannelAdapter.class);
 		assertFalse(TestUtils.getPropertyValue(adapter, "autoStartup", Boolean.class));
-		Comparator<File> comparator = TestUtils.getPropertyValue(adapter, "source.fileSource.toBeReceived.q.comparator", Comparator.class);
-		assertNotNull(comparator);
 		assertEquals("ftpInbound", adapter.getComponentName());
 		assertEquals("ftp:inbound-channel-adapter", adapter.getComponentType());
 		assertNotNull(TestUtils.getPropertyValue(adapter, "poller"));

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
@@ -16,15 +16,15 @@
 
 package org.springframework.integration.gemfire.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.*;
 
 import java.util.Properties;
 
+import com.gemstone.gemfire.cache.Cache;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.data.gemfire.CacheFactoryBean;
 import org.springframework.data.gemfire.RegionFactoryBean;
 import org.springframework.integration.Message;
@@ -33,9 +33,6 @@ import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
-import org.springframework.util.Assert;
-
-import com.gemstone.gemfire.cache.Cache;
 
 /**
  * @author Mark Fisher
@@ -45,18 +42,18 @@ import com.gemstone.gemfire.cache.Cache;
 public class GemfireMessageStoreTests {
 
 	private Cache cache;
-	
+
 	@Test
 	public void addAndGetMessage() throws Exception {
 		GemfireMessageStore store = new GemfireMessageStore(this.cache);
 		store.afterPropertiesSet();
-		
+
 		Message<?> message = MessageBuilder.withPayload("test").build();
 		store.addMessage(message);
 		Message<?> retrieved = store.getMessage(message.getHeaders().getId());
 		assertEquals(message, retrieved);
 	}
-	
+
 	@Test
 	public void testRegionConstructor() throws Exception {
 		RegionFactoryBean<Object, Object> region = new RegionFactoryBean<Object, Object>();
@@ -68,18 +65,18 @@ public class GemfireMessageStoreTests {
 		store.afterPropertiesSet();
 		assertSame(region.getObject(),TestUtils.getPropertyValue(store, "messageStoreRegion"));
 	}
-	
+
 	@Test
-	public void testWithMessageHistory() throws Exception{	
+	public void testWithMessageHistory() throws Exception{
 		GemfireMessageStore store = new GemfireMessageStore(this.cache);
 		store.afterPropertiesSet();
-		
+
 		Message<?> message = new GenericMessage<String>("Hello");
 		DirectChannel fooChannel = new DirectChannel();
 		fooChannel.setBeanName("fooChannel");
 		DirectChannel barChannel = new DirectChannel();
 		barChannel.setBeanName("barChannel");
-		
+
 		message = MessageHistory.write(message, fooChannel);
 		message = MessageHistory.write(message, barChannel);
 		store.addMessage(message);
@@ -96,12 +93,12 @@ public class GemfireMessageStoreTests {
 	public void init() throws Exception{
 		CacheFactoryBean cacheFactoryBean = new CacheFactoryBean();
 		cacheFactoryBean.afterPropertiesSet();
-		this.cache = (Cache)cacheFactoryBean.getObject();
+		this.cache = (Cache) cacheFactoryBean.getObject();
 	}
-	
+
 	@After
 	public void cleanup(){
-		this.cache.close();
-		Assert.isTrue(this.cache.isClosed(), "Cache did not close after close() call");
+//		this.cache.close();
+//		Assert.isTrue(this.cache.isClosed(), "Cache did not close after close() call");
 	}
 }

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -94,6 +94,7 @@ import org.springframework.web.util.UrlPathHelper;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.0
  */
 public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewaySupport
@@ -147,7 +148,9 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 		this.expectReply = expectReply;
 		this.messageConverters.add(new MultipartAwareFormHttpMessageConverter());
 		this.messageConverters.add(new ByteArrayHttpMessageConverter());
-		this.messageConverters.add(new StringHttpMessageConverter());
+		StringHttpMessageConverter stringHttpMessageConverter = new StringHttpMessageConverter();
+		stringHttpMessageConverter.setWriteAcceptCharset(false);
+		this.messageConverters.add(stringHttpMessageConverter);
 		this.messageConverters.add(new ResourceHttpMessageConverter());
 		this.messageConverters.add(new SourceHttpMessageConverter());
 		if (jaxb2Present) {

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGatewayTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGatewayTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.http.inbound;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -50,6 +51,7 @@ import org.springframework.util.SerializationUtils;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Gunnar Hillert
+ * @author Artem Bilan
  * @since 2.0
  */
 public class HttpRequestHandlingMessagingGatewayTests {
@@ -144,6 +146,8 @@ public class HttpRequestHandlingMessagingGatewayTests {
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		gateway.handleRequest(request, response);
 		assertEquals("HELLO", response.getContentAsString());
+		//INT-3120
+		assertNull(response.getHeader("Accept-Charset"));
 	}
 
 	@Test

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -30,9 +30,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.context.SmartLifecycle;
@@ -56,6 +59,10 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 		implements ConnectionFactory, SmartLifecycle {
 
 	protected static final int DEFAULT_REPLY_TIMEOUT = 10000;
+
+	private static final int DEFAULT_NIO_HARVEST_INTERVAL = 2000;
+
+	private static final int DEFAULT_READ_DELAY = 100;
 
 	private volatile String host;
 
@@ -107,7 +114,9 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 
 	private volatile int nioHarvestInterval = DEFAULT_NIO_HARVEST_INTERVAL;
 
-	private static final int DEFAULT_NIO_HARVEST_INTERVAL = 2000;
+	private final BlockingQueue<PendingIO> delayedReads = new LinkedBlockingQueue<AbstractConnectionFactory.PendingIO>();
+
+	private volatile long readDelay = DEFAULT_READ_DELAY;
 
 	public AbstractConnectionFactory(int port) {
 		this.port = port;
@@ -415,8 +424,25 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 		this.nioHarvestInterval = nioHarvestInterval;
 	}
 
+	protected BlockingQueue<PendingIO> getDelayedReads() {
+		return delayedReads;
+	}
+
+	protected long getReadDelay() {
+		return readDelay;
+	}
+
 	/**
-	 * Closes the server.
+	 * The delay (in milliseconds) before retrying a read after the previous attempt
+	 * failed due to insufficient threads. Default 100.
+	 * @param readDelay the readDelay to set.
+	 */
+	public void setReadDelay(long readDelay) {
+		Assert.isTrue(readDelay > 0, "'readDelay' must be positive");
+		this.readDelay = readDelay;
+	}
+
+	/** Closes the factory.
 	 */
 	public abstract void close();
 
@@ -522,7 +548,8 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 	 */
 	protected void processNioSelections(int selectionCount, final Selector selector, ServerSocketChannel server,
 			Map<SocketChannel, TcpNioConnection> connections) throws IOException {
-		long now = System.currentTimeMillis();
+		final long now = System.currentTimeMillis();
+		rescheduleDelayedReads(selector, now);
 		if (this.soTimeout > 0 ||
 				now >= this.nextCheckForClosedNioConnections ||
 				selectionCount == 0) {
@@ -585,25 +612,40 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 						final TcpNioConnection connection;
 						connection = (TcpNioConnection) key.attachment();
 						connection.setLastRead(System.currentTimeMillis());
-						this.taskExecutor.execute(new Runnable() {
-							public void run() {
-								try {
-									connection.readPacket();
-								} catch (Exception e) {
-									if (connection.isOpen()) {
-										logger.error("Exception on read " +
-												connection.getConnectionId() + " " +
-												e.getMessage());
-										connection.close();
-									} else {
-										logger.debug("Connection closed");
+						try {
+							this.taskExecutor.execute(new Runnable() {
+								@Override
+								public void run() {
+									boolean delayed = false;
+									try {
+										connection.readPacket();
 									}
-								}
-								if (key.channel().isOpen()) {
-									key.interestOps(SelectionKey.OP_READ);
-									selector.wakeup();
-								}
-							}});
+									catch (RejectedExecutionException e) {
+										delayRead(selector, now, key);
+										delayed = true;
+									}
+									catch (Exception e) {
+										if (connection.isOpen()) {
+											logger.error("Exception on read " +
+													connection.getConnectionId() + " " +
+													e.getMessage());
+											connection.close();
+										}
+										else {
+											logger.debug("Connection closed");
+										}
+									}
+									if (!delayed) {
+										if (key.channel().isOpen()) {
+											key.interestOps(SelectionKey.OP_READ);
+											selector.wakeup();
+										}
+									}
+								}});
+						}
+						catch (RejectedExecutionException e) {
+							delayRead(selector, now, key);
+						}
 					}
 					else if (key.isAcceptable()) {
 						try {
@@ -615,21 +657,75 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 					else {
 						logger.error("Unexpected key: " + key);
 					}
-				} catch (CancelledKeyException e) {
+				}
+				catch (CancelledKeyException e) {
 					if (logger.isDebugEnabled()) {
 						logger.debug("Selection key " + key + " cancelled");
 					}
-				} catch (Exception e) {
+				}
+				catch (Exception e) {
 					logger.error("Exception on selection key " + key, e);
 				}
 			}
 		}
 	}
 
+	protected void delayRead(Selector selector, long now, final SelectionKey key) {
+		TcpNioConnection connection = (TcpNioConnection) key.attachment();
+		if (!this.delayedReads.add(new PendingIO(now, key))) { // should never happen - unbounded queue
+			logger.error("Failed to delay read; closing " + connection.getConnectionId());
+			connection.close();
+		}
+		else {
+			if (logger.isDebugEnabled()) {
+				logger.debug("No threads available, delaying read for " + connection.getConnectionId());
+			}
+			// wake the selector in case it is currently blocked, and waiting for longer than readDelay
+			selector.wakeup();
+		}
+	}
+
 	/**
-	 * @param selector
-	 * @param now
-	 * @throws IOException
+	 * If any reads were delayed due to insufficient threads, reschedule them if
+	 * the readDelay has passed.
+	 * @param selector the selector to wake if necessary.
+	 * @param now the current time.
+	 */
+	private void rescheduleDelayedReads(Selector selector, long now) {
+		boolean wakeSelector = false;
+		try {
+			while (this.delayedReads.size() > 0) {
+				if (this.delayedReads.peek().failedAt + this.readDelay < now) {
+					PendingIO pendingRead = this.delayedReads.take();
+					if (pendingRead.key.channel().isOpen()) {
+						pendingRead.key.interestOps(SelectionKey.OP_READ);
+						wakeSelector = true;
+						if (logger.isDebugEnabled()) {
+							logger.debug("Rescheduling delayed read for " + ((TcpNioConnection) pendingRead.key.attachment()).getConnectionId());
+						}
+					}
+				}
+				else {
+					// remaining delayed reads have not expired yet.
+					break;
+				}
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		finally {
+			if (wakeSelector) {
+				selector.wakeup();
+			}
+		}
+	}
+
+	/**
+	 * @param selector The selector.
+	 * @param server The server socket channel.
+	 * @param now The current time.
+	 * @throws IOException Any IOException.
 	 */
 	protected void doAccept(final Selector selector, ServerSocketChannel server, long now) throws IOException {
 		throw new UnsupportedOperationException("Nio server factory must override this method");
@@ -705,6 +801,20 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 	public void setTcpSocketSupport(TcpSocketSupport tcpSocketSupport) {
 		Assert.notNull(tcpSocketSupport, "TcpSocketSupport must not be null");
 		this.tcpSocketSupport = tcpSocketSupport;
+	}
+
+
+	private class PendingIO {
+
+		private final long failedAt;
+
+		private final SelectionKey key;
+
+		private PendingIO(long failedAt, SelectionKey key) {
+			this.failedAt = failedAt;
+			this.key = key;
+		}
+
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
@@ -148,7 +148,11 @@ public class TcpNioClientConnectionFactory extends
 				int soTimeout = this.getSoTimeout();
 				int selectionCount = 0;
 				try {
-					selectionCount = selector.select(soTimeout < 0 ? 0 : soTimeout);
+					long timeout = soTimeout < 0 ? 0 : soTimeout;
+					if (getDelayedReads().size() > 0 && (timeout == 0 || getReadDelay() < timeout)) {
+						timeout = getReadDelay();
+					}
+					selectionCount = selector.select(timeout);
 				} catch (CancelledKeyException cke) {
 					if (logger.isDebugEnabled()) {
 						logger.debug("CancelledKeyException during Selector.select()");

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -36,7 +36,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.core.serializer.Serializer;
 import org.springframework.integration.Message;
-import org.springframework.integration.MessagingException;
 import org.springframework.integration.ip.tcp.serializer.SoftEndOfStreamException;
 import org.springframework.integration.util.CompositeExecutor;
 import org.springframework.util.Assert;
@@ -45,6 +44,7 @@ import org.springframework.util.Assert;
  * A TcpConnection that uses and underlying {@link SocketChannel}.
  *
  * @author Gary Russell
+ * @author John Anderson
  * @since 2.0
  *
  */
@@ -188,8 +188,8 @@ public class TcpNioConnection extends AbstractTcpConnection {
 							catch (RejectedExecutionException e) {
 								this.executionControl.decrementAndGet();
 								if (logger.isInfoEnabled()) {
-									logger.info("Insufficient threads in the assembler fixed thread pool; consider " +
-											"increasing this task executor pool size");
+									logger.info(getConnectionId() + " Insufficient threads in the assembler fixed thread pool; consider " +
+											"increasing this task executor pool size; data avail: " + this.channelInputStream.available());
 								}
 							}
 						}
@@ -222,7 +222,6 @@ public class TcpNioConnection extends AbstractTcpConnection {
 						}
 					}
 					this.closeConnection(true);
-					this.sendExceptionToListener(e);
 					return;
 				}
 			}
@@ -232,27 +231,27 @@ public class TcpNioConnection extends AbstractTcpConnection {
 				// timing was such that we were the last assembler and
 				// a new one wasn't run
 				try {
-					if (this.isOpen() && dataAvailable()) {
+					if (dataAvailable()) {
 						synchronized(this.executionControl) {
 							if (this.executionControl.incrementAndGet() <= 1) {
 								// only continue if we don't already have another assembler running
 								this.executionControl.set(1);
 								moreDataAvailable = true;
-								
-							} else {
+
+							}
+							else {
 								this.executionControl.decrementAndGet();
 							}
 						}
 					}
 					if (moreDataAvailable) {
-						Thread.yield();
 						if (logger.isTraceEnabled()) {
 							logger.trace(this.getConnectionId() + " Nio message assembler continuing...");
 						}
 					}
 					else {
 						if (logger.isTraceEnabled()) {
-							logger.trace(this.getConnectionId() + " Nio message assembler exiting...");
+							logger.trace(this.getConnectionId() + " Nio message assembler exiting... avail: " + this.channelInputStream.available());
 						}
 					}
 				}
@@ -342,27 +341,35 @@ public class TcpNioConnection extends AbstractTcpConnection {
 				this.taskExecutor = new CompositeExecutor(executor, executor);
 			}
 			// If there is no assembler running, start one
-if (checkForAssembler()) {
-				if (logger.isTraceEnabled()) {
-					logger.trace("Before read:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());				}
-				int len = this.socketChannel.read(this.rawBuffer);
-				if (len < 0) {
-					this.writingToPipe = false;
-					this.closeConnection(true);
-				}
-				if (logger.isTraceEnabled()) {
-					logger.trace("After read:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
-				}
-				this.rawBuffer.flip();
-				if (logger.isTraceEnabled()) {
-					logger.trace("After flip:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
-				}
-				if (logger.isDebugEnabled()) {
-					logger.debug("Read " + rawBuffer.limit() + " into raw buffer");
-				}
-				this.sendToPipe(rawBuffer);
+			checkForAssembler();
+
+			if (logger.isTraceEnabled()) {
+				logger.trace("Before read:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
 			}
-		} finally {
+			int len = this.socketChannel.read(this.rawBuffer);
+			if (len < 0) {
+				this.writingToPipe = false;
+				this.closeConnection(true);
+			}
+			if (logger.isTraceEnabled()) {
+				logger.trace("After read:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
+			}
+			this.rawBuffer.flip();
+			if (logger.isTraceEnabled()) {
+				logger.trace("After flip:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
+			}
+			if (logger.isDebugEnabled()) {
+				logger.debug("Read " + rawBuffer.limit() + " into raw buffer");
+			}
+			this.sendToPipe(rawBuffer);
+		}
+		catch (RejectedExecutionException e) {
+			throw e;
+		}
+		catch (Exception e) {
+			throw e;
+		}
+		finally {
 			this.writingToPipe = false;
 		}
 	}
@@ -376,7 +383,7 @@ if (checkForAssembler()) {
 		rawBuffer.clear();
 	}
 
-	private boolean checkForAssembler() {
+	private void checkForAssembler() {
 		synchronized(this.executionControl) {
 			if (this.executionControl.incrementAndGet() <= 1) {
 				// only execute run() if we don't already have one running
@@ -390,13 +397,13 @@ if (checkForAssembler()) {
 						logger.info("Insufficient threads in the assembler fixed thread pool; consider increasing " +
 								"this task executor pool size");
 					}
-					return false;
+					throw e;
 				}
-			} else {
+			}
+			else {
 				this.executionControl.decrementAndGet();
 			}
 		}
-		return true;
 	}
 
 	/**
@@ -414,6 +421,9 @@ if (checkForAssembler()) {
 				logger.debug(this.getConnectionId() + " Channel is closed");
 			}
 			this.closeConnection(true);
+		}
+		catch (RejectedExecutionException e) {
+			throw e;
 		}
 		catch (Exception e) {
 			logger.error("Exception on Read " +

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -26,11 +26,11 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -168,62 +168,97 @@ public class TcpNioConnection extends AbstractTcpConnection {
 		if (logger.isTraceEnabled()) {
 			logger.trace(this.getConnectionId() + " Nio message assembler running...");
 		}
-		try {
-			if (this.getListener() == null && !this.isSingleUse()) {
-				logger.debug("TcpListener exiting - no listener and not single use");
-				return;
-			}
+		boolean moreDataAvailable = true;
+		while(moreDataAvailable) {
 			try {
-				if (dataAvailable()) {
-					Message<?> message = convert();
+				if (this.getListener() == null && !this.isSingleUse()) {
+					logger.debug("TcpListener exiting - no listener and not single use");
+					return;
+				}
+				try {
 					if (dataAvailable()) {
-						// there is more data in the pipe; run another assembler
-						// to assemble the next message, while we send ours
-						this.executionControl.incrementAndGet();
-						this.taskExecutor.execute(this);
+						Message<?> message = convert();
+						if (dataAvailable()) {
+							// there is more data in the pipe; run another assembler
+							// to assemble the next message, while we send ours
+							this.executionControl.incrementAndGet();
+							try {
+								this.taskExecutor.execute2(this);
+							}
+							catch (RejectedExecutionException e) {
+								this.executionControl.decrementAndGet();
+								if (logger.isInfoEnabled()) {
+									logger.info("Insufficient threads in the assembler fixed thread pool; consider " +
+											"increasing this task executor pool size");
+								}
+							}
+						}
+						this.executionControl.decrementAndGet();
+						if (message != null) {
+							sendToChannel(message);
+						}
 					}
-					this.executionControl.decrementAndGet();
-					if (message != null) {
-						sendToChannel(message);
+					else {
+						this.executionControl.decrementAndGet();
 					}
-				} else {
-					this.executionControl.decrementAndGet();
 				}
-			} catch (Exception e) {
-				if (logger.isTraceEnabled()) {
-					logger.error("Read exception " +
-							 this.getConnectionId(), e);
-				}
-				else if (!this.isNoReadErrorOnClose()) {
-					logger.error("Read exception " +
-								 this.getConnectionId() + " " +
-								 e.getClass().getSimpleName() +
-							     ":" + e.getCause() + ":" + e.getMessage());
-				}
-				else {
-					if (logger.isDebugEnabled()) {
-						logger.debug("Read exception " +
+				catch (Exception e) {
+					if (logger.isTraceEnabled()) {
+						logger.error("Read exception " +
+								 this.getConnectionId(), e);
+					}
+					else if (!this.isNoReadErrorOnClose()) {
+						logger.error("Read exception " +
 									 this.getConnectionId() + " " +
 									 e.getClass().getSimpleName() +
 								     ":" + e.getCause() + ":" + e.getMessage());
 					}
+					else {
+						if (logger.isDebugEnabled()) {
+							logger.debug("Read exception " +
+										 this.getConnectionId() + " " +
+										 e.getClass().getSimpleName() +
+									     ":" + e.getCause() + ":" + e.getMessage());
+						}
+					}
+					this.closeConnection(true);
+					this.sendExceptionToListener(e);
+					return;
 				}
-				this.closeConnection(true);
-				return;
 			}
-		} finally {
-			if (logger.isTraceEnabled()) {
-				logger.trace(this.getConnectionId() + " Nio message assembler exiting...");
-			}
-			// Final check in case new data came in and the
-			// timing was such that we were the last assembler and
-			// a new one wasn't run
-			try {
-				if (this.isOpen() && dataAvailable()) {
-					checkForAssembler();
+			finally {
+				moreDataAvailable = false;
+				// Final check in case new data came in and the
+				// timing was such that we were the last assembler and
+				// a new one wasn't run
+				try {
+					if (this.isOpen() && dataAvailable()) {
+						synchronized(this.executionControl) {
+							if (this.executionControl.incrementAndGet() <= 1) {
+								// only continue if we don't already have another assembler running
+								this.executionControl.set(1);
+								moreDataAvailable = true;
+								
+							} else {
+								this.executionControl.decrementAndGet();
+							}
+						}
+					}
+					if (moreDataAvailable) {
+						Thread.yield();
+						if (logger.isTraceEnabled()) {
+							logger.trace(this.getConnectionId() + " Nio message assembler continuing...");
+						}
+					}
+					else {
+						if (logger.isTraceEnabled()) {
+							logger.trace(this.getConnectionId() + " Nio message assembler exiting...");
+						}
+					}
 				}
-			} catch (IOException e) {
-				logger.error("Exception when checking for assembler", e);
+				catch (IOException e) {
+					logger.error("Exception when checking for assembler", e);
+				}
 			}
 		}
 	}
@@ -307,47 +342,25 @@ public class TcpNioConnection extends AbstractTcpConnection {
 				this.taskExecutor = new CompositeExecutor(executor, executor);
 			}
 			// If there is no assembler running, start one
-			checkForAssembler();
-			if (logger.isTraceEnabled()) {
-				logger.trace("Before read:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
-			}
-			int len = this.socketChannel.read(this.rawBuffer);
-			if (len < 0) {
-				this.writingToPipe = false;
-				this.closeConnection(true);
-			}
-			if (logger.isTraceEnabled()) {
-				logger.trace("After read:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
-			}
-			this.rawBuffer.flip();
-			if (logger.isTraceEnabled()) {
-				logger.trace("After flip:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
-			}
-			if (logger.isDebugEnabled()) {
-				logger.debug("Read " + rawBuffer.limit() + " into raw buffer");
-			}
-			final CountDownLatch latch = new CountDownLatch(1);
-			/*
-			 * If there are insufficient threads, either to run the
-			 * write to the pipe, or to assemble the data, we need
-			 * avoid a deadlock (block on the write to the pipe).
-			 * Hence the count down latch.
-			 */
-			this.taskExecutor.execute2(new Runnable() {
-				public void run() {
-					try {
-						TcpNioConnection.this.sendToPipe(rawBuffer);
-						latch.countDown();
-					}
-					catch (Exception e) {
-						logger.error(getConnectionId() + " Failed to write to pipe", e);
-					}
+if (checkForAssembler()) {
+				if (logger.isTraceEnabled()) {
+					logger.trace("Before read:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());				}
+				int len = this.socketChannel.read(this.rawBuffer);
+				if (len < 0) {
+					this.writingToPipe = false;
+					this.closeConnection(true);
 				}
-			});
-			if (!latch.await(this.pipeTimeout , TimeUnit.MILLISECONDS)) {
-				this.close();
-				throw new MessagingException("Timed out writing to ChannelInputStream, probably due to insufficient threads in " +
-						"a fixed thread pool; consider increasing this task executor pool size");
+				if (logger.isTraceEnabled()) {
+					logger.trace("After read:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
+				}
+				this.rawBuffer.flip();
+				if (logger.isTraceEnabled()) {
+					logger.trace("After flip:" + this.rawBuffer.position() + "/" + this.rawBuffer.limit());
+				}
+				if (logger.isDebugEnabled()) {
+					logger.debug("Read " + rawBuffer.limit() + " into raw buffer");
+				}
+				this.sendToPipe(rawBuffer);
 			}
 		} finally {
 			this.writingToPipe = false;
@@ -363,16 +376,27 @@ public class TcpNioConnection extends AbstractTcpConnection {
 		rawBuffer.clear();
 	}
 
-	private void checkForAssembler() {
+	private boolean checkForAssembler() {
 		synchronized(this.executionControl) {
 			if (this.executionControl.incrementAndGet() <= 1) {
 				// only execute run() if we don't already have one running
 				this.executionControl.set(1);
-				this.taskExecutor.execute2(this);
+				try {
+					this.taskExecutor.execute2(this);
+				}
+				catch (RejectedExecutionException e) {
+					this.executionControl.decrementAndGet();
+					if (logger.isInfoEnabled()) {
+						logger.info("Insufficient threads in the assembler fixed thread pool; consider increasing " +
+								"this task executor pool size");
+					}
+					return false;
+				}
 			} else {
 				this.executionControl.decrementAndGet();
 			}
 		}
+		return true;
 	}
 
 	/**

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
@@ -126,7 +126,14 @@ public class TcpNioServerConnectionFactory extends AbstractServerConnectionFacto
 			int soTimeout = this.getSoTimeout();
 			int selectionCount = 0;
 			try {
-				selectionCount = selector.select(soTimeout < 0 ? 0 : soTimeout);
+				long timeout = soTimeout < 0 ? 0 : soTimeout;
+				if (getDelayedReads().size() > 0 && (timeout == 0 || getReadDelay() < timeout)) {
+					timeout = getReadDelay();
+				}
+				if (logger.isTraceEnabled()) {
+					logger.trace("Delayed reads:" + getDelayedReads().size() + " timeout " + timeout);
+				}
+				selectionCount = selector.select(timeout);
 			} catch (CancelledKeyException cke) {
 				if (logger.isDebugEnabled()) {
 					logger.debug("CancelledKeyException during Selector.select()");

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
@@ -73,11 +73,15 @@ public class TcpOutboundGatewayTests {
 		AbstractConnectionFactory ccf = new TcpNetClientConnectionFactory("localhost", port);
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port, 100);
+					serverSocket.set(server);
 					latch.countDown();
+					List<Socket> sockets = new ArrayList<Socket>();
 					int i = 0;
 					while (true) {
 						Socket socket = server.accept();
@@ -85,8 +89,10 @@ public class TcpOutboundGatewayTests {
 						ois.readObject();
 						ObjectOutputStream oos = new ObjectOutputStream(socket.getOutputStream());
 						oos.writeObject("Reply" + (i++));
+						sockets.add(socket);
 					}
-				} catch (Exception e) {
+				}
+				catch (Exception e) {
 					if (!done.get()) {
 						e.printStackTrace();
 					}
@@ -126,6 +132,8 @@ public class TcpOutboundGatewayTests {
 		for (int i = 0; i < 100; i++) {
 			assertTrue(replies.remove("Reply" + i));
 		}
+		done.set(true);
+		serverSocket.get().close();
 	}
 
 	@Test
@@ -134,6 +142,7 @@ public class TcpOutboundGatewayTests {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port, 10);
@@ -178,6 +187,7 @@ public class TcpOutboundGatewayTests {
 			assertTrue(replies.remove("Reply" + i));
 		}
 		done.set(true);
+		gateway.stop();
 	}
 
 	@Test
@@ -186,6 +196,7 @@ public class TcpOutboundGatewayTests {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
@@ -219,11 +230,12 @@ public class TcpOutboundGatewayTests {
 		QueueChannel replyChannel = new QueueChannel();
 		gateway.setRequiresReply(true);
 		gateway.setOutputChannel(replyChannel);
-		@SuppressWarnings({"rawtypes", "unchecked"})
-		Future<Integer>[] results = new Future[2];
+		@SuppressWarnings("unchecked")
+		Future<Integer>[] results = (Future<Integer>[]) new Future<?>[2];
 		for (int i = 0; i < 2; i++) {
 			final int j = i;
 			results[j] = (Executors.newSingleThreadExecutor().submit(new Callable<Integer>(){
+				@Override
 				public Integer call() throws Exception {
 					gateway.handleMessage(MessageBuilder.withPayload("Test" + j).build());
 					return 0;
@@ -256,6 +268,7 @@ public class TcpOutboundGatewayTests {
 			assertTrue(replies.remove("Reply" + i));
 		}
 		done.set(true);
+		gateway.stop();
 	}
 
 	@Test
@@ -302,6 +315,7 @@ public class TcpOutboundGatewayTests {
 
 		Executors.newSingleThreadExecutor().execute(new Runnable() {
 
+			@Override
 			public void run() {
 				try {
 					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
@@ -347,10 +361,11 @@ public class TcpOutboundGatewayTests {
 		gateway.setOutputChannel(replyChannel);
 		gateway.setRemoteTimeout(500);
 		@SuppressWarnings("unchecked")
-		Future<Integer>[] results = new Future[2];
+		Future<Integer>[] results = (Future<Integer>[]) new Future<?>[2];
 		for (int i = 0; i < 2; i++) {
 			final int j = i;
 			results[j] = (Executors.newSingleThreadExecutor().submit(new Callable<Integer>() {
+				@Override
 				public Integer call() throws Exception {
 					// increase the timeout after the first send
 					if (j > 0) {
@@ -390,6 +405,7 @@ public class TcpOutboundGatewayTests {
 		assertEquals(lastReceived.get().replace("Test", "Reply"), replies.get(0));
 		done.set(true);
 		assertEquals(0, TestUtils.getPropertyValue(gateway, "pendingReplies", Map.class).size());
+		gateway.stop();
 	}
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
@@ -219,7 +219,7 @@ public class TcpOutboundGatewayTests {
 		QueueChannel replyChannel = new QueueChannel();
 		gateway.setRequiresReply(true);
 		gateway.setOutputChannel(replyChannel);
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({"rawtypes", "unchecked"})
 		Future<Integer>[] results = new Future[2];
 		for (int i = 0; i < 2; i++) {
 			final int j = i;

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -15,18 +15,8 @@
  */
 package org.springframework.integration.ip.tcp.connection;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -57,6 +47,7 @@ import org.springframework.integration.ip.util.TestingUtilities;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -67,6 +58,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode= DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class CachingClientConnectionFactoryTests {
 
 	@Autowired

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -290,9 +291,7 @@ public class TcpNioConnectionTests {
 			fail("Expected exception, got " + o);
 		}
 		catch (ExecutionException e) {
-			assertEquals("Timed out writing to ChannelInputStream, probably due to insufficient threads in " +
-					"a fixed thread pool; consider increasing this task executor pool size", e.getCause()
-					.getMessage());
+			assertEquals("Timed out waiting for buffer space", e.getCause().getMessage());
 		}
 	}
 
@@ -388,18 +387,74 @@ public class TcpNioConnectionTests {
 		factory.stop();
 	}
 
+	@Test
+	public void testAllMessagesDelivered() throws Exception {
+		final int numberOfSockets = 25;
+		final int port = SocketUtils.findAvailableServerSocket();
+		TcpNioServerConnectionFactory factory = new TcpNioServerConnectionFactory(port);
+		factory.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
+
+		CompositeExecutor compositeExec = compositeExecutor();
+
+		factory.setTaskExecutor(compositeExec);
+		final CountDownLatch latch = new CountDownLatch(numberOfSockets);
+		factory.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				if (!(message instanceof ErrorMessage)) {
+					latch.countDown();
+				}
+				return false;
+			}
+
+		});
+		factory.start();
+		
+		Socket[] sockets = new Socket[numberOfSockets];
+		for (int i = 0; i < numberOfSockets; i++) {
+			Socket socket = null;
+			int n = 0;
+			while (n++ < 100) {
+				try {
+					socket = SocketFactory.getDefault().createSocket("localhost", port);
+					break;
+				}
+				catch (ConnectException e) {}
+				Thread.sleep(100);
+			}
+			assertTrue("Could not open socket to localhost:" + port, n < 100);
+			sockets[i] = socket;
+		}
+		for (int i = 0; i < numberOfSockets; i++) {
+			sockets[i].getOutputStream().write("foo1 and...".getBytes());
+			sockets[i].getOutputStream().flush();
+		}
+		Thread.sleep(100);
+		for (int i = 0; i < numberOfSockets; i++) {
+			sockets[i].getOutputStream().write(("...foo2\r\n").getBytes());
+			sockets[i].close();
+		}
+		
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+		factory.stop();
+	}
+
 	private CompositeExecutor compositeExecutor() {
 		ThreadPoolTaskExecutor ioExec = new ThreadPoolTaskExecutor();
 		ioExec.setCorePoolSize(2);
-		ioExec.setQueueCapacity(10);
+		ioExec.setMaxPoolSize(4);
+		ioExec.setQueueCapacity(0);
 		ioExec.setThreadNamePrefix("io-");
-		ioExec.setRejectedExecutionHandler(new CallerBlocksPolicy(10000));
+		ioExec.setRejectedExecutionHandler(new CallerBlocksPolicy(5000));
 		ioExec.initialize();
 		ThreadPoolTaskExecutor assemblerExec = new ThreadPoolTaskExecutor();
 		assemblerExec.setCorePoolSize(2);
-		assemblerExec.setQueueCapacity(10);
+		assemblerExec.setMaxPoolSize(5);
+		assemblerExec.setQueueCapacity(0);
 		assemblerExec.setThreadNamePrefix("assembler-");
-		assemblerExec.setRejectedExecutionHandler(new CallerBlocksPolicy(10000));
+		assemblerExec.setRejectedExecutionHandler(new AbortPolicy());
 		assemblerExec.initialize();
 		return new CompositeExecutor(ioExec, assemblerExec);
 	}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -16,17 +16,15 @@
 
 package org.springframework.integration.ip.tcp.connection;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.net.ConnectException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
@@ -46,18 +44,25 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ServerSocketFactory;
+import javax.net.SocketFactory;
 
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import org.springframework.integration.Message;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer;
+import org.springframework.integration.message.ErrorMessage;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.SocketUtils;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.integration.util.CallerBlocksPolicy;
+import org.springframework.integration.util.CompositeExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.ReflectionUtils.FieldCallback;
 import org.springframework.util.ReflectionUtils.FieldFilter;
@@ -335,6 +340,68 @@ public class TcpNioConnectionTests {
 		});
 		future.get(60, TimeUnit.SECONDS);
 		assertTrue(messageLatch.await(10, TimeUnit.SECONDS));
+	}
+
+	@Test
+	public void testAssemblerUsesSecondaryExecutor() throws Exception {
+		final int port = SocketUtils.findAvailableServerSocket();
+		TcpNioServerConnectionFactory factory = new TcpNioServerConnectionFactory(port);
+//		factory.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
+
+		CompositeExecutor compositeExec = compositeExecutor();
+
+		factory.setSoTimeout(1000);
+		factory.setTaskExecutor(compositeExec);
+		final AtomicReference<String> threadName = new AtomicReference<String>();
+		final CountDownLatch latch = new CountDownLatch(1);
+		factory.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				if (!(message instanceof ErrorMessage)) {
+					threadName.set(Thread.currentThread().getName());
+					latch.countDown();
+				}
+				return false;
+			}
+
+		});
+		factory.start();
+
+		Socket socket = null;
+		int n = 0;
+		while (n++ < 100) {
+			try {
+				socket = SocketFactory.getDefault().createSocket("localhost", port);
+				break;
+			}
+			catch (ConnectException e) {}
+			Thread.sleep(100);
+		}
+		assertTrue("Could not open socket to localhost:" + port, n < 100);
+		socket.getOutputStream().write("foo\r\n".getBytes());
+		socket.close();
+
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+		assertThat(threadName.get(), containsString("assembler"));
+
+		factory.stop();
+	}
+
+	private CompositeExecutor compositeExecutor() {
+		ThreadPoolTaskExecutor ioExec = new ThreadPoolTaskExecutor();
+		ioExec.setCorePoolSize(2);
+		ioExec.setQueueCapacity(10);
+		ioExec.setThreadNamePrefix("io-");
+		ioExec.setRejectedExecutionHandler(new CallerBlocksPolicy(10000));
+		ioExec.initialize();
+		ThreadPoolTaskExecutor assemblerExec = new ThreadPoolTaskExecutor();
+		assemblerExec.setCorePoolSize(2);
+		assemblerExec.setQueueCapacity(10);
+		assemblerExec.setThreadNamePrefix("assembler-");
+		assemblerExec.setRejectedExecutionHandler(new CallerBlocksPolicy(10000));
+		assemblerExec.initialize();
+		return new CompositeExecutor(ioExec, assemblerExec);
 	}
 
 	private void readFully(InputStream is, byte[] buff) throws IOException {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -61,7 +61,6 @@ import org.springframework.integration.message.ErrorMessage;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.SocketUtils;
 import org.springframework.integration.test.util.TestUtils;
-import org.springframework.integration.util.CallerBlocksPolicy;
 import org.springframework.integration.util.CompositeExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.util.ReflectionUtils;
@@ -71,6 +70,7 @@ import org.springframework.util.ReflectionUtils.FieldFilter;
 
 /**
  * @author Gary Russell
+ * @author John Anderson
  * @since 2.0
  *
  */
@@ -389,15 +389,15 @@ public class TcpNioConnectionTests {
 
 	@Test
 	public void testAllMessagesDelivered() throws Exception {
-		final int numberOfSockets = 25;
+		final int numberOfSockets = 100;
 		final int port = SocketUtils.findAvailableServerSocket();
 		TcpNioServerConnectionFactory factory = new TcpNioServerConnectionFactory(port);
-		factory.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
+//		factory.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
 
 		CompositeExecutor compositeExec = compositeExecutor();
 
 		factory.setTaskExecutor(compositeExec);
-		final CountDownLatch latch = new CountDownLatch(numberOfSockets);
+		final CountDownLatch latch = new CountDownLatch(numberOfSockets * 4);
 		factory.registerListener(new TcpListener() {
 
 			@Override
@@ -410,7 +410,7 @@ public class TcpNioConnectionTests {
 
 		});
 		factory.start();
-		
+
 		Socket[] sockets = new Socket[numberOfSockets];
 		for (int i = 0; i < numberOfSockets; i++) {
 			Socket socket = null;
@@ -432,11 +432,28 @@ public class TcpNioConnectionTests {
 		}
 		Thread.sleep(100);
 		for (int i = 0; i < numberOfSockets; i++) {
-			sockets[i].getOutputStream().write(("...foo2\r\n").getBytes());
+			sockets[i].getOutputStream().write(("...foo2\r\nbar1 and...").getBytes());
+			sockets[i].getOutputStream().flush();
+		}
+		for (int i = 0; i < numberOfSockets; i++) {
+			sockets[i].getOutputStream().write(("...bar2\r\n").getBytes());
+			sockets[i].getOutputStream().flush();
+		}
+		for (int i = 0; i < numberOfSockets; i++) {
+			sockets[i].getOutputStream().write("foo3 and...".getBytes());
+			sockets[i].getOutputStream().flush();
+		}
+		Thread.sleep(100);
+		for (int i = 0; i < numberOfSockets; i++) {
+			sockets[i].getOutputStream().write(("...foo4\r\nbar3 and...").getBytes());
+			sockets[i].getOutputStream().flush();
+		}
+		for (int i = 0; i < numberOfSockets; i++) {
+			sockets[i].getOutputStream().write(("...bar4\r\n").getBytes());
 			sockets[i].close();
 		}
-		
-		assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+		assertTrue("latch is still " + latch.getCount(), latch.await(60, TimeUnit.SECONDS));
 
 		factory.stop();
 	}
@@ -447,7 +464,7 @@ public class TcpNioConnectionTests {
 		ioExec.setMaxPoolSize(4);
 		ioExec.setQueueCapacity(0);
 		ioExec.setThreadNamePrefix("io-");
-		ioExec.setRejectedExecutionHandler(new CallerBlocksPolicy(5000));
+		ioExec.setRejectedExecutionHandler(new AbortPolicy());
 		ioExec.initialize();
 		ThreadPoolTaskExecutor assemblerExec = new ThreadPoolTaskExecutor();
 		assemblerExec.setCorePoolSize(2);

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.context.support.AbstractApplicationContext;
@@ -51,6 +52,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  * @author Artem Bilan
  * @author Gary Russell
  */
+@Ignore
 public class DelayerHandlerRescheduleIntegrationTests {
 
 	public static final String DELAYER_ID = "delayerWithJdbcMS";

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+* Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,6 +201,7 @@ class SftpSession implements Session<LsEntry> {
 			}
 		}
 		catch (JSchException e) {
+			this.close();
 			throw new IllegalStateException("failed to connect", e);
 		}
 	}

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserTests-context.xml
@@ -22,11 +22,7 @@
 	<channel id="requestChannel">
 		<queue/>
 	</channel>
-	
-	<beans:bean id="pattern" class="java.util.regex.Pattern" factory-method="compile">
-		<beans:constructor-arg value="."/>
-	</beans:bean>
-	
+
 	<beans:bean id="sftpSessionFactory" class="org.springframework.integration.sftp.session.DefaultSftpSessionFactory">
 		<beans:property name="host" value="loclahost"/>
 		<beans:property name="knownHosts" value="local, foo.com, bar.foo"/>
@@ -53,7 +49,7 @@
 			<transactional synchronization-factory="syncFactory"/>
 		</poller>
 	</sftp:inbound-channel-adapter>
-	
+
 	<transaction-synchronization-factory id="syncFactory">
 		<after-commit expression="'foo'" channel="successChannel"/>
 		<after-rollback expression="'bar'" channel="failureChannel"/>
@@ -115,7 +111,7 @@
 	</sftp:inbound-channel-adapter>
 
 	<bridge input-channel="autoChannel" output-channel="nullChannel" />
-	
+
 	<beans:bean id="transactionManager" class="org.springframework.integration.transaction.PseudoTransactionManager"/>
 
 </beans:beans>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserTests.java
@@ -23,7 +23,6 @@ import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertSame;
 
 import java.io.File;
-import java.util.Comparator;
 
 import org.junit.After;
 import org.junit.Before;
@@ -73,8 +72,6 @@ public class InboundChannelAdapterParserTests {
 		SftpInboundFileSynchronizingMessageSource source =
 			(SftpInboundFileSynchronizingMessageSource) TestUtils.getPropertyValue(adapter, "source");
 		assertNotNull(source);
-		Comparator<File> comparator = TestUtils.getPropertyValue(adapter, "source.fileSource.toBeReceived.q.comparator", Comparator.class);
-		assertNotNull(comparator);
 		SftpInboundFileSynchronizer synchronizer =  (SftpInboundFileSynchronizer) TestUtils.getPropertyValue(source, "synchronizer");
 		assertNotNull(TestUtils.getPropertyValue(synchronizer, "localFilenameGeneratorExpression"));
 		String remoteFileSeparator = (String) TestUtils.getPropertyValue(synchronizer, "remoteFileSeparator");

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/INT3305Tests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/INT3305Tests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.sftp.session;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import org.apache.sshd.SshServer;
+import org.apache.sshd.common.session.AbstractSession;
+import org.apache.sshd.server.PasswordAuthenticator;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.session.ServerSession;
+import org.junit.Test;
+
+import org.springframework.integration.test.util.SocketUtils;
+
+/**
+ * @author Gary Russell
+ * @since 3.0.2
+ *
+ */
+public class INT3305Tests {
+
+	/*
+	 * Verify the socket is closed if the channel.connect() fails.
+	 */
+	@Test
+	public void testConnectFailSocketOpen() throws Exception {
+		final int port = SocketUtils.findAvailableServerSocket();
+		SshServer server = SshServer.setUpDefaultServer();
+		try {
+			server.setPasswordAuthenticator(new PasswordAuthenticator() {
+
+				@Override
+				public boolean authenticate(String arg0, String arg1, ServerSession arg2) {
+					return true;
+				}
+			});
+			server.setPort(port);
+			server.setKeyPairProvider(new SimpleGeneratorHostKeyProvider("hostkey.ser"));
+			server.start();
+
+			DefaultSftpSessionFactory f = new DefaultSftpSessionFactory();
+			f.setHost("localhost");
+			f.setPort(port);
+			f.setUser("user");
+			f.setPassword("pass");
+			try {
+				f.getSession();
+				fail("Expected Exception");
+			}
+			catch (Exception e) {
+				assertThat(e, instanceOf(IllegalStateException.class));
+				assertThat(e.getCause(), instanceOf(IllegalStateException.class));
+				assertThat(e.getCause().getMessage(), equalTo("failed to connect"));
+			}
+			List<AbstractSession> sessions = server.getActiveSessions();
+
+			assertEquals(0, sessions.size());
+		}
+		finally {
+			server.stop(true);
+		}
+	}
+
+}

--- a/src/reference/docbook/ip.xml
+++ b/src/reference/docbook/ip.xml
@@ -841,13 +841,110 @@
     detection logic has been added such that if thread starvation occurs, instead of
     deadlocking, an exception is thrown, thus releasing the deadlocked resources.
    </para>
-   <note>
+   <important>
     Now that the default task executor is unbounded, it is possible that an out of
     memory condition might occur with high rates of incoming messages, if message
     processing takes extended time. If your application exhibits this type of
     behavior, you are advised to use a pooled task executor with an appropriate
-    pool size.
-   </note>
+    pool size, but see the next section.
+   </important>
+   <section>
+     <title>Thread Pool Task Executor with CALLER_RUNS Policy</title>
+     <para>
+      There are some important considerations when using a fixed thread pool with
+      the <classname>CallerRunsPolicy</classname> (<code>CALLER_RUNS</code> when
+      using the <code>&lt;task/&gt;</code> namespace) and the queue capacity is small.
+     </para>
+     <para>
+      With NIO connections there are 3 distinct task types; the IO Selector processing
+      is performed on one dedicated thread - detecting events, accepting new connections,
+      and dispatching the IO read operations to other threads, using the task
+      executor. When an IO reader thread (to which the read operation is dispatched)
+      reads data, it hands off to another thread
+      to assemble the incoming message; large messages may take several reads to complete.
+      These "assembler" threads can block waiting for data. When a new read event
+      occurs, the reader determines if this socket already has an assembler and
+      runs a new one if not. When the assembly process is complete, the assembler
+      thread is returned to the pool.
+     </para>
+     <para>
+      This can cause a deadlock when the pool is exhausted and the CALLER_RUNS
+      rejection policy is in use, and the task queue is full.
+      When the pool is empty and there is no room in the queue, the IO selector thread
+      receives an <code>OP_READ</code> event and dispatches the read using the
+      executor; the queue is full, so the selector thread itself starts the
+      read process; now, it detects that there is not an assembler for this
+      socket and, before it does the read, fires off an assembler; again, the
+      queue is full, and the selector thread becomes the assembler. The assembler
+      is now blocked awaiting the data to be read, which will never happen.
+      The connection factory is now deadlocked because the selector thread
+      can't handle new events.
+     </para>
+     <para>
+      We must avoid the selector (or reader) threads performing the
+      assembly task to avoid this deadlock.
+     </para>
+     <para>
+      Two classes are provided by the framework to avoid this problem. The
+      <classname>CompositeExecutor</classname> allows the configuration
+      of two distinct executors; one for performing IO operations, and
+      one for message assembly. The <classname>CallerBlocksPolicy</classname>
+      (which should be configured for both task executors) will suspend
+      the IO operation until an assembler thread is available (or a timeout
+      occurs). In this environment, an IO thread can never
+      become an assembler thread, and the deadlock cannot occur.
+      Example configuration of the composite executor is shown below. The
+      <code>maxPoolSize</code> (or <code>queueCapacity</code>)
+      of the assembler executor should be slightly
+      larger than those on the IO executor.
+     </para>
+     <programlisting language="java"><![CDATA[@Bean
+private CompositeExecutor compositeExecutor() {
+    ThreadPoolTaskExecutor ioExec = new ThreadPoolTaskExecutor();
+    ioExec.setCorePoolSize(4);
+    ioExec.setMaxPoolSize(8);
+    ioExec.setQueueCapacity(10);
+    ioExec.setThreadNamePrefix("io-");
+    ioExec.setRejectedExecutionHandler(new CallerRunsPolicy());
+    ioExec.initialize();
+    ThreadPoolTaskExecutor assemblerExec = new ThreadPoolTaskExecutor();
+    assemblerExec.setCorePoolSize(2);
+    assemblerExec.setMaxPoolSize(10);
+    assemblerExec.setQueueCapacity(12);
+    assemblerExec.setThreadNamePrefix("assembler-");
+    assemblerExec.setRejectedExecutionHandler(new CallerBlocksPolicy(10000));
+    assemblerExec.initialize();
+    return new CompositeExecutor(ioExec, assemblerExec);
+}]]></programlisting>
+<programlisting language="xml"><![CDATA[<bean id="myTaskExecutor" class="org.springframework.integration.util.CompositeExecutor">
+    <constructor-arg>
+        <bean class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
+            <property name="threadNamePrefix" value="io-" />
+            <property name="corePoolSize" value="4" />
+            <property name="maxPoolSize" value="8" />
+            <property name="queueCapacity" value="10" />
+            <property name="rejectedExecutionHandler">
+                <bean class="org.springframework.integration.util.CallerBlocksPolicy">
+                    <constructor-arg value="10000" />
+                </bean>
+            </property>
+        </bean>
+    </constructor-arg>
+    <constructor-arg>
+        <bean class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
+            <property name="threadNamePrefix" value="assembler-" />
+            <property name="corePoolSize" value="4" />
+            <property name="maxPoolSize" value="10" />
+            <property name="queueCapacity" value="10" />
+            <property name="rejectedExecutionHandler">
+                <bean class="org.springframework.integration.util.CallerBlocksPolicy">
+                    <constructor-arg value="10000" />
+                </bean>
+            </property>
+        </bean>
+    </constructor-arg>
+</bean>]]></programlisting>
+   </section>
   </section>
   <section id="ssl-tls">
     <title>SSL/TLS Support</title>

--- a/src/reference/docbook/ip.xml
+++ b/src/reference/docbook/ip.xml
@@ -856,6 +856,9 @@
       using the <code>&lt;task/&gt;</code> namespace) and the queue capacity is small.
      </para>
      <para>
+      The following does not apply if you are not using a fixed thread pool.
+     </para>
+     <para>
       With NIO connections there are 3 distinct task types; the IO Selector processing
       is performed on one dedicated thread - detecting events, accepting new connections,
       and dispatching the IO read operations to other threads, using the task
@@ -882,30 +885,34 @@
      </para>
      <para>
       We must avoid the selector (or reader) threads performing the
-      assembly task to avoid this deadlock.
+      assembly task to avoid this deadlock. It is desirable to use seperate
+      pools for the IO and assembly operations.
      </para>
      <para>
-      Two classes are provided by the framework to avoid this problem. The
-      <classname>CompositeExecutor</classname> allows the configuration
+      The framework providers a
+      <classname>CompositeExecutor</classname>, which allows the configuration
       of two distinct executors; one for performing IO operations, and
-      one for message assembly. The <classname>CallerBlocksPolicy</classname>
-      (which should be configured for the first task executors) will suspend
-      the IO operation until an assembler thread is available (or a timeout
-      occurs). In this environment, an IO thread can never
+      one for message assembly. In this environment, an IO thread can never
       become an assembler thread, and the deadlock cannot occur.
-      Example configuration of the composite executor is shown below. The
-      <code>maxPoolSize</code> (or <code>queueCapacity</code>)
-      of the assembler executor should be slightly
-      larger than those on the IO executor.
+     </para>
+     <para>
+      In addition, the task executors should be configured to use a
+      <classname>AbortPolicy</classname> (ABORT when using <code>&lt;task&gt;</code>).
+      When an IO cannot be completed, it is deferred for a short time and
+      retried continually until it can be completed and an assembler
+      allocated.
+     </para>
+     <para>
+      Example configuration of the composite executor is shown below.
      </para>
      <programlisting language="java"><![CDATA[@Bean
 private CompositeExecutor compositeExecutor() {
     ThreadPoolTaskExecutor ioExec = new ThreadPoolTaskExecutor();
     ioExec.setCorePoolSize(4);
-    ioExec.setMaxPoolSize(8);
+    ioExec.setMaxPoolSize(10);
     ioExec.setQueueCapacity(0);
     ioExec.setThreadNamePrefix("io-");
-    ioExec.setRejectedExecutionHandler(new CallerRunsPolicy());
+    ioExec.setRejectedExecutionHandler(new AbortPolicy());
     ioExec.initialize();
     ThreadPoolTaskExecutor assemblerExec = new ThreadPoolTaskExecutor();
     assemblerExec.setCorePoolSize(4);
@@ -917,6 +924,14 @@ private CompositeExecutor compositeExecutor() {
     return new CompositeExecutor(ioExec, assemblerExec);
 }]]></programlisting>
 <programlisting language="xml"><![CDATA[<bean id="myTaskExecutor" class="org.springframework.integration.util.CompositeExecutor">
+    <constructor-arg ref="io"/>
+    <constructor-arg ref="assembler"/>
+</bean>
+
+<task:executor id="io" pool-size="4-10" queue-capacity="0" rejection-policy="ABORT" />
+<task:executor id="assembler" pool-size="4-10" queue-capacity="0" rejection-policy="ABORT" />]]></programlisting>
+
+<programlisting language="xml"><![CDATA[<bean id="myTaskExecutor" class="org.springframework.integration.util.CompositeExecutor">
     <constructor-arg>
         <bean class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
             <property name="threadNamePrefix" value="io-" />
@@ -924,9 +939,7 @@ private CompositeExecutor compositeExecutor() {
             <property name="maxPoolSize" value="8" />
             <property name="queueCapacity" value="0" />
             <property name="rejectedExecutionHandler">
-                <bean class="org.springframework.integration.util.CallerBlocksPolicy">
-                    <constructor-arg value="10000" />
-                </bean>
+                <bean class="java.util.concurrent.ThreadPoolExecutor.AbortPolicy" />
             </property>
         </bean>
     </constructor-arg>

--- a/src/reference/docbook/ip.xml
+++ b/src/reference/docbook/ip.xml
@@ -889,7 +889,7 @@
       <classname>CompositeExecutor</classname> allows the configuration
       of two distinct executors; one for performing IO operations, and
       one for message assembly. The <classname>CallerBlocksPolicy</classname>
-      (which should be configured for both task executors) will suspend
+      (which should be configured for the first task executors) will suspend
       the IO operation until an assembler thread is available (or a timeout
       occurs). In this environment, an IO thread can never
       become an assembler thread, and the deadlock cannot occur.
@@ -903,16 +903,16 @@ private CompositeExecutor compositeExecutor() {
     ThreadPoolTaskExecutor ioExec = new ThreadPoolTaskExecutor();
     ioExec.setCorePoolSize(4);
     ioExec.setMaxPoolSize(8);
-    ioExec.setQueueCapacity(10);
+    ioExec.setQueueCapacity(0);
     ioExec.setThreadNamePrefix("io-");
     ioExec.setRejectedExecutionHandler(new CallerRunsPolicy());
     ioExec.initialize();
     ThreadPoolTaskExecutor assemblerExec = new ThreadPoolTaskExecutor();
-    assemblerExec.setCorePoolSize(2);
+    assemblerExec.setCorePoolSize(4);
     assemblerExec.setMaxPoolSize(10);
-    assemblerExec.setQueueCapacity(12);
+    assemblerExec.setQueueCapacity(0);
     assemblerExec.setThreadNamePrefix("assembler-");
-    assemblerExec.setRejectedExecutionHandler(new CallerBlocksPolicy(10000));
+    assemblerExec.setRejectedExecutionHandler(new AbortPolicy());
     assemblerExec.initialize();
     return new CompositeExecutor(ioExec, assemblerExec);
 }]]></programlisting>
@@ -922,7 +922,7 @@ private CompositeExecutor compositeExecutor() {
             <property name="threadNamePrefix" value="io-" />
             <property name="corePoolSize" value="4" />
             <property name="maxPoolSize" value="8" />
-            <property name="queueCapacity" value="10" />
+            <property name="queueCapacity" value="0" />
             <property name="rejectedExecutionHandler">
                 <bean class="org.springframework.integration.util.CallerBlocksPolicy">
                     <constructor-arg value="10000" />
@@ -935,11 +935,9 @@ private CompositeExecutor compositeExecutor() {
             <property name="threadNamePrefix" value="assembler-" />
             <property name="corePoolSize" value="4" />
             <property name="maxPoolSize" value="10" />
-            <property name="queueCapacity" value="10" />
+            <property name="queueCapacity" value="0" />
             <property name="rejectedExecutionHandler">
-                <bean class="org.springframework.integration.util.CallerBlocksPolicy">
-                    <constructor-arg value="10000" />
-                </bean>
+                <bean class="java.util.concurrent.ThreadPoolExecutor.AbortPolicy" />
             </property>
         </bean>
     </constructor-arg>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3457

Backport for:
https://jira.spring.io/browse/INT-3120
https://jira.spring.io/browse/INT-3305
https://jira.spring.io/browse/INT-3410
https://jira.spring.io/browse/INT-3433
https://jira.spring.io/browse/INT-3453

The https://jira.spring.io/browse/INT-3123 can't be backported bacause it depends on https://jira.spring.io/browse/INT-3103, but `TcpEvents` have been introduced since **3.0**
