### PR TITLE
[BACKPORT] INT-3545: Don't AutoStart HeaderChannelRegistry

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/DefaultHeaderChannelRegistry.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/DefaultHeaderChannelRegistry.java
@@ -62,7 +62,9 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 
 	private volatile int phase;
 
-	private volatile boolean autoStartup = true;
+	private volatile boolean autoStartup = false;
+
+	private volatile boolean explicitlyStopped;
 
 	/**
 	 * Constructs a registry with the default delay for channel expiry.
@@ -100,20 +102,36 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 		super.setTaskScheduler(taskScheduler);
 	}
 
+	/**
+	 * @deprecated - this class will not implement {@link SmartLifecycle} in 4.2, just {@code Lifecycle}.
+	 */
+	@Deprecated
 	@Override
 	public int getPhase() {
 		return this.phase;
 	}
 
+	/**
+	 * @deprecated - this class will not implement {@link SmartLifecycle} in 4.2, just {@code Lifecycle}.
+	 */
+	@Deprecated
 	public final void setPhase(int phase) {
 		this.phase = phase;
 	}
 
+	/**
+	 * @deprecated - this class will not implement {@link SmartLifecycle} in 4.2, just {@code Lifecycle}.
+	 */
+	@Deprecated
 	@Override
 	public boolean isAutoStartup() {
 		return this.autoStartup;
 	}
 
+	/**
+	 * @deprecated - this class will not implement {@link SmartLifecycle} in 4.2, just {@code Lifecycle}.
+	 */
+	@Deprecated
 	public final void setAutoStartup(boolean autoStartup) {
 		this.autoStartup = autoStartup;
 	}
@@ -145,6 +163,7 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 		if (this.reaperScheduledFuture != null) {
 			this.reaperScheduledFuture.cancel(true);
 		}
+		this.explicitlyStopped = true;
 	}
 
 	@Override
@@ -160,6 +179,9 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 
 	@Override
 	public Object channelToChannelName(Object channel) {
+		if (!this.running && !this.explicitlyStopped && this.getTaskScheduler() != null) {
+			start();
+		}
 		if (channel != null && channel instanceof MessageChannel) {
 			String name = this.uuid + DefaultHeaderChannelRegistry.id.incrementAndGet();
 			channels.put(name, new MessageChannelWrapper((MessageChannel) channel));

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
@@ -149,7 +149,6 @@ public class HeaderChannelRegistryTests {
 	public void testExpire() throws Exception {
 		DefaultHeaderChannelRegistry registry = new DefaultHeaderChannelRegistry(50);
 		registry.setTaskScheduler(this.taskScheduler);
-		registry.start();
 		String id = (String) registry.channelToChannelName(new DirectChannel());
 		int n = 0;
 		while (n++ < 100 && registry.channelNameToChannel(id) != null) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3545

Previously, the `DefaultHeaderChannelRegistry` was auto-started.
This caused the reaper to run and eventually start all the
`taskScheduler` threads, even if the registry was not being used.
- Defer the `start()` until the first channel is stored.
- Do not start the reaper if the bean has been explicitly stopped.
- Deprecate the implementation of `SmartLifecycle`.

Conflicts:
    spring-integration-core/src/main/java/org/springframework/integration/channel/DefaultHeaderChannelRegistry.java

Resolved.

**cherry-pick to 3.0.x**
