### PR TITLE
Upgrade to Spring Web Services 2.2.1.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ subprojects { subproject ->
 		springSocialTwitterVersion = '1.1.0.RELEASE'
 		springRetryVersion = '1.1.1.RELEASE'
 		springVersion = project.hasProperty('springVersion') ? project.springVersion : '4.0.8.RELEASE'
-		springWsVersion = '2.2.0.RELEASE'
+		springWsVersion = '2.2.1.RELEASE'
 		xmlUnitVersion = '1.5'
 		xstreamVersion = '1.4.7'
 	}

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests.java
@@ -249,7 +249,7 @@ public class UriVariableTests {
 			else {
 				throw new IllegalStateException("expected WebServiceConnection in the TransportContext");
 			}
-			return false;
+			return true;
 		}
 
 		public boolean handleResponse(MessageContext messageContext) throws WebServiceClientException {


### PR DESCRIPTION
This commit updates the version of Spring Web Services to
2.2.1.RELEASE. The fix for SWS-892 means that in the event of an
interceptor failing to handle a request, the request is no longer
sent. The interceptor in UriVariableTests has been updated to return
true, indicating that the request has been handled and should be
sent.
