### PR TITLE
INT-3730: TCP Expose SSLSession for Header Mapping

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
+import javax.net.ssl.SSLSession;
+
 import org.springframework.core.serializer.Deserializer;
 import org.springframework.core.serializer.Serializer;
 import org.springframework.integration.ip.IpHeaders;
@@ -350,6 +352,11 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 		@Override
 		public void setSerializer(Serializer<?> serializer) {
 			this.delegate.setSerializer(serializer);
+		}
+
+		@Override
+		public SSLSession getSslSession() {
+			return this.delegate.getSslSession();
 		}
 
 		/**

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2014 the original author or authors.
+ * Copyright 2001-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springframework.integration.ip.tcp.connection;
 
 import java.net.Socket;
 import java.nio.channels.SocketChannel;
+
+import javax.net.ssl.SSLSession;
 
 import org.springframework.core.serializer.Deserializer;
 import org.springframework.core.serializer.Serializer;
@@ -121,5 +123,12 @@ public interface TcpConnection extends Runnable {
 	 * and ONLY used as a key.
 	 */
 	Object getDeserializerStateKey();
+
+	/**
+	 * @return the {@link SSLSession} associated with this connection, if SSL is in use,
+	 * null otherwise.
+	 * @since 4.2
+	 */
+	SSLSession getSslSession();
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.integration.ip.tcp.connection;
+
+import javax.net.ssl.SSLSession;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.serializer.Deserializer;
@@ -142,6 +144,11 @@ public abstract class TcpConnectionInterceptorSupport extends TcpConnectionSuppo
 	@Override
 	public boolean isServer() {
 		return this.theConnection.isServer();
+	}
+
+	@Override
+	public SSLSession getSslSession() {
+		return this.theConnection.getSslSession();
 	}
 
 	@Override

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
@@ -22,6 +22,9 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.serializer.Deserializer;
 import org.springframework.core.serializer.Serializer;
@@ -125,6 +128,16 @@ public class TcpNetConnection extends TcpConnectionSupport implements Scheduling
 			return this.socket.getInputStream();
 		}
 		catch (Exception e) {
+			return null;
+		}
+	}
+
+	@Override
+	public SSLSession getSslSession() {
+		if (this.socket instanceof SSLSocket) {
+			return ((SSLSocket) this.socket).getSession();
+		}
+		else {
 			return null;
 		}
 	}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -36,6 +36,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.net.ssl.SSLSession;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.serializer.Serializer;
 import org.springframework.integration.ip.tcp.serializer.SoftEndOfStreamException;
@@ -169,6 +171,11 @@ public class TcpNioConnection extends TcpConnectionSupport {
 	@Override
 	public Object getDeserializerStateKey() {
 		return this.channelInputStream;
+	}
+
+	@Override
+	public SSLSession getSslSession() {
+		return null;
 	}
 
 	/**

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioSSLConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioSSLConnection.java
@@ -26,6 +26,7 @@ import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 import javax.net.ssl.SSLEngineResult.Status;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.MessagingException;
@@ -72,6 +73,11 @@ public class TcpNioSSLConnection extends TcpNioConnection {
 			SSLEngine sslEngine) throws Exception {
 		super(socketChannel, server, lookupHost, applicationEventPublisher, connectionFactoryName);
 		this.sslEngine = sslEngine;
+	}
+
+	@Override
+	public SSLSession getSslSession() {
+		return this.sslEngine.getSession();
 	}
 
 	/**

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import javax.net.SocketFactory;
+import javax.net.ssl.SSLSession;
 
 import org.junit.Test;
 
@@ -73,34 +74,55 @@ public class TcpMessageMapperTests {
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		Socket socket = SocketFactory.getDefault().createSocket();
 		TcpConnection connection = new TcpConnectionSupport(socket, false, false, null, null) {
+
+			@Override
 			public void run() {
 			}
+
+			@Override
 			public void send(Message<?> message) throws Exception {
 			}
+
+			@Override
 			public boolean isOpen() {
 				return false;
 			}
+
+			@Override
 			public int getPort() {
 				return 1234;
 			}
+
+			@Override
 			public Object getPayload() throws Exception {
 				return TEST_PAYLOAD.getBytes();
 			}
+
 			@Override
 			public String getHostName() {
 				return "MyHost";
 			}
+
 			@Override
 			public String getHostAddress() {
 				return "1.1.1.1";
 			}
+
 			@Override
 			public String getConnectionId() {
 				return "anId";
 			}
+
+			@Override
 			public Object getDeserializerStateKey() {
 				return null;
 			}
+
+			@Override
+			public SSLSession getSslSession() {
+				return null;
+			}
+
 		};
 		Message<?> message = mapper.toMessage(connection);
 		assertEquals(TEST_PAYLOAD, new String((byte[]) message.getPayload()));
@@ -135,34 +157,55 @@ public class TcpMessageMapperTests {
 		mapper.setApplySequence(true);
 		Socket socket = SocketFactory.getDefault().createSocket();
 		TcpConnection connection = new TcpConnectionSupport(socket, false, false, null, null) {
+
+			@Override
 			public void run() {
 			}
+
+			@Override
 			public void send(Message<?> message) throws Exception {
 			}
+
+			@Override
 			public boolean isOpen() {
 				return false;
 			}
+
+			@Override
 			public int getPort() {
 				return 1234;
 			}
+
+			@Override
 			public Object getPayload() throws Exception {
 				return TEST_PAYLOAD.getBytes();
 			}
+
 			@Override
 			public String getHostName() {
 				return "MyHost";
 			}
+
 			@Override
 			public String getHostAddress() {
 				return "1.1.1.1";
 			}
+
 			@Override
 			public String getConnectionId() {
 				return "anId";
 			}
+
+			@Override
 			public Object getDeserializerStateKey() {
 				return null;
 			}
+
+			@Override
+			public SSLSession getSslSession() {
+				return null;
+			}
+
 		};
 		Message<?> message = mapper.toMessage(connection);
 		assertEquals(TEST_PAYLOAD, new String((byte[]) message.getPayload()));

--- a/src/reference/asciidoc/ip.adoc
+++ b/src/reference/asciidoc/ip.adoc
@@ -1359,6 +1359,12 @@ The framework includes acknowledgment information in the data packet.
 | For information only - when using a cached or failover client connection factory, contains the actual underlying connection id.
 |===
 
+For inbound messages, `ip_hostname`, `ip_address`, `ip_tcp_remotePort` and `ip_connectionId` are mapped by the default
+`TcpHeaderMapper`.
+Users can add additional headers by subclassing `TcpHeaderMapper`, overriding the method `supplyCustomHeaders`, and
+providing an instance to the connection factory using the `mapper` property.
+For example, when using SSL, properties of the `SSLSession` can be added by obtaining the session object from the
+`TcpConnection` object which is provided as an argument to the `supplyCustomHeaders` method.
 
 [[ip-annotation]]
 === Annotation-Based Configuration

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -77,6 +77,15 @@ Also, the `remote-timeout` no longer defaults to the same value as `reply-timeou
 
 See <<tcp-ob-gateway-attributes>> for more information.
 
+[[x4.2-tcp-ssl]]
+==== TCP SSLSession Available for Header Mapping
+
+`TcpConnection` s now support `getSslSession()` to enable users to extract information from the session to add to
+message headers.
+
+See <<ip-msg-headers>> for more information.
+
+
 [[x4.2-inbound-channel-adapter-annotation]]
 ==== @InboundChannelAdapter
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3730

Expose the `SSLSession` on `TcpConnection` to support custom header
mapping of properties from the session.
