### PR TITLE
INT-3555: Fix Header Channel Mapping

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -196,7 +197,7 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	private void populateUserDefinedHeaders(Map<String, Object> headers, T target) {
 		for (String headerName : headers.keySet()) {
 			Object value = headers.get(headerName);
-			if (value != null) {
+			if (value != null && !isMessageChannel(headerName, value)) {
 				try {
 					if (!headerName.startsWith(this.standardHeaderPrefix)) {
 						String key = this.createTargetPropertyName(headerName, true);
@@ -210,6 +211,16 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 				}
 			}
 		}
+	}
+
+	private boolean isMessageChannel(String headerName, Object headerValue) {
+		if (MessageChannel.class.isAssignableFrom(headerValue.getClass())) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Cannot map a MessageChannel in header " + headerName);
+			}
+			return true;
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3555

Previously, `replyChannel` and `errorChannel` headers were
unconditionally dropped in `AbstractHeaderMapper`. This was
changed in 4.1.0.M1 to allow these headers to be transmitted
in the case that they were translated to a String by a
`HeaderChannelRegistry`.

However, we should still drop these headers if they reference live
`MessageChannel` instances.
