### PR TITLE
 	INT-3508: HTTP: Map `MessageHeaders.CONTENT_TYPE`

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -188,6 +188,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			CONNECTION,
 			CONTENT_LENGTH,
 			CONTENT_TYPE,
+			MessageHeaders.CONTENT_TYPE,
 			COOKIE,
 			DATE,
 			EXPECT,
@@ -223,6 +224,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			CONTENT_MD5,
 			CONTENT_RANGE,
 			CONTENT_TYPE,
+			MessageHeaders.CONTENT_TYPE,
 			CONTENT_DISPOSITION,
 			TRANSFER_ENCODING,
 			DATE,
@@ -380,7 +382,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 		Set<String> headerNames = source.keySet();
 		for (String name : headerNames) {
 			if (this.shouldMapInboundHeader(name)) {
-				if (!ObjectUtils.containsElement(HTTP_REQUEST_HEADER_NAMES, name) && !ObjectUtils.containsElement(HTTP_RESPONSE_HEADER_NAMES, name)) {
+				if (!containsElementIgnoreCase(HTTP_REQUEST_HEADER_NAMES, name) && !containsElementIgnoreCase(HTTP_RESPONSE_HEADER_NAMES, name)) {
 					String prefixedName = StringUtils.startsWithIgnoreCase(name, this.userDefinedHeaderPrefix) ? name :
 							this.userDefinedHeaderPrefix + name;
 					Object value = source.containsKey(prefixedName) ? this.getHttpHeader(source, prefixedName) : this.getHttpHeader(source, name);
@@ -396,6 +398,9 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 					if (value != null) {
 						if (logger.isDebugEnabled()) {
 							logger.debug(MessageFormat.format("setting headerName=[{0}], value={1}", name, value));
+						}
+						if (CONTENT_TYPE.equals(name)) {
+							name = MessageHeaders.CONTENT_TYPE;
 						}
 						this.setMessageHeader(target, name, value);
 					}
@@ -647,7 +652,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 						"Expected Number or String value for 'Content-Length' header value, but received: " + clazz);
 			}
 		}
-		else if (CONTENT_TYPE.equalsIgnoreCase(name)) {
+		else if (CONTENT_TYPE.equalsIgnoreCase(name) || MessageHeaders.CONTENT_TYPE.equalsIgnoreCase(name)) {
 			if (value instanceof MediaType) {
 				target.setContentType((MediaType) value);
 			}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -111,7 +111,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 
 	private static final String CONTENT_DISPOSITION = "Content-Disposition";
 
-	public  static final String COOKIE = "Cookie";
+	public static final String COOKIE = "Cookie";
 
 	private static final String DATE = "Date";
 
@@ -157,7 +157,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 
 	private static final String SERVER = "Server";
 
-	public  static final String SET_COOKIE = "Set-Cookie";
+	public static final String SET_COOKIE = "Set-Cookie";
 
 	private static final String TE = "TE";
 
@@ -245,9 +245,9 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			WWW_AUTHENTICATE
 	};
 
-	private static String[] HTTP_REQUEST_HEADER_NAMES_OUTBOUND_EXCLUSIONS = new String[0];
+	private static final String[] HTTP_REQUEST_HEADER_NAMES_OUTBOUND_EXCLUSIONS = new String[0];
 
-	private static String[] HTTP_RESPONSE_HEADER_NAMES_INBOUND_EXCLUSIONS = new String[] {
+	private static final String[] HTTP_RESPONSE_HEADER_NAMES_INBOUND_EXCLUSIONS = new String[] {
 			CONTENT_LENGTH, TRANSFER_ENCODING
 	};
 
@@ -283,10 +283,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	 * Provide the header names that should be mapped to an HTTP request (for outbound adapters)
 	 * or HTTP response (for inbound adapters) from a Spring Integration Message's headers.
 	 * The values can also contain simple wildcard patterns (e.g. "foo*" or "*foo") to be matched.
-	 * <p>
-	 * Any non-standard headers will be prefixed with the value specified by
+	 * <p> Any non-standard headers will be prefixed with the value specified by
 	 * {@link DefaultHttpHeaderMapper#setUserDefinedHeaderPrefix(String)}. The default is 'X-'.
-	 *
 	 * @param outboundHeaderNames The outbound header names.
 	 */
 	public void setOutboundHeaderNames(String[] outboundHeaderNames) {
@@ -297,11 +295,9 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	 * Provide the header names that should be mapped from an HTTP request (for inbound adapters)
 	 * or HTTP response (for outbound adapters) to a Spring Integration Message's headers.
 	 * The values can also contain simple wildcard patterns (e.g. "foo*" or "*foo") to be matched.
-	 * <p>
-	 * This will match the header name directly or, for non-standard HTTP headers, it will match
+	 * <p> This will match the header name directly or, for non-standard HTTP headers, it will match
 	 * the header name prefixed with the value specified by
 	 * {@link DefaultHttpHeaderMapper#setUserDefinedHeaderPrefix(String)}. The default is 'X-'.
-	 *
 	 * @param inboundHeaderNames The inbound header names.
 	 */
 	public void setInboundHeaderNames(String[] inboundHeaderNames) {
@@ -314,23 +310,24 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	 * @param excludedOutboundStandardRequestHeaderNames the excludedStandardRequestHeaderNames to set
 	 */
 	public void setExcludedOutboundStandardRequestHeaderNames(String[] excludedOutboundStandardRequestHeaderNames) {
-		Assert.notNull(excludedOutboundStandardRequestHeaderNames, "'excludedOutboundStandardRequestHeaderNames' must not be null");
+		Assert.notNull(excludedOutboundStandardRequestHeaderNames,
+				"'excludedOutboundStandardRequestHeaderNames' must not be null");
 		this.excludedOutboundStandardRequestHeaderNames = excludedOutboundStandardRequestHeaderNames;
 	}
 
 	/**
 	 * Provide header names from the list of standard headers that should be suppressed when
-	 * mapping inbound endopoint response headers.
+	 * mapping inbound endpoint response headers.
 	 * @param excludedInboundStandardResponseHeaderNames the excludedStandardResponseHeaderNames to set
 	 */
 	public void setExcludedInboundStandardResponseHeaderNames(String[] excludedInboundStandardResponseHeaderNames) {
-		Assert.notNull(excludedInboundStandardResponseHeaderNames, "'excludedInboundStandardResponseHeaderNames' must not be null");
+		Assert.notNull(excludedInboundStandardResponseHeaderNames,
+				"'excludedInboundStandardResponseHeaderNames' must not be null");
 		this.excludedInboundStandardResponseHeaderNames = excludedInboundStandardResponseHeaderNames;
 	}
 
 	/**
 	 * Sets the prefix to use with user-defined (non-standard) headers. Default is 'X-'.
-	 *
 	 * @param userDefinedHeaderPrefix The user defined header prefix.
 	 */
 	public void setUserDefinedHeaderPrefix(String userDefinedHeaderPrefix) {
@@ -344,8 +341,9 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	 */
 	@Override
 	public void fromHeaders(MessageHeaders headers, HttpHeaders target) {
-		if (logger.isDebugEnabled()){
-			logger.debug(MessageFormat.format("outboundHeaderNames={0}", CollectionUtils.arrayToList(outboundHeaderNames)));
+		if (logger.isDebugEnabled()) {
+			logger.debug(MessageFormat.format("outboundHeaderNames={0}",
+					CollectionUtils.arrayToList(outboundHeaderNames)));
 		}
 		Set<String> headerNames = headers.keySet();
 		for (String name : headerNames) {
@@ -376,16 +374,21 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	@Override
 	public Map<String, Object> toHeaders(HttpHeaders source) {
 		if (logger.isDebugEnabled()) {
-			logger.debug(MessageFormat.format("inboundHeaderNames={0}", CollectionUtils.arrayToList(inboundHeaderNames)));
+			logger.debug(MessageFormat.format("inboundHeaderNames={0}",
+					CollectionUtils.arrayToList(inboundHeaderNames)));
 		}
 		Map<String, Object> target = new HashMap<String, Object>();
 		Set<String> headerNames = source.keySet();
 		for (String name : headerNames) {
 			if (this.shouldMapInboundHeader(name)) {
-				if (!containsElementIgnoreCase(HTTP_REQUEST_HEADER_NAMES, name) && !containsElementIgnoreCase(HTTP_RESPONSE_HEADER_NAMES, name)) {
-					String prefixedName = StringUtils.startsWithIgnoreCase(name, this.userDefinedHeaderPrefix) ? name :
-							this.userDefinedHeaderPrefix + name;
-					Object value = source.containsKey(prefixedName) ? this.getHttpHeader(source, prefixedName) : this.getHttpHeader(source, name);
+				if (!containsElementIgnoreCase(HTTP_REQUEST_HEADER_NAMES, name)
+						&& !containsElementIgnoreCase(HTTP_RESPONSE_HEADER_NAMES, name)) {
+					String prefixedName = StringUtils.startsWithIgnoreCase(name, this.userDefinedHeaderPrefix)
+							? name
+							: this.userDefinedHeaderPrefix + name;
+					Object value = source.containsKey(prefixedName)
+							? this.getHttpHeader(source, prefixedName)
+							: this.getHttpHeader(source, name);
 					if (value != null) {
 						if (logger.isDebugEnabled()) {
 							logger.debug(MessageFormat.format("setting headerName=[{0}], value={1}", name, value));
@@ -412,14 +415,14 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		if (this.beanFactory != null){
+		if (this.beanFactory != null) {
 			this.conversionService = IntegrationUtils.getConversionService(this.beanFactory);
 		}
 	}
 
-	private boolean containsElementIgnoreCase(String[] headerNames, String name){
+	private boolean containsElementIgnoreCase(String[] headerNames, String name) {
 		for (String headerName : headerNames) {
-			if (headerName.equalsIgnoreCase(name)){
+			if (headerName.equalsIgnoreCase(name)) {
 				return true;
 			}
 		}
@@ -463,21 +466,24 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			for (String pattern : patterns) {
 				if (PatternMatchUtils.simpleMatch(pattern.toLowerCase(), headerName.toLowerCase())) {
 					if (logger.isDebugEnabled()) {
-						logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}", headerName, pattern));
+						logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}",
+								headerName, pattern));
 					}
 					return true;
 				}
 				else if (HTTP_REQUEST_HEADER_NAME_PATTERN.equals(pattern)
 						&& this.containsElementIgnoreCase(HTTP_REQUEST_HEADER_NAMES, headerName)) {
 					if (logger.isDebugEnabled()) {
-						logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}", headerName, pattern));
+						logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}",
+								headerName, pattern));
 					}
 					return true;
 				}
 				else if (HTTP_RESPONSE_HEADER_NAME_PATTERN.equals(pattern)
 						&& this.containsElementIgnoreCase(HTTP_RESPONSE_HEADER_NAMES, headerName)) {
 					if (logger.isDebugEnabled()) {
-						logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}", headerName, pattern));
+						logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}",
+								headerName, pattern));
 					}
 					return true;
 				}
@@ -505,7 +511,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 						else {
 							Class<?> clazz = (type != null) ? type.getClass() : null;
 							throw new IllegalArgumentException(
-									"Expected MediaType or String value for 'Accept' header value, but received: " + clazz);
+									"Expected MediaType or String value for 'Accept' header value, but received: "
+											+ clazz);
 						}
 					}
 					target.setAccept(acceptableMediaTypes);
@@ -545,7 +552,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 						else {
 							Class<?> clazz = (charset != null) ? charset.getClass() : null;
 							throw new IllegalArgumentException(
-									"Expected Charset or String value for 'Accept-Charset' header value, but received: " + clazz);
+									"Expected Charset or String value for 'Accept-Charset' header value, but received: "
+											+ clazz);
 						}
 					}
 					target.setAcceptCharset(acceptableCharsets);
@@ -596,7 +604,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 						else {
 							Class<?> clazz = (method != null) ? method.getClass() : null;
 							throw new IllegalArgumentException(
-									"Expected HttpMethod or String value for 'Allow' header value, but received: " + clazz);
+									"Expected HttpMethod or String value for 'Allow' header value, but received: "
+											+ clazz);
 						}
 					}
 					target.setAllow(allowedMethods);
@@ -608,9 +617,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 				}
 				else if (value instanceof HttpMethod[]) {
 					Set<HttpMethod> allowedMethods = new HashSet<HttpMethod>();
-					for (HttpMethod next : (HttpMethod[]) value) {
-						allowedMethods.add(next);
-					}
+					Collections.addAll(allowedMethods, (HttpMethod[]) value);
 					target.setAllow(allowedMethods);
 				}
 				else if (value instanceof String || value instanceof String[]) {
@@ -735,7 +742,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			else {
 				Class<?> clazz = (value != null) ? value.getClass() : null;
 				throw new IllegalArgumentException(
-						"Expected Date, Number, or String value for 'If-Modified-Since' header value, but received: " + clazz);
+						"Expected Date, Number, or String value for 'If-Modified-Since' header value, but received: "
+								+ clazz);
 			}
 		}
 		else if (IF_UNMODIFIED_SINCE.equalsIgnoreCase(name)) {
@@ -758,7 +766,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			else {
 				Class<?> clazz = (value != null) ? value.getClass() : null;
 				throw new IllegalArgumentException(
-						"Expected Date, Number, or String value for 'If-Unmodified-Since' header value, but received: " + clazz);
+						"Expected Date, Number, or String value for 'If-Unmodified-Since' header value, but received: "
+								+ clazz);
 			}
 			target.set(IF_UNMODIFIED_SINCE, ifUnmodifiedSinceValue);
 		}
@@ -806,7 +815,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			else {
 				Class<?> clazz = (value != null) ? value.getClass() : null;
 				throw new IllegalArgumentException(
-						"Expected Date, Number, or String value for 'Last-Modified' header value, but received: " + clazz);
+						"Expected Date, Number, or String value for 'Last-Modified' header value, but received: "
+								+ clazz);
 			}
 		}
 		else if (LOCATION.equalsIgnoreCase(name)) {
@@ -854,13 +864,13 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 				else {
 					convertedValue = this.convertToString(value);
 				}
-				if (StringUtils.hasText(convertedValue)){
-					target.add(name, (String) next);
+				if (StringUtils.hasText(convertedValue)) {
+					target.add(name, convertedValue);
 				}
 				else {
 					logger.warn("Element of the header '" + name + "' with value '" + value +
-							"' will not be set since it is not a String and no Converter " +
-							"is available. Consider registering a Converter with ConversionService (e.g., <int:converter>)");
+							"' will not be set since it is not a String and no Converter is available. " +
+							"Consider registering a Converter with ConversionService (e.g., <int:converter>)");
 				}
 			}
 		}
@@ -871,8 +881,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			}
 			else {
 				logger.warn("Header '" + name + "' with value '" + value +
-						"' will not be set since it is not a String and no Converter " +
-						"is available. Consider registering a Converter with ConversionService (e.g., <int:converter>)");
+						"' will not be set since it is not a String and no Converter is available. " +
+						"Consider registering a Converter with ConversionService (e.g., <int:converter>)");
 			}
 		}
 	}
@@ -912,7 +922,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 				return (expires > -1) ? expires : null;
 			}
 			catch (Exception e) {
-				if(logger.isDebugEnabled()) {
+				if (logger.isDebugEnabled()) {
 					logger.debug(e.getMessage());
 				}
 				// According to RFC 2616
@@ -972,9 +982,10 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 		}
 	}
 
-	private String convertToString(Object value){
+	private String convertToString(Object value) {
 		if (this.conversionService != null &&
-				this.conversionService.canConvert(TypeDescriptor.forObject(value), TypeDescriptor.valueOf(String.class))){
+				this.conversionService.canConvert(TypeDescriptor.forObject(value),
+						TypeDescriptor.valueOf(String.class))) {
 			return this.conversionService.convert(value, String.class);
 		}
 		return null;
@@ -993,7 +1004,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 				// ignore
 			}
 		}
-		throw new IllegalArgumentException("Cannot parse date value '" + headerValue +"' for '" + headerName + "' header");
+		throw new IllegalArgumentException("Cannot parse date value '" + headerValue + "' for '" + headerName
+				+ "' header");
 	}
 
 	private String formatDate(long date) {
@@ -1006,7 +1018,6 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	 * Factory method for creating a basic outbound mapper instance.
 	 * This will map all standard HTTP request headers when sending an HTTP request,
 	 * and it will map all standard HTTP response headers when receiving an HTTP response.
-	 *
 	 * @return The default outbound mapper.
 	 */
 	public static DefaultHttpHeaderMapper outboundMapper() {
@@ -1021,7 +1032,6 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	 * Factory method for creating a basic inbound mapper instance.
 	 * This will map all standard HTTP request headers when receiving an HTTP request,
 	 * and it will map all standard HTTP response headers when sending an HTTP response.
-	 *
 	 * @return The default inbound mapper.
 	 */
 	public static DefaultHttpHeaderMapper inboundMapper() {

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -211,7 +211,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			WARNING
 	};
 
-	private static String[] HTTP_RESPONSE_HEADER_NAMES = new String[] {
+	private static final String[] HTTP_RESPONSE_HEADER_NAMES = new String[] {
 			ACCEPT_RANGES,
 			AGE,
 			ALLOW,
@@ -659,7 +659,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 						"Expected Number or String value for 'Content-Length' header value, but received: " + clazz);
 			}
 		}
-		else if (CONTENT_TYPE.equalsIgnoreCase(name) || MessageHeaders.CONTENT_TYPE.equalsIgnoreCase(name)) {
+		else if (MessageHeaders.CONTENT_TYPE.equalsIgnoreCase(name)) {
 			if (value instanceof MediaType) {
 				target.setContentType((MediaType) value);
 			}

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:int="http://www.springframework.org/schema/integration"
-	xmlns:int-http="http://www.springframework.org/schema/integration/http"
-	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int="http://www.springframework.org/schema/integration"
+	   xmlns:int-http="http://www.springframework.org/schema/integration/http"
+	   xmlns:util="http://www.springframework.org/schema/util"
+	   xsi:schemaLocation="http://www.springframework.org/schema/integration/http
+	    http://www.springframework.org/schema/integration/http/spring-integration-http.xsd
+		http://www.springframework.org/schema/integration
+		http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util
+		http://www.springframework.org/schema/util/spring-util.xsd">
 
-	<bean id="portBean" class="org.springframework.integration.http.config.OutboundResponseTypeTests$Port" />
+	<bean id="portBean" class="org.springframework.integration.http.config.OutboundResponseTypeTests$Port"/>
 
 	<int-http:outbound-gateway url="http://localhost:#{portBean.port}/testApps/outboundResponse"
 							   request-channel="requestChannel"
@@ -47,8 +51,8 @@
 
 
 	<util:list id="stringAndSerializingConverters">
-		<bean class="org.springframework.integration.http.converter.SerializingHttpMessageConverter" />
-		<bean class="org.springframework.http.converter.StringHttpMessageConverter" />
+		<bean class="org.springframework.integration.http.converter.SerializingHttpMessageConverter"/>
+		<bean class="org.springframework.http.converter.StringHttpMessageConverter"/>
 	</util:list>
 
 	<int:channel id="replyChannel">

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests-context.xml
@@ -40,6 +40,11 @@
 							   request-channel="invalidResponseTypeChannel"
 							   expected-response-type-expression="new java.util.Date()"/>
 
+	<int:chain input-channel="contentTypePropagationChannel" output-channel="nullChannel">
+		<int:object-to-json-transformer/>
+		<int-http:outbound-gateway url="http://localhost:#{portBean.port}/testApps/outboundResponse"/>
+	</int:chain>
+
 
 	<util:list id="stringAndSerializingConverters">
 		<bean class="org.springframework.integration.http.converter.SerializingHttpMessageConverter" />

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.integration.http.config;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -23,6 +24,8 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.Map;
 
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
@@ -30,24 +33,25 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.test.util.SocketUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
 
 /**
  * @author Oleg Zhurakousky
@@ -86,6 +90,9 @@ public class OutboundResponseTypeTests {
 
 	@Autowired
 	private MessageChannel invalidResponseTypeChannel;
+
+	@Autowired
+	private MessageChannel contentTypePropagationChannel;
 
 	private static int port = SocketUtils.findAvailableServerSocket();
 
@@ -177,9 +184,18 @@ public class OutboundResponseTypeTests {
 		}
 	}
 
+	@Test
+	public void testContentTypePropagation() throws Exception {
+		this.contentTypePropagationChannel
+				.send(new GenericMessage<Map<String, String>>(Collections.singletonMap("foo", "bar")));
+		assertEquals(MediaType.APPLICATION_JSON.toString(), httpHandler.requestHeaders.getFirst("Content-Type"));
+	}
+
 	static class MyHandler implements HttpHandler {
 
 		private String httpMethod = "POST";
+
+		private volatile Headers requestHeaders;
 
 		public void setHttpMethod(String httpMethod) {
 			this.httpMethod = httpMethod;
@@ -187,6 +203,7 @@ public class OutboundResponseTypeTests {
 
 		public void handle(HttpExchange t) throws IOException {
 			String requestMethod = t.getRequestMethod();
+			requestHeaders = t.getRequestHeaders();
 			String response = null;
 			if (requestMethod.equalsIgnoreCase(this.httpMethod)) {
 				response = httpMethod;

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/OutboundResponseTypeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,8 +167,8 @@ public class OutboundResponseTypeTests {
 			assertThat(e, Matchers.instanceOf(MessageHandlingException.class));
 			Throwable t = e.getCause();
 			assertThat(t, Matchers.instanceOf(IllegalArgumentException.class));
-			assertThat(t.getMessage(),
-					Matchers.containsString("'expectedResponseType' can be an instance of 'Class<?>', 'String' or 'ParameterizedTypeReference<?>'"));
+			assertThat(t.getMessage(), Matchers.containsString("'expectedResponseType' can be an instance of " +
+					"'Class<?>', 'String' or 'ParameterizedTypeReference<?>'"));
 		}
 	}
 
@@ -180,7 +180,8 @@ public class OutboundResponseTypeTests {
 		}
 		catch (BeansException e) {
 			assertTrue(e instanceof BeanDefinitionParsingException);
-			assertTrue(e.getMessage().contains("The 'expected-response-type' and 'expected-response-type-expression' are mutually exclusive"));
+			assertTrue(e.getMessage().contains("The 'expected-response-type' " +
+					"and 'expected-response-type-expression' are mutually exclusive"));
 		}
 	}
 
@@ -219,6 +220,7 @@ public class OutboundResponseTypeTests {
 			os.write(response.getBytes());
 			os.close();
 		}
+
 	}
 
 	public static class Port {

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -37,11 +38,10 @@ import org.junit.Test;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.util.CollectionUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 
 /**
  * @author Oleg Zhurakousky
@@ -53,9 +53,9 @@ import org.springframework.util.CollectionUtils;
 public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 
 	// ACCEPT tests
-	@Test(expected=IllegalArgumentException.class)
-	public void validateAcceptHeaderWithNoSlash(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	@Test(expected = IllegalArgumentException.class)
+	public void validateAcceptHeaderWithNoSlash() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Accept", "bar");
 		HttpHeaders headers = new HttpHeaders();
@@ -64,8 +64,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptHeaderSingleString(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptHeaderSingleString() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Accept", "bar/foo");
 
@@ -77,8 +77,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptHeaderSingleMediaType(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptHeaderSingleMediaType() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Accept", new MediaType("bar", "foo"));
 
@@ -90,8 +90,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptHeaderMultipleAsDelimitedString(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptHeaderMultipleAsDelimitedString() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Accept", "bar/foo, text/xml");
 		HttpHeaders headers = new HttpHeaders();
@@ -103,10 +103,10 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptHeaderMultipleAsStringArray(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptHeaderMultipleAsStringArray() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("Accept", new String[]{"bar/foo", "text/xml"});
+		messageHeaders.put("Accept", new String[] {"bar/foo", "text/xml"});
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -116,10 +116,10 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptHeaderMultipleAsStringCollection(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptHeaderMultipleAsStringCollection() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("Accept", CollectionUtils.arrayToList(new String[]{"bar/foo", "text/xml"}));
+		messageHeaders.put("Accept", Arrays.asList("bar/foo", "text/xml"));
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -129,10 +129,10 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptHeaderMultipleAsStringCollectionCaseInsensitive(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptHeaderMultipleAsStringCollectionCaseInsensitive() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("acCePt", CollectionUtils.arrayToList(new String[]{"bar/foo", "text/xml"}));
+		messageHeaders.put("acCePt", Arrays.asList("bar/foo", "text/xml"));
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -142,11 +142,10 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptHeaderMultipleAsMediatypeCollection(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptHeaderMultipleAsMediatypeCollection() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("Accept",
-				CollectionUtils.arrayToList(new MediaType[]{new MediaType("bar", "foo"), new MediaType("text", "xml")}));
+		messageHeaders.put("Accept", Arrays.asList(new MediaType("bar", "foo"), new MediaType("text", "xml")));
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -157,9 +156,9 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 
 	// ACCEPT_CHARSET tests
 
-	@Test(expected=UnsupportedCharsetException.class)
-	public void validateAcceptCharsetHeaderWithWrongCharset(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	@Test(expected = UnsupportedCharsetException.class)
+	public void validateAcceptCharsetHeaderWithWrongCharset() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Accept-Charset", "foo");
 		HttpHeaders headers = new HttpHeaders();
@@ -167,8 +166,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptCharsetHeaderSingleString(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptCharsetHeaderSingleString() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Accept-Charset", "UTF-8");
 		HttpHeaders headers = new HttpHeaders();
@@ -179,8 +178,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptCharsetHeaderSingleCharset(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptCharsetHeaderSingleCharset() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Accept-Charset", Charset.forName("UTF-8"));
 		HttpHeaders headers = new HttpHeaders();
@@ -191,8 +190,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptCharsetHeaderMultipleAsDelimitedString(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptCharsetHeaderMultipleAsDelimitedString() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Accept-Charset", "UTF-8, ISO-8859-1");
 		HttpHeaders headers = new HttpHeaders();
@@ -205,10 +204,10 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptCharsetHeaderMultipleAsStringArray(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptCharsetHeaderMultipleAsStringArray() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("Accept-Charset", new String[]{"UTF-8", "ISO-8859-1"});
+		messageHeaders.put("Accept-Charset", new String[] {"UTF-8", "ISO-8859-1"});
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -219,10 +218,10 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptCharsetHeaderMultipleAsCharsetArray(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptCharsetHeaderMultipleAsCharsetArray() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("Accept-Charset", new Charset[]{ Charset.forName("UTF-8"), Charset.forName("ISO-8859-1") });
+		messageHeaders.put("Accept-Charset", new Charset[] {Charset.forName("UTF-8"), Charset.forName("ISO-8859-1")});
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -233,10 +232,10 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptCharsetHeaderMultipleAsCollectionOfStrings(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptCharsetHeaderMultipleAsCollectionOfStrings() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("Accept-Charset", CollectionUtils.arrayToList(new String[]{"UTF-8", "ISO-8859-1"}));
+		messageHeaders.put("Accept-Charset", Arrays.asList("UTF-8", "ISO-8859-1"));
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -247,11 +246,10 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateAcceptCharsetHeaderMultipleAsCollectionOfCharsets(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateAcceptCharsetHeaderMultipleAsCollectionOfCharsets() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("Accept-Charset",
-				CollectionUtils.arrayToList(new Charset[]{Charset.forName("UTF-8"), Charset.forName("ISO-8859-1")}));
+		messageHeaders.put("Accept-Charset", Arrays.asList(Charset.forName("UTF-8"), Charset.forName("ISO-8859-1")));
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -264,8 +262,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	// Cache-Control tests
 
 	@Test
-	public void validateCacheControl(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateCacheControl() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Cache-Control", "foo");
 		HttpHeaders headers = new HttpHeaders();
@@ -277,8 +275,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	// Content-Length tests
 
 	@Test
-	public void validateContentLengthAsString(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateContentLengthAsString() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Content-Length", "1");
 		HttpHeaders headers = new HttpHeaders();
@@ -288,8 +286,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateContentLengthAsNumber(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateContentLengthAsNumber() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Content-Length", 1);
 		HttpHeaders headers = new HttpHeaders();
@@ -298,9 +296,9 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 		assertEquals(1, headers.getContentLength());
 	}
 
-	@Test(expected=NumberFormatException.class)
-	public void validateContentLengthAsNonNumericString(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	@Test(expected = NumberFormatException.class)
+	public void validateContentLengthAsNonNumericString() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Content-Length", "foo");
 		HttpHeaders headers = new HttpHeaders();
@@ -310,9 +308,9 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 
 	// Content-Type test
 
-	@Test(expected=IllegalArgumentException.class)
-	public void validateContentTypeWrongValue(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	@Test(expected = IllegalArgumentException.class)
+	public void validateContentTypeWrongValue() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Content-Type", "foo");
 		HttpHeaders headers = new HttpHeaders();
@@ -321,8 +319,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateContentTypeAsString(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateContentTypeAsString() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Content-Type", "text/html");
 		HttpHeaders headers = new HttpHeaders();
@@ -333,8 +331,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateContentTypeAsMediaType(){
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateContentTypeAsMediaType() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put(MessageHeaders.CONTENT_TYPE, new MediaType("text", "html"));
 		HttpHeaders headers = new HttpHeaders();
@@ -347,8 +345,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	// Date test
 
 	@Test
-	public void validateDateAsNumber() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateDateAsNumber() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Date", 12345678);
 		HttpHeaders headers = new HttpHeaders();
@@ -360,8 +358,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateDateAsString() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateDateAsString() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Date", "12345678");
 		HttpHeaders headers = new HttpHeaders();
@@ -371,9 +369,10 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 
 		assertEquals(simpleDateFormat.parse("Thu, 01 Jan 1970 03:25:45 GMT").getTime(), headers.getDate());
 	}
+
 	@Test
-	public void validateDateAsDate() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateDateAsDate() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Date", new Date(12345678));
 		HttpHeaders headers = new HttpHeaders();
@@ -387,8 +386,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	// If-Modified-Since tests
 
 	@Test
-	public void validateIfModifiedSinceAsNumber() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateIfModifiedSinceAsNumber() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("If-Modified-Since", 12345678);
 		HttpHeaders headers = new HttpHeaders();
@@ -400,8 +399,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateIfModifiedSinceAsString() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateIfModifiedSinceAsString() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("If-Modified-Since", "12345678");
 		HttpHeaders headers = new HttpHeaders();
@@ -411,9 +410,10 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 
 		assertEquals(simpleDateFormat.parse("Thu, 01 Jan 1970 03:25:45 GMT").getTime(), headers.getIfModifiedSince());
 	}
+
 	@Test
-	public void validateIfModifiedSinceAsDate() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateIfModifiedSinceAsDate() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("If-Modified-Since", new Date(12345678));
 		HttpHeaders headers = new HttpHeaders();
@@ -427,8 +427,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	// If-None-Match
 
 	@Test
-	public void validateIfNoneMatch() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateIfNoneMatch() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("If-None-Match", "1234567");
 		HttpHeaders headers = new HttpHeaders();
@@ -439,8 +439,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateIfNoneMatchAsDelimitedString() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateIfNoneMatchAsDelimitedString() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("If-None-Match", "1234567, 123");
 		HttpHeaders headers = new HttpHeaders();
@@ -452,10 +452,10 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateIfNoneMatchAsStringArray() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateIfNoneMatchAsStringArray() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("If-None-Match", new String[]{"1234567", "123"});
+		messageHeaders.put("If-None-Match", new String[] {"1234567", "123"});
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
 
@@ -465,8 +465,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateIfNoneMatchAsCommaDelimitedString() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateIfNoneMatchAsCommaDelimitedString() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("If-None-Match", "1234567, 123");
 		HttpHeaders headers = new HttpHeaders();
@@ -478,10 +478,10 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateIfNoneMatchAsStringCollection() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateIfNoneMatchAsStringCollection() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("If-None-Match", CollectionUtils.arrayToList(new String[]{"1234567", "123"}));
+		messageHeaders.put("If-None-Match", Arrays.asList("1234567", "123"));
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
 
@@ -492,8 +492,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 
 	// Pragma tests
 	@Test
-	public void validatePragma() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validatePragma() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Pragma", "foo");
 		HttpHeaders headers = new HttpHeaders();
@@ -503,8 +503,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 
 	// Transfer-Encoding tests
 	@Test
-	public void validateTransferEncoding() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateTransferEncoding() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("Transfer-Encoding", "chunked");
 		HttpHeaders headers = new HttpHeaders();
@@ -513,8 +513,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateTransferEncodingToHeaders() throws ParseException{
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+	public void validateTransferEncodingToHeaders() throws ParseException {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 
 		HttpHeaders httpHeaders = new HttpHeaders();
 		httpHeaders.set("Transfer-Encoding", "chunked");
@@ -527,8 +527,8 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	// Custom headers
 
 	@Test
-	public void validateCustomHeaderWithNoHeaderNames() throws ParseException{
-		DefaultHttpHeaderMapper mapper  = new DefaultHttpHeaderMapper();
+	public void validateCustomHeaderWithNoHeaderNames() throws ParseException {
+		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("foo", "foo");
 		HttpHeaders headers = new HttpHeaders();
@@ -538,9 +538,9 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateCustomHeaderWithHeaderNames() throws ParseException{
-		DefaultHttpHeaderMapper mapper  = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[]{"foo"});
+	public void validateCustomHeaderWithHeaderNames() throws ParseException {
+		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
+		mapper.setOutboundHeaderNames(new String[] {"foo"});
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("foo", "foo");
 		HttpHeaders headers = new HttpHeaders();
@@ -552,9 +552,9 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateCustomHeaderWithHeaderNamePatterns() throws ParseException{
-		DefaultHttpHeaderMapper mapper  = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[]{"x*", "*z", "a*f"});
+	public void validateCustomHeaderWithHeaderNamePatterns() throws ParseException {
+		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
+		mapper.setOutboundHeaderNames(new String[] {"x*", "*z", "a*f"});
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("x1", "x1-value");
 		messageHeaders.put("1x", "1x-value");
@@ -579,9 +579,9 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateCustomHeaderWithHeaderNamePatternsAndStandardRequestHeaders() throws ParseException{
-		DefaultHttpHeaderMapper mapper  = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[]{"foo*", "HTTP_REQUEST_HEADERS"});
+	public void validateCustomHeaderWithHeaderNamePatternsAndStandardRequestHeaders() throws ParseException {
+		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
+		mapper.setOutboundHeaderNames(new String[] {"foo*", "HTTP_REQUEST_HEADERS"});
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
 		messageHeaders.put("foobar", "abc");
 		messageHeaders.put("Content-Type", "text/html");
@@ -597,9 +597,9 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateCustomHeaderWithHeaderNamePatternsAndStandardResponseHeaders() throws ParseException{
-		DefaultHttpHeaderMapper mapper  = new DefaultHttpHeaderMapper();
-		mapper.setInboundHeaderNames(new String[]{"foo*", "HTTP_RESPONSE_HEADERS"});
+	public void validateCustomHeaderWithHeaderNamePatternsAndStandardResponseHeaders() throws ParseException {
+		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
+		mapper.setInboundHeaderNames(new String[] {"foo*", "HTTP_RESPONSE_HEADERS"});
 		HttpHeaders httpHeaders = new HttpHeaders();
 		httpHeaders.set("foobar", "abc");
 		httpHeaders.setContentType(MediaType.TEXT_HTML);
@@ -612,7 +612,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateCustomHeaderWithStandardPrefix() throws Exception{
+	public void validateCustomHeaderWithStandardPrefix() throws Exception {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
 		mapper.setInboundHeaderNames(new String[] {"X-Foo"});
 		HttpHeaders headers = new HttpHeaders();
@@ -623,7 +623,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateCustomHeaderWithStandardPrefixSameCase() throws Exception{
+	public void validateCustomHeaderWithStandardPrefixSameCase() throws Exception {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
 		mapper.setInboundHeaderNames(new String[] {"X-Foo"});
 		HttpHeaders headers = new HttpHeaders();
@@ -632,38 +632,40 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 		assertEquals(1, result.size());
 		assertEquals("x-foo-value", result.get("X-Foo"));
 	}
-	@Test
-    public void validateCustomHeaderCaseInsensitivity() throws ParseException{
-            DefaultHttpHeaderMapper mapper  = new DefaultHttpHeaderMapper();
-            mapper.setOutboundHeaderNames(new String[]{"*", "HTTP_REQUEST_HEADERS"});
-            Map<String, Object> messageHeaders = new HashMap<String, Object>();
-            messageHeaders.put("foobar", "abc");
-            messageHeaders.put("X-bar", "xbar");
-            messageHeaders.put("x-baz", "xbaz");
-            messageHeaders.put("Content-Type", "text/html");
-            messageHeaders.put("Accept", "text/xml");
-            HttpHeaders headers = new HttpHeaders();
-            mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-            assertEquals(5, headers.size());
-            assertEquals(1, headers.get("X-foobar").size());
-            assertEquals(1, headers.get("x-foobar").size());
-            assertEquals(1, headers.get("X-bar").size());
-            assertEquals(1, headers.get("x-bar").size());
-            assertEquals(1, headers.get("X-baz").size());
-            assertEquals(1, headers.get("x-baz").size());
-    }
-    @Test
-    public void dontPropagateContentLength() {
-        DefaultHttpHeaderMapper mapper  = DefaultHttpHeaderMapper.outboundMapper();
-        // not suppressed on outbound request, by default
-        mapper.setExcludedOutboundStandardRequestHeaderNames(new String[] {"Content-Length"});
-        Map<String, Object> messageHeaders = new HashMap<String, Object>();
-        messageHeaders.put("Content-Length", 4);
 
-        HttpHeaders headers = new HttpHeaders();
-        mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-        assertNull(headers.get("Content-Length"));
-    }
+	@Test
+	public void validateCustomHeaderCaseInsensitivity() throws ParseException {
+		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
+		mapper.setOutboundHeaderNames(new String[] {"*", "HTTP_REQUEST_HEADERS"});
+		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		messageHeaders.put("foobar", "abc");
+		messageHeaders.put("X-bar", "xbar");
+		messageHeaders.put("x-baz", "xbaz");
+		messageHeaders.put("Content-Type", "text/html");
+		messageHeaders.put("Accept", "text/xml");
+		HttpHeaders headers = new HttpHeaders();
+		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
+		assertEquals(5, headers.size());
+		assertEquals(1, headers.get("X-foobar").size());
+		assertEquals(1, headers.get("x-foobar").size());
+		assertEquals(1, headers.get("X-bar").size());
+		assertEquals(1, headers.get("x-bar").size());
+		assertEquals(1, headers.get("X-baz").size());
+		assertEquals(1, headers.get("x-baz").size());
+	}
+
+	@Test
+	public void dontPropagateContentLength() {
+		DefaultHttpHeaderMapper mapper = DefaultHttpHeaderMapper.outboundMapper();
+		// not suppressed on outbound request, by default
+		mapper.setExcludedOutboundStandardRequestHeaderNames(new String[] {"Content-Length"});
+		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		messageHeaders.put("Content-Length", 4);
+
+		HttpHeaders headers = new HttpHeaders();
+		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
+		assertNull(headers.get("Content-Length"));
+	}
 
 	@Test
 	public void testInt3063InvalidExpiresHeader() {
@@ -674,13 +676,13 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void testInt2995IfModifiedSince() throws Exception{
+	public void testInt2995IfModifiedSince() throws Exception {
 		Date ifModifiedSince = new Date();
 		SimpleDateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss yyyy", Locale.US);
 		dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
 		String value = dateFormat.format(ifModifiedSince);
 		Message<?> testMessage = MessageBuilder.withPayload("foo").setHeader("If-Modified-Since", value).build();
-		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(testMessage.getHeaders(), headers);
 		Calendar c = Calendar.getInstance();
@@ -690,7 +692,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void testContentDispositionHeader() throws Exception{
+	public void testContentDispositionHeader() throws Exception {
 		HttpHeaders headers = new HttpHeaders();
 		String headerValue = "attachment; filename=\"test.txt\"";
 		headers.set("Content-Disposition", headerValue);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
@@ -336,7 +336,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	public void validateContentTypeAsMediaType(){
 		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("Content-Type", new MediaType("text", "html"));
+		messageHeaders.put(MessageHeaders.CONTENT_TYPE, new MediaType("text", "html"));
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -608,7 +608,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 		assertEquals(2, messageHeaders.size());
 		assertNull(messageHeaders.get("Accept"));
 		assertEquals("abc", messageHeaders.get("foobar"));
-		assertEquals("text/html", messageHeaders.get("Content-Type").toString());
+		assertEquals("text/html", messageHeaders.get(MessageHeaders.CONTENT_TYPE).toString());
 	}
 
 	@Test

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
@@ -312,7 +312,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	public void validateContentTypeWrongValue() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("Content-Type", "foo");
+		messageHeaders.put(MessageHeaders.CONTENT_TYPE, "foo");
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3508

Before SI 4.0 and moving `MessageHeaders` to the Spring Messaging the `MessageHeaders.CONTENT_TYPE` had a value as `content-type`,
which was mapped to the HTTP Header `Content-Type` well.
Starting with SF 4.0 `MessageHeaders.CONTENT_TYPE` has a value `contentType`. It doesn't allow to map HTTP headers properly.
- Add `contentType` mapping logic to the `DefaultHttpHeaderMapper`, to map to the `Content-Type` HTTP header and vice versa.
- Fix bug in the `DefaultHttpHeaderMapper#toHeaders`: `ObjectUtils.containsElement` -> `containsElementIgnoreCase`.
  Some HTTP servers can return `Content-Type` as `Content-type` or even `content-type`, although it is `Content-Type` anyway.
- Add test-case with `<int:object-to-json-transformer/>`, when the `application/json` value from `MessageHeaders.CONTENT_TYPE` is properly
  mapped to the HTTP `Content-Type`. Previously this fix we had to remap `MessageHeaders.CONTENT_TYPE` to the `Content-Type` manually using `<header-enricher>`

The second commit is about code reformatting for affected classes
