### PR TITLE
INT-3550: RoutingSlip improvements

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -34,7 +34,6 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.core.DestinationResolver;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * The base {@link AbstractMessageHandler} implementation for the {@link MessageProducer}.
@@ -196,8 +195,8 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 			return routingSlipPathValue;
 		}
 		else {
-			String nextPath = ((RoutingSlipRouteStrategy) routingSlipPathValue).getNextPath(requestMessage, reply);
-			if (StringUtils.hasText(nextPath)) {
+			Object nextPath = ((RoutingSlipRouteStrategy) routingSlipPathValue).getNextPath(requestMessage, reply);
+			if (nextPath != null) {
 				return nextPath;
 			}
 			else {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -34,6 +34,7 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.core.DestinationResolver;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * The base {@link AbstractMessageHandler} implementation for the {@link MessageProducer}.
@@ -196,7 +197,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 		}
 		else {
 			Object nextPath = ((RoutingSlipRouteStrategy) routingSlipPathValue).getNextPath(requestMessage, reply);
-			if (nextPath != null) {
+			if (nextPath != null && (!(nextPath instanceof String) || StringUtils.hasText((String) nextPath))) {
 				return nextPath;
 			}
 			else {

--- a/spring-integration-core/src/main/java/org/springframework/integration/routingslip/ExpressionEvaluatingRoutingSlipRouteStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/routingslip/ExpressionEvaluatingRoutingSlipRouteStrategy.java
@@ -79,7 +79,7 @@ public class ExpressionEvaluatingRoutingSlipRouteStrategy
 	}
 
 	@Override
-	public String getNextPath(Message<?> requestMessage, Object reply) {
+	public Object getNextPath(Message<?> requestMessage, Object reply) {
 		return this.expression.getValue(this.evaluationContext, new RequestAndReply(requestMessage, reply),
 				String.class);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/routingslip/RoutingSlipRouteStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/routingslip/RoutingSlipRouteStrategy.java
@@ -26,6 +26,6 @@ import org.springframework.messaging.Message;
  */
 public interface RoutingSlipRouteStrategy {
 
-	String getNextPath(Message<?> requestMessage, Object reply);
+	Object getNextPath(Message<?> requestMessage, Object reply);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/routingslip/RoutingSlipRouteStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/routingslip/RoutingSlipRouteStrategy.java
@@ -20,9 +20,12 @@ import org.springframework.messaging.Message;
 
 /**
  * The {@code RoutingSlip} strategy to determine the next {@code replyChannel}.
+ * <p>
+ * This strategy is called repeatedly until null or empty String is returned.
  *
  * @author Artem Bilan
  * @since 4.1
+ * @see org.springframework.integration.handler.AbstractMessageProducingHandler
  */
 public interface RoutingSlipRouteStrategy {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/RoutingSlipHeaderValueMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/RoutingSlipHeaderValueMessageProcessor.java
@@ -59,6 +59,15 @@ public class RoutingSlipHeaderValueMessageProcessor
 	public RoutingSlipHeaderValueMessageProcessor(Object... routingSlipPath) {
 		Assert.notNull(routingSlipPath);
 		Assert.noNullElements(routingSlipPath);
+		for (Object entry : routingSlipPath) {
+			if (!(entry instanceof String
+					|| entry instanceof MessageChannel
+					|| entry instanceof RoutingSlipRouteStrategy)) {
+				throw new IllegalArgumentException("The RoutingSlip can contain " +
+						"only bean names of MessageChannel or RoutingSlipRouteStrategy, " +
+						"or MessageChannel and RoutingSlipRouteStrategy instances: " + entry);
+			}
+		}
 		this.routingSlipPath = Arrays.asList(routingSlipPath);
 	}
 
@@ -80,9 +89,11 @@ public class RoutingSlipHeaderValueMessageProcessor
 							String entry = (String) path;
 							if (this.beanFactory.containsBean(entry)) {
 								Object bean = this.beanFactory.getBean(entry);
-								Assert.state(bean instanceof MessageChannel || bean instanceof RoutingSlipRouteStrategy,
-										"The RoutingSlip can contain only bean names of MessageChannel or " +
-												"RoutingSlipRouteStrategy: " + bean);
+								if (!(bean instanceof MessageChannel
+										|| bean instanceof RoutingSlipRouteStrategy)) {
+									throw new IllegalArgumentException("The RoutingSlip can contain " +
+											"only bean names of MessageChannel or RoutingSlipRouteStrategy: " + bean);
+								}
 								routingSlipValues.add(entry);
 							}
 							else {

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/RoutingSlipHeaderValueMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/RoutingSlipHeaderValueMessageProcessor.java
@@ -48,7 +48,7 @@ public class RoutingSlipHeaderValueMessageProcessor
 		extends AbstractHeaderValueMessageProcessor<Map<List<Object>, Integer>>
 		implements BeanFactoryAware {
 
-	private final List<String> routingSlipPath;
+	private final List<Object> routingSlipPath;
 
 	private EvaluationContext evaluationContext;
 
@@ -56,7 +56,7 @@ public class RoutingSlipHeaderValueMessageProcessor
 
 	private BeanFactory beanFactory;
 
-	public RoutingSlipHeaderValueMessageProcessor(String... routingSlipPath) {
+	public RoutingSlipHeaderValueMessageProcessor(Object... routingSlipPath) {
 		Assert.notNull(routingSlipPath);
 		Assert.noNullElements(routingSlipPath);
 		this.routingSlipPath = Arrays.asList(routingSlipPath);
@@ -75,20 +75,27 @@ public class RoutingSlipHeaderValueMessageProcessor
 			synchronized (this) {
 				if (this.routingSlip == null) {
 					List<Object> routingSlipValues = new ArrayList<Object>(this.routingSlipPath.size());
-					for (String path : this.routingSlipPath) {
-						if (this.beanFactory.containsBean(path)) {
-							Object bean = this.beanFactory.getBean(path);
-							Assert.state(bean instanceof MessageChannel || bean instanceof RoutingSlipRouteStrategy,
-									"The RoutingSlip can contain only bean names of MessageChannel or " +
-											"RoutingSlipRouteStrategy: " + bean);
-							routingSlipValues.add(path);
+					for (Object path : this.routingSlipPath) {
+						if (path instanceof String) {
+							String entry = (String) path;
+							if (this.beanFactory.containsBean(entry)) {
+								Object bean = this.beanFactory.getBean(entry);
+								Assert.state(bean instanceof MessageChannel || bean instanceof RoutingSlipRouteStrategy,
+										"The RoutingSlip can contain only bean names of MessageChannel or " +
+												"RoutingSlipRouteStrategy: " + bean);
+								routingSlipValues.add(entry);
+							}
+							else {
+								ExpressionEvaluatingRoutingSlipRouteStrategy strategy = new
+										ExpressionEvaluatingRoutingSlipRouteStrategy(entry);
+								strategy.setIntegrationEvaluationContext(this.evaluationContext);
+								routingSlipValues.add(strategy);
+							}
 						}
 						else {
-							ExpressionEvaluatingRoutingSlipRouteStrategy strategy = new
-									ExpressionEvaluatingRoutingSlipRouteStrategy(path);
-							strategy.setIntegrationEvaluationContext(this.evaluationContext);
-							routingSlipValues.add(strategy);
+							routingSlipValues.add(path);
 						}
+
 					}
 					this.routingSlip = Collections.singletonMap(Collections.unmodifiableList(routingSlipValues), 0);
 				}

--- a/spring-integration-core/src/test/java/org/springframework/integration/routingslip/RoutingSlipTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/routingslip/RoutingSlipTests-context.xml
@@ -61,4 +61,6 @@
 
 	<aggregator input-channel="aggregate" expression="new java.util.ArrayList(#root)"/>
 
+	<beans:bean class="org.springframework.integration.routingslip.RoutingSlipTests$RoutingSlipConfiguration"/>
+
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/routingslip/RoutingSlipTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/routingslip/RoutingSlipTests.java
@@ -126,6 +126,17 @@ public class RoutingSlipTests {
 	@Test
 	public void testInvalidRoutingSlipRoutStrategy() {
 		try {
+			new RoutingSlipHeaderValueMessageProcessor(new Date());
+			fail("IllegalArgumentException expected");
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(IllegalArgumentException.class));
+			assertThat(e.getMessage(),
+					containsString("The RoutingSlip can contain " +
+							"only bean names of MessageChannel or RoutingSlipRouteStrategy, " +
+							"or MessageChannel and RoutingSlipRouteStrategy instances"));
+		}
+		try {
 			this.invalidRoutingSlipChannel.send(new GenericMessage<>("foo"));
 			fail("MessagingException expected");
 		}

--- a/src/reference/docbook/router.xml
+++ b/src/reference/docbook/router.xml
@@ -1196,5 +1196,46 @@ public HeaderEnricher headerEnricher() {
                 </listitem>
             </itemizedlist>
         </section>
+        <section id="process-manager">
+            <title>Process Manager Enterprise Integration Pattern</title>
+            <para>
+                The EIP defines the separate
+                <ulink url="http://www.eaipatterns.com/ProcessManager.html">Process Manager</ulink>, but Spring
+                Integration doesn't provide a direct implementation for that. Having the
+                <interfacename>RoutingSlipRouteStrategy</interfacename> we achieve the same solution, when
+                <emphasis>Process Manager</emphasis> logic is encapsulated in the custom implementation. Alongside
+                with bean name, the <interfacename>RoutingSlipRouteStrategy</interfacename> can return
+                <interfacename>MessageChannel</interfacename> object as well, and their is no requirements, that this
+                <interfacename>MessageChannel</interfacename> instance should be a bean in the application context.
+                With that we can provide more powerful dynamic routing logic, when there is no predictions which
+                channel from application we should use, and we just create <interfacename>MessageChannel</interfacename>
+                from the <interfacename>RoutingSlipRouteStrategy</interfacename> and return it. The
+                <classname>FixedSubscriberChannel</classname> with inline <interfacename>MessageHandler</interfacename>
+                implementation is good combination for such cases. For example we can route to the
+                <ulink url="https://github.com/reactor/reactor/wiki/Streams">Reactor Stream</ulink>:
+            </para>
+            <programlisting language="java"><![CDATA[@Bean
+public PollableChannel resultsChannel() {
+	return new QueueChannel();
+}
+@Bean
+public RoutingSlipRouteStrategy routeStrategy() {
+	return (requestMessage, reply) -> requestMessage.getPayload() instanceof String
+			? new FixedSubscriberChannel(m ->
+			Streams.defer((String) m.getPayload())
+					.env(this.reactorEnv)
+					.get()
+					.map(String::toUpperCase)
+					.consume(v -> messagingTemplate().convertAndSend(resultsChannel(), v))
+					.flush())
+			: new FixedSubscriberChannel(m ->
+			Streams.defer((Integer) m.getPayload())
+					.env(this.reactorEnv)
+					.get()
+					.map(v -> v * 2)
+					.consume(v -> messagingTemplate().convertAndSend(resultsChannel(), v))
+					.flush());
+}]]></programlisting>
+        </section>
     </section>
 </section>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3550
- Make `RoutingSlipRouteStrategy#getNextPath` as `Object` return type. to allow to produce `MessageChannel` result, not only `beanName`
- Make `RoutingSlipHeaderValueMessageProcessor` ctor to accept `Object... routingSlipPath` instead of just String.
  It is useful from JavaConfig, when we can use `RoutingSlipRouteStrategy` `@Bean` reference.
- Add JavaConfig test case to demonstrate how `RoutingSlipRouteStrategy` can get deal with inline `FixedSubscriberChannel`
  and Lambdas together with Reactor Streams.
