### PR TITLE
Allow Spring Boot to determine type created by GatewayProxyFactoryBean

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,11 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
+import org.springframework.beans.BeanMetadataAttribute;
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -163,7 +164,10 @@ public class MessagingGatewayRegistrar implements ImportBeanDefinitionRegistrar 
 
 		gatewayProxyBuilder.addConstructorArgValue(serviceInterface);
 
-		return new BeanDefinitionHolder(gatewayProxyBuilder.getBeanDefinition(), id);
+		AbstractBeanDefinition beanDefinition = gatewayProxyBuilder.getBeanDefinition();
+		beanDefinition.addMetadataAttribute(new BeanMetadataAttribute("factoryBeanObjectType", serviceInterface));
+
+		return new BeanDefinitionHolder(beanDefinition, id);
 	}
 
 	/**

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests-context.xml
@@ -49,7 +49,7 @@
 			 reactor-environment="reactorEnvironment"/>
 
 	<!-- no assertions for this. The fact that this config does not result in error is sufficient -->
-	<gateway default-request-channel="nullChannel"/>
+	<gateway id="defaultConfig" default-request-channel="nullChannel"/>
 
 	<beans:bean id="testExecutor" class="org.springframework.integration.config.xml.GatewayParserTests$TestExecutor"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.integration.gateway.RequestReplyExchanger;
 import org.springframework.integration.gateway.TestService;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
@@ -103,6 +106,20 @@ public class GatewayParserTests {
 	public void testAsyncDisabledGateway() throws Exception {
 		Object service = context.getBean("&asyncOff");
 		assertNull(TestUtils.getPropertyValue(service, "asyncExecutor"));
+	}
+
+	@Test
+	public void testFactoryBeanObjectTypeWithServiceInterface() throws Exception {
+		ConfigurableListableBeanFactory beanFactory = ((GenericApplicationContext)context).getBeanFactory();
+		Object attribute = beanFactory.getMergedBeanDefinition("&oneWay").getAttribute("factoryBeanObjectType");
+		assertEquals(TestService.class.getName(), attribute);
+	}
+
+	@Test
+	public void testFactoryBeanObjectTypeWithNoServiceInterface() throws Exception {
+		ConfigurableListableBeanFactory beanFactory = ((GenericApplicationContext)context).getBeanFactory();
+		Object attribute = beanFactory.getMergedBeanDefinition("&defaultConfig").getAttribute("factoryBeanObjectType");
+		assertEquals(RequestReplyExchanger.class.getName(), attribute);
 	}
 
 	@Test


### PR DESCRIPTION
This PR fixes the Spring Integration portion of spring-projects/spring-boot#2811. Please see the commit message for further details. I've tested the changes against a Spring Boot 1.2.4 snapshot and confirmed that it resolves the problem.
