### PR TITLE
INT-3745: More TCP Events (Failed Correlation)

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandler.java
@@ -20,8 +20,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.Lifecycle;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.ip.tcp.connection.AbstractClientConnectionFactory;
@@ -30,8 +30,11 @@ import org.springframework.integration.ip.tcp.connection.ClientModeCapable;
 import org.springframework.integration.ip.tcp.connection.ClientModeConnectionManager;
 import org.springframework.integration.ip.tcp.connection.ConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.TcpConnection;
+import org.springframework.integration.ip.tcp.connection.TcpConnectionFailedCorrelationEvent;
 import org.springframework.integration.ip.tcp.connection.TcpSender;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.MessagingException;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 
@@ -110,7 +113,10 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 			}
 			else {
 				logger.error("Unable to find outbound socket for " + message);
-				throw new MessageHandlingException(message, "Unable to find outbound socket");
+				MessageHandlingException messageHandlingException = new MessageHandlingException(message,
+						"Unable to find outbound socket");
+				publishNoConnectionEvent(message, (String) connectionId);
+				throw messageHandlingException;
 			}
 			return;
 		}
@@ -159,6 +165,16 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 		}
 	}
 
+	private void publishNoConnectionEvent(Message<?> message, String connectionId) {
+		AbstractConnectionFactory cf = this.serverConnectionFactory != null ? this.serverConnectionFactory
+				: this.clientConnectionFactory;
+		ApplicationEventPublisher applicationEventPublisher = cf.getApplicationEventPublisher();
+		if (applicationEventPublisher != null) {
+			applicationEventPublisher.publishEvent(
+				new TcpConnectionFailedCorrelationEvent(this, connectionId, new MessagingException(message)));
+		}
+	}
+
 	/**
 	 * Sets the client or server connection factory; for this (an outbound adapter), if
 	 * the factory is a server connection factory, the sockets are owned by a receiving
@@ -175,10 +191,12 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 		}
 	}
 
+	@Override
 	public void addNewConnection(TcpConnection connection) {
 		connections.put(connection.getConnectionId(), connection);
 	}
 
+	@Override
 	public void removeDeadConnection(TcpConnection connection) {
 		connections.remove(connection.getConnectionId());
 	}
@@ -199,6 +217,7 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 		}
 	}
 
+	@Override
 	public void start() {
 		synchronized (this.lifecycleMonitor) {
 			if (!this.active) {
@@ -220,6 +239,7 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 		}
 	}
 
+	@Override
 	public void stop() {
 		synchronized (this.lifecycleMonitor) {
 			if (this.active) {
@@ -237,6 +257,7 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 		}
 	}
 
+	@Override
 	public boolean isRunning() {
 		return this.active;
 	}
@@ -283,6 +304,7 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 	/**
 	 * @return the isClientMode
 	 */
+	@Override
 	public boolean isClientMode() {
 		return this.isClientMode;
 	}
@@ -315,6 +337,7 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 		this.retryInterval = retryInterval;
 	}
 
+	@Override
 	public boolean isClientModeConnected() {
 		if (this.isClientMode && this.clientModeConnectionManager != null) {
 			return this.clientModeConnectionManager.isConnected();
@@ -323,6 +346,7 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 		}
 	}
 
+	@Override
 	public void retryConnection() {
 		if (this.active && this.isClientMode && this.clientModeConnectionManager != null) {
 			this.clientModeConnectionManager.run();

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandler.java
@@ -34,7 +34,6 @@ import org.springframework.integration.ip.tcp.connection.TcpConnectionFailedCorr
 import org.springframework.integration.ip.tcp.connection.TcpSender;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
-import org.springframework.messaging.MessagingException;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 
@@ -115,7 +114,7 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 				logger.error("Unable to find outbound socket for " + message);
 				MessageHandlingException messageHandlingException = new MessageHandlingException(message,
 						"Unable to find outbound socket");
-				publishNoConnectionEvent(message, (String) connectionId);
+				publishNoConnectionEvent(messageHandlingException, (String) connectionId);
 				throw messageHandlingException;
 			}
 			return;
@@ -165,13 +164,13 @@ public class TcpSendingMessageHandler extends AbstractMessageHandler implements
 		}
 	}
 
-	private void publishNoConnectionEvent(Message<?> message, String connectionId) {
+	private void publishNoConnectionEvent(MessageHandlingException messageHandlingException, String connectionId) {
 		AbstractConnectionFactory cf = this.serverConnectionFactory != null ? this.serverConnectionFactory
 				: this.clientConnectionFactory;
 		ApplicationEventPublisher applicationEventPublisher = cf.getApplicationEventPublisher();
 		if (applicationEventPublisher != null) {
 			applicationEventPublisher.publishEvent(
-				new TcpConnectionFailedCorrelationEvent(this, connectionId, new MessagingException(message)));
+				new TcpConnectionFailedCorrelationEvent(this, connectionId, messageHandlingException));
 		}
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -147,7 +147,7 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 		}
 	}
 
-	protected ApplicationEventPublisher getApplicationEventPublisher() {
+	public ApplicationEventPublisher getApplicationEventPublisher() {
 		return applicationEventPublisher;
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionFailedCorrelationEvent.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionFailedCorrelationEvent.java
@@ -16,6 +16,7 @@
 package org.springframework.integration.ip.tcp.connection;
 
 import org.springframework.integration.ip.event.IpIntegrationEvent;
+import org.springframework.messaging.MessagingException;
 
 
 
@@ -33,7 +34,7 @@ public class TcpConnectionFailedCorrelationEvent extends IpIntegrationEvent {
 
 	private final String connectionId;
 
-	public TcpConnectionFailedCorrelationEvent(Object source, String connectionId, Throwable cause) {
+	public TcpConnectionFailedCorrelationEvent(Object source, String connectionId, MessagingException cause) {
 		super(source, cause);
 		this.connectionId = connectionId;
 	}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionFailedCorrelationEvent.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionFailedCorrelationEvent.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.ip.tcp.connection;
+
+import org.springframework.integration.ip.event.IpIntegrationEvent;
+
+
+
+/**
+ * An event emitted when an endpoint cannot correlate a connection id to a
+ * connection; the cause is a messaging exception with the failed message.
+ *
+ * @author Gary Russell
+ * @since 4.2
+ *
+ */
+public class TcpConnectionFailedCorrelationEvent extends IpIntegrationEvent {
+
+	private static final long serialVersionUID = -7460880274740273542L;
+
+	private final String connectionId;
+
+	public TcpConnectionFailedCorrelationEvent(Object source, String connectionId, Throwable cause) {
+		super(source, cause);
+		this.connectionId = connectionId;
+	}
+
+	public String getConnectionId() {
+		return connectionId;
+	}
+
+	@Override
+	public String toString() {
+		return super.toString() +
+				", [connectionId=" + this.connectionId + "]";
+	}
+
+}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
@@ -30,6 +30,7 @@ import org.springframework.core.serializer.Deserializer;
 import org.springframework.core.serializer.Serializer;
 import org.springframework.integration.ip.tcp.serializer.SoftEndOfStreamException;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 import org.springframework.scheduling.SchedulingAwareRunnable;
 
 /**
@@ -105,7 +106,7 @@ public class TcpNetConnection extends TcpConnectionSupport implements Scheduling
 			this.socketOutputStream.flush();
 		}
 		catch (Exception e) {
-			this.publishConnectionExceptionEvent(e);
+			this.publishConnectionExceptionEvent(new MessagingException(message, e));
 			this.closeConnection(true);
 			throw e;
 		}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -43,6 +43,7 @@ import org.springframework.core.serializer.Serializer;
 import org.springframework.integration.ip.tcp.serializer.SoftEndOfStreamException;
 import org.springframework.integration.util.CompositeExecutor;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
 
 /**
@@ -150,7 +151,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 				this.bufferedOutputStream.flush();
 			}
 			catch (Exception e) {
-				this.publishConnectionExceptionEvent(e);
+				this.publishConnectionExceptionEvent(new MessagingException(message, e));
 				this.closeConnection(true);
 				throw e;
 			}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionEventTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionEventTests.java
@@ -141,7 +141,7 @@ public class ConnectionEventTests {
 	}
 
 	@Test
-	public void testOCANoConnectionEvents() {
+	public void testOutboundChannelAdapterNoConnectionEvents() {
 		TcpSendingMessageHandler handler = new TcpSendingMessageHandler();
 		AbstractServerConnectionFactory scf = new AbstractServerConnectionFactory(0) {
 
@@ -181,7 +181,7 @@ public class ConnectionEventTests {
 	}
 
 	@Test
-	public void testIGNoConnectionEvents() {
+	public void testInboundGatewayNoConnectionEvents() {
 		TcpInboundGateway gw = new TcpInboundGateway();
 		AbstractServerConnectionFactory scf = new AbstractServerConnectionFactory(0) {
 
@@ -224,7 +224,7 @@ public class ConnectionEventTests {
 	}
 
 	@Test
-	public void testOGNoConnectionEvents() {
+	public void testOutboundGatewayNoConnectionEvents() {
 		TcpOutboundGateway gw = new TcpOutboundGateway();
 		AbstractClientConnectionFactory ccf = new AbstractClientConnectionFactory("localhost", 0) {
 		};

--- a/src/reference/asciidoc/ip.adoc
+++ b/src/reference/asciidoc/ip.adoc
@@ -373,8 +373,14 @@ In addition, since _version 4.0_ the standard deserializers discussed in <<conne
 These events contain the exception, the buffer that was in the process of being built, and an offset into the buffer (if available) at the point the exception occurred.
 Applications can use a normal `ApplicationListener`, or see <<applicationevent-inbound>>, to capture these events, allowing analysis of the problem.
 
-Starting with _versions 4.0.7, 4.1.3_`TcpConnectionServerExceptionEvent` s are published whenever an unexpected exception occurs on a server socket (such as a `BindException` when the server socket is in use).
+Starting with _versions 4.0.7, 4.1.3_, `TcpConnectionServerExceptionEvent` s are published whenever an unexpected exception occurs on a server socket (such as a `BindException` when the server socket is in use).
 These events have a reference to the connection factory and the cause.
+
+Starting with _version 4.2_, `TcpConnectionFailedCorrelationEvent` s are published whenever an endpoint (inbound gateway or
+collaborating outbound channel adapter) receives a message that cannot be routed to a connection because the
+`ip_connectionId` header is invalid.
+Outbound gateways also publish this event when a late reply is received (the sender thread has timed out).
+The event contains the connection id as well as an exception in the `cause` property that contains the failed message.
 
 [[tcp-adapters]]
 === TCP Adapters

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -63,20 +63,22 @@ See <<files>> for more information.
 
 The `ScatterGatherHandler` class has been moved from the `org.springframework.integration.handler` to the `org.springframework.integration.scattergather`.
 
+==== TCP Changes
+
 [[x4.2-tcp-serializers]]
-==== TCP Serializers
+===== TCP Serializers
 
 The TCP `Serializers` no longer `flush()` the `OutputStream`; this is now done by the `TcpNxxConnection` classes.
 If you are using the serializers directly within user code, you may have to `flush()` the `OutputStream`.
 
 [[x4.2-tcp-server-exceptions]]
-==== Server Socket Exceptions
+===== Server Socket Exceptions
 
 `TcpConnectionServerExceptionEvent` s are now published whenever an unexpected exception occurs on a TCP server socket (also added to 4.1.3, 4.0.7).
 See <<tcp-events>> for more information.
 
 [[x4.2-tcp-gw-rto]]
-==== TCP Gateway Remote Timeout
+===== TCP Gateway Remote Timeout
 
 The `TcpOutboundGateway` now supports `remote-timeout-expression` as an alternative to the existing `remote-timeout` attribute.
 This allows setting the timeout based on each message.
@@ -86,13 +88,19 @@ Also, the `remote-timeout` no longer defaults to the same value as `reply-timeou
 See <<tcp-ob-gateway-attributes>> for more information.
 
 [[x4.2-tcp-ssl]]
-==== TCP SSLSession Available for Header Mapping
+===== TCP SSLSession Available for Header Mapping
 
 `TcpConnection` s now support `getSslSession()` to enable users to extract information from the session to add to
 message headers.
 
 See <<ip-msg-headers>> for more information.
 
+
+[[x4.2-tcp-events]]
+===== TCP Events
+
+New events are now published whenever a correlation exception occurs - for example sending a message to a
+non-existent socket. See <<tcp-events>> for more information.
 
 [[x4.2-inbound-channel-adapter-annotation]]
 ==== @InboundChannelAdapter


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3745

Emit events whenever a message is received that can't be correlated to
a connection (or request in the case of an outbound gateway).

Also, when sending messages, wrap the exception in a `MessagingException` so that
the `TcpConnectionExceptionEvent` provides access to the failed message.
