### PR TITLE
INT-3571-4.2: Propagate Lifecycle to the target

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/core/LifecycleMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/LifecycleMessageSource.java
@@ -24,6 +24,8 @@ import org.springframework.context.Lifecycle;
  *
  * @author Artem Bilan
  * @since 4.0.6
+ * @deprecated since 4.2 in favor of direct {@link Lifecycle} usage.
  */
+@Deprecated
 public interface LifecycleMessageSource<T> extends MessageSource<T>, Lifecycle {
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MethodInvokingMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MethodInvokingMessageSource.java
@@ -19,6 +19,7 @@ package org.springframework.integration.endpoint;
 import java.lang.reflect.Method;
 
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.Lifecycle;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
@@ -30,8 +31,10 @@ import org.springframework.util.ReflectionUtils;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
-public class MethodInvokingMessageSource extends AbstractMessageSource<Object> implements InitializingBean {
+public class MethodInvokingMessageSource extends AbstractMessageSource<Object>
+		implements InitializingBean, Lifecycle {
 
 	private volatile Object object;
 
@@ -83,6 +86,25 @@ public class MethodInvokingMessageSource extends AbstractMessageSource<Object> i
 			this.method.setAccessible(true);
 			this.initialized = true;
 		}
+	}
+
+	@Override
+	public void start() {
+		if (this.object instanceof Lifecycle) {
+			((Lifecycle) this.object).start();
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (this.object instanceof Lifecycle) {
+			((Lifecycle) this.object).stop();
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return !(this.object instanceof Lifecycle) || ((Lifecycle) this.object).isRunning();
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.endpoint;
 
 import org.springframework.context.Lifecycle;
-import org.springframework.integration.core.LifecycleMessageSource;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.history.MessageHistory;
@@ -95,7 +94,7 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 
 	@Override
 	protected void doStart() {
-		if (this.source instanceof LifecycleMessageSource) {
+		if (this.source instanceof Lifecycle) {
 			((Lifecycle) this.source).start();
 		}
 		super.doStart();
@@ -104,7 +103,7 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 
 	@Override
 	protected void doStop() {
-		if (this.source instanceof LifecycleMessageSource) {
+		if (this.source instanceof Lifecycle) {
 			((Lifecycle) this.source).stop();
 		}
 		super.doStop();

--- a/spring-integration-core/src/main/java/org/springframework/integration/filter/AbstractMessageProcessingSelector.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/filter/AbstractMessageProcessingSelector.java
@@ -19,6 +19,7 @@ package org.springframework.integration.filter;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.Lifecycle;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.messaging.Message;
 import org.springframework.integration.core.MessageSelector;
@@ -31,8 +32,10 @@ import org.springframework.util.Assert;
  * a {@link MessageProcessor}.
  *
  * @author Mark Fisher
+ * @author Artem Bilan
  */
-public abstract class AbstractMessageProcessingSelector implements MessageSelector, BeanFactoryAware {
+public abstract class AbstractMessageProcessingSelector
+		implements MessageSelector, BeanFactoryAware, Lifecycle {
 
 	private final MessageProcessor<Boolean> messageProcessor;
 
@@ -60,6 +63,25 @@ public abstract class AbstractMessageProcessingSelector implements MessageSelect
 		Assert.notNull(result, "result must not be null");
 		Assert.isAssignable(Boolean.class, result.getClass(), "a boolean result is required");
 		return (Boolean) result;
+	}
+
+	@Override
+	public void start() {
+		if (this.messageProcessor instanceof Lifecycle) {
+			((Lifecycle) this.messageProcessor).start();
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (this.messageProcessor instanceof Lifecycle) {
+			((Lifecycle) this.messageProcessor).stop();
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return !(this.messageProcessor instanceof Lifecycle) || ((Lifecycle) this.messageProcessor).isRunning();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
@@ -18,6 +18,7 @@ package org.springframework.integration.filter;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.Lifecycle;
 import org.springframework.integration.MessageRejectedException;
 import org.springframework.integration.core.MessageSelector;
 import org.springframework.integration.handler.AbstractReplyProducingPostProcessingMessageHandler;
@@ -41,7 +42,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author David Liu
  */
-public class MessageFilter extends AbstractReplyProducingPostProcessingMessageHandler {
+public class MessageFilter extends AbstractReplyProducingPostProcessingMessageHandler implements Lifecycle {
 
 	private final MessageSelector selector;
 
@@ -120,6 +121,25 @@ public class MessageFilter extends AbstractReplyProducingPostProcessingMessageHa
 		if (this.selector instanceof BeanFactoryAware && this.getBeanFactory() != null) {
 			((BeanFactoryAware) this.selector).setBeanFactory(this.getBeanFactory());
 		}
+	}
+
+	@Override
+	public void start() {
+		if (this.selector instanceof Lifecycle) {
+			((Lifecycle) this.selector).start();
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (this.selector instanceof Lifecycle) {
+			((Lifecycle) this.selector).stop();
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return !(this.selector instanceof Lifecycle) || ((Lifecycle) this.selector).isRunning();
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.handler;
 
 import java.lang.reflect.Method;
 
+import org.springframework.context.Lifecycle;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.MessageHandler;
@@ -25,14 +26,15 @@ import org.springframework.util.Assert;
 
 /**
  * A {@link MessageHandler} that invokes the specified method on the provided object.
- * 
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  */
-public class MethodInvokingMessageHandler extends AbstractMessageHandler {
+public class MethodInvokingMessageHandler extends AbstractMessageHandler implements Lifecycle {
 
 	private volatile MethodInvokingMessageProcessor<Object> processor;
-	
+
 	private volatile String componentType;
 
 	public MethodInvokingMessageHandler(Object object, Method method) {
@@ -44,7 +46,7 @@ public class MethodInvokingMessageHandler extends AbstractMessageHandler {
 	public MethodInvokingMessageHandler(Object object, String methodName) {
 		processor = new MethodInvokingMessageProcessor<Object>(object, methodName);
 	}
-	
+
 	public void setComponentType(String componentType) {
 		this.componentType = componentType;
 	}
@@ -55,11 +57,26 @@ public class MethodInvokingMessageHandler extends AbstractMessageHandler {
 	}
 
 	@Override
+	public void start() {
+		this.processor.start();
+	}
+
+	@Override
+	public void stop() {
+		this.processor.stop();
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.processor.isRunning();
+	}
+
+	@Override
 	protected void handleMessageInternal(Message<?> message) throws Exception {
 		Object result = processor.processMessage(message);
 		if (result != null) {
 			throw new MessagingException(message, "the MethodInvokingMessageHandler method must "
-					+ "have a void return, but '" + this + "' received a value: [" + result + "]");			
+					+ "have a void return, but '" + this + "' received a value: [" + result + "]");
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
@@ -20,16 +20,19 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.Lifecycle;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.integration.util.MessagingMethodInvokerHelper;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 
 /**
- * A MessageProcessor implementation that invokes a method on a target Object. The Method instance or method name may be
- * provided as a constructor argument. If a method name is provided, and more than one declared method has that name,
- * the method-selection will be dynamic, based on the underlying SpEL method resolution. Alternatively, an annotation
- * type may be provided so that the candidates for SpEL's method resolution are determined by the presence of that
+ * A MessageProcessor implementation that invokes a method on a target Object.
+ * The Method instance or method name may be provided as a constructor argument.
+ * If a method name is provided, and more than one declared method has that name,
+ * the method-selection will be dynamic, based on the underlying SpEL method resolution.
+ * Alternatively, an annotation type may be provided so that the candidates for
+ * SpEL's method resolution are determined by the presence of that
  * annotation rather than the method name.
  *
  * @author Dave Syer
@@ -37,7 +40,7 @@ import org.springframework.messaging.MessageHandlingException;
  *
  * @since 2.0
  */
-public class MethodInvokingMessageProcessor<T> extends AbstractMessageProcessor<T> {
+public class MethodInvokingMessageProcessor<T> extends AbstractMessageProcessor<T> implements Lifecycle {
 
 	private final MessagingMethodInvokerHelper<T> delegate;
 
@@ -67,6 +70,21 @@ public class MethodInvokingMessageProcessor<T> extends AbstractMessageProcessor<
 	public void setBeanFactory(BeanFactory beanFactory) {
 		super.setBeanFactory(beanFactory);
 		delegate.setBeanFactory(beanFactory);
+	}
+
+	@Override
+	public void start() {
+		this.delegate.start();
+	}
+
+	@Override
+	public void stop() {
+		this.delegate.stop();
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.delegate.isRunning();
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
@@ -19,6 +19,7 @@ package org.springframework.integration.handler;
 import java.lang.reflect.Method;
 
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.Lifecycle;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
@@ -28,7 +29,7 @@ import org.springframework.messaging.MessageHandlingException;
  * @author Artem Bilan
  * @author Gary Russell
  */
-public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandler {
+public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandler implements Lifecycle {
 
 	private final MessageProcessor<?> processor;
 
@@ -63,6 +64,25 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 		if (this.processor instanceof BeanFactoryAware && this.getBeanFactory() != null) {
 			((BeanFactoryAware) this.processor).setBeanFactory(this.getBeanFactory());
 		}
+	}
+
+	@Override
+	public void start() {
+		if (this.processor instanceof Lifecycle) {
+			((Lifecycle) this.processor).start();
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (this.processor instanceof Lifecycle) {
+			((Lifecycle) this.processor).stop();
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return !(this.processor instanceof Lifecycle) || ((Lifecycle) this.processor).isRunning();
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.Lifecycle;
 import org.springframework.messaging.Message;
 import org.springframework.integration.handler.AbstractMessageProcessor;
 import org.springframework.integration.handler.MessageProcessor;
@@ -32,7 +33,8 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @since 2.0
  */
-class AbstractMessageProcessingRouter extends AbstractMappingMessageRouter {
+class AbstractMessageProcessingRouter extends AbstractMappingMessageRouter
+		implements Lifecycle {
 
 	private final MessageProcessor<?> messageProcessor;
 
@@ -52,6 +54,25 @@ class AbstractMessageProcessingRouter extends AbstractMappingMessageRouter {
 		if (this.messageProcessor instanceof BeanFactoryAware && this.getBeanFactory() != null) {
 			((BeanFactoryAware) this.messageProcessor).setBeanFactory(this.getBeanFactory());
 		}
+	}
+
+	@Override
+	public void start() {
+		if (this.messageProcessor instanceof Lifecycle) {
+			((Lifecycle) this.messageProcessor).start();
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (this.messageProcessor instanceof Lifecycle) {
+			((Lifecycle) this.messageProcessor).stop();
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return !(this.messageProcessor instanceof Lifecycle) || ((Lifecycle) this.messageProcessor).isRunning();
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageProcessingSplitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageProcessingSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.splitter;
 import java.util.Collection;
 
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.Lifecycle;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.messaging.Message;
 import org.springframework.integration.handler.AbstractMessageProcessor;
@@ -30,9 +31,11 @@ import org.springframework.util.Assert;
  * {@link MessageProcessor} instance.
  *
  * @author Mark Fisher
+ * @author Artem Bilan
  * @since 2.0
  */
-abstract class AbstractMessageProcessingSplitter extends AbstractMessageSplitter {
+abstract class AbstractMessageProcessingSplitter extends AbstractMessageSplitter
+		implements Lifecycle {
 
 	private final MessageProcessor<Collection<?>> messageProcessor;
 
@@ -56,6 +59,25 @@ abstract class AbstractMessageProcessingSplitter extends AbstractMessageSplitter
 	@Override
 	protected final Object splitMessage(Message<?> message) {
 		return this.messageProcessor.processMessage(message);
+	}
+
+	@Override
+	public void start() {
+		if (this.messageProcessor instanceof Lifecycle) {
+			((Lifecycle) this.messageProcessor).start();
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (this.messageProcessor instanceof Lifecycle) {
+			((Lifecycle) this.messageProcessor).stop();
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return !(this.messageProcessor instanceof Lifecycle) || ((Lifecycle) this.messageProcessor).isRunning();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/AbstractMessageProcessingTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/AbstractMessageProcessingTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.transformer;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.Lifecycle;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.integration.handler.AbstractMessageProcessor;
 import org.springframework.integration.handler.MessageProcessor;
@@ -31,8 +32,10 @@ import org.springframework.util.Assert;
  * Base class for Message Transformers that delegate to a {@link MessageProcessor}.
  *
  * @author Mark Fisher
+ * @author Artem Bilan
  */
-public abstract class AbstractMessageProcessingTransformer implements Transformer, BeanFactoryAware {
+public abstract class AbstractMessageProcessingTransformer
+		implements Transformer, BeanFactoryAware, Lifecycle {
 
 	private final MessageProcessor<?> messageProcessor;
 
@@ -57,6 +60,25 @@ public abstract class AbstractMessageProcessingTransformer implements Transforme
 			((AbstractMessageProcessor<?>) this.messageProcessor).setConversionService(conversionService);
 		}
 		this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(beanFactory);
+	}
+
+	@Override
+	public void start() {
+		if (this.messageProcessor instanceof Lifecycle) {
+			((Lifecycle) this.messageProcessor).start();
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (this.messageProcessor instanceof Lifecycle) {
+			((Lifecycle) this.messageProcessor).stop();
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return !(this.messageProcessor instanceof Lifecycle) || ((Lifecycle) this.messageProcessor).isRunning();
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.transformer;
 
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.Lifecycle;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.messaging.Message;
@@ -30,8 +31,9 @@ import org.springframework.util.Assert;
  *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  */
-public class MessageTransformingHandler extends AbstractReplyProducingMessageHandler {
+public class MessageTransformingHandler extends AbstractReplyProducingMessageHandler implements Lifecycle {
 
 	private final Transformer transformer;
 
@@ -60,6 +62,25 @@ public class MessageTransformingHandler extends AbstractReplyProducingMessageHan
 		if (this.getBeanFactory() != null && this.transformer instanceof BeanFactoryAware) {
 			((BeanFactoryAware) this.transformer).setBeanFactory(this.getBeanFactory());
 		}
+	}
+
+	@Override
+	public void start() {
+		if (this.transformer instanceof Lifecycle) {
+			((Lifecycle) this.transformer).start();
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (this.transformer instanceof Lifecycle) {
+			((Lifecycle) this.transformer).stop();
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return !(this.transformer instanceof Lifecycle) || ((Lifecycle) this.transformer).isRunning();
 	}
 
 	@Override

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests-context.xml
@@ -6,7 +6,7 @@
 			http://www.springframework.org/schema/integration
 			http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<message-history tracked-components="publishedChannel,input,*AnnotationTestService*"/>
+	<message-history tracked-components="publishedChannel,input,annotationTestService*"/>
 
 	<annotation-config default-publisher-channel="publishedChannel"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -142,28 +142,32 @@ public class EnableIntegrationTests {
 	private PollableChannel input;
 
 	@Autowired
-	@Qualifier("enableIntegrationTests.AnnotationTestService.handle.serviceActivator")
+	@Qualifier("annotationTestService.handle.serviceActivator")
 	private PollingConsumer serviceActivatorEndpoint;
 
 	@Autowired
-	@Qualifier("enableIntegrationTests.AnnotationTestService.handle1.serviceActivator")
+	@Qualifier("annotationTestService.handle1.serviceActivator")
 	private PollingConsumer serviceActivatorEndpoint1;
 
 	@Autowired
-	@Qualifier("enableIntegrationTests.AnnotationTestService.handle2.serviceActivator")
+	@Qualifier("annotationTestService.handle2.serviceActivator")
 	private PollingConsumer serviceActivatorEndpoint2;
 
 	@Autowired
-	@Qualifier("enableIntegrationTests.AnnotationTestService.handle3.serviceActivator")
+	@Qualifier("annotationTestService.handle3.serviceActivator")
 	private PollingConsumer serviceActivatorEndpoint3;
 
 	@Autowired
-	@Qualifier("enableIntegrationTests.AnnotationTestService.handle4.serviceActivator")
+	@Qualifier("annotationTestService.handle4.serviceActivator")
 	private PollingConsumer serviceActivatorEndpoint4;
 
 	@Autowired
-	@Qualifier("enableIntegrationTests.AnnotationTestService.transform.transformer")
+	@Qualifier("annotationTestService.transform.transformer")
 	private PollingConsumer transformer;
+
+	@Autowired
+	@Qualifier("annotationTestService")
+	private Lifecycle annotationTestService;
 
 	@Autowired
 	private Trigger myTrigger;
@@ -256,6 +260,12 @@ public class EnableIntegrationTests {
 		assertEquals(100L, TestUtils.getPropertyValue(trigger, "period"));
 		assertFalse(TestUtils.getPropertyValue(trigger, "fixedRate", Boolean.class));
 
+		assertTrue(this.annotationTestService.isRunning());
+		this.serviceActivatorEndpoint.stop();
+		assertFalse(this.annotationTestService.isRunning());
+		this.serviceActivatorEndpoint.start();
+		assertTrue(this.annotationTestService.isRunning());
+
 		trigger = TestUtils.getPropertyValue(this.serviceActivatorEndpoint1, "trigger", Trigger.class);
 		assertThat(trigger, Matchers.instanceOf(PeriodicTrigger.class));
 		assertEquals(100L, TestUtils.getPropertyValue(trigger, "period"));
@@ -283,11 +293,11 @@ public class EnableIntegrationTests {
 
 		this.input.send(MessageBuilder.withPayload("Foo").build());
 
-		Message<?> interceptedMessage = this.wireTapChannel.receive(1000);
+		Message<?> interceptedMessage = this.wireTapChannel.receive(10000);
 		assertNotNull(interceptedMessage);
 		assertEquals("Foo", interceptedMessage.getPayload());
 
-		Message<?> receive = this.output.receive(1000);
+		Message<?> receive = this.output.receive(10000);
 		assertNotNull(receive);
 		assertEquals("FOO", receive.getPayload());
 
@@ -296,7 +306,7 @@ public class EnableIntegrationTests {
 		String messageHistoryString = messageHistory.toString();
 		assertThat(messageHistoryString, Matchers.containsString("input"));
 		assertThat(messageHistoryString,
-				Matchers.containsString("AnnotationTestService.handle.serviceActivator.handler"));
+				Matchers.containsString("annotationTestService.handle.serviceActivator.handler"));
 		assertThat(messageHistoryString, Matchers.not(Matchers.containsString("output")));
 
 		receive = this.publishedChannel.receive(1000);
@@ -314,15 +324,13 @@ public class EnableIntegrationTests {
 		assertThat(this.testChannelInterceptor.getInvoked(), Matchers.greaterThan(0));
 		assertThat(this.fbInterceptorCounter.get(), Matchers.greaterThan(0));
 
-		assertTrue(this.context
-				.containsBean("enableIntegrationTests.AnnotationTestService.count.inboundChannelAdapter.source"));
-		Object messageSource = this.context
-				.getBean("enableIntegrationTests.AnnotationTestService.count.inboundChannelAdapter.source");
+		assertTrue(this.context.containsBean("annotationTestService.count.inboundChannelAdapter.source"));
+		Object messageSource = this.context.getBean("annotationTestService.count.inboundChannelAdapter.source");
 		assertThat(messageSource, Matchers.instanceOf(MethodInvokingMessageSource.class));
 
 		assertNull(this.counterChannel.receive(10));
 
-		SmartLifecycle countSA = this.context.getBean("enableIntegrationTests.AnnotationTestService.count.inboundChannelAdapter",
+		SmartLifecycle countSA = this.context.getBean("annotationTestService.count.inboundChannelAdapter",
 				SmartLifecycle.class);
 		assertFalse(countSA.isAutoStartup());
 		assertEquals(23, countSA.getPhase());
@@ -404,7 +412,7 @@ public class EnableIntegrationTests {
 		assertThat(this.testConverter.getInvoked(), Matchers.greaterThan(0));
 
 		assertTrue(this.bytesChannel.send(new GenericMessage<byte[]>("foo".getBytes())));
-		assertTrue(this.bytesChannel.send(new GenericMessage<Message<?>>(MutableMessageBuilder.withPayload("").build())));
+		assertTrue(this.bytesChannel.send(new GenericMessage<>(MutableMessageBuilder.withPayload("").build())));
 
 	}
 
@@ -413,8 +421,7 @@ public class EnableIntegrationTests {
 
 		assertEquals(2, this.context.getBeanNamesForType(GatewayProxyFactoryBean.class).length);
 
-		PollingConsumer consumer = this.context.getBean(
-				"enableIntegrationTests.AnnotationTestService.annCount.serviceActivator",
+		PollingConsumer consumer = this.context.getBean("annotationTestService.annCount.serviceActivator",
 				PollingConsumer.class);
 		assertFalse(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class));
 		assertEquals(23, TestUtils.getPropertyValue(consumer, "phase"));
@@ -424,8 +431,7 @@ public class EnableIntegrationTests {
 				"handler.adviceChain", List.class).get(0));
 		assertEquals(1000L, TestUtils.getPropertyValue(consumer, "trigger.period"));
 
-		consumer = this.context.getBean(
-				"enableIntegrationTests.AnnotationTestService.annCount1.serviceActivator",
+		consumer = this.context.getBean("annotationTestService.annCount1.serviceActivator",
 				PollingConsumer.class);
 		consumer.stop();
 		assertTrue(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class));
@@ -436,8 +442,7 @@ public class EnableIntegrationTests {
 				"handler.adviceChain", List.class).get(0));
 		assertEquals(2000L, TestUtils.getPropertyValue(consumer, "trigger.period"));
 
-		consumer = this.context.getBean(
-				"enableIntegrationTests.AnnotationTestService.annCount2.serviceActivator",
+		consumer = this.context.getBean("annotationTestService.annCount2.serviceActivator",
 				PollingConsumer.class);
 		assertFalse(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class));
 		assertEquals(23, TestUtils.getPropertyValue(consumer, "phase"));
@@ -448,9 +453,7 @@ public class EnableIntegrationTests {
 		assertEquals(1000L, TestUtils.getPropertyValue(consumer, "trigger.period"));
 
 		// Tests when the channel is in a "middle" annotation
-		consumer = this.context.getBean(
-				"enableIntegrationTests.AnnotationTestService.annCount5.serviceActivator",
-				PollingConsumer.class);
+		consumer = this.context.getBean("annotationTestService.annCount5.serviceActivator", PollingConsumer.class);
 		assertFalse(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class));
 		assertEquals(23, TestUtils.getPropertyValue(consumer, "phase"));
 		assertSame(context.getBean("annInput3"), TestUtils.getPropertyValue(consumer, "inputChannel"));
@@ -459,9 +462,7 @@ public class EnableIntegrationTests {
 				"handler.adviceChain", List.class).get(0));
 		assertEquals(1000L, TestUtils.getPropertyValue(consumer, "trigger.period"));
 
-		consumer = this.context.getBean(
-				"enableIntegrationTests.AnnotationTestService.annAgg1.aggregator",
-				PollingConsumer.class);
+		consumer = this.context.getBean("annotationTestService.annAgg1.aggregator", PollingConsumer.class);
 		assertFalse(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class));
 		assertEquals(23, TestUtils.getPropertyValue(consumer, "phase"));
 		assertSame(context.getBean("annInput"), TestUtils.getPropertyValue(consumer, "inputChannel"));
@@ -471,9 +472,7 @@ public class EnableIntegrationTests {
 		assertEquals(1000L, TestUtils.getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout"));
 		assertFalse(TestUtils.getPropertyValue(consumer, "handler.sendPartialResultOnExpiry", Boolean.class));
 
-		consumer = this.context.getBean(
-				"enableIntegrationTests.AnnotationTestService.annAgg2.aggregator",
-				PollingConsumer.class);
+		consumer = this.context.getBean("annotationTestService.annAgg2.aggregator", PollingConsumer.class);
 		assertFalse(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class));
 		assertEquals(23, TestUtils.getPropertyValue(consumer, "phase"));
 		assertSame(context.getBean("annInput"), TestUtils.getPropertyValue(consumer, "inputChannel"));
@@ -598,7 +597,7 @@ public class EnableIntegrationTests {
 	@IntegrationComponentScan
 	@EnableIntegration
 	@PropertySource("classpath:org/springframework/integration/configuration/EnableIntegrationTests.properties")
-	@EnableMessageHistory({"input", "publishedChannel", "*AnnotationTestService*"})
+	@EnableMessageHistory({"input", "publishedChannel", "annotationTestService*"})
 	public static class ContextConfiguration {
 
 		@Bean
@@ -854,11 +853,13 @@ public class EnableIntegrationTests {
 		@ServiceActivator(inputChannel = "sendAsyncChannel")
 		public MessageHandler sendAsyncHandler() {
 			return new MessageHandler() {
+
 				@Override
 				public void handleMessage(Message<?> message) throws MessagingException {
 					asyncAnnotationProcessLatch().countDown();
 					asyncAnnotationProcessThread().set(Thread.currentThread());
 				}
+
 			};
 		}
 
@@ -950,12 +951,54 @@ public class EnableIntegrationTests {
 
 	}
 
+	public interface AnnotationTestService {
 
-	@MessageEndpoint
-	public static class AnnotationTestService {
+		String handle(String payload);
+
+		String handle1(String payload);
+
+		String handle2(String payload);
+
+		String handle3(String payload);
+
+		String handle4(String payload);
+
+		String transform(Message<String> message);
+
+		String transform2(Message<String> message);
+
+		Integer count();
+
+		String foo();
+
+		Message<?> message();
+
+		Integer annCount();
+
+		Integer annCount1();
+
+		Integer annCount2();
+
+		Integer annCount5();
+
+		Integer annCount8();
+
+		Integer annAgg1(List<?> messages);
+
+		Integer annAgg2(List<?> messages);
+
+		Integer multiply(Integer value);
+
+	}
+
+	@MessageEndpoint("annotationTestService")
+	public static class AnnotationTestServiceImpl implements Lifecycle, AnnotationTestService {
 
 		private final AtomicInteger counter = new AtomicInteger();
 
+		private boolean running;
+
+		@Override
 		@ServiceActivator(inputChannel = "input", outputChannel = "output",
 				poller = @Poller(maxMessagesPerPoll = "${poller.maxMessagesPerPoll}", fixedDelay = "${poller.interval}"))
 		@Publisher
@@ -964,6 +1007,7 @@ public class EnableIntegrationTests {
 			return payload.toUpperCase();
 		}
 
+		@Override
 		@ServiceActivator(inputChannel = "input1", outputChannel = "output",
 				poller = @Poller(maxMessagesPerPoll = "${poller.maxMessagesPerPoll}", fixedRate = "${poller.interval}"))
 		@Publisher
@@ -972,6 +1016,7 @@ public class EnableIntegrationTests {
 			return payload.toUpperCase();
 		}
 
+		@Override
 		@ServiceActivator(inputChannel = "input2", outputChannel = "output",
 				poller = @Poller(maxMessagesPerPoll = "${poller.maxMessagesPerPoll}", cron = "0 5 7 * * *"))
 		@Publisher
@@ -980,6 +1025,7 @@ public class EnableIntegrationTests {
 			return payload.toUpperCase();
 		}
 
+		@Override
 		@ServiceActivator(inputChannel = "input3", outputChannel = "output", poller = @Poller("myPoller"))
 		@Publisher
 		@Payload("#args[0].toLowerCase()")
@@ -987,6 +1033,7 @@ public class EnableIntegrationTests {
 			return payload.toUpperCase();
 		}
 
+		@Override
 		@ServiceActivator(inputChannel = "input4", outputChannel = "output",
 				poller = @Poller(trigger = "myTrigger"))
 		@Publisher
@@ -1005,6 +1052,7 @@ public class EnableIntegrationTests {
 			return payload.toUpperCase();
 		}*/
 
+		@Override
 		@Transformer(inputChannel = "gatewayChannel")
 		public String transform(Message<String> message) {
 			assertTrue(message.getHeaders().containsKey("foo"));
@@ -1014,6 +1062,7 @@ public class EnableIntegrationTests {
 			return this.handle(message.getPayload());
 		}
 
+		@Override
 		@Transformer(inputChannel = "gatewayChannel2")
 		public String transform2(Message<String> message) {
 			assertTrue(message.getHeaders().containsKey("foo"));
@@ -1023,16 +1072,19 @@ public class EnableIntegrationTests {
 			return this.handle(message.getPayload()) + "2";
 		}
 
+		@Override
 		@MyInboundChannelAdapter1
 		public Integer count() {
 			return this.counter.incrementAndGet();
 		}
 
+		@Override
 		@InboundChannelAdapter(value = "fooChannel", poller = @Poller(trigger = "onlyOnceTrigger", maxMessagesPerPoll = "1"))
 		public String foo() {
 			return "foo";
 		}
 
+		@Override
 		@InboundChannelAdapter(value = "messageChannel", poller = @Poller(fixedDelay = "${poller.interval}",
 				maxMessagesPerPoll = "1"))
 		public Message<?> message() {
@@ -1056,37 +1108,44 @@ public class EnableIntegrationTests {
 
 		// metaAnnotation tests
 
+		@Override
 		@MyServiceActivator
 		public Integer annCount() {
 			return 0;
 		}
 
+		@Override
 		@MyServiceActivator1(inputChannel = "annInput1", autoStartup = "true",
 				adviceChain = {"annAdvice1"}, poller = @Poller(fixedRate = "2000"))
 		public Integer annCount1() {
 			return 0;
 		}
 
+		@Override
 		@MyServiceActivatorNoLocalAtts()
 		public Integer annCount2() {
 			return 0;
 		}
 
+		@Override
 		@MyServiceActivator5
 		public Integer annCount5() {
 			return 0;
 		}
 
+		@Override
 		@MyServiceActivator8
 		public Integer annCount8() {
 			return 0;
 		}
 
+		@Override
 		@MyAggregator
 		public Integer annAgg1(List<?> messages) {
 			return 42;
 		}
 
+		@Override
 		@MyAggregatorDefaultOverrideDefaults
 		public Integer annAgg2(List<?> messages) {
 			return 42;
@@ -1096,10 +1155,27 @@ public class EnableIntegrationTests {
 		/*@BridgeFrom("")
 		public void invalidBridgeAnnotationMethod(Object payload) {}*/
 
+		@Override
 		@ServiceActivator(inputChannel = "promiseChannel")
 		public Integer multiply(Integer value) {
 			return value * 2;
 		}
+
+		@Override
+		public void start() {
+			this.running = true;
+		}
+
+		@Override
+		public void stop() {
+			this.running = false;
+		}
+
+		@Override
+		public boolean isRunning() {
+			return this.running;
+		}
+
 	}
 
 	@TestMessagingGateway

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.properties
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.properties
@@ -1,3 +1,3 @@
-message.history.tracked.components=input, publishedChannel, *AnnotationTestService*
+message.history.tracked.components=input, publishedChannel, annotationTestService*
 poller.maxMessagesPerPoll=10
 poller.interval=100

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollingLifecycleTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollingLifecycleTests.java
@@ -34,11 +34,11 @@ import org.mockito.Mockito;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.Lifecycle;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.SourcePollingChannelAdapterFactoryBean;
 import org.springframework.integration.config.TestErrorHandler;
-import org.springframework.integration.core.LifecycleMessageSource;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.messaging.Message;
@@ -178,7 +178,8 @@ public class PollingLifecycleTests {
 
 		final AtomicBoolean stopInvoked = new AtomicBoolean();
 
-		adapterFactory.setSource(new LifecycleMessageSource<Object>() {
+		MethodInvokingMessageSource source = new MethodInvokingMessageSource();
+		source.setObject(new Lifecycle() {
 
 			@Override
 			public void start() {
@@ -195,12 +196,10 @@ public class PollingLifecycleTests {
 				return false;
 			}
 
-			@Override
-			public Message<Object> receive() {
-				return null;
-			}
-
 		});
+		source.setMethodName("isRunning");
+
+		adapterFactory.setSource(source);
 
 		SourcePollingChannelAdapter adapter = adapterFactory.getObject();
 		adapter.setTaskScheduler(this.taskScheduler);

--- a/spring-integration-core/src/test/java/org/springframework/integration/filter/FilterContextTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/filter/FilterContextTests-context.xml
@@ -13,7 +13,7 @@
 		<queue capacity="50"/>
 	</channel>
 
-	<filter input-channel="input"
+	<filter id="pojoFilter" input-channel="input"
 			ref="testBean"
 			method="acceptStringWithMoreThanThreeChars"
 			output-channel="output"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/filter/FilterContextTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/filter/FilterContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,41 +17,59 @@
 package org.springframework.integration.filter;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
 public class FilterContextTests {
+
+	@Autowired
+	private MessageChannel input;
+
+	@Autowired
+	private PollableChannel output;
+
+	@Autowired
+	private AbstractEndpoint pojoFilter;
+
+	@Autowired
+	private TestBean testBean;
 
 	@Test
 	public void methodInvokingFilterRejects() {
-		ApplicationContext context = new ClassPathXmlApplicationContext(
-				"filterContextTests.xml", this.getClass());
-		MessageChannel input = (MessageChannel) context.getBean("input");
-		PollableChannel output = (PollableChannel) context.getBean("output");
-		input.send(new GenericMessage<String>("foo"));
-		Message<?> reply = output.receive(0);
+		this.input.send(new GenericMessage<String>("foo"));
+		Message<?> reply = this.output.receive(0);
 		assertNull(reply);
+
+		assertTrue(this.testBean.isRunning());
+		this.pojoFilter.stop();
+		assertFalse(this.testBean.isRunning());
+		this.pojoFilter.start();
+		assertTrue(this.testBean.isRunning());
 	}
 
 	@Test
 	public void methodInvokingFilterAccepts() {
-		ApplicationContext context = new ClassPathXmlApplicationContext(
-				"filterContextTests.xml", this.getClass());
-		MessageChannel input = (MessageChannel) context.getBean("input");
-		PollableChannel output = (PollableChannel) context.getBean("output");
-		input.send(new GenericMessage<String>("foobar"));
-		Message<?> reply = output.receive(0);
+		this.input.send(new GenericMessage<String>("foobar"));
+		Message<?> reply = this.output.receive(0);
 		assertEquals("foobar", reply.getPayload());
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/filter/TestBean.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/filter/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,33 @@
 
 package org.springframework.integration.filter;
 
+import org.springframework.context.Lifecycle;
+
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  */
-public class TestBean {
+public class TestBean implements Lifecycle {
+
+	private boolean running;
 
 	public boolean acceptStringWithMoreThanThreeChars(String s) {
 		return s.length() > 3;
+	}
+
+	@Override
+	public void start() {
+		this.running = true;
+	}
+
+	@Override
+	public void stop() {
+		this.running = false;
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.running;
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterWithMappingTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterWithMappingTests-context.xml
@@ -38,7 +38,7 @@
 		<queue capacity="1" />
 	</channel>
 
-	<router input-channel="pojoRouter" ref="testBean"
+	<router id="pojoRouterEndpoint" input-channel="pojoRouter" ref="testBean"
 			default-output-channel="defaultChannelForPojo"
 			resolution-required="false">
 		<mapping value="foo" channel="fooChannelForPojo"/>

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/TestBean.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,33 @@
 
 package org.springframework.integration.transformer;
 
+import org.springframework.context.Lifecycle;
+
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  */
-public class TestBean {
+public class TestBean implements Lifecycle {
+
+	private boolean running;
 
 	public String upperCase(String input) {
 		return input.toUpperCase();
+	}
+
+	@Override
+	public void start() {
+		this.running = true;
+	}
+
+	@Override
+	public void stop() {
+		this.running = false;
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.running;
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/TransformerContextTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/TransformerContextTests-context.xml
@@ -13,7 +13,7 @@
 		<queue capacity="50"/>
 	</channel>
 
-	<transformer input-channel="input" ref="testBean" method="upperCase" output-channel="output">
+	<transformer id="pojoTransformer" input-channel="input" ref="testBean" method="upperCase" output-channel="output">
 		<request-handler-advice-chain>
 			<beans:bean class="org.springframework.integration.transformer.TransformerContextTests$FooAdvice" />
 		</request-handler-advice-chain>
@@ -26,7 +26,7 @@
 	</transformer>
 
 	<transformer input-channel="directRef" output-channel="output" ref="trans" method="handleMessage"/>
-	
+
 	<beans:bean id="trans" class="org.springframework.integration.transformer.TransformerContextTests$Bar"/>
 
 </beans:beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3571
- Deprecate `LifecycleMessageSource` and change `SourcePollingChannelAdapter` to get deal with `Lifecycle` directly
- Add `Lifecycle` propagation for the `MessagingMethodInvokerHelper` and its users: `MethodInvokingMessageProcessor`,
  `ServiceActivatingHandler`, `MethodInvokingMessageHandler`, `MessageTransformingHandler` etc.
- Fix the bug with `MessagingAnnotationPostProcessor` and `Proxy` for the target object, when we should process annotation on the root method,
  but create `MethodInvokingMessageHandler` for the method on the `Proxy`. Apply this logic only when `Proxy` is `JdkDynamic`, because of `CGLIB`
  does `proxy-target-class`. In case of `JdkDynamicProxy` throw `IllegalArgumentException` if the method isn't extracted to the service interface.
