### PR TITLE
INT-3672: Fix IdempotentReceiver for MH `@Bean`s

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IdempotentReceiverAutoProxyCreator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IdempotentReceiverAutoProxyCreator.java
@@ -62,8 +62,7 @@ class IdempotentReceiverAutoProxyCreator extends AbstractAutoProxyCreator {
 			for (Map.Entry<String, List<String>> entry : this.idempotentEndpoints.entrySet()) {
 				List<String> mappedNames = entry.getValue();
 				for (String mappedName : mappedNames) {
-					String pattern = mappedName + IntegrationConfigUtils.HANDLER_ALIAS_SUFFIX;
-					if (isMatch(pattern, beanName)) {
+					if (isMatch(mappedName, beanName)) {
 						DefaultBeanFactoryPointcutAdvisor idempotentReceiverInterceptor
 								= new DefaultBeanFactoryPointcutAdvisor();
 						idempotentReceiverInterceptor.setAdviceBeanName(entry.getKey());

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/IdempotentReceiverParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/IdempotentReceiverParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ public class IdempotentReceiverParserTests {
 		List<String> endpoints = idempotentEndpoints.get("selectorInterceptor");
 		assertNotNull(endpoints);
 		assertFalse(endpoints.isEmpty());
-		assertTrue(endpoints.contains("foo"));
+		assertTrue(endpoints.contains("foo.handler"));
 	}
 
 	@Test
@@ -124,7 +124,7 @@ public class IdempotentReceiverParserTests {
 		List<String> endpoints = idempotentEndpoints.get("strategyInterceptor");
 		assertNotNull(endpoints);
 		assertFalse(endpoints.isEmpty());
-		assertTrue(endpoints.contains("foo"));
+		assertTrue(endpoints.contains("foo.handler"));
 	}
 
 	@Test
@@ -142,8 +142,8 @@ public class IdempotentReceiverParserTests {
 		List<String> endpoints = idempotentEndpoints.get("expressionInterceptor");
 		assertNotNull(endpoints);
 		assertFalse(endpoints.isEmpty());
-		assertTrue(endpoints.contains("foo"));
-		assertTrue(endpoints.contains("bar*"));
+		assertTrue(endpoints.contains("foo.handler"));
+		assertTrue(endpoints.contains("bar*.handler"));
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3672

Previously the `IdempotentReceiverInterceptor` has been applied only for the `MessageHandler`s which were registered with `.handler` suffix.

Rework `IdempotentReceiverAutoProxyCreatorInitializer` and `IdempotentReceiverAutoProxyCreator` to get deal with **direct** `MessageHandler`s
which can be resulted from `@Bean` methods.
Use the `MessageHandler` real bean name instead of `endpoint pattern` in that case

**Cherry-pick to 4.1.x**
