### PR TITLE
INT-3744: Fix IMAPMessage receivedDate

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.mail;
 
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
@@ -434,8 +435,11 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 	 */
 	private class IntegrationMimeMessage extends MimeMessage {
 
+		private final MimeMessage source;
+
 		public IntegrationMimeMessage(MimeMessage source) throws MessagingException {
 			super(source);
+			this.source = source;
 		}
 
 		@Override
@@ -448,5 +452,14 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 			}
 		}
 
+		@Override
+		public Date getReceivedDate() throws MessagingException {
+			/*
+			 * Basic MimeMessage always returns null; delegate to the original.
+			 */
+			return source.getReceivedDate();
+		}
+
 	}
+
 }

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
@@ -157,7 +157,11 @@ public class ImapMailReceiverTests {
 		adapter.setOutputChannel(channel);
 		adapter.setTaskScheduler(taskScheduler);
 		adapter.start();
-		assertNotNull(channel.receive(6000));
+		@SuppressWarnings("unchecked")
+		org.springframework.messaging.Message<MimeMessage> received =
+				(org.springframework.messaging.Message<MimeMessage>) channel.receive(6000);
+		assertNotNull(received);
+		assertNotNull(received.getPayload().getReceivedDate());
 		assertNotNull(channel.receive(6000)); // new message after idle
 		assertNull(channel.receive(10000)); // no new message after second and third idle
 		verify(logger).debug("Canceling IDLE");
@@ -755,9 +759,9 @@ public class ImapMailReceiverTests {
 
 			@Override
 			public void publishEvent(Object event) {
-				
+
 			}
-			
+
 		});
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 		taskScheduler.initialize();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3744

MimeMessages are copied to eagerly fetch IMAP messages, this process loses
the `receivedDate` property.

Keep a reference to the source Message and delegate to its `receiveDate()`.

**cherry-pick to 4.1.x, 4.0.x, 3.0.x**
