### PR TITLE
INT-3531 Varargs for JavaMailSender

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ subprojects { subproject ->
 		springSecurityVersion = '3.2.5.RELEASE'
 		springSocialTwitterVersion = '1.1.0.RELEASE'
 		springRetryVersion = '1.1.1.RELEASE'
-		springVersion = project.hasProperty('springVersion') ? project.springVersion : '4.1.1.RELEASE'
+		springVersion = project.hasProperty('springVersion') ? project.springVersion : '4.1.2.BUILD-SNAPSHOT'
 		springWsVersion = '2.2.0.RELEASE'
 		xmlUnitVersion = '1.5'
 		xstreamVersion = '1.4.7'
@@ -241,6 +241,7 @@ project('spring-integration-core') {
 		compile "org.springframework:spring-context:$springVersion"
 		compile "org.springframework:spring-messaging:$springVersion"
 		compile "org.springframework:spring-tx:$springVersion"
+		compile ("org.springframework:spring-context-support:$springVersion", optional) // override the reactor version
 		compile "org.springframework.retry:spring-retry:$springRetryVersion"
 		compile "org.projectreactor:reactor-core:$reactorVersion"
 		compile("org.projectreactor.spring:reactor-spring-context:$reactorSpringVersion", optional)

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/StubJavaMailSender.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/StubJavaMailSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2007 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,11 @@ import org.springframework.mail.javamail.MimeMessagePreparator;
 
 /**
  * @author Marius Bogoevici
+ * @author Gary Russell
  */
 public class StubJavaMailSender implements JavaMailSender {
 
-	private MimeMessage uniqueMessage;
+	private final MimeMessage uniqueMessage;
 
 	private final List<MimeMessage> sentMimeMessages = new ArrayList<MimeMessage>();
 
@@ -53,35 +54,43 @@ public class StubJavaMailSender implements JavaMailSender {
 		return this.sentSimpleMailMessages;
 	}
 
+	@Override
 	public MimeMessage createMimeMessage() {
 		return this.uniqueMessage;
 	}
 
+	@Override
 	public MimeMessage createMimeMessage(InputStream contentStream) throws MailException {
 		return this.uniqueMessage;
 	}
 
+	@Override
 	public void send(MimeMessage mimeMessage) throws MailException {
 		this.sentMimeMessages.add(mimeMessage);
 	}
 
-	public void send(MimeMessage[] mimeMessages) throws MailException {
+	@Override
+	public void send(MimeMessage... mimeMessages) throws MailException {
 		this.sentMimeMessages.addAll(Arrays.asList(mimeMessages));
 	}
 
+	@Override
 	public void send(MimeMessagePreparator mimeMessagePreparator) throws MailException {
 		throw new UnsupportedOperationException("MimeMessagePreparator not supported");
 	}
 
-	public void send(MimeMessagePreparator[] mimeMessagePreparators) throws MailException {
+	@Override
+	public void send(MimeMessagePreparator... mimeMessagePreparators) throws MailException {
 	    throw new UnsupportedOperationException("MimeMessagePreparator not supported");
 	}
 
+	@Override
 	public void send(SimpleMailMessage simpleMessage) throws MailException {
 		this.sentSimpleMailMessages.add(simpleMessage);
 	}
 
-	public void send(SimpleMailMessage[] simpleMessages) throws MailException {
+	@Override
+	public void send(SimpleMailMessage... simpleMessages) throws MailException {
 		this.sentSimpleMailMessages.addAll(Arrays.asList(simpleMessages));
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3531

JavaMailSender now uses varargs instead of [].

Also, add spring-context-support as an optional
dependency to avoid reactor pulling in an old version into
the eclipse .classpath.

You cannot exclude transitive dependencies from optional
(reactor) dependencies.
