### PR TITLE
Use com.sun.mail:javax.mail for ReadableMime dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -444,7 +444,7 @@ project('spring-integration-mail') {
 		compile "org.springframework:spring-context-support:$springVersion"
 		compile("javax.mail:javax.mail-api:$javaxMailVersion", provided)
 		compile("com.sun.mail:imap:$javaxMailVersion", provided)
-		compile("com.sun.mail:mailapi:$javaxMailVersion", provided);
+		compile("com.sun.mail:javax.mail:$javaxMailVersion", provided);
 		compile("javax.activation:activation:$javaxActivationVersion", optional)
 	}
 


### PR DESCRIPTION
`com.sun.mail:javax.mail` is already part of the Spring IO Platform, whereas `com.sun.mail:mailapi` is not.
