### PR TITLE
INT-3536 Fix Mail Receiver Regression Issue

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -202,6 +202,9 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 				this.session = Session.getInstance(this.javaMailProperties);
 			}
 		}
+	}
+
+	private void connectStoreIfNecessary() throws MessagingException {
 		if (this.store == null) {
 			if (this.url != null) {
 				this.store = this.session.getStore(this.url);
@@ -224,7 +227,11 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 	protected void openFolder() throws MessagingException {
 		if (this.folder == null) {
 			openSession();
+			connectStoreIfNecessary();
 			this.folder = obtainFolderInstance();
+		}
+		else {
+			connectStoreIfNecessary();
 		}
 		if (this.folder == null || !this.folder.exists()) {
 			throw new IllegalStateException("no such folder [" + this.url.getFile() + "]");

--- a/spring-integration-mail/src/test/java/log4j.properties
+++ b/spring-integration-mail/src/test/java/log4j.properties
@@ -5,4 +5,4 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%c{1}: %m%n
 
 log4j.category.org.springframework.integration=WARN
-log4j.category.org.springframework.integration.mail=DEBUG
+log4j.category.org.springframework.integration.mail=WARN

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/MailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/MailReceiverTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.mail;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+
+import javax.mail.Folder;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.Store;
+import javax.mail.URLName;
+
+import org.junit.Test;
+import org.mockito.internal.stubbing.answers.DoesNothing;
+
+import org.springframework.beans.DirectFieldAccessor;
+
+/**
+ * @author Gary Russell
+ * @since 3.0.6
+ *
+ */
+public class MailReceiverTests {
+
+	@Test
+	public void testStoreConnect() throws Exception {
+		AbstractMailReceiver receiver = new AbstractMailReceiver() {
+
+			@Override
+			protected Message[] searchForNewMessages() throws MessagingException {
+				return null;
+			}
+		};
+		Properties props = new Properties();
+		Session session = Session.getInstance(props);
+		receiver.setSession(session);
+		receiver.setProtocol("imap");
+		Store store = session.getStore("imap");
+		store = spy(store);
+		new DirectFieldAccessor(receiver).setPropertyValue("store", store);
+		when(store.isConnected()).thenReturn(false);
+		Folder folder = mock(Folder.class);
+		when(folder.exists()).thenReturn(true);
+		when(folder.isOpen()).thenReturn(false);
+		doReturn(folder).when(store).getFolder((URLName)null);
+		doAnswer(new DoesNothing()).when(store).connect();
+		receiver.openFolder();
+		receiver.openFolder();
+		verify(store, times(2)).connect();
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3536

The fix for opening multiple IMAP connections in the idle
adapter inadvertently removed the check for the store being
open.

Add `connectStoreIfNecessary()` and test case.

**cherry-pick to 3.0.x, 4.0.x**
