### PR TITLE
INT-3601: Use `ChannelResolver` instead of BF

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -461,14 +461,8 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		if (this.discardChannelName != null) {
 			synchronized (this) {
 				if (this.discardChannelName != null) {
-					try {
-						this.discardChannel = getBeanFactory().getBean(this.discardChannelName, MessageChannel.class);
-						this.discardChannelName = null;
-					}
-					catch (BeansException e) {
-						throw new DestinationResolutionException("Failed to look up MessageChannel with name '"
-								+ this.discardChannelName + "' in the BeanFactory.");
-					}
+					this.discardChannel = getChannelResolver().resolveDestination(this.discardChannelName);
+					this.discardChannelName = null;
 				}
 			}
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -131,6 +131,16 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 		this.applicationContext = applicationContext;
 	}
 
+	/**
+	 * Specify the {@link DestinationResolver} strategy to use.
+	 * The default is a BeanFactoryChannelResolver.
+	 * @param channelResolver The channel resolver.
+	 */
+	public void setChannelResolver(DestinationResolver<MessageChannel> channelResolver) {
+		Assert.notNull(channelResolver, "'channelResolver' must not be null");
+		this.channelResolver = channelResolver;
+	}
+
 	@Override
 	public final void afterPropertiesSet() {
 		try {
@@ -145,23 +155,6 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 			}
 			throw new BeanInitializationException("failed to initialize", e);
 		}
-	}
-
-	/**
-	 * Specify the {@link DestinationResolver} strategy to use.
-	 * The default is a BeanFactoryChannelResolver.
-	 * @param channelResolver The channel resolver.
-	 */
-	public void setChannelResolver(DestinationResolver<MessageChannel> channelResolver) {
-		Assert.notNull(channelResolver, "'channelResolver' must not be null");
-		this.channelResolver = channelResolver;
-	}
-
-	protected DestinationResolver<MessageChannel> getChannelResolver() {
-		if (this.channelResolver == null) {
-			this.channelResolver = new BeanFactoryChannelResolver(this.beanFactory);
-		}
-		return this.channelResolver;
 	}
 
 	/**
@@ -180,6 +173,13 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 			this.taskScheduler = IntegrationContextUtils.getTaskScheduler(this.beanFactory);
 		}
 		return this.taskScheduler;
+	}
+
+	protected DestinationResolver<MessageChannel> getChannelResolver() {
+		if (this.channelResolver == null) {
+			this.channelResolver = new BeanFactoryChannelResolver(this.beanFactory);
+		}
+		return this.channelResolver;
 	}
 
 	protected void setTaskScheduler(TaskScheduler taskScheduler) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,11 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
+import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.integration.support.utils.IntegrationUtils;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.core.DestinationResolver;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -66,6 +69,8 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 	protected final Log logger = LogFactory.getLog(getClass());
 
 	private final ConversionService defaultConversionService = new DefaultConversionService();
+
+	private volatile DestinationResolver<MessageChannel> channelResolver;
 
 	private volatile String beanName;
 
@@ -140,6 +145,23 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 			}
 			throw new BeanInitializationException("failed to initialize", e);
 		}
+	}
+
+	/**
+	 * Specify the {@link DestinationResolver} strategy to use.
+	 * The default is a BeanFactoryChannelResolver.
+	 * @param channelResolver The channel resolver.
+	 */
+	public void setChannelResolver(DestinationResolver<MessageChannel> channelResolver) {
+		Assert.notNull(channelResolver, "'channelResolver' must not be null");
+		this.channelResolver = channelResolver;
+	}
+
+	protected DestinationResolver<MessageChannel> getChannelResolver() {
+		if (this.channelResolver == null) {
+			this.channelResolver = new BeanFactoryChannelResolver(this.beanFactory);
+		}
+		return this.channelResolver;
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,15 +158,8 @@ public class MessageFilter extends AbstractReplyProducingPostProcessingMessageHa
 			if (this.discardChannelName != null) {
 				synchronized (this) {
 					if (this.discardChannelName != null) {
-						try {
-							this.discardChannel = this.getBeanFactory()
-									.getBean(this.discardChannelName, MessageChannel.class);
-							this.discardChannelName = null;
-						}
-						catch (BeansException e) {
-							throw new DestinationResolutionException("Failed to look up MessageChannel with name '"
-									+ this.discardChannelName + "' in the BeanFactory.");
-						}
+						this.discardChannel = getChannelResolver().resolveDestination(this.discardChannelName);
+						this.discardChannelName = null;
 					}
 				}
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.gateway;
 
-import org.springframework.beans.BeansException;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
@@ -34,7 +33,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.SubscribableChannel;
-import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.util.Assert;
 
@@ -236,8 +234,6 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint implement
 		if (this.requestChannelName != null) {
 			synchronized (this) {
 				if (this.requestChannelName != null) {
-					Assert.state(getBeanFactory() != null,
-							"A bean factory is required to resolve the requestChannel at runtime.");
 					this.requestChannel = getChannelResolver().resolveDestination(this.requestChannelName);
 					this.requestChannelName = null;
 				}
@@ -250,8 +246,6 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint implement
 		if (this.replyChannelName != null) {
 			synchronized (this) {
 				if (this.replyChannelName != null) {
-					Assert.state(getBeanFactory() != null,
-							"A bean factory is required to resolve the replyChannel at runtime.");
 					this.replyChannel = getChannelResolver().resolveDestination(this.replyChannelName);
 					this.replyChannelName = null;
 				}
@@ -264,8 +258,6 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint implement
 		if (this.errorChannelName != null) {
 			synchronized (this) {
 				if (this.errorChannelName != null) {
-					Assert.state(getBeanFactory() != null,
-							"A bean factory is required to resolve the errorChannel at runtime.");
 					this.errorChannel = getChannelResolver().resolveDestination(this.errorChannelName);
 					this.errorChannelName = null;
 				}

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,16 +236,10 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint implement
 		if (this.requestChannelName != null) {
 			synchronized (this) {
 				if (this.requestChannelName != null) {
-					try {
-						Assert.state(getBeanFactory() != null,
-								"A bean factory is required to resolve the requestChannel at runtime.");
-						this.requestChannel = getBeanFactory().getBean(this.requestChannelName, MessageChannel.class);
-						this.requestChannelName = null;
-					}
-					catch (BeansException e) {
-						throw new DestinationResolutionException("Failed to look up MessageChannel with name '"
-								+ this.requestChannelName + "' in the BeanFactory.");
-					}
+					Assert.state(getBeanFactory() != null,
+							"A bean factory is required to resolve the requestChannel at runtime.");
+					this.requestChannel = getChannelResolver().resolveDestination(this.requestChannelName);
+					this.requestChannelName = null;
 				}
 			}
 		}
@@ -256,16 +250,10 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint implement
 		if (this.replyChannelName != null) {
 			synchronized (this) {
 				if (this.replyChannelName != null) {
-					try {
-						Assert.state(getBeanFactory() != null,
-								"A bean factory is required to resolve the replyChannel at runtime.");
-						this.replyChannel = getBeanFactory().getBean(this.replyChannelName, MessageChannel.class);
-						this.replyChannelName = null;
-					}
-					catch (BeansException e) {
-						throw new DestinationResolutionException("Failed to look up MessageChannel with name '"
-								+ this.replyChannelName + "' in the BeanFactory.");
-					}
+					Assert.state(getBeanFactory() != null,
+							"A bean factory is required to resolve the replyChannel at runtime.");
+					this.replyChannel = getChannelResolver().resolveDestination(this.replyChannelName);
+					this.replyChannelName = null;
 				}
 			}
 		}
@@ -276,16 +264,10 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint implement
 		if (this.errorChannelName != null) {
 			synchronized (this) {
 				if (this.errorChannelName != null) {
-					try {
-						Assert.state(getBeanFactory() != null,
-								"A bean factory is required to resolve the errorChannel at runtime.");
-						this.errorChannel = getBeanFactory().getBean(this.errorChannelName, MessageChannel.class);
-						this.errorChannelName = null;
-					}
-					catch (BeansException e) {
-						throw new DestinationResolutionException("Failed to look up MessageChannel with name '"
-								+ this.errorChannelName + "' in the BeanFactory.");
-					}
+					Assert.state(getBeanFactory() != null,
+							"A bean factory is required to resolve the errorChannel at runtime.");
+					this.errorChannel = getChannelResolver().resolveDestination(this.errorChannelName);
+					this.errorChannelName = null;
 				}
 			}
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.springframework.beans.BeansException;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.core.MessagingTemplate;
@@ -32,7 +31,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.core.DestinationResolutionException;
-import org.springframework.messaging.core.DestinationResolver;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -86,8 +84,6 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 		if (this.outputChannelName != null) {
 			synchronized (this) {
 				if (this.outputChannelName != null) {
-					Assert.state(getBeanFactory() != null,
-							"A bean factory is required to resolve the outputChannel at runtime.");
 					this.outputChannel = getChannelResolver().resolveDestination(this.outputChannelName);
 					this.outputChannelName = null;
 				}

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
@@ -46,7 +46,7 @@ class AbstractMessageProcessingRouter extends AbstractMappingMessageRouter
 
 
 	@Override
-	public final void onInit() {
+	public final void onInit() throws Exception {
 		super.onInit();
 		if (this.messageProcessor instanceof AbstractMessageProcessor) {
 			((AbstractMessageProcessor<?>) this.messageProcessor).setConversionService(this.getConversionService());

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageRouter.java
@@ -181,15 +181,8 @@ public abstract class AbstractMessageRouter extends AbstractMessageHandler {
 			if (this.defaultOutputChannelName != null) {
 				synchronized (this) {
 					if (this.defaultOutputChannelName != null) {
-						try {
-							this.defaultOutputChannel = getBeanFactory()
-									.getBean(this.defaultOutputChannelName, MessageChannel.class);
-							this.defaultOutputChannelName = null;
-						}
-						catch (BeansException e) {
-							throw new DestinationResolutionException("Failed to look up MessageChannel with name '"
-									+ this.defaultOutputChannelName + "' in the BeanFactory.");
-						}
+						this.defaultOutputChannel = getChannelResolver().resolveDestination(this.defaultOutputChannelName);
+						this.defaultOutputChannelName = null;
 					}
 				}
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
@@ -148,7 +148,7 @@ public class RecipientListRouter extends AbstractMessageRouter
 	public void addRecipient(String channelName, String selectorExpression) {
 		Assert.hasText(channelName, "'channelName' must not be empty.");
 		Assert.hasText(selectorExpression, "'selectorExpression' must not be empty.");
-		MessageChannel channel = this.getBeanFactory().getBean(channelName, MessageChannel.class);
+		MessageChannel channel = getChannelResolver().resolveDestination(channelName);
 		ExpressionEvaluatingSelector expressionEvaluatingSelector = new ExpressionEvaluatingSelector(selectorExpression);
 		expressionEvaluatingSelector.setBeanFactory(this.getBeanFactory());
 		this.recipients.add(new Recipient(channel, expressionEvaluatingSelector));
@@ -158,7 +158,7 @@ public class RecipientListRouter extends AbstractMessageRouter
 	@ManagedOperation
 	public void addRecipient(String channelName) {
 		Assert.hasText(channelName, "'channelName' must not be empty.");
-		MessageChannel channel = this.getBeanFactory().getBean(channelName, MessageChannel.class);
+		MessageChannel channel = getChannelResolver().resolveDestination(channelName);
 		this.recipients.add(new Recipient(channel));
 	}
 
@@ -166,7 +166,7 @@ public class RecipientListRouter extends AbstractMessageRouter
 	@ManagedOperation
 	public int removeRecipient(String channelName) {
 		int counter = 0;
-		MessageChannel channel = this.getBeanFactory().getBean(channelName, MessageChannel.class);
+		MessageChannel channel = getChannelResolver().resolveDestination(channelName);
 		for (Iterator<Recipient> it = this.recipients.iterator(); it.hasNext(); ) {
 			if (it.next().getChannel() == channel) {
 				it.remove();
@@ -180,7 +180,7 @@ public class RecipientListRouter extends AbstractMessageRouter
 	@ManagedOperation
 	public int removeRecipient(String channelName, String selectorExpression) {
 		int counter = 0;
-		MessageChannel targetChannel = this.getBeanFactory().getBean(channelName, MessageChannel.class);
+		MessageChannel targetChannel = getChannelResolver().resolveDestination(channelName);
 		for (Iterator<Recipient> it = this.recipients.iterator(); it.hasNext(); ) {
 			Recipient next = it.next();
 			MessageSelector selector = next.getSelector();

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorEndpointTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorEndpointTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -90,6 +91,7 @@ public class ServiceActivatorEndpointTests {
 		channelResolver.addChannel("testChannel", channel);
 		ServiceActivatingHandler endpoint = this.createEndpoint();
 		endpoint.setChannelResolver(channelResolver);
+		endpoint.setBeanFactory(mock(BeanFactory.class));
 		endpoint.afterPropertiesSet();
 		Message<?> message = MessageBuilder.withPayload("foo")
 				.setReplyChannelName("testChannel").build();
@@ -114,6 +116,7 @@ public class ServiceActivatorEndpointTests {
 		TestChannelResolver channelResolver = new TestChannelResolver();
 		channelResolver.addChannel("replyChannel2", replyChannel2);
 		endpoint.setChannelResolver(channelResolver);
+		endpoint.setBeanFactory(mock(BeanFactory.class));
 		endpoint.afterPropertiesSet();
 		Message<String> testMessage1 = MessageBuilder.withPayload("bar")
 				.setReplyChannel(replyChannel1).build();
@@ -211,7 +214,7 @@ public class ServiceActivatorEndpointTests {
 	@Test
 	public void testBeanFactoryPopulation() {
 		ServiceActivatingHandler endpoint = this.createEndpoint();
-		BeanFactory mock = Mockito.mock(BeanFactory.class);
+		BeanFactory mock = mock(BeanFactory.class);
 		endpoint.setBeanFactory(mock);
 		endpoint.afterPropertiesSet();
 		Object beanFactory = TestUtils.getPropertyValue(endpoint, "processor.beanFactory");

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorEndpointTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,6 +90,7 @@ public class ServiceActivatorEndpointTests {
 		channelResolver.addChannel("testChannel", channel);
 		ServiceActivatingHandler endpoint = this.createEndpoint();
 		endpoint.setChannelResolver(channelResolver);
+		endpoint.afterPropertiesSet();
 		Message<?> message = MessageBuilder.withPayload("foo")
 				.setReplyChannelName("testChannel").build();
 		endpoint.handleMessage(message);
@@ -113,6 +114,7 @@ public class ServiceActivatorEndpointTests {
 		TestChannelResolver channelResolver = new TestChannelResolver();
 		channelResolver.addChannel("replyChannel2", replyChannel2);
 		endpoint.setChannelResolver(channelResolver);
+		endpoint.afterPropertiesSet();
 		Message<String> testMessage1 = MessageBuilder.withPayload("bar")
 				.setReplyChannel(replyChannel1).build();
 		endpoint.handleMessage(testMessage1);

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MessageHandlerChainTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MessageHandlerChainTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@ public class MessageHandlerChainTests {
 		chain.setBeanName("testChain");
 		chain.setHandlers(handlers);
 		chain.setOutputChannel(outputChannel);
+		chain.setBeanFactory(mock(BeanFactory.class));
 		chain.handleMessage(message);
 		Mockito.verify(outputChannel).send(Mockito.eq(message));
 	}
@@ -112,6 +113,7 @@ public class MessageHandlerChainTests {
 		MessageHandlerChain chain = new MessageHandlerChain();
 		chain.setBeanName("testChain");
 		chain.setHandlers(handlers);
+		chain.setBeanFactory(mock(BeanFactory.class));
 		chain.handleMessage(message);
 	}
 
@@ -125,6 +127,7 @@ public class MessageHandlerChainTests {
 		MessageHandlerChain chain = new MessageHandlerChain();
 		chain.setBeanName("testChain");
 		chain.setHandlers(handlers);
+		chain.setBeanFactory(mock(BeanFactory.class));
 		chain.handleMessage(message);
 		Mockito.verify(outputChannel).send(Mockito.any(Message.class));
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -153,6 +153,7 @@ public class AdvisedMessageHandlerTests {
 		List<Advice> adviceChain = new ArrayList<Advice>();
 		adviceChain.add(advice);
 		handler.setAdviceChain(adviceChain);
+		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		// advice with success


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3601
- Move `setChannelResolver(DestinationResolver<MessageChannel> channelResolver)` to the `IntegrationObjectSupport`
- Introduce `IntegrationObjectSupport#getChannelResolver()`
- Change all `IntegrationObjectSupport` inheritors to use `getChannelResolver()` instead of direct `beanFactory` usage
- Fix `ServiceActivatorEndpointTests` do not fall

**Cherry-pick to 4.1.x**
