### PR TITLE
INT-3387: Add Lazy-Load for PersistenceMGS

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageListProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageListProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,16 @@ package org.springframework.integration.aggregator;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
-import org.springframework.messaging.Message;
 import org.springframework.integration.util.AbstractExpressionEvaluator;
 import org.springframework.integration.util.MessagingMethodInvokerHelper;
+import org.springframework.messaging.Message;
 
 /**
  * A MessageListProcessor implementation that invokes a method on a target POJO.
- * 
+ *
  * @author Dave Syer
  * @since 2.0
  */
@@ -61,9 +60,9 @@ public class MethodInvokingMessageListProcessor<T> extends AbstractExpressionEva
 		return delegate.toString();
 	}
 
-	public T process(Collection<? extends Message<?>> messages, Map<String, Object> aggregateHeaders) {
+	public T process(Collection<Message<?>> messages, Map<String, Object> aggregateHeaders) {
 		try {
-			return delegate.process(new ArrayList<Message<?>>(messages), aggregateHeaders);
+			return delegate.process(messages, aggregateHeaders);
 		}
 		catch (RuntimeException e) {
 			throw e;

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -15,7 +15,6 @@ package org.springframework.integration.aggregator;
 
 import java.util.Collection;
 
-import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.messaging.Message;
@@ -67,6 +66,8 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 		afterRelease(messageGroup, completedMessages, false);
 	}
 
+	@Override
+	protected void afterRelease(MessageGroup messageGroup, Collection<Message<?>> completedMessages, boolean timeout) {
 		int size = messageGroup.size();
 		int sequenceSize = messageGroup.getSequenceSize();
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -25,6 +25,7 @@ import org.springframework.messaging.Message;
  * Will remove {@link MessageGroup}s only if 'sequenceSize' is provided and reached.
  *
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  * @since 2.1
  */
 public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandler {
@@ -66,23 +67,19 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 		afterRelease(messageGroup, completedMessages, false);
 	}
 
-	@Override
-	protected void afterRelease(MessageGroup messageGroup, Collection<Message<?>> completedMessages, boolean timeout) {
+		int size = messageGroup.size();
+		int sequenceSize = messageGroup.getSequenceSize();
 
-		int size = messageGroup.getMessages().size();
-		int sequenceSize = 0;
-		Message<?> message = messageGroup.getOne();
-		if (message != null){
-			sequenceSize = new IntegrationMessageHeaderAccessor(message).getSequenceSize();
-		}
 		// If there is no sequence then it must be incomplete or unbounded
-		if (sequenceSize > 0 && sequenceSize == size){
+		if (sequenceSize > 0 && sequenceSize == size) {
 			remove(messageGroup);
 		}
 		else {
-			if (completedMessages != null){
-				int lastReleasedSequenceNumber = this.findLastReleasedSequenceNumber(messageGroup.getGroupId(), completedMessages);
-				messageStore.setLastReleasedSequenceNumberForGroup(messageGroup.getGroupId(), lastReleasedSequenceNumber);
+			if (completedMessages != null) {
+				int lastReleasedSequenceNumber =
+						findLastReleasedSequenceNumber(messageGroup.getGroupId(), completedMessages);
+				this.messageStore.setLastReleasedSequenceNumberForGroup(messageGroup.getGroupId(),
+						lastReleasedSequenceNumber);
 				for (Message<?> msg : completedMessages) {
 					this.messageStore.removeMessageFromGroup(messageGroup.getGroupId(), msg);
 				}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/SequenceSizeReleaseStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/SequenceSizeReleaseStrategy.java
@@ -36,6 +36,7 @@ import org.springframework.messaging.Message;
  * @author Dave Syer
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  * @author Enrique Rodríguez
  */
 public class SequenceSizeReleaseStrategy implements ReleaseStrategy {
@@ -55,9 +56,9 @@ public class SequenceSizeReleaseStrategy implements ReleaseStrategy {
 	}
 
 	/**
-	 * Flag that determines if partial sequences are allowed. If true then as soon as enough messages arrive that can be
-	 * ordered they will be released, provided they all have sequence numbers greater than those already released.
-	 *
+	 * Flag that determines if partial sequences are allowed. If true then as soon as
+	 * enough messages arrive that can be ordered they will be released, provided they
+	 * all have sequence numbers greater than those already released.
 	 * @param releasePartialSequences true when partial sequences should be released.
 	 */
 	public void setReleasePartialSequences(boolean releasePartialSequences) {
@@ -69,32 +70,30 @@ public class SequenceSizeReleaseStrategy implements ReleaseStrategy {
 
 		boolean canRelease = false;
 
-		Collection<Message<?>> messages = messageGroup.getMessages();
-
-		if (releasePartialSequences && !messages.isEmpty()) {
+		int size = messageGroup.size();
+		if (releasePartialSequences && size > 0) {
 
 			if (logger.isTraceEnabled()) {
 				logger.trace("Considering partial release of group [" + messageGroup + "]");
 			}
+			Collection<Message<?>> messages = messageGroup.getMessages();
 			Message<?> minMessage = Collections.min(messages, this.comparator);
 
 			int nextSequenceNumber = new IntegrationMessageHeaderAccessor(minMessage).getSequenceNumber();
 			int lastReleasedMessageSequence = messageGroup.getLastReleasedMessageSequenceNumber();
 
-			if (nextSequenceNumber - lastReleasedMessageSequence == 1){
-				canRelease = true;;
+			if (nextSequenceNumber - lastReleasedMessageSequence == 1) {
+				canRelease = true;
 			}
 		}
 		else {
-			int size = messages.size();
-
-			if (size == 0){
+			if (size == 0) {
 				canRelease = true;
 			}
 			else {
-				int sequenceSize = new IntegrationMessageHeaderAccessor(messageGroup.getOne()).getSequenceSize();
+				int sequenceSize = messageGroup.getSequenceSize();
 				// If there is no sequence then it must be incomplete....
-				if (sequenceSize == size){
+				if (sequenceSize == size) {
 					canRelease = true;
 				}
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
@@ -346,4 +346,9 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 		return this.getMessageGroup(groupId).getOne();
 	}
 
+	@Override
+	protected Collection<Message<?>> getMessagesForGroup(Object groupId) {
+		return getMessageGroup(groupId).getMessages();
+	}
+
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class MessageStoreTests {
 		assertEquals(1, store.getMessageCountForAllMessageGroups());
 	}
 
-	private static class TestMessageStore extends AbstractMessageGroupStore {
+	private static class TestMessageStore extends SimpleMessageStore {
 
 		@SuppressWarnings("unchecked")
 		MessageGroup testMessages = new SimpleMessageGroup(Arrays.asList(new GenericMessage<String>("foo")), "bar");

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
@@ -17,16 +17,13 @@
 package org.springframework.integration.mongodb.store;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-
-import com.mongodb.DB;
-import com.mongodb.MongoException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.DirectFieldAccessor;
@@ -53,13 +50,18 @@ import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.integration.store.AbstractMessageGroupStore;
 import org.springframework.integration.store.BasicMessageGroupStore;
+import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
+
+import com.mongodb.DB;
+import com.mongodb.MongoException;
 
 /**
  * The abstract MongoDB {@link BasicMessageGroupStore} implementation to provide configuration for common options
@@ -69,8 +71,8 @@ import org.springframework.util.Assert;
  * @since 4.0
  */
 
-public abstract class AbstractConfigurableMongoDbMessageStore implements BasicMessageGroupStore, InitializingBean,
-		ApplicationContextAware {
+public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMessageGroupStore
+		implements InitializingBean, ApplicationContextAware {
 
 	public final static String SEQUENCE_NAME = "messagesSequence";
 
@@ -84,8 +86,6 @@ public abstract class AbstractConfigurableMongoDbMessageStore implements BasicMe
 	 * The name of the message header that stores a timestamp for the time the message was inserted.
 	 */
 	public static final String CREATED_DATE_KEY = "MongoDbMessageStore.CREATED_DATE";
-
-	protected final Log logger = LogFactory.getLog(this.getClass());
 
 	protected final String collectionName;
 
@@ -218,6 +218,37 @@ public abstract class AbstractConfigurableMongoDbMessageStore implements BasicMe
 			}
 		});
 	}
+
+	@Override
+	protected Collection<Message<?>> getMessagesForGroup(Object groupId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public MessageGroup removeMessageFromGroup(Object key, Message<?> messageToRemove) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setLastReleasedSequenceNumberForGroup(Object groupId, int sequenceNumber) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Iterator<MessageGroup> iterator() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void completeGroup(Object groupId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Message<?> getOneMessageFromGroup(Object groupId) {
+		throw new UnsupportedOperationException();
+	}
+
 
 	protected static Query groupIdQuery(Object groupId) {
 		return Query.query(Criteria.where(MessageDocumentFields.GROUP_ID).is(groupId));

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-config.xml
@@ -5,7 +5,8 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="mongoStore"/>
+	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="mongoStore"
+			release-strategy-expression="size() == 10"/>
 
 	<int:channel id="outputChannel">
 		<int:queue/>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-confugurable-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-confugurable-config.xml
@@ -5,7 +5,8 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="mongoStore"/>
+	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="mongoStore"
+					release-strategy-expression="size() == 10"/>
 
 	<int:channel id="outputChannel">
 		<int:queue/>

--- a/src/reference/docbook/aggregator.xml
+++ b/src/reference/docbook/aggregator.xml
@@ -168,13 +168,13 @@
 
       <itemizedlist>
         <listitem>
-          <para>if the argument is a <interfacename>java.util.List&lt;T&gt;</interfacename>, and the
-          parameter type T is assignable to <interfacename>Message</interfacename>, then the whole list of
+          <para>if the argument is a <interfacename>java.util.Collection&lt;T&gt;</interfacename>, and the
+          parameter type <code>T</code> is assignable to <interfacename>Message</interfacename>, then the whole list of
           messages accumulated for aggregation will be sent to the aggregator</para>
         </listitem>
 
         <listitem>
-          <para>if the argument is a non-parameterized <interfacename>java.util.List</interfacename> or the
+          <para>if the argument is a non-parameterized <interfacename>java.util.Collection</interfacename> or the
           parameter type is not assignable to <interfacename>Message</interfacename>, then the method will
           receive the payloads of the accumulated messages</para>
         </listitem>
@@ -193,6 +193,22 @@
         XML or annotation support for configuring it in the application.</para>
       </note>
 
+        <important>
+            The <code>SimpleMessageGroup.getMessages()</code> returns <code>unmodifiableCollection</code>,
+            therefore, if your aggregating POJO is based on the <code>Collection&lt;Message&gt;</code>, it will be
+            exactly that <interfacename>Collection</interfacename>, and in the case of
+            <classname>SimpleMessageStore</classname> usage for the Aggregator, that original
+            <code>Collection&lt;Message&gt;</code> will be clear after releasing the group.
+            Hence the <code>Collection&lt;Message&gt;</code> variable in the POJO will be empty too.
+            It is recommended to build a new <interfacename>Collection</interfacename>
+            (<code>new ArrayList&lt;Message&gt;(messages)</code>) if there are plans to use the entire list of
+            messages in the further logic, e.g. produce from aggregator a message with <code>payload</code>
+            as a <code>Collection&lt;Message&gt;</code> of all messages from the group.
+            The Framework doesn't copy those messages to a new collection to avoid undesired extra object creation.
+            And since <emphasis>version 4.1</emphasis> the persistence
+            <interfacename>MessageGroupStore</interfacename>s provide <emphasis>Lazy-Load</emphasis> algorithm
+            for <interfacename>MessageGroup</interfacename> and its messages. See <xref linkend="message-store"/>.
+        </important>
     </section>
 
     <section>

--- a/src/reference/docbook/message-store.xml
+++ b/src/reference/docbook/message-store.xml
@@ -125,4 +125,17 @@
 			property to <code>true</code>.
 		</para>
 	</caution>
+
+    <para>
+        <emphasis>Persistence MessageGroupStore and Lazy-Load</emphasis>
+    </para>
+
+    <para>
+        Starting with <emphasis>version 4.1</emphasis> all persistence <interfacename>MessageGroupStore</interfacename>s
+        retrieve <interfacename>MessageGroup</interfacename>s and their <code>messages</code> from the store with the
+        <emphasis>Lazy-Load</emphasis> manner. In most cases it is useful for the Correlation
+        <interfacename>MessageHandler</interfacename>s, when it would be an overhead to load entire
+        <interfacename>MessageGroup</interfacename> from the store on each correlation operation.
+    </para>
+
 </section>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -272,5 +272,13 @@
 				See <xref linkend="channel-configuration-queuechannel"/>.
 			</para>
 		</section>
+		<section id="4.1-message-store-lazy-load">
+			<title>MessageGroupStore: Lazy-Load implementation</title>
+			<para>
+				The persistence <interfacename>MessageGroupStore</interfacename>s now retrieve MessageGroups
+				and their messages from the store with the <emphasis>Lazy-Load</emphasis> manner.
+				See <xref linkend="message-store"/>.
+			</para>
+		</section>
 	</section>
 </chapter>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3387
- Introduce `AbstractMessageGroupStore.PersistentMessageGroup` and `AbstractMessageGroupStore.PersistentMessageGroup.PersistentCollection`
  to achieve two-level Lazy-Load algorithm
- Add `AbstractMessageGroupStore` `protected abstract Collection<Message<?>> getMessagesForGroup(Object groupId);` to be used to lazy-load `PersistentCollection`
- Provide some refactoring for `Correlation` Components to achieve better performance with lazy-load
- Refactoring for the `AbstractKeyValueMessageStore` to avoid extra load of messages
- Introduce some **breaking** change to the `MessageGroupMetadata`
- Tested with 1000 messages with MongoDB with `sequenceAware = true`, when entire group is loaded for each message, and with `release-strategy-expression="size() == 1000"`.
  Looks like performance is growing exponentially, because in case of `sequenceAware = false` we load whole group only once for the last message.
