### PR TITLE
INT-3739: FileSplitter - Add LineCount to EOF Mark

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/splitter/FileSplitter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/splitter/FileSplitter.java
@@ -168,6 +168,8 @@ public class FileSplitter extends AbstractMessageSplitter {
 
 			String line;
 
+			long lineCount;
+
 			boolean hasNextCalled;
 
 			@Override
@@ -204,17 +206,18 @@ public class FileSplitter extends AbstractMessageSplitter {
 				this.hasNextCalled = false;
 				if (this.sof) {
 					this.sof = false;
-					return new FileMarker(filePath, Mark.START);
+					return new FileMarker(filePath, Mark.START, 0);
 				}
 				if (this.eof) {
 					this.eof = false;
 					this.markers = false;
 					this.done = true;
-					return new FileMarker(filePath, Mark.END);
+					return new FileMarker(filePath, Mark.END, this.lineCount);
 				}
 				if (this.line != null) {
 					String line = this.line;
 					this.line = null;
+					this.lineCount++;
 					return line;
 				}
 				else {
@@ -250,9 +253,12 @@ public class FileSplitter extends AbstractMessageSplitter {
 
 		private final Mark mark;
 
-		public FileMarker(String filePath, Mark mark) {
+		private final long lineCount;
+
+		public FileMarker(String filePath, Mark mark, long lineCount) {
 			this.filePath = filePath;
 			this.mark = mark;
+			this.lineCount = lineCount;
 		}
 
 		public String getFilePath() {
@@ -263,10 +269,20 @@ public class FileSplitter extends AbstractMessageSplitter {
 			return mark;
 		}
 
+		public long getLineCount() {
+			return lineCount;
+		}
+
 		@Override
 		public String toString() {
-			return "FileMarker [filePath=" + filePath + ", mark=" + mark + "]";
+			if (this.mark.equals(Mark.START)) {
+				return "FileMarker [filePath=" + filePath + ", mark=" + mark + "]";
+			}
+			else {
+				return "FileMarker [filePath=" + filePath + ", mark=" + mark + ", lineCount=" + lineCount + "]";
+			}
 		}
+
 
 	}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/splitter/FileSplitterTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/splitter/FileSplitterTests.java
@@ -196,6 +196,7 @@ public class FileSplitterTests {
 		fileMarker = (FileSplitter.FileMarker) received.getPayload();
 		assertEquals(FileSplitter.FileMarker.Mark.END, fileMarker.getMark());
 		assertEquals(file.getAbsolutePath(), fileMarker.getFilePath());
+		assertEquals(2, fileMarker.getLineCount());
 	}
 
 	@Configuration


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3739

Since iterating splitters don't have a sequence size, it would be useful to
include a line count in the EOF marker, to facilitate some downstream process
knowing that all lines have been processed, in a multi-threaded situation.

**cherry-pick to 4.1.x**

**includes the changes in #1465 and should be merged after that**

(rework may be needed if that PR needs polish)
