### PR TITLE
INT-3499 AMQP Confirms/Returns Polishing

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
@@ -272,6 +272,12 @@ public class AmqpOutboundEndpoint extends AbstractReplyProducingMessageHandler
 	@Override
 	public void confirm(CorrelationData correlationData, boolean ack) {
 		Object userCorrelationData = correlationData;
+		if (correlationData == null) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("No correlation data provided for ack: " + ack);
+			}
+			return;
+		}
 		if (correlationData instanceof CorrelationDataWrapper) {
 			userCorrelationData = ((CorrelationDataWrapper) correlationData).getUserData();
 		}

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests-context.xml
@@ -40,9 +40,12 @@
 		<amqp:outbound-channel-adapter exchange-name="outboundchanneladapter.test.1"/>
 	</int:chain>
 
+	<rabbit:template id="amqpTemplateConfirms" connection-factory="connectionFactory"/>
+
 	<amqp:outbound-channel-adapter id="withPublisherConfirms" channel="pcRequestChannel"
 								   exchange-name="outboundchanneladapter.test.1"
 								   mapped-request-headers="foo*"
+								   amqp-template="amqpTemplateConfirms"
 								   confirm-correlation-expression="headers['amqp_confirmCorrelationData']"
 								   confirm-ack-channel="ackChannel"/>
 
@@ -52,9 +55,12 @@
 		<int:queue/>
 	</int:channel>
 
+	<rabbit:template id="amqpTemplateReturns" connection-factory="connectionFactory" mandatory="true" />
+
 	<amqp:outbound-channel-adapter id="withReturns" channel="returnRequestChannel"
 								   exchange-name="outboundchanneladapter.test.1"
 								   mapped-request-headers="foo*"
+								   amqp-template="amqpTemplateReturns"
 								   return-channel="returnChannel"/>
 
 	<int:channel id="returnRequestChannel"/>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
@@ -241,7 +241,7 @@ public class AmqpOutboundChannelAdapterParserTests {
 		Message<?> message = MessageBuilder.withPayload("hello").build();
 		requestChannel.send(message);
 		PollableChannel returnChannel = context.getBean("returnChannel", PollableChannel.class);
-		RabbitTemplate template = context.getBean("amqpTemplate", RabbitTemplate.class);
+		RabbitTemplate template = context.getBean("amqpTemplateReturns", RabbitTemplate.class);
 		Map<String, Object> headers = new HashMap<String, Object>();
 		headers.put(PublisherCallbackChannel.RETURN_CORRELATION, template.getUUID());
 		BasicProperties properties = mock(BasicProperties.class);

--- a/src/reference/docbook/amqp.xml
+++ b/src/reference/docbook/amqp.xml
@@ -471,10 +471,12 @@ public Object handle(@Payload String payload, @Header(AmqpHeaders.CHANNEL) Chann
 			</callout>
             <callout arearefs="amqp-outbound-channel-adapter-xml-8-co" id="amqp-outbound-channel-adapter-xml-8">
                 <para>An expression defining correlation data. When provided, this configures the underlying
-                amqp template to receive publisher confirms. Requires a <classname>RabbitTemplate</classname> and a
+                amqp template to receive publisher confirms. Requires a dedicated
+                <classname>RabbitTemplate</classname> and a
                 <classname>CachingConnectionFactory</classname> with the <code>publisherConfirms</code> property
                 set to <code>true</code>. When a publisher confirm
-                is received, it is written to either the confirm-ack-channel, or the confirm-nack-channel,
+                is received, and correlation data is supplied,
+                it is written to either the confirm-ack-channel, or the confirm-nack-channel,
                 depending on the confirmation type. The payload of the confirm is the correlation data as
                 defined by this expression and the message will have a header 'amqp_publishConfirm' set to
                 true (ack) or false (nack). Examples: "headers['myCorrelationData']", "payload".
@@ -497,8 +499,8 @@ public Object handle(@Payload String payload, @Header(AmqpHeaders.CHANNEL) Chann
                 amqp_returnReplyText, amqp_returnExchange, amqp_returnRoutingKey</emphasis>.
                 <emphasis>Optional</emphasis>.</para>
                 <important>
-                  Using a <code>return-channel</code> requires a <classname>RabbitTemplate</classname> with either
-                  the <code>mandatory</code> or <code>immediate</code> properties set to <code>true</code>,
+                  Using a <code>return-channel</code> requires a <classname>RabbitTemplate</classname> with
+                  the <code>mandatory</code> property set to <code>true</code>,
                   and a <classname>CachingConnectionFactory</classname>
                   with the <code>publisherReturns</code> property set to <code>true</code>. When using multiple
                   outbound endpoints with returns, a separate <classname>RabbitTemplate</classname> is needed
@@ -585,8 +587,8 @@ public Object handle(@Payload String payload, @Header(AmqpHeaders.CHANNEL) Chann
                 amqp_returnReplyText, amqp_returnExchange, amqp_returnRoutingKey</emphasis>.
                 <emphasis>Optional</emphasis>.</para>
                 <important>
-                  Using a <code>return-channel</code> requires a <classname>RabbitTemplate</classname> with either
-                  the <code>mandatory</code> or <code>immediate</code> properties set to <code>true</code>,
+                  Using a <code>return-channel</code> requires a <classname>RabbitTemplate</classname> with
+                  the <code>mandatory</code> property set to <code>true</code>,
                   and a <classname>CachingConnectionFactory</classname>
                   with the <code>publisherReturns</code> property set to <code>true</code>. When using multiple
                   outbound endpoints with returns, a separate <classname>RabbitTemplate</classname> is needed


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3499
- Suppress (log) 'null' payload error when no correlation data
- Change tests to use a dedicated template for confirms/returns

Conflicts:
    spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
    src/reference/docbook/amqp.xml

Resolved.

**Already applied to master via** https://github.com/spring-projects/spring-integration/commit/8b5c1c5053d37ffd6a01629322110426d730446e

**cherry-pick to 3.0.x**
