### PR TITLE
INT-3722: Additional Fix: TCP OG with Caching CF

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -457,6 +457,7 @@ public class CachingClientConnectionFactoryTests {
 	}
 
 	@Test
+//	@Repeat(1000) // INT-3722
 	public void gatewayIntegrationTest() throws Exception {
 		final List<String> connectionIds = new ArrayList<String>();
 		final AtomicBoolean okToRun = new AtomicBoolean(true);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3722

While the initial fix solved the reported problem, it caused a memory leak when
the gateway completed its work before the reader thread "closed" the connection,
releasing it to the pool. This left the connection in the deferred close state.

Handle the condition where the gateway signals it has completed its work
before the connection is released to the pool.

**cherry-pick to 4.1.x**
