### PR TITLE
INT-3661: Fix the eager BF access from BPPs (P I)

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.amqp.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -57,7 +58,7 @@ public class AmqpChannelParserTests {
 				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers", Integer.class).intValue());
 		channel = context.getBean("pubSub", MessageChannel.class);
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertSame(mbf, TestUtils.getPropertyValue(channel, "dispatcher.messageBuilderFactory"));
+		assertNotSame(mbf, TestUtils.getPropertyValue(channel, "dispatcher.messageBuilderFactory"));
 		assertSame(mbf, TestUtils.getPropertyValue(channel, "container.messageListener.messageBuilderFactory"));
 		assertTrue(TestUtils.getPropertyValue(channel, "container.missingQueuesFatal", Boolean.class));
 		assertFalse(TestUtils.getPropertyValue(channel, "container.transactional", Boolean.class));

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests.java
@@ -18,7 +18,6 @@ package org.springframework.integration.amqp.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -58,7 +57,6 @@ public class AmqpChannelParserTests {
 				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers", Integer.class).intValue());
 		channel = context.getBean("pubSub", MessageChannel.class);
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertNotSame(mbf, TestUtils.getPropertyValue(channel, "dispatcher.messageBuilderFactory"));
 		assertSame(mbf, TestUtils.getPropertyValue(channel, "container.messageListener.messageBuilderFactory"));
 		assertTrue(TestUtils.getPropertyValue(channel, "container.missingQueuesFatal", Boolean.class));
 		assertFalse(TestUtils.getPropertyValue(channel, "container.transactional", Boolean.class));

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractAggregatingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractAggregatingMessageGroupProcessor.java
@@ -79,12 +79,11 @@ public abstract class AbstractAggregatingMessageGroupProcessor implements Messag
 		Map<String, Object> headers = this.aggregateHeaders(group);
 		Object payload = this.aggregatePayloads(group, headers);
 		AbstractIntegrationMessageBuilder<?> builder;
-		MessageBuilderFactory messageBuilderFactory = getMessageBuilderFactory();
 		if (payload instanceof Message<?>) {
-			builder = messageBuilderFactory.fromMessage((Message<?>) payload).copyHeadersIfAbsent(headers);
+			builder = getMessageBuilderFactory().fromMessage((Message<?>) payload).copyHeadersIfAbsent(headers);
 		}
 		else {
-			builder = messageBuilderFactory.withPayload(payload).copyHeadersIfAbsent(headers);
+			builder = getMessageBuilderFactory().withPayload(payload).copyHeadersIfAbsent(headers);
 		}
 
 		return builder.popSequenceDetails().build();

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageListProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageListProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,14 +22,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.messaging.Message;
 import org.springframework.integration.util.AbstractExpressionEvaluator;
 import org.springframework.integration.util.MessagingMethodInvokerHelper;
 
 /**
  * A MessageListProcessor implementation that invokes a method on a target POJO.
- * 
+ *
  * @author Dave Syer
+ * @author Artem Bilan
  * @since 2.0
  */
 public class MethodInvokingMessageListProcessor<T> extends AbstractExpressionEvaluator {
@@ -55,6 +57,12 @@ public class MethodInvokingMessageListProcessor<T> extends AbstractExpressionEva
 
 	public MethodInvokingMessageListProcessor(Object targetObject, Class<? extends Annotation> annotationType) {
 		delegate = new MessagingMethodInvokerHelper<T>(targetObject, annotationType, Object.class, true);
+	}
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) {
+		super.setBeanFactory(beanFactory);
+		this.delegate.setBeanFactory(beanFactory);
 	}
 
 	public String toString() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/MessagePublishingInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/MessagePublishingInterceptor.java
@@ -173,10 +173,9 @@ public class MessagePublishingInterceptor implements MethodInterceptor, BeanFact
 		Expression expression = this.parser.parseExpression(payloadExpressionString);
 		Object result = expression.getValue(context);
 		if (result != null) {
-			MessageBuilderFactory messageBuilderFactory = getMessageBuilderFactory();
 			AbstractIntegrationMessageBuilder<?> builder = (result instanceof Message<?>)
-					? messageBuilderFactory.fromMessage((Message<?>) result)
-					: messageBuilderFactory.withPayload(result);
+					? getMessageBuilderFactory().fromMessage((Message<?>) result)
+					: getMessageBuilderFactory().withPayload(result);
 			Map<String, Object> headers = this.evaluateHeaders(method, context);
 			if (headers != null) {
 				builder.copyHeaders(headers);

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -119,10 +119,9 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 	}
 
 	@Override
-	public final void setBeanFactory(BeanFactory beanFactory) {
+	public void setBeanFactory(BeanFactory beanFactory) {
 		Assert.notNull(beanFactory, "'beanFactory' must not be null");
 		this.beanFactory = beanFactory;
-		this.integrationProperties = IntegrationContextUtils.getIntegrationProperties(this.beanFactory);
 	}
 
 	@Override
@@ -143,9 +142,15 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 
 	@Override
 	public final void afterPropertiesSet() {
+		this.integrationProperties = IntegrationContextUtils.getIntegrationProperties(this.beanFactory);
 		try {
 			if (this.messageBuilderFactory == null) {
-				this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.beanFactory);
+				if (this.beanFactory != null) {
+					this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.beanFactory);
+				}
+				else {
+					this.messageBuilderFactory = new DefaultMessageBuilderFactory();
+				}
 			}
 			this.onInit();
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/IntegrationEvaluationContextAware.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/IntegrationEvaluationContextAware.java
@@ -19,8 +19,21 @@ package org.springframework.integration.expression;
 import org.springframework.expression.EvaluationContext;
 
 /**
+ * Interface to be implemented by beans that wish to be aware of their
+ * owning integration {@link EvaluationContext}, which is the result of
+ * {@link org.springframework.integration.config.IntegrationEvaluationContextFactoryBean}
+ * <p>
+ * The {@link #setIntegrationEvaluationContext} is invoked from
+ * the {@link IntegrationEvaluationContextAwareBeanPostProcessor#afterSingletonsInstantiated()},
+ * not during standard {@code postProcessBefore(After)Initialization} to avoid any
+ * {@code BeanFactory} early access during integration {@link EvaluationContext} retrieval.
+ * Therefore, if it is necessary to use {@link EvaluationContext} in the {@code afterPropertiesSet()},
+ * the {@code IntegrationContextUtils.getEvaluationContext(this.beanFactory)} should be used instead
+ * of this interface implementation.
+ *
  * @author Artem Bilan
  * @since 3.0
+ * @see IntegrationEvaluationContextAwareBeanPostProcessor
  */
 public interface IntegrationEvaluationContextAware {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageHandler.java
@@ -18,6 +18,7 @@ package org.springframework.integration.handler;
 
 import java.lang.reflect.Method;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.Lifecycle;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
@@ -45,6 +46,12 @@ public class MethodInvokingMessageHandler extends AbstractMessageHandler impleme
 
 	public MethodInvokingMessageHandler(Object object, String methodName) {
 		processor = new MethodInvokingMessageProcessor<Object>(object, methodName);
+	}
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) {
+		super.setBeanFactory(beanFactory);
+		this.processor.setBeanFactory(beanFactory);
 	}
 
 	public void setComponentType(String componentType) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -33,9 +33,9 @@ import org.springframework.messaging.Message;
  * @author Dave Syer
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 2.0
- *
  */
 @ManagedResource
 @IntegrationManagedResource
@@ -52,6 +52,8 @@ public abstract class AbstractMessageGroupStore implements MessageGroupStore, It
 
 	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 
+	private volatile boolean messageBuilderFactorySet;
+
 	public AbstractMessageGroupStore() {
 		super();
 	}
@@ -59,11 +61,17 @@ public abstract class AbstractMessageGroupStore implements MessageGroupStore, It
 	@Override
 	public final void setBeanFactory(BeanFactory beanFactory) {
 		this.beanFactory = beanFactory;
-		this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.beanFactory);
+
 	}
 
 	protected MessageBuilderFactory getMessageBuilderFactory() {
-		return messageBuilderFactory;
+		if (!this.messageBuilderFactorySet) {
+			if (this.beanFactory != null) {
+				this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.beanFactory);
+			}
+			this.messageBuilderFactorySet = true;
+		}
+		return this.messageBuilderFactory;
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/AbstractMessageProcessingTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/AbstractMessageProcessingTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@ package org.springframework.integration.transformer;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.context.Lifecycle;
-import org.springframework.core.convert.ConversionService;
-import org.springframework.integration.handler.AbstractMessageProcessor;
 import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
@@ -41,25 +39,31 @@ public abstract class AbstractMessageProcessingTransformer
 
 	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 
+	private volatile boolean messageBuilderFactorySet;
+
+	private BeanFactory beanFactory;
+
 	protected AbstractMessageProcessingTransformer(MessageProcessor<?> messageProcessor) {
 		Assert.notNull(messageProcessor, "messageProcessor must not be null");
 		this.messageProcessor = messageProcessor;
 	}
 
-	protected MessageBuilderFactory getMessageBuilderFactory() {
-		return messageBuilderFactory;
-	}
-
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) {
+		this.beanFactory = beanFactory;
 		if (this.messageProcessor instanceof BeanFactoryAware) {
 			((BeanFactoryAware) this.messageProcessor).setBeanFactory(beanFactory);
 		}
-		ConversionService conversionService = IntegrationUtils.getConversionService(beanFactory);
-		if (conversionService != null && this.messageProcessor instanceof AbstractMessageProcessor) {
-			((AbstractMessageProcessor<?>) this.messageProcessor).setConversionService(conversionService);
+	}
+
+	protected MessageBuilderFactory getMessageBuilderFactory() {
+		if (!this.messageBuilderFactorySet) {
+			if (this.beanFactory != null) {
+				this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.beanFactory);
+			}
+			this.messageBuilderFactorySet = true;
 		}
-		this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(beanFactory);
+		return this.messageBuilderFactory;
 	}
 
 	@Override
@@ -90,7 +94,7 @@ public abstract class AbstractMessageProcessingTransformer
 		if (result instanceof Message<?>) {
 			return (Message<?>) result;
 		}
-		return this.messageBuilderFactory.withPayload(result).copyHeaders(message.getHeaders()).build();
+		return getMessageBuilderFactory().withPayload(result).copyHeaders(message.getHeaders()).build();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/MessageProcessingHeaderValueMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/support/MessageProcessingHeaderValueMessageProcessor.java
@@ -16,6 +16,9 @@
 
 package org.springframework.integration.transformer.support;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.handler.MethodInvokingMessageProcessor;
 import org.springframework.messaging.Message;
@@ -25,7 +28,8 @@ import org.springframework.messaging.Message;
  * @author Artem Bilan
  * @since 3.0
  */
-public class MessageProcessingHeaderValueMessageProcessor extends AbstractHeaderValueMessageProcessor<Object> {
+public class MessageProcessingHeaderValueMessageProcessor extends AbstractHeaderValueMessageProcessor<Object>
+		implements BeanFactoryAware {
 
 	private final MessageProcessor<?> targetProcessor;
 
@@ -39,6 +43,13 @@ public class MessageProcessingHeaderValueMessageProcessor extends AbstractHeader
 
 	public MessageProcessingHeaderValueMessageProcessor(Object targetObject, String method) {
 		this.targetProcessor = new MethodInvokingMessageProcessor<Object>(targetObject, method);
+	}
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		if (this.targetProcessor instanceof BeanFactoryAware) {
+			((BeanFactoryAware) this.targetProcessor).setBeanFactory(beanFactory);
+		}
 	}
 
 	public Object processMessage(Message<?> message) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/AbstractExpressionEvaluator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/AbstractExpressionEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -54,7 +54,9 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 
 	private volatile BeanFactory beanFactory;
 
-	private volatile MessageBuilderFactory messageBuilderFactory;
+	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
+
+	private volatile boolean messageBuilderFactorySet;
 
 	/**
 	 * Specify a BeanFactory in order to enable resolution via <code>@beanName</code> in the expression.
@@ -67,7 +69,6 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 			if (this.evaluationContext != null && this.evaluationContext.getBeanResolver() == null) {
 				this.evaluationContext.setBeanResolver(new BeanFactoryResolver(beanFactory));
 			}
-			this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(beanFactory);
 		}
 	}
 
@@ -114,6 +115,12 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 				this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
 			}
 			this.evaluationContext.setTypeConverter(this.typeConverter);
+			if (this.beanFactory != null) {
+				ConversionService conversionService = IntegrationUtils.getConversionService(beanFactory);
+				if (conversionService != null) {
+					this.typeConverter.setConversionService(conversionService);
+				}
+			}
 		}
 		return this.evaluationContext;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/AbstractExpressionEvaluator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/AbstractExpressionEvaluator.java
@@ -56,8 +56,6 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 
 	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 
-	private volatile boolean messageBuilderFactorySet;
-
 	/**
 	 * Specify a BeanFactory in order to enable resolution via <code>@beanName</code> in the expression.
 	 */
@@ -83,16 +81,13 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 	}
 
 	protected MessageBuilderFactory getMessageBuilderFactory() {
-		if (this.messageBuilderFactory == null) {
-			this.messageBuilderFactory = new DefaultMessageBuilderFactory();
-		}
 		return this.messageBuilderFactory;
 	}
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		getEvaluationContext();
-		if (this.messageBuilderFactory == null) {
+		if (this.beanFactory != null) {
 			this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.beanFactory);
 		}
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingReleaseStrategyTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingReleaseStrategyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.aggregator;
 
+import static org.mockito.Mockito.mock;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedList;
@@ -23,16 +25,18 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
+
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Marius Bogoevici
  * @author Dave Syer
+ * @author Artem Bilan
  */
 public class MethodInvokingReleaseStrategyTests {
 
@@ -248,13 +252,18 @@ public class MethodInvokingReleaseStrategyTests {
 	@Test(expected = IllegalStateException.class)
 	public void testWrongReturnTypeUsingMethodObject() throws SecurityException, NoSuchMethodException {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			public int wrongReturnType(List<Message<?>> message) {
 				return 0;
 			}
+
 		}
-		new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), TestReleaseStrategy.class.getMethod(
-				"wrongReturnType", new Class<?>[] { List.class }));
+
+		MethodInvokingReleaseStrategy wrongReturnType =
+				new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), TestReleaseStrategy.class.getMethod(
+						"wrongReturnType", new Class<?>[] {List.class}));
+		wrongReturnType.canRelease(mock(MessageGroup.class));
 	}
 
 	private static MessageGroup createListOfMessages(int size) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -94,7 +95,7 @@ public class AggregatorParserTests {
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
 		Object handler = context.getBean("aggregatorWithReference.handler");
 		assertSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.messageBuilderFactory"));
-		assertSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.processor.messageBuilderFactory"));
+		assertNotSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.processor.messageBuilderFactory"));
 	}
 
 	@Test
@@ -121,7 +122,7 @@ public class AggregatorParserTests {
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
 		Object handler = context.getBean("aggregatorWithExpressions.handler");
 		assertSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.messageBuilderFactory"));
-		assertSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.processor.messageBuilderFactory"));
+		assertNotSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.processor.messageBuilderFactory"));
 		assertTrue(TestUtils.getPropertyValue(handler, "expireGroupsUponTimeout", Boolean.class));
 	}
 
@@ -175,7 +176,7 @@ public class AggregatorParserTests {
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
 		Object handler = context.getBean("aggregatorWithReferenceAndMethod.handler");
 		assertSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.messageBuilderFactory"));
-		assertSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.processor.messageBuilderFactory"));
+		assertNotSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.processor.messageBuilderFactory"));
 	}
 
 	@Test(expected = BeanCreationException.class)
@@ -249,7 +250,7 @@ public class AggregatorParserTests {
 		AggregatingMessageHandler aggregatingMessageHandler = (AggregatingMessageHandler) TestUtils.getPropertyValue(aggregatorConsumer, "handler");
 		MethodInvokingMessageGroupProcessor messageGroupProcessor = (MethodInvokingMessageGroupProcessor) TestUtils.getPropertyValue(aggregatingMessageHandler, "outputProcessor");
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertSame(mbf, TestUtils.getPropertyValue(messageGroupProcessor, "messageBuilderFactory"));
+		assertNotSame(mbf, TestUtils.getPropertyValue(messageGroupProcessor, "messageBuilderFactory"));
 		Object messageGroupProcessorTargetObject = TestUtils.getPropertyValue(messageGroupProcessor, "processor.delegate.targetObject");
 		assertSame(context.getBean("aggregatorBean"), messageGroupProcessorTargetObject);
 		ReleaseStrategy releaseStrategy = (ReleaseStrategy) TestUtils.getPropertyValue(aggregatingMessageHandler, "releaseStrategy");

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
@@ -20,7 +20,6 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -95,7 +94,6 @@ public class AggregatorParserTests {
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
 		Object handler = context.getBean("aggregatorWithReference.handler");
 		assertSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.messageBuilderFactory"));
-		assertNotSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.processor.messageBuilderFactory"));
 	}
 
 	@Test
@@ -122,7 +120,6 @@ public class AggregatorParserTests {
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
 		Object handler = context.getBean("aggregatorWithExpressions.handler");
 		assertSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.messageBuilderFactory"));
-		assertNotSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.processor.messageBuilderFactory"));
 		assertTrue(TestUtils.getPropertyValue(handler, "expireGroupsUponTimeout", Boolean.class));
 	}
 
@@ -176,7 +173,6 @@ public class AggregatorParserTests {
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
 		Object handler = context.getBean("aggregatorWithReferenceAndMethod.handler");
 		assertSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.messageBuilderFactory"));
-		assertNotSame(mbf, TestUtils.getPropertyValue(handler, "outputProcessor.processor.messageBuilderFactory"));
 	}
 
 	@Test(expected = BeanCreationException.class)
@@ -249,8 +245,6 @@ public class AggregatorParserTests {
 		EventDrivenConsumer aggregatorConsumer = (EventDrivenConsumer) context.getBean("aggregatorWithExpressionsAndPojoAggregator");
 		AggregatingMessageHandler aggregatingMessageHandler = (AggregatingMessageHandler) TestUtils.getPropertyValue(aggregatorConsumer, "handler");
 		MethodInvokingMessageGroupProcessor messageGroupProcessor = (MethodInvokingMessageGroupProcessor) TestUtils.getPropertyValue(aggregatingMessageHandler, "outputProcessor");
-		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertNotSame(mbf, TestUtils.getPropertyValue(messageGroupProcessor, "messageBuilderFactory"));
 		Object messageGroupProcessorTargetObject = TestUtils.getPropertyValue(messageGroupProcessor, "processor.delegate.targetObject");
 		assertSame(context.getBean("aggregatorBean"), messageGroupProcessorTargetObject);
 		ReleaseStrategy releaseStrategy = (ReleaseStrategy) TestUtils.getPropertyValue(aggregatingMessageHandler, "releaseStrategy");
@@ -272,4 +266,5 @@ public class AggregatorParserTests {
 		return MessageBuilder.withPayload(payload).setCorrelationId(correlationId).setSequenceSize(sequenceSize)
 				.setSequenceNumber(sequenceNumber).setReplyChannel(outputChannel).build();
 	}
+	
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/PublishSubscribeChannelParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/PublishSubscribeChannelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,11 +33,16 @@ import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.dispatcher.BroadcastingDispatcher;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.integration.util.ErrorHandlingTaskExecutor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.ErrorHandler;
 
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class PublishSubscribeChannelParserTests {
 
@@ -50,10 +55,20 @@ public class PublishSubscribeChannelParserTests {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(channel);
 		BroadcastingDispatcher dispatcher = (BroadcastingDispatcher)
 				accessor.getPropertyValue("dispatcher");
+		dispatcher.setApplySequence(true);
+		dispatcher.addHandler(new MessageHandler() {
+
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+
+			}
+
+		});
+		dispatcher.dispatch(new GenericMessage<String>("foo"));
 		DirectFieldAccessor dispatcherAccessor = new DirectFieldAccessor(dispatcher);
 		assertNull(dispatcherAccessor.getPropertyValue("executor"));
 		assertFalse((Boolean) dispatcherAccessor.getPropertyValue("ignoreFailures"));
-		assertFalse((Boolean) dispatcherAccessor.getPropertyValue("applySequence"));
+		assertTrue((Boolean) dispatcherAccessor.getPropertyValue("applySequence"));
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
 		assertSame(mbf, dispatcherAccessor.getPropertyValue("messageBuilderFactory"));
 		context.close();

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -134,9 +134,6 @@ public class GatewayInterfaceTests {
 		bar.foo("hello");
 		assertTrue(called.get());
 		Map<?,?> gateways = TestUtils.getPropertyValue(ac.getBean("&sampleGateway"), "gatewayMap", Map.class);
-		Object mbf = ac.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertNotSame(mbf, TestUtils.getPropertyValue(gateways.values().iterator().next(),
-				"messageConverter.messageBuilderFactory"));
 		ac.close();
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -134,7 +135,7 @@ public class GatewayInterfaceTests {
 		assertTrue(called.get());
 		Map<?,?> gateways = TestUtils.getPropertyValue(ac.getBean("&sampleGateway"), "gatewayMap", Map.class);
 		Object mbf = ac.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertSame(mbf, TestUtils.getPropertyValue(gateways.values().iterator().next(),
+		assertNotSame(mbf, TestUtils.getPropertyValue(gateways.values().iterator().next(),
 				"messageConverter.messageBuilderFactory"));
 		ac.close();
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -151,7 +151,6 @@ public abstract class AbstractInboundFileSynchronizer<F> implements InboundFileS
 	@Override
 	public final void afterPropertiesSet() {
 		Assert.notNull(this.remoteDirectory, "remoteDirectory must not be null");
-		Assert.notNull(this.evaluationContext, "evaluationContext must not be null");
 	}
 
 	protected final List<F> filterFiles(F[] files) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/transformer/AbstractFilePayloadTransformer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/transformer/AbstractFilePayloadTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
  * Base class for transformers that convert a File payload.
  *
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public abstract class AbstractFilePayloadTransformer<T> implements Transformer, BeanFactoryAware {
 
@@ -45,6 +46,10 @@ public abstract class AbstractFilePayloadTransformer<T> implements Transformer, 
 	private volatile boolean deleteFiles;
 
 	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
+
+	private boolean messageBuilderFactorySet;
+
+	private volatile BeanFactory beanFactory;
 
 	/**
 	 * Specify whether to delete the File after transformation.
@@ -58,7 +63,17 @@ public abstract class AbstractFilePayloadTransformer<T> implements Transformer, 
 
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-		this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(beanFactory);
+		this.beanFactory = beanFactory;
+	}
+
+	protected MessageBuilderFactory getMessageBuilderFactory() {
+		if (!this.messageBuilderFactorySet) {
+			if (this.beanFactory != null) {
+				this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.beanFactory);
+			}
+			this.messageBuilderFactorySet = true;
+		}
+		return this.messageBuilderFactory;
 	}
 
 	@Override
@@ -66,11 +81,11 @@ public abstract class AbstractFilePayloadTransformer<T> implements Transformer, 
 		try {
 			Assert.notNull(message, "Message must not be null");
 			Object payload = message.getPayload();
-			Assert.notNull(payload, "Mesasge payload must not be null");
+			Assert.notNull(payload, "Message payload must not be null");
 			Assert.isInstanceOf(File.class, payload, "Message payload must be of type [java.io.File]");
 			File file = (File) payload;
 	        T result = this.transformFile(file);
-	        Message<?> transformedMessage = this.messageBuilderFactory.withPayload(result)
+	        Message<?> transformedMessage = getMessageBuilderFactory().withPayload(result)
 	        		.copyHeaders(message.getHeaders())
 	        		.setHeaderIfAbsent(FileHeaders.ORIGINAL_FILE, file)
 	        		.setHeaderIfAbsent(FileHeaders.FILENAME, file.getName())

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileToStringTransformerParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileToStringTransformerParserTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.file.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
@@ -57,7 +58,7 @@ public class FileToStringTransformerParserTests {
                 handlerAccessor.getPropertyValue("transformer");
         DirectFieldAccessor transformerAccessor = new DirectFieldAccessor(transformer);
         assertEquals(Boolean.TRUE, transformerAccessor.getPropertyValue("deleteFiles"));
-        assertSame(this.messageBuilderFactory, transformerAccessor.getPropertyValue("messageBuilderFactory"));
+        assertNotSame(this.messageBuilderFactory, transformerAccessor.getPropertyValue("messageBuilderFactory"));
     }
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileToStringTransformerParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileToStringTransformerParserTests.java
@@ -45,9 +45,6 @@ public class FileToStringTransformerParserTests {
     @Qualifier("transformer")
     EventDrivenConsumer endpoint;
 
-    @Autowired
-    MessageBuilderFactory messageBuilderFactory;
-
     @Test
     public void checkDeleteFilesValue() {
         DirectFieldAccessor endpointAccessor = new DirectFieldAccessor(endpoint);
@@ -58,7 +55,6 @@ public class FileToStringTransformerParserTests {
                 handlerAccessor.getPropertyValue("transformer");
         DirectFieldAccessor transformerAccessor = new DirectFieldAccessor(transformer);
         assertEquals(Boolean.TRUE, transformerAccessor.getPropertyValue("deleteFiles"));
-        assertNotSame(this.messageBuilderFactory, transformerAccessor.getPropertyValue("messageBuilderFactory"));
     }
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -275,9 +275,6 @@ public class ParserUnitTests {
 	@Autowired
 	QueueChannel eventChannel;
 
-	@Autowired
-	MessageBuilderFactory messageBuilderFactory;
-
 	private static volatile int adviceCalled;
 
 	@Test
@@ -299,7 +296,6 @@ public class ParserUnitTests {
 		assertFalse((Boolean)mapperAccessor.getPropertyValue("lookupHost"));
 		assertFalse(TestUtils.getPropertyValue(udpIn, "autoStartup", Boolean.class));
 		assertEquals(1234, dfa.getPropertyValue("phase"));
-		assertNotSame(this.messageBuilderFactory, mapperAccessor.getPropertyValue("messageBuilderFactory"));
 	}
 
 	@Test
@@ -318,14 +314,12 @@ public class ParserUnitTests {
 		DatagramPacketMessageMapper mapper = (DatagramPacketMessageMapper) dfa.getPropertyValue("mapper");
 		DirectFieldAccessor mapperAccessor = new DirectFieldAccessor(mapper);
 		assertTrue((Boolean)mapperAccessor.getPropertyValue("lookupHost"));
-		assertNotSame(this.messageBuilderFactory, mapperAccessor.getPropertyValue("messageBuilderFactory"));
 	}
 
 	@Test
 	public void testInTcp() {
 		DirectFieldAccessor dfa = new DirectFieldAccessor(tcpIn);
 		assertSame(cfS1, dfa.getPropertyValue("serverConnectionFactory"));
-		assertNotSame(this.messageBuilderFactory, TestUtils.getPropertyValue(cfS1, "mapper.messageBuilderFactory"));
 		assertEquals("testInTcp",tcpIn.getComponentName());
 		assertEquals("ip:tcp-inbound-channel-adapter", tcpIn.getComponentType());
 		assertEquals(errorChannel, dfa.getPropertyValue("errorChannel"));
@@ -353,7 +347,6 @@ public class ParserUnitTests {
 	public void testInTcpNioSSLDefaultConfig() {
 		assertFalse(cfS1Nio.isLookupHost());
 		assertTrue((Boolean) TestUtils.getPropertyValue(cfS1Nio, "mapper.applySequence"));
-		assertNotSame(this.messageBuilderFactory, TestUtils.getPropertyValue(cfS1Nio, "mapper.messageBuilderFactory"));
 		Object connectionSupport = TestUtils.getPropertyValue(cfS1Nio, "tcpNioConnectionSupport");
 		assertTrue(connectionSupport instanceof DefaultTcpNioSSLConnectionSupport);
 		assertNotNull(TestUtils.getPropertyValue(connectionSupport, "sslContext"));
@@ -381,7 +374,6 @@ public class ParserUnitTests {
 		assertEquals(23, dfa.getPropertyValue("order"));
 		assertEquals("testOutUdp",udpOut.getComponentName());
 		assertEquals("ip:udp-outbound-channel-adapter", udpOut.getComponentType());
-		assertNotSame(this.messageBuilderFactory, TestUtils.getPropertyValue(mapper, "messageBuilderFactory"));
 	}
 
 	@Test
@@ -403,7 +395,6 @@ public class ParserUnitTests {
 		assertEquals(54, dfa.getPropertyValue("soTimeout"));
 		assertEquals(55, dfa.getPropertyValue("timeToLive"));
 		assertEquals(12, dfa.getPropertyValue("order"));
-		assertNotSame(this.messageBuilderFactory, TestUtils.getPropertyValue(mapper, "messageBuilderFactory"));
 	}
 
 	@Test

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -299,7 +299,7 @@ public class ParserUnitTests {
 		assertFalse((Boolean)mapperAccessor.getPropertyValue("lookupHost"));
 		assertFalse(TestUtils.getPropertyValue(udpIn, "autoStartup", Boolean.class));
 		assertEquals(1234, dfa.getPropertyValue("phase"));
-		assertSame(this.messageBuilderFactory, mapperAccessor.getPropertyValue("messageBuilderFactory"));
+		assertNotSame(this.messageBuilderFactory, mapperAccessor.getPropertyValue("messageBuilderFactory"));
 	}
 
 	@Test
@@ -318,14 +318,14 @@ public class ParserUnitTests {
 		DatagramPacketMessageMapper mapper = (DatagramPacketMessageMapper) dfa.getPropertyValue("mapper");
 		DirectFieldAccessor mapperAccessor = new DirectFieldAccessor(mapper);
 		assertTrue((Boolean)mapperAccessor.getPropertyValue("lookupHost"));
-		assertSame(this.messageBuilderFactory, mapperAccessor.getPropertyValue("messageBuilderFactory"));
+		assertNotSame(this.messageBuilderFactory, mapperAccessor.getPropertyValue("messageBuilderFactory"));
 	}
 
 	@Test
 	public void testInTcp() {
 		DirectFieldAccessor dfa = new DirectFieldAccessor(tcpIn);
 		assertSame(cfS1, dfa.getPropertyValue("serverConnectionFactory"));
-		assertSame(this.messageBuilderFactory, TestUtils.getPropertyValue(cfS1, "mapper.messageBuilderFactory"));
+		assertNotSame(this.messageBuilderFactory, TestUtils.getPropertyValue(cfS1, "mapper.messageBuilderFactory"));
 		assertEquals("testInTcp",tcpIn.getComponentName());
 		assertEquals("ip:tcp-inbound-channel-adapter", tcpIn.getComponentType());
 		assertEquals(errorChannel, dfa.getPropertyValue("errorChannel"));
@@ -353,7 +353,7 @@ public class ParserUnitTests {
 	public void testInTcpNioSSLDefaultConfig() {
 		assertFalse(cfS1Nio.isLookupHost());
 		assertTrue((Boolean) TestUtils.getPropertyValue(cfS1Nio, "mapper.applySequence"));
-		assertSame(this.messageBuilderFactory, TestUtils.getPropertyValue(cfS1Nio, "mapper.messageBuilderFactory"));
+		assertNotSame(this.messageBuilderFactory, TestUtils.getPropertyValue(cfS1Nio, "mapper.messageBuilderFactory"));
 		Object connectionSupport = TestUtils.getPropertyValue(cfS1Nio, "tcpNioConnectionSupport");
 		assertTrue(connectionSupport instanceof DefaultTcpNioSSLConnectionSupport);
 		assertNotNull(TestUtils.getPropertyValue(connectionSupport, "sslContext"));
@@ -381,7 +381,7 @@ public class ParserUnitTests {
 		assertEquals(23, dfa.getPropertyValue("order"));
 		assertEquals("testOutUdp",udpOut.getComponentName());
 		assertEquals("ip:udp-outbound-channel-adapter", udpOut.getComponentType());
-		assertSame(this.messageBuilderFactory, TestUtils.getPropertyValue(mapper, "messageBuilderFactory"));
+		assertNotSame(this.messageBuilderFactory, TestUtils.getPropertyValue(mapper, "messageBuilderFactory"));
 	}
 
 	@Test
@@ -403,7 +403,7 @@ public class ParserUnitTests {
 		assertEquals(54, dfa.getPropertyValue("soTimeout"));
 		assertEquals(55, dfa.getPropertyValue("timeToLive"));
 		assertEquals(12, dfa.getPropertyValue("order"));
-		assertSame(this.messageBuilderFactory, TestUtils.getPropertyValue(mapper, "messageBuilderFactory"));
+		assertNotSame(this.messageBuilderFactory, TestUtils.getPropertyValue(mapper, "messageBuilderFactory"));
 	}
 
 	@Test

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -166,9 +166,6 @@ public class TcpNioConnectionReadTests {
 		done.countDown();
 	}
 
-	/**
-	 * Test method for {@link org.springframework.integration.ip.tcp.NioSocketReader}.
-	 */
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testReadCrLf() throws Exception {

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -157,6 +157,8 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 
 	private boolean priorityEnabled;
 
+	private BeanFactory beanFactory;
+
 	/**
 	 * Convenient constructor for configuration use.
 	 */
@@ -362,7 +364,7 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-		this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(beanFactory);
+		this.beanFactory = beanFactory;
 	}
 
 	/**
@@ -392,6 +394,9 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 			logger.warn("The jdbcTemplate's fetchsize is not 1. This may cause FIFO issues with Oracle databases.");
 		}
 
+		if (this.beanFactory != null) {
+			this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.beanFactory);
+		}
 		this.jdbcTemplate.afterPropertiesSet();
 	}
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
@@ -170,8 +170,6 @@ public class JmsChannelParserTests {
 		AbstractMessageListenerContainer container = (AbstractMessageListenerContainer) accessor.getPropertyValue("container");
 		assertEquals(topic, jmsTemplate.getDefaultDestination());
 		assertEquals(topic, container.getDestination());
-		assertNotSame(this.messageBuilderFactory, TestUtils.getPropertyValue(channel, "dispatcher" +
-				".messageBuilderFactory"));
 		assertSame(this.messageBuilderFactory,
 				TestUtils.getPropertyValue(channel, "container.messageListener.messageBuilderFactory"));
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.integration.jms.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import java.util.List;
@@ -168,7 +170,8 @@ public class JmsChannelParserTests {
 		AbstractMessageListenerContainer container = (AbstractMessageListenerContainer) accessor.getPropertyValue("container");
 		assertEquals(topic, jmsTemplate.getDefaultDestination());
 		assertEquals(topic, container.getDestination());
-		assertSame(this.messageBuilderFactory, TestUtils.getPropertyValue(channel, "dispatcher.messageBuilderFactory"));
+		assertNotSame(this.messageBuilderFactory, TestUtils.getPropertyValue(channel, "dispatcher" +
+				".messageBuilderFactory"));
 		assertSame(this.messageBuilderFactory,
 				TestUtils.getPropertyValue(channel, "container.messageListener.messageBuilderFactory"));
 	}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/AbstractMailMessageTransformer.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/AbstractMailMessageTransformer.java
@@ -44,6 +44,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public abstract class AbstractMailMessageTransformer<T> implements Transformer,
 		BeanFactoryAware {
@@ -54,15 +55,22 @@ public abstract class AbstractMailMessageTransformer<T> implements Transformer,
 
 	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 
+	private volatile boolean messageBuilderFactorySet;
+
 
 	@Override
 	public final void setBeanFactory(BeanFactory beanFactory) {
 		this.beanFactory = beanFactory;
-		this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.beanFactory);
 	}
 
 	protected MessageBuilderFactory getMessageBuilderFactory() {
-		return messageBuilderFactory;
+		if (!this.messageBuilderFactorySet) {
+			if (this.beanFactory != null) {
+				this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.beanFactory);
+			}
+			this.messageBuilderFactorySet = true;
+		}
+		return this.messageBuilderFactory;
 	}
 
 	@Override

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageStoreClaimCheckIntegrationTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageStoreClaimCheckIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,24 @@
 
 package org.springframework.integration.mongodb.store;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.Serializable;
 
-import com.mongodb.MongoClient;
 import org.junit.Test;
 
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
 import org.springframework.integration.mongodb.rules.MongoDbAvailableTests;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.transformer.ClaimCheckInTransformer;
 import org.springframework.integration.transformer.ClaimCheckOutTransformer;
 import org.springframework.messaging.Message;
+
+import com.mongodb.MongoClient;
 
 /**
  * @author Mark Fisher
@@ -81,6 +84,9 @@ public class MongoDbMessageStoreClaimCheckIntegrationTests extends MongoDbAvaila
 	public void stringPayloadConfigurable() throws Exception {
 		MongoDbFactory mongoDbFactory = new SimpleMongoDbFactory(new MongoClient(), "test");
 		ConfigurableMongoDbMessageStore messageStore = new ConfigurableMongoDbMessageStore(mongoDbFactory);
+		GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
+		testApplicationContext.refresh();
+		messageStore.setApplicationContext(testApplicationContext);
 		messageStore.afterPropertiesSet();
 		ClaimCheckInTransformer checkin = new ClaimCheckInTransformer(messageStore);
 		ClaimCheckOutTransformer checkout = new ClaimCheckOutTransformer(messageStore);
@@ -98,6 +104,9 @@ public class MongoDbMessageStoreClaimCheckIntegrationTests extends MongoDbAvaila
 	public void objectPayloadConfigurable() throws Exception {
 		MongoDbFactory mongoDbFactory = new SimpleMongoDbFactory(new MongoClient(), "test");
 		ConfigurableMongoDbMessageStore messageStore = new ConfigurableMongoDbMessageStore(mongoDbFactory);
+		GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
+		testApplicationContext.refresh();
+		messageStore.setApplicationContext(testApplicationContext);
 		messageStore.afterPropertiesSet();
 		ClaimCheckInTransformer checkin = new ClaimCheckInTransformer(messageStore);
 		ClaimCheckOutTransformer checkout = new ClaimCheckOutTransformer(messageStore);

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.mqtt.inbound;
 
 import java.util.LinkedHashSet;
@@ -240,7 +241,10 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter extends MessagePro
 	protected void onInit() {
 		super.onInit();
 		if (this.converter == null) {
-			this.converter = new DefaultPahoMessageConverter();
+			DefaultPahoMessageConverter pahoMessageConverter = new DefaultPahoMessageConverter();
+			pahoMessageConverter.setBeanFactory(getBeanFactory());
+			this.converter = pahoMessageConverter;
+
 		}
 	}
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisChannelParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisChannelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ public class RedisChannelParserTests extends RedisAvailableTests {
 		redisChannel = context.getBean("redisChannelWithSubLimit", SubscribableChannel.class);
 		assertEquals(1, TestUtils.getPropertyValue(redisChannel, "dispatcher.maxSubscribers", Integer.class).intValue());
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertSame(mbf, TestUtils.getPropertyValue(redisChannel, "dispatcher.messageBuilderFactory"));
+		assertNotSame(mbf, TestUtils.getPropertyValue(redisChannel, "dispatcher.messageBuilderFactory"));
 		assertSame(mbf, TestUtils.getPropertyValue(redisChannel, "messageBuilderFactory"));
 		context.close();
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisChannelParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisChannelParserTests.java
@@ -62,7 +62,6 @@ public class RedisChannelParserTests extends RedisAvailableTests {
 		redisChannel = context.getBean("redisChannelWithSubLimit", SubscribableChannel.class);
 		assertEquals(1, TestUtils.getPropertyValue(redisChannel, "dispatcher.maxSubscribers", Integer.class).intValue());
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertNotSame(mbf, TestUtils.getPropertyValue(redisChannel, "dispatcher.messageBuilderFactory"));
 		assertSame(mbf, TestUtils.getPropertyValue(redisChannel, "messageBuilderFactory"));
 		context.close();
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
@@ -79,8 +79,6 @@ public class RedisInboundChannelAdapterParserTests extends RedisAvailableTests {
 		Object bean = context.getBean("withoutSerializer.adapter");
 		assertNotNull(bean);
 		assertNull(TestUtils.getPropertyValue(bean, "serializer"));
-		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertNotSame(mbf, TestUtils.getPropertyValue(bean, "messageConverter.messageBuilderFactory"));
 	}
 
 	@Test

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.redis.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -79,7 +80,7 @@ public class RedisInboundChannelAdapterParserTests extends RedisAvailableTests {
 		assertNotNull(bean);
 		assertNull(TestUtils.getPropertyValue(bean, "serializer"));
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertSame(mbf, TestUtils.getPropertyValue(bean, "messageConverter.messageBuilderFactory"));
+		assertNotSame(mbf, TestUtils.getPropertyValue(bean, "messageConverter.messageBuilderFactory"));
 	}
 
 	@Test

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ public class RedisOutboundChannelAdapterParserTests extends RedisAvailableTests 
 		assertEquals(converterBean, accessor.getPropertyValue("messageConverter"));
 		assertEquals(context.getBean("serializer"), accessor.getPropertyValue("serializer"));
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertSame(mbf, TestUtils.getPropertyValue(handler, "messageConverter.messageBuilderFactory"));
+		assertNotSame(mbf, TestUtils.getPropertyValue(handler, "messageConverter.messageBuilderFactory"));
 
 		Object endpointHandler = TestUtils.getPropertyValue(adapter, "handler");
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
@@ -77,8 +77,6 @@ public class RedisOutboundChannelAdapterParserTests extends RedisAvailableTests 
 		Object converterBean = context.getBean("testConverter");
 		assertEquals(converterBean, accessor.getPropertyValue("messageConverter"));
 		assertEquals(context.getBean("serializer"), accessor.getPropertyValue("serializer"));
-		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertNotSame(mbf, TestUtils.getPropertyValue(handler, "messageConverter.messageBuilderFactory"));
 
 		Object endpointHandler = TestUtils.getPropertyValue(adapter, "handler");
 

--- a/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/TcpSyslogReceivingChannelAdapter.java
+++ b/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/TcpSyslogReceivingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.syslog.inbound;
 
 
@@ -28,6 +29,7 @@ import org.springframework.messaging.Message;
  * TCP implementation of a syslog inbound channel adapter.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 3.0
  *
  */
@@ -61,9 +63,11 @@ public class TcpSyslogReceivingChannelAdapter extends SyslogReceivingChannelAdap
 		if (this.connectionFactory == null) {
 			this.connectionFactory = new TcpNioServerConnectionFactory(this.getPort());
 			this.connectionFactory.setDeserializer(new ByteArrayLfSerializer());
+			this.connectionFactory.setBeanFactory(getBeanFactory());
 			if (this.applicationEventPublisher != null) {
 				this.connectionFactory.setApplicationEventPublisher(this.applicationEventPublisher);
 			}
+			this.connectionFactory.afterPropertiesSet();
 		}
 		this.connectionFactory.registerListener(this);
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3661
## Status Quo

Previously there were a lot of noise from the `PostProcessorRegistrationDelegate$BeanPostProcessorChecker` for early access for beans.
That may produce some side-effects when some of `BeanFactoryPostProcessor`s won't adjust those beans.

The issue is based on two facts:
1. Loading beans from `BPP`, e.g. `IntegrationEvaluationContextAwareBeanPostProcessor` (or `ChannelSecurityInterceptorBeanPostProcessor` - https://jira.spring.io/browse/INT-3663)
2. Loading beans from `setBeanFactory()/setApplicationContext()` container methods
## The fix
- Move all stuff from `setBeanFactory()` with access to the `BeanFactory` (e.g. `this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.beanFactory);`)
  to some other lazy-load methods like `getMessageBuilderFactory()`
- Fix parser tests to `assertNotSame` for `messageBuilderFactory` since there is no activity for target components to lazy-load the stuff
- Polish some test according the new lazy-load logic
- Rework `IntegrationEvaluationContextAwareBeanPostProcessor` to the `SmartInitializingSingleton` and make it `Ordered`
- Populate `beanFactory` for the internal instance of `connectionFactory` in the `TcpSyslogReceivingChannelAdapter`
- Populate `beanFactory` for the internal `UnicastReceivingChannelAdapter` in the `UdpSyslogReceivingChannelAdapter`
- Add `log.info` that `UdpSyslogReceivingChannelAdapter` overrides `outputChannel` for the provided `UnicastReceivingChannelAdapter`
- Change the internal `MessageChannel` in the `UdpSyslogReceivingChannelAdapter` to the `FixedSubscriberChannel` for better performance
