### PR TITLE
[4.1.x] INT-3624: Register `#jsonPath` only for `0.9.1`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
@@ -216,8 +216,22 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar, Bean
 				jsonPathClass = ClassUtils.forName("com.jayway.jsonpath.JsonPath", this.classLoader);
 			}
 			catch (ClassNotFoundException e) {
-				logger.debug("SpEL function '#jsonPath' isn't registered: " +
+				logger.debug("The '#jsonPath' SpEL function cannot be registered: " +
 						"there is no jayway json-path.jar on the classpath.");
+			}
+
+			if (jsonPathClass != null) {
+				try {
+					ClassUtils.forName("com.jayway.jsonpath.Predicate", this.classLoader);
+					logger.warn("The '#jsonPath' SpEL function cannot be registered. " +
+							"The newest version of json-path isn't supported. " +
+							"Upgrade to Spring Integration 4.2 or later for that case. " +
+							"Supported json-path version is '0.9.1'.");
+					jsonPathClass = null;
+				}
+				catch (ClassNotFoundException e) {
+					//No-op
+				}
 			}
 
 			if (jsonPathClass != null) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3624

Add assert to the `IntegrationRegistrar` for the `#jsonPath` that we register this SpEL function only for support old `json-path` version
