### PR TITLE
INT-3549 Fix AMQP o-c-a Validation

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
@@ -196,9 +196,11 @@ public class AmqpOutboundEndpoint extends AbstractReplyProducingMessageHandler
 			}
 		}
 		else {
-			Assert.state(this.confirmAckChannel == null || this.confirmAckChannel instanceof NullChannel,
+			NullChannel nullChannel = extractTypeIfPossible(this.confirmAckChannel, NullChannel.class);
+			Assert.state(this.confirmAckChannel == null || nullChannel != null,
 					"A 'confirmCorrelationExpression' is required when specifying a 'confirmAckChannel'");
-			Assert.state(this.confirmNackChannel == null || this.confirmNackChannel instanceof NullChannel,
+			nullChannel = extractTypeIfPossible(this.confirmNackChannel, NullChannel.class);
+			Assert.state(this.confirmNackChannel == null || nullChannel != null,
 					"A 'confirmCorrelationExpression' is required when specifying a 'confirmNackChannel'");
 		}
 		if (this.returnChannel != null) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3549

`afterPropertiesSet()` checks for `NullChannel` to determine
whether a correlation expression is needed for confirms.

This code fails when `nullChannel` is proxied.

Extract the type before testing.
