### PR TITLE
INT-3501 Fix IMAP Idle

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -181,7 +181,7 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 		return this.shouldDeleteMessages;
 	}
 
-	protected Folder getFolder() {
+	public Folder getFolder() {
 		return this.folder;
 	}
 
@@ -222,8 +222,8 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 	}
 
 	protected void openFolder() throws MessagingException {
-		this.openSession();
 		if (this.folder == null) {
+			openSession();
 			this.folder = obtainFolderInstance();
 		}
 		if (this.folder == null || !this.folder.exists()) {

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -181,7 +181,7 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 		return this.shouldDeleteMessages;
 	}
 
-	public Folder getFolder() {
+	protected Folder getFolder() {
 		return this.folder;
 	}
 

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
@@ -64,8 +64,6 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport implements Be
 
 	private static final int DEFAULT_RECONNECT_DELAY = 10000;
 
-	private static final int DEFAULT_CANCEL_IDLE_INTERVAL = 120000;
-
 	private final IdleTask idleTask = new IdleTask();
 
 	private volatile Executor sendingTaskExecutor;
@@ -83,8 +81,6 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport implements Be
 	private volatile long reconnectDelay = DEFAULT_RECONNECT_DELAY; // milliseconds
 
 	private volatile ScheduledFuture<?> receivingTask;
-
-	private volatile long cancelIdleInterval = DEFAULT_CANCEL_IDLE_INTERVAL;
 
 	private final ExceptionAwarePeriodicTrigger receivingTaskTrigger = new ExceptionAwarePeriodicTrigger();
 
@@ -131,19 +127,10 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport implements Be
 	/**
 	 * The time between connection attempts in milliseconds (default 10 seconds).
 	 * @param reconnectDelay the reconnectDelay to set
+	 * @since 3.0.5
 	 */
 	public void setReconnectDelay(long reconnectDelay) {
 		this.reconnectDelay = reconnectDelay;
-	}
-
-	/**
-	 * IDLE commands will be terminated after this interval; useful in cases where a connection
-	 * might be silently dropped. A new IDLE will usually immediately be processed. Specified in
-	 * seconds; default 120.
-	 * @param cancelIdleInterval the cancelIdleInterval to set
-	 */
-	public void setCancelIdleInterval(long cancelIdleInterval) {
-		this.cancelIdleInterval = cancelIdleInterval * 1000;
 	}
 
 	@Override
@@ -172,7 +159,6 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport implements Be
 		if (this.sendingTaskExecutor == null) {
 			this.sendingTaskExecutor = Executors.newFixedThreadPool(1);
 		}
-		this.mailReceiver.setCancelIdleInterval(this.cancelIdleInterval);
 		this.receivingTask = scheduler.schedule(new ReceivingTask(), this.receivingTaskTrigger);
 	}
 

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
@@ -54,6 +54,8 @@ import com.sun.mail.imap.IMAPMessage;
  */
 public class ImapMailReceiver extends AbstractMailReceiver {
 
+	private static final int DEFAULT_CANCEL_IDLE_INTERVAL = 120000;
+
 	private final MessageCountListener messageCountListener = new SimpleMessageCountListener();
 
 	private final IdleCanceler idleCanceler = new IdleCanceler();
@@ -62,7 +64,7 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 
 	private volatile SearchTermStrategy searchTermStrategy = new DefaultSearchTermStrategy();
 
-	private volatile long cancelIdleInterval;
+	private volatile long cancelIdleInterval = DEFAULT_CANCEL_IDLE_INTERVAL;
 
 	private volatile TaskScheduler scheduler;
 
@@ -114,17 +116,16 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 		this.shouldMarkMessagesAsRead = shouldMarkMessagesAsRead;
 	}
 
-
 	/**
 	 * IDLE commands will be terminated after this interval; useful in cases where a connection
-	 * might be silently dropped. A new IDLE will usually immediately be processed. DO NOT
-	 * SET DIRECTLY - set by the ImapIdleChannelAdapter.
+	 * might be silently dropped. A new IDLE will usually immediately be processed. Specified
+	 * in seconds; default 120 (2 minutes). RFC 2177 recommends an interval no larger than 29 minutes.
 	 * @param cancelIdleInterval the cancelIdleInterval to set
+	 * @since 3.0.5
 	 */
 	public void setCancelIdleInterval(long cancelIdleInterval) {
-		this.cancelIdleInterval = cancelIdleInterval;
+		this.cancelIdleInterval = cancelIdleInterval * 1000;
 	}
-
 
 	@Override
 	protected void onInit() throws Exception {

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
@@ -16,6 +16,9 @@
 
 package org.springframework.integration.mail;
 
+import java.util.Date;
+import java.util.concurrent.ScheduledFuture;
+
 import javax.mail.Flags;
 import javax.mail.Flags.Flag;
 import javax.mail.Folder;
@@ -29,6 +32,8 @@ import javax.mail.search.FlagTerm;
 import javax.mail.search.NotTerm;
 import javax.mail.search.SearchTerm;
 
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.Assert;
 
 import com.sun.mail.imap.IMAPFolder;
@@ -49,11 +54,19 @@ import com.sun.mail.imap.IMAPMessage;
  */
 public class ImapMailReceiver extends AbstractMailReceiver {
 
+	private final MessageCountListener messageCountListener = new SimpleMessageCountListener();
+
+	private final IdleCanceler idleCanceler = new IdleCanceler();
+
 	private volatile boolean shouldMarkMessagesAsRead = true;
 
 	private volatile SearchTermStrategy searchTermStrategy = new DefaultSearchTermStrategy();
 
-	private final MessageCountListener messageCountListener = new SimpleMessageCountListener();
+	private volatile long cancelIdleInterval;
+
+	private volatile TaskScheduler scheduler;
+
+	private volatile ScheduledFuture<?> pingTask;
 
 	public ImapMailReceiver() {
 		super();
@@ -101,6 +114,29 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 		this.shouldMarkMessagesAsRead = shouldMarkMessagesAsRead;
 	}
 
+
+	/**
+	 * IDLE commands will be terminated after this interval; useful in cases where a connection
+	 * might be silently dropped. A new IDLE will usually immediately be processed. DO NOT
+	 * SET DIRECTLY - set by the ImapIdleChannelAdapter.
+	 * @param cancelIdleInterval the cancelIdleInterval to set
+	 */
+	public void setCancelIdleInterval(long cancelIdleInterval) {
+		this.cancelIdleInterval = cancelIdleInterval;
+	}
+
+
+	@Override
+	protected void onInit() throws Exception {
+		super.onInit();
+		this.scheduler = getTaskScheduler();
+		if (this.scheduler == null) {
+			ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+			scheduler.initialize();
+			this.scheduler = scheduler;
+		}
+	}
+
 	/**
 	 * This method is unique to the IMAP receiver and only works if IMAP IDLE
 	 * is supported (see RFC 2177 for more detail).
@@ -123,10 +159,15 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 		}
 		imapFolder.addMessageCountListener(this.messageCountListener);
 		try {
+			this.pingTask = this.scheduler.schedule(this.idleCanceler,
+					new Date(System.currentTimeMillis() + this.cancelIdleInterval));
 			imapFolder.idle();
 		}
 		finally {
 			imapFolder.removeMessageCountListener(this.messageCountListener);
+			if (this.pingTask != null) {
+				this.pingTask.cancel(true);
+			}
 		}
 	}
 
@@ -168,23 +209,32 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 		}
 	}
 
+	private class IdleCanceler implements Runnable {
+		@Override
+		public void run() {
+			try {
+				IMAPFolder folder = (IMAPFolder) getFolder();
+				logger.debug("Canceling IDLE");
+				if (folder != null) {
+					folder.isOpen(); // resets idle state
+				}
+			}
+			catch (Exception ignore) {
+			}
+		}
+	}
 
 	/**
 	 * Callback used for handling the event-driven idle response.
 	 */
-	private static class SimpleMessageCountListener extends MessageCountAdapter {
+	private class SimpleMessageCountListener extends MessageCountAdapter {
 
 		@Override
 		public void messagesAdded(MessageCountEvent event) {
 			Message[] messages = event.getMessages();
-			for (Message message : messages) {
-				try {
-					// this will return the flow to the idle call
-					message.getLineCount();
-				}
-				catch (MessagingException e) {
-					// ignored;
-				}
+			if (messages.length > 0) {
+				// this will return the flow to the idle call
+				messages[0].getFolder().isOpen();
 			}
 		}
 	}
@@ -254,6 +304,5 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 		}
 
 	}
-
 
 }

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/PoorMansMailServer.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/PoorMansMailServer.java
@@ -1,0 +1,440 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.mail;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.net.ServerSocketFactory;
+
+import org.springframework.util.Base64Utils;
+
+/**
+ * @author Gary Russell
+ *
+ */
+public class PoorMansMailServer {
+
+	public static SmtpServer smtp(int port) {
+		try {
+			return new SmtpServer(port);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static Pop3Server pop3(int port) {
+		try {
+			return new Pop3Server(port);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static ImapServer imap(int port) {
+		try {
+			return new ImapServer(port);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static class SmtpServer extends MailServer {
+
+		public SmtpServer(int port) throws IOException {
+			super(port);
+		}
+
+		@Override
+		protected MailHandler mailHandler(Socket socket) {
+			return new SmtpHandler(socket);
+		}
+
+		public class SmtpHandler extends MailHandler {
+
+			public SmtpHandler(Socket socket) {
+				super(socket);
+			}
+
+			@Override
+			void doRun() {
+				try {
+					write("220 foo SMTP");
+					while (!socket.isClosed()) {
+						String line = reader.readLine();
+						if (line.contains("EHLO")) {
+							write("250-foo hello [0,0,0,0], foo");
+							write("250-AUTH LOGIN PLAIN");
+							write("250 OK");
+						}
+						else if (line.contains("MAIL FROM")) {
+							write("250 OK");
+						}
+						else if (line.contains("RCPT TO")) {
+							write("250 OK");
+						}
+						else if (line.contains("AUTH LOGIN")) {
+							write("334 VXNlcm5hbWU6");
+						}
+						else if (line.contains("dXNlcg==")) { // base64 'user'
+							sb.append("user:");
+							sb.append((new String(Base64Utils.decode(line.getBytes()))));
+							sb.append("\n");
+							write("334 UGFzc3dvcmQ6");
+						}
+						else if (line.contains("cHc=")) { // base64 'pw'
+							sb.append("password:");
+							sb.append((new String(Base64Utils.decode(line.getBytes()))));
+							sb.append("\n");
+							write("235");
+						}
+						else if (line.equals("DATA")) {
+							write("354");
+						}
+						else if (line.equals(".")) {
+							write("250");
+						}
+						else if (line.equals("QUIT")) {
+							write("221");
+							socket.close();
+						}
+						else {
+							sb.append(line);
+							sb.append("\n");
+						}
+					}
+					messages.add(sb.toString());
+				}
+				catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+
+		}
+
+	}
+
+	public static class Pop3Server extends MailServer {
+
+		public Pop3Server(int port) throws IOException {
+			super(port);
+		}
+
+		@Override
+		protected MailHandler mailHandler(Socket socket) {
+			return new Pop3Handler(socket);
+		}
+
+		public class Pop3Handler extends MailHandler {
+
+			public Pop3Handler(Socket socket) {
+				super(socket);
+			}
+
+			@Override
+			void doRun() {
+				try {
+					write("+OK POP3");
+					while (!socket.isClosed()) {
+						String line = reader.readLine();
+						if ("CAPA".equals(line)) {
+							write("+OK");
+							write("USER");
+							write(".");
+						}
+						else if ("USER user".equals(line)) {
+							write("+OK");
+						}
+						else if ("PASS pw".equals(line)) {
+							write("+OK");
+						}
+						else if ("STAT".equals(line)) {
+							write("+OK 1 3");
+						}
+						else if ("NOOP".equals(line)) {
+							write("+OK");
+						}
+						else if ("RETR 1".equals(line)) {
+							write("+OK");
+							write(MESSAGE);
+							write(".");
+						}
+						else if ("QUIT".equals(line)) {
+							write("+OK");
+							socket.close();
+						}
+					}
+				}
+				catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+
+		}
+
+	}
+
+	public static class ImapServer extends MailServer {
+
+		private boolean seen;
+
+		private boolean idled;
+
+		public ImapServer(int port) throws IOException {
+			super(port);
+		}
+
+		@Override
+		protected MailHandler mailHandler(Socket socket) {
+			return new ImapHandler(socket);
+		}
+
+		public class ImapHandler extends MailHandler {
+
+			public ImapHandler(Socket socket) {
+				super(socket);
+			}
+
+			@Override
+			void doRun() {
+				try {
+					write("* OK IMAP4rev1 Service Ready");
+					String idleTag = "";
+					while (!socket.isClosed()) {
+						String line = reader.readLine();
+						if (line == null) {
+							break;
+						}
+						String tag = line.substring(0, line.indexOf(" ") + 1);
+						if (line.endsWith("CAPABILITY")) {
+							write("* CAPABILITY IDLE IMAP4rev1");
+							write(tag + "OK CAPABILITY completed");
+						}
+						else if (line.endsWith("LOGIN user pw")) {
+							write(tag + "OK LOGIN completed");
+						}
+						else if (line.endsWith("LIST \"\" INBOX")) {
+							write("* LIST \"/\" \"INBOX\"");
+							write(tag + "OK LIST completed");
+						}
+						else if (line.endsWith("LIST \"\" \"\"")) {
+							write("* LIST \"/\" \"\"");
+							write(tag + "OK LIST completed");
+						}
+						else if (line.endsWith("SELECT INBOX")) {
+							write("* 1 EXISTS");
+							if (!seen) {
+								write("* 1 RECENT");
+								write("* OK [UNSEEN 1]");
+							}
+							else {
+								write("* OK");
+							}
+							write(tag + "OK SELECT completed");
+						}
+						else if (line.endsWith("EXAMINE INBOX")) {
+							write(tag + "OK");
+						}
+						else if (line.endsWith("SEARCH FROM bar@baz UNSEEN ALL")) {
+							if (seen) {
+								write("* SEARCH");
+							}
+							else {
+								write("* SEARCH 1");
+							}
+							write(tag + "OK SEARCH completed");
+						}
+						else if (line.contains("FETCH 1 (ENVELOPE")) {
+							write("* 1 FETCH (RFC822.SIZE 6909 INTERNALDATE \"27-May-2013 09:45:41 +0000\" "
+									+ "FLAGS (\\Seen) "
+									+ "ENVELOPE (\"Mon, 27 May 2013 15:14:49 +0530\" "
+									+ "\"Test Email\" ((\"Foo\" NIL \"foo\" \"bar.tv\")) "
+									+ "((\"Foo\" NIL \"foo\" \"bar.tv\")) "
+									+ "((\"Foo\" NIL \"foo\" \"bar.tv\")) "
+									+ "((\"Bar\" NIL \"bar\" \"baz.net\")) NIL NIL "
+									+ "\"<4DA0A7E4.3010506@baz.net>\" "
+									+ "\"<CACVnpJkAUUfa3d_-4GNZW2WpxbB39tBCHC=T0gc7hty6dOEHcA@foo.bar.com>\") "
+									+ "BODYSTRUCTURE (\"TEXT\" \"PLAIN\" (\"CHARSET\" \"ISO-8859-1\") NIL NIL \"7BIT\" 1176 43)))");
+							write(tag + "OK FETCH completed");
+						}
+						else if (line.contains("FETCH 2 (BODYSTRUCTURE)")) {
+							write("* 2 FETCH " +
+									"BODYSTRUCTURE (\"TEXT\" \"PLAIN\" (\"CHARSET\" \"ISO-8859-1\") NIL NIL \"7BIT\" 1176 43)))");
+							write(tag + "OK FETCH completed");
+						}
+						else if (line.contains("STORE 1 +FLAGS (\\Flagged)")) {
+							write("* 1 FETCH (FLAGS (\\Flagged))");
+							write(tag + "OK STORE completed");
+						}
+						else if (line.contains("STORE 1 +FLAGS (\\Seen)")) {
+							write("* 1 FETCH (FLAGS (\\Flagged \\Seen))");
+							write(tag + "OK STORE completed");
+							seen = true;
+						}
+						else if (line.contains("FETCH 1 FLAGS")) {
+							write("* 1 FLAGS(\\Seen)");
+							write(tag + "OK FETCH completed");
+						}
+						else if (line.contains("FETCH 1 (BODY.PEEK")) {
+							write("* 1 FETCH (BODY[]<0> {" + (MESSAGE.length() + 2) + "}");
+							write(MESSAGE);
+							write(")");
+							write(tag + "OK FETCH completed");
+						}
+						else if (line.contains("CLOSE")) {
+							write(tag + "OK CLOSE completed");
+						}
+						else if (line.contains("NOOP")) {
+							write(tag + "OK NOOP completed");
+						}
+						else if (line.endsWith("IDLE")) {
+							write("+ idling");
+							idleTag = tag;
+							if (!idled) {
+								try {
+									Thread.sleep(3000);
+									write("* 2 EXISTS");
+									seen = false;
+								}
+								catch (InterruptedException e) {
+									Thread.currentThread().interrupt();
+								}
+							}
+							idled = true;
+						}
+						else if (line.equals("DONE")) {
+							write(idleTag + "OK");
+						}
+						else if (line.contains("LOGOUT")) {
+							write(tag + "OK LOGOUT completed");
+							this.socket.close();
+						}
+					}
+				}
+				catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+
+		}
+
+	}
+
+	public abstract static class MailServer implements Runnable {
+
+		private final ServerSocket socket;
+
+		private final ExecutorService exec = Executors.newCachedThreadPool();
+
+		protected final List<String> messages = new ArrayList<String>();
+
+		private volatile boolean listening;
+
+		public MailServer(int port) throws IOException {
+			this.socket = ServerSocketFactory.getDefault().createServerSocket(port);
+			this.listening = true;
+			exec.execute(this);
+		}
+
+		public boolean isListening() {
+			return listening;
+		}
+
+		public List<String> getMessages() {
+			return messages;
+		}
+
+		@Override
+		public void run() {
+			try {
+				while (!socket.isClosed()) {
+					Socket socket = this.socket.accept();
+					exec.execute(mailHandler(socket));
+				}
+			}
+			catch (IOException e) {
+				this.listening = false;
+			}
+		}
+
+		protected abstract MailHandler mailHandler(Socket socket);
+
+		public void stop() {
+			try {
+				this.socket.close();
+			}
+			catch (IOException e) {
+				e.printStackTrace();
+			}
+			this.exec.shutdownNow();
+		}
+
+		public abstract class MailHandler implements Runnable {
+
+			protected static final String MESSAGE = "To: foo@bar\r\nFrom: bar@baz\r\nSubject: Test Email\r\n\r\nfoo";
+
+			protected final Socket socket;
+
+			private BufferedWriter writer;
+
+			protected StringBuilder sb = new StringBuilder();
+
+			protected BufferedReader reader;
+
+			public MailHandler(Socket socket) {
+				this.socket = socket;
+			}
+
+			@Override
+			public void run() {
+				try {
+					this.reader = new BufferedReader(new InputStreamReader(this.socket.getInputStream()));
+					this.writer = new BufferedWriter(new OutputStreamWriter(this.socket.getOutputStream()));
+				}
+				catch (IOException e) {
+					e.printStackTrace();
+				}
+				doRun();
+			}
+
+			protected void write(String str) throws IOException {
+				this.writer.write(str);
+				this.writer.write("\r\n");
+				this.writer.flush();
+			}
+
+			abstract void doRun();
+
+		}
+
+	}
+
+	private PoorMansMailServer() {
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3501

There were several problems:

When a `Folder` is open, an activity on the `Store` opens a new
connection.

The `PingTask` called `isConnected()` on the store, creating a new
connection. The pings (NOOPs)  were performed on this connection and
therefore did NOT cancel the `IDLE`.

In any case, the `IDLE` was issued on the folder not the store and
the only way to cancel that IDLE is to cause its `waitIfIdle()` to
be invoked. Conveniently, simply calling `isOpen()` invokes that
method and cancels the IDLE.

Finally, the `SimpleMessageCountListener` unnecessarily invoked
`message.getLineCount()` when a simple `folder.isOpen()` is
sufficient.

Fixes:
1. Do not invoke `openSession` if `this.folder` is not null.
2. Change the `PingTask` to simply invoke `isOpen()`.
3. Move the `PingTask to the receiver for a more efficient algorithm
   instead of running on fixed interval. Rename it`IdleCanceler`.
4. Increase the PING timer from 10 to 120 seconds; add setters for it
   and the `reconnectionDelay`.

TODO: Namespace support for 4.1. (Not to be back ported).

Add a test IMAP server (ported from Java DSL and enhanced to simulate IDLE
with a new message arriving for the first idle period.

Also tested with GMail.

**cherry-pick to 4.0.x, 3.0.x**
