### PR TITLE
Add BF Required to Test Builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,6 +210,8 @@ subprojects { subproject ->
 		if (name ==~ /(springIo.*)|(testAll)/) {
 			systemProperty 'RUN_LONG_INTEGRATION_TESTS', 'true'
 		}
+
+		environment 'SI_FATAL_WHEN_NO_BEANFACTORY', 'true'
 	}
 
 	task sourcesJar(type: Jar) {


### PR DESCRIPTION
Previously, the environment variable that ensures all message creators have
a `BeanFactory` required setting the `SI_FATAL_WHEN_NO_BEANFACTORY` environment
variable to `true`.

Add this variable to `build.gradle`, enforcing the test for all builds.

**Once merged, we can remove the env. variable from the CI build(s)**
