### PR TITLE
INT-3539: Fix `ChannelSecurityInterceptorBPP`

### DIFF
--- a/spring-integration-security/src/main/java/org/springframework/integration/security/config/SecurityIntegrationConfigurationInitializer.java
+++ b/spring-integration-security/src/main/java/org/springframework/integration/security/config/SecurityIntegrationConfigurationInitializer.java
@@ -16,11 +16,23 @@
 
 package org.springframework.integration.security.config;
 
+import java.lang.reflect.Method;
+import java.util.List;
+
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.CannotLoadBeanClassException;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.core.type.MethodMetadata;
+import org.springframework.core.type.StandardMethodMetadata;
 import org.springframework.integration.config.IntegrationConfigurationInitializer;
+import org.springframework.integration.security.channel.ChannelSecurityInterceptor;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * The Integration Security infrastructure {@code beanFactory} initializer.
@@ -30,13 +42,49 @@ import org.springframework.integration.config.IntegrationConfigurationInitialize
  */
 public class SecurityIntegrationConfigurationInitializer implements IntegrationConfigurationInitializer {
 
-	private static final String CHANNEL_SECURITY_INTERCEPTOR_BPP_BEAN_NAME = ChannelSecurityInterceptorBeanPostProcessor.class.getName();
+	private static final String CHANNEL_SECURITY_INTERCEPTOR_BPP_BEAN_NAME =
+			ChannelSecurityInterceptorBeanPostProcessor.class.getName();
 
 	@Override
 	public void initialize(ConfigurableListableBeanFactory beanFactory) throws BeansException {
 		BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
-		if (!registry.containsBeanDefinition(CHANNEL_SECURITY_INTERCEPTOR_BPP_BEAN_NAME)) {
-			registry.registerBeanDefinition(CHANNEL_SECURITY_INTERCEPTOR_BPP_BEAN_NAME, new RootBeanDefinition(ChannelSecurityInterceptorBeanPostProcessor.class));
+
+		List<BeanDefinition> securityInterceptors = new ManagedList<BeanDefinition>();
+
+		for (String beanName : registry.getBeanDefinitionNames()) {
+			BeanDefinition beanDefinition = registry.getBeanDefinition(beanName);
+			String beanClassName = beanDefinition.getBeanClassName();
+			Class<?> clazz = null;
+			if (StringUtils.hasText(beanClassName)) {
+				try {
+					clazz = ClassUtils.forName(beanClassName, beanFactory.getBeanClassLoader());
+				}
+				catch (ClassNotFoundException e) {
+					throw new CannotLoadBeanClassException(this.toString(), beanName, beanClassName, e);
+				}
+			}
+			else if (beanDefinition instanceof AnnotatedBeanDefinition
+					&& beanDefinition.getSource() instanceof MethodMetadata) {
+				MethodMetadata beanMethod = (MethodMetadata) beanDefinition.getSource();
+				if (beanMethod instanceof StandardMethodMetadata) {
+					Method method = ((StandardMethodMetadata) beanMethod).getIntrospectedMethod();
+					clazz = method.getReturnType();
+				}
+			}
+
+			if (clazz != null &&
+					(ChannelSecurityInterceptor.class.isAssignableFrom(clazz)
+							|| ChannelSecurityInterceptorFactoryBean.class.isAssignableFrom(clazz))) {
+				securityInterceptors.add(beanDefinition);
+			}
+		}
+
+		if (!securityInterceptors.isEmpty()) {
+			BeanDefinition securityPostProcessorBd =
+					BeanDefinitionBuilder.rootBeanDefinition(ChannelSecurityInterceptorBeanPostProcessor.class)
+							.addConstructorArgValue(securityInterceptors)
+							.getBeanDefinition();
+			registry.registerBeanDefinition(CHANNEL_SECURITY_INTERCEPTOR_BPP_BEAN_NAME, securityPostProcessorBd);
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3539

Previously the `ChannelSecurityInterceptorBeanPostProcessor` eagerly loaded all beans from its `afterPropertiesSet`
to retrieve the `ChannelSecurityInterceptor`s. According to the `BeanPostProcessor` nature the `afterPropertiesSet` hook isn't legitimate.
It may cause some bad side-effects for other beans, which might not been initialized yet.

Rework `ChannelSecurityInterceptorBeanPostProcessor` to accept `Collection<ChannelSecurityInterceptor>` in the ctor.
Rework `SecurityIntegrationConfigurationInitializer` to iterate over `BeanDefinition`s to determine those of them, which
are `ChannelSecurityInterceptor` or `ChannelSecurityInterceptorFactoryBean`.

**Cherry-pick to 4.0.x**
