### PR TITLE
MessagingGatewaySupport - log exception stack trace.

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -336,7 +336,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint implement
 		}
 		catch (Exception e) {
 			if (logger.isDebugEnabled()) {
-				logger.debug("failure occurred in gateway sendAndReceive: " + e.getMessage());
+				logger.debug("failure occurred in gateway sendAndReceive", e);
 			}
 			error = e;
 		}


### PR DESCRIPTION
In one of recent commits, we've lowered logging level in case of error in org.springframework.integration.gateway.MessagingGatewaySupport from warn to debug.
See: https://github.com/spring-projects/spring-integration/commit/5f214ea5596e8b34861157d1f051d30e19531b46#diff-76cdf28789db118253cbca3e59bdca70

As part of the commit we've removed throwable (second parameter), so stack trace is not accessible in logs any more. I would propose to restore throwable parameter:

```
        if (logger.isDebugEnabled()) {
            logger.debug("failure occurred in gateway sendAndReceive", e);
        }
```
