### PR TITLE
[3.0.x backport] INT-3565 Inject Advice Chain to Direct Handlers

### DIFF
--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/transformerContextTests.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/transformerContextTests.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:int-jmx="http://www.springframework.org/schema/integration/jmx"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<context:mbean-server/>
+
+	<int-jmx:mbean-export default-domain="transformers" />
+
+	<channel id="input"/>
+	
+	<recipient-list-router input-channel="input"> <!-- INT-3565 ClassCastException with DEBUG -->
+		<recipient channel="input1" selector-expression="true" />
+	</recipient-list-router>
+
+	<channel id="output">
+		<queue capacity="50"/>
+	</channel>
+
+	<transformer input-channel="input1" ref="testBean" method="upperCase" output-channel="output">
+		<request-handler-advice-chain>
+			<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$FooAdvice" />
+		</request-handler-advice-chain>
+	</transformer>
+
+	<beans:bean id="testBean" class="org.springframework.integration.monitor.TransformerContextTests$BazService"/>
+
+	<transformer input-channel="direct" output-channel="output">
+		<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$Bar"/>
+	</transformer>
+
+	<transformer input-channel="directRef" output-channel="output" ref="trans" method="handleMessage">
+		<request-handler-advice-chain>
+			<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$FooAdvice" />
+		</request-handler-advice-chain>
+	</transformer>
+	
+	<beans:bean id="trans" class="org.springframework.integration.monitor.TransformerContextTests$Bar"/>
+
+	<service-activator input-channel="service" method="qux">
+		<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$BazService" />
+		<request-handler-advice-chain>
+			<beans:bean class="org.springframework.integration.monitor.TransformerContextTests$FooAdvice" />
+		</request-handler-advice-chain>
+	</service-activator>
+
+</beans:beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3565

Cast to `IntegrationObjectSupport` fails if the handler is
already proxied in `AbstractSimpleMessageHandlerFactoryBean`.

Conflicts:
    spring-integration-core/src/main/java/org/springframework/integration/config/AbstractSimpleMessageHandlerFactoryBean.java

Resolved.

INT-3565 Polishing
- Fix test.
- enhance test to show that directly bound message handler beans are not advised if already proxied.

Conflicts:
    spring-integration-core/src/main/java/org/springframework/integration/config/AbstractSimpleMessageHandlerFactoryBean.java

Resolved.
