### PR TITLE
INT-3420 Aggregator Expiry Doc Clarification

### DIFF
--- a/src/reference/docbook/aggregator.xml
+++ b/src/reference/docbook/aggregator.xml
@@ -629,7 +629,9 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 		</para>
 		<note>
 			When a group is timed out, the <interfacename>ReleaseStrategy</interfacename> is given
-			one more opportunity to release the group; if it does so, then expiration is controlled
+			one more opportunity to release the group; if it does so, and
+			<code>expire-groups-upon-timeout</code> is false,
+			then expiration is controlled
 			by <code>expire-groups-upon-completion</code>. If the group is not released by the release
 			strategy during timeout, then the expiration is controlled by the
 			<code>expire-groups-upon-timeout</code>. Timed-out groups are either discarded, or a


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3420

New documentation implied that if `expire-groups-upon-timeout`
was true, the group would NOT be removed if the group
was released by the release strategy in `forceComplete()`.

"...if it does so, then expiration is controlled by..."

In fact, `afterRelease()` (which is where `expire-groups-upon-completion`
is only invoked if `expire-groups-upon-timeout` is false.

Clarify that if the release strategy releases the group during timeout
then the group will always be expired if `expire-groups-upon-timeout` is
true (default).
