### PR TITLE
INT-3471 DefaultHeaderChannelRegistry Improvements

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/HeaderEnricherParserSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/HeaderEnricherParserSupport.java
@@ -59,9 +59,9 @@ public abstract class HeaderEnricherParserSupport extends AbstractTransformerPar
 	static {
 		cannedHeaderElementExpressions.put("header-channels-to-string", new String[][] {
 				{"replyChannel", "@" + IntegrationContextUtils.INTEGRATION_HEADER_CHANNEL_REGISTRY_BEAN_NAME
-						+ ".channelToChannelName(headers.replyChannel)" },
+						+ ".channelToChannelName(headers.replyChannel, ####)" },
 				{"errorChannel", "@" + IntegrationContextUtils.INTEGRATION_HEADER_CHANNEL_REGISTRY_BEAN_NAME
-						+ ".channelToChannelName(headers.errorChannel)" },
+						+ ".channelToChannelName(headers.errorChannel, ####)" },
 		});
 	}
 
@@ -132,10 +132,17 @@ public abstract class HeaderEnricherParserSupport extends AbstractTransformerPar
 					}
 				}
 				if (headerName == null) {
+					String ttlExpression = headerElement.getAttribute("time-to-live-expression");
 					if (cannedHeaderElementExpressions.containsKey(elementName)) {
 						for (int j = 0; j < cannedHeaderElementExpressions.get(elementName).length; j++) {
 							headerName = cannedHeaderElementExpressions.get(elementName)[j][0];
 							expression = cannedHeaderElementExpressions.get(elementName)[j][1];
+							if (StringUtils.hasText(ttlExpression)) {
+								expression = expression.replace("####", ttlExpression);
+							}
+							else {
+								expression = expression.replace(", ####", "");
+							}
 							overwrite = "true";
 							this.addHeader(element, headers, parserContext, headerName, headerElement, headerType,
 									expression, overwrite);

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/channel/HeaderChannelRegistry.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/channel/HeaderChannelRegistry.java
@@ -37,7 +37,19 @@ public interface HeaderChannelRegistry {
 	 * @param channel The channel.
 	 * @return The channel name, or the channel if it is not a MessageChannel.
 	 */
-	public abstract Object channelToChannelName(Object channel);
+	Object channelToChannelName(Object channel);
+
+	/**
+	 * Converts the channel to a name (String). If the channel is not a
+	 * {@link MessageChannel}, it is returned unchanged.
+	 *
+	 * @param channel The channel.
+	 * @param timeToLive How long (ms) at a minimum, the channel mapping should
+	 * remain in the registry.
+	 * @return The channel name, or the channel if it is not a MessageChannel.
+	 * @since 4.1
+	 */
+	Object channelToChannelName(Object channel, long timeToLive);
 
 	/**
 	 * Converts the channel name back to a {@link MessageChannel} (if it is
@@ -45,18 +57,18 @@ public interface HeaderChannelRegistry {
 	 * @param name The name of the channel.
 	 * @return The channel, or null if there is no channel registered with the name.
 	 */
-	public abstract MessageChannel channelNameToChannel(String name);
+	MessageChannel channelNameToChannel(String name);
 
 	/**
 	 * @return the current size of the registry
 	 */
 	@ManagedAttribute
-	public abstract int size();
+	int size();
 
 	/**
 	 * Cancel the scheduled reap task and run immediately; then reschedule.
 	 */
 	@ManagedOperation(description = "Cancel the scheduled reap task and run immediately; then reschedule.")
-	public abstract void runReaper();
+	void runReaper();
 
 }

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.1.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.1.xsd
@@ -1909,6 +1909,16 @@
 					if the header does not exist, or if the header does not currently reference a MessageChannel.
 					</xsd:documentation>
 				</xsd:annotation>
+				<xsd:complexType>
+					<xsd:attribute name="time-to-live-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+							Overrides the header channel registry default 'reaperDelay' - specifies the minimum time
+							that the mapping will remain in the registry, in milliseconds.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+				</xsd:complexType>
 			</xsd:element>
 			<xsd:element name="error-channel" type="referenceOrValueHeaderType">
 				<xsd:annotation>

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests-context.xml
@@ -11,6 +11,14 @@
 		<int:header-channels-to-string />
 	</int:header-enricher>
 
+	<int:header-enricher input-channel="inputTtl" output-channel="next">
+		<int:header-channels-to-string time-to-live-expression="120000" />
+	</int:header-enricher>
+
+	<int:header-enricher input-channel="inputCustomTtl" output-channel="next">
+		<int:header-channels-to-string time-to-live-expression="headers['channelTTL'] ?: 240000" />
+	</int:header-enricher>
+
 	<int:transformer input-channel="next">
 		<bean class="org.springframework.integration.channel.registry.HeaderChannelRegistryTests$Foo" />
 	</int:transformer>

--- a/src/reference/docbook/content-enrichment.xml
+++ b/src/reference/docbook/content-enrichment.xml
@@ -148,7 +148,8 @@
 			the incoming Message.
 	    </para>
 
-		<para><emphasis role="bold">Header Channel Registry</emphasis></para>
+	  <section id="header-channel-registry">
+		<title>Header Channel Registry</title>
 
 		<para>
 			Starting with <emphasis>Spring Integration 3.0</emphasis>, a new sub-element
@@ -169,8 +170,15 @@
 			bean. By default, the framework creates a <classname>DefaultHeaderChannelRegistry</classname>
 			with the default expiry (60 seconds). Channels
 			are removed from the registry after this time. To change this, simply define a bean
-			with id <code>integrationHeaderChannelRegistry</code> and configure the required delay using
+			with id <code>integrationHeaderChannelRegistry</code> and configure the required default delay using
 			a constructor argument (milliseconds).
+		</para>
+		
+		<para>
+			Since <emphasis>version 4.1</emphasis>, you can set a property <code>removeOnGet</code>
+			to <code>true</code> on the <code>&lt;bean/&gt;</code> definition, and the mapping entry will be removed
+			immediately on first use. This might be useful in a high-volume environment and when
+			the channel is only used once, rather than waiting for the reaper to remove it.
 		</para>
 
 		<para>
@@ -188,15 +196,32 @@
 			This sub-element is a convenience only, and is the equivalent of specifying:
 		</para>
 		<programlisting language="xml"><![CDATA[<int:reply-channel
-	expression="@integrationHeaderChannelRegistry.channelToChannelName(headers.replyChannel)"/>
+	expression="@integrationHeaderChannelRegistry.channelToChannelName(headers.replyChannel)"
+	overwrite="true" />
 <int:error-channel
-	expression="@integrationHeaderChannelRegistry.channelToChannelName(headers.errorChannel)"/>]]></programlisting>
+	expression="@integrationHeaderChannelRegistry.channelToChannelName(headers.errorChannel)"
+	overwrite="true" />]]></programlisting>
 
-		<tip>
-			For more examples for configuring header enrichers, see
-			<ulink url="https://github.com/SpringSource/spring-integration/wiki/Header-Enricher-Advanced-Configuration">
-			Header Enricher Advanced Configuration</ulink>.
-		</tip>
+		<para>
+			Starting with <emphasis>version 4.1</emphasis>, you can now override the registry's configured
+			reaper delay, so the the channel mapping is retained for at least the specified time, regardless
+			of the reaper delay:
+		</para>
+		<programlisting language="xml"><![CDATA[<int:header-enricher input-channel="inputTtl" output-channel="next">
+	<int:header-channels-to-string time-to-live-expression="120000" />
+</int:header-enricher>
+
+<int:header-enricher input-channel="inputCustomTtl" output-channel="next">
+	<int:header-channels-to-string 
+		time-to-live-expression="headers['channelTTL'] ?: 120000" />
+</int:header-enricher>]]></programlisting>
+
+		<para>
+			In the first case, the time to live for every header channel mapping will be 2 minutes; in the second case,
+			the time to live is specified in the message header and uses an elvis operator to use
+			2 minutes if there is no header.
+		</para>
+	  </section>
     </section>
 
     <section id="payload-enricher">

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -89,5 +89,14 @@
 				See <xref linkend="aggregator-config"/> for more information.
 			</para>
 		</section>
+		<section id="4.1-header-channel-registry">
+			<title>Header Channel Registry</title>
+			<para>
+				The <code>&lt;header-enricher/&gt;</code>'s <code>&lt;header-channels-to-string/&gt;</code>
+				element can now override the header channel registry's default time for retaining channel
+				mappings.
+				See <xref linkend="header-channel-registry"/> for more information.
+			</para>
+		</section>
 	</section>
 </chapter>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3471
- Make final fields protected so they are available to subclasses
- Add property `removeOnGet` allowing the map entry to be removed immediately when it is used
- Add `time-to-live-expression` allowing override of the reaper delay
