### PR TITLE
INT-3495 Add `error-channel` to <tail-inbound-channel-adapter>

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
@@ -124,9 +124,8 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport implemen
 	}
 
 	/**
-	 * Subclasses may override this method to invoke the callback before
-	 * or after the start behavior.
-	 * @param callback the Runnable to invoke
+	 * Stop the component and invoke callback.
+	 * @param callback the Runnable to invoke.
 	 */
 	protected void doStop(Runnable callback) {
 	    doStop();

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.file.config;
 
 import java.io.File;
@@ -33,6 +34,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 3.0
  *
  */
@@ -60,6 +62,8 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 	private volatile String beanName;
 
 	private volatile MessageChannel outputChannel;
+
+	private volatile MessageChannel errorChannel;
 
 	private volatile Boolean autoStartup;
 
@@ -110,6 +114,10 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 		this.outputChannel = outputChannel;
 	}
 
+	public void setErrorChannel(MessageChannel errorChannel) {
+		this.errorChannel = errorChannel;
+	}
+
 	public void setAutoStartup(boolean autoStartup) {
 		this.autoStartup = autoStartup;
 	}
@@ -139,10 +147,7 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 
 	@Override
 	public boolean isRunning() {
-		if (this.adapter != null) {
-			return this.adapter.isRunning();
-		}
-		return false;
+		return this.adapter != null && this.adapter.isRunning();
 	}
 
 	@Override
@@ -155,10 +160,7 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 
 	@Override
 	public boolean isAutoStartup() {
-		if (this.adapter != null) {
-			return this.adapter.isAutoStartup();
-		}
-		return false;
+		return this.adapter != null && this.adapter.isAutoStartup();
 	}
 
 	@Override
@@ -206,7 +208,8 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 		if (this.fileDelay != null) {
 			adapter.setTailAttemptsDelay(this.fileDelay);
 		}
-		adapter.setOutputChannel(outputChannel);
+		adapter.setOutputChannel(this.outputChannel);
+		adapter.setErrorChannel(this.errorChannel);
 		adapter.setBeanName(this.beanName);
 		if (this.autoStartup != null) {
 			adapter.setAutoStartup(this.autoStartup);
@@ -217,8 +220,8 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 		if (this.applicationEventPublisher != null) {
 			adapter.setApplicationEventPublisher(this.applicationEventPublisher);
 		}
-		if (this.getBeanFactory() != null) {
-			adapter.setBeanFactory(this.getBeanFactory());
+		if (getBeanFactory() != null) {
+			adapter.setBeanFactory(getBeanFactory());
 		}
 		adapter.afterPropertiesSet();
 		this.adapter = adapter;

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.file.config;
 
 import org.w3c.dom.Element;
@@ -26,6 +27,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 3.0
  *
  */
@@ -46,6 +48,7 @@ public class FileTailInboundChannelAdapterParser extends AbstractChannelAdapterP
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "file-delay");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "end");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reopen");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel");
 
 		return builder.getBeanDefinition();
 	}

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-4.1.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-4.1.xsd
@@ -263,6 +263,18 @@ Only files matching this regular expression will be picked up by this adapter.
 					<xsd:union memberTypes="xsd:boolean xsd:string"/>
 				</xsd:simpleType>
             </xsd:attribute>
+			<xsd:attribute name="error-channel" use="optional" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						Message Channel to which error Messages should be sent.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.messaging.MessageChannel"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
         </xsd:complexType>
     </xsd:element>
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests-context.xml
@@ -13,12 +13,15 @@
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
+	<int:channel id="tailErrorChannel"/>
+
 	<int-file:tail-inbound-channel-adapter id="default"
 		channel="input"
 		task-executor="exec"
 		file="/tmp/baz"
 		auto-startup="false"
-		phase="123" />
+		phase="123"
+		error-channel="tailErrorChannel"/>
 
 	<int-file:tail-inbound-channel-adapter id="native"
 		channel="input"
@@ -42,7 +45,7 @@
 		file-delay="10000"
 		auto-startup="false"
 		phase="123" />
-	
+
 	<context:property-placeholder properties-ref="props"/>
 
 	<util:properties id="props">
@@ -62,7 +65,7 @@
 		phase="123" />
 
 	<int:channel id="input" />
-	
+
 	<task:executor id="exec" />
 
 	<task:scheduler id="sched" />

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.file.config;
 
 import static org.junit.Assert.assertEquals;
@@ -30,14 +31,15 @@ import org.springframework.core.task.TaskExecutor;
 import org.springframework.integration.file.tail.ApacheCommonsFileTailingMessageProducer;
 import org.springframework.integration.file.tail.OSDelegatingFileTailingMessageProducer;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 3.0
- *
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -64,6 +66,9 @@ public class FileTailInboundChannelAdapterParserTests {
 	@Autowired
 	private TaskScheduler taskScheduler;
 
+	@Autowired
+	private MessageChannel tailErrorChannel;
+
 	@Test
 	public void testDefault() {
 		String fileName = TestUtils.getPropertyValue(defaultAdapter, "file", File.class).getAbsolutePath();
@@ -73,6 +78,7 @@ public class FileTailInboundChannelAdapterParserTests {
 		assertSame(exec, TestUtils.getPropertyValue(defaultAdapter, "taskExecutor"));
 		assertFalse(TestUtils.getPropertyValue(defaultAdapter, "autoStartup", Boolean.class));
 		assertEquals(123, TestUtils.getPropertyValue(defaultAdapter, "phase"));
+		assertSame(this.tailErrorChannel, TestUtils.getPropertyValue(defaultAdapter, "errorChannel"));
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3495
- Fix `AbstractEndpoint` JavaDoc

**Cherry-pick to 4.0.x & 3.0.x** only the first commit, because we can't change XSD for maintenance versions.
