### PR TITLE
INT-3486 SimplePool suppress InterruptedException

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageBuilderFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageBuilderFactory.java
@@ -22,7 +22,7 @@ import org.springframework.messaging.Message;
  * @since 4.0
  *
  */
-public class MutableMessageBuilderFacfory implements MessageBuilderFactory {
+public class MutableMessageBuilderFactory implements MessageBuilderFactory {
 
 	@Override
 	public <T> MutableMessageBuilder<T> fromMessage(Message<T> message) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/SimplePool.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/SimplePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.util;
 
 import java.util.Collections;
@@ -34,6 +35,7 @@ import org.springframework.util.Assert;
  * Implementation of {@link Pool} supporting dynamic resizing and a variable
  * timeout when attempting to obtain an item from the pool. Pool grows on
  * demand up to the limit.
+ *
  * @author Gary Russell
  * @since 2.2
  *
@@ -158,14 +160,13 @@ public class SimplePool<T> implements Pool<T> {
 				permitted = this.permits.tryAcquire(this.waitTimeout, TimeUnit.MILLISECONDS);
 			}
 			catch (InterruptedException e) {
+				logger.error("Interrupted awaiting a pooled resource.");
 				Thread.currentThread().interrupt();
-				throw new MessagingException("Interrupted awaiting a pooled resource", e);
 			}
 			if (!permitted) {
 				throw new IllegalStateException("Timed out while waiting to aquire a pool entry.");
 			}
-			T item = doGetItem();
-			return item;
+			return doGetItem();
 		}
 		catch (Exception e) {
 			if (permitted) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/expression/ChildContext-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/expression/ChildContext-context.xml
@@ -31,6 +31,6 @@
 
 	<bean id="jsonPropertyAccessor" class="org.springframework.integration.json.JsonPropertyAccessor"/>
 
-	<bean id="messageBuilderFactory" class="org.springframework.integration.support.MutableMessageBuilderFacfory" />
+	<bean id="messageBuilderFactory" class="org.springframework.integration.support.MutableMessageBuilderFactory" />
 
 </beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderAtConfigTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderAtConfigTests.java
@@ -33,7 +33,7 @@ import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.handler.BridgeHandler;
 import org.springframework.integration.message.MessageBuilderAtConfigTests.MBConfig;
 import org.springframework.integration.support.MessageBuilderFactory;
-import org.springframework.integration.support.MutableMessageBuilderFacfory;
+import org.springframework.integration.support.MutableMessageBuilderFactory;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
@@ -59,7 +59,7 @@ public class MessageBuilderAtConfigTests {
 
 	@Test
 	public void mutate() {
-		assertTrue(messageBuilderFactory instanceof MutableMessageBuilderFacfory);
+		assertTrue(messageBuilderFactory instanceof MutableMessageBuilderFactory);
 		in.send(new GenericMessage<String>("foo"));
 		Message<?> m1 = out.receive(0);
 		Message<?> m2 = out.receive(0);
@@ -83,7 +83,7 @@ public class MessageBuilderAtConfigTests {
 
 		@Bean
 		public MessageBuilderFactory messageBuilderFactory() {
-			return new MutableMessageBuilderFacfory();
+			return new MutableMessageBuilderFactory();
 		}
 
 		@Bean

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderTests-context.xml
@@ -19,6 +19,6 @@
 		<int:queue/>
 	</int:channel>
 
-	<bean id="messageBuilderFactory" class="org.springframework.integration.support.MutableMessageBuilderFacfory" />
+	<bean id="messageBuilderFactory" class="org.springframework.integration.support.MutableMessageBuilderFactory" />
 
 </beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderTests.java
@@ -35,7 +35,7 @@ import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.MutableMessageBuilder;
-import org.springframework.integration.support.MutableMessageBuilderFacfory;
+import org.springframework.integration.support.MutableMessageBuilderFactory;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
@@ -145,7 +145,7 @@ public class MessageBuilderTests {
 
 	@Test
 	public void mutate() {
-		assertTrue(messageBuilderFactory instanceof MutableMessageBuilderFacfory);
+		assertTrue(messageBuilderFactory instanceof MutableMessageBuilderFactory);
 		in.send(new GenericMessage<String>("foo"));
 		Message<?> m1 = out.receive(0);
 		Message<?> m2 = out.receive(0);
@@ -179,7 +179,7 @@ public class MessageBuilderTests {
 	public void mutableFromImmutableMutate() {
 		Message<String> message1 = MessageBuilder.withPayload("test")
 				.setHeader("foo", "bar").build();
-		Message<String> message2 = new MutableMessageBuilderFacfory().fromMessage(message1).setHeader("another", 1).build();
+		Message<String> message2 = new MutableMessageBuilderFactory().fromMessage(message1).setHeader("another", 1).build();
 		assertEquals("bar", message2.getHeaders().get("foo"));
 		assertSame(message1.getHeaders().getId(), message2.getHeaders().getId());
 		assertNotSame(message1, message2);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3486

Previously the undesired StackTrace has been logged in case of Thread interruption, e.g. component `stop()`

Suppress `InterruptedException` in the `SimplePool#getItem()`.
Since we do the `Thread.currentThread().interrupt();` on the `catch (InterruptedException e) {` it does not make sense
to rethrow it as a `MessagingException`, because the thread is interrupted anyway.

**Cherry pick to 4.0.x**
