### PR TITLE
Add the ability to point own local LockRegistry.

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -94,7 +94,7 @@ public final class RedisLockRegistry implements LockRegistry {
 
 	private final long expireAfter;
 
-	private final LockRegistry localRegistry = new DefaultLockRegistry();
+	private final LockRegistry localRegistry;
 
 	private final LockSerializer lockSerializer = new LockSerializer();
 
@@ -125,8 +125,22 @@ public final class RedisLockRegistry implements LockRegistry {
 	 * @param expireAfter The expiration in milliseconds.
 	 */
 	public RedisLockRegistry(RedisConnectionFactory connectionFactory, String registryKey, long expireAfter) {
+		this(connectionFactory, registryKey, expireAfter, new DefaultLockRegistry());
+	}
+
+	/**
+	 * Constructs a lock registry with the supplied lock expiration.
+	 * @param connectionFactory The connection factory.
+	 * @param registryKey The key prefix for locks.
+	 * @param expireAfter The expiration in milliseconds.
+	 * @param localRegistry The local registry used to reduce wait time,
+	 * {@link DefaultLockRegistry} is used by default.
+	 */
+	public RedisLockRegistry(RedisConnectionFactory connectionFactory, String registryKey,
+							 long expireAfter, LockRegistry localRegistry) {
 		Assert.notNull(connectionFactory, "'connectionFactory' cannot be null");
 		Assert.notNull(registryKey, "'registryKey' cannot be null");
+		Assert.notNull(localRegistry, "'localRegistry' cannot be null");
 		this.redisTemplate = new RedisTemplate<String, RedisLockRegistry.RedisLock>();
 		this.redisTemplate.setConnectionFactory(connectionFactory);
 		this.redisTemplate.setKeySerializer(new StringRedisSerializer());
@@ -134,6 +148,7 @@ public final class RedisLockRegistry implements LockRegistry {
 		this.redisTemplate.afterPropertiesSet();
 		this.registryKey = registryKey;
 		this.expireAfter = expireAfter;
+		this.localRegistry = localRegistry;
 	}
 
 	@Override


### PR DESCRIPTION
There is no ability to use own local LockRegistry to avoid overlapping of produced ReentrantLock objects, it can happens if used unique keys have same masked value for DefaultLockRegistry.
