### PR TITLE
INT-3653: JMX: Use System.nanoTime()

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/management/DefaultMessageChannelMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/management/DefaultMessageChannelMetrics.java
@@ -83,9 +83,9 @@ public class DefaultMessageChannelMetrics extends AbstractMessageChannelMetrics 
 			logger.trace("Recording send on channel(" + this.name + ")");
 		}
 
-		long start = 0;
+		double start = 0;
 		if (isFullStatsEnabled()) {
-			start = System.nanoTime();
+			start = System.nanoTime() / 1000000.;
 			this.sendRate.increment();
 		}
 		this.sendCount.incrementAndGet();
@@ -95,20 +95,20 @@ public class DefaultMessageChannelMetrics extends AbstractMessageChannelMetrics 
 	@Override
 	public void afterSend(MetricsContext context, boolean result) {
 		if (result && isFullStatsEnabled()) {
-			long now = System.nanoTime();
+			double now = System.nanoTime() / 1000000.;
 			this.sendSuccessRatio.success(now);
-			this.sendDuration.appendNanos(now - ((DefaultChannelMetricsContext) context).start);
+			this.sendDuration.append(now - ((DefaultChannelMetricsContext) context).start);
 		}
 		else {
 			if (isFullStatsEnabled()) {
-				this.sendSuccessRatio.failure(System.nanoTime());
+				this.sendSuccessRatio.failure(System.nanoTime() / 1000000.);
 				this.sendErrorRate.increment();
 			}
 			this.sendErrorCount.incrementAndGet();
 		}
 		if (logger.isTraceEnabled()) {
 			logger.trace("Elapsed: " + this.name
-					+ ": " + ((System.nanoTime() - ((DefaultChannelMetricsContext) context).start) / 1000000.) + "ms");
+					+ ": " + ((System.nanoTime() / 1000000. - ((DefaultChannelMetricsContext) context).start)) + "ms");
 		}
 	}
 
@@ -241,9 +241,9 @@ public class DefaultMessageChannelMetrics extends AbstractMessageChannelMetrics 
 
 	private static class DefaultChannelMetricsContext implements MetricsContext {
 
-		private final long start;
+		private final double start;
 
-		public DefaultChannelMetricsContext(long start) {
+		public DefaultChannelMetricsContext(double start) {
 			this.start = start;
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/management/DefaultMessageHandlerMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/management/DefaultMessageHandlerMetrics.java
@@ -55,9 +55,9 @@ public class DefaultMessageHandlerMetrics extends AbstractMessageHandlerMetrics 
 		if (logger.isTraceEnabled()) {
 			logger.trace("messageHandler(" + this.name + ") message(" + message + ") :");
 		}
-		long start = 0;
+		double start = 0;
 		if (isFullStatsEnabled()) {
-			start = System.nanoTime();
+			start = System.nanoTime() / 1000000.;
 		}
 		this.handleCount.incrementAndGet();
 		this.activeCount.incrementAndGet();
@@ -68,7 +68,7 @@ public class DefaultMessageHandlerMetrics extends AbstractMessageHandlerMetrics 
 	public void afterHandle(MetricsContext context, boolean success) {
 		this.activeCount.decrementAndGet();
 		if (isFullStatsEnabled() && success) {
-			this.duration.appendNanos(System.nanoTime() - ((DefaultHandlerMetricsContext) context).start);
+			this.duration.append(System.nanoTime() / 1000000. - ((DefaultHandlerMetricsContext) context).start);
 		}
 		else if (!success) {
 			this.errorCount.incrementAndGet();
@@ -142,9 +142,9 @@ public class DefaultMessageHandlerMetrics extends AbstractMessageHandlerMetrics 
 
 	private static class DefaultHandlerMetricsContext implements MetricsContext {
 
-		private final long start;
+		private final double start;
 
-		public DefaultHandlerMetricsContext(long start) {
+		public DefaultHandlerMetricsContext(double start) {
 			this.start = start;
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverage.java
@@ -66,18 +66,9 @@ public class ExponentialMovingAverage {
 	/**
 	 * Add a new measurement to the series.
 	 *
-	 * @param value the measurement to append (milliseconds)
+	 * @param value the measurement to append
 	 */
 	public synchronized void append(double value) {
-		appendNanos(value * 1000000);
-	}
-
-	/**
-	 * Add a new measurement to the series.
-	 *
-	 * @param value the measurement to append (nanoseconds)
-	 */
-	public synchronized void appendNanos(double value) {
 		if (value > max || count == 0) {
 			max = value;
 		}
@@ -85,8 +76,7 @@ public class ExponentialMovingAverage {
 			min = value;
 		}
 		sum = decay * sum + value;
-		double valueMillis = value / 1000000.;
-		sumSquares = decay * sumSquares + valueMillis * valueMillis;
+		sumSquares = decay * sumSquares + value * value;
 		weight = decay * weight + 1;
 		count++;//NOSONAR - false positive, we're synchronized
 	}
@@ -106,16 +96,9 @@ public class ExponentialMovingAverage {
 	}
 
 	/**
-	 * @return the mean value (milliseconds)
+	 * @return the mean value
 	 */
 	public double getMean() {
-		return weight > 0 ? sum / weight / 1000000. : 0.;
-	}
-
-	/**
-	 * @return the mean value (nanoseconds)
-	 */
-	public double getMeanNanos() {
 		return weight > 0 ? sum / weight : 0.;
 	}
 
@@ -129,24 +112,24 @@ public class ExponentialMovingAverage {
 	}
 
 	/**
-	 * @return the maximum value recorded (not weighted, milliseconds).
+	 * @return the maximum value recorded (not weighted)
 	 */
 	public double getMax() {
-		return max / 1000000.;
+		return max;
 	}
 
 	/**
-	 * @return the minimum value recorded (not weighted, milliseconds).
+	 * @return the minimum value recorded (not weighted)
 	 */
 	public double getMin() {
-		return min / 1000000.;
+		return min;
 	}
 
 	/**
 	 * @return summary statistics (count, mean, standard deviation etc.)
 	 */
 	public Statistics getStatistics() {
-		return new Statistics(count, getMin(), getMax(), getMean(), getStandardDeviation());
+		return new Statistics(count, min, max, getMean(), getStandardDeviation());
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRate.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRate.java
@@ -44,7 +44,7 @@ public class ExponentialMovingAverageRate {
 
 	private volatile double max;
 
-	private volatile long t0 = System.currentTimeMillis();
+	private volatile double t0 = System.nanoTime() / 1000000.;
 
 	private final double lapse;
 
@@ -68,7 +68,7 @@ public class ExponentialMovingAverageRate {
 		max = 0;
 		weight = 0;
 		sum = 0;
-		t0 = System.currentTimeMillis();
+		t0 = System.nanoTime() / 1000000.;
 		rates.reset();
 	}
 
@@ -76,7 +76,7 @@ public class ExponentialMovingAverageRate {
 	 * Add a new event to the series.
 	 */
 	public synchronized void increment() {
-		long t = System.currentTimeMillis();
+		double t = System.nanoTime() / 1000000.;
 		double value = t > t0 ? (t - t0) / period : 0;
 		if (value > max || getCount() == 0) {
 			max = value;
@@ -110,7 +110,7 @@ public class ExponentialMovingAverageRate {
 	 * @return the time in seconds since the last measurement
 	 */
 	public double getTimeSinceLastMeasurement() {
-		return (System.currentTimeMillis() - t0) / 1000.;
+		return System.nanoTime() / 1000000. - t0;
 	}
 
 	/**
@@ -121,7 +121,7 @@ public class ExponentialMovingAverageRate {
 		if (count == 0) {
 			return 0;
 		}
-		long t = System.currentTimeMillis();
+		double t = System.nanoTime() / 1000000.;
 		double value = t > t0 ? (t - t0) / period : 0;
 		return count / (count / rates.getMean() + value);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRate.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRate.java
@@ -44,7 +44,7 @@ public class ExponentialMovingAverageRate {
 
 	private volatile double max;
 
-	private volatile long t0 = System.nanoTime();
+	private volatile long t0 = System.currentTimeMillis();
 
 	private final double lapse;
 
@@ -58,8 +58,8 @@ public class ExponentialMovingAverageRate {
 	 */
 	public ExponentialMovingAverageRate(double period, double lapsePeriod, int window) {
 		rates = new ExponentialMovingAverage(window);
-		this.lapse = lapsePeriod > 0 ? 0.000000001 / lapsePeriod : 0; // convert to nanoseconds
-		this.period = period * 1000000000; // convert to nanoseconds
+		this.lapse = lapsePeriod > 0 ? 0.001 / lapsePeriod : 0; // convert to milliseconds
+		this.period = period * 1000; // convert to milliseconds
 	}
 
 
@@ -68,7 +68,7 @@ public class ExponentialMovingAverageRate {
 		max = 0;
 		weight = 0;
 		sum = 0;
-		t0 = System.nanoTime();
+		t0 = System.currentTimeMillis();
 		rates.reset();
 	}
 
@@ -76,16 +76,15 @@ public class ExponentialMovingAverageRate {
 	 * Add a new event to the series.
 	 */
 	public synchronized void increment() {
-		long t = System.nanoTime();
-		double delta = t - t0;
-		double value = delta > 0 ? delta / period : 0;
+		long t = System.currentTimeMillis();
+		double value = t > t0 ? (t - t0) / period : 0;
 		if (value > max || getCount() == 0) {
 			max = value;
 		}
 		if (value < min || getCount() == 0) {
 			min = value;
 		}
-		double alpha = Math.exp(-delta * lapse);
+		double alpha = Math.exp((t0 - t) * lapse);
 		t0 = t;
 		sum = alpha * sum + value;
 		weight = alpha * weight + 1;
@@ -111,7 +110,7 @@ public class ExponentialMovingAverageRate {
 	 * @return the time in seconds since the last measurement
 	 */
 	public double getTimeSinceLastMeasurement() {
-		return (System.nanoTime() - t0) / 1000000000.;
+		return (System.currentTimeMillis() - t0) / 1000.;
 	}
 
 	/**
@@ -122,8 +121,8 @@ public class ExponentialMovingAverageRate {
 		if (count == 0) {
 			return 0;
 		}
-		long delta = System.nanoTime() - t0;
-		double value = delta > 0 ? delta / period : 0;
+		long t = System.currentTimeMillis();
+		double value = t > t0 ? (t - t0) / period : 0;
 		return count / (count / rates.getMean() + value);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRatio.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRatio.java
@@ -36,7 +36,7 @@ public class ExponentialMovingAverageRatio {
 
 	private volatile double sum;
 
-	private volatile long t0 = System.nanoTime();
+	private volatile long t0 = System.currentTimeMillis();
 
 	private final double lapse;
 
@@ -57,41 +57,26 @@ public class ExponentialMovingAverageRatio {
 	 * Add a new event with successful outcome.
 	 */
 	public void success() {
-		append(1, System.nanoTime());
-	}
-
-	/**
-	 * Add a new event with successful outcome.
-	 * @param t The current timestamp (System.nanoTime()).
-	 */
-	public void success(long t) {
-		append(1, t);
+		append(1);
 	}
 
 	/**
 	 * Add a new event with failed outcome.
 	 */
 	public void failure() {
-		append(0, System.nanoTime());
-	}
-
-	/**
-	 * Add a new event with failed outcome.
-	 * @param t the current timestamp (System.nanoTime()).
-	 */
-	public void failure(long t) {
-		append(0, t);
+		append(0);
 	}
 
 	public synchronized void reset() {
 		weight = 0;
 		sum = 0;
-		t0 = System.nanoTime();
+		t0 = System.currentTimeMillis();
 		cumulative.reset();
 	}
 
-	private synchronized void append(int value, long t) {
-		double alpha = Math.exp((t0 - t) / 1000000. * lapse);
+	private synchronized void append(int value) {
+		long t = System.currentTimeMillis();
+		double alpha = Math.exp((t0 - t) * lapse);
 		t0 = t;
 		sum = alpha * sum + value;
 		weight = alpha * weight + 1;
@@ -116,7 +101,7 @@ public class ExponentialMovingAverageRatio {
 	 * @return the time in seconds since the last measurement
 	 */
 	public double getTimeSinceLastMeasurement() {
-		return (System.nanoTime() - t0) / 1000000000.;
+		return (System.currentTimeMillis() - t0) / 1000.;
 	}
 
 	/**
@@ -128,8 +113,8 @@ public class ExponentialMovingAverageRatio {
 			// Optimistic to start: success rate is 100%
 			return 1;
 		}
-		long t = System.nanoTime();
-		double alpha = Math.exp((t0 - t) / 1000000. * lapse);
+		long t = System.currentTimeMillis();
+		double alpha = Math.exp((t0 - t) * lapse);
 		return alpha * cumulative.getMean() + 1 - alpha;
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/ExponentialMovingAverageTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/ExponentialMovingAverageTests.java
@@ -71,19 +71,19 @@ public class ExponentialMovingAverageTests {
 		for (int i = 0; i < 10000; i++) {
 			switch (i % 3) {
 				case 0:
-					av.appendNanos(20000);
+					av.append(20);
 					break;
 				case 1:
-					av.appendNanos(30000);
+					av.append(30);
 					break;
 				case 2:
-					av.appendNanos(40000);
+					av.append(40);
 					break;
 			}
 		}
-		assertEquals(0.04, av.getMax(), 0.001);
-		assertEquals(0.02, av.getMin(), 0.001);
-		assertEquals(0.03, av.getMean(), 0.001);
+		assertEquals(40, av.getMax(), 0.1);
+		assertEquals(20, av.getMin(), 0.1);
+		assertEquals(30, av.getMean(), 1.0);
 	}
 
 


### PR DESCRIPTION
Reverted `ExponentialMoving*` and changed the switch to `System.nanoTime()` by simply converting back to milliseconds using doubles.

I left it as 2 commits to make it easier to review.
