### PR TITLE
INT-3598: Disambiguate MQTT Namespace Constructor

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/config/xml/MqttParserUtils.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/config/xml/MqttParserUtils.java
@@ -18,14 +18,17 @@ package org.springframework.integration.mqtt.config.xml;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConstructorArgumentValues.ValueHolder;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.mqtt.core.DefaultMqttPahoClientFactory;
 import org.springframework.util.StringUtils;
 
 /**
  * Contains various utility methods for parsing Mqtt Adapter
- * specific namesspace elements as well as for the generation of the the
+ * specific namespace elements as well as for the generation of the the
  * respective {@link BeanDefinition}s.
  *
  * @author Gary Russell
@@ -41,11 +44,17 @@ public final class MqttParserUtils {
 
 	public static void parseCommon(Element element, BeanDefinitionBuilder builder, ParserContext parserContext) {
 
+		ValueHolder holder;
+		int n = 0;
 		String url = element.getAttribute("url");
 		if (StringUtils.hasText(url)) {
 			builder.addConstructorArgValue(url);
+			holder = builder.getRawBeanDefinition().getConstructorArgumentValues().getIndexedArgumentValues().get(n++);
+			holder.setType("java.lang.String");
 		}
 		builder.addConstructorArgValue(element.getAttribute("client-id"));
+		holder = builder.getRawBeanDefinition().getConstructorArgumentValues().getIndexedArgumentValues().get(n++);
+		holder.setType("java.lang.String");
 		String clientFactory = element.getAttribute("client-factory");
 		if (StringUtils.hasText(clientFactory)) {
 			builder.addConstructorArgReference(clientFactory);
@@ -55,6 +64,7 @@ public final class MqttParserUtils {
 				parserContext.getReaderContext().error("If no 'url' attribute is provided, a 'client-factory' " +
 						"(with serverURIs) is required", element);
 			}
+			builder.addConstructorArgValue(new RootBeanDefinition(DefaultMqttPahoClientFactory.class));
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "converter");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "send-timeout");

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/config/xml/MqttMessageDrivenChannelAdapterParserTests-context.xml
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/config/xml/MqttMessageDrivenChannelAdapterParserTests-context.xml
@@ -17,6 +17,12 @@
 		client-factory="clientFactory"
 		channel="out" />
 
+	<int-mqtt:message-driven-channel-adapter id="noTopicsAdapterDefaultCF"
+		auto-startup="false"
+		client-id="foo"
+		url="tcp://localhost:1883"
+		channel="out" />
+
 	<int-mqtt:message-driven-channel-adapter id="oneTopicAdapter"
 		auto-startup="false"
 		phase="25"

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/config/xml/MqttMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/config/xml/MqttMessageDrivenChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,9 @@ public class MqttMessageDrivenChannelAdapterParserTests {
 	private MqttPahoMessageDrivenChannelAdapter noTopicsAdapter;
 
 	@Autowired
+	private MqttPahoMessageDrivenChannelAdapter noTopicsAdapterDefaultCF;
+
+	@Autowired
 	private MqttPahoMessageDrivenChannelAdapter oneTopicAdapter;
 
 	@Autowired
@@ -75,6 +78,15 @@ public class MqttMessageDrivenChannelAdapterParserTests {
 		assertEquals(0, TestUtils.getPropertyValue(noTopicsAdapter, "topics", Collection.class).size());
 		assertSame(out, TestUtils.getPropertyValue(noTopicsAdapter, "outputChannel"));
 		assertSame(clientFactory, TestUtils.getPropertyValue(noTopicsAdapter, "clientFactory"));
+	}
+
+	@Test
+	public void testNoTopicsDefaultCF() { // INT-3598
+		assertEquals("tcp://localhost:1883", TestUtils.getPropertyValue(noTopicsAdapterDefaultCF, "url"));
+		assertFalse(TestUtils.getPropertyValue(noTopicsAdapterDefaultCF, "autoStartup", Boolean.class));
+		assertEquals("foo", TestUtils.getPropertyValue(noTopicsAdapterDefaultCF, "clientId"));
+		assertEquals(0, TestUtils.getPropertyValue(noTopicsAdapterDefaultCF, "topics", Collection.class).size());
+		assertSame(out, TestUtils.getPropertyValue(noTopicsAdapterDefaultCF, "outputChannel"));
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3598
- Force the first two constructor args to be of type `String`.
- When no client factory, add one in the parser rather than selecing an alternate ctor.

**cherry-pick to 4.0.x**
