### PR TITLE
Add XML Namespace support for appendNewLine to FileWritingMessageHandler (See INT-3621)

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerBeanDefinitionBuilder.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerBeanDefinitionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gunnar Hillert
+ * @author Tony Falabella
  *
  * @since 1.0.3
  */
@@ -58,6 +59,7 @@ abstract class FileWritingMessageHandlerBeanDefinitionBuilder {
 		}
 
 		builder.addPropertyValue("expectReply", expectReply);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "append-new-line");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "directory");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-create-directory");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "delete-source-files");

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.integration.file.support.FileExistsMode;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Gunnar Hillert
+ * @author Tony Falabella
  *
  * @since 1.0.3
  */
@@ -59,6 +60,8 @@ public class FileWritingMessageHandlerFactoryBean extends AbstractSimpleMessageH
 	private volatile FileExistsMode fileExistsMode;
 
 	private volatile boolean expectReply = true;
+	
+	private volatile Boolean appendNewLine;
 
 	public void setFileExistsMode(String fileExistsModeAsString) {
 		this.fileExistsMode = FileExistsMode.getForString(fileExistsModeAsString);
@@ -104,6 +107,10 @@ public class FileWritingMessageHandlerFactoryBean extends AbstractSimpleMessageH
 		this.expectReply = expectReply;
 	}
 
+	public void setAppendNewLine(Boolean appendNewLine) {
+		this.appendNewLine = appendNewLine;
+	}
+	
 	@Override
 	protected FileWritingMessageHandler createHandler() {
 
@@ -143,7 +150,9 @@ public class FileWritingMessageHandlerFactoryBean extends AbstractSimpleMessageH
 			handler.setTemporaryFileSuffix(this.temporaryFileSuffix);
 		}
 		handler.setExpectReply(this.expectReply);
-
+		if (this.appendNewLine != null) {
+			handler.setAppendNewLine(this.appendNewLine);
+		}
 		if (this.fileExistsMode != null) {
 			handler.setFileExistsMode(this.fileExistsMode);
 		}

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-4.2.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-4.2.xsd
@@ -447,6 +447,14 @@ Only files matching this regular expression will be picked up by this adapter.
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+    	<xsd:attribute name="append-new-line" type="xsd:string" default="false">
+    	    <xsd:annotation>
+    			<xsd:documentation>
+    				<![CDATA[Set to 'true' to append a new-line after each write. 
+    				It is 'false' by default.]]>
+    			</xsd:documentation>
+    		</xsd:annotation>
+    	</xsd:attribute>        
 		<xsd:attributeGroup ref="integration:smartLifeCycleAttributeGroup"/>
     </xsd:complexType>
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
@@ -60,7 +60,7 @@ public class FileWritingMessageHandlerTests {
 
 	static final String DEFAULT_ENCODING = "UTF-8";
 
-	static final String SAMPLE_CONTENT = "HelloWorld\n√§√∂√º√ü";
+	static final String SAMPLE_CONTENT = "HelloWorld\n‰ˆ¸ﬂ";
 
 
 	private File sourceFile;
@@ -118,7 +118,6 @@ public class FileWritingMessageHandlerTests {
 		Message<?> message = MessageBuilder.withPayload(SAMPLE_CONTENT).build();
 		QueueChannel output = new QueueChannel();
 		String newLine = System.getProperty("line.separator");
-		handler.setFileExistsMode(FileExistsMode.APPEND);
 		handler.setCharset(DEFAULT_ENCODING);
 		handler.setOutputChannel(output);
 		handler.setAppendNewLine(true);
@@ -144,7 +143,6 @@ public class FileWritingMessageHandlerTests {
 				SAMPLE_CONTENT.getBytes(DEFAULT_ENCODING)).build();
 		QueueChannel output = new QueueChannel();
 		String newLine = System.getProperty("line.separator");
-		handler.setFileExistsMode(FileExistsMode.APPEND);
 		handler.setOutputChannel(output);
 		handler.setAppendNewLine(true);
 		handler.handleMessage(message);
@@ -167,7 +165,6 @@ public class FileWritingMessageHandlerTests {
 		Message<?> message = MessageBuilder.withPayload(sourceFile).build();
 		QueueChannel output = new QueueChannel();
 		handler.setOutputChannel(output);
-		handler.setFileExistsMode(FileExistsMode.APPEND);
 		handler.setAppendNewLine(true);
 		handler.handleMessage(message);
 		Message<?> result = output.receive(0);

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
@@ -113,6 +113,19 @@ public class FileWritingMessageHandlerTests {
 	}
 
 	@Test
+	public void stringPayloadCopiedToNewFileWithNewLines() throws Exception {
+		Message<?> message = MessageBuilder.withPayload(SAMPLE_CONTENT).build();
+		QueueChannel output = new QueueChannel();
+		String newLine = System.getProperty("line.separator");
+		handler.setCharset(DEFAULT_ENCODING);
+		handler.setOutputChannel(output);
+		handler.setShouldAppendNewLine(true);
+		handler.handleMessage(message);
+		Message<?> result = output.receive(0);
+		assertFileContentIs(result, SAMPLE_CONTENT + newLine);
+	}
+	
+	@Test
 	public void byteArrayPayloadCopiedToNewFile() throws Exception {
 		Message<?> message = MessageBuilder.withPayload(
 				SAMPLE_CONTENT.getBytes(DEFAULT_ENCODING)).build();
@@ -122,7 +135,20 @@ public class FileWritingMessageHandlerTests {
 		Message<?> result = output.receive(0);
 		assertFileContentIsMatching(result);
 	}
-
+	
+	@Test
+	public void byteArrayPayloadCopiedToNewFileWithNewLines() throws Exception {
+		Message<?> message = MessageBuilder.withPayload(
+				SAMPLE_CONTENT.getBytes(DEFAULT_ENCODING)).build();
+		QueueChannel output = new QueueChannel();
+		String newLine = System.getProperty("line.separator");
+		handler.setOutputChannel(output);
+		handler.setShouldAppendNewLine(true);
+		handler.handleMessage(message);
+		Message<?> result = output.receive(0);
+		assertFileContentIs(result, SAMPLE_CONTENT + newLine);
+	}
+	
 	@Test
 	public void filePayloadCopiedToNewFile() throws Exception {
 		Message<?> message = MessageBuilder.withPayload(sourceFile).build();

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ import org.springframework.util.FileCopyUtils;
  * @author Iwein Fuld
  * @author Alex Peters
  * @author Gary Russell
+ * @author Tony Falabella
  */
 public class FileWritingMessageHandlerTests {
 
@@ -117,14 +118,15 @@ public class FileWritingMessageHandlerTests {
 		Message<?> message = MessageBuilder.withPayload(SAMPLE_CONTENT).build();
 		QueueChannel output = new QueueChannel();
 		String newLine = System.getProperty("line.separator");
+		handler.setFileExistsMode(FileExistsMode.APPEND);
 		handler.setCharset(DEFAULT_ENCODING);
 		handler.setOutputChannel(output);
-		handler.setShouldAppendNewLine(true);
+		handler.setAppendNewLine(true);
 		handler.handleMessage(message);
 		Message<?> result = output.receive(0);
 		assertFileContentIs(result, SAMPLE_CONTENT + newLine);
 	}
-	
+
 	@Test
 	public void byteArrayPayloadCopiedToNewFile() throws Exception {
 		Message<?> message = MessageBuilder.withPayload(
@@ -135,20 +137,21 @@ public class FileWritingMessageHandlerTests {
 		Message<?> result = output.receive(0);
 		assertFileContentIsMatching(result);
 	}
-	
+
 	@Test
 	public void byteArrayPayloadCopiedToNewFileWithNewLines() throws Exception {
 		Message<?> message = MessageBuilder.withPayload(
 				SAMPLE_CONTENT.getBytes(DEFAULT_ENCODING)).build();
 		QueueChannel output = new QueueChannel();
 		String newLine = System.getProperty("line.separator");
+		handler.setFileExistsMode(FileExistsMode.APPEND);
 		handler.setOutputChannel(output);
-		handler.setShouldAppendNewLine(true);
+		handler.setAppendNewLine(true);
 		handler.handleMessage(message);
 		Message<?> result = output.receive(0);
 		assertFileContentIs(result, SAMPLE_CONTENT + newLine);
 	}
-	
+
 	@Test
 	public void filePayloadCopiedToNewFile() throws Exception {
 		Message<?> message = MessageBuilder.withPayload(sourceFile).build();
@@ -157,6 +160,18 @@ public class FileWritingMessageHandlerTests {
 		handler.handleMessage(message);
 		Message<?> result = output.receive(0);
 		assertFileContentIsMatching(result);
+	}
+
+	@Test
+	public void filePayloadCopiedToNewFileWithNewLines() throws Exception {
+		Message<?> message = MessageBuilder.withPayload(sourceFile).build();
+		QueueChannel output = new QueueChannel();
+		handler.setOutputChannel(output);
+		handler.setFileExistsMode(FileExistsMode.APPEND);
+		handler.setAppendNewLine(true);
+		handler.handleMessage(message);
+		Message<?> result = output.receive(0);
+		assertFileContentIs(result, SAMPLE_CONTENT + System.getProperty("line.separator"));
 	}
 
 	@Test @Ignore // INT-3289 ignored because it won't fail on all OS

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests-context.xml
@@ -28,6 +28,11 @@
 								   channel="testChannel"
 								   directory-expression="'foo/bar'"/>
 
+	<file:outbound-channel-adapter id="adapterWithAppendNewLine"
+								   channel="testChannel"
+								   append-new-line="true"
+								   directory="${java.io.tmpdir}"/>
+
 	<file:outbound-channel-adapter id="adapterWithDeleteFlag"
 								   channel="testChannel"
 								   delete-source-files="true"
@@ -52,7 +57,21 @@
 			<bean class="org.springframework.integration.file.config.FileOutboundChannelAdapterParserTests$FooAdvice" />
 		</file:request-handler-advice-chain>
 	</file:outbound-channel-adapter>
+	
+	<file:outbound-channel-adapter id="adapterUsageWithAppendAndAppendNewLineTrue"
+	                               filename-generator-expression="@fooString"
+								   mode="APPEND"
+								   append-new-line="true"
+								   directory-expression="@barString">	
+	</file:outbound-channel-adapter>
 
+	<file:outbound-channel-adapter id="adapterUsageWithAppendAndAppendNewLineFalse"
+	                               filename-generator-expression="@fooString"
+								   mode="APPEND"
+								   append-new-line="false"
+								   directory-expression="@barString">	
+	</file:outbound-channel-adapter>
+	
 	<bean id="fooString" class="java.lang.String">
 		<constructor-arg value="fileToAppend.txt"/>
 	</bean>

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests-context.xml
@@ -49,6 +49,12 @@
 		request-channel="gatewayWithFailModeLowercaseChannel"
 		filename-generator-expression="'fileToAppend.txt'" mode="fail"
 		directory="test" />
+
+	<int-file:outbound-gateway id="gatewayWithAppendNewLine"
+		request-channel="gatewayWithAppendNewLineChannel"
+		filename-generator-expression="'fileToAppend.txt'"
+		append-new-line="true"
+		directory="test" />		
 	<context:property-placeholder />
 
 </beans:beans>

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import org.springframework.util.FileCopyUtils;
  * @author Mark Fisher
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Tony Falabella
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -80,6 +81,9 @@ public class FileOutboundGatewayParserTests {
 	@Autowired
 	MessageChannel gatewayWithFailModeLowercaseChannel;
 
+	@Autowired
+	EventDrivenConsumer gatewayWithAppendNewLine;
+	
 	private volatile static int adviceCalled;
 
 	@Test
@@ -304,7 +308,21 @@ public class FileOutboundGatewayParserTests {
 
 	}
 
-    public static class FooAdvice extends AbstractRequestHandlerAdvice {
+	/**
+	 * Test that the underlying {@link FileWritingMessageHandler} bean of the File Outbound Gateway
+	 * gets it's {@link FileWritingMessageHandler#setAppendNewLine(boolean)} called when XML 
+	 * config file has <code>append-new-line="true"</code>.
+	 */
+	@Test
+	public void gatewayWithAppendNewLine() {
+		DirectFieldAccessor adapterAccessor = new DirectFieldAccessor(gatewayWithAppendNewLine);
+		FileWritingMessageHandler handler = (FileWritingMessageHandler)
+			adapterAccessor.getPropertyValue("handler");
+		DirectFieldAccessor handlerAccessor = new DirectFieldAccessor(handler);
+		assertEquals(Boolean.TRUE, handlerAccessor.getPropertyValue("appendNewLine"));
+	}	
+
+	public static class FooAdvice extends AbstractRequestHandlerAdvice {
 
 		@Override
 		protected Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) throws Exception {

--- a/src/reference/docbook/file.xml
+++ b/src/reference/docbook/file.xml
@@ -477,7 +477,13 @@
 				The <code>delete-source-files</code> attribute will only have an effect if the inbound
 				Message has a File payload or if the <classname>FileHeaders.ORIGINAL_FILE</classname> header
 				value contains either the source File instance or a String representing the original file path.
-			</note>
+			</note>						
+			<para>
+				The namespace based configuration also supports an <code>append-new-line</code> attribute (newly introduced in 4.2).
+				If set to <code>true</code>, a new line is appended to the file after a message is written.  The default attribute value is <code>false</code>.
+			</para>
+			<programlisting language="xml"><![CDATA[<int-file:outbound-channel-adapter id="newlineAdapter" append-new-line="true"
+    directory="${output.directory}"/>]]></programlisting>			
 		</section>
 		<section id="file-writing-output-gateway">
 			<title>Outbound Gateway</title>

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -22,5 +22,12 @@
 				attribute.
 			</para>
 		</section>
+		<section id="4.2-file-outbound-channel-adapter">
+			<title>File Outbound Channel Adapter</title>
+			<para>
+				The <code>&lt;int-file:outbound-channel-adapter&gt;</code> now supports an <code>append-new-line</code> attribute.
+				If set to <code>true</code>, a new line is appended to the file after a message is written.  The default attribute value is <code>false</code>.
+			</para>
+		</section>		
 	</section>
 </chapter>


### PR DESCRIPTION
I've added XML Namespace support for `appendNewLine(boolean)` to `FileWritingMessageHandler` to be considered for Spring Integration 4.2.  See https://jira.spring.io/browse/INT-3621 

Note that the attribute in the XML is named `append-new-line` which is slightly different than what it is called for the `CharacterStreamWritingMessageHandler` (that being `append-newline`).  The reason for the difference is that it must match the setter that was chosen on the class:  `FileWritingMessageHandler.setAppendNewLine(boolean)`.

/CC @artembilan @garyrussell 
