### PR TITLE
INT-3526 Used Expanded URI In Exception Message

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -397,6 +397,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 	protected Object handleRequestMessage(Message<?> requestMessage) {
 		String uri = this.uriExpression.getValue(this.evaluationContext, requestMessage, String.class);
 		Assert.notNull(uri, "URI Expression evaluation cannot result in null");
+		URI realUri = null;
 		try {
 			HttpMethod httpMethod = this.determineHttpMethod(requestMessage);
 
@@ -412,7 +413,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 			HttpEntity<?> httpRequest = this.generateHttpRequest(requestMessage, httpMethod);
 			Map<String, ?> uriVariables = this.determineUriVariables(requestMessage);
 			UriComponents uriComponents = UriComponentsBuilder.fromUriString(uri).buildAndExpand(uriVariables);
-			URI realUri = this.encodeUri ? uriComponents.toUri() : new URI(uriComponents.toUriString());
+			realUri = this.encodeUri ? uriComponents.toUri() : new URI(uriComponents.toUriString());
 			ResponseEntity<?> httpResponse;
 			if (expectedResponseType instanceof ParameterizedTypeReference<?>) {
 				httpResponse = this.restTemplate.exchange(realUri, httpMethod, httpRequest, (ParameterizedTypeReference<?>) expectedResponseType);
@@ -445,7 +446,9 @@ public class HttpRequestExecutingMessageHandler extends AbstractReplyProducingMe
 			throw e;
 		}
 		catch (Exception e) {
-			throw new MessageHandlingException(requestMessage, "HTTP request execution failed for URI [" + uri + "]", e);
+			throw new MessageHandlingException(requestMessage, "HTTP request execution failed for URI ["
+					+ (realUri == null ? uri : realUri.toString())
+					+ "]", e);
 		}
 	}
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/UriVariableExpressionTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/UriVariableExpressionTests.java
@@ -16,7 +16,9 @@
 
 package org.springframework.integration.http.outbound;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
@@ -71,6 +73,7 @@ public class UriVariableExpressionTests {
 		}
 		catch (Exception e) {
 			assertEquals("intentional", e.getCause().getMessage());
+			assertThat(e.getMessage(), containsString("http://test/bar"));
 		}
 		assertEquals("http://test/bar", uriHolder.get().toString());
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3526

Previously, the URI in the exception message is the raw
URI with placeholders, if present.

Use the expanded URI in the message instead.

**cherry-pick to 4.0.x**
