### PR TITLE
INT-3697: Map `contentType` to HTTP Response

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -490,7 +490,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	}
 
 	private boolean shouldMapOutboundHeader(String headerName) {
-		String[] outboundHeaderNamesLower = this.outboundHeaderNamesLower;
+		String[] outboundHeaderNamesLower = this.outboundHeaderNamesLowerWithContentType;
 
 		if (this.isDefaultInboundMapper) {
 			/*

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests.java
@@ -41,6 +41,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandler;
 import org.springframework.messaging.Message;
@@ -101,6 +102,7 @@ public class HttpProxyScenarioTests {
 		request.addHeader("If-Modified-Since", ifModifiedSinceValue);
 		request.addHeader("If-Unmodified-Since", ifUnmodifiedSinceValue);
 		request.addHeader("Connection", "Keep-Alive");
+		request.setContentType("text/plain");
 
 		Object handler = this.handlerMapping.getHandler(request).getHandler();
 		assertNotNull(handler);
@@ -142,6 +144,7 @@ public class HttpProxyScenarioTests {
 		assertNull(response.getHeaderValue("If-Unmodified-Since"));
 		assertEquals("close", response.getHeaderValue("Connection"));
 		assertEquals(contentDispositionValue, response.getHeader("Content-Disposition"));
+		assertEquals("text/plain", response.getContentType());
 
 		Message<?> message = this.checkHeadersChannel.receive(2000);
 		MessageHeaders headers = message.getHeaders();

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageInboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageInboundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 import java.net.URI;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -42,8 +41,8 @@ import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.integration.mapping.HeaderMapper;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -550,7 +549,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
         HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.inboundMapper();
         HttpHeaders headers = new HttpHeaders();
         // suppressed in response on inbound, by default
-        headers.put("Content-Length", Arrays.asList("3"));
+        headers.put("Content-Length", Collections.singletonList("3"));
         Map<String, Object> messageHeaders = mapper.toHeaders(headers);
         headers = new HttpHeaders();
         mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -570,6 +569,18 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 		c.set(Calendar.MILLISECOND, 0);
 		assertEquals(c.getTimeInMillis(), result.get("If-Modified-Since"));
 	}
+
+	@Test
+	public void testContentTypeHeader() throws Exception{
+		HeaderMapper<HttpHeaders> mapper  = DefaultHttpHeaderMapper.inboundMapper();
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put(MessageHeaders.CONTENT_TYPE, "text/plain");
+		MessageHeaders messageHeaders = new MessageHeaders(map);
+		HttpHeaders httpHeaders = new HttpHeaders();
+		mapper.fromHeaders(messageHeaders, httpHeaders);
+		assertEquals(MediaType.valueOf("text/plain"), httpHeaders.getContentType());
+	}
+
 
 	public static class TestClass {
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3697

Since Spring Integration 4.0 the `MessageHeaders` had been moved to the Spring Messaging module
and `MessageHeaders.CONTENT_TYPE` had been changed from `content-type` name to the `contentType`.

Previously the automatic mapping of `contentType` to the HTTP Request `Content-Type` has been introduced
for the `HttpRequestExecutingMessageHandler`.

This fix do the same for the HTTP Response in case of HTTP Inbound Endpoint.
This allows to transfer HTTP headers automatically from underlying HTTP Outbound Endpoint for HTTP Proxy scenario.
The response from that external HTTP service maybe changed during a downstream flow before sending HTTP Response from the HTTP Inbound Endpoint.
Before this we was forced to map `contentType` to `Content-Type` manually or just rely on the `HttpMessageConverter`s.

**Cherry-pick to 4.1.x**
