### PR TITLE
INT-3680: Fix JMS Durable Subscription Name

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsMessageDrivenEndpointParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsMessageDrivenEndpointParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Fisher
  * @author Michael Bannister
+ * @author Gary Russell
  */
 public class JmsMessageDrivenEndpointParser extends AbstractSingleBeanDefinitionParser {
 
@@ -117,7 +118,7 @@ public class JmsMessageDrivenEndpointParser extends AbstractSingleBeanDefinition
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, IntegrationNamespaceUtils.AUTO_STARTUP);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, IntegrationNamespaceUtils.PHASE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "acknowledge", "sessionAcknowledgeMode");
-		
+
 	}
 
 	private String parseMessageListenerContainer(Element element, ParserContext parserContext) {
@@ -177,7 +178,8 @@ public class JmsMessageDrivenEndpointParser extends AbstractSingleBeanDefinition
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "idle-task-execution-limit");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "cache-level");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "subscription-durable");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "durable-subscription-name");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "durable-subscription-name",
+				"subscriptionName");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "client-id");
 		builder.addPropertyValue("autoStartup", false);
 		return BeanDefinitionReaderUtils.registerWithGeneratedName(builder.getBeanDefinition(), parserContext.getRegistry());

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package org.springframework.integration.jms.config;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import java.util.Properties;
 
@@ -30,7 +34,6 @@ import org.springframework.integration.jms.JmsMessageDrivenEndpoint;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
-import org.springframework.jms.support.destination.JmsDestinationAccessor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
@@ -67,8 +70,10 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"jmsInboundWithPubSubDomain.xml", this.getClass());
 		JmsMessageDrivenEndpoint endpoint = context.getBean("messageDrivenAdapter", JmsMessageDrivenEndpoint.class);
-		JmsDestinationAccessor container = (JmsDestinationAccessor) new DirectFieldAccessor(endpoint).getPropertyValue("listenerContainer");
+		AbstractMessageListenerContainer container = (AbstractMessageListenerContainer) new DirectFieldAccessor(endpoint).getPropertyValue("listenerContainer");
 		assertEquals(Boolean.TRUE, container.isPubSubDomain());
+		assertFalse(container.isSubscriptionDurable()); // INT-3680
+		assertNull(container.getDurableSubscriptionName());
 		endpoint.stop();
 		context.close();
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithPubSubDomain.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithPubSubDomain.xml
@@ -17,7 +17,10 @@
 	<jms:message-driven-channel-adapter id="messageDrivenAdapter"
 			destination-name="testDestination"
 			pub-sub-domain="true"
+			subscription-durable="false"
+			durable-subscription-name="foo"
 			channel="output"/>
+	 <!-- adding a sub name should not make it durable INT-3680 -->
 
 	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>

--- a/src/reference/docbook/preface.xml
+++ b/src/reference/docbook/preface.xml
@@ -28,7 +28,7 @@
 			<para>
 				<emphasis>Spring Integration</emphasis>
 				<emphasis role="strong">4.1.x</emphasis> requires
-				<emphasis>Spring Framework</emphasis> <emphasis role="strong">4.0.5</emphasis> or
+				<emphasis>Spring Framework</emphasis> <emphasis role="strong">4.1.4</emphasis> or
 				later.
 			</para>
 		</section>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3680

Change parser to use the `setSubscriptionName` setter instead
of `setDurableSubscriptionName` which as the side effect of
unconditionally setting the subscription as durable.

Also fix dependency in docs.

**cherry-pick to 4.1.x**
