### PR TITLE
INT-3585: Handle `payload.class.name` Expressions

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationEvaluationContextFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationEvaluationContextFactoryBean.java
@@ -176,7 +176,7 @@ public class IntegrationEvaluationContextFactoryBean implements FactoryBean<Stan
 	/**
 	 * Sort the property accessors thus: unordered, ordered; when applied to the evaluation
 	 * context; unordered will be followed by ordered with a negative order, followed by the default
-	 * (currenly reflective) followed by ordered with >= 0 order. Within the same order (or unordered)
+	 * (currently reflective) followed by ordered with >= 0 order. Within the same order (or unordered)
 	 * the original order is retained.
 	 */
 	private void sortPropertyAccessors() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/AbstractJsonPropertyAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/AbstractJsonPropertyAccessor.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.json;
+
+import org.springframework.expression.AccessException;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.PropertyAccessor;
+import org.springframework.expression.TypedValue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ContainerNode;
+
+/**
+ * Base class for json {@link PropertyAccessor}s.
+ *
+ * @author Eric Bottard
+ * @author Artem Bilan
+ * @author Gary Russell
+ * @since 3.0
+ */
+public abstract class AbstractJsonPropertyAccessor implements PropertyAccessor {
+
+	@Override
+	public boolean canRead(EvaluationContext context, Object target, String name) throws AccessException {
+		ContainerNode<?> container = asJson(target);
+		Integer index = maybeIndex(name);
+		return ((index != null && container.has(index)) || container.has(name));
+	}
+
+	protected ContainerNode<?> assertContainerNode(JsonNode json) throws AccessException {
+		if (json instanceof ContainerNode) {
+			return (ContainerNode<?>) json;
+		}
+		else {
+			throw new AccessException("Can not act on json that is not a ContainerNode: "
+					+ json.getClass().getSimpleName());
+		}
+	}
+
+	abstract ContainerNode<?> asJson(Object target) throws AccessException;
+
+	/**
+	 * Return an integer if the String property name can be parsed as an int, or null otherwise.
+	 */
+	private Integer maybeIndex(String name) {
+		try {
+			return Integer.valueOf(name);
+		}
+		catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	@Override
+	public TypedValue read(EvaluationContext context, Object target, String name) throws AccessException {
+		ContainerNode<?> container = asJson(target);
+		Integer index = maybeIndex(name);
+		if (index != null && container.has(index)) {
+			return new TypedValue(wrap(container.get(index)));
+		}
+		else {
+			return new TypedValue(wrap(container.get(name)));
+		}
+	}
+
+	@Override
+	public boolean canWrite(EvaluationContext context, Object target, String name) throws AccessException {
+		return false;
+	}
+
+	@Override
+	public void write(EvaluationContext context, Object target, String name, Object newValue) throws AccessException {
+		throw new UnsupportedOperationException("Write is not supported");
+	}
+
+	protected ToStringFriendlyJsonNode wrap(JsonNode json) {
+		return new ToStringFriendlyJsonNode(json);
+	}
+
+	public static class ToStringFriendlyJsonNode {
+
+		protected final JsonNode node;
+
+		public ToStringFriendlyJsonNode(JsonNode node) {
+			this.node = node;
+		}
+
+		@Override
+		public String toString() {
+			if (node.isValueNode()) {
+				// This is to avoid quotes around a TextNode for example
+				return node.asText();
+			}
+			else {
+				return node.toString();
+			}
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			return this == o
+					|| (!(o == null || getClass() != o.getClass())
+							&& this.node.equals(((ToStringFriendlyJsonNode) o).node));
+		}
+
+		@Override
+		public int hashCode() {
+			return this.node.toString().hashCode();
+		}
+
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonNodePropertyAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonNodePropertyAccessor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.json;
+
+import org.springframework.expression.AccessException;
+import org.springframework.expression.PropertyAccessor;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ContainerNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * A SpEL {@link PropertyAccessor} that knows how to read on Jackson JSON objects.
+ *
+ * @author Eric Bottard
+ * @author Artem Bilan
+ * @since 3.0
+ */
+public class JsonNodePropertyAccessor extends AbstractJsonPropertyAccessor {
+
+	/**
+	 * The kind of types this can work with.
+	 */
+	private static final Class<?>[] SUPPORTED_CLASSES = new Class<?>[] {ToStringFriendlyJsonNode.class,
+			ObjectNode.class, ArrayNode.class};
+
+	@Override
+	public Class<?>[] getSpecificTargetClasses() {
+		return SUPPORTED_CLASSES;
+	}
+
+	@Override
+	ContainerNode<?> asJson(Object target) throws AccessException {
+		if (target instanceof ContainerNode) {
+			return (ContainerNode<?>) target;
+		}
+		else if (target instanceof ToStringFriendlyJsonNode) {
+			ToStringFriendlyJsonNode wrapper = (ToStringFriendlyJsonNode) target;
+			return assertContainerNode(wrapper.node);
+		}
+		else {
+			throw new IllegalStateException("Can't happen. Check SUPPORTED_CLASSES");
+		}
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPropertyAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPropertyAccessor.java
@@ -18,7 +18,6 @@ package org.springframework.integration.json;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 import org.springframework.expression.AccessException;
 import org.springframework.expression.EvaluationContext;
@@ -41,18 +40,15 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * @author Gary Russell
  * @since 3.0
  */
-public class JsonPropertyAccessor implements PropertyAccessor, CompositePropertyAccessor {
+public class JsonPropertyAccessor implements CompositePropertyAccessor {
 
 	private final JsonNodePropertyAccessor nodeAccessor = new JsonNodePropertyAccessor();
 
 	private final JsonStringPropertyAccessor stringAccessor = new JsonStringPropertyAccessor();
 
-	private final List<PropertyAccessor> accessors = Arrays.<PropertyAccessor>asList(nodeAccessor, stringAccessor);
-
-
 	@Override
 	public Collection<PropertyAccessor> accessors() {
-		return accessors;
+		return Arrays.<PropertyAccessor>asList(nodeAccessor, stringAccessor);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonStringPropertyAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonStringPropertyAccessor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.json;
+
+import java.io.IOException;
+
+import org.springframework.core.Ordered;
+import org.springframework.expression.AccessException;
+import org.springframework.expression.PropertyAccessor;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ContainerNode;
+
+/**
+ * A SpEL {@link PropertyAccessor} that knows how to read on Jackson JSON objects.
+ *
+ * @author Eric Bottard
+ * @author Artem Bilan
+ * @author Gary Russell
+ * @since 3.0
+ */
+public class JsonStringPropertyAccessor extends AbstractJsonPropertyAccessor implements Ordered {
+
+	// Note: ObjectMapper is thread-safe
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	private int order = Integer.MAX_VALUE / 2;
+
+	public void setObjectMapper(ObjectMapper objectMapper) {
+		Assert.notNull(objectMapper, "'objectMapper' cannot be null");
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	public void setOrder(int order) {
+		this.order = order;
+	}
+
+	@Override
+	public Class<?>[] getSpecificTargetClasses() {
+		return null; // so it can be positioned after the Reflection Accessor INT-3585
+	}
+
+	@Override
+	ContainerNode<?> asJson(Object target) throws AccessException {
+		if (target instanceof String) {
+			try {
+				JsonNode json = this.objectMapper.readTree((String) target);
+				return assertContainerNode(json);
+			}
+			catch (JsonProcessingException e) {
+				throw new AccessException("Exception while trying to deserialize String", e);
+			}
+			catch (IOException e) {
+				throw new AccessException("Exception while trying to deserialize String", e);
+			}
+		}
+		else {
+			throw new IllegalStateException("Can't happen. Check SUPPORTED_CLASSES");
+		}
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonStringPropertyAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonStringPropertyAccessor.java
@@ -23,7 +23,6 @@ import org.springframework.expression.AccessException;
 import org.springframework.expression.PropertyAccessor;
 import org.springframework.util.Assert;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ContainerNode;
@@ -68,9 +67,6 @@ public class JsonStringPropertyAccessor extends AbstractJsonPropertyAccessor imp
 			try {
 				JsonNode json = this.objectMapper.readTree((String) target);
 				return assertContainerNode(json);
-			}
-			catch (JsonProcessingException e) {
-				throw new AccessException("Exception while trying to deserialize String", e);
 			}
 			catch (IOException e) {
 				throw new AccessException("Exception while trying to deserialize String", e);

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/ToStringFriendlyJsonNodeToStringConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/ToStringFriendlyJsonNodeToStringConverter.java
@@ -25,13 +25,14 @@ import org.springframework.core.convert.converter.Converter;
  * expression for JSON in case of the {@link JsonPropertyAccessor} usage.
  *
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 4.1
  */
 class ToStringFriendlyJsonNodeToStringConverter
-		implements Converter<JsonPropertyAccessor.ToStringFriendlyJsonNode, String> {
+		implements Converter<AbstractJsonPropertyAccessor.ToStringFriendlyJsonNode, String> {
 
 	@Override
-	public String convert(JsonPropertyAccessor.ToStringFriendlyJsonNode source) {
+	public String convert(AbstractJsonPropertyAccessor.ToStringFriendlyJsonNode source) {
 		return source.toString();
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/CompositePropertyAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/CompositePropertyAccessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.support;
+
+import java.util.Collection;
+
+import org.springframework.expression.PropertyAccessor;
+
+/**
+ * A {@link PropertyAccessor} that wraps 2 or more actual {@link PropertyAccessor}s.
+ *
+ * @author Gary Russell
+ * @since 4.1.2
+ *
+ */
+public interface CompositePropertyAccessor extends PropertyAccessor {
+
+	Collection<PropertyAccessor> accessors();
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/IntegrationEvaluationContextFactoryBeanTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/IntegrationEvaluationContextFactoryBeanTests.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.config;
+
+import static org.junit.Assert.assertSame;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.core.Ordered;
+import org.springframework.expression.AccessException;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.PropertyAccessor;
+import org.springframework.expression.TypedValue;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * @author Gary Russell
+ * @since 4.1.2
+ *
+ */
+public class IntegrationEvaluationContextFactoryBeanTests {
+
+	@Test
+	public void testPropertyAccessorOrder1() throws Exception {
+		IntegrationEvaluationContextFactoryBean factoryBean = new IntegrationEvaluationContextFactoryBean();
+		Foo foo1 = new Foo();
+		Foo foo2 = new Foo();
+		Foo foo3 = new Foo();
+		Foo foo4 = new Foo();
+		Bar bar1 = new Bar(10);
+		Bar bar2 = new Bar(10);
+		Bar bar3 = new Bar(-10);
+		Bar bar4 = new Bar(-10);
+		Bar bar5 = new Bar(-20);
+		Bar bar6 = new Bar(5);
+		Map<String, PropertyAccessor> map = new LinkedHashMap<String, PropertyAccessor>();
+		map.put("foo1", foo1); // unordered first
+		map.put("foo2", foo2);
+		map.put("bar3", bar3);
+		map.put("bar2", bar2);
+		map.put("bar1", bar1);
+		map.put("bar4", bar4);
+		map.put("foo3", foo3);
+		map.put("foo4", foo4);
+		map.put("bar5", bar5);
+		map.put("bar6", bar6);
+		factoryBean.setPropertyAccessors(map);
+		factoryBean.afterPropertiesSet();
+		StandardEvaluationContext context = factoryBean.getObject();
+		List<PropertyAccessor> propertyAccessors = context.getPropertyAccessors();
+		Iterator<PropertyAccessor> iterator = propertyAccessors.iterator();
+		assertSame(foo1, iterator.next()); // unordered, then < 0; then reflect; then >= 0
+		assertSame(foo2, iterator.next());
+		assertSame(foo3, iterator.next());
+		assertSame(foo4, iterator.next());
+		assertSame(bar5, iterator.next());
+		assertSame(bar3, iterator.next());
+		assertSame(bar4, iterator.next());
+		iterator.next(); // map
+		iterator.next(); // reflective
+		assertSame(bar6, iterator.next());
+		assertSame(bar2, iterator.next());
+		assertSame(bar1, iterator.next());
+	}
+
+	@Test
+	public void testPropertyAccessorOrder2() throws Exception {
+		IntegrationEvaluationContextFactoryBean factoryBean = new IntegrationEvaluationContextFactoryBean();
+		Foo foo1 = new Foo();
+		Foo foo2 = new Foo();
+		Foo foo3 = new Foo();
+		Foo foo4 = new Foo();
+		Bar bar1 = new Bar(10);
+		Bar bar2 = new Bar(10);
+		Bar bar3 = new Bar(-10);
+		Bar bar4 = new Bar(-10);
+		Bar bar5 = new Bar(-20);
+		Bar bar6 = new Bar(5);
+		Map<String, PropertyAccessor> map = new LinkedHashMap<String, PropertyAccessor>();
+		map.put("bar3", bar3); // ordered first
+		map.put("bar2", bar2);
+		map.put("foo1", foo1);
+		map.put("foo2", foo2);
+		map.put("bar1", bar1);
+		map.put("bar4", bar4);
+		map.put("foo3", foo3);
+		map.put("foo4", foo4);
+		map.put("bar5", bar5);
+		map.put("bar6", bar6);
+		factoryBean.setPropertyAccessors(map);
+		factoryBean.afterPropertiesSet();
+		StandardEvaluationContext context = factoryBean.getObject();
+		List<PropertyAccessor> propertyAccessors = context.getPropertyAccessors();
+		Iterator<PropertyAccessor> iterator = propertyAccessors.iterator();
+		assertSame(foo1, iterator.next());
+		assertSame(foo2, iterator.next());
+		assertSame(foo3, iterator.next());
+		assertSame(foo4, iterator.next());
+		assertSame(bar5, iterator.next());
+		assertSame(bar3, iterator.next());
+		assertSame(bar4, iterator.next());
+		iterator.next(); // map
+		iterator.next(); // reflective
+		assertSame(bar6, iterator.next());
+		assertSame(bar2, iterator.next());
+		assertSame(bar1, iterator.next());
+	}
+
+	public class Foo implements PropertyAccessor {
+
+		@Override
+		public Class<?>[] getSpecificTargetClasses() {
+			return null;
+		}
+
+		@Override
+		public boolean canRead(EvaluationContext context, Object target, String name) throws AccessException {
+			return false;
+		}
+
+		@Override
+		public TypedValue read(EvaluationContext context, Object target, String name) throws AccessException {
+			return null;
+		}
+
+		@Override
+		public boolean canWrite(EvaluationContext context, Object target, String name) throws AccessException {
+			return false;
+		}
+
+		@Override
+		public void write(EvaluationContext context, Object target, String name, Object newValue)
+				throws AccessException {
+		}
+
+	}
+
+	public class Bar extends Foo implements Ordered {
+
+		private final int order;
+
+		public Bar(int order) {
+			this.order = order;
+		}
+
+		@Override
+		public int getOrder() {
+			return this.order;
+		}
+
+	}
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/expression/ChildContext-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/expression/ChildContext-context.xml
@@ -29,7 +29,7 @@
 		<ref bean="jsonPropertyAccessor"/>
 	</int:spel-property-accessors>
 
-	<bean id="jsonPropertyAccessor" class="org.springframework.integration.json.JsonPropertyAccessor"/>
+	<bean id="jsonPropertyAccessor" class="org.springframework.integration.json.JsonNodePropertyAccessor"/>
 
 	<bean id="messageBuilderFactory" class="org.springframework.integration.support.MutableMessageBuilderFactory" />
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/expression/ParentContext-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/expression/ParentContext-context.xml
@@ -30,9 +30,9 @@
 		<ref bean="jsonPropertyAccessor"/>
 	</int:spel-property-accessors>
 
-	<bean id="jsonPropertyAccessor" class="org.springframework.integration.json.JsonPropertyAccessor"/>
+	<bean id="jsonPropertyAccessor" class="org.springframework.integration.json.JsonNodePropertyAccessor"/>
 
-	<bean id="parentJsonPropertyAccessor" class="org.springframework.integration.json.JsonPropertyAccessor"/>
+	<bean id="parentJsonPropertyAccessor" class="org.springframework.integration.json.JsonNodePropertyAccessor"/>
 
 	<bean id="barService" class="org.springframework.integration.expression.ParentContextTests$Bar" />
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/JsonPropertyAccessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/JsonPropertyAccessorTests.java
@@ -54,11 +54,11 @@ public class JsonPropertyAccessorTests {
 	public void testSimpleLookup() throws Exception {
 		Object json = mapper.readTree("{\"foo\": \"bar\"}");
 		Object value = evaluate(json, "foo", Object.class);
-		assertThat(value, Matchers.instanceOf(JsonPropertyAccessor.ToStringFriendlyJsonNode.class));
+		assertThat(value, Matchers.instanceOf(AbstractJsonPropertyAccessor.ToStringFriendlyJsonNode.class));
 		assertEquals("bar", value.toString());
 		Object json2 = mapper.readTree("{\"foo\": \"bar\"}");
 		Object value2 = evaluate(json2, "foo", Object.class);
-		assertThat(value2, Matchers.instanceOf(JsonPropertyAccessor.ToStringFriendlyJsonNode.class));
+		assertThat(value2, Matchers.instanceOf(AbstractJsonPropertyAccessor.ToStringFriendlyJsonNode.class));
 		assertTrue(value.equals(value2));
 		assertEquals(value.hashCode(), value2.hashCode());
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests-context.xml
@@ -25,4 +25,8 @@
 
 	<beans:bean id="customJsonObjectMapper" class="org.springframework.integration.json.ObjectToJsonTransformerParserTests$CustomJsonObjectMapper"/>
 
+	<spel-property-accessors>
+		<beans:bean id="json" class="org.springframework.integration.json.JsonPropertyAccessor" />
+	</spel-property-accessors>
+
 </beans:beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3585

The spring integration `EvaluationContext` places custom
property accessors before the default `ReflectivePropertyAccessor` in.

The order is:

```
custom accessors + `MapAccessor` + `ReflectivePropertyAccessor`
```

If the `JsonPropertyAccessor` is included, it will attempt to
decode String arguments, such as `class` in `payload.class.name` when the
Payload class is `String`.

`payload.getClass().name` works ok.

The root cause is that the `JsonPropertyAccessor` can handle both Json nodes
and Strings.

Split the property accessor into two versions, one for Json nodes, one for
String. Add support so that the String version can be placed after the
`ReflecivePropertyAccessor`, enabling expressions such as the above to work.

For backwards compatibility, add a `CompositePropertyAccessor` and have the evaulation
context factory bean replace it with the delegates.

Add support for `Orderable`. Order property accessors as follows:

`Unordered custom` + `ordered custom < 0` + `map` + `standard` + `ordered custom >= 0`

In addition, the String version of the `JsonPropertyAccessor` returns `null` for the
target types so it is considered a general, not specific accessor.

See `PropertyOrFieldReference.getPropertyAccessorsToTry()`.

The old `JsonPropertyAccessor` functionality is retained for those cases where the
accessor is being used programmatically.
