### PR TITLE
INT-3506 Async Gateway Improvements

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/AnnotationAttributeValueConstants.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/AnnotationAttributeValueConstants.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.annotation;
+
+/**
+ * @author Gary Russell
+ * @since 4.1
+ *
+ */
+public class AnnotationAttributeValueConstants {
+
+	public static final String NULL = "__NULL__";
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/AnnotationConstants.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/AnnotationConstants.java
@@ -20,7 +20,7 @@ package org.springframework.integration.annotation;
  * @since 4.1
  *
  */
-public class AnnotationAttributeValueConstants {
+public class AnnotationConstants {
 
 	public static final String NULL = "__NULL__";
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
@@ -83,6 +83,8 @@ public @interface MessagingGateway {
 	 * to use for any of the interface methods that have a {@link java.util.concurrent.Future} return type.
 	 * This {@code Executor} will only be used for those async methods; the sync methods
 	 * will be invoked in the caller's thread.
+	 * Use {@code AnnotationAttributeValueConstants.NULL} to specify no async executor - for example
+	 * if your downstream flow returns a {@code Future<?>}.
 	 * @return the suggested executor bean name, if any
 	 */
 	String asyncExecutor() default "";

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.expression.common.LiteralExpression;
+import org.springframework.integration.annotation.AnnotationAttributeValueConstants;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.gateway.GatewayMethodMetadata;
 import org.springframework.integration.gateway.GatewayProxyFactoryBean;
@@ -133,7 +134,7 @@ public class MessagingGatewayRegistrar implements ImportBeanDefinitionRegistrar 
 		if (StringUtils.hasText(errorChannel)) {
 			gatewayProxyBuilder.addPropertyReference("errorChannel", errorChannel);
 		}
-		if (asyncExecutor == null) {
+		if (asyncExecutor == null || AnnotationAttributeValueConstants.NULL.equals(asyncExecutor)) {
 			gatewayProxyBuilder.addPropertyValue("asyncExecutor", null);
 		}
 		else if (StringUtils.hasText(asyncExecutor)) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
@@ -38,9 +38,9 @@ import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.annotation.MessagingGateway;
-import org.springframework.integration.util.MessagingAnnotationUtils;
 import org.springframework.integration.gateway.GatewayMethodMetadata;
 import org.springframework.integration.gateway.GatewayProxyFactoryBean;
+import org.springframework.integration.util.MessagingAnnotationUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.ObjectUtils;
@@ -133,7 +133,10 @@ public class MessagingGatewayRegistrar implements ImportBeanDefinitionRegistrar 
 		if (StringUtils.hasText(errorChannel)) {
 			gatewayProxyBuilder.addPropertyReference("errorChannel", errorChannel);
 		}
-		if (StringUtils.hasText(asyncExecutor)) {
+		if (asyncExecutor == null) {
+			gatewayProxyBuilder.addPropertyValue("asyncExecutor", null);
+		}
+		else if (StringUtils.hasText(asyncExecutor)) {
 			gatewayProxyBuilder.addPropertyReference("asyncExecutor", asyncExecutor);
 		}
 		if (StringUtils.hasText(reactorEnvironment)) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
@@ -37,7 +37,7 @@ import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.expression.common.LiteralExpression;
-import org.springframework.integration.annotation.AnnotationAttributeValueConstants;
+import org.springframework.integration.annotation.AnnotationConstants;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.gateway.GatewayMethodMetadata;
 import org.springframework.integration.gateway.GatewayProxyFactoryBean;
@@ -134,7 +134,7 @@ public class MessagingGatewayRegistrar implements ImportBeanDefinitionRegistrar 
 		if (StringUtils.hasText(errorChannel)) {
 			gatewayProxyBuilder.addPropertyReference("errorChannel", errorChannel);
 		}
-		if (asyncExecutor == null || AnnotationAttributeValueConstants.NULL.equals(asyncExecutor)) {
+		if (asyncExecutor == null || AnnotationConstants.NULL.equals(asyncExecutor)) {
 			gatewayProxyBuilder.addPropertyValue("asyncExecutor", null);
 		}
 		else if (StringUtils.hasText(asyncExecutor)) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GatewayParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GatewayParser.java
@@ -61,7 +61,13 @@ public class GatewayParser implements BeanDefinitionParser {
 		gatewayAttributes.put("defaultRequestChannel", element.getAttribute(isNested ? "request-channel" : "default-request-channel"));
 		gatewayAttributes.put("defaultReplyChannel", element.getAttribute(isNested ? "reply-channel" : "default-reply-channel"));
 		gatewayAttributes.put("errorChannel", element.getAttribute("error-channel"));
-		gatewayAttributes.put("asyncExecutor", element.getAttribute("async-executor"));
+		String asyncExecutor = element.getAttribute("async-executor");
+		if (!element.hasAttribute("async-executor") || StringUtils.hasLength(asyncExecutor)) {
+			gatewayAttributes.put("asyncExecutor", asyncExecutor);
+		}
+		else {
+			gatewayAttributes.put("asyncExecutor", null);
+		}
 		gatewayAttributes.put("mapper", element.getAttribute("mapper"));
 		gatewayAttributes.put("reactorEnvironment", element.getAttribute("reactor-environment"));
 		gatewayAttributes.put("defaultReplyTimeout", element.getAttribute(isNested ? "reply-timeout" : "default-reply-timeout"));

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.core.convert.ConversionService;
+import org.springframework.core.task.AsyncListenableTaskExecutor;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.support.TaskExecutorAdapter;
@@ -110,6 +111,10 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 	private final Map<Method, MethodInvocationGateway> gatewayMap = new HashMap<Method, MethodInvocationGateway>();
 
 	private volatile AsyncTaskExecutor asyncExecutor = new SimpleAsyncTaskExecutor();
+
+	private volatile Class<?> asyncSubmitType;
+
+	private volatile Class<?> asyncSubmitListenableType;
 
 	private volatile Environment reactorEnvironment;
 
@@ -214,9 +219,17 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 		}
 	}
 
+	/**
+	 * Set the executor for use when the gateway method returns {@code Future<?>} or
+	 * {@code ListenableFuture<?>}. Set it to null to disable the async processing, and any
+	 * {@code Future<?>} return types must be returned by the downstream flow.
+	 * @param executor The executor.
+	 */
 	public void setAsyncExecutor(Executor executor) {
-		Assert.notNull(executor, "executor must not be null");
-		this.asyncExecutor = (executor instanceof AsyncTaskExecutor) ? (AsyncTaskExecutor) executor
+		if (executor == null && logger.isInfoEnabled()) {
+			logger.info("A null executor disables the async gateway; methods returning Future<?> will run on the calling thread");
+		}
+		this.asyncExecutor = (executor instanceof AsyncTaskExecutor || executor == null) ? (AsyncTaskExecutor) executor
 				: new TaskExecutorAdapter(executor);
 	}
 
@@ -275,6 +288,21 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 				this.gatewayMap.put(method, gateway);
 			}
 			this.serviceProxy = new ProxyFactory(proxyInterface, this).getProxy(this.beanClassLoader);
+			if (this.asyncExecutor != null) {
+				Callable<String> task = new Callable<String>() {
+
+					@Override
+					public String call() throws Exception {
+						return null;
+					}
+				};
+				Future<String> submitType = this.asyncExecutor.submit(task);
+				this.asyncSubmitType = submitType.getClass();
+				if (this.asyncExecutor instanceof AsyncListenableTaskExecutor) {
+					submitType = ((AsyncListenableTaskExecutor) this.asyncExecutor).submitListenable(task);
+					this.asyncSubmitListenableType = submitType.getClass();
+				}
+			}
 			this.start();
 			this.initialized = true;
 		}
@@ -309,8 +337,20 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 	@Override
 	public Object invoke(final MethodInvocation invocation) throws Throwable {
 		final Class<?> returnType = invocation.getMethod().getReturnType();
-		if (Future.class.isAssignableFrom(returnType)) {
-			return this.asyncExecutor.submit(new AsyncInvocationTask(invocation));
+		if (this.asyncExecutor != null && !Object.class.equals(returnType)) {
+			if (returnType.isAssignableFrom(this.asyncSubmitType)) {
+				return this.asyncExecutor.submit(new AsyncInvocationTask(invocation));
+			}
+			else if (returnType.isAssignableFrom(asyncSubmitListenableType)) {
+				return ((AsyncListenableTaskExecutor) this.asyncExecutor).submitListenable(new AsyncInvocationTask(invocation));
+			}
+			else if (Future.class.isAssignableFrom(returnType)) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("AsyncTaskExecutor submit*() return types are incompatible with the method return type; "
+							+ "running on calling thread; the downstream flow must return the required Future: "
+							+ returnType.getSimpleName());
+				}
+			}
 		}
 		if (Promise.class.isAssignableFrom(returnType)) {
 			if (this.reactorEnvironment == null) {

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.1.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.1.xsd
@@ -755,9 +755,17 @@
 					<xsd:documentation>
 							<![CDATA[
 					Provide a reference to an implementation of java.util.concurrent.Executor
-					to use for any of the interface methods that have a Future return type.
+					to use for any of the interface methods that have a Future or
+					ListenableFuture return type.
 					This Executor will only be used for those async methods; the sync methods
-					will be invoked in the caller's thread.
+					will be invoked on the caller's thread. By default, a SimpleAsyncTaskExecutor
+					is used. Most executors return a FutureTask or FutureListenableTask respectively
+					but a custom executor can return any Future. If the method return type is
+					not compatible with the executor the flow will run on the caller's thread and
+					the flow must return an appropriate Future. Finally, you can disable the
+					gateway ansync handling by setting this attribute to "". This allows the downstream
+					flow to return a Future that would otherwise have been compatible with the
+					default executor.
 							]]>
 					</xsd:documentation>
 				</xsd:annotation>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests-context.xml
@@ -36,6 +36,12 @@
 			 default-reply-channel="replyChannel"
 			 async-executor="testExecutor"/>
 
+	<gateway id="asyncOff"
+			 service-interface="org.springframework.integration.gateway.TestService"
+			 default-request-channel="requestChannel"
+			 default-reply-channel="replyChannel"
+			 async-executor=""/>
+
 	<gateway id="promise"
 			 service-interface="org.springframework.integration.gateway.TestService"
 			 default-request-channel="requestChannel"

--- a/src/reference/docbook/gateway.xml
+++ b/src/reference/docbook/gateway.xml
@@ -442,13 +442,13 @@ of this chapter.
   <section id="async-gateway">
     <title>Asynchronous Gateway</title>
     <para>
-      As a pattern the Messaging Gateway is a very nice way to hide messaging-specific code while still exposing the full capabilities of the
+      As a pattern, the Messaging Gateway is a very nice way to hide messaging-specific code while still exposing the full capabilities of the
       messaging system. As you've seen, the <classname>GatewayProxyFactoryBean</classname> provides a convenient way to expose a Proxy over a service-interface
       thus giving you POJO-based access to a messaging system (based on objects in your own domain, or primitives/Strings, etc).  But when a
       gateway is exposed via simple POJO methods which return values it does imply that for each Request message (generated when the method is invoked)
       there must be a Reply message (generated when the method has returned). Since Messaging systems naturally are asynchronous you may not always be
       able to guarantee the contract where <emphasis>"for each request there will always be be a reply"</emphasis>. 
-      With Spring Integration 2.0 we are introducing support for an <emphasis>Asynchronous Gateway</emphasis> which is a convenient way to initiate
+      With Spring Integration 2.0 we introduced support for an <emphasis>Asynchronous Gateway</emphasis> which is a convenient way to initiate
       flows where you may not know if a reply is expected or how long will it take for replies to arrive.
       </para>
       <para>
@@ -462,14 +462,16 @@ of this chapter.
      service-interface="org.springframework.integration.sample.gateway.futures.MathServiceGateway"
      default-request-channel="requestChannel"/>]]></programlisting>
      <para>
-      However the Gateway Interface (service-interface) is a bit different.
+      However the Gateway Interface (service-interface) is a little different:
      </para>
       <programlisting language="java">public interface MathServiceGateway {
+      
   Future&lt;Integer&gt; multiplyByTwo(int i);
+  
 }</programlisting>
 
     <para>
-    As you can see from the example above the return type for the gateway method is a <classname>Future</classname>. When
+    As you can see from the example above, the return type for the gateway method is a <classname>Future</classname>. When
     <classname>GatewayProxyFactoryBean</classname> sees that the
     return type of the gateway method is a <classname>Future</classname>, it immediately switches to the async mode by utilizing
     an <classname>AsyncTaskExecutor</classname>. That is all. The call to such a method always returns immediately with a <classname>Future</classname> instance.
@@ -483,18 +485,85 @@ int finalResult =  result.get(1000, TimeUnit.SECONDS);</programlisting>
     <ulink url="https://github.com/SpringSource/spring-integration-samples/tree/master/intermediate/async-gateway">
     <emphasis>async-gateway</emphasis></ulink> sample distributed within the Spring Integration samples.
     </para>
+    <para>
+    <emphasis role="bold">ListenableFuture</emphasis>
+    </para>
+    <para>
+    Starting with <emphasis>version 4.1</emphasis>, async gateway methods can also return
+    <interfacename>ListenableFuture</interfacename> (introduced in Spring Framework 4.0). These
+    return types allow you to provide a callback which is invoked when the result is available
+    (or an exception occurs). When the gateway detects this return type, and the task executor
+    (see below) is an <interfacename>AsyncListenableTaskExecutor</interfacename>, the executor's
+    <code>submitListenable()</code> method is invoked.
+    </para>
+    <programlisting language="java"><![CDATA[ListenableFuture<String> result = this.asyncGateway.async("foo");
+result.addCallback(new ListenableFutureCallback<Thread>() {
 
+    @Override
+    public void onSuccess(Thread result) {
+        ...
+    }
+
+    @Override
+    public void onFailure(Throwable t) {
+        ...
+    }
+});]]></programlisting>
     <para><emphasis role="bold">Asynchronous Gateway and AsyncTaskExecutor</emphasis></para>
     <para>
-     By default <classname>GatewayProxyFactoryBean</classname> uses <classname>org.springframework.core.task.SimpleAsyncTaskExecutor</classname>
+     By default, the <classname>GatewayProxyFactoryBean</classname> uses <classname>org.springframework.core.task.SimpleAsyncTaskExecutor</classname>
      when submitting internal <classname>AsyncInvocationTask</classname> instances for any gateway method whose
-     return type is <classname>Future.class</classname>. However the <literal>async-executor</literal> attribute in the
+     return type is <classname>Future</classname>. However the <literal>async-executor</literal> attribute in the
      <literal>&lt;gateway/&gt;</literal> element's configuration allows you to provide a reference to any implementation of
      <classname>java.util.concurrent.Executor</classname> available within the Spring application context.
     </para>
+    <para>
+      The (default) <classname>SimpleAsyncTaskExecutor</classname> supports both
+      <interfacename>Future</interfacename> and <interfacename>ListenableFuture</interfacename>
+      return types, returning <classname>FutureTask</classname> or <classname>ListenableFutureTask</classname>
+      respectively. Even though there is a default executor, it is often useful to provide an external
+      one so that you can identify its threads in logs (when using XML, the thread name is based on the executor's
+      bean name):
+     <para>
+    <programlisting language="java"><![CDATA[@Bean
+public AsyncTaskExecutor exec() {
+    SimpleAsyncTaskExecutor simpleAsyncTaskExecutor = new SimpleAsyncTaskExecutor();
+    simpleAsyncTaskExecutor.setThreadNamePrefix("exec-");
+    return simpleAsyncTaskExecutor;
+}
+
+@MessagingGateway(asyncExecutor = "exec")
+public interface ExecGateway {
+
+    @Gateway(requestChannel = "gatewayChannel")
+    Future<?> doAsync(String foo);
+
+}]]></programlisting>
+     </para>
+      If you wish to return a different <interfacename>Future</interfacename>
+      implementation, you can provide a custom executor, or disable the executor altogether and
+      return the <interfacename>Future</interfacename> in the reply message payload from the downstream flow.
+      To disable the executor, simply set it to <code>null</code> in the
+      <classname>GatewayProxyFactoryBean</classname> (<code>setAsyncTaskExecutor(null)</code>). When configuring
+      the gateway with XML, use <code>async-executor=""</code>; when configuring using the
+      <classname>@MessagingGateway</classname> annotation, use:
+    </para>
+    <programlisting language="java"><![CDATA[@MessagingGateway(asyncExecutor = AnnotationConstants.NULL)
+public interface NoExecGateway {
+
+    @Gateway(requestChannel = "gatewayChannel")
+    Future<?> doAsync(String foo);
+
+}]]></programlisting>
+    <important>
+      If the return type is a specific concrete <interfacename>Future</interfacename> implementation
+      or some other subinterface that is not supported by the configured executor, the flow will
+      run on the caller's thread and the flow must return the required type in the reply message
+      payload.
+    </important>
 	<para><emphasis role="bold">Asynchronous Gateway and Reactor Promise</emphasis></para>
 	<para>
-		Starting with <emphasis>version 4.1</emphasis>, the <classname>GatewayProxyFactoryBean</classname> allows the
+		Also starting with <emphasis>version 4.1</emphasis>, the <classname>GatewayProxyFactoryBean</classname> allows the
 		use of a <classname>Reactor</classname> with gateway interface methods, utilizing a
 		<ulink url="https://github.com/reactor/reactor/wiki/Promises"><classname>Promise&lt;?&gt;</classname></ulink>
 		return type. The internal <classname>AsyncInvocationTask</classname> is wrapped in a

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -11,13 +11,13 @@
 	</para>
 	<section id="4.1-new-components">
 	<title>New Components</title>
-	<section id="4.1-promise-gateway">
-		<title>Promise&lt;?&gt; Gateway</title>
-		<para>
-			A Reactor <classname>Promise</classname> return type is now supported for Messaging Gateway methods.
-			See <xref linkend="async-gateway"/>.
-		</para>
-	</section>
+		<section id="4.1-promise-gateway">
+			<title>Promise&lt;?&gt; Gateway</title>
+			<para>
+				A Reactor <classname>Promise</classname> return type is now supported for Messaging Gateway methods.
+				See <xref linkend="async-gateway"/>.
+			</para>
+		</section>
 	</section>
 	<section id="4.1-general">
 		<title>General Changes</title>
@@ -175,6 +175,16 @@
 				The default syslog message converter now has an option to retain the original message in
 				the payload, while still setting the headers.
 				See <xref linkend="syslog-inbound-adapter"/> for more information.
+			</para>
+		</section>
+		<section id="4.1-async-gateway">
+			<title>Async Gateway</title>
+			<para>
+				In addition to the <classname>Promise</classname> return type mentioned above,
+				gateway methods may now return a <classname>ListenableFuture</classname>, introduced
+				in Spring Framework 4.0. You can also disable the async processing in the gateway,
+				allowing a downstream flow to directly return a <classname>Future</classname>.
+				See <xref linkend="async-gateway"/>.
 			</para>
 		</section>
 	</section>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3506
JIRA: https://jira.spring.io/browse/INT-3428

Support flows downstream of the gateway that support
returning a `Future<?>` payload.

Currently, any method that returns a type that is assignable
to `Future<?>` runs async and returns a `FutureTask<?>`.

This prevents a service-interface method that returns a
custom `Future<?>` object from being invoked without wrapping
that `Future<?>` in a `FutureTask<?>`.

Allow the async-executor to be set to `null` causing any method
returning `Future<?>` to run on the calling thread.

Add support for `ListenableFuture<?>`.

If the return type is a `RunnableFuture`, `ListenableFuture` or
`Future`, or exactly a `FutureTask` or `ListenableFutureTask`, run the flow
on the executor (if present); otherwise run on the calling thread.

Still needs docs.
