### PR TITLE
INT-3677: Support PPH and SpEL for Container Class

### DIFF
--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests-context.xml
@@ -79,6 +79,9 @@
 		container-type="simple"/>
 
 	<jms:channel id="withContainerClass" queue-name="custom.container.queue"
-		container-class="org.springframework.integration.jms.config.JmsChannelParserTests$CustomTestMessageListenerContainer" />
+		container-class="${container.class}" />
+
+	<jms:channel id="withContainerClassSpEL" queue-name="custom.container.queue"
+		container-class="#{'org.springframework.integration.jms.config.JmsChannelParserTests$CustomTestMessageListenerContainer'}" />
 
 </beans>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
@@ -17,8 +17,6 @@
 package org.springframework.integration.jms.config;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import java.util.List;
@@ -116,6 +114,9 @@ public class JmsChannelParserTests {
 
 	@Autowired
 	private MessageChannel withContainerClass;
+
+	@Autowired
+	private MessageChannel withContainerClassSpEL;
 
 	@Autowired
 	private MessageBuilderFactory messageBuilderFactory;
@@ -296,6 +297,14 @@ public class JmsChannelParserTests {
 	public void withContainerClass() {
 		CustomTestMessageListenerContainer container = TestUtils.getPropertyValue(
 				withContainerClass, "container",
+				CustomTestMessageListenerContainer.class);
+		assertEquals("custom.container.queue", container.getDestinationName());
+	}
+
+	@Test
+	public void withContainerClassSpEL() {
+		CustomTestMessageListenerContainer container = TestUtils.getPropertyValue(
+				withContainerClassSpEL, "container",
 				CustomTestMessageListenerContainer.class);
 		assertEquals("custom.container.queue", container.getDestinationName());
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
@@ -173,6 +173,29 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		assertSame(channel, TestUtils.getPropertyValue(adapter, "listener.gatewayDelegate.requestChannel"));
 		adapter.start();
 		FooContainer container = TestUtils.getPropertyValue(adapter, "listenerContainer", FooContainer.class);
+		assertSame(container, context.getBean("adapterWithIdleConsumerLimit.container"));
+		assertEquals(33, new DirectFieldAccessor(container).getPropertyValue("idleConsumerLimit"));
+		assertEquals(3, new DirectFieldAccessor(container).getPropertyValue("cacheLevel"));
+		assertSame(context.getBean("adapterWithIdleConsumerLimit.listener"),
+				TestUtils.getPropertyValue(container, "messageListener"));
+		adapter.stop();
+
+		adapter = context.getBean("adapterWithIdleConsumerLimit2.adapter", JmsMessageDrivenEndpoint.class);
+		channel = context.getBean("adapterWithIdleConsumerLimit2", MessageChannel.class);
+		assertSame(channel, TestUtils.getPropertyValue(adapter, "listener.gatewayDelegate.requestChannel"));
+		adapter.start();
+		container = TestUtils.getPropertyValue(adapter, "listenerContainer", FooContainer.class);
+		assertSame(container, context.getBean("adapterWithIdleConsumerLimit2.container"));
+		assertEquals(33, new DirectFieldAccessor(container).getPropertyValue("idleConsumerLimit"));
+		assertEquals(3, new DirectFieldAccessor(container).getPropertyValue("cacheLevel"));
+		adapter.stop();
+
+		adapter = context.getBean("org.springframework.integration.jms.JmsMessageDrivenEndpoint#0", JmsMessageDrivenEndpoint.class);
+		channel = context.getBean("in", MessageChannel.class);
+		assertSame(channel, TestUtils.getPropertyValue(adapter, "listener.gatewayDelegate.requestChannel"));
+		adapter.start();
+		container = TestUtils.getPropertyValue(adapter, "listenerContainer", FooContainer.class);
+		assertSame(container, context.getBean("org.springframework.integration.jms.JmsMessageDrivenEndpoint#0.container"));
 		assertEquals(33, new DirectFieldAccessor(container).getPropertyValue("idleConsumerLimit"));
 		assertEquals(3, new DirectFieldAccessor(container).getPropertyValue("cacheLevel"));
 		adapter.stop();

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/channel.properties
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/channel.properties
@@ -1,2 +1,3 @@
 queue=testQueue
 concurrency=5-25
+container.class=org.springframework.integration.jms.config.JmsChannelParserTests$CustomTestMessageListenerContainer

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithContainerClass.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithContainerClass.xml
@@ -3,20 +3,46 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:si="http://www.springframework.org/schema/integration"
 	xmlns:jms="http://www.springframework.org/schema/integration/jms"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
-			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd
-			http://www.springframework.org/schema/integration/jms
-			http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd">
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+	<util:properties id="props">
+		<prop key="container.class">org.springframework.integration.jms.config.JmsMessageDrivenChannelAdapterParserTests$FooContainer</prop>
+	</util:properties>
+
+	<context:property-placeholder properties-ref="props"/>
 
 	<jms:message-driven-channel-adapter id="adapterWithIdleConsumerLimit"
 						 connection-factory="testConnectionFactory"
 						 destination-name="testQueue"
-						 container-class="org.springframework.integration.jms.config.JmsMessageDrivenChannelAdapterParserTests$FooContainer"
+						 container-class="${container.class}"
 						 idle-consumer-limit="33"
 						 cache-level="3"
 						 auto-startup="false" />
+
+	<jms:message-driven-channel-adapter id="adapterWithIdleConsumerLimit2"
+						 connection-factory="testConnectionFactory"
+						 destination-name="testQueue"
+						 container-class="#{props['container.class']}"
+						 idle-consumer-limit="33"
+						 cache-level="3"
+						 auto-startup="false" />
+
+	<!-- no id -->
+	<jms:message-driven-channel-adapter channel="in"
+						 connection-factory="testConnectionFactory"
+						 destination-name="testQueue"
+						 container-class="#{props['container.class']}"
+						 idle-consumer-limit="33"
+						 cache-level="3"
+						 auto-startup="false" />
+
+	<si:channel id="in" />
 
 	<bean id="testConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3677

Previously, you could not use a property placeholder or SpEL when
defining the `container-class` attribute on message-driven endpoints.

Register the container with bean name `adapterId.container`.

Also add an alias for the container message listener `adapterId.listener`.

Add tests for JMS-backed channels - no code changes needed because a factory bean is used.
