### PR TITLE
INT-3577: Remove flush() from TCP Serializers

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,6 +145,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 			this.lastSend = System.currentTimeMillis();
 			try {
 				((Serializer<Object>) this.getSerializer()).serialize(object, this.bufferedOutputStream);
+				this.bufferedOutputStream.flush();
 			}
 			catch (Exception e) {
 				this.publishConnectionExceptionEvent(e);

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayCrLfSerializer.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayCrLfSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,6 @@ public class ByteArrayCrLfSerializer extends AbstractByteArraySerializer {
 	public void serialize(byte[] bytes, OutputStream outputStream) throws IOException {
 		outputStream.write(bytes);
 		outputStream.write(CRLF);
-		outputStream.flush();
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayLengthHeaderSerializer.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayLengthHeaderSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,7 +133,6 @@ public class ByteArrayLengthHeaderSerializer extends AbstractByteArraySerializer
 	public void serialize(byte[] bytes, OutputStream outputStream) throws IOException {
 		this.writeHeader(outputStream, bytes.length);
 		outputStream.write(bytes);
-		outputStream.flush();
 	}
 
 	/**
@@ -253,4 +252,5 @@ public class ByteArrayLengthHeaderSerializer extends AbstractByteArraySerializer
 			throw e;
 		}
 	}
+
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayLfSerializer.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayLfSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,4 +25,5 @@ public class ByteArrayLfSerializer extends ByteArraySingleTerminatorSerializer {
 	public ByteArrayLfSerializer() {
 		super((byte) 0x0a);
 	}
+
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayRawSerializer.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayRawSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ public class ByteArrayRawSerializer extends AbstractByteArraySerializer {
 	public void serialize(byte[] bytes, OutputStream outputStream)
 			throws IOException {
 		outputStream.write(bytes);
-		outputStream.flush();
 	}
 
 	@Override

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArraySingleTerminatorSerializer.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArraySingleTerminatorSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,6 @@ public class ByteArraySingleTerminatorSerializer extends AbstractByteArraySerial
 	public void serialize(byte[] bytes, OutputStream outputStream) throws IOException {
 		outputStream.write(bytes);
 		outputStream.write(terminator);
-		outputStream.flush();
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayStxEtxSerializer.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/ByteArrayStxEtxSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,6 @@ public class ByteArrayStxEtxSerializer extends AbstractByteArraySerializer {
 		outputStream.write(STX);
 		outputStream.write(bytes);
 		outputStream.write(ETX);
-		outputStream.flush();
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/MapJsonSerializer.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/serializer/MapJsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ import java.util.Map;
 
 import org.springframework.core.serializer.Deserializer;
 import org.springframework.core.serializer.Serializer;
-import org.springframework.integration.support.json.JsonObjectMapperProvider;
 import org.springframework.integration.support.json.JsonObjectMapper;
+import org.springframework.integration.support.json.JsonObjectMapperProvider;
 import org.springframework.util.Assert;
 
 /**
@@ -107,7 +107,6 @@ public class MapJsonSerializer implements Serializer<Map<?, ?>>, Deserializer<Ma
 			throw new IOException(e);
 		}
 		this.packetSerializer.serialize(baos.toByteArray(), outputStream);
-		outputStream.flush();
 	}
 
 }

--- a/src/reference/docbook/whats-new.xml
+++ b/src/reference/docbook/whats-new.xml
@@ -39,6 +39,15 @@
 				<code>org.springframework.integration.scattergather</code>.
 			</para>
 		</section>
+		<section>
+			<title>TCP Serializers</title>
+			<para>
+				The TCP <interfacename>Serializers</interfacename> no longer <code>flush()</code> the
+				<classname>OutputStream</classname>; this is now done by the <classname>TcpNxxConnection</classname>
+				classes. If you are using the serializers directly within user code, you may have to
+				<code>flush()</code> the <classname>OutputStream</classname>.
+			</para>
+		</section>
 		<section id="4.2-tcp-server-exceptions">
 			<title>Server Socket Exceptions</title>
 			<para>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3577

It is no longer necessary to `flush()` the `BufferedOutputStream`.

Since INT-3575, the `TcpNetConnection` has flushed the stream.

The `TcpNioConnection` now does so too.
