### PR TITLE
Fix Redis Synchronization Tests

### DIFF
--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisStoreInboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisStoreInboundChannelAdapterIntegrationTests.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.support.collections.RedisList;
 import org.springframework.data.redis.support.collections.RedisZSet;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
@@ -59,14 +58,14 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 		spca.start();
 		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
 
-		Message<RedisList<Object>> message = (Message<RedisList<Object>>) redisChannel.receive(1000);
+		Message<Integer> message = (Message<Integer>) redisChannel.receive(1000);
 		assertNotNull(message);
-		assertEquals(13, message.getPayload().size());
+		assertEquals(Integer.valueOf(13), message.getPayload());
 
 		//poll again, should get the same stuff
-		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
+		message = (Message<Integer>) redisChannel.receive(1000);
 		assertNotNull(message);
-		assertEquals(13, message.getPayload().size());
+		assertEquals(Integer.valueOf(13), message.getPayload());
 		this.deletePresidents(jcf);
 		context.close();
 	}
@@ -85,12 +84,12 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 		spca.start();
 		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
 
-		Message<RedisList<Object>> message = (Message<RedisList<Object>>) redisChannel.receive(1000);
+		Message<Integer> message = (Message<Integer>) redisChannel.receive(1000);
 		assertNotNull(message);
-		assertEquals(13, message.getPayload().size());
+		assertEquals(Integer.valueOf(13), message.getPayload());
 
 		//poll again, should get nothing since the collection was removed during synchronization
-		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
+		message = (Message<Integer>) redisChannel.receive(1000);
 		assertNull(message);
 		assertEquals(Long.valueOf(13), template.boundListOps("bar").size());
 		template.delete("bar");
@@ -149,12 +148,12 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 		spca.start();
 		QueueChannel redisChannel = context.getBean("redisChannel", QueueChannel.class);
 
-		Message<RedisList<Object>> message = (Message<RedisList<Object>>) redisChannel.receive(1000);
+		Message<Integer> message = (Message<Integer>) redisChannel.receive(1000);
 		assertNotNull(message);
-		assertEquals(13, message.getPayload().size());
+		assertEquals(Integer.valueOf(13), message.getPayload());
 
 		//poll again, should get nothing since the collection was removed during synchronization
-		message = (Message<RedisList<Object>>) redisChannel.receive(1000);
+		message = (Message<Integer>) redisChannel.receive(1000);
 		assertNull(message);
 		assertEquals(Long.valueOf(13), template.boundListOps("bar").size());
 		template.delete("bar");
@@ -239,9 +238,9 @@ public class RedisStoreInboundChannelAdapterIntegrationTests extends RedisAvaila
 
 		// get only presidents for 18th century
 		zsetAdapterWithSingleScoreAndSynchronization.start();
-		message = (Message<RedisZSet<Object>>) otherRedisChannel.receive(2000);
-		assertNotNull(message);
-		assertEquals(2, message.getPayload().rangeByScore(18, 18).size());
+		Message<Integer> sizeMessage = (Message<Integer>) otherRedisChannel.receive(2000);
+		assertNotNull(sizeMessage);
+		assertEquals(Integer.valueOf(2), sizeMessage.getPayload());
 
 		// ... however other elements are still available 13-2=11
 		zsetAdapterNoScore.start();

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/list-inbound-adapter.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/list-inbound-adapter.xml
@@ -10,7 +10,7 @@
 	<int-redis:store-inbound-channel-adapter id="listAdapter"
 											connection-factory="redisConnectionFactory"
 											key-expression="'presidents'"
-											channel="redisChannel"
+											channel="transformChannel"
 											auto-startup="false"
 											collection-type="LIST">
 		<int:poller fixed-rate="2000" max-messages-per-poll="10"/>
@@ -19,7 +19,7 @@
 	<int-redis:store-inbound-channel-adapter id="listAdapterWithSynchronization"
 											connection-factory="redisConnectionFactory"
 											key-expression="'presidents'"
-											channel="redisChannel"
+											channel="transformChannel"
 											auto-startup="false">
 		<int:poller fixed-rate="2000" max-messages-per-poll="10">
 			<int:transactional synchronization-factory="syncFactory"/>
@@ -41,7 +41,7 @@
 	<int-redis:store-inbound-channel-adapter id="listAdapterWithSynchronizationAndRedisTemplate"
 											redis-template="redisTemplate"
 											key-expression="'presidents'"
-											channel="redisChannel"
+											channel="transformChannel"
 											auto-startup="false">
 		<int:poller fixed-rate="2000" max-messages-per-poll="10">
 		    <int:transactional synchronization-factory="syncFactory"/>
@@ -56,7 +56,7 @@
 	<int-redis:store-inbound-channel-adapter id="listAdapterWithSynchronizationBeforeCommit"
 											redis-template="redisTemplate"
 											key-expression="'presidents'"
-											channel="redisChannel"
+											channel="transformChannel"
 											auto-startup="false">
 		<int:poller fixed-rate="2000" max-messages-per-poll="10" error-channel="adapterErrors">
 		    <int:transactional synchronization-factory="syncFactory2"/>
@@ -80,6 +80,8 @@
 			<bean class="org.springframework.data.redis.serializer.StringRedisSerializer"/>
 		</property>
 	</bean>
+
+	<int:transformer input-channel="transformChannel" output-channel="redisChannel" expression="payload.size()"/>
 
 	<int:channel id="redisChannel">
 		<int:queue/>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/zset-inbound-adapter.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/zset-inbound-adapter.xml
@@ -37,7 +37,7 @@
 	<int-redis:store-inbound-channel-adapter id="zsetAdapterWithSingleScoreAndSynchronization"
 											connection-factory="redisConnectionFactory"
 											key-expression="'presidents'"
-											channel="otherRedisChannel"
+											channel="transformChannel"
 											auto-startup="false"
 											collection-type="ZSET">
 		<int:poller fixed-rate="1000">
@@ -52,6 +52,9 @@
 	<int:channel id="redisChannel">
 		<int:queue/>
 	</int:channel>
+
+	<int:transformer input-channel="transformChannel" output-channel="otherRedisChannel"
+		expression="payload.rangeByScore(18, 18).size()" />
 
 	<int:channel id="otherRedisChannel">
 		<int:queue/>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/rules/RedisAvailableTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/rules/RedisAvailableTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,7 +129,7 @@ public class RedisAvailableTests {
 		ops.add("Ronald Reagan", 20);
 		ops.add("William J. Clinton", 20);
 		ops.add("Abraham Lincoln", 19);
-		ops.add("George Wahington", 18);
+		ops.add("George Washington", 18);
 	}
 
 	protected void deletePresidents(RedisConnectionFactory connectionFactory){


### PR DESCRIPTION
The "transaction" synchronization tests use a `QueueChannel`.

The payload is a live reference to the Redis object.

It is possible that the test for the returned size occurs after
the "transaction" commits.

Change the tests to extract the size() on the poller thread so
that the size is always captured before the "transaction" commits.
