### PR TITLE
INT-3728: TCP: Fix Early Receive with Caching CCF

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactory.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.ip.tcp.connection;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -141,8 +142,7 @@ public class CachingClientConnectionFactory extends AbstractClientConnectionFact
 
 	@Override
 	public TcpConnectionSupport obtainConnection() throws Exception {
-		CachedConnection cachedConnection = new CachedConnection(this.pool.getItem());
-		cachedConnection.registerListener(getListener());
+		CachedConnection cachedConnection = new CachedConnection(this.pool.getItem(), getListener());
 		return cachedConnection;
 	}
 
@@ -168,9 +168,9 @@ public class CachingClientConnectionFactory extends AbstractClientConnectionFact
 
 		private volatile boolean released;
 
-		public CachedConnection(TcpConnectionSupport connection) {
+		public CachedConnection(TcpConnectionSupport connection, TcpListener tcpListener) {
 			super.setTheConnection(connection);
-			connection.registerListener(this);
+			registerListener(tcpListener);
 		}
 
 		@Override
@@ -225,17 +225,30 @@ public class CachingClientConnectionFactory extends AbstractClientConnectionFact
 		 */
 		@Override
 		public boolean onMessage(Message<?> message) {
-			AbstractIntegrationMessageBuilder<?> messageBuilder =
-					CachingClientConnectionFactory.this.getMessageBuilderFactory()
-							.fromMessage(message)
-							.setHeader(IpHeaders.CONNECTION_ID, getConnectionId());
-			if (message.getHeaders().get(IpHeaders.ACTUAL_CONNECTION_ID) == null) {
-				messageBuilder.setHeader(IpHeaders.ACTUAL_CONNECTION_ID,
-						message.getHeaders().get(IpHeaders.CONNECTION_ID));
+			Message<?> modifiedMessage;
+			if (message instanceof ErrorMessage) {
+				Map<String, Object> headers = new HashMap<String, Object>(message.getHeaders());
+				headers.put(IpHeaders.CONNECTION_ID, getConnectionId());
+				if (headers.get(IpHeaders.ACTUAL_CONNECTION_ID) == null) {
+					headers.put(IpHeaders.ACTUAL_CONNECTION_ID,
+							message.getHeaders().get(IpHeaders.CONNECTION_ID));
+				}
+				modifiedMessage = new ErrorMessage((Throwable) message.getPayload(), headers);
+			}
+			else {
+				AbstractIntegrationMessageBuilder<?> messageBuilder =
+						CachingClientConnectionFactory.this.getMessageBuilderFactory()
+								.fromMessage(message)
+								.setHeader(IpHeaders.CONNECTION_ID, getConnectionId());
+				if (message.getHeaders().get(IpHeaders.ACTUAL_CONNECTION_ID) == null) {
+					messageBuilder.setHeader(IpHeaders.ACTUAL_CONNECTION_ID,
+							message.getHeaders().get(IpHeaders.CONNECTION_ID));
+				}
+				modifiedMessage = messageBuilder.build();
 			}
 			TcpListener listener = getListener();
 			if (listener != null) {
-				listener.onMessage(messageBuilder.build());
+				listener.onMessage(modifiedMessage);
 			}
 			else {
 				if (logger.isDebugEnabled()) {
@@ -413,17 +426,7 @@ public class CachingClientConnectionFactory extends AbstractClientConnectionFact
 	@Override
 	public void registerListener(TcpListener listener) {
 		super.registerListener(listener);
-		this.targetConnectionFactory.registerListener(new TcpListener() {
-
-			@Override
-			public boolean onMessage(Message<?> message) {
-				if (!(message instanceof ErrorMessage)) {
-					throw new UnsupportedOperationException("This should never be called");
-				}
-				return false;
-			}
-
-		});
+		this.targetConnectionFactory.enableManualListenerRegistration();
 	}
 
 	@Override

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,6 +90,13 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 					return false;
 				}
 			});
+		}
+	}
+
+	@Override
+	public void enableManualListenerRegistration() {
+		for (AbstractClientConnectionFactory factory : this.factories) {
+			factory.enableManualListenerRegistration();
 		}
 	}
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
@@ -50,6 +51,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.logging.Log;
 import org.junit.Test;
@@ -694,7 +696,48 @@ public class CachingClientConnectionFactoryTests {
 		verify(logger, never()).error(anyString());
 	}
 
-	public TcpConnectionSupport makeMockConnection() {
+	@Test // INT-3728
+	public void testEarlyReceive() throws Exception {
+		final CountDownLatch latch = new CountDownLatch(1);
+		final AbstractClientConnectionFactory factory = new TcpNetClientConnectionFactory("", 0) {
+
+			@Override
+			protected Socket createSocket(String host, int port) throws IOException {
+				Socket mock = mock(Socket.class);
+				when(mock.getInputStream()).thenReturn(new ByteArrayInputStream("foo\r\n".getBytes()));
+				return mock;
+			}
+
+			@Override
+			public boolean isActive() {
+				return true;
+			}
+
+		};
+		factory.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
+		final CachingClientConnectionFactory cachingFactory = new CachingClientConnectionFactory(factory, 1);
+		final AtomicReference<Message<?>> received = new AtomicReference<Message<?>>();
+		cachingFactory.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				if (!(message instanceof ErrorMessage)) {
+					received.set(message);
+					latch.countDown();
+				}
+				return false;
+			}
+		});
+		cachingFactory.start();
+
+		cachingFactory.getConnection();
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+		assertNotNull(received.get());
+		assertNotNull(received.get().getHeaders().get(IpHeaders.ACTUAL_CONNECTION_ID));
+		cachingFactory.stop();
+	}
+
+	private TcpConnectionSupport makeMockConnection() {
 		TcpConnectionSupport connection = mock(TcpConnectionSupport.class);
 		when(connection.isOpen()).thenReturn(true);
 		return connection;


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3728

The `CachingClientConnectionFactory` uses a temporary (rejecting) listener until
the connection is established and then replaces the listener in the connection.

There is a race condition in that if the server starts sending messages before the
listener is replaced, the message is rejected.

Add a mechanism to delay `onMessage` calls until the real listener has been
registered.

Also fix `onMessage` in the cached connection so an `ErrorMessage` is propagated correctly.

To reproduce: revert src/main; add `Thread.sleep(1000)` before `registerListener(tcpListener);`
in `CachedConnection` ctor and run the new test.

To introduce a similar timing hole with the new code, add the sleep before
`this.theConnection.registerListener(this);` in `TcpConnectionInterceptorSupport`.

Summary of changes:

`CachingClientConnectionFactory`
- register the underlying connection's listener in the ctor, utilizing the
  `TcpConnectionInterceptorSupport.registerListener()` method.
- fix `ErrorMessage` propagation.

`AbstractClientConnectionFactory`
- propagate the `enableManualListenerRegistration` to connections.

`TcpConnectionSuport`
- implement delay when manual listener registration is enabled.

Add test case.

**cherry-pick to 4.1.x**
