### PR TITLE
INT-3693: Eliminate xml-apis Redirect on Build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ subprojects { subproject ->
 		}
 	}
 
+	task listAllDependencies(type: DependencyReportTask) {}
 
 	compileJava {
 		sourceCompatibility = 1.6
@@ -76,6 +77,11 @@ subprojects { subproject ->
 		targetCompatibility = 1.6
 	}
 
+	configurations.all {
+		resolutionStrategy {
+			force 'xml-apis:xml-apis:1.4.01'
+		}
+	}
 
 	ext {
 		activeMqVersion = '5.11.0'


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3693

Force xml-apis dep to 1.4.01.

Also add task `listAllDependencies`.

**see: https://discuss.gradle.org/t/oddity-in-the-output-of-dependencyinsight-task/7553/11**
