### PR TITLE
INT-3614 Fix `extractPayload` for JMS i-c-adapter

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsDestinationPollingSource.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsDestinationPollingSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,8 @@ public class JmsDestinationPollingSource extends IntegrationObjectSupport implem
 
 	private volatile String sessionAcknowledgeMode;
 
+	private volatile boolean extractPayload = true;
+
 	public JmsDestinationPollingSource(JmsTemplate jmsTemplate) {
 		this.jmsTemplate = jmsTemplate;
 	}
@@ -68,6 +70,16 @@ public class JmsDestinationPollingSource extends IntegrationObjectSupport implem
 		this.destinationName = destinationName;
 	}
 
+	/**
+	 * The flag to indicate if we should extract {@code body} from JMS Message,
+	 * or use the received JMS Message as {@link Message} {@code payload}.
+	 * @param extractPayload the boolean flag. Defaults to {@code true}.
+	 * @since 3.0.7
+	 */
+	public void setExtractPayload(boolean extractPayload) {
+		this.extractPayload = extractPayload;
+	}
+
 	@Override
 	public String getComponentType() {
 		return "jms:inbound-channel-adapter";
@@ -75,7 +87,6 @@ public class JmsDestinationPollingSource extends IntegrationObjectSupport implem
 
 	/**
 	 * Specify a JMS Message Selector expression to use when receiving Messages.
-	 *
 	 * @param messageSelector The message selector.
 	 */
 	public void setMessageSelector(String messageSelector) {
@@ -98,25 +109,25 @@ public class JmsDestinationPollingSource extends IntegrationObjectSupport implem
 	@Override
 	@SuppressWarnings("unchecked")
 	public Message<Object> receive() {
-		Message<Object> convertedMessage = null;
-		javax.jms.Message jmsMessage = this.doReceiveJmsMessage();
+		javax.jms.Message jmsMessage = doReceiveJmsMessage();
 		if (jmsMessage == null) {
 			return null;
 		}
 		try {
 			// Map headers
 			Map<String, Object> mappedHeaders = this.headerMapper.toHeaders(jmsMessage);
-			MessageConverter converter = this.jmsTemplate.getMessageConverter();
-			Object convertedObject = converter.fromMessage(jmsMessage);
-			AbstractIntegrationMessageBuilder<Object> builder = (convertedObject instanceof Message) ?
-					this.getMessageBuilderFactory().fromMessage((Message<Object>) convertedObject) :
-					this.getMessageBuilderFactory().withPayload(convertedObject);
-			convertedMessage = builder.copyHeadersIfAbsent(mappedHeaders).build();
+			Object object = jmsMessage;
+			if (this.extractPayload) {
+				object = this.jmsTemplate.getMessageConverter().fromMessage(jmsMessage);
+			}
+			AbstractIntegrationMessageBuilder<Object> builder = (object instanceof Message) ?
+					getMessageBuilderFactory().fromMessage((Message<Object>) object) :
+					getMessageBuilderFactory().withPayload(object);
+			return builder.copyHeadersIfAbsent(mappedHeaders).build();
 		}
 		catch (Exception e) {
 			throw new MessagingException(e.getMessage(), e);
 		}
-		return convertedMessage;
 	}
 
 	private javax.jms.Message doReceiveJmsMessage() {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsInboundChannelAdapterParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.util.StringUtils;
  * Parser for the &lt;inbound-channel-adapter/&gt; element of the 'jms' namespace.
  *
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public class JmsInboundChannelAdapterParser extends AbstractPollingInboundChannelAdapterParser {
 
@@ -87,6 +88,7 @@ public class JmsInboundChannelAdapterParser extends AbstractPollingInboundChanne
 			builder.addPropertyReference(JmsAdapterParserUtils.HEADER_MAPPER_PROPERTY, headerMapper);
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "selector", "messageSelector");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "extract-payload");
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithConnectionFactoryAndDestination.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithConnectionFactoryAndDestination.xml
@@ -11,9 +11,13 @@
 			http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd">
 
 	<jms:inbound-channel-adapter id="adapter"
-								 channel="output"
+								 channel="transformChannel"
 								 connection-factory="testConnectionFactory"
-	                			 destination="testDestination"/>
+	                			 destination="testDestination"
+								 extract-payload="false"/>
+
+	<integration:transformer input-channel="transformChannel" output-channel="output"
+			expression="payload.text"/>
 
 	<integration:channel id="output">
 		<integration:queue capacity="1"/>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3614

The `extractPayload` is presented in the namespace support for `<int-jms:inbound-channel-adapter>`,
but nor `JmsInboundChannelAdapterParser`, neither `JmsDestinationPollingSource` take care of that value.

To be consist with `<int-jms:message-driven-channel-adapter>` and documentation introduce that option for
`JmsDestinationPollingSource` and populate it from the `JmsInboundChannelAdapterParser`.

**Cherry-pick to 4.1.x, 4.0.x and 3.0.x**

Note: 3.0.x will be with conflicts: there is still no `getMessageBuilderFactory()`
