### PR TITLE
INT-3474 Suppress DEBUG StackTrace in MIMHelper

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,13 +50,13 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.TypeConverter;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.integration.annotation.Header;
 import org.springframework.integration.annotation.Headers;
 import org.springframework.integration.annotation.Payload;
 import org.springframework.integration.annotation.Payloads;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -327,6 +327,13 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 				HandlerMethod handlerMethod = null;
 				try {
 					handlerMethod = new HandlerMethod(method, canProcessMessageList);
+				}
+				catch (IneligibleMethodException e) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Method [" + method + "] is not eligible for Message handling "
+								+ e.getMessage() + ".");
+					}
+					return;
 				}
 				catch (Exception e) {
 					if (logger.isDebugEnabled()) {
@@ -741,8 +748,10 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 		}
 
 		private synchronized void setExclusiveTargetParameterType(TypeDescriptor targetParameterType, MethodParameter methodParameter) {
-			Assert.isNull(this.targetParameterTypeDescriptor, "Found more than one parameter type candidate: ["
+			if (this.targetParameterTypeDescriptor != null) {
+				throw new IneligibleMethodException("Found more than one parameter type candidate: ["
 					+ this.targetParameterTypeDescriptor + "] and [" + targetParameterType + "]");
+			}
 			this.targetParameterTypeDescriptor = targetParameterType;
 			if (Message.class.isAssignableFrom(targetParameterType.getObjectType())) {
 				methodParameter.increaseNestingLevel();
@@ -802,6 +811,15 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 				return payload.getClass();
 			}
 			return this.messages.getClass();
+		}
+
+	}
+
+	@SuppressWarnings("serial")
+	private static class IneligibleMethodException extends RuntimeException {
+
+		private IneligibleMethodException(String message) {
+			super(message);
 		}
 
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -506,6 +506,16 @@ public class MethodInvokingMessageProcessorTests {
 		assertEquals("FOO", helper.process(new GenericMessage<Object>(targetObject)));
 	}
 
+	@Test
+	public void testIneligible() {
+		IneligibleMethodBean bean = new IneligibleMethodBean();
+		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, "foo");
+		processor.processMessage(MessageBuilder.withPayload("true").build());
+		assertNotNull(bean.lastArg);
+		assertEquals(String.class, bean.lastArg.getClass());
+		assertEquals("true", bean.lastArg);
+	}
+
 	private static class ExceptionCauseMatcher extends TypeSafeMatcher<Exception> {
 		private Throwable cause;
 
@@ -679,6 +689,22 @@ public class MethodInvokingMessageProcessorTests {
 		public String foo(String s) {
 			this.lastArg = s;
 			return s;
+		}
+
+	}
+
+	private static class IneligibleMethodBean {
+
+		private volatile Object lastArg = null;
+
+		@SuppressWarnings("unused")
+		public void foo(String s) {
+			this.lastArg = s;
+		}
+
+		@SuppressWarnings("unused")
+		public void foo(String s, int i) {
+			throw new RuntimeException("expected ineligible");
 		}
 
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3474

When the `MethodInvokingMessageHandler` skips ineligible methods while
searching it emits a stack trace under DEBUG logging. This is not
needed, a simple log message is enough to convey the information.

Some POJOs gain ineligible methods when wrapped in a proxy so this
is no fault of the developer.

Other reasons for skipping methods (improperly set annotations etc)
continue to emit a stack trace.

**cherry-pick to 4.0.x**
