### PR TITLE
INT-3470: SF 4.1 compatibility #2

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AnnotationAggregatorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AnnotationAggregatorTests.java
@@ -55,8 +55,8 @@ public class AnnotationAggregatorTests {
 		@SuppressWarnings("unchecked")
 		Message<String> result = (Message<String>) output.receive();
 		String payload = result.getPayload();
-		assertTrue("Wrong payload: "+payload, payload.contains("Payload String content=a"));
-		assertTrue("Wrong payload: "+payload, payload.contains("Payload String content=b"));
+		assertTrue("Wrong payload: "+payload, payload.matches(".*Payload.*?=a.*"));
+		assertTrue("Wrong payload: "+payload, payload.matches(".*Payload.*?=b.*"));
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalChannelInterceptorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalChannelInterceptorTests.java
@@ -30,11 +30,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.Ordered;
-import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.channel.ChannelInterceptorAware;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -127,7 +127,7 @@ public class GlobalChannelInterceptorTests {
 	}
 
 
-	public static class SampleInterceptor implements ChannelInterceptor {
+	public static class SampleInterceptor extends ChannelInterceptorAdapter {
 
 		private String testIdentifier;
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ImplicitConsumerChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ImplicitConsumerChannelTests.java
@@ -15,10 +15,8 @@
  */
 package org.springframework.integration.channel.interceptor;
 
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
 import java.util.List;
 
@@ -31,6 +29,7 @@ import org.springframework.integration.channel.ChannelInterceptorAware;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -69,7 +68,7 @@ public class ImplicitConsumerChannelTests {
 		assertThat(bazInterceptors.get(1), anyOf(instanceOf(WireTap.class), instanceOf(Interceptor1.class)));
 	}
 
-	public static class Interceptor1 implements ChannelInterceptor, VetoCapableInterceptor {
+	public static class Interceptor1 extends ChannelInterceptorAdapter implements VetoCapableInterceptor {
 
 		private MessageChannel channel;
 
@@ -107,7 +106,7 @@ public class ImplicitConsumerChannelTests {
 
 	}
 
-	public static class Interceptor2 implements ChannelInterceptor, VetoCapableInterceptor {
+	public static class Interceptor2 extends ChannelInterceptorAdapter implements VetoCapableInterceptor {
 
 		private MessageChannel channel;
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/PollableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/PollableJmsChannelTests.java
@@ -52,6 +52,7 @@ import org.springframework.jms.core.MessageCreator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.messaging.support.GenericMessage;
 
 /**
@@ -266,8 +267,10 @@ public class PollableJmsChannelTests {
 		assertEquals("bar", result2.getPayload());
 	}
 
-	public static class SampleInterceptor implements ChannelInterceptor {
+	public static class SampleInterceptor extends ChannelInterceptorAdapter {
+
 		private final boolean preReceiveFlag;
+
 		public SampleInterceptor(boolean preReceiveFlag){
 			this.preReceiveFlag = preReceiveFlag;
 		}

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -265,7 +265,6 @@ public class WebServiceOutboundGatewayParserTests {
 		assertEquals(PeriodicTrigger.class, triggerObject.getClass());
 		PeriodicTrigger trigger = (PeriodicTrigger) triggerObject;
 		DirectFieldAccessor accessor = new DirectFieldAccessor(trigger);
-		accessor = new DirectFieldAccessor(trigger);
 		assertEquals("PeriodicTrigger had wrong period",
 				5000, ((Long)accessor.getPropertyValue("period")).longValue());
 	}
@@ -396,6 +395,7 @@ public class WebServiceOutboundGatewayParserTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void jmsUri() {
 		ApplicationContext context = new ClassPathXmlApplicationContext(
 				"simpleWebServiceOutboundGatewayParserTests.xml", this.getClass());

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/MarshallingTransformerParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/MarshallingTransformerParserTests.java
@@ -113,9 +113,9 @@ public class MarshallingTransformerParserTests  {
 		Message<?> result = output.receive(0);
 		assertTrue("Wrong payload type", result.getPayload() instanceof DOMResult);
 		Document doc = (Document) ((DOMResult) result.getPayload()).getNode();
-		String expected = "[Payload String content=hello]";
 		String actual = doc.getDocumentElement().getTextContent();
-		assertThat(actual, Matchers.containsString(expected));
+		assertThat(actual, Matchers.containsString("[Payload"));
+		assertThat(actual, Matchers.containsString("=hello]"));
 		assertThat(actual, Matchers.containsString("[Headers="));
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3470
- Apply the last `ChannelInterceptor` changes - just `extends ChannelInterceptorAdapter`
- Change some tests to check content according to the new changes to the `GenericMessage#toString()`

**Cherry-pick to 4.0.x**
