### PR TITLE
INT-3751: Fix Python Scripting

### DIFF
--- a/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/jsr223/DefaultScriptExecutor.java
+++ b/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/jsr223/DefaultScriptExecutor.java
@@ -1,26 +1,28 @@
 /*
- * Copyright 2002-2011 the original author or authors.
- * 
+ * Copyright 2002-2015 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 package org.springframework.integration.scripting.jsr223;
 
+import javax.script.Bindings;
 import javax.script.ScriptEngine;
 
 import org.springframework.integration.scripting.ScriptExecutor;
 
 /**
  * Default implementation of the {@link ScriptExecutor}
- * 
+ *
  * @author David Turanski
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.1
  */
  class DefaultScriptExecutor extends AbstractScriptExecutor {
@@ -32,16 +34,8 @@ import org.springframework.integration.scripting.ScriptExecutor;
 		super(language);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see
-	 * org.springframework.integration.scripting.jsr223.AbstractScriptExecutor
-	 * #postProcess(java.lang.Object, javax.script.ScriptEngine,
-	 * java.lang.String)
-	 */
 	@Override
-	protected Object postProcess(Object result, ScriptEngine scriptEngine, String script) {
+	protected Object postProcess(Object result, ScriptEngine scriptEngine, String script, Bindings bindings) {
 		return result;
 	}
 

--- a/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/jsr223/PythonScriptExecutor.java
+++ b/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/jsr223/PythonScriptExecutor.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2002-2011 the original author or authors.
- * 
+ * Copyright 2002-2015 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 package org.springframework.integration.scripting.jsr223;
 
+import javax.script.Bindings;
 import javax.script.ScriptEngine;
 
 import org.springframework.integration.scripting.ScriptExecutor;
@@ -19,11 +20,12 @@ import org.springframework.integration.scripting.ScriptExecutor;
 /**
  * A {@link ScriptExecutor} that implements special handling required for Python to emulate behavior similar to other JSR223 scripting languages.
  * <p>
- * Script evaluation using the Jython implementation results in a <code>null</code> return value for normal variable expressions such as 
+ * Script evaluation using the Jython implementation results in a <code>null</code> return value for normal variable expressions such as
  * <code>x=2</code>. As a work around, it is necessary to get the value of 'x' explicitly following the script evaluation. This class performs
- * simple parsing on the last line of the script to obtain the variable name, if any, and return its value.  
- *    
+ * simple parsing on the last line of the script to obtain the variable name, if any, and return its value.
+ *
  * @author David Turanski
+ * @author Gary Russell
  * @since 2.1
  *
  */
@@ -32,22 +34,24 @@ import org.springframework.integration.scripting.ScriptExecutor;
 	 * @param language
 	 */
 	public PythonScriptExecutor() {
-		super("python"); 
+		super("python");
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.springframework.integration.scripting.jsr223.AbstractScriptExecutor#postProcess(java.lang.Object, javax.script.ScriptEngine, java.lang.String)
-	 */
+
 	@Override
-	protected Object postProcess(Object result, ScriptEngine scriptEngine, String script) {
+	protected Object postProcess(Object result, ScriptEngine scriptEngine, String script, Bindings bindings) {
 		Object newResult= result;
 		if (newResult == null) {
 			String returnVariableName = PythonVariableParser.parseReturnVariable(script);
-			newResult = scriptEngine.get(returnVariableName);
+			if (bindings != null) {
+				newResult = bindings.get(returnVariableName);
+			}
+			if (newResult == null) {
+				newResult = scriptEngine.get(returnVariableName);
+			}
 		}
 		return newResult;
 	}
-	
+
 	public static class PythonVariableParser {
 		public static String parseReturnVariable(String script){
 			String[] lines = script.trim().split("\n");

--- a/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/jsr223/PythonScriptExecutorTests.java
+++ b/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/jsr223/PythonScriptExecutorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
 package org.springframework.integration.scripting.jsr223;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,6 +21,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.python.core.PyTuple;
+
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.integration.scripting.ScriptExecutor;
 import org.springframework.scripting.ScriptSource;
@@ -28,6 +30,7 @@ import org.springframework.scripting.support.StaticScriptSource;
 
 /**
  * @author David Turanski
+ * @author Gary Russell
  *
  */
 public class PythonScriptExecutorTests {
@@ -62,9 +65,23 @@ public class PythonScriptExecutorTests {
 	@Test
 	public void test3() {
 		ScriptSource source =
-			new ResourceScriptSource(new ClassPathResource("/org/springframework/integration/scripting/jsr223/test3.py"));
+			new ResourceScriptSource(
+					new ClassPathResource("/org/springframework/integration/scripting/jsr223/test3.py"));
 		Object obj =  executor.executeScript(source);
 		PyTuple tuple = (PyTuple) obj;
+		assertEquals(1, tuple.get(0));
+	}
+
+	@Test
+	public void test3WithVariables() {
+		ScriptSource source =
+			new ResourceScriptSource(
+					new ClassPathResource("/org/springframework/integration/scripting/jsr223/test3.py"));
+		HashMap<String, Object> variables = new HashMap<String, Object>();
+		variables.put("foo", "bar");
+		Object obj =  executor.executeScript(source, variables);
+		PyTuple tuple = (PyTuple) obj;
+		assertNotNull(tuple);
 		assertEquals(1, tuple.get(0));
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3751

Result was null when `executeScript()` was invoked with non-null variables.

When variable are provided, the result variable is stored in the provided bindings.

**cherry-pick to 4.1.x, 4.0.x, 3.0.x**
