### PR TITLE
INT-3560: Fix DelayHandler for double emitting

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -17,11 +17,12 @@
 package org.springframework.integration.handler;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Queue;
+import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.aopalliance.aop.Advice;
@@ -87,7 +88,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 
 	private final String messageGroupId;
 
-	private final Queue<UUID> delayedMessages = new LinkedBlockingQueue<UUID>(Integer.MAX_VALUE);
+	private final Set<UUID> delayedMessages = Collections.newSetFromMap(new ConcurrentHashMap<UUID, Boolean>());
 
 	private volatile long defaultDelay;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -18,12 +18,7 @@ package org.springframework.integration.handler;
 
 import java.io.Serializable;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.aopalliance.aop.Advice;
@@ -41,6 +36,7 @@ import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.MessageStore;
+import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.messaging.Message;
@@ -88,8 +84,6 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 	private static final ExpressionParser expressionParser = new SpelExpressionParser();
 
 	private final String messageGroupId;
-
-	private final Map<UUID, ScheduledFuture<?>> delayTasks = new HashMap<UUID, ScheduledFuture<?>>();
 
 	private volatile long defaultDelay;
 
@@ -324,27 +318,20 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 		}
 		else {
 			messageWrapper = new DelayedMessageWrapper(message, System.currentTimeMillis());
-			delayedMessage = this.getMessageBuilderFactory()
-					.withPayload(messageWrapper)
-					.copyHeaders(message.getHeaders())
-					.build();
+			delayedMessage = this.getMessageBuilderFactory().withPayload(messageWrapper).copyHeaders(message.getHeaders()).build();
 			this.messageStore.addMessageToGroup(this.messageGroupId, delayedMessage);
 		}
 
 		final Message<?> messageToSchedule = delayedMessage;
 
+		this.getTaskScheduler().schedule(new Runnable() {
 
-		ScheduledFuture<?> schedule = this.getTaskScheduler().schedule(
-				new Runnable() {
+			@Override
+			public void run() {
+				releaseMessage(messageToSchedule);
+			}
 
-					@Override
-					public void run() {
-						releaseMessage(messageToSchedule);
-					}
-
-				},
-				new Date(messageWrapper.getRequestDate() + delay));
-		this.delayTasks.put(message.getHeaders().getId(), schedule);
+		}, new Date(messageWrapper.getRequestDate() + delay));
 	}
 
 	private void releaseMessage(Message<?> message) {
@@ -352,10 +339,8 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 	}
 
 	private void doReleaseMessage(Message<?> message) {
-		if (this.messageStore instanceof SimpleMessageStore
-				|| ((MessageStore) this.messageStore).removeMessage(message.getHeaders().getId()) != null) {
+		if (removeDelayedMessageFromMessageStore(message)) {
 			this.messageStore.removeMessageFromGroup(this.messageGroupId, message);
-			this.delayTasks.remove(message.getHeaders().getId());
 			this.handleMessageInternal(message);
 		}
 		else {
@@ -363,6 +348,17 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 				logger.debug("No message in the Message Store to release: " + message +
 						". Likely another instance has already released it.");
 			}
+		}
+	}
+
+	private boolean removeDelayedMessageFromMessageStore(Message<?> message) {
+		if (this.messageStore instanceof SimpleMessageStore) {
+			SimpleMessageGroup messageGroup =
+					(SimpleMessageGroup) this.messageStore.getMessageGroup(this.messageGroupId);
+			return messageGroup.remove(message);
+		}
+		else {
+			return ((MessageStore) this.messageStore).removeMessage(message.getHeaders().getId()) != null;
 		}
 	}
 
@@ -380,17 +376,10 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 	 */
 	@Override
 	public synchronized void reschedulePersistedMessages() {
-		Iterator<Map.Entry<UUID, ScheduledFuture<?>>> iterator = this.delayTasks.entrySet().iterator();
-		while (iterator.hasNext()) {
-			Map.Entry<UUID, ScheduledFuture<?>> entry = iterator.next();
-			entry.getValue().cancel(true);
-			iterator.remove();
-		}
-
 		MessageGroup messageGroup = this.messageStore.getMessageGroup(this.messageGroupId);
 		for (final Message<?> message : messageGroup.getMessages()) {
-			DelayedMessageWrapper messageWrapper = (DelayedMessageWrapper) message.getPayload();
 			this.getTaskScheduler().schedule(new Runnable() {
+
 				@Override
 				public void run() {
 					long delay = determineDelayForMessage(message);
@@ -401,6 +390,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 						releaseMessage(message);
 					}
 				}
+
 			}, new Date());
 		}
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -91,8 +91,8 @@ public class SimpleMessageGroup implements MessageGroup {
 		addMessage(message);
 	}
 
-	public void remove(Message<?> message) {
-		messages.remove(message);
+	public boolean remove(Message<?> message) {
+		return this.messages.remove(message);
 	}
 
 	@Override

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
@@ -449,12 +449,13 @@ public class DelayHandlerTests {
 		QueueChannel results = new QueueChannel();
 		delayHandler.setOutputChannel(results);
 		this.delayHandler.setDefaultDelay(100);
-		delayHandler.afterPropertiesSet();
+		startDelayerHandler();
+
 		this.input.send(new GenericMessage<>("foo"));
-		delayHandler.onApplicationEvent(new ContextRefreshedEvent(TestUtils.createTestApplicationContext()));
+		this.delayHandler.reschedulePersistedMessages();
 		Message<?> message = results.receive(10000);
 		assertNotNull(message);
-		message = results.receive(1000);
+		message = results.receive(500);
 		assertNull(message);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
@@ -17,7 +17,9 @@
 package org.springframework.integration.handler;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -37,6 +39,7 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.integration.channel.QueueChannel;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.MessagePublishingErrorHandler;
@@ -435,6 +438,24 @@ public class DelayHandlerTests {
 		this.delayHandler.setIgnoreExpressionFailures(false);
 		this.startDelayerHandler();
 		this.delayHandler.handleMessage(new GenericMessage<String>("test"));
+	}
+
+	@Test //INT-3560
+	/*
+	 It's difficult to test it from real ctx, because any async process from 'inbound-channel-adapter'
+	 can't achieve the DelayHandler before the main thread emits 'ContextRefreshedEvent'.
+	 */
+	public void testRescheduleAndHandleAtTheSameTime() throws Exception {
+		QueueChannel results = new QueueChannel();
+		delayHandler.setOutputChannel(results);
+		this.delayHandler.setDefaultDelay(100);
+		delayHandler.afterPropertiesSet();
+		this.input.send(new GenericMessage<>("foo"));
+		delayHandler.onApplicationEvent(new ContextRefreshedEvent(TestUtils.createTestApplicationContext()));
+		Message<?> message = results.receive(10000);
+		assertNotNull(message);
+		message = results.receive(1000);
+		assertNull(message);
 	}
 
 	private void waitForLatch(long timeout) {

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/GroovyControlBusIntegrationTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/GroovyControlBusIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -45,9 +45,6 @@ public class GroovyControlBusIntegrationTests {
 	private MessageChannel controlBus;
 
 	@Autowired
-	private PollableChannel controlBusOutput;
-
-	@Autowired
 	private PollableChannel output;
 
 	@Autowired
@@ -75,4 +72,5 @@ public class GroovyControlBusIntegrationTests {
 		assertNotNull(this.output.receive(10000));
 		assertNotNull(this.output.receive(10000));
 	}
+
 }

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/GroovyControlBusIntegrationTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/GroovyControlBusIntegrationTests.java
@@ -72,7 +72,7 @@ public class GroovyControlBusIntegrationTests {
 		Message<?> message = MessageBuilder.withPayload(scriptSource.getScriptAsString()).build();
 		this.controlBus.send(message);
 
-		assertNotNull(this.output.receive(1000));
-		assertNotNull(this.output.receive(1000));
+		assertNotNull(this.output.receive(10000));
+		assertNotNull(this.output.receive(10000));
 	}
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3560

`AbstractApplicationContext` has the code:

``` java
getLifecycleProcessor().onRefresh();

// Publish the final event.
publishEvent(new ContextRefreshedEvent(this));
```

So, some `Lifecycle`s (e.g. `InboundChannelAdapter`) can emit `Message<?>` and send to the `DelayHandler` before the `ContextRefreshedEvent`.
In this case `DelayHandler` `delays` the `Message<?>` and store it to the `MessageStore`.
When `ContextRefreshedEvent` is happened the `DelayHandler` reschedules all stored `Message<?>` and our 'early' `Message<?>` may be scheduled twice.

Fix an issue with an internal `Map<UUID, ScheduledFuture<?>> delayTasks` for each delayed `Message<?>`.
Remove the `ScheduledFuture<?>` for the `Message<?>` on release.
`cancel(true)` and `clear` all `delayTasks` on the `reschedulePersistedMessages()`.

**Cherry-pick to 4.0.x & 3.0.x**
