### PR TITLE
INT-3748 BridgeHandler should not copy request headers

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/BridgeHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/BridgeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.messaging.Message;
  *
  * @author Mark Fisher
  * @author Iwein Fuld
+ * @author Marius Bogoevici
  */
 public class BridgeHandler extends AbstractReplyProducingMessageHandler {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/BridgeHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/BridgeHandler.java
@@ -44,4 +44,8 @@ public class BridgeHandler extends AbstractReplyProducingMessageHandler {
 		return requestMessage;
 	}
 
+	@Override
+	protected boolean shouldCopyRequestHeaders() {
+		return false;
+	}
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderAtConfigTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderAtConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Marius Bogoevici
  */
 @ContextConfiguration(classes=MBConfig.class)
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -101,7 +102,7 @@ public class MessageBuilderAtConfigTests {
 
 		@Bean
 		public AbstractReplyProducingMessageHandler handler1() {
-			AbstractReplyProducingMessageHandler handler = new TestHandlers.RequestHeaderCopyingEchoHandler();
+			AbstractReplyProducingMessageHandler handler = new RequestHeaderCopyingEchoHandler();
 			handler.setOutputChannel(pubSub());
 			return handler;
 		}
@@ -116,7 +117,7 @@ public class MessageBuilderAtConfigTests {
 
 		@Bean
 		public AbstractReplyProducingMessageHandler handler2() {
-			AbstractReplyProducingMessageHandler handler = new TestHandlers.RequestHeaderCopyingEchoHandler();
+			AbstractReplyProducingMessageHandler handler = new RequestHeaderCopyingEchoHandler();
 			handler.setOutputChannel(out());
 			return handler;
 		}
@@ -131,11 +132,17 @@ public class MessageBuilderAtConfigTests {
 
 		@Bean
 		public AbstractReplyProducingMessageHandler handler3() {
-			AbstractReplyProducingMessageHandler handler = new TestHandlers.RequestHeaderCopyingEchoHandler();
+			AbstractReplyProducingMessageHandler handler = new RequestHeaderCopyingEchoHandler();
 			handler.setOutputChannel(out());
 			return handler;
 		}
 
 	}
 
+	private static class RequestHeaderCopyingEchoHandler extends AbstractReplyProducingMessageHandler {
+		@Override
+		protected Object handleRequestMessage(Message<?> requestMessage) {
+			return requestMessage;
+		}
+	}
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderAtConfigTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderAtConfigTests.java
@@ -30,7 +30,7 @@ import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.config.EnableIntegration;
-import org.springframework.integration.handler.BridgeHandler;
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.message.MessageBuilderAtConfigTests.MBConfig;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.MutableMessageBuilderFactory;
@@ -92,7 +92,7 @@ public class MessageBuilderAtConfigTests {
 		}
 
 		@Bean
-		public ConsumerEndpointFactoryBean bridge1() throws Exception {
+		public ConsumerEndpointFactoryBean echo1() throws Exception {
 			ConsumerEndpointFactoryBean factory = new ConsumerEndpointFactoryBean();
 			factory.setHandler(handler1());
 			factory.setInputChannel(in());
@@ -100,14 +100,14 @@ public class MessageBuilderAtConfigTests {
 		}
 
 		@Bean
-		public BridgeHandler handler1() {
-			BridgeHandler handler = new BridgeHandler();
+		public AbstractReplyProducingMessageHandler handler1() {
+			AbstractReplyProducingMessageHandler handler = new TestHandlers.RequestHeaderCopyingEchoHandler();
 			handler.setOutputChannel(pubSub());
 			return handler;
 		}
 
 		@Bean
-		public ConsumerEndpointFactoryBean bridge2() throws Exception {
+		public ConsumerEndpointFactoryBean echo2() throws Exception {
 			ConsumerEndpointFactoryBean factory = new ConsumerEndpointFactoryBean();
 			factory.setHandler(handler2());
 			factory.setInputChannel(pubSub());
@@ -115,14 +115,14 @@ public class MessageBuilderAtConfigTests {
 		}
 
 		@Bean
-		public BridgeHandler handler2() {
-			BridgeHandler handler = new BridgeHandler();
+		public AbstractReplyProducingMessageHandler handler2() {
+			AbstractReplyProducingMessageHandler handler = new TestHandlers.RequestHeaderCopyingEchoHandler();
 			handler.setOutputChannel(out());
 			return handler;
 		}
 
 		@Bean
-		public ConsumerEndpointFactoryBean bridge3() throws Exception {
+		public ConsumerEndpointFactoryBean echo3() throws Exception {
 			ConsumerEndpointFactoryBean factory = new ConsumerEndpointFactoryBean();
 			factory.setHandler(handler3());
 			factory.setInputChannel(pubSub());
@@ -130,8 +130,8 @@ public class MessageBuilderAtConfigTests {
 		}
 
 		@Bean
-		public BridgeHandler handler3() {
-			BridgeHandler handler = new BridgeHandler();
+		public AbstractReplyProducingMessageHandler handler3() {
+			AbstractReplyProducingMessageHandler handler = new TestHandlers.RequestHeaderCopyingEchoHandler();
 			handler.setOutputChannel(out());
 			return handler;
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderTests-context.xml
@@ -8,7 +8,7 @@
 	<int:channel id="in" />
 
 	<int:service-activator input-channel="in" output-channel="pub">
-		<bean class="org.springframework.integration.message.TestHandlers.RequestHeaderCopyingEchoHandler"/>
+		<bean class="org.springframework.integration.message.MessageBuilderAtConfigTests.RequestHeaderCopyingEchoHandler"/>
 	</int:service-activator>
 
 	<int:publish-subscribe-channel id="pub" />

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderTests-context.xml
@@ -7,7 +7,9 @@
 
 	<int:channel id="in" />
 
-	<int:bridge input-channel="in" output-channel="pub" />
+	<int:service-activator input-channel="in" output-channel="pub">
+		<bean class="org.springframework.integration.message.TestHandlers.RequestHeaderCopyingEchoHandler"/>
+	</int:service-activator>
 
 	<int:publish-subscribe-channel id="pub" />
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/TestHandlers.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/TestHandlers.java
@@ -90,10 +90,4 @@ public abstract class TestHandlers {
 		};
 	}
 
-	public static class RequestHeaderCopyingEchoHandler extends AbstractReplyProducingMessageHandler {
-		@Override
-		protected Object handleRequestMessage(Message<?> requestMessage) {
-			return requestMessage;
-		}
-	}
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/TestHandlers.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/TestHandlers.java
@@ -19,6 +19,7 @@ package org.springframework.integration.message;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.messaging.Message;
 
 /**
@@ -89,4 +90,10 @@ public abstract class TestHandlers {
 		};
 	}
 
+	public static class RequestHeaderCopyingEchoHandler extends AbstractReplyProducingMessageHandler {
+		@Override
+		protected Object handleRequestMessage(Message<?> requestMessage) {
+			return requestMessage;
+		}
+	}
 }


### PR DESCRIPTION
- override `shouldCopyRequestHeaders` to return false;
- modify existing tests (not specific to `BridgeHandler`) that rely on the fact that `BridgeHandler` copies headers and creates a new message instance to use a custom test handler with the expected behaviour;
