### PR TITLE
Fix JavaMail Dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -444,8 +444,8 @@ project('spring-integration-mail') {
 		compile "org.springframework:spring-context-support:$springVersion"
 		compile("javax.mail:javax.mail-api:$javaxMailVersion", provided)
 		compile("com.sun.mail:imap:$javaxMailVersion", provided)
+		compile("com.sun.mail:mailapi:$javaxMailVersion", provided);
 		compile("javax.activation:activation:$javaxActivationVersion", optional)
-		testRuntime "com.sun.mail:mailapi:$javaxMailVersion"
 	}
 
 	// suppress javax.activation path warnings


### PR DESCRIPTION
`ImapMessage` has a direct dependency on `ReadableMime`. It is
not clear why this started failing only on the MJATS41 build
but changing the `mailapi` dependency to `compile` fixes it
(tested by pointing the plan to my repo).
