### PR TITLE
INT-3470: Fix SF 4.1 compatibility

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
@@ -16,18 +16,22 @@
 
 package org.springframework.integration.amqp.channel;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.rabbitmq.client.AMQP.Queue.DeclareOk;
-import com.rabbitmq.client.Channel;
 import org.apache.commons.logging.Log;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -45,6 +49,9 @@ import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.MessageDeliveryException;
+
+import com.rabbitmq.client.AMQP.Queue.DeclareOk;
+import com.rabbitmq.client.Channel;
 
 
 /**
@@ -67,7 +74,8 @@ public class DispatcherHasNoSubscribersTests {
 			@Override
 			public Channel answer(InvocationOnMock invocation) throws Throwable {
 				return channel;
-			}}).when(connection).createChannel(anyBoolean());
+			}
+		}).when(connection).createChannel(anyBoolean());
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
@@ -86,7 +94,8 @@ public class DispatcherHasNoSubscribersTests {
 			fail("Exception expected");
 		}
 		catch (MessageDeliveryException e) {
-			assertEquals("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'.", e.getMessage());
+			assertThat(e.getMessage(),
+					containsString("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'."));
 		}
 	}
 
@@ -98,7 +107,8 @@ public class DispatcherHasNoSubscribersTests {
 			@Override
 			public Channel answer(InvocationOnMock invocation) throws Throwable {
 				return channel;
-			}}).when(connection).createChannel(anyBoolean());
+			}
+		}).when(connection).createChannel(anyBoolean());
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
@@ -107,11 +117,12 @@ public class DispatcherHasNoSubscribersTests {
 		final Queue queue = new Queue("noSubscribersQueue");
 		PublishSubscribeAmqpChannel amqpChannel = new PublishSubscribeAmqpChannel("noSubscribersChannel",
 				container, amqpTemplate) {
-					@Override
-					protected String obtainQueueName(AmqpAdmin admin,
-							String channelName) {
-						return queue.getName();
-					}};
+			@Override
+			protected String obtainQueueName(AmqpAdmin admin,
+					String channelName) {
+				return queue.getName();
+			}
+		};
 		amqpChannel.setBeanName("noSubscribersChannel");
 		amqpChannel.setBeanFactory(mock(BeanFactory.class));
 		amqpChannel.afterPropertiesSet();
@@ -137,7 +148,8 @@ public class DispatcherHasNoSubscribersTests {
 					logList.add(message);
 				}
 				return null;
-			}}).when(logger).warn(anyString(), any(Exception.class));
+			}
+		}).when(logger).warn(anyString(), any(Exception.class));
 		when(logger.isWarnEnabled()).thenReturn(true);
 		Object listener = container.getMessageListener();
 		DirectFieldAccessor dfa = new DirectFieldAccessor(listener);
@@ -153,7 +165,8 @@ public class DispatcherHasNoSubscribersTests {
 			assertNotNull("Failed to get expected exception", message);
 			if (message.startsWith("Dispatcher has no subscribers")) {
 				expectedExceptionFound = true;
-				assertEquals("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'.", message);
+				assertThat(message,
+						containsString("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'."));
 				break;
 			}
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/DispatcherHasNoSubscribersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.channel;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.messaging.MessageChannel;
@@ -31,6 +34,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.1
  *
  */
@@ -57,8 +61,10 @@ public class DispatcherHasNoSubscribersTests {
 		try {
 			noSubscribersChannel.send(new GenericMessage<String>("Hello, world!"));
 			fail("Exception expected");
-		} catch (MessagingException e) {
-			assertEquals("Dispatcher has no subscribers for channel 'foo.noSubscribersChannel'.", e.getMessage());
+		}
+		catch (MessagingException e) {
+			assertThat(e.getMessage(),
+					containsString("Dispatcher has no subscribers for channel 'foo.noSubscribersChannel'."));
 		}
 	}
 
@@ -67,8 +73,10 @@ public class DispatcherHasNoSubscribersTests {
 		try {
 			subscribedChannel.send(new GenericMessage<String>("Hello, world!"));
 			fail("Exception expected");
-		} catch (MessagingException e) {
-			assertEquals("Dispatcher has no subscribers for channel 'foo.noSubscribersChannel'.", e.getMessage());
+		}
+		catch (MessagingException e) {
+			assertThat(e.getMessage(),
+					containsString("Dispatcher has no subscribers for channel 'foo.noSubscribersChannel'."));
 		}
 	}
 
@@ -79,8 +87,10 @@ public class DispatcherHasNoSubscribersTests {
 		try {
 			channel.send(new GenericMessage<String>("Hello, world!"));
 			fail("Exception expected");
-		} catch (MessagingException e) {
-			assertEquals("Dispatcher has no subscribers for channel 'bar'.", e.getMessage());
+		}
+		catch (MessagingException e) {
+			assertThat(e.getMessage(),
+					containsString("Dispatcher has no subscribers for channel 'bar'."));
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.channel.registry;
 
 import static org.hamcrest.Matchers.allOf;
@@ -240,7 +241,7 @@ public class HeaderChannelRegistryTests {
 		}
 		catch (DestinationResolutionException e){
 			assertThat(e.getMessage(),
-				Matchers.equalTo("failed to look up MessageChannel with name 'foo' in the BeanFactory."));
+				Matchers.containsString("failed to look up MessageChannel with name 'foo' in the BeanFactory."));
 		}
 	}
 
@@ -262,7 +263,8 @@ public class HeaderChannelRegistryTests {
 		}
 		catch (DestinationResolutionException e){
 			assertThat(e.getMessage(),
-				Matchers.equalTo("failed to look up MessageChannel with name 'foo' in the BeanFactory (and there is no HeaderChannelRegistry present)."));
+				Matchers.containsString("failed to look up MessageChannel with name 'foo' in the BeanFactory " +
+						"(and there is no HeaderChannelRegistry present)."));
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.handler.advice;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -113,7 +115,7 @@ public class AdvisedMessageHandlerTests {
 			fail("expected exception");
 		}
 		catch (RuntimeException e) {
-			assertThat(e.getMessage(), endsWith("(myService)]"));
+			assertThat(e.getMessage(), containsString("(myService)]"));
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/ContentEnricherTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/ContentEnricherTests.java
@@ -16,10 +16,12 @@
 
 package org.springframework.integration.transformer;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -414,7 +416,7 @@ public class ContentEnricherTests {
 		try {
 		    enricher.handleMessage(requestMessage);
 		} catch (MessageHandlingException e) {
-			assertEquals("Failed to clone payload object", e.getMessage());
+			assertThat(e.getMessage(), containsString("Failed to clone payload object"));
             return;
 		}
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/SubscribableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/SubscribableJmsChannelTests.java
@@ -16,9 +16,11 @@
 
 package org.springframework.integration.jms;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -307,7 +309,8 @@ public class SubscribableJmsChannelTests {
 			fail("Exception expected");
 		}
 		catch (MessageDeliveryException e) {
-			assertEquals("Dispatcher has no subscribers for jms-channel 'noSubscribersChannel'.", e.getMessage());
+			assertThat(e.getMessage(),
+					containsString("Dispatcher has no subscribers for jms-channel 'noSubscribersChannel'."));
 		}
 	}
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageStoreTests.java
@@ -15,13 +15,17 @@
  */
 package org.springframework.integration.mongodb.store;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import java.util.Properties;
 import java.util.UUID;
 
-import com.mongodb.MongoClient;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -38,6 +42,8 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
+
+import com.mongodb.MongoClient;
 
 /**
  *
@@ -249,7 +255,8 @@ public abstract class AbstractMongoDbMessageStoreTests extends MongoDbAvailableT
 		assertNotNull(retrievedMessage);
 		assertTrue(retrievedMessage instanceof ErrorMessage);
 		assertThat(retrievedMessage.getPayload(), Matchers.instanceOf(MessagingException.class));
-		assertEquals("intentional MessagingException", ((MessagingException) retrievedMessage.getPayload()).getMessage());
+		assertThat(((MessagingException) retrievedMessage.getPayload()).getMessage(),
+				containsString("intentional MessagingException"));
 		assertEquals(failedMessage, ((MessagingException) retrievedMessage.getPayload()).getFailedMessage());
 		assertEquals(messageToStore.getHeaders(), retrievedMessage.getHeaders());
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/channel/SubscribableRedisChannelTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/channel/SubscribableRedisChannelTests.java
@@ -15,8 +15,9 @@
  */
 package org.springframework.integration.redis.channel;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -104,8 +105,8 @@ public class SubscribableRedisChannelTests extends RedisAvailableTests {
 		catch (InvocationTargetException e) {
 			Throwable cause = e.getCause();
 			assertNotNull(cause);
-			assertEquals("Dispatcher has no subscribers for redis-channel 'si.test.channel.no.subs' (dhnsChannel).",
-					cause.getMessage());
+			assertThat(cause.getMessage(),
+					containsString("Dispatcher has no subscribers for redis-channel 'si.test.channel.no.subs' (dhnsChannel)."));
 		}
 
 	}

--- a/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/BackToBackTests.java
+++ b/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/BackToBackTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.rmi;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -78,7 +81,8 @@ public class BackToBackTests {
 			fail("Expected exception");
 		}
 		catch (Exception e) {
-			assertEquals("Dispatcher has no subscribers for channel 'context.baz'.", e.getCause().getMessage());
+			assertThat(e.getCause().getMessage(),
+					containsString("Dispatcher has no subscribers for channel 'context.baz'."));
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3470

According to the commit https://github.com/spring-projects/spring-framework/commit/c06ac06,
the `MessagingException` is now `NestedRuntimeException` including nested StackTrace.
Hence test-cases have to be changed to the `Matchers.containsString` instead of `equals` for the `e.getMessage()`

**Cherry-pick to the 4.0.x**
