### PR TITLE
INT-3687: Fix CORS & upgrade to IO 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ subprojects { subproject ->
 		apply plugin: 'spring-io'
 
 		dependencies {
-			springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+			springIoVersions "io.spring.platform:platform-bom:${platformVersion}@properties"
 		}
 	}
 
@@ -104,7 +104,7 @@ subprojects { subproject ->
 		jpaApiVersion = '2.0.0'
 		jrubyVersion = '1.7.19'
 		jschVersion = '0.1.52'
-		jsonpathVersion = '1.2.0'
+		jsonpathVersion = '2.0.0'
 		junitVersion = '4.11'
 		jythonVersion = '2.5.3'
 		log4jVersion = '1.2.17'

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/IntegrationRequestMappingHandlerMapping.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/IntegrationRequestMappingHandlerMapping.java
@@ -90,9 +90,22 @@ public final class IntegrationRequestMappingHandlerMapping extends RequestMappin
 	protected final HandlerExecutionChain getHandlerExecutionChain(Object handler, HttpServletRequest request) {
 		if (handler instanceof HandlerMethod) {
 			HandlerMethod handlerMethod = (HandlerMethod) handler;
-			handler = handlerMethod.getBean();
+			Object bean = handlerMethod.getBean();
+			if (bean instanceof HttpRequestHandlingEndpointSupport) {
+				handler = bean;
+			}
 		}
 		return super.getHandlerExecutionChain(handler, request);
+	}
+
+	@Override
+	protected CorsConfiguration getCorsConfiguration(Object handler, HttpServletRequest request) {
+		if (handler instanceof HandlerMethod) {
+			return super.getCorsConfiguration(handler, request);
+		}
+		else {
+			return super.getCorsConfiguration(new HandlerMethod(handler, HANDLE_REQUEST_METHOD), request);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3687
- Change `master` to use IO 2.0 BOM for versions
- Upgrade `jsonPath` to `2.0.0`
- Fix `IntegrationRequestMappingHandlerMapping` according the latest MVC changes around CORS:
  https://jira.spring.io/browse/SPR-12933.
- No yet any tests for `Global CORS`: waiting for Namespace support in MVC

Test this with:

```
./gradlew clean springIoCheck -PplatformVersion=2.0.0.BUILD-SNAPSHOT -PJDK8_HOME=<jdk8-home>
```
