### PR TITLE
INT-3513 Removes the use of DirectFieldAccessor

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessage.java
@@ -45,9 +45,7 @@ class MutableMessage<T> implements Message<T>, Serializable {
 
 	private T payload;
 
-	private final MessageHeaders headers;
-
-	private final Map<String, Object> rawHeaders;
+	private final MutableMessageHeaders headers;
 
 	MutableMessage(T payload) {
 		this(payload, null);
@@ -56,20 +54,19 @@ class MutableMessage<T> implements Message<T>, Serializable {
 	@SuppressWarnings("unchecked")
 	MutableMessage(T payload, Map<String, Object> headers) {
 		Assert.notNull(payload, "payload must not be null");
-		this.headers = new MessageHeaders(headers);
-		this.payload = payload;
-		// Needs SPR-11468 to avoid DFA and header manipulation
-		rawHeaders = (Map<String, Object>) new DirectFieldAccessor(this.headers)
-				.getPropertyValue("headers");
+        this.payload = payload;
+
+		this.headers = new MutableMessageHeaders(headers);
+
 		if (headers != null) {
-			this.rawHeaders.put(MessageHeaders.ID, headers.get(MessageHeaders.ID));
-			this.rawHeaders.put(MessageHeaders.TIMESTAMP, headers.get(MessageHeaders.TIMESTAMP));
+			this.headers.put(MessageHeaders.ID, headers.get(MessageHeaders.ID));
+			this.headers.put(MessageHeaders.TIMESTAMP, headers.get(MessageHeaders.TIMESTAMP));
 		}
 	}
 
 
 	@Override
-	public MessageHeaders getHeaders() {
+	public MutableMessageHeaders getHeaders() {
 		return this.headers;
 	}
 
@@ -84,7 +81,7 @@ class MutableMessage<T> implements Message<T>, Serializable {
 	}
 
 	public Map<String, Object> getRawHeaders() {
-		return this.rawHeaders;
+		return this.headers.getRawHeaders();
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageHeaders.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageHeaders.java
@@ -11,7 +11,7 @@ import java.util.UUID;
  * header map.
  *
  * @author Stuart Williams
- * @since 4.1
+ * @since 4.2
  */
 class MutableMessageHeaders extends MessageHeaders {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageHeaders.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageHeaders.java
@@ -1,0 +1,61 @@
+package org.springframework.integration.support;
+
+import org.springframework.messaging.MessageHeaders;
+
+import java.util.Map;
+import java.util.UUID;
+
+
+/**
+ * A MessageHeaders that permits direct access to and modification of the
+ * header map.
+ *
+ * @author Stuart Williams
+ * @since 4.1
+ */
+class MutableMessageHeaders extends MessageHeaders {
+
+    private static final long serialVersionUID = 3084692953798643018L;
+
+    /**
+     * @param headers map
+     */
+    public MutableMessageHeaders(Map<String, Object> headers) {
+        super(headers);
+    }
+
+    /**
+     * @param headers map
+     * @param id of message
+     * @param timestamp of message
+     */
+    public MutableMessageHeaders(Map<String, Object> headers, UUID id, Long timestamp) {
+        super(headers, id, timestamp);
+    }
+
+    @Override
+    public Map<String, Object> getRawHeaders() {
+        return super.getRawHeaders();
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends Object> map) {
+        super.getRawHeaders().putAll(map);
+    }
+
+    @Override
+    public Object put(String key, Object value) {
+        return super.getRawHeaders().put(key, value);
+    }
+
+    @Override
+    public void clear() {
+        super.getRawHeaders().clear();
+    }
+
+    @Override
+    public Object remove(Object key) {
+        return super.getRawHeaders().remove(key);
+    }
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/MutableMessageBuilderFactoryTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/MutableMessageBuilderFactoryTests.java
@@ -1,0 +1,109 @@
+package org.springframework.integration.support;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.annotation.*;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * @author swilliams
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class MutableMessageBuilderFactoryTests {
+
+    @Autowired
+    ContextConfiguration.TestGateway gateway;
+
+    @Autowired
+    CountDownLatch latch;
+
+    @Test
+    public void test() throws InterruptedException {
+
+        gateway.input("hello!");
+
+        boolean result = latch.await(2L, TimeUnit.SECONDS);
+
+        assertTrue("A failure means that that MMBF wasn't used", result);
+    }
+
+    @Configuration
+    @EnableIntegration
+    @IntegrationComponentScan
+    static class ContextConfiguration {
+
+        @Bean
+        public MutableMessageBuilderFactory messageBuilderFactory() {
+            return new MutableMessageBuilderFactory();
+        }
+
+        @Bean
+        public DirectChannel input() {
+            return new DirectChannel();
+        }
+
+        @Bean
+        public DirectChannel output() {
+            return new DirectChannel();
+        }
+
+        @Bean
+        public CountDownLatch latch() {
+            return new CountDownLatch(1);
+        }
+
+        @MessagingGateway
+        static interface TestGateway {
+
+            @Gateway(requestChannel = "input")
+            void input(String payload);
+
+        }
+
+        @MessageEndpoint
+        static class TestFilter {
+
+            @Filter(inputChannel = "input", outputChannel = "output")
+            public boolean filter(MessageHeaders headers) {
+                // headers are immutable, so if this passes without exception,
+                // the MutableMessageBuilderFactory *was* used...
+                try {
+                    headers.put("foo", "bar");
+                    return true;
+                }
+                catch (UnsupportedOperationException e) {
+                    return false;
+                }
+            }
+        }
+
+        @MessageEndpoint
+        static class Counter {
+
+            @Autowired
+            CountDownLatch latch;
+
+            @ServiceActivator(inputChannel = "output")
+            public void count(@Payload String message) {
+                latch.countDown();
+            }
+        }
+    }
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/MutableMessageTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/MutableMessageTests.java
@@ -1,0 +1,57 @@
+package org.springframework.integration.support;
+
+import org.junit.Test;
+import org.springframework.messaging.MessageHeaders;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author swilliams
+ */
+public class MutableMessageTests {
+
+    @Test
+    public void testMessageIdTimestampRemains() {
+
+        UUID uuid = UUID.randomUUID();
+        long timestamp = System.currentTimeMillis();
+
+        Object payload = new Object();
+        Map<String, Object> headerMap = new HashMap<>();
+
+        headerMap.put(MessageHeaders.ID, uuid);
+        headerMap.put(MessageHeaders.TIMESTAMP, timestamp);
+
+        MutableMessage<Object> mutableMessage = new MutableMessage<>(payload, headerMap);
+        MutableMessageHeaders headers = mutableMessage.getHeaders();
+
+        assertThat(headers.getRawHeaders(), hasEntry(MessageHeaders.ID, (Object) uuid));
+        assertThat(headers.getRawHeaders(), hasEntry(MessageHeaders.TIMESTAMP, (Object) timestamp));
+    }
+
+    @Test
+    public void testMessageHeaderIsSettable() {
+
+        Object payload = new Object();
+        Map<String, Object> headerMap = new HashMap<>();
+        Map<String, Object> additional = new HashMap<>();
+
+        MutableMessage<Object> mutableMessage = new MutableMessage<>(payload, headerMap);
+        MutableMessageHeaders headers = mutableMessage.getHeaders();
+
+        // Should not throw an UnsupportedOperationException
+        headers.put("foo", "bar");
+        headers.put("eep", "bar");
+        headers.remove("eep");
+        headers.putAll(additional);
+
+        assertThat(headers.getRawHeaders(), hasEntry("foo", (Object) "bar"));
+    }
+
+}


### PR DESCRIPTION
Removing the rawHeader access by the DFA improves performance.
Tests are added to verify that MutableMessageBuilderFactory does
what it purports to, and that the MutableMessageHeaders is now
applied, permitting updates to individual headers.
