### PR TITLE
INT-3722: Fix Timing Issue TCP OG and Cached CF

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
@@ -34,6 +34,7 @@ import org.springframework.integration.handler.AbstractReplyProducingMessageHand
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.ip.tcp.connection.AbstractClientConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.AbstractConnectionFactory;
+import org.springframework.integration.ip.tcp.connection.CloseDeferrable;
 import org.springframework.integration.ip.tcp.connection.TcpConnection;
 import org.springframework.integration.ip.tcp.connection.TcpListener;
 import org.springframework.integration.ip.tcp.connection.TcpSender;
@@ -155,6 +156,9 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler
 					logger.debug("released semaphore");
 				}
 			}
+			if (this.connectionFactory instanceof CloseDeferrable) {
+				((CloseDeferrable) this.connectionFactory).closeDeferred(connectionId);
+			}
 		}
 	}
 
@@ -221,6 +225,9 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler
 
 	@Override
 	public void start() {
+		if (this.connectionFactory instanceof CloseDeferrable) {
+			((CloseDeferrable) this.connectionFactory).enableCloseDeferral(true);
+		}
 		this.connectionFactory.start();
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/CloseDeferrable.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/CloseDeferrable.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.ip.tcp.connection;
+
+/**
+ * Temporary interface on the {@code CachingClientConnectionFactory} enabling the gateway
+ * to defer the implicit close after onMessage so the connection is not reused until after the
+ * gateway has completely finished with it. Will be removed when INT-3654 is resolved, whereby
+ * the gateway will be completely responsible for the close.
+ *
+ * @author Gary Russell
+ * @since 4.1.5
+ *
+ */
+public interface CloseDeferrable {
+
+	/**
+	 * Enable deferred closure.
+	 * @param defer true to defer.
+	 */
+	void enableCloseDeferral(boolean defer);
+
+	/**
+	 * Close (release) the connection if deferred.
+	 * @param connectionId the connection id.
+	 */
+	void closeDeferred(String connectionId);
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3722

The TCP outbound gateway correlates replies based on the connection id.

When a `CachingClientConnectionFactory` is being used, the connection is
returned to the pool too early, and can be reused. It is possible that
the current thread then removes the "next" pending reply from the correlation map.

Add code to the `CachingClientConnectionFactory` so that the "self" close from the
connection (called after `onMessage`) is deferred and the actual close (return to cache)
is controlled by the gateway itself.

This mechanism will no longer be needed when INT-3654 is resolved (removal of the "self"
closing by connections). At that time, connection users (such as the gateway) will be
in complete control.

**cherry-pick to 4.1.x**
