### PR TITLE
INT-3535: Fix `JmsHM` to not override properties

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
@@ -51,6 +51,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class DefaultJmsHeaderMapper implements JmsHeaderMapper {
 
@@ -140,7 +141,8 @@ public class DefaultJmsHeaderMapper implements JmsHeaderMapper {
 			}
 			Set<String> headerNames = headers.keySet();
 			for (String headerName : headerNames) {
-				if (StringUtils.hasText(headerName) && !headerName.startsWith(JmsHeaders.PREFIX)) {
+				if (StringUtils.hasText(headerName) && !headerName.startsWith(JmsHeaders.PREFIX)
+						&& jmsMessage.getObjectProperty(headerName) == null) {
 					Object value = headers.get(headerName);
 					if (value != null && SUPPORTED_PROPERTY_TYPES.contains(value.getClass())) {
 						try {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3535

Previously when `DefaultJmsHeaderMapper` overrode values, which had been able to be populated by the `MessageConverter`.

Since `MessageConverter` result has a precedence which is closer to JMS, skip those custom `MessageHeaders` which already has been populated by `MessageConverter`
