### PR TITLE
Adding initial delay option for pollers in XML configuration.

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PollerParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PollerParser.java
@@ -113,6 +113,7 @@ public class PollerParser extends AbstractBeanDefinitionParser {
 		String triggerAttribute = pollerElement.getAttribute("trigger");
 		String fixedRateAttribute = pollerElement.getAttribute("fixed-rate");
 		String fixedDelayAttribute = pollerElement.getAttribute("fixed-delay");
+		String initialDelayAttribute = pollerElement.getAttribute("initial-delay");
 		String cronAttribute = pollerElement.getAttribute("cron");
 		String timeUnit = pollerElement.getAttribute("time-unit");
 
@@ -129,6 +130,9 @@ public class PollerParser extends AbstractBeanDefinitionParser {
 			if (StringUtils.hasText(timeUnit)) {
 				builder.addConstructorArgValue(timeUnit);
 			}
+			if (StringUtils.hasText(initialDelayAttribute)) {
+			    builder.addPropertyValue("initialDelay", initialDelayAttribute);
+			}
 			builder.addPropertyValue("fixedRate", Boolean.TRUE);
 			String triggerBeanName = BeanDefinitionReaderUtils.registerWithGeneratedName(
 					builder.getBeanDefinition(), parserContext.getRegistry());
@@ -140,6 +144,9 @@ public class PollerParser extends AbstractBeanDefinitionParser {
 			if (StringUtils.hasText(timeUnit)) {
 				builder.addConstructorArgValue(timeUnit);
 			}
+	        if (StringUtils.hasText(initialDelayAttribute)) {
+	            builder.addPropertyValue("initialDelay", initialDelayAttribute);
+	        }
 			builder.addPropertyValue("fixedRate", Boolean.FALSE);
 			String triggerBeanName = BeanDefinitionReaderUtils.registerWithGeneratedName(
 					builder.getBeanDefinition(), parserContext.getRegistry());

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.2.xsd
@@ -1796,6 +1796,11 @@
 				<xsd:documentation>Fixed delay trigger (in milliseconds).</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="initial-delay" type="xsd:string">
+		    <xsd:annotation>
+		        <xsd:documentation>Initial delay (in milliseconds).</xsd:documentation>
+		    </xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="ref" type="xsd:string" use="optional">
 			<xsd:annotation>
 				<xsd:documentation>


### PR DESCRIPTION
PeriodicTrigger is supporting 'initialDelay' property. However, there is not possible to set that property with XML configuration. Changes are minimal.
