### PR TITLE
INT-3578 Fix IllegalArgumentException

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
@@ -107,7 +107,7 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 
 	private volatile boolean applySequence;
 
-	private volatile long readDelay;
+	private volatile Long readDelay;
 
 	private volatile TcpSSLContextSupport sslContextSupport;
 
@@ -191,7 +191,9 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 		factory.setBeanName(this.beanName);
 		factory.setTcpSocketSupport(this.socketSupport);
 		factory.setApplicationEventPublisher(this.applicationEventPublisher);
-		factory.setReadDelay(this.readDelay);
+		if (this.readDelay != null) {
+			factory.setReadDelay(this.readDelay);
+		}
 	}
 
 	private void setServerAttributes(AbstractServerConnectionFactory factory) {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBeanTest.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBeanTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.ip.config;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.springframework.integration.test.util.TestUtils;
+
+/**
+ * @author Gary Russell
+ * @since 4.1.1
+ *
+ */
+public class TcpConnectionFactoryFactoryBeanTest {
+
+	@Test
+	public void testNoReadDelay() throws Exception {
+		TcpConnectionFactoryFactoryBean fb = new TcpConnectionFactoryFactoryBean();
+		fb.setHost("foo");
+		fb.afterPropertiesSet();
+		fb.getObject(); // INT-3578 IllegalArgumentException on 'readDelay'
+	}
+
+	@Test
+	public void testReadDelay() throws Exception {
+		TcpConnectionFactoryFactoryBean fb = new TcpConnectionFactoryFactoryBean();
+		fb.setHost("foo");
+		fb.setReadDelay(1000);
+		fb.afterPropertiesSet();
+		assertEquals(1000L, TestUtils.getPropertyValue(fb.getObject(), "readDelay"));
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3578

Adding `readDelay` to XML namespace for the `TcpConnectionFactoryFactoryBean`
caused an `IllegalArgumentException` when configuring with Java instea of
XML.
