### PR TITLE
INT-3719: AbstractMessageChannel Optimizations

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
@@ -468,13 +468,21 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 		}
 
 		public boolean remove(ChannelInterceptor interceptor) {
-			this.size--;
-			return this.interceptors.remove(interceptor);
+			if (this.interceptors.remove(interceptor)) {
+				this.size--;
+				return true;
+			}
+			else {
+				return false;
+			}
 		}
 
 		public ChannelInterceptor remove(int index) {
-			this.size--;
-			return this.interceptors.remove(index);
+			ChannelInterceptor removed = this.interceptors.remove(index);
+			if (removed != null) {
+				this.size--;
+			}
+			return removed;
 		}
 
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3719

YourKit profiling for a lightweight XD stream indicates a large
amount of time in `AMC.send()`.
- Only call `logger.isDebugEnabled()` once
- Eliminate the need to create an `UnmodifiableList` and calling `size()` to get the size of the interceptor list.

Polishing
