### PR TITLE
Fix properties setting of conv in ctx

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/DefaultPahoMessageConverter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/DefaultPahoMessageConverter.java
@@ -78,10 +78,14 @@ public class DefaultPahoMessageConverter implements MqttMessageConverter, BeanFa
 	 *
 	 * @param payloadAsBytes The payloadAsBytes to set.
 	 */
-	protected final void setPayloadAsBytes(boolean payloadAsBytes) {
+	public void setPayloadAsBytes(boolean payloadAsBytes) {
 		this.payloadAsBytes = payloadAsBytes;
 	}
 
+	public boolean isPayloadAsBytes() {
+		return this.payloadAsBytes;
+	}
+	
 	public DefaultPahoMessageConverter(int defaultQos, boolean defaultRetained, String charset) {
 		this.defaultQos = defaultQos;
 		this.defaultRetained = defaultRetained;


### PR DESCRIPTION
In docs, it s said: 

```
The DefaultPahoMessageConverter can be configured to return the raw byte[] in the payload by declaring it as a <bean/> and setting the payloadAsBytes property.
```

http://docs.spring.io/spring-integration/docs/4.0.0.M3/reference/html/mqtt.html

How should we do that if this attribute is not writable?
