### PR TITLE
INT-3524 Fix Tooling MessageChannel References

### DIFF
--- a/spring-integration-feed/src/main/resources/org/springframework/integration/feed/config/spring-integration-feed-4.1.xsd
+++ b/spring-integration-feed/src/main/resources/org/springframework/integration/feed/config/spring-integration-feed-4.1.xsd
@@ -35,7 +35,7 @@
 				<xsd:annotation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.MessageChannel" />
+							<tool:expected-type type="org.springframework.messaging.MessageChannel" />
 						</tool:annotation>
 					</xsd:appinfo>
 					<xsd:documentation>

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-4.1.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-4.1.xsd
@@ -316,7 +316,7 @@
 			<xsd:annotation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						<tool:expected-type type="org.springframework.messaging.MessageChannel" />
 					</tool:annotation>
 				</xsd:appinfo>
 				<xsd:documentation>

--- a/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-4.1.xsd
+++ b/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-4.1.xsd
@@ -284,7 +284,7 @@
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
 							<tool:expected-type
-								type="org.springframework.integration.MessageChannel" />
+								type="org.springframework.messaging.MessageChannel" />
 						</tool:annotation>
 					</xsd:appinfo>
 					<xsd:documentation>
@@ -735,7 +735,7 @@
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
 							<tool:expected-type
-								type="org.springframework.integration.MessageChannel" />
+								type="org.springframework.messaging.MessageChannel" />
 						</tool:annotation>
 					</xsd:appinfo>
 					<xsd:documentation>

--- a/spring-integration-mqtt/src/main/resources/org/springframework/integration/mqtt/config/xml/spring-integration-mqtt-4.1.xsd
+++ b/spring-integration-mqtt/src/main/resources/org/springframework/integration/mqtt/config/xml/spring-integration-mqtt-4.1.xsd
@@ -105,7 +105,7 @@
 								to be executed.
 							</xsd:documentation>
 							<tool:annotation kind="ref">
-								<tool:expected-type type="org.springframework.integration.MessageChannel" />
+								<tool:expected-type type="org.springframework.messaging.MessageChannel" />
 							</tool:annotation>
 						</xsd:appinfo>
 					</xsd:annotation>

--- a/spring-integration-rmi/src/main/resources/org/springframework/integration/rmi/config/spring-integration-rmi-4.1.xsd
+++ b/spring-integration-rmi/src/main/resources/org/springframework/integration/rmi/config/spring-integration-rmi-4.1.xsd
@@ -53,7 +53,7 @@
 						<xsd:annotation>
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
-									<tool:expected-type type="org.springframework.integration.MessageChannel"/>
+									<tool:expected-type type="org.springframework.messaging.MessageChannel"/>
 								</tool:annotation>
 							</xsd:appinfo>
 							<xsd:documentation>

--- a/spring-integration-syslog/src/main/resources/org/springframework/integration/syslog/config/spring-integration-syslog-4.1.xsd
+++ b/spring-integration-syslog/src/main/resources/org/springframework/integration/syslog/config/spring-integration-syslog-4.1.xsd
@@ -58,7 +58,7 @@
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
 							<tool:expected-type
-								type="org.springframework.integration.MessageChannel" />
+								type="org.springframework.messaging.MessageChannel" />
 						</tool:annotation>
 					</xsd:appinfo>
 					<xsd:documentation>

--- a/spring-integration-twitter/src/main/resources/org/springframework/integration/twitter/config/spring-integration-twitter-4.1.xsd
+++ b/spring-integration-twitter/src/main/resources/org/springframework/integration/twitter/config/spring-integration-twitter-4.1.xsd
@@ -235,7 +235,7 @@
 			<xsd:annotation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.integration.MessageChannel" />
+						<tool:expected-type type="org.springframework.messaging.MessageChannel" />
 					</tool:annotation>
 				</xsd:appinfo>
 				<xsd:documentation>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3524

A number of references (expected-type) still referred to
the Spring Integration 3.0 MessageChanel.
