### PR TITLE
INT-3565 ClassCastException with Proxy and DEBUG

### DIFF
--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/TransformerContextTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/TransformerContextTests.java
@@ -38,6 +38,8 @@ public class TransformerContextTests {
 
 	private static volatile int adviceCalled;
 
+	private static volatile int bazCalled;
+
 	@Test
 	public void methodInvokingTransformer() {
 		ConfigurableApplicationContext context = new ClassPathXmlApplicationContext(
@@ -53,15 +55,18 @@ public class TransformerContextTests {
 		input.send(new GenericMessage<String>("foo"));
 		reply = output.receive(0);
 		assertEquals("FOO", reply.getPayload());
-		StackTraceElement[] st = (StackTraceElement[]) reply.getHeaders().get("callStack");
-		assertEquals("doSend", st[18].getMethodName()); // no MethodInvokerHelper
 
 		input = context.getBean("directRef", MessageChannel.class);
 		input.send(new GenericMessage<String>("foo"));
 		reply = output.receive(0);
 		assertEquals("FOO", reply.getPayload());
-		st = (StackTraceElement[]) reply.getHeaders().get("callStack");
-		assertEquals("doSend", st[18].getMethodName()); // no MethodInvokerHelper
+		assertEquals(2, adviceCalled);
+
+		input = context.getBean("service", MessageChannel.class);
+		input.send(new GenericMessage<String>("foo"));
+		assertEquals(1, bazCalled);
+		assertEquals(3, adviceCalled);
+
 		context.close();
 	}
 
@@ -86,4 +91,17 @@ public class TransformerContextTests {
 		}
 
 	}
+
+	public static class BazService {
+
+		public void qux() {
+			bazCalled++;
+		}
+
+		public String upperCase(String input) {
+			return input.toUpperCase();
+		}
+
+	}
+
 }

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/TransformerContextTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/TransformerContextTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.transformer;
+package org.springframework.integration.monitor;
 
 import static org.junit.Assert.assertEquals;
 
@@ -31,8 +31,6 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
 
 /**
- * Also in JMX - changes here should be reflected there.
- *
  * @author Mark Fisher
  * @author Gary Russell
  */
@@ -56,14 +54,14 @@ public class TransformerContextTests {
 		reply = output.receive(0);
 		assertEquals("FOO", reply.getPayload());
 		StackTraceElement[] st = (StackTraceElement[]) reply.getHeaders().get("callStack");
-		assertEquals("doSend", st[6].getMethodName()); // no MethodInvokerHelper
+		assertEquals("doSend", st[18].getMethodName()); // no MethodInvokerHelper
 
 		input = context.getBean("directRef", MessageChannel.class);
 		input.send(new GenericMessage<String>("foo"));
 		reply = output.receive(0);
 		assertEquals("FOO", reply.getPayload());
 		st = (StackTraceElement[]) reply.getHeaders().get("callStack");
-		assertEquals("doSend", st[6].getMethodName()); // no MethodInvokerHelper
+		assertEquals("doSend", st[18].getMethodName()); // no MethodInvokerHelper
 		context.close();
 	}
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/transformerContextTests.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/transformerContextTests.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:int-jmx="http://www.springframework.org/schema/integration/jmx"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx-4.1.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<context:mbean-server/>
+
+	<int-jmx:mbean-export default-domain="transformers" />
+
+	<channel id="input"/>
+	
+	<recipient-list-router input-channel="input"> <!-- INT-3565 ClassCastException with DEBUG -->
+		<recipient channel="input1" selector-expression="true" />
+	</recipient-list-router>
+
+	<channel id="output">
+		<queue capacity="50"/>
+	</channel>
+
+	<transformer input-channel="input1" ref="testBean" method="upperCase" output-channel="output">
+		<request-handler-advice-chain>
+			<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$FooAdvice" />
+		</request-handler-advice-chain>
+	</transformer>
+
+	<beans:bean id="testBean" class="org.springframework.integration.transformer.TestBean"/>
+
+	<transformer input-channel="direct" output-channel="output">
+		<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$Bar"/>
+	</transformer>
+
+	<transformer input-channel="directRef" output-channel="output" ref="trans" method="handleMessage"/>
+	
+	<beans:bean id="trans" class="org.springframework.integration.monitor.TransformerContextTests$Bar"/>
+
+</beans:beans>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/transformerContextTests.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/transformerContextTests.xml
@@ -6,7 +6,7 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx-4.1.xsd
+		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<context:mbean-server/>
@@ -29,14 +29,25 @@
 		</request-handler-advice-chain>
 	</transformer>
 
-	<beans:bean id="testBean" class="org.springframework.integration.transformer.TestBean"/>
+	<beans:bean id="testBean" class="org.springframework.integration.monitor.TransformerContextTests$BazService"/>
 
 	<transformer input-channel="direct" output-channel="output">
 		<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$Bar"/>
 	</transformer>
 
-	<transformer input-channel="directRef" output-channel="output" ref="trans" method="handleMessage"/>
+	<transformer input-channel="directRef" output-channel="output" ref="trans" method="handleMessage">
+		<request-handler-advice-chain>
+			<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$FooAdvice" />
+		</request-handler-advice-chain>
+	</transformer>
 	
 	<beans:bean id="trans" class="org.springframework.integration.monitor.TransformerContextTests$Bar"/>
+
+	<service-activator input-channel="service" method="qux">
+		<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$BazService" />
+		<request-handler-advice-chain>
+			<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$FooAdvice" />
+		</request-handler-advice-chain>
+	</service-activator>
 
 </beans:beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3565

Cast to `IntegrationObjectSupport` fails if the handler is
already proxied in `AbstractSimpleMessageHandlerFactoryBean`.
