### PR TITLE
INT-3489 Reschedule Aggregator's group-timeout

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -123,14 +123,15 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 	private volatile boolean expireGroupsUponTimeout = true;
 
 	public AbstractCorrelatingMessageHandler(MessageGroupProcessor processor, MessageGroupStore store,
-									 CorrelationStrategy correlationStrategy, ReleaseStrategy releaseStrategy) {
+			CorrelationStrategy correlationStrategy, ReleaseStrategy releaseStrategy) {
 		Assert.notNull(processor);
 
 		Assert.notNull(store);
 		setMessageStore(store);
 		this.outputProcessor = processor;
-		this.correlationStrategy = correlationStrategy == null ?
-				new HeaderAttributeCorrelationStrategy(IntegrationMessageHeaderAccessor.CORRELATION_ID) : correlationStrategy;
+		this.correlationStrategy = (correlationStrategy == null
+				? new HeaderAttributeCorrelationStrategy(IntegrationMessageHeaderAccessor.CORRELATION_ID)
+				: correlationStrategy);
 		this.releaseStrategy = releaseStrategy == null ? new SequenceSizeReleaseStrategy() : releaseStrategy;
 		setSendTimeout(DEFAULT_SEND_TIMEOUT);
 		sequenceAware = this.releaseStrategy instanceof SequenceSizeReleaseStrategy;
@@ -215,9 +216,9 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 
 		if (this.releasePartialSequences) {
 			Assert.isInstanceOf(SequenceSizeReleaseStrategy.class, this.releaseStrategy,
-					"Release strategy of type [" + this.releaseStrategy.getClass().getSimpleName()
-							+ "] cannot release partial sequences. Use the default SequenceSizeReleaseStrategy instead.");
-			((SequenceSizeReleaseStrategy)this.releaseStrategy).setReleasePartialSequences(releasePartialSequences);
+					"Release strategy of type [" + this.releaseStrategy.getClass().getSimpleName() +
+							"] cannot release partial sequences. Use the default SequenceSizeReleaseStrategy instead.");
+			((SequenceSizeReleaseStrategy) this.releaseStrategy).setReleasePartialSequences(releasePartialSequences);
 		}
 
 		/*
@@ -340,7 +341,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 	@Override
 	protected void handleMessageInternal(Message<?> message) throws Exception {
 		Object correlationKey = correlationStrategy.getCorrelationKey(message);
-		Assert.state(correlationKey!=null, "Null correlation not allowed.  Maybe the CorrelationStrategy is failing?");
+		Assert.state(correlationKey != null, "Null correlation not allowed.  Maybe the CorrelationStrategy is failing?");
 
 		if (logger.isDebugEnabled()) {
 			logger.debug("Handling message with correlationKey [" + correlationKey + "]: " + message);
@@ -355,11 +356,12 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 			if (scheduledFuture != null) {
 				boolean canceled = scheduledFuture.cancel(true);
 				if (canceled && logger.isDebugEnabled()) {
-					logger.debug("Cancel 'forceComplete' scheduling for MessageGroup with Correlation Key [ " + correlationKey + "].");
+					logger.debug("Cancel 'forceComplete' scheduling for MessageGroup with Correlation Key [ "
+							+ correlationKey + "].");
 				}
 			}
 			MessageGroup messageGroup = messageStore.getMessageGroup(correlationKey);
-			if (this.sequenceAware){
+			if (this.sequenceAware) {
 				messageGroup = new SequenceAwareMessageGroup(messageGroup);
 			}
 
@@ -381,22 +383,52 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 					}
 				}
 				else {
-					Long groupTimeout = this.obtainGroupTimeout(messageGroup);
-					if (groupTimeout != null && groupTimeout >= 0) {
-						if (groupTimeout > 0) {
-							scheduleGroupToForceComplete(messageGroup, groupTimeout);
-						}
-						else {
-							this.forceComplete(messageGroup);
-						}
-					}
+					scheduleGroupToForceComplete(messageGroup);
 				}
 			}
 			else {
-				discardMessage(message);			}
+				discardMessage(message);
+			}
 		}
 		finally {
 			lock.unlock();
+		}
+	}
+
+	private void scheduleGroupToForceComplete(final MessageGroup messageGroup) {
+		final Long groupTimeout = this.obtainGroupTimeout(messageGroup);
+		/*
+		 * When 'groupTimeout' is evaluated to 'null' we do nothing.
+		 * The 'MessageGroupStoreReaper' can be used to 'forceComplete' message groups.
+		 */
+		if (groupTimeout != null && groupTimeout >= 0) {
+			if (groupTimeout > 0) {
+				ScheduledFuture<?> scheduledFuture = this.getTaskScheduler()
+						.schedule(new Runnable() {
+
+							@Override
+							public void run() {
+								try {
+									AbstractCorrelatingMessageHandler.this.forceComplete(messageGroup);
+								}
+								catch (MessageDeliveryException e) {
+									if (logger.isDebugEnabled()) {
+										logger.debug("The MessageGroup [ " + messageGroup +
+												"] is rescheduled by the reason: " + e.getMessage());
+									}
+									scheduleGroupToForceComplete(messageGroup);
+								}
+							}
+						}, new Date(System.currentTimeMillis() + groupTimeout));
+
+				if (logger.isDebugEnabled()) {
+					logger.debug("Schedule MessageGroup [ " + messageGroup + "] to 'forceComplete'.");
+				}
+				this.expireGroupScheduledFutures.put(UUIDConverter.getUUID(messageGroup.getGroupId()), scheduledFuture);
+			}
+			else {
+				forceComplete(messageGroup);
+			}
 		}
 	}
 
@@ -417,30 +449,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		}
 		this.messagingTemplate.send(this.discardChannel, message);
 	}
-private void scheduleGroupToForceComplete(final MessageGroup messageGroup, final long groupTimeout) {
-		ScheduledFuture<?> scheduledFuture = this.getTaskScheduler()
-				.schedule(new Runnable() {
 
-					@Override
-					public void run() {
-						try {
-							AbstractCorrelatingMessageHandler.this.forceComplete(messageGroup);
-						}
-						catch (MessageDeliveryException e) {
-							if (logger.isDebugEnabled()) {
-								logger.debug("The MessageGroup [ " + messageGroup + "] is rescheduled by the reason: "
-										+ e.getMessage());
-							}
-							scheduleGroupToForceComplete(messageGroup, groupTimeout);
-						}
-					}
-				}, new Date(System.currentTimeMillis() + groupTimeout));
-
-		if (logger.isDebugEnabled()) {
-			logger.debug("Schedule MessageGroup [ " + messageGroup + "] to 'forceComplete'.");
-		}
-		this.expireGroupScheduledFutures.put(UUIDConverter.getUUID(messageGroup.getGroupId()), scheduledFuture);
-	}
 	/**
 	 * Allows you to provide additional logic that needs to be performed after the MessageGroup was released.
 	 * @param group The group.
@@ -457,7 +466,8 @@ private void scheduleGroupToForceComplete(final MessageGroup messageGroup, final
 		try {
 			lock.lockInterruptibly();
 			try {
-				ScheduledFuture<?> scheduledFuture = this.expireGroupScheduledFutures.remove(UUIDConverter.getUUID(correlationKey));
+				ScheduledFuture<?> scheduledFuture =
+						this.expireGroupScheduledFutures.remove(UUIDConverter.getUUID(correlationKey));
 				if (scheduledFuture != null) {
 					boolean canceled = scheduledFuture.cancel(false);
 					if (canceled && logger.isDebugEnabled()) {
@@ -552,7 +562,7 @@ private void scheduleGroupToForceComplete(final MessageGroup messageGroup, final
 		messageStore.removeMessageGroup(correlationKey);
 	}
 
-	protected int findLastReleasedSequenceNumber(Object groupId, Collection<Message<?>> partialSequence){
+	protected int findLastReleasedSequenceNumber(Object groupId, Collection<Message<?>> partialSequence) {
 		List<Message<?>> sorted = new ArrayList<Message<?>>(partialSequence);
 		Collections.sort(sorted, new SequenceNumberComparator());
 
@@ -588,7 +598,7 @@ private void scheduleGroupToForceComplete(final MessageGroup messageGroup, final
 		}
 		if (this.applicationEventPublisher != null) {
 			this.applicationEventPublisher.publishEvent(new MessageGroupExpiredEvent(this, correlationKey, group
-					.size(), new Date(group.getLastModified()) , new Date(), !sendPartialResultOnExpiry));
+					.size(), new Date(group.getLastModified()), new Date(), !sendPartialResultOnExpiry));
 		}
 	}
 
@@ -616,9 +626,10 @@ private void scheduleGroupToForceComplete(final MessageGroup messageGroup, final
 		return partialSequence;
 	}
 
-	protected void verifyResultCollectionConsistsOfMessages(Collection<?> elements){
+	protected void verifyResultCollectionConsistsOfMessages(Collection<?> elements) {
 		Class<?> commonElementType = CollectionUtils.findCommonElementType(elements);
-		Assert.isAssignable(Message.class, commonElementType, "The expected collection of Messages contains non-Message element: " + commonElementType);
+		Assert.isAssignable(Message.class, commonElementType,
+				"The expected collection of Messages contains non-Message element: " + commonElementType);
 	}
 
 	@SuppressWarnings("rawtypes")
@@ -637,7 +648,8 @@ private void scheduleGroupToForceComplete(final MessageGroup messageGroup, final
 			for (Object next : (Iterable<?>) processorResult) {
 				this.sendReplyMessage(next, replyChannel);
 			}
-		} else {
+		}
+		else {
 			this.sendReplyMessage(processorResult, replyChannel);
 		}
 	}
@@ -646,16 +658,20 @@ private void scheduleGroupToForceComplete(final MessageGroup messageGroup, final
 		if (replyChannel instanceof MessageChannel) {
 			if (reply instanceof Message<?>) {
 				this.messagingTemplate.send((MessageChannel) replyChannel, (Message<?>) reply);
-			} else {
+			}
+			else {
 				this.messagingTemplate.convertAndSend((MessageChannel) replyChannel, reply);
 			}
-		} else if (replyChannel instanceof String) {
+		}
+		else if (replyChannel instanceof String) {
 			if (reply instanceof Message<?>) {
 				this.messagingTemplate.send((String) replyChannel, (Message<?>) reply);
-			} else {
+			}
+			else {
 				this.messagingTemplate.convertAndSend((String) replyChannel, reply);
 			}
-		} else {
+		}
+		else {
 			throw new MessagingException("replyChannel must be a MessageChannel or String");
 		}
 	}

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.1.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.1.xsd
@@ -4295,8 +4295,10 @@ The list of component name patterns you want to track (e.g.,  tracked-components
 			<xsd:annotation>
 				<xsd:documentation>
 					Specify the maximum amount of time in milliseconds to wait when sending a reply
-					Message to the
-					output channel. By default the send will block for one second.
+					Message to the output channel. By default the send will block for one second.
+					It is applied only if the output channel has some 'sending' limitations, e.g. QueueChannel with
+					fixed a 'capacity'. In this case a MessageDeliveryException is thrown. The 'send-timeout'
+					is ignored in case of AbstractSubscribableChannel implementations.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelatingMessageHandlerIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelatingMessageHandlerIntegrationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.aggregator;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -63,6 +64,7 @@ public class CorrelatingMessageHandlerIntegrationTests {
 	public void completesAfterThreshold() throws Exception {
 		defaultHandler.setReleaseStrategy(new MessageCountReleaseStrategy());
 		MessageChannel discardChannel = mock(MessageChannel.class);
+		when(discardChannel.send(any(Message.class))).thenReturn(true);
 		defaultHandler.setDiscardChannel(discardChannel);
 		Message<?> message1 = correlatedMessage(1, 2, 1);
 		Message<?> message2 = correlatedMessage(1, 2, 2);

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
@@ -37,6 +37,7 @@
 	<aggregator id="gta"
 				input-channel="groupTimeoutAggregatorInput" output-channel="output" discard-channel="discard"
 				send-partial-result-on-expiry="true"
+				send-timeout="100"
 				group-timeout="100"/>
 
 	<aggregator input-channel="groupTimeoutExpressionAggregatorInput" output-channel="output" discard-channel="discard"

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,21 +53,21 @@ public class ObjectToJsonTransformerTests {
 
 	@Test
 	public void simpleStringPayload() throws Exception {
-		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		String result = (String) transformer.transform(new GenericMessage<String>("foo")).getPayload();
 		assertEquals("\"foo\"", result);
 	}
 
 	@Test
 	public void withDefaultContentType() throws Exception {
-		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		Message<?> result = transformer.transform(new GenericMessage<String>("foo"));
 		assertEquals(ObjectToJsonTransformer.JSON_CONTENT_TYPE, result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test
 	public void withProvidedContentType() throws Exception {
-		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "text/xml").build();
 		Message<?> result = transformer.transform(message);
 		assertEquals("text/xml", result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
@@ -75,7 +75,7 @@ public class ObjectToJsonTransformerTests {
 
 	@Test
 	public void withProvidedContentTypeWithOverride() throws Exception {
-		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		transformer.setContentType(ObjectToJsonTransformer.JSON_CONTENT_TYPE);
 		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "text/xml").build();
 		Message<?> result = transformer.transform(message);
@@ -84,7 +84,7 @@ public class ObjectToJsonTransformerTests {
 
 	@Test
 	public void withProvidedContentTypeAsEmptyString() throws Exception {
-		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		transformer.setContentType("");
 		Message<?> message = MessageBuilder.withPayload("foo").build();
 		Message<?> result = transformer.transform(message);
@@ -93,29 +93,29 @@ public class ObjectToJsonTransformerTests {
 
 	@Test
 	public void withProvidedContentTypeAsEmptyStringDoesNotOverride() throws Exception {
-		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		transformer.setContentType("");
 		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "text/xml").build();
 		Message<?> result = transformer.transform(message);
 		assertEquals("text/xml", result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 	}
 
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void withProvidedContentTypeAsNull() throws Exception {
-		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		transformer.setContentType(null);
 	}
 
 	@Test
 	public void simpleIntegerPayload() throws Exception {
-		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		String result = (String) transformer.transform(new GenericMessage<Integer>(123)).getPayload();
 		assertEquals("123", result);
 	}
 
 	@Test
 	public void objectPayload() throws Exception {
-		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer();
+		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		TestAddress address = new TestAddress(123, "Main Street");
 		TestPerson person = new TestPerson("John", "Doe", 42);
 		person.setAddress(address);
@@ -135,7 +135,7 @@ public class ObjectToJsonTransformerTests {
 	public void objectPayloadWithCustomObjectMapper() throws Exception {
 		ObjectMapper customMapper = new ObjectMapper();
 		customMapper.configure(JsonGenerator.Feature.QUOTE_FIELD_NAMES, Boolean.FALSE);
-		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer(new Jackson2JsonObjectMapper(customMapper));
+		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer(new Jackson2JsonObjectMapper(customMapper));
 		TestPerson person = new TestPerson("John", "Doe", 42);
 		person.setAddress(new TestAddress(123, "Main Street"));
 		String result = (String) transformer.transform(new GenericMessage<TestPerson>(person)).getPayload();
@@ -152,7 +152,7 @@ public class ObjectToJsonTransformerTests {
 
 	@Test
 	public void testBoonJsonObjectMapper() throws Exception {
-		ObjectToJsonTransformer transformer = new  ObjectToJsonTransformer(new BoonJsonObjectMapper());
+		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer(new BoonJsonObjectMapper());
 		TestPerson person = new TestPerson("John", "Doe", 42);
 		person.setAddress(new TestAddress(123, "Main Street"));
 		String result = (String) transformer.transform(new GenericMessage<TestPerson>(person)).getPayload();

--- a/src/reference/docbook/aggregator.xml
+++ b/src/reference/docbook/aggregator.xml
@@ -459,7 +459,7 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
 			with a fixed 'capacity'. In this case a <classname>MessageDeliveryException</classname> is thrown.
 			The <code>send-timeout</code> is ignored in case of <classname>AbstractSubscribableChannel</classname> implementations.
 			In case of <code>group-timeout(-expression)</code> the <classname>MessageDeliveryException</classname>
-			from the scheduled expire task leads this task to be rescheduled with the same <code>timeout</code>.
+			from the scheduled expire task leads this task to be rescheduled.
 			<emphasis>Optional</emphasis>.</para>
       </callout>
 

--- a/src/reference/docbook/aggregator.xml
+++ b/src/reference/docbook/aggregator.xml
@@ -452,8 +452,15 @@ then you should simply provide an implementation of the <classname>ReleaseStrate
       </callout>
 
        <callout arearefs="aggxml09" id="aggxml09-txt">
-        <para>The timeout interval for sending the aggregated messages to the output or
-        reply channel. <emphasis>Optional</emphasis>.</para>
+        <para>The timeout interval to wait when sending a reply
+			<interfacename>Message</interfacename> to the <code>output-channel</code> or <code>discard-channel</code>.
+			By default the send will block for one second.
+			It is applied only if the output channel has some 'sending' limitations, e.g. <classname>QueueChannel</classname>
+			with a fixed 'capacity'. In this case a <classname>MessageDeliveryException</classname> is thrown.
+			The <code>send-timeout</code> is ignored in case of <classname>AbstractSubscribableChannel</classname> implementations.
+			In case of <code>group-timeout(-expression)</code> the <classname>MessageDeliveryException</classname>
+			from the scheduled expire task leads this task to be rescheduled with the same <code>timeout</code>.
+			<emphasis>Optional</emphasis>.</para>
       </callout>
 
        <callout arearefs="aggxml10" id="aggxml10-txt">

--- a/src/reference/docbook/resequencer.xml
+++ b/src/reference/docbook/resequencer.xml
@@ -102,8 +102,15 @@
         </callout>
 
         <callout arearefs="resxml10-co" id="resxml10">
-          <para>The timeout for sending out messages.
-          <emphasis>Optional</emphasis>.</para>
+		<para>The timeout interval to wait when sending a reply
+			<interfacename>Message</interfacename> to the <code>output-channel</code> or <code>discard-channel</code>.
+			By default the send will block for one second.
+			It is applied only if the output channel has some 'sending' limitations, e.g. <classname>QueueChannel</classname>
+			with a fixed 'capacity'. In this case a <classname>MessageDeliveryException</classname> is thrown.
+			The <code>send-timeout</code> is ignored in case of <classname>AbstractSubscribableChannel</classname> implementations.
+			In case of <code>group-timeout(-expression)</code> the <classname>MessageDeliveryException</classname>
+			from the scheduled expire task leads this task to be rescheduled with the same <code>timeout</code>.
+			<emphasis>Optional</emphasis>.</para>
         </callout>
 
         <callout arearefs="resxml11-co" id="resxml11">

--- a/src/reference/docbook/resequencer.xml
+++ b/src/reference/docbook/resequencer.xml
@@ -109,7 +109,7 @@
 			with a fixed 'capacity'. In this case a <classname>MessageDeliveryException</classname> is thrown.
 			The <code>send-timeout</code> is ignored in case of <classname>AbstractSubscribableChannel</classname> implementations.
 			In case of <code>group-timeout(-expression)</code> the <classname>MessageDeliveryException</classname>
-			from the scheduled expire task leads this task to be rescheduled with the same <code>timeout</code>.
+			from the scheduled expire task leads this task to be rescheduled.
 			<emphasis>Optional</emphasis>.</para>
         </callout>
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3489
- Catch `MessageDeliveryException` and reschedule `group-time out task`: `AbstractCorrelatingMessageHandler#scheduleGroupToForceComplete`
- Apply `send-timeout` for the `discardChannel`
- Mark `groupRemove = false` in case of `MessageDeliveryException`
- Improve `send-timeout` docs
