### PR TITLE
INT-3642: Improve MessageGroupStore Removal

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -26,6 +26,7 @@ import org.springframework.messaging.Message;
  *
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 2.1
  */
 public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler {
@@ -64,9 +65,7 @@ public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler
 			remove(messageGroup);
 		}
 		else {
-			for (Message<?> message : messageGroup.getMessages()) {
-				this.messageStore.removeMessageFromGroup(messageGroup.getGroupId(), message);
-			}
+			this.messageStore.removeMessagesFromGroup(messageGroup.getGroupId(), messageGroup.getMessages());
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageBarrier.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageBarrier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -43,6 +43,7 @@ import org.springframework.messaging.Message;
  *
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  *
  * @see AbstractCorrelatingMessageHandler
  */
@@ -118,7 +119,7 @@ public class CorrelatingMessageBarrier extends AbstractMessageHandler implements
 						Iterator<Message<?>> messages = group.getMessages().iterator();
 						if (messages.hasNext()) {
 							nextMessage = messages.next();
-							store.removeMessageFromGroup(key, nextMessage);
+							this.store.removeMessagesFromGroup(key, nextMessage);
 							if (log.isDebugEnabled()) {
 								log.debug(String.format("Released message for key [%s]: %s.", key, nextMessage));
 							}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -25,6 +25,7 @@ import org.springframework.messaging.Message;
  * Will remove {@link MessageGroup}s only if 'sequenceSize' is provided and reached.
  *
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  * @since 2.1
  */
 public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandler {
@@ -83,9 +84,7 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 			if (completedMessages != null){
 				int lastReleasedSequenceNumber = this.findLastReleasedSequenceNumber(messageGroup.getGroupId(), completedMessages);
 				messageStore.setLastReleasedSequenceNumberForGroup(messageGroup.getGroupId(), lastReleasedSequenceNumber);
-				for (Message<?> msg : completedMessages) {
-					this.messageStore.removeMessageFromGroup(messageGroup.getGroupId(), msg);
-				}
+				this.messageStore.removeMessagesFromGroup(messageGroup.getGroupId(), completedMessages);
 			}
 			if (timeout) {
 				this.messageStore.completeGroup(messageGroup.getGroupId());

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -352,7 +352,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 
 	private void doReleaseMessage(Message<?> message) {
 		if (removeDelayedMessageFromMessageStore(message)) {
-			this.messageStore.removeMessageFromGroup(this.messageGroupId, message);
+			this.messageStore.removeMessagesFromGroup(this.messageGroupId, message);
 			this.handleMessageInternal(message);
 		}
 		else {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractBatchingMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractBatchingMessageGroupStore.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.store;
+
+
+/**
+ * @author Gary Russell
+ * @since 4.2
+ *
+ */
+public abstract class AbstractBatchingMessageGroupStore implements BasicMessageGroupStore {
+
+	private static final int DEFAULT_REMOVE_BATCH_SIZE = 100;
+
+	private volatile int removeBatchSize = DEFAULT_REMOVE_BATCH_SIZE;
+
+	/**
+	 * Set the batch size when bulk removing messages from groups for message stores
+	 * that support batch removal.
+	 * Default 100.
+	 * @param removeBatchSize the batch size.
+	 * @since 4.2
+	 */
+	public void setRemoveBatchSize(int removeBatchSize) {
+		this.removeBatchSize = removeBatchSize;
+	}
+
+	public int getRemoveBatchSize() {
+		return removeBatchSize;
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -13,6 +13,7 @@
 
 package org.springframework.integration.store;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 
@@ -163,6 +164,11 @@ public abstract class AbstractMessageGroupStore implements MessageGroupStore, It
 	@Override
 	public MessageGroupMetadata getGroupMetadata(Object groupId) {
 		throw new UnsupportedOperationException("Not yet implemented for this store");
+	}
+
+	@Override
+	public void removeMessagesFromGroup(Object key, Message<?>... messages) {
+		removeMessagesFromGroup(key, Arrays.asList(messages));
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -40,8 +40,8 @@ import org.springframework.messaging.Message;
  */
 @ManagedResource
 @IntegrationManagedResource
-public abstract class AbstractMessageGroupStore implements MessageGroupStore, Iterable<MessageGroup>,
-		BeanFactoryAware {
+public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageGroupStore
+		implements MessageGroupStore, Iterable<MessageGroup>, BeanFactoryAware {
 
 	protected final Log logger = LogFactory.getLog(getClass());
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,8 +50,6 @@ public class MessageGroupMetadata implements Serializable {
 
 	private final boolean hasMessages;
 
-	private final int size;
-
 	private final UUID first;
 
 	public MessageGroupMetadata(MessageGroup messageGroup) {
@@ -66,10 +64,6 @@ public class MessageGroupMetadata implements Serializable {
 			for (Message<?> message : messageGroup.getMessages()) {
 				this.messageIds.add(message.getHeaders().getId());
 			}
-			this.size = this.messageIds.size();
-		}
-		else {
-			this.size = messageGroup.size();
 		}
 		this.complete = messageGroup.isComplete();
 		this.timestamp = messageGroup.getTimestamp();
@@ -102,7 +96,7 @@ public class MessageGroupMetadata implements Serializable {
 	}
 
 	public int size(){
-		return this.size;
+		return this.messageIds.size();
 	}
 
 	public UUID firstId(){

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -12,6 +12,7 @@
  */
 package org.springframework.integration.store;
 
+import java.util.Collection;
 import java.util.Iterator;
 
 import org.springframework.jmx.export.annotation.ManagedAttribute;
@@ -50,7 +51,7 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	int getMessageGroupCount();
 
 	/**
-	 * Persist a deletion on a single message from the group. The group is modified to reflect that 'messageToRemove' is
+	 * Persist the deletion of a single message from the group. The group is modified to reflect that 'messageToRemove' is
 	 * no longer present in the group.
 	 *
 	 * @param key The groupId for the group containing the message.
@@ -58,6 +59,26 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	 * @return The message Group.
 	 */
 	MessageGroup removeMessageFromGroup(Object key, Message<?> messageToRemove);
+
+	/**
+	 * Persist the deletion of messages from the group.
+	 *
+	 * @param key The groupId for the group containing the message(s).
+	 * @param messages The messages to be removed.
+	 *
+	 * @since 4.2
+	 */
+	void removeMessagesFromGroup(Object key, Collection<Message<?>> messages);
+
+	/**
+	 * Persist the deletion of messages from the group.
+	 *
+	 * @param key The groupId for the group containing the message(s).
+	 * @param messages The messages to be removed.
+	 *
+	 * @since 4.2
+	 */
+	void removeMessagesFromGroup(Object key, Message<?>... messages);
 
 	/**
 	 * Register a callback for when a message group is expired through {@link #expireMessageGroups(long)}.

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,10 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.junit.Test;
+
+import org.springframework.integration.store.MessageGroupStore.MessageGroupCallback;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.integration.store.MessageGroupStore.MessageGroupCallback;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -40,6 +41,7 @@ public class MessageStoreTests {
 	public void shouldRegisterCallbacks() throws Exception {
 		TestMessageStore store = new TestMessageStore();
 		store.setExpiryCallbacks(Arrays.<MessageGroupCallback> asList(new MessageGroupStore.MessageGroupCallback() {
+			@Override
 			public void execute(MessageGroupStore messageGroupStore, MessageGroup group) {
 			}
 		}));
@@ -52,6 +54,7 @@ public class MessageStoreTests {
 		TestMessageStore store = new TestMessageStore();
 		final List<String> list = new ArrayList<String>();
 		store.registerMessageGroupExpiryCallback(new MessageGroupCallback() {
+			@Override
 			public void execute(MessageGroupStore messageGroupStore, MessageGroup group) {
 				list.add(group.getOne().getPayload().toString());
 				messageGroupStore.removeMessageGroup(group.getGroupId());
@@ -84,41 +87,55 @@ public class MessageStoreTests {
 		private boolean removed = false;
 
 
+		@Override
 		public Iterator<MessageGroup> iterator() {
 			return Arrays.asList(testMessages).iterator();
 		}
 
+		@Override
 		public MessageGroup addMessageToGroup(Object correlationKey, Message<?> message) {
 			throw new UnsupportedOperationException();
 		}
 
+		@Override
 		public MessageGroup getMessageGroup(Object correlationKey) {
 			return removed ? new SimpleMessageGroup(correlationKey) : testMessages;
 		}
 
+		@Override
 		public MessageGroup removeMessageFromGroup(Object key, Message<?> messageToRemove) {
 			throw new UnsupportedOperationException();
 		}
 
+		@Override
+		public void removeMessagesFromGroup(Object key, Collection<Message<?>> messages) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
 		public void removeMessageGroup(Object correlationKey) {
 			if (correlationKey.equals(testMessages.getGroupId())) {
 				removed = true;
 			}
 		}
 
+		@Override
 		public void setLastReleasedSequenceNumberForGroup(Object groupId, int sequenceNumber) {
 			throw new UnsupportedOperationException();
 		}
 
+		@Override
 		public void completeGroup(Object groupId) {
 
 			throw new UnsupportedOperationException();
 		}
 
+		@Override
 		public Message<?> pollMessageFromGroup(Object groupId) {
 			return null;
 		}
 
+		@Override
 		public int messageGroupSize(Object groupId) {
 			return 0;
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageStoreTests.java
@@ -161,8 +161,10 @@ public class SimpleMessageStoreTests {
 			messageStore.addMessageToGroup(groupId, message);
 			messages.add(message);
 		}
-		messageStore.removeMessagesFromGroup(groupId, messages);
 		MessageGroup group = messageStore.getMessageGroup(groupId);
+		assertEquals(25, group.size());
+		messageStore.removeMessagesFromGroup(groupId, messages);
+		group = messageStore.getMessageGroup(groupId);
 		assertEquals(0, group.size());
 	}
 

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import org.junit.After;
@@ -30,6 +32,7 @@ import org.springframework.data.gemfire.CacheFactoryBean;
 import org.springframework.data.gemfire.RegionFactoryBean;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.history.MessageHistory;
+import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
@@ -96,6 +99,23 @@ public class GemfireMessageStoreTests {
 		Properties fooChannelHistory = messageHistory.get(0);
 		assertEquals("fooChannel", fooChannelHistory.get("name"));
 		assertEquals("channel", fooChannelHistory.get("type"));
+	}
+
+	@Test
+	public void testAddAndRemoveMessagesFromMessageGroup() throws Exception {
+		GemfireMessageStore messageStore = new GemfireMessageStore(this.cache);
+		messageStore.afterPropertiesSet();
+
+		String groupId = "X";
+		List<Message<?>> messages = new ArrayList<Message<?>>();
+		for (int i = 0; i < 25; i++) {
+			Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
+			messageStore.addMessageToGroup(groupId, message);
+			messages.add(message);
+		}
+		messageStore.removeMessagesFromGroup(groupId, messages);
+		MessageGroup group = messageStore.getMessageGroup(groupId);
+		assertEquals(0, group.size());
 	}
 
 	@Before

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
@@ -103,7 +103,7 @@ public class GemfireMessageStoreTests {
 
 	@Test
 	public void testAddAndRemoveMessagesFromMessageGroup() throws Exception {
-		GemfireMessageStore messageStore = new GemfireMessageStore(this.cache);
+		GemfireMessageStore messageStore = new GemfireMessageStore(this.region);
 		messageStore.afterPropertiesSet();
 
 		String groupId = "X";
@@ -113,8 +113,10 @@ public class GemfireMessageStoreTests {
 			messageStore.addMessageToGroup(groupId, message);
 			messages.add(message);
 		}
-		messageStore.removeMessagesFromGroup(groupId, messages);
 		MessageGroup group = messageStore.getMessageGroup(groupId);
+		assertEquals(25, group.size());
+		messageStore.removeMessagesFromGroup(groupId, messages);
+		group = messageStore.getMessageGroup(groupId);
 		assertEquals(0, group.size());
 	}
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreTests.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -242,6 +244,23 @@ public class JdbcMessageStoreTests {
 		Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
 		messageStore.addMessageToGroup(groupId, message);
 		messageStore.removeMessageFromGroup(groupId, message);
+		MessageGroup group = messageStore.getMessageGroup(groupId);
+		assertEquals(0, group.size());
+	}
+
+	@Test
+	@Transactional
+	@DirtiesContext
+	public void testAddAndRemoveMessagesFromMessageGroup() throws Exception {
+		String groupId = "X";
+		messageStore.setMaxRemovalsPerQuery(10);
+		List<Message<?>> messages = new ArrayList<Message<?>>();
+		for (int i = 0; i < 25; i++) {
+			Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
+			messageStore.addMessageToGroup(groupId, message);
+			messages.add(message);
+		}
+		messageStore.removeMessagesFromGroup(groupId, messages);
 		MessageGroup group = messageStore.getMessageGroup(groupId);
 		assertEquals(0, group.size());
 	}

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreTests.java
@@ -253,15 +253,17 @@ public class JdbcMessageStoreTests {
 	@DirtiesContext
 	public void testAddAndRemoveMessagesFromMessageGroup() throws Exception {
 		String groupId = "X";
-		messageStore.setMaxRemovalsPerQuery(10);
+		messageStore.setRemoveBatchSize(10);
 		List<Message<?>> messages = new ArrayList<Message<?>>();
 		for (int i = 0; i < 25; i++) {
 			Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
 			messageStore.addMessageToGroup(groupId, message);
 			messages.add(message);
 		}
-		messageStore.removeMessagesFromGroup(groupId, messages);
 		MessageGroup group = messageStore.getMessageGroup(groupId);
+		assertEquals(25, group.size());
+		messageStore.removeMessagesFromGroup(groupId, messages);
+		group = messageStore.getMessageGroup(groupId);
 		assertEquals(0, group.size());
 	}
 

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
@@ -49,6 +49,7 @@ import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.integration.store.AbstractBatchingMessageGroupStore;
 import org.springframework.integration.store.BasicMessageGroupStore;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
@@ -65,8 +66,8 @@ import org.springframework.util.Assert;
  * @since 4.0
  */
 
-public abstract class AbstractConfigurableMongoDbMessageStore implements BasicMessageGroupStore, InitializingBean,
-		ApplicationContextAware {
+public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractBatchingMessageGroupStore
+		implements BasicMessageGroupStore, InitializingBean, ApplicationContextAware {
 
 	public final static String SEQUENCE_NAME = "messagesSequence";
 

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -335,19 +335,13 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 	}
 
 	private void bulkRemove(Object groupId, Collection<UUID> ids) {
-		if (ids.size() > 0) {
-			BulkWriteOperation bulkOp = this.template.getCollection(this.collectionName)
-					.initializeOrderedBulkOperation();
-			for (UUID id : ids) {
-				bulkOp.find(whereMessageIdIsAndGroupIdIs(id, groupId).getQueryObject()).remove();
-			}
-			bulkOp.execute();
+		BulkWriteOperation bulkOp = this.template.getCollection(this.collectionName)
+				.initializeOrderedBulkOperation();
+		for (UUID id : ids) {
+			bulkOp.find(whereMessageIdIsAndGroupIdIs(id, groupId).getQueryObject())
+				  .remove();
 		}
-		else {
-			if (logger.isDebugEnabled()) {
-				logger.debug("no messages found to delete");
-			}
-		}
+		bulkOp.execute();
 	}
 
 	@Override

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.mongodb.store;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -311,6 +312,18 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 				MessageWrapper.class, collectionName);
 		updateGroup(groupId, lastModifiedUpdate());
 		return getMessageGroup(groupId);
+	}
+
+	@Override
+	public void removeMessagesFromGroup(Object groupId, Collection<Message<?>> messages) {
+		Assert.notNull(groupId, "'groupId' must not be null");
+		Assert.notNull(messages, "'messageToRemove' must not be null");
+
+		for (Message<?> messageToRemove : messages) {
+			template.findAndRemove(whereMessageIdIsAndGroupIdIs(messageToRemove.getHeaders().getId(), groupId),
+					MessageWrapper.class, collectionName);
+		}
+		updateGroup(groupId, lastModifiedUpdate());
 	}
 
 	@Override

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageStoreTests.java
@@ -23,8 +23,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -37,8 +35,6 @@ import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.message.AdviceMessage;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
 import org.springframework.integration.mongodb.rules.MongoDbAvailableTests;
-import org.springframework.integration.store.MessageGroup;
-import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.MessageStore;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.MutableMessageBuilder;
@@ -263,22 +259,6 @@ public abstract class AbstractMongoDbMessageStoreTests extends MongoDbAvailableT
 				containsString("intentional MessagingException"));
 		assertEquals(failedMessage, ((MessagingException) retrievedMessage.getPayload()).getFailedMessage());
 		assertEquals(messageToStore.getHeaders(), retrievedMessage.getHeaders());
-	}
-
-	@Test
-	@MongoDbAvailable
-	public void testAddAndRemoveMessagesFromMessageGroup() throws Exception {
-		MessageGroupStore messageStore = (MessageGroupStore) this.getMessageStore();
-		String groupId = "X";
-		List<Message<?>> messages = new ArrayList<Message<?>>();
-		for (int i = 0; i < 25; i++) {
-			Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
-			messageStore.addMessageToGroup(groupId, message);
-			messages.add(message);
-		}
-		messageStore.removeMessagesFromGroup(groupId, messages);
-		MessageGroup group = messageStore.getMessageGroup(groupId);
-		assertEquals(0, group.size());
 	}
 
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageStoreTests.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -35,6 +37,8 @@ import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.message.AdviceMessage;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
 import org.springframework.integration.mongodb.rules.MongoDbAvailableTests;
+import org.springframework.integration.store.MessageGroup;
+import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.MessageStore;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.MutableMessageBuilder;
@@ -259,6 +263,22 @@ public abstract class AbstractMongoDbMessageStoreTests extends MongoDbAvailableT
 				containsString("intentional MessagingException"));
 		assertEquals(failedMessage, ((MessagingException) retrievedMessage.getPayload()).getFailedMessage());
 		assertEquals(messageToStore.getHeaders(), retrievedMessage.getHeaders());
+	}
+
+	@Test
+	@MongoDbAvailable
+	public void testAddAndRemoveMessagesFromMessageGroup() throws Exception {
+		MessageGroupStore messageStore = (MessageGroupStore) this.getMessageStore();
+		String groupId = "X";
+		List<Message<?>> messages = new ArrayList<Message<?>>();
+		for (int i = 0; i < 25; i++) {
+			Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
+			messageStore.addMessageToGroup(groupId, message);
+			messages.add(message);
+		}
+		messageStore.removeMessagesFromGroup(groupId, messages);
+		MessageGroup group = messageStore.getMessageGroup(groupId);
+		assertEquals(0, group.size());
 	}
 
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
@@ -15,12 +15,12 @@
  */
 package org.springframework.integration.mongodb.store;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 import java.util.Map;
 
-import com.mongodb.DBObject;
-import com.mongodb.MongoClient;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -38,6 +38,9 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 
+import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
+
 /**
  * @author Amol Nayak
  * @author Artem Bilan
@@ -45,9 +48,6 @@ import org.springframework.messaging.Message;
  */
 public class ConfigurableMongoDbMessageGroupStoreTests extends AbstractMongoDbMessageGroupStoreTests {
 
-	/* (non-Javadoc)
-	 * @see org.springframework.integration.mongodb.store.AbstractMongoDbMessageGroupStoreTests#getMessageGroupStore()
-	 */
 	@Override
 	protected ConfigurableMongoDbMessageStore getMessageGroupStore() throws Exception {
 		MongoDbFactory mongoDbFactory = new SimpleMongoDbFactory(new MongoClient(), "test");
@@ -59,9 +59,6 @@ public class ConfigurableMongoDbMessageGroupStoreTests extends AbstractMongoDbMe
 		return mongoDbMessageStore;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.springframework.integration.mongodb.store.AbstractMongoDbMessageGroupStoreTests#getMessageStore()
-	 */
 	@Override
 	protected MessageStore getMessageStore() throws Exception {
 		return this.getMessageGroupStore();

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2014 the original author or authors
+ * Copyright 2007-2015 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -29,8 +29,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.AssertionFailedError;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -51,6 +49,8 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 
+import junit.framework.AssertionFailedError;
+
 /**
  * @author Oleg Zhurakousky
  * @author Artem Bilan
@@ -62,7 +62,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Before
 	@After
 	public void setUpTearDown() {
-		StringRedisTemplate template = this.createStringRedisTemplate(this.getConnectionFactoryForTest());
+		StringRedisTemplate template = createStringRedisTemplate(getConnectionFactoryForTest());
 		template.delete("MESSAGE_GROUP_1");
 		template.delete("MESSAGE_GROUP_2");
 		template.delete("MESSAGE_GROUP_3");
@@ -71,7 +71,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testNonExistingEmptyMessageGroup() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
@@ -83,7 +83,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testMessageGroupUpdatedDateChangesWithEachAddedMessage() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
@@ -110,7 +110,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testMessageGroupWithAddedMessage() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
@@ -128,7 +128,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testRemoveMessageGroup() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
@@ -155,7 +155,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testCompleteMessageGroup() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
@@ -169,7 +169,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testLastReleasedSequenceNumber() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
@@ -183,7 +183,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testRemoveMessageFromTheGroup() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
@@ -206,7 +206,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testWithMessageHistory() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 
 		store.getMessageGroup(1);
@@ -233,7 +233,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testRemoveNonExistingMessageFromTheGroup() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
@@ -244,7 +244,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testRemoveNonExistingMessageFromNonExistingTheGroup() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 		store.removeMessageFromGroup(1, new GenericMessage<String>("2"));
 	}
@@ -254,7 +254,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testMultipleInstancesOfGroupStore() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store1 = new RedisMessageStore(jcf);
 
 		RedisMessageStore store2 = new RedisMessageStore(jcf);
@@ -275,7 +275,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testIteratorOfMessageGroups() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store1 = new RedisMessageStore(jcf);
 		RedisMessageStore store2 = new RedisMessageStore(jcf);
 
@@ -317,7 +317,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable @Ignore
 	public void testConcurrentModifications() throws Exception{
-		RedisConnectionFactory jcf = this.getConnectionFactoryForTest();
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		final RedisMessageStore store1 = new RedisMessageStore(jcf);
 		final RedisMessageStore store2 = new RedisMessageStore(jcf);
 
@@ -361,7 +361,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	@Test
 	@RedisAvailable
 	public void testWithAggregatorWithShutdown(){
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("redis-aggregator-config.xml", this.getClass());
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("redis-aggregator-config.xml", getClass());
 		MessageChannel input = context.getBean("inputChannel", MessageChannel.class);
 		QueueChannel output = context.getBean("outputChannel", QueueChannel.class);
 
@@ -373,7 +373,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 		assertNull(output.receive(1000));
 		context.close();
 
-		context = new ClassPathXmlApplicationContext("redis-aggregator-config.xml", this.getClass());
+		context = new ClassPathXmlApplicationContext("redis-aggregator-config.xml", getClass());
 		input = context.getBean("inputChannel", MessageChannel.class);
 		output = context.getBean("outputChannel", QueueChannel.class);
 
@@ -381,6 +381,27 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 		input.send(m3);
 		assertNotNull(output.receive(1000));
 		context.close();
+	}
+
+	@Test
+	@RedisAvailable
+	public void testAddAndRemoveMessagesFromMessageGroup() throws Exception {
+		RedisConnectionFactory jcf = getConnectionFactoryForTest();
+		RedisMessageStore messageStore = new RedisMessageStore(jcf);
+		String groupId = "X";
+		messageStore.removeMessageGroup("X");
+		List<Message<?>> messages = new ArrayList<Message<?>>();
+		for (int i = 0; i < 25; i++) {
+			Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
+			messageStore.addMessageToGroup(groupId, message);
+			messages.add(message);
+		}
+		MessageGroup group = messageStore.getMessageGroup(groupId);
+		assertEquals(25, group.size());
+		messageStore.removeMessagesFromGroup(groupId, messages);
+		group = messageStore.getMessageGroup(groupId);
+		assertEquals(0, group.size());
+		messageStore.removeMessageGroup("X");
 	}
 
 }

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -168,3 +168,12 @@ metadata store if it implements `Flushable` (e.g. the `PropertiesPersistenMetada
 
 When using Java 8, gateway methods can now return `CompletableFuture<?>`.
 See <<gw-completable-future>> for more information.
+
+[[x4.2-aggregator-perf]]
+==== Aggregator Performance
+
+This release includes some performance improvements for aggregating components (aggregator, resequencer, etc),
+by more efficiently removing messages from groups when they are released.
+New methods (`removeMessagesFromGroup`) have been added to the message store.
+Set the `removeBatchSize` property (default `100`) to adjust the number of messages deleted in each operation.
+Currently, JDBC, Redis and MongoDB message stores support this property.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3642

Currently, `removeMessageFromGroup` rebuilds the group on every removal.

In every case where this method is used in the framework, the result is not used.

Add `removeMessagesFromGroup` that removes a collection of messages and returns no result.
