### PR TITLE
INT-3517: Fix HTTP rome dep logic accord SF in CP

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -181,7 +181,7 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 		}
 		//The 'rometools' has been introduced since Spring Framework 4.1, hence we should check the version
 		// of Spring Framework using the class 'org.springframework.http.RequestEntity' from that version.
-		if ((spring41Present && romeToolsPresent) || romePresent) {
+		if ((spring41Present && romeToolsPresent) || (!spring41Present && romePresent)) {
 			this.defaultMessageConverters.add(new AtomFeedHttpMessageConverter());
 			this.defaultMessageConverters.add(new RssChannelHttpMessageConverter());
 			if (logger.isDebugEnabled()) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3517

Note: this fix doesn't make sence for master, because it is fully based on SF 4.1.

Maybe there is a reason to get rid of `rome` for master at all and just rely on the SF 4.1 line ?
