### PR TITLE
Update spring-integration-mqtt-4.1.xsd

### DIFF
--- a/spring-integration-mqtt/src/main/resources/org/springframework/integration/mqtt/config/xml/spring-integration-mqtt-4.1.xsd
+++ b/spring-integration-mqtt/src/main/resources/org/springframework/integration/mqtt/config/xml/spring-integration-mqtt-4.1.xsd
@@ -232,7 +232,7 @@
 						override the defaults. Default is DefaultMqttClientFactory.
 					]]></xsd:documentation>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.integration.mqtt.support.MqttMessageConverter" />
+						<tool:expected-type type="org.springframework.integration.mqtt.core.MqttPahoClientFactory" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>


### PR DESCRIPTION
seems a bug that client-factory should be a type of org.springframework.integration.mqtt.core.MqttPahoClientFactory rather than org.springframework.integration.mqtt.support.MqttMessageConverter since Default is DefaultMqttClientFactory.
