### PR TITLE
INT-3422: Add `ChannelInterceptorAware.remove()`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
@@ -173,7 +173,7 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 	}
 
 	@Override
-	public boolean removeInterceptor(int index) {
+	public ChannelInterceptor removeInterceptor(int index) {
 		return this.interceptors.remove(index);
 	}
 
@@ -405,8 +405,8 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 			return this.interceptors.remove(interceptor);
 		}
 
-		public boolean remove(int index) {
-			return this.interceptors.remove(index) != null;
+		public ChannelInterceptor remove(int index) {
+			return this.interceptors.remove(index);
 		}
 
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
@@ -167,6 +167,16 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 		return this.interceptors.getInterceptors();
 	}
 
+	@Override
+	public boolean removeInterceptor(ChannelInterceptor interceptor) {
+		return this.interceptors.remove(interceptor);
+	}
+
+	@Override
+	public boolean removeInterceptor(int index) {
+		return this.interceptors.remove(index);
+	}
+
 	/**
 	 * Exposes the interceptor list for subclasses.
 	 *
@@ -390,5 +400,15 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 		public List<ChannelInterceptor> getInterceptors() {
 			return Collections.unmodifiableList(this.interceptors);
 		}
+
+		public boolean remove(ChannelInterceptor interceptor) {
+			return this.interceptors.remove(interceptor);
+		}
+
+		public boolean remove(int index) {
+			return this.interceptors.remove(index) != null;
+		}
+
 	}
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/ChannelInterceptorAware.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/ChannelInterceptorAware.java
@@ -66,9 +66,9 @@ public interface ChannelInterceptorAware {
 
 	/**
 	 * Remove a {@link ChannelInterceptor} from the target implementation for specific index.
-	 * @param index the index for the {@link ChannelInterceptor} to remove.
+	 * @param index the index for the {@link org.springframework.messaging.support.ChannelInterceptor} to remove.
 	 * @return the {@code boolean} if the {@link ChannelInterceptor} has been removed.
 	 */
-	boolean removeInterceptor(int index);
+	ChannelInterceptor removeInterceptor(int index);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/ChannelInterceptorAware.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/ChannelInterceptorAware.java
@@ -32,12 +32,43 @@ import org.springframework.messaging.support.ChannelInterceptor;
  */
 public interface ChannelInterceptorAware {
 
+	/**
+	 * Populate the {@link ChannelInterceptor}s to the target implementation.
+	 * @param interceptors the {@link ChannelInterceptor}s to populate.
+	 */
 	void setInterceptors(List<ChannelInterceptor> interceptors);
 
+	/**
+	 * And a {@link ChannelInterceptor} to the target implementation.
+	 * @param interceptor the {@link ChannelInterceptor} to add.
+	 */
 	void addInterceptor(ChannelInterceptor interceptor);
 
+	/**
+	 * And a {@link ChannelInterceptor} to the target implementation for the specific index.
+	 * @param index the index for {@link ChannelInterceptor} to add.
+	 * @param interceptor the {@link ChannelInterceptor} to add.
+	 */
 	void addInterceptor(int index, ChannelInterceptor interceptor);
 
+	/**
+	 * return the {@link ChannelInterceptor} list.
+	 * @return the {@link ChannelInterceptor} list.
+	 */
 	List<ChannelInterceptor> getChannelInterceptors();
+
+	/**
+	 * Remove the provided {@link ChannelInterceptor} from the target implementation.
+	 * @param interceptor {@link ChannelInterceptor} to remove.
+	 * @return the {@code boolean} if {@link ChannelInterceptor} has been removed.
+	 */
+	boolean removeInterceptor(ChannelInterceptor interceptor);
+
+	/**
+	 * Remove a {@link ChannelInterceptor} from the target implementation for specific index.
+	 * @param index the index for the {@link ChannelInterceptor} to remove.
+	 * @return the {@code boolean} if the {@link ChannelInterceptor} has been removed.
+	 */
+	boolean removeInterceptor(int index);
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ChannelInterceptorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ChannelInterceptorTests.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.channel.ChannelInterceptorAware;
@@ -70,8 +70,15 @@ public class ChannelInterceptorTests {
 		Message<?> message = new GenericMessage<String>("test");
 		channel.send(message);
 		assertEquals(1, interceptor.getCount());
+
+		assertTrue(channel.removeInterceptor(interceptor));
+
+		channel.send(new GenericMessage<String>("TEST"));
+		assertEquals(1, interceptor.getCount());
+
 		Message<?> result = channel.receive(0);
-		assertNull(result);
+		assertNotNull(result);
+		assertEquals("TEST", result.getPayload());
 	}
 
 	@Test
@@ -113,6 +120,11 @@ public class ChannelInterceptorTests {
 		singleItemChannel.send(new GenericMessage<String>("test1"));
 		assertEquals(1, invokedCounter.get());
 		assertEquals(1, sentCounter.get());
+		singleItemChannel.send(new GenericMessage<String>("test2"), 0);
+		assertEquals(2, invokedCounter.get());
+		assertEquals(1, sentCounter.get());
+
+		assertTrue(singleItemChannel.removeInterceptor(0));
 		singleItemChannel.send(new GenericMessage<String>("test2"), 0);
 		assertEquals(2, invokedCounter.get());
 		assertEquals(1, sentCounter.get());
@@ -164,8 +176,9 @@ public class ChannelInterceptorTests {
 		assertEquals(1, messageCount.get());
 	}
 	@Test
-	public void testInterceptorBeanWithPnamespace(){
-		ApplicationContext ac = new ClassPathXmlApplicationContext("ChannelInterceptorTests-context.xml", ChannelInterceptorTests.class);
+	public void testInterceptorBeanWithPNamespace(){
+		ConfigurableApplicationContext ac =
+				new ClassPathXmlApplicationContext("ChannelInterceptorTests-context.xml", ChannelInterceptorTests.class);
 		ChannelInterceptorAware channel = ac.getBean("input", AbstractMessageChannel.class);
 		List<ChannelInterceptor> interceptors = channel.getChannelInterceptors();
 		ChannelInterceptor channelInterceptor = interceptors.get(0);
@@ -173,6 +186,7 @@ public class ChannelInterceptorTests {
 		String foo = ((PreSendReturnsMessageInterceptor) channelInterceptor).getFoo();
 		assertTrue(StringUtils.hasText(foo));
 		assertEquals("foo", foo);
+		ac.close();
 	}
 
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ChannelInterceptorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ChannelInterceptorTests.java
@@ -124,7 +124,7 @@ public class ChannelInterceptorTests {
 		assertEquals(2, invokedCounter.get());
 		assertEquals(1, sentCounter.get());
 
-		assertTrue(singleItemChannel.removeInterceptor(0));
+		assertNotNull(singleItemChannel.removeInterceptor(0));
 		singleItemChannel.send(new GenericMessage<String>("test2"), 0);
 		assertEquals(2, invokedCounter.get());
 		assertEquals(1, sentCounter.get());


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3422
- Add two methods:

```
boolean removeInterceptor(ChannelInterceptor interceptor);
boolean removeInterceptor(int index);
```

The method `removeInterceptorsOfType(Class<?> clazz)` isn't good, because we lead undesired behavior, when several provided interceptors might be of the same type (e.g. by superclass)

Anyway I'm open for discussion. E.g. how about `clean()` ?
