### PR TITLE
[4.0.x backport] INT-3565 Inject Advice Chain to Direct Handlers

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractSimpleMessageHandlerFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractSimpleMessageHandlerFactoryBean.java
@@ -19,6 +19,7 @@ import org.aopalliance.aop.Advice;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.aop.framework.Advised;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -29,6 +30,7 @@ import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.context.Orderable;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.util.Assert;
@@ -117,12 +119,25 @@ public abstract class AbstractSimpleMessageHandlerFactoryBean<H extends MessageH
 			if (this.handler instanceof MessageProducer && this.outputChannel != null) {
 				((MessageProducer) this.handler).setOutputChannel(this.outputChannel);
 			}
-			if (this.handler instanceof IntegrationObjectSupport && this.componentName != null) {
-				((IntegrationObjectSupport) this.handler).setComponentName(this.componentName);
+			Object actualHandler = extractTarget(this.handler);
+			if (actualHandler == null) {
+				actualHandler = this.handler;
 			}
-			if (!CollectionUtils.isEmpty(this.adviceChain) &&
-					this.handler instanceof AbstractReplyProducingMessageHandler) {
-				((AbstractReplyProducingMessageHandler) this.handler).setAdviceChain(this.adviceChain);
+			if (actualHandler instanceof IntegrationObjectSupport && this.componentName != null) {
+				((IntegrationObjectSupport) actualHandler).setComponentName(this.componentName);
+			}
+			if (!CollectionUtils.isEmpty(this.adviceChain)) {
+				if (actualHandler instanceof AbstractReplyProducingMessageHandler) {
+					((AbstractReplyProducingMessageHandler) actualHandler).setAdviceChain(this.adviceChain);
+				}
+				else if (logger.isDebugEnabled()) {
+					String name = this.componentName;
+					if (name == null && actualHandler instanceof NamedComponent) {
+						name = ((NamedComponent) actualHandler).getComponentName();
+					}
+					logger.debug("adviceChain can only be set on an AbstractReplyProducingMessageHandler"
+						+ (name == null ? "" : (", " + name)) + ".");
+				}
 			}
 			if (this.handler instanceof Orderable && this.order != null) {
 				((Orderable) this.handler).setOrder(this.order);
@@ -153,6 +168,23 @@ public abstract class AbstractSimpleMessageHandlerFactoryBean<H extends MessageH
 	@Override
 	public boolean isSingleton() {
 		return true;
+	}
+
+	private Object extractTarget(Object object) {
+		if (!(object instanceof Advised)) {
+			return object;
+		}
+		Advised advised = (Advised) object;
+		if (advised.getTargetSource() == null) {
+			return null;
+		}
+		try {
+			return extractTarget(advised.getTargetSource().getTarget());
+		}
+		catch (Exception e) {
+			logger.error("Could not extract target", e);
+			return null;
+		}
 	}
 
 }

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/transformerContextTests.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/transformerContextTests.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:int-jmx="http://www.springframework.org/schema/integration/jmx"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<context:mbean-server/>
+
+	<int-jmx:mbean-export default-domain="transformers" />
+
+	<channel id="input"/>
+	
+	<recipient-list-router input-channel="input"> <!-- INT-3565 ClassCastException with DEBUG -->
+		<recipient channel="input1" selector-expression="true" />
+	</recipient-list-router>
+
+	<channel id="output">
+		<queue capacity="50"/>
+	</channel>
+
+	<transformer input-channel="input1" ref="testBean" method="upperCase" output-channel="output">
+		<request-handler-advice-chain>
+			<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$FooAdvice" />
+		</request-handler-advice-chain>
+	</transformer>
+
+	<beans:bean id="testBean" class="org.springframework.integration.monitor.TransformerContextTests$BazService"/>
+
+	<transformer input-channel="direct" output-channel="output">
+		<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$Bar"/>
+	</transformer>
+
+	<transformer input-channel="directRef" output-channel="output" ref="trans" method="handleMessage">
+		<request-handler-advice-chain>
+			<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$FooAdvice" />
+		</request-handler-advice-chain>
+	</transformer>
+	
+	<beans:bean id="trans" class="org.springframework.integration.monitor.TransformerContextTests$Bar"/>
+
+	<service-activator input-channel="service" method="qux">
+		<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$BazService" />
+		<request-handler-advice-chain>
+			<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$FooAdvice" />
+		</request-handler-advice-chain>
+	</service-activator>
+
+</beans:beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3565

Cast to `IntegrationObjectSupport` fails if the handler is
already proxied in `AbstractSimpleMessageHandlerFactoryBean`.

Conflicts:
    spring-integration-core/src/main/java/org/springframework/integration/config/AbstractSimpleMessageHandlerFactoryBean.java

Resolved.

INT-3565 Polishing
- Fix test.
- enhance test to show that directly bound message handler beans are not advised if already proxied.
