### PR TITLE
INT-3488: Map `Content-Disposition` HTTP header

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -67,7 +67,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @since 2.0
  */
-public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanFactoryAware, InitializingBean{
+public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanFactoryAware, InitializingBean {
 
 	private static final Log logger = LogFactory.getLog(DefaultHttpHeaderMapper.class);
 
@@ -108,6 +108,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	private static final String CONTENT_RANGE = "Content-Range";
 
 	private static final String CONTENT_TYPE = "Content-Type";
+
+	private static final String CONTENT_DISPOSITION = "Content-Disposition";
 
 	public  static final String COOKIE = "Cookie";
 
@@ -173,6 +175,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 
 	private static final String WWW_AUTHENTICATE = "WWW-Authenticate";
 
+	private static final String TRANSFER_ENCODING = "Transfer-Encoding";
+
 	private static final String[] HTTP_REQUEST_HEADER_NAMES = new String[] {
 			ACCEPT,
 			ACCEPT_CHARSET,
@@ -219,6 +223,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			CONTENT_MD5,
 			CONTENT_RANGE,
 			CONTENT_TYPE,
+			CONTENT_DISPOSITION,
+			TRANSFER_ENCODING,
 			DATE,
 			ETAG,
 			EXPIRES,
@@ -240,7 +246,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	private static String[] HTTP_REQUEST_HEADER_NAMES_OUTBOUND_EXCLUSIONS = new String[0];
 
 	private static String[] HTTP_RESPONSE_HEADER_NAMES_INBOUND_EXCLUSIONS = new String[] {
-		CONTENT_LENGTH
+			CONTENT_LENGTH, TRANSFER_ENCODING
 	};
 
 	public static final String HTTP_REQUEST_HEADER_NAME_PATTERN = "HTTP_REQUEST_HEADERS";
@@ -345,11 +351,11 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 				Object value = headers.get(name);
 				if (value != null) {
 					if (!this.containsElementIgnoreCase(HTTP_REQUEST_HEADER_NAMES, name) &&
-						!this.containsElementIgnoreCase(HTTP_RESPONSE_HEADER_NAMES, name)) {
+							!this.containsElementIgnoreCase(HTTP_RESPONSE_HEADER_NAMES, name)) {
 						// prefix the user-defined header names if not already prefixed
 
 						name = StringUtils.startsWithIgnoreCase(name, this.userDefinedHeaderPrefix) ? name :
-							this.userDefinedHeaderPrefix + name;
+								this.userDefinedHeaderPrefix + name;
 					}
 					if (logger.isDebugEnabled()) {
 						logger.debug(MessageFormat.format("setting headerName=[{0}], value={1}", name, value));
@@ -376,7 +382,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			if (this.shouldMapInboundHeader(name)) {
 				if (!ObjectUtils.containsElement(HTTP_REQUEST_HEADER_NAMES, name) && !ObjectUtils.containsElement(HTTP_RESPONSE_HEADER_NAMES, name)) {
 					String prefixedName = StringUtils.startsWithIgnoreCase(name, this.userDefinedHeaderPrefix) ? name :
-						this.userDefinedHeaderPrefix + name;
+							this.userDefinedHeaderPrefix + name;
 					Object value = source.containsKey(prefixedName) ? this.getHttpHeader(source, prefixedName) : this.getHttpHeader(source, name);
 					if (value != null) {
 						if (logger.isDebugEnabled()) {

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests.java
@@ -109,6 +109,8 @@ public class HttpProxyScenarioTests {
 
 		RestTemplate template = Mockito.spy(new RestTemplate());
 
+		final String contentDispositionValue = "attachment; filename=\"test.txt\"";
+
 		Mockito.doAnswer(new Answer<ResponseEntity<?>>() {
 			@Override
 			public ResponseEntity<?> answer(InvocationOnMock invocation) throws Throwable {
@@ -122,6 +124,7 @@ public class HttpProxyScenarioTests {
 
 				MultiValueMap<String, String> responseHeaders = new LinkedMultiValueMap<String, String>(httpHeaders);
 				responseHeaders.set("Connection", "close");
+				responseHeaders.set("Content-Disposition", contentDispositionValue);
 				return new ResponseEntity<Object>(responseHeaders, HttpStatus.OK);
 			}
 		}).when(template).exchange(Mockito.any(URI.class), Mockito.any(HttpMethod.class),
@@ -138,6 +141,7 @@ public class HttpProxyScenarioTests {
 		assertNull(response.getHeaderValue("If-Modified-Since"));
 		assertNull(response.getHeaderValue("If-Unmodified-Since"));
 		assertEquals("close", response.getHeaderValue("Connection"));
+		assertEquals(contentDispositionValue, response.getHeader("Content-Disposition"));
 
 		Message<?> message = this.checkHeadersChannel.receive(2000);
 		MessageHeaders headers = message.getHeaders();

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
@@ -520,7 +520,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 		httpHeaders.set("Transfer-Encoding", "chunked");
 
 		Map<String, ?> messageHeaders = mapper.toHeaders(httpHeaders);
-		assertEquals(0, messageHeaders.size());
+		assertEquals(1, messageHeaders.size());
 
 	}
 
@@ -673,6 +673,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 		assertEquals(0, messageHeaders.size());
 	}
 
+	@Test
 	public void testInt2995IfModifiedSince() throws Exception{
 		Date ifModifiedSince = new Date();
 		SimpleDateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss yyyy", Locale.US);
@@ -686,6 +687,16 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 		c.setTime(ifModifiedSince);
 		c.set(Calendar.MILLISECOND, 0);
 		assertEquals(c.getTimeInMillis(), headers.getIfModifiedSince());
+	}
+
+	@Test
+	public void testContentDispositionHeader() throws Exception{
+		HttpHeaders headers = new HttpHeaders();
+		String headerValue = "attachment; filename=\"test.txt\"";
+		headers.set("Content-Disposition", headerValue);
+		Map<String, Object> messageHeaders = DefaultHttpHeaderMapper.outboundMapper().toHeaders(headers);
+		assertEquals(1, messageHeaders.size());
+		assertEquals(headerValue, messageHeaders.get("Content-Disposition"));
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3488

In addition map all standard HTTP Headers

The `Transfer-Encoding` has been remained as unmapped
