### PR TITLE
INT-3719: AbstractMessageChannel Optimizations

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
@@ -621,13 +621,21 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 		}
 
 		public boolean remove(ChannelInterceptor interceptor) {
-			this.size--;
-			return this.interceptors.remove(interceptor);
+			if (this.interceptors.remove(interceptor)) {
+				this.size--;
+				return true;
+			}
+			else {
+				return false;
+			}
 		}
 
 		public ChannelInterceptor remove(int index) {
-			this.size--;
-			return this.interceptors.remove(index);
+			ChannelInterceptor removed = this.interceptors.remove(index);
+			if (removed != null) {
+				this.size--;
+			}
+			return removed;
 		}
 
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
@@ -413,10 +413,11 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 			if (this.datatypes.length > 0) {
 				message = this.convertPayloadIfNecessary(message);
 			}
-			if (logger.isDebugEnabled()) {
+			boolean debugEnabled = logger.isDebugEnabled();
+			if (debugEnabled) {
 				logger.debug("preSend on channel '" + this + "', message: " + message);
 			}
-			if (interceptors.getInterceptors().size() > 0) {
+			if (interceptors.getSize() > 0) {
 				interceptorStack = new ArrayDeque<ChannelInterceptor>();
 				message = interceptors.preSend(message, this, interceptorStack);
 				if (message == null) {
@@ -431,7 +432,8 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 				channelMetrics.afterSend(metrics, sent);
 				metricsProcessed = true;
 			}
-			if (logger.isDebugEnabled()) {
+
+			if (debugEnabled) {
 				logger.debug("postSend (sent=" + sent + ") on channel '" + this + "', message: " + message);
 			}
 			if (interceptorStack != null) {
@@ -508,6 +510,8 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 
 		private final List<ChannelInterceptor> interceptors = new CopyOnWriteArrayList<ChannelInterceptor>();
 
+		private volatile int size;
+
 		public ChannelInterceptorList(Log logger) {
 			this.logger = logger;
 		}
@@ -515,21 +519,28 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 		public boolean set(List<ChannelInterceptor> interceptors) {
 			synchronized (this.interceptors) {
 				this.interceptors.clear();
+				this.size = interceptors.size();
 				return this.interceptors.addAll(interceptors);
 			}
 		}
 
+		public int getSize() {
+			return this.size;
+		}
+
 		public boolean add(ChannelInterceptor interceptor) {
+			this.size++;
 			return this.interceptors.add(interceptor);
 		}
 
 		public void add(int index, ChannelInterceptor interceptor) {
+			this.size++;
 			this.interceptors.add(index, interceptor);
 		}
 
 		public Message<?> preSend(Message<?> message, MessageChannel channel,
 				Deque<ChannelInterceptor> interceptorStack) {
-			if (this.interceptors.size() > 0) {
+			if (this.size > 0) {
 				for (ChannelInterceptor interceptor : this.interceptors) {
 					message = interceptor.preSend(message, channel);
 					if (message == null) {
@@ -547,7 +558,7 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 		}
 
 		public void postSend(Message<?> message, MessageChannel channel, boolean sent) {
-			if (this.interceptors.size() > 0) {
+			if (this.size > 0) {
 				for (ChannelInterceptor interceptor : interceptors) {
 					interceptor.postSend(message, channel, sent);
 				}
@@ -568,7 +579,7 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 		}
 
 		public boolean preReceive(MessageChannel channel, Deque<ChannelInterceptor> interceptorStack) {
-			if (this.interceptors.size() > 0) {
+			if (this.size > 0) {
 				for (ChannelInterceptor interceptor : interceptors) {
 					if (!interceptor.preReceive(channel)) {
 						afterReceiveCompletion(null, channel, null, interceptorStack);
@@ -581,7 +592,7 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 		}
 
 		public Message<?> postReceive(Message<?> message, MessageChannel channel) {
-			if (this.interceptors.size() > 0) {
+			if (this.size > 0) {
 				for (ChannelInterceptor interceptor : interceptors) {
 					message = interceptor.postReceive(message, channel);
 					if (message == null) {
@@ -610,10 +621,12 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 		}
 
 		public boolean remove(ChannelInterceptor interceptor) {
+			this.size--;
 			return this.interceptors.remove(interceptor);
 		}
 
 		public ChannelInterceptor remove(int index) {
+			this.size--;
 			return this.interceptors.remove(index);
 		}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3719

YourKit profiling for a lightweight XD stream indicates a large
amount of time in `AMC.send()`.
- Only call `logger.isDebugEnabled()` once
- Eliminate the need to create an `UnmodifiableList` and calling `size()` to get the size of the interceptor list.

Polishing
