### PR TITLE
INT-3664: Rework BPP stuff in the `IntMBExporter`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,12 +133,16 @@ class DefaultConfiguringBeanFactoryPostProcessor implements BeanFactoryPostProce
 		registry.registerBeanDefinition(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME,
 				new RootBeanDefinition(PublishSubscribeChannel.class));
 
-		BeanDefinitionBuilder loggingHandlerBuilder =
-				BeanDefinitionBuilder.genericBeanDefinition(LoggingHandler.class).addConstructorArgValue("ERROR");
+		BeanDefinition loggingHandler =
+				BeanDefinitionBuilder.genericBeanDefinition(LoggingHandler.class).addConstructorArgValue("ERROR")
+				.getBeanDefinition();
+
+		String errorLoggerBeanName = ERROR_LOGGER_BEAN_NAME + IntegrationConfigUtils.HANDLER_ALIAS_SUFFIX;
+		registry.registerBeanDefinition(errorLoggerBeanName, loggingHandler);
 
 		BeanDefinitionBuilder loggingEndpointBuilder =
 				BeanDefinitionBuilder.genericBeanDefinition(ConsumerEndpointFactoryBean.class)
-						.addPropertyValue("handler", loggingHandlerBuilder.getBeanDefinition())
+						.addPropertyReference("handler", errorLoggerBeanName)
 						.addPropertyValue("inputChannelName", IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME);
 
 		BeanComponentDefinition componentDefinition =

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
@@ -126,6 +126,7 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar, Bean
 			BeanDefinitionBuilder channelRegistryBuilder = BeanDefinitionBuilder
 					.genericBeanDefinition(ChannelInitializer.AutoCreateCandidatesCollector.class);
 			channelRegistryBuilder.addConstructorArgValue(new ManagedSet<String>());
+			channelRegistryBuilder.setRole(BeanDefinition.ROLE_INFRASTRUCTURE); //SPR-12761
 			BeanDefinitionHolder channelRegistryHolder =
 					new BeanDefinitionHolder(channelRegistryBuilder.getBeanDefinition(),
 							IntegrationContextUtils.AUTO_CREATE_CHANNEL_CANDIDATES_BEAN_NAME);

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
@@ -342,7 +342,7 @@ public class IntegrationMBeanExporter extends MBeanExporter implements Applicati
 				}
 			}
 		}
-		catch (Exception e) {
+		catch (RuntimeException e) {
 			unregisterBeans();
 			throw e;
 		}

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
@@ -326,21 +326,26 @@ public class IntegrationMBeanExporter extends MBeanExporter implements Applicati
 			}
 		}
 		super.afterSingletonsInstantiated();
-		registerChannels();
-		registerHandlers();
-		registerSources();
-		registerEndpoints();
+		try {
+			registerChannels();
+			registerHandlers();
+			registerSources();
+			registerEndpoints();
 
-		if (this.applicationContext
-				.containsBean(IntegrationContextUtils.INTEGRATION_MESSAGE_HISTORY_CONFIGURER_BEAN_NAME)) {
-			Object messageHistoryConfigurer = this.applicationContext
-					.getBean(IntegrationContextUtils.INTEGRATION_MESSAGE_HISTORY_CONFIGURER_BEAN_NAME);
-			if (messageHistoryConfigurer instanceof MessageHistoryConfigurer) {
-				registerBeanInstance(messageHistoryConfigurer,
-						IntegrationContextUtils.INTEGRATION_MESSAGE_HISTORY_CONFIGURER_BEAN_NAME);
+			if (this.applicationContext
+					.containsBean(IntegrationContextUtils.INTEGRATION_MESSAGE_HISTORY_CONFIGURER_BEAN_NAME)) {
+				Object messageHistoryConfigurer = this.applicationContext
+						.getBean(IntegrationContextUtils.INTEGRATION_MESSAGE_HISTORY_CONFIGURER_BEAN_NAME);
+				if (messageHistoryConfigurer instanceof MessageHistoryConfigurer) {
+					registerBeanInstance(messageHistoryConfigurer,
+							IntegrationContextUtils.INTEGRATION_MESSAGE_HISTORY_CONFIGURER_BEAN_NAME);
+				}
 			}
 		}
-
+		catch (Exception e) {
+			unregisterBeans();
+			throw e;
+		}
 
 	}
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/MBeanExporterIntegrationTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/MBeanExporterIntegrationTests.java
@@ -190,6 +190,15 @@ public class MBeanExporterIntegrationTests {
 		}
 		// Lifecycle method name
 		assertEquals("start", startName);
+
+		context.close();
+
+		context = new GenericXmlApplicationContext(getClass(), "lifecycle-no-source.xml");
+		server = context.getBean(MBeanServer.class);
+		names = server.queryNames(ObjectName.getInstance("org.springframework.integration:type=ManagedEndpoint,*"), null);
+		assertEquals(1, names.size());
+		names = server.queryNames(ObjectName.getInstance("org.springframework.integration:name=gateway,*"), null);
+		assertEquals(1, names.size());
 	}
 
 	@Test

--- a/src/reference/docbook/jmx.xml
+++ b/src/reference/docbook/jmx.xml
@@ -860,6 +860,20 @@ public class ContextConfiguration {
 						allowing the invocation of <interfacename>Lifecycle</interfacename> methods.
 					</para>
 				</listitem>
+				<listitem>
+					<para><emphasis role="bold">IntegrationMBeanExporter changes</emphasis></para>
+					<para>
+						The <classname>IntegrationMBeanExporter</classname> doesn't implement
+						<interfacename>BeanPostProcessor</interfacename>, nor
+						<interfacename>SmartLifecycle</interfacename>, as it was prior version
+						<emphasis>4.2</emphasis>. After reworking metrics for the direct implementation instead of
+						proxying, there is no any adjustment options from
+						<classname>IntegrationMBeanExporter</classname> to expose
+						<interfacename>BeanPostProcessor</interfacename> operations. From other side, thanks to
+						<interfacename>SmartInitializingSingleton</interfacename> implementation, there is no reason
+						to support <interfacename>SmartLifecycle</interfacename> any more.
+					</para>
+				</listitem>
 			</itemizedlist>
 		</section>
 

--- a/src/reference/docbook/jmx.xml
+++ b/src/reference/docbook/jmx.xml
@@ -863,15 +863,11 @@ public class ContextConfiguration {
 				<listitem>
 					<para><emphasis role="bold">IntegrationMBeanExporter changes</emphasis></para>
 					<para>
-						The <classname>IntegrationMBeanExporter</classname> doesn't implement
-						<interfacename>BeanPostProcessor</interfacename>, nor
-						<interfacename>SmartLifecycle</interfacename>, as it was prior version
-						<emphasis>4.2</emphasis>. After reworking metrics for the direct implementation instead of
-						proxying, there is no any adjustment options from
-						<classname>IntegrationMBeanExporter</classname> to expose
-						<interfacename>BeanPostProcessor</interfacename> operations. From other side, thanks to
-						<interfacename>SmartInitializingSingleton</interfacename> implementation, there is no reason
-						to support <interfacename>SmartLifecycle</interfacename> any more.
+						The <classname>IntegrationMBeanExporter</classname> no longer implements
+						<interfacename>SmartLifecycle</interfacename>; this means that <code>start()</code>
+						and <code>stop()</code> operations are no longer available to register/unregister
+						MBeans. The MBeans are now registered during context initialization and unregistered
+						when the context is destroyed.
 					</para>
 				</listitem>
 			</itemizedlist>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3664

Since all metrics are already direct for the integration components, we don't do any proxying from `IntegrationMBeanExporter`,
and even any other adjustments during BPP phases. Hence this stuff is already redundant for `IntegrationMBeanExporter`.
In addition this change fix the `early access to the BeanFactory from BPP` issue.
