### PR TITLE
INT-3737: (S)FTP Outbound Gateway Streaming GET

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileHeaders.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@ public abstract class FileHeaders {
 	public static final String REMOTE_DIRECTORY = PREFIX + "remoteDirectory";
 
 	public static final String REMOTE_FILE = PREFIX + "remoteFile";
+
+	public static final String REMOTE_SESSION = PREFIX + "remoteSession";
 
 	public static final String RENAME_TO = PREFIX + "renameTo";
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
@@ -100,6 +100,7 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 
 	/**
 	 * @return this template's {@link SessionFactory}.
+	 * @since 4.2
 	 */
 	public SessionFactory<F> getSessionFactory() {
 		return sessionFactory;

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,6 +96,13 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 	public RemoteFileTemplate(SessionFactory<F> sessionFactory) {
 		Assert.notNull(sessionFactory, "sessionFactory must not be null");
 		this.sessionFactory = sessionFactory;
+	}
+
+	/**
+	 * @return this template's {@link SessionFactory}.
+	 */
+	public SessionFactory<F> getSessionFactory() {
+		return sessionFactory;
 	}
 
 	/**

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileUtils.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,16 @@ public class RemoteFileUtils {
 				session.mkdir(path);
 			}
 		}
+	}
+
+	/**
+	 * Invoke this method to clean up and close the session after using {@link Session#readRaw(String)}.
+	 * @param session The session.
+	 * @throws IOException if an IO error occurs.
+	 */
+	public static <F> void closeSession(Session<F> session) throws IOException {
+		session.finalizeRaw();
+		session.close();
 	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileUtils.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,16 +74,6 @@ public class RemoteFileUtils {
 				session.mkdir(path);
 			}
 		}
-	}
-
-	/**
-	 * Invoke this method to clean up and close the session after using {@link Session#readRaw(String)}.
-	 * @param session The session.
-	 * @throws IOException if an IO error occurs.
-	 */
-	public static <F> void closeSession(Session<F> session) throws IOException {
-		session.finalizeRaw();
-		session.close();
 	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/splitter/FileSplitter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/splitter/FileSplitter.java
@@ -38,6 +38,7 @@ import org.springframework.integration.file.splitter.FileSplitter.FileMarker.Mar
 import org.springframework.integration.splitter.AbstractMessageSplitter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
+import org.springframework.util.StringUtils;
 
 /**
  * The {@link AbstractMessageSplitter} implementation to split the {@link File}
@@ -147,11 +148,11 @@ public class FileSplitter extends AbstractMessageSplitter {
 			else {
 				reader = new InputStreamReader((InputStream) payload, this.charset);
 			}
-			filePath = ":stream:";
+			filePath = buildPathFromMessage(message, ":stream:");
 		}
 		else if (payload instanceof Reader) {
 			reader = (Reader) payload;
-			filePath = ":reader:";
+			filePath = buildPathFromMessage(message, ":reader:");
 		}
 		else {
 			return message;
@@ -242,7 +243,6 @@ public class FileSplitter extends AbstractMessageSplitter {
 		}
 	}
 
-
 	@Override
 	protected boolean willAddHeaders(Message<?> message) {
 		Object payload = message.getPayload();
@@ -265,6 +265,17 @@ public class FileSplitter extends AbstractMessageSplitter {
 			if (!headers.containsKey(FileHeaders.FILENAME)) {
 				headers.put(FileHeaders.FILENAME, file.getName());
 			}
+		}
+	}
+
+	private String buildPathFromMessage(Message<?> message, String defaultPath) {
+		String remoteDir = (String) message.getHeaders().get(FileHeaders.REMOTE_DIRECTORY);
+		String remoteFile = (String) message.getHeaders().get(FileHeaders.REMOTE_FILE);
+		if (StringUtils.hasText(remoteDir) && StringUtils.hasText(remoteFile)) {
+			return remoteDir + remoteFile;
+		}
+		else {
+			return defaultPath;
 		}
 	}
 

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
@@ -144,6 +144,9 @@ public class FtpSession implements Session<FTPFile> {
 	@Override
 	public void close() {
 		try {
+			if (this.readingRaw.get()) {
+				finalizeRaw();
+			}
 			this.client.disconnect();
 		}
 		catch (Exception e) {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -104,6 +104,30 @@
 							  remote-directory="ftpTarget"
 							  reply-channel="output"/>
 
+	<int-ftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="inboundGetStream"
+							  command="get"
+							  command-options="-stream"
+							  expression="payload"
+							  remote-directory="ftpTarget"
+							  reply-channel="stream" />
+
+	<int:chain input-channel="stream">
+		<int:splitter>
+			<bean class="org.springframework.integration.file.splitter.FileSplitter">
+				<constructor-arg value="true" />
+				<constructor-arg value="true" /> <!-- TODO: convert to namespace when INT-3600 merged -->
+			</bean>
+		</int:splitter>
+		<int:payload-type-router resolution-required="false" default-output-channel="output">
+			<int:mapping type="org.springframework.integration.file.splitter.FileSplitter$FileMarker"
+						 channel="markers" />
+		</int:payload-type-router>
+	</int:chain>
+
+	<int:service-activator input-channel="markers"
+	  expression="payload.mark.toString().equals('END') ? T(org.springframework.integration.file.remote.RemoteFileUtils).closeSession(headers['file_remoteSession']) : null"/>
+
 	<int:channel id="appending" />
 
 	<int-ftp:outbound-channel-adapter id="appender"

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-ftp="http://www.springframework.org/schema/integration/ftp"
-	   xmlns:int="http://www.springframework.org/schema/integration"
-	   xsi:schemaLocation="http://www.springframework.org/schema/integration/ftp
-	 http://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int-ftp="http://www.springframework.org/schema/integration/ftp"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-file="http://www.springframework.org/schema/integration/file"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
+		http://www.springframework.org/schema/integration/ftp http://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<bean id="ftpServer" class="org.springframework.integration.ftp.TestFtpServer">
 		<constructor-arg value="FtpServerOutboundTests"/>
@@ -113,12 +114,7 @@
 							  reply-channel="stream" />
 
 	<int:chain input-channel="stream">
-		<int:splitter>
-			<bean class="org.springframework.integration.file.splitter.FileSplitter">
-				<constructor-arg value="true" />
-				<constructor-arg value="true" /> <!-- TODO: convert to namespace when INT-3600 merged -->
-			</bean>
-		</int:splitter>
+		<int-file:splitter markers="true" />
 		<int:payload-type-router resolution-required="false" default-output-channel="output">
 			<int:mapping type="org.springframework.integration.file.splitter.FileSplitter$FileMarker"
 						 channel="markers" />
@@ -126,7 +122,7 @@
 	</int:chain>
 
 	<int:service-activator input-channel="markers"
-	  expression="payload.mark.toString().equals('END') ? T(org.springframework.integration.file.remote.RemoteFileUtils).closeSession(headers['file_remoteSession']) : null"/>
+	  expression="payload.mark.toString().equals('END') ? headers['file_remoteSession'].close() : null"/>
 
 	<int:channel id="appending" />
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -353,6 +353,8 @@ public class FtpServerOutboundTests {
 		Message<?> result = this.output.receive(1000);
 		assertNotNull(result);
 		assertEquals("source1", result.getPayload());
+		assertEquals("ftpSource/", result.getHeaders().get(FileHeaders.REMOTE_DIRECTORY));
+		assertEquals("ftpSource1.txt", result.getHeaders().get(FileHeaders.REMOTE_FILE));
 		assertFalse(((Session<?>) result.getHeaders().get(FileHeaders.REMOTE_SESSION)).isOpen());
 	}
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -111,6 +112,9 @@ public class FtpServerOutboundTests {
 
 	@Autowired
 	private DirectChannel failing;
+
+	@Autowired
+	private DirectChannel inboundGetStream;
 
 	@Before
 	public void setup() {
@@ -340,6 +344,16 @@ public class FtpServerOutboundTests {
 			assertThat(e.getCause().getCause().getMessage(), containsString("The destination file already exists"));
 		}
 
+	}
+
+	@Test
+	public void testStream() {
+		String dir = "ftpSource/";
+		this.inboundGetStream.send(new GenericMessage<Object>(dir + "ftpSource1.txt"));
+		Message<?> result = this.output.receive(1000);
+		assertNotNull(result);
+		assertEquals("source1", result.getPayload());
+		assertFalse(((Session<?>) result.getHeaders().get(FileHeaders.REMOTE_SESSION)).isOpen());
 	}
 
 	private void assertLength6(FtpRemoteFileTemplate template) {

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
@@ -133,4 +133,28 @@
 							  auto-create-directory="true"
 							  remote-file-separator="/"	/>
 
+	<int-sftp:outbound-gateway session-factory="sftpSessionFactory"
+							  request-channel="inboundGetStream"
+							  command="get"
+							  command-options="-stream"
+							  expression="payload"
+							  remote-directory="ftpTarget"
+							  reply-channel="stream" />
+
+	<int:chain input-channel="stream">
+		<int:splitter>
+			<bean class="org.springframework.integration.file.splitter.FileSplitter">
+				<constructor-arg value="true" />
+				<constructor-arg value="true" /> <!-- TODO: convert to namespace when INT-3600 merged -->
+			</bean>
+		</int:splitter>
+		<int:payload-type-router resolution-required="false" default-output-channel="output">
+			<int:mapping type="org.springframework.integration.file.splitter.FileSplitter$FileMarker"
+						 channel="markers" />
+		</int:payload-type-router>
+	</int:chain>
+
+	<int:service-activator input-channel="markers"
+	  expression="payload.mark.toString().equals('END') ? T(org.springframework.integration.file.remote.RemoteFileUtils).closeSession(headers['file_remoteSession']) : null"/>
+
 </beans>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-sftp="http://www.springframework.org/schema/integration/sftp"
-	   xmlns:int="http://www.springframework.org/schema/integration"
-	   xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp
-	 http://www.springframework.org/schema/integration/sftp/spring-integration-sftp.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int-sftp="http://www.springframework.org/schema/integration/sftp"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-file="http://www.springframework.org/schema/integration/file"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/sftp http://www.springframework.org/schema/integration/sftp/spring-integration-sftp.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<int:channel id="output">
 		<int:queue/>
@@ -142,12 +143,7 @@
 							  reply-channel="stream" />
 
 	<int:chain input-channel="stream">
-		<int:splitter>
-			<bean class="org.springframework.integration.file.splitter.FileSplitter">
-				<constructor-arg value="true" />
-				<constructor-arg value="true" /> <!-- TODO: convert to namespace when INT-3600 merged -->
-			</bean>
-		</int:splitter>
+		<int-file:splitter markers="true" />
 		<int:payload-type-router resolution-required="false" default-output-channel="output">
 			<int:mapping type="org.springframework.integration.file.splitter.FileSplitter$FileMarker"
 						 channel="markers" />
@@ -155,6 +151,6 @@
 	</int:chain>
 
 	<int:service-activator input-channel="markers"
-	  expression="payload.mark.toString().equals('END') ? T(org.springframework.integration.file.remote.RemoteFileUtils).closeSession(headers['file_remoteSession']) : null"/>
+	  expression="payload.mark.toString().equals('END') ? headers['file_remoteSession'].close() : null"/>
 
 </beans>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -124,6 +125,9 @@ public class SftpServerOutboundTests {
 
 	@Autowired
 	private TestSftpServer sftpServer;
+
+	@Autowired
+	private DirectChannel inboundGetStream;
 
 	@Before
 	@After
@@ -402,6 +406,16 @@ public class SftpServerOutboundTests {
 			assertThat(e.getCause().getCause().getMessage(), containsString("The destination file already exists"));
 		}
 
+	}
+
+	@Test
+	public void testStream() {
+		String dir = "sftpSource/";
+		this.inboundGetStream.send(new GenericMessage<Object>(dir + "sftpSource1.txt"));
+		Message<?> result = this.output.receive(1000);
+		assertNotNull(result);
+		assertEquals("source1", result.getPayload());
+		assertFalse(((Session<?>) result.getHeaders().get(FileHeaders.REMOTE_SESSION)).isOpen());
 	}
 
 	private void assertLength6(SftpRemoteFileTemplate template) {

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
@@ -415,6 +415,8 @@ public class SftpServerOutboundTests {
 		Message<?> result = this.output.receive(1000);
 		assertNotNull(result);
 		assertEquals("source1", result.getPayload());
+		assertEquals("sftpSource/", result.getHeaders().get(FileHeaders.REMOTE_DIRECTORY));
+		assertEquals("sftpSource1.txt", result.getHeaders().get(FileHeaders.REMOTE_FILE));
 		assertFalse(((Session<?>) result.getHeaders().get(FileHeaders.REMOTE_SESSION)).isOpen());
 	}
 

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -328,9 +328,43 @@ _get_ retrieves a remote file and supports the following option:
 
 * -P - preserve the timestamp of the remote file
 
-The message payload resulting from a _get_ operation is a `File` object representing the retrieved file.
+* -stream - retrieve the remote file as a stream.
 
 The remote directory is provided in the `file_remoteDirectory` header, and the filename is provided in the `file_remoteFile` header.
+
+The message payload resulting from a _get_ operation is a `File` object representing the retrieved file, or
+an `InputStream` when the `-stream` option is provided.
+This option allows retrieving the file as a stream.
+For text files, a common use case is to combine this operation with a <<file-splitter>>.
+When consuming remote files as streams, the user is responsible for closing the `Session` after the stream is
+consumed.
+For convenience, the `Session` is provided in the `file_remoteSession` header.
+
+The following shows an example of consuming a file as a stream:
+
+[source, xml]
+----
+<int-ftp:outbound-gateway session-factory="ftpSessionFactory"
+							request-channel="inboundGetStream"
+							command="get"
+							command-options="-stream"
+							expression="payload"
+							remote-directory="ftpTarget"
+							reply-channel="stream" />
+
+<int:chain input-channel="stream">
+	<int-file:splitter markers="true" />
+	<int:payload-type-router resolution-required="false" default-output-channel="output">
+		<int:mapping type="org.springframework.integration.file.splitter.FileSplitter$FileMarker"
+					channel="markers" />
+	</int:payload-type-router>
+</int:chain>
+
+<int:service-activator input-channel="markers"
+	expression="payload.mark.toString().equals('END') ? headers['file_remoteSession'].close() : null"/>
+----
+
+The file lines are sent to the channel `output`.
 
 *mget*
 

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -391,9 +391,43 @@ _get_ retrieves a remote file and supports the following option:
 
 * -P - preserve the timestamp of the remote file
 
-The message payload resulting from a _get_ operation is a `File` object representing the retrieved file.
+* -stream - retrieve the remote file as a stream.
 
 The remote directory is provided in the `file_remoteDirectory` header, and the filename is provided in the `file_remoteFile` header.
+
+The message payload resulting from a _get_ operation is a `File` object representing the retrieved file, or
+an `InputStream` when the `-stream` option is provided.
+This option allows retrieving the file as a stream.
+For text files, a common use case is to combine this operation with a <<file-splitter>>.
+When consuming remote files as streams, the user is responsible for closing the `Session` after the stream is
+consumed.
+For convenience, the `Session` is provided in the `file_remoteSession` header.
+
+The following shows an example of consuming a file as a stream:
+
+[source, xml]
+----
+<int-sftp:outbound-gateway session-factory="sftpSessionFactory"
+              request-channel="inboundGetStream"
+              command="get"
+              command-options="-stream"
+              expression="payload"
+              remote-directory="ftpTarget"
+              reply-channel="stream" />
+
+<int:chain input-channel="stream">
+  <int-file:splitter markers="true" />
+  <int:payload-type-router resolution-required="false" default-output-channel="output">
+    <int:mapping type="org.springframework.integration.file.splitter.FileSplitter$FileMarker"
+           channel="markers" />
+  </int:payload-type-router>
+</int:chain>
+
+<int:service-activator input-channel="markers"
+  expression="payload.mark.toString().equals('END') ? headers['file_remoteSession'].close() : null"/>
+----
+
+The file lines are sent to the channel `output`.
 
 *mget*
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -153,3 +153,9 @@ See <<cors>> for more information.
 
 The `AbstractPersistentFileListFilter` has a new property `flushOnUpdate` which, when set to true, will `flush()` the
 metadata store if it implements `Flushable` (e.g. the `PropertiesPersistenMetadataStore`).
+
+[[x4.2-ftp-changes]]
+==== (S)FTP Changes
+
+The SFTP/FTP outbound gateway `get` operations now support the `-stream` option, allowing files to be retrieved as
+a stream. See <<ftp-outbound-gateway>> and <<sftp-outbound-gateway>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3737

Support returning an `InputStream` from a GET operation.

This can be used in conjuction with a `<file:splitter/>` to stream a text file.

The user is responsible for releasing the session when the download is complete.

The session object is stored in the message header and `RemoteFileUtils.closeSession()` should be called to clean up and close the session.
