### PR TITLE
INT-3547 Fix stop(Runnable) in AbstractEndpoint

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
@@ -139,6 +139,7 @@ class GatewayMethodInboundMessageMapper implements InboundMessageMapper<Object[]
 		this.payloadExpression = PARSER.parseExpression(expressionString);
 	}
 
+	@Override
 	public void setBeanFactory(final BeanFactory beanFactory) {
 		if (beanFactory != null) {
 			this.beanFactory = beanFactory;
@@ -146,7 +147,8 @@ class GatewayMethodInboundMessageMapper implements InboundMessageMapper<Object[]
 		}
 	}
 
- 	public Message<?> toMessage(Object[] arguments) {
+	@Override
+	public Message<?> toMessage(Object[] arguments) {
 		Assert.notNull(arguments, "cannot map null arguments to Message");
 		if (arguments.length != this.parameterList.size()) {
 			String prefix = (arguments.length < this.parameterList.size()) ? "Not enough" : "Too many";
@@ -275,7 +277,7 @@ class GatewayMethodInboundMessageMapper implements InboundMessageMapper<Object[]
 				Object argumentValue = arguments[i];
 				MethodParameter methodParameter = GatewayMethodInboundMessageMapper.this.parameterList.get(i);
 				Annotation annotation =
-						MessagingAnnotationUtils.findMessagePartAnnotation(methodParameter.getParameterAnnotations());
+						MessagingAnnotationUtils.findMessagePartAnnotation(methodParameter.getParameterAnnotations(), false);
 				if (annotation != null) {
 					if (annotation.annotationType().equals(org.springframework.integration.annotation.Payload.class)
 							|| annotation.annotationType().equals(Payload.class)) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingAnnotationUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingAnnotationUtils.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.integration.annotation.Payloads;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Headers;
@@ -97,14 +98,15 @@ public final class MessagingAnnotationUtils {
 
 	/**
 	 * Find the one of {@link Payload}, {@link Header} or {@link Headers} annotation from
-	 * the provided {@code annotations} array.
+	 * the provided {@code annotations} array. Optionally also detects {@link Payloads}.
 	 * @param annotations the annotations to scan.
+	 * @param payloads true if @Payloads should be detected.
 	 * @return the matched annotation or {@code null}.
 	 * @throws MessagingException if more than one of {@link Payload}, {@link Header}
 	 * or {@link Headers} annotations are presented.
 	 */
 	@SuppressWarnings("deprecation")
-	public static Annotation findMessagePartAnnotation(Annotation[] annotations) {
+	public static Annotation findMessagePartAnnotation(Annotation[] annotations, boolean payloads) {
 		if (annotations == null || annotations.length == 0) {
 			return null;
 		}
@@ -116,7 +118,8 @@ public final class MessagingAnnotationUtils {
 					|| type.equals(org.springframework.integration.annotation.Header.class)
 					|| type.equals(Header.class)
 					|| type.equals(org.springframework.integration.annotation.Headers.class)
-					|| type.equals(Headers.class)) {
+					|| type.equals(Headers.class)
+					|| (payloads && type.equals(Payloads.class))) {
 				if (match != null) {
 					throw new MessagingException("At most one parameter annotation can be provided "
 							+ "for message mapping, but found two: [" + match.annotationType().getName() + "] and ["

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
@@ -605,7 +605,7 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 				TypeDescriptor parameterTypeDescriptor = new TypeDescriptor(methodParameter);
 				Class<?> parameterType = parameterTypeDescriptor.getObjectType();
 				Annotation mappingAnnotation =
-						MessagingAnnotationUtils.findMessagePartAnnotation(parameterAnnotations[i]);
+						MessagingAnnotationUtils.findMessagePartAnnotation(parameterAnnotations[i], true);
 				if (mappingAnnotation != null) {
 					Class<? extends Annotation> annotationType = mappingAnnotation.annotationType();
 					if (annotationType.equals(org.springframework.integration.annotation.Payload.class)

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
@@ -119,28 +119,30 @@ public class MqttPahoMessageDrivenChannelAdapter extends AbstractMqttMessageDriv
 	protected void doStop() {
 		this.cancelReconnect();
 		super.doStop();
-		try {
-			this.client.unsubscribe(this.getTopic())
-					.waitForCompletion(this.completionTimeout);
+		if (this.client != null) {
+			try {
+				this.client.unsubscribe(this.getTopic())
+						.waitForCompletion(this.completionTimeout);
+			}
+			catch (MqttException e) {
+				logger.error("Exception while unsubscribing", e);
+			}
+			try {
+				this.client.disconnect()
+						.waitForCompletion(this.completionTimeout);
+			}
+			catch (MqttException e) {
+				logger.error("Exception while disconnecting", e);
+			}
+			try {
+				this.client.close();
+			}
+			catch (MqttException e) {
+				logger.error("Exception while closing", e);
+			}
+			this.connected = false;
+			this.client = null;
 		}
-		catch (MqttException e) {
-			logger.error("Exception while unsubscribing", e);
-		}
-		try {
-			this.client.disconnect()
-					.waitForCompletion(this.completionTimeout);
-		}
-		catch (MqttException e) {
-			logger.error("Exception while disconnecting", e);
-		}
-		try {
-			this.client.close();
-		}
-		catch (MqttException e) {
-			logger.error("Exception while closing", e);
-		}
-		this.connected = false;
-		this.client = null;
 	}
 
 	@Override


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3547
JIRA: https://jira.spring.io/browse/INT-3546

INT-3486 changed stop(Runnable) so that it could be
overridden by subclasses, to allow separation of the
`stop()` and `callback` invocation.

However, the refactoring changed the logic such that
the `running` field is not reset, causing `doStop()` to
be called even when the component was not running.

Reset the running field.

Also, the MQTT inbound channel adapter did not test
for a `null` `client` in `doStop()`.
