### PR TITLE
INT-3706: Support FileExistModes in (S)FTP Gateway

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ public abstract class AbstractRemoteFileOutboundGatewayParser extends AbstractCo
 			localFileGeneratorExpressionBuilder.addConstructorArgValue(localFileGeneratorExpression);
 			builder.addPropertyValue("localFilenameGeneratorExpression", localFileGeneratorExpressionBuilder.getBeanDefinition());
 		}
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "mode", "fileExistsMode");
 		return builder;
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
@@ -258,7 +258,9 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 
 	@Override
 	public String send(final Message<?> message, String subDirectory, FileExistsMode... mode) {
-		FileExistsMode modeToUse = mode == null || mode.length < 1 ? FileExistsMode.REPLACE : mode[0];
+		FileExistsMode modeToUse = mode == null || mode.length < 1 || mode[0] == null
+				? FileExistsMode.REPLACE
+				: mode[0];
 		return send(message, subDirectory, modeToUse);
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,9 +43,11 @@ import org.springframework.integration.file.remote.RemoteFileTemplate;
 import org.springframework.integration.file.remote.SessionCallback;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
+import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -214,6 +217,8 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 
 	private volatile Expression localFilenameGeneratorExpression;
 
+	private volatile FileExistsMode fileExistsMode;
+
 	public AbstractRemoteFileOutboundGateway(SessionFactory<F> sessionFactory, String command,
 			String expression) {
 		Assert.notNull(sessionFactory, "'sessionFactory' cannot be null");
@@ -338,6 +343,19 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 		this.localFilenameGeneratorExpression = localFilenameGeneratorExpression;
 	}
 
+	/**
+	 * Determine the action to take when using GET and MGET operations when the file
+	 * already exists locally, or PUT and MPUT when the file exists on the remote
+	 * system.
+	 * @param fileExistsMode the fileExistsMode to set.
+	 * @since 4.2
+	 */
+	public void setFileExistsMode(FileExistsMode fileExistsMode) {
+		this.fileExistsMode = fileExistsMode;
+		if (FileExistsMode.APPEND.equals(fileExistsMode)) {
+			this.remoteFileTemplate.setUseTemporaryFileName(false);
+		}
+	}
 
 	@Override
 	protected void doInit() {
@@ -494,7 +512,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	}
 
 	private String doPut(Message<?> requestMessage, String subDirectory) {
-		String path = this.remoteFileTemplate.send(requestMessage, subDirectory);
+		String path = this.remoteFileTemplate.send(requestMessage, subDirectory, this.fileExistsMode);
 		if (path == null) {
 			throw new MessagingException(requestMessage, "No local file found for " + requestMessage);
 		}
@@ -661,10 +679,22 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 			}
 		}
 		File localFile = new File(this.generateLocalDirectory(message, remoteDir), this.generateLocalFileName(message, remoteFilename));
-		if (!localFile.exists()) {
+		FileExistsMode fileExistsMode = this.fileExistsMode;
+		boolean appending = FileExistsMode.APPEND.equals(fileExistsMode);
+		boolean replacing = FileExistsMode.REPLACE.equals(fileExistsMode);
+		if (!localFile.exists() || appending || replacing) {
+			OutputStream outputStream;
 			String tempFileName = localFile.getAbsolutePath() + this.remoteFileTemplate.getTemporaryFileSuffix();
 			File tempFile = new File(tempFileName);
-			BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(tempFile));
+			if (appending) {
+				outputStream = new BufferedOutputStream(new FileOutputStream(localFile, true));
+			}
+			else {
+				outputStream = new BufferedOutputStream(new FileOutputStream(tempFile));
+			}
+			if (replacing) {
+				localFile.delete();
+			}
 			try {
 				session.read(remoteFilePath, outputStream);
 			}
@@ -690,17 +720,22 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 					//Ignore it
 				}
 			}
-			if (!tempFile.renameTo(localFile)) {
+			if (!appending && !tempFile.renameTo(localFile)) {
 				throw new MessagingException("Failed to rename local file");
 			}
 			if (lsFirst && this.options.contains(Option.PRESERVE_TIMESTAMP)) {
 				localFile.setLastModified(getModified(files[0]));
 			}
-			return localFile;
+		}
+		else if (FileExistsMode.IGNORE != fileExistsMode) {
+			throw new MessageHandlingException(message, "Local file " + localFile + " already exists");
 		}
 		else {
-			throw new MessagingException("Local file " + localFile + " already exists");
+			if (logger.isDebugEnabled()) {
+				logger.debug("Existing file skipped: " + localFile);
+			}
 		}
+		return localFile;
 	}
 
 	protected List<File> mGet(Message<?> message, Session<F> session, String remoteDirectory,

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests-context.xml
@@ -33,6 +33,7 @@
 							  command-options="-1 -f"
 							  expression="payload"
 							  order="1"
+							  mode="APPEND"
 							  mput-regex=".*">
 		<int:poller fixed-delay="1000"/>
 	</int-ftp:outbound-gateway>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
@@ -39,6 +39,7 @@ import org.springframework.integration.file.filters.SimplePatternFileListFilter;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway.Command;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway.Option;
 import org.springframework.integration.file.remote.session.CachingSessionFactory;
+import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.ftp.gateway.FtpOutboundGateway;
 import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
@@ -105,6 +106,7 @@ public class FtpOutboundGatewayParserTests {
 		assertEquals(Long.valueOf(777), sendTimeout);
 		assertTrue(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class));
 		assertThat(TestUtils.getPropertyValue(gateway, "mputFilter"), Matchers.instanceOf(RegexPatternFileListFilter.class));
+		assertEquals(FileExistsMode.APPEND, TestUtils.getPropertyValue(gateway, "fileExistsMode"));
 	}
 
 	@Test

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -427,10 +427,17 @@ Here is an example of a gateway configured for an ls command...
     reply-channel="toSplitter"/>
 ----
 
-The payload of the message sent to the toSplitter channel is a list of String objects containing the filename of each file.
+The payload of the message sent to the toSplitter channel is a list of String objects containing the filename of each
+file.
 If the `command-options` was omitted, it would be a list of `FileInfo` objects.
 Options are provided space-delimited, e.g.
 `command-options="-1 -dirs -links"`.
+
+Starting with _version 4.2_, the `GET`, `MGET`, `PUT` and `MPUT` commands support a `FileExistsMode` property (`mode`
+when using the namespace support). This affects the behavior when the local file exists (`GET` and `MGET`) or the remote
+file exists (`PUT` and `MPUT`). Supported modes are `REPLACE`, `APPEND`, `FAIL` and `IGNORE`.
+For backwards compatibility, the default mode for `PUT` and `MPUT` operations is `REPLACE` and for `GET` and `MGET`
+operations, the default is `FAIL`.
 
 [[ftp-session-caching]]
 === FTP Session Caching

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -497,6 +497,12 @@ If the `command-options` was omitted, it would be a list of `FileInfo` objects.
 Options are provided space-delimited, e.g.
 `command-options="-1 -dirs -links"`.
 
+Starting with _version 4.2_, the `GET`, `MGET`, `PUT` and `MPUT` commands support a `FileExistsMode` property (`mode`
+when using the namespace support). This affects the behavior when the local file exists (`GET` and `MGET`) or the remote
+file exists (`PUT` and `MPUT`). Supported modes are `REPLACE`, `APPEND`, `FAIL` and `IGNORE`.
+For backwards compatibility, the default mode for `PUT` and `MPUT` operations is `REPLACE` and for `GET` and `MGET`
+operations, the default is `FAIL`.
+
 [[sftp-jsch-logging]]
 === SFTP/JSCH Logging
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3706

Previously, the `mode` attribute on the (S)FTP outbound gateways was ignored.

Take account of the mode on (M)GET and (M)PUT commands.
