### PR TITLE
INT-3686: CONNECTED & RECEIPT on WebSocket client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -585,8 +585,9 @@ project('spring-integration-websocket') {
 
 		compile ("org.springframework:spring-webmvc:$springVersion", optional)
 
+		testCompile project(":spring-integration-event")
 		testCompile "org.apache.tomcat.embed:tomcat-embed-websocket:$tomcatVersion"
-		testCompile("org.apache.tomcat.embed:tomcat-embed-logging-juli:${tomcatVersion}")
+		testCompile("org.apache.tomcat.embed:tomcat-embed-logging-juli:$tomcatVersion")
 	}
 }
 

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/event/ReceiptEvent.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/event/ReceiptEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.websocket.event;
+
+import org.springframework.messaging.Message;
+import org.springframework.web.socket.messaging.AbstractSubProtocolEvent;
+
+/**
+ * The {@link AbstractSubProtocolEvent} implementation, which is emitted
+ * for the WebSocket sub-protocol-specific {@code RECEIPT} frame on the client side.
+ *
+ * @author Artem Bilan
+ * @since 4.1.3
+ */
+@SuppressWarnings("serial")
+public class ReceiptEvent extends AbstractSubProtocolEvent {
+
+	public ReceiptEvent(Object source, Message<byte[]> message) {
+		super(source, message);
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3686

Since `WebSocketInboundChannelAdapter` is positioned as an adapter for WebSocket client side as well,
the appropriate Server-side frames should be handler properly there, too, even if `StompSubProtocolHandler`
isn't designed for the client side usage.
- Add catch of the `CONNECTED` and `RECEIPT` STOMP message types to the `WebSocketInboundChannelAdapter`
- Emit `CONNECTED` as a `SessionConnectedEvent`
- Emit `RECEIPT` as a new introduced `ReceiptEvent`

**Cherry-pick to 4.1.x**
