### PR TITLE
INT-3749: Get rid of `IECA` logic

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -24,10 +24,6 @@ import java.util.UUID;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.locks.Lock;
 
-import org.aopalliance.aop.Advice;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -38,7 +34,7 @@ import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.NullChannel;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
+import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.handler.AbstractMessageProducingHandler;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
@@ -55,6 +51,10 @@ import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+
+import org.aopalliance.aop.Advice;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Abstract Message handler that holds a buffer of correlated messages in a
@@ -82,7 +82,7 @@ import org.springframework.util.CollectionUtils;
  * @since 2.0
  */
 public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageProducingHandler
-		implements DisposableBean, IntegrationEvaluationContextAware, ApplicationEventPublisherAware {
+		implements DisposableBean, ApplicationEventPublisherAware {
 
 	private static final Log logger = LogFactory.getLog(AbstractCorrelatingMessageHandler.class);
 
@@ -186,11 +186,6 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 	}
 
 	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		this.evaluationContext = evaluationContext;
-	}
-
-	@Override
 	public void setTaskScheduler(TaskScheduler taskScheduler) {
 		super.setTaskScheduler(taskScheduler);
 	}
@@ -228,6 +223,8 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 							"] cannot release partial sequences. Use the default SequenceSizeReleaseStrategy instead.");
 			((SequenceSizeReleaseStrategy) this.releaseStrategy).setReleasePartialSequences(releasePartialSequences);
 		}
+
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 
 		/*
 		 * Disallow any further changes to the lock registry

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
@@ -23,9 +23,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -47,11 +44,13 @@ import org.springframework.integration.channel.DefaultHeaderChannelRegistry;
 import org.springframework.integration.config.annotation.MessagingAnnotationPostProcessor;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.IntegrationProperties;
-import org.springframework.integration.expression.IntegrationEvaluationContextAwareBeanPostProcessor;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.converter.DefaultDatatypeChannelMessageConverter;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.util.ClassUtils;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * {@link ImportBeanDefinitionRegistrar} implementation that configures integration infrastructure.
@@ -87,9 +86,11 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar, Bean
 	 * to register the messaging annotation post processors (for {@code <int:annotation-config/>}).
 	 */
 	@Override
+	@SuppressWarnings("deprecation")
 	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
 		this.registerImplicitChannelCreator(registry);
 		this.registerIntegrationConfigurationBeanFactoryPostProcessor(registry);
+		//TODO remove this line in the 4.3
 		this.registerIntegrationEvaluationContext(registry);
 		this.registerIntegrationProperties(registry);
 		this.registerHeaderChannelRegistry(registry);
@@ -174,9 +175,14 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar, Bean
 
 	/**
 	 * Register {@link IntegrationEvaluationContextFactoryBean} bean
-	 * and {@link IntegrationEvaluationContextAwareBeanPostProcessor}, if necessary.
+	 * and {@code IntegrationEvaluationContextAwareBeanPostProcessor}, if necessary.
 	 * @param registry The {@link BeanDefinitionRegistry} to register additional {@link BeanDefinition}s.
+	 * @deprecated since 4.2 in favor of {@link IntegrationContextUtils#getEvaluationContext}
+	 * direct usage from the {@code afterPropertiesSet} implementation.
+	 * Will be removed in the next release.
 	 */
+	@Deprecated
+	@SuppressWarnings("deprecation")
 	private void registerIntegrationEvaluationContext(BeanDefinitionRegistry registry) {
 		if (!registry.containsBeanDefinition(IntegrationContextUtils.INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME)) {
 			BeanDefinitionBuilder integrationEvaluationContextBuilder = BeanDefinitionBuilder
@@ -191,7 +197,7 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar, Bean
 					registry);
 
 			RootBeanDefinition integrationEvalContextBPP =
-					new RootBeanDefinition(IntegrationEvaluationContextAwareBeanPostProcessor.class);
+					new RootBeanDefinition(org.springframework.integration.expression.IntegrationEvaluationContextAwareBeanPostProcessor.class);
 			BeanDefinitionReaderUtils.registerWithGeneratedName(integrationEvalContextBPP, registry);
 		}
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ExpressionMessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ExpressionMessageProducerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,13 +10,13 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package org.springframework.integration.endpoint;
 
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.expression.ExpressionUtils;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
 import org.springframework.util.Assert;
 
 /**
@@ -29,7 +29,7 @@ import org.springframework.util.Assert;
  * @since 2.1
  *
  */
-public abstract class ExpressionMessageProducerSupport extends MessageProducerSupport implements IntegrationEvaluationContextAware {
+public abstract class ExpressionMessageProducerSupport extends MessageProducerSupport {
 
 	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
 
@@ -57,16 +57,9 @@ public abstract class ExpressionMessageProducerSupport extends MessageProducerSu
 	}
 
 	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		this.evaluationContext = evaluationContext;
-	}
-
-	@Override
 	protected void onInit() {
 		super.onInit();
-		if (this.evaluationContext == null) {
-			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());
-		}
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 	}
 
 	protected Object evaluatePayloadExpression(Object payload){

--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/ExpressionUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/ExpressionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014	 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,6 @@
 
 package org.springframework.integration.expression;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.context.expression.MapAccessor;
@@ -27,6 +24,9 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.expression.spel.support.StandardTypeConverter;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.support.utils.IntegrationUtils;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Utility class with static methods for helping with establishing environments for
@@ -76,7 +76,7 @@ public abstract class ExpressionUtils {
 	 */
 	public static StandardEvaluationContext createStandardEvaluationContext(BeanFactory beanFactory) {
 		if (beanFactory == null) {
-			logger.warn("Creating EvaluationContext with no beanFactory", new RuntimeException("No beanfactory"));
+			logger.warn("Creating EvaluationContext with no beanFactory", new RuntimeException("No beanFactory"));
 		}
 		return doCreateContext(beanFactory);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/IntegrationEvaluationContextAware.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/IntegrationEvaluationContextAware.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.expression;
 
 import org.springframework.expression.EvaluationContext;
+import org.springframework.integration.context.IntegrationContextUtils;
 
 /**
  * Interface to be implemented by beans that wish to be aware of their
@@ -24,7 +25,7 @@ import org.springframework.expression.EvaluationContext;
  * {@link org.springframework.integration.config.IntegrationEvaluationContextFactoryBean}
  * <p>
  * The {@link #setIntegrationEvaluationContext} is invoked from
- * the {@link IntegrationEvaluationContextAwareBeanPostProcessor#afterSingletonsInstantiated()},
+ * the {@code IntegrationEvaluationContextAwareBeanPostProcessor#afterSingletonsInstantiated()},
  * not during standard {@code postProcessBefore(After)Initialization} to avoid any
  * {@code BeanFactory} early access during integration {@link EvaluationContext} retrieval.
  * Therefore, if it is necessary to use {@link EvaluationContext} in the {@code afterPropertiesSet()},
@@ -33,8 +34,11 @@ import org.springframework.expression.EvaluationContext;
  *
  * @author Artem Bilan
  * @since 3.0
- * @see IntegrationEvaluationContextAwareBeanPostProcessor
+ * @deprecated since 4.2 in favor of {@link IntegrationContextUtils#getEvaluationContext}
+ * direct usage from the {@code afterPropertiesSet} implementation.
+ * Will be removed in the next release.
  */
+@Deprecated
 public interface IntegrationEvaluationContextAware {
 
 	void setIntegrationEvaluationContext(EvaluationContext evaluationContext);

--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/IntegrationEvaluationContextAwareBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/IntegrationEvaluationContextAwareBeanPostProcessor.java
@@ -32,7 +32,12 @@ import org.springframework.integration.context.IntegrationContextUtils;
  * @author Artem Bilan
  * @author Gary Russell
  * @since 3.0
+ * @deprecated since 4.2 in favor of {@link IntegrationContextUtils#getEvaluationContext}
+ * direct usage from the {@code afterPropertiesSet} implementation.
+ * Will be removed in the next release.
  */
+@Deprecated
+@SuppressWarnings("deprecation")
 public class IntegrationEvaluationContextAwareBeanPostProcessor
 		implements BeanPostProcessor, Ordered, BeanFactoryAware, SmartInitializingSingleton {
 
@@ -71,5 +76,5 @@ public class IntegrationEvaluationContextAwareBeanPostProcessor
 	public int getOrder() {
 		return LOWEST_PRECEDENCE;
 	}
-	
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/routingslip/ExpressionEvaluatingRoutingSlipRouteStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/routingslip/ExpressionEvaluatingRoutingSlipRouteStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,15 @@
 
 package org.springframework.integration.routingslip;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
+import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.messaging.Message;
 
 /**
@@ -57,13 +61,15 @@ import org.springframework.messaging.Message;
  * @since 4.1
  */
 public class ExpressionEvaluatingRoutingSlipRouteStrategy
-		implements RoutingSlipRouteStrategy, IntegrationEvaluationContextAware {
+		implements RoutingSlipRouteStrategy, BeanFactoryAware, InitializingBean {
 
 	private static final ExpressionParser PARSER = new SpelExpressionParser();
 
 	private final Expression expression;
 
 	private EvaluationContext evaluationContext;
+
+	private BeanFactory beanFactory;
 
 	public ExpressionEvaluatingRoutingSlipRouteStrategy(String expression) {
 		this(PARSER.parseExpression(expression));
@@ -74,8 +80,13 @@ public class ExpressionEvaluatingRoutingSlipRouteStrategy
 	}
 
 	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		this.evaluationContext = evaluationContext;
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/transaction/ExpressionEvaluatingTransactionSynchronizationProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transaction/ExpressionEvaluatingTransactionSynchronizationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with
@@ -24,7 +24,6 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.expression.ExpressionUtils;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -56,7 +55,7 @@ import org.springframework.util.Assert;
  *
  */
 public class ExpressionEvaluatingTransactionSynchronizationProcessor extends IntegrationObjectSupport
-		implements TransactionSynchronizationProcessor, IntegrationEvaluationContextAware {
+		implements TransactionSynchronizationProcessor {
 
 	private volatile EvaluationContext evaluationContext;
 
@@ -71,11 +70,6 @@ public class ExpressionEvaluatingTransactionSynchronizationProcessor extends Int
 	private volatile MessageChannel afterCommitChannel = new NullChannel();
 
 	private volatile MessageChannel afterRollbackChannel = new NullChannel();
-
-	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		this.evaluationContext = evaluationContext;
-	}
 
 	public void setBeforeCommitChannel(MessageChannel beforeCommitChannel) {
 		Assert.notNull(beforeCommitChannel, "'beforeCommitChannel' must not be null");
@@ -105,6 +99,12 @@ public class ExpressionEvaluatingTransactionSynchronizationProcessor extends Int
 	public void setAfterRollbackExpression(Expression afterRollbackExpression) {
 		Assert.notNull(afterRollbackExpression, "'afterRollbackExpression' must not be null");
 		this.afterRollbackExpression = afterRollbackExpression;
+	}
+
+	@Override
+	protected void onInit() throws Exception {
+		super.onInit();
+		this.evaluationContext = createEvaluationContext();
 	}
 
 	public void processBeforeCommit(IntegrationResourceHolder holder) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import org.springframework.expression.spel.SpelParserConfiguration;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.expression.ExpressionUtils;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
 import org.springframework.integration.gateway.MessagingGatewaySupport;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.transformer.support.HeaderValueMessageProcessor;
@@ -53,7 +52,7 @@ import org.springframework.util.ReflectionUtils;
  * @since 2.1
  */
 public class ContentEnricher extends AbstractReplyProducingMessageHandler
-		implements Lifecycle, IntegrationEvaluationContextAware {
+		implements Lifecycle {
 
 	private final SpelExpressionParser parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
 
@@ -246,11 +245,6 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler
 	}
 
 	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		this.sourceEvaluationContext = evaluationContext;
-	}
-
-	@Override
 	public String getComponentType() {
 		return "enricher";
 	}
@@ -309,9 +303,7 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler
 			this.gateway.afterPropertiesSet();
 		}
 
-		if (this.sourceEvaluationContext == null) {
-			this.sourceEvaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
-		}
+		this.sourceEvaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 
 		StandardEvaluationContext targetContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 		// bean resolution is NOT allowed for the target of the enrichment

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,12 +27,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.store.MessageGroupStore;
@@ -41,6 +37,9 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @author Marius Bogoevici
@@ -328,7 +327,6 @@ public class ResequencerTests {
 	@Test
 	public void testTimeoutDefaultExpiry() throws InterruptedException {
 		this.resequencer.setGroupTimeoutExpression(new SpelExpressionParser().parseExpression("100"));
-		this.resequencer.setIntegrationEvaluationContext(new StandardEvaluationContext());
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 		taskScheduler.afterPropertiesSet();
 		this.resequencer.setTaskScheduler(taskScheduler);
@@ -336,6 +334,7 @@ public class ResequencerTests {
 		this.resequencer.setDiscardChannel(discardChannel);
 		QueueChannel replyChannel = new QueueChannel();
 		this.resequencer.setOutputChannel(replyChannel);
+
 		Message<?> message3 = createMessage("789", "ABC", 3, 3, null);
 		Message<?> message2 = createMessage("456", "ABC", 3, 2, null);
 		this.resequencer.handleMessage(message3);
@@ -355,7 +354,6 @@ public class ResequencerTests {
 	@Test
 	public void testTimeoutDontExpire() throws InterruptedException {
 		this.resequencer.setGroupTimeoutExpression(new SpelExpressionParser().parseExpression("100"));
-		this.resequencer.setIntegrationEvaluationContext(new StandardEvaluationContext());
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 		taskScheduler.afterPropertiesSet();
 		this.resequencer.setTaskScheduler(taskScheduler);
@@ -364,6 +362,7 @@ public class ResequencerTests {
 		QueueChannel replyChannel = new QueueChannel();
 		this.resequencer.setOutputChannel(replyChannel);
 		this.resequencer.setExpireGroupsUponTimeout(true);
+
 		Message<?> message3 = createMessage("789", "ABC", 3, 3, null);
 		Message<?> message2 = createMessage("456", "ABC", 3, 2, null);
 		this.resequencer.handleMessage(message3);

--- a/spring-integration-core/src/test/java/org/springframework/integration/expression/ParentContextTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/expression/ParentContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,9 +33,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.hamcrest.Matchers;
-import org.junit.Test;
-
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.expression.EvaluationContext;
@@ -51,6 +52,9 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
 /**
  * @author Gary Russell
@@ -207,11 +211,18 @@ public class ParentContextTests {
 		parent.close();
 	}
 
-	public static class Foo implements IntegrationEvaluationContextAware {
+	public static class Foo implements BeanFactoryAware, InitializingBean {
+
+		private BeanFactory beanFactory;
 
 		@Override
-		public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-			evalContexts.add(evaluationContext);
+		public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+			this.beanFactory = beanFactory;
+		}
+
+		@Override
+		public void afterPropertiesSet() throws Exception {
+			evalContexts.add(ExpressionUtils.createStandardEvaluationContext(this.beanFactory));
 		}
 
 	}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpInboundRemoteFileSystemSynchronizerTests.java
@@ -35,20 +35,11 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.commons.net.ftp.FTPClient;
-import org.apache.commons.net.ftp.FTPFile;
-import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.SpelParserConfiguration;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.file.filters.AcceptOnceFileListFilter;
 import org.springframework.integration.file.filters.CompositeFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
@@ -59,6 +50,14 @@ import org.springframework.integration.ftp.session.AbstractFtpSessionFactory;
 import org.springframework.integration.metadata.PropertiesPersistingMetadataStore;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
+
+import org.apache.commons.net.ftp.FTPClient;
+import org.apache.commons.net.ftp.FTPFile;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * @author Oleg Zhurakousky
@@ -108,11 +107,12 @@ public class FtpInboundRemoteFileSystemSynchronizerTests {
 		filters.add(patternFilter);
 		CompositeFileListFilter<FTPFile> filter = new CompositeFileListFilter<FTPFile>(filters);
 		synchronizer.setFilter(filter);
-		synchronizer.setIntegrationEvaluationContext(ExpressionUtils.createStandardEvaluationContext());
 
 		ExpressionParser expressionParser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
 		Expression expression = expressionParser.parseExpression("#this.toUpperCase() + '.a'");
 		synchronizer.setLocalFilenameGeneratorExpression(expression);
+		synchronizer.setBeanFactory(mock(BeanFactory.class));
+		synchronizer.afterPropertiesSet();
 
 		FtpInboundFileSynchronizingMessageSource ms = new FtpInboundFileSynchronizingMessageSource(synchronizer);
 

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/inbound/ContinuousQueryMessageProducerTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/inbound/ContinuousQueryMessageProducerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,20 +10,21 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package org.springframework.integration.gemfire.inbound;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.data.gemfire.listener.ContinuousQueryListenerContainer;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import org.springframework.data.gemfire.listener.ContinuousQueryListenerContainer;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessagingException;
-import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.expression.ExpressionUtils;
-import org.springframework.messaging.MessageHandler;
 
 import com.gemstone.gemfire.cache.Operation;
 import com.gemstone.gemfire.cache.query.CqEvent;
@@ -36,6 +37,7 @@ import com.gemstone.gemfire.cache.query.internal.CqQueryImpl;
  * @since 2.1
  */
 public class ContinuousQueryMessageProducerTests {
+
 	ContinuousQueryListenerContainer queryListenerContainer;
 
 	ContinuousQueryMessageProducer cqMessageProducer;
@@ -45,10 +47,10 @@ public class ContinuousQueryMessageProducerTests {
 	@Before
 	public void setUp() {
 		queryListenerContainer = mock(ContinuousQueryListenerContainer.class);
-		cqMessageProducer = new ContinuousQueryMessageProducer(queryListenerContainer, "");
+		cqMessageProducer = new ContinuousQueryMessageProducer(queryListenerContainer, "foo");
 		DirectChannel outputChannel = new DirectChannel();
 		cqMessageProducer.setOutputChannel(outputChannel);
-		cqMessageProducer.setIntegrationEvaluationContext(ExpressionUtils.createStandardEvaluationContext());
+		cqMessageProducer.setBeanFactory(mock(BeanFactory.class));
 		handler = new CqMessageHandler();
 		outputChannel.subscribe(handler);
 	}
@@ -89,6 +91,8 @@ public class ContinuousQueryMessageProducerTests {
 	public void testPayloadExpression() {
 		CqEvent cqEvent = event(Operation.CREATE, "hello");
 		cqMessageProducer.setPayloadExpression("newValue.toUpperCase() + ', WORLD'");
+		cqMessageProducer.afterPropertiesSet();
+
 		cqMessageProducer.onEvent(cqEvent);
 		assertEquals(1, handler.count);
 		assertEquals("HELLO, WORLD", handler.payload);
@@ -133,26 +137,23 @@ public class ContinuousQueryMessageProducerTests {
 			public Throwable getThrowable() {
 				return ex;
 			}
+
 		};
 
 		return event;
 	}
 
 	private static class CqMessageHandler implements MessageHandler {
+
 		public int count;
 
 		public Object payload;
 
-		/*
-		 * (non-Javadoc)
-		 *
-		 * @see
-		 * org.springframework.messaging.MessageHandler#handleMessage
-		 * (org.springframework.messaging.Message)
-		 */
 		public void handleMessage(Message<?> message) throws MessagingException {
 			count++;
 			payload = message.getPayload();
 		}
+
 	}
+
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
@@ -30,7 +30,7 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.MessageTimeoutException;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
+import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.ip.tcp.connection.AbstractClientConnectionFactory;
@@ -59,7 +59,7 @@ import org.springframework.util.Assert;
  * @since 2.0
  */
 public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler
-		implements TcpSender, TcpListener, IntegrationEvaluationContextAware, Lifecycle {
+		implements TcpSender, TcpListener, Lifecycle {
 
 	private volatile AbstractClientConnectionFactory connectionFactory;
 
@@ -97,8 +97,10 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler
 	}
 
 	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		this.evaluationContext = evaluationContext;
+	protected void doInit() {
+		super.doInit();
+
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 	}
 
 	@Override
@@ -227,12 +229,12 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler
 	/**
 	 * Specify the Spring Integration reply channel. If this property is not
 	 * set the gateway will check for a 'replyChannel' header on the request.
-	 *
 	 * @param replyChannel The reply channel.
 	 */
 	public void setReplyChannel(MessageChannel replyChannel) {
 		this.setOutputChannel(replyChannel);
 	}
+
 	@Override
 	public String getComponentType(){
 		return "ip:tcp-outbound-gateway";
@@ -332,6 +334,7 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler
 				this.secondChanceLatch.countDown();
 			}
 		}
+
 	}
 
 }

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/core/JpaExecutor.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/core/JpaExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.jpa.core;
 
 import java.util.List;
-
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Query;
@@ -28,7 +28,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
+import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.jpa.support.JpaParameter;
 import org.springframework.integration.jpa.support.PersistMode;
 import org.springframework.integration.jpa.support.parametersource.BeanPropertyParameterSourceFactory;
@@ -65,7 +65,7 @@ import org.springframework.util.Assert;
  * @since 2.2
  *
  */
-public class JpaExecutor implements InitializingBean, BeanFactoryAware, IntegrationEvaluationContextAware {
+public class JpaExecutor implements InitializingBean, BeanFactoryAware {
 
 	private final JpaOperations jpaOperations;
 
@@ -205,6 +205,8 @@ public class JpaExecutor implements InitializingBean, BeanFactoryAware, Integrat
 		else if (this.flush) {
 			this.flushSize = 1;
 		}
+
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
 	}
 
 	/**
@@ -616,15 +618,5 @@ public class JpaExecutor implements InitializingBean, BeanFactoryAware, Integrat
 	 public void setMaxNumberOfResults(int maxNumberOfResults) {
 		 this.setMaxResultsExpression(new LiteralExpression("" + maxNumberOfResults));
 	 }
-
-	/**
-	 * Sets the evaluation context for evaluating the expression to get the from record of the
-	 * result set retrieved by the retrieving gateway.
-	 * @param evaluationContext The evaluation context.
-	 */
-	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		this.evaluationContext = evaluationContext;
-	}
 
 }

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/ExpressionArgumentsStrategy.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/ExpressionArgumentsStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,12 @@ import java.util.List;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.context.IntegrationContextUtils;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
+import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
@@ -35,7 +36,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @since 4.0
  */
-public class ExpressionArgumentsStrategy implements ArgumentsStrategy, IntegrationEvaluationContextAware, BeanFactoryAware {
+public class ExpressionArgumentsStrategy implements ArgumentsStrategy, BeanFactoryAware, InitializingBean {
 
 	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
 
@@ -63,14 +64,13 @@ public class ExpressionArgumentsStrategy implements ArgumentsStrategy, Integrati
 	}
 
 	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		Assert.notNull(evaluationContext, "'evaluationContext' must not be null");
-		this.evaluationContext = evaluationContext;
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
 	}
 
 	@Override
-	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-		this.beanFactory = beanFactory;
+	public void afterPropertiesSet() throws Exception {
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
 	}
 
 	@Override

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisOutboundGateway.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
+import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.redis.support.RedisHeaders;
 import org.springframework.messaging.Message;
@@ -39,8 +39,7 @@ import org.springframework.util.ObjectUtils;
  * @author Artem Bilan
  * @since 4.0
  */
-public class RedisOutboundGateway extends AbstractReplyProducingMessageHandler
-		implements IntegrationEvaluationContextAware {
+public class RedisOutboundGateway extends AbstractReplyProducingMessageHandler {
 
 	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
 
@@ -64,12 +63,6 @@ public class RedisOutboundGateway extends AbstractReplyProducingMessageHandler
 		this.redisTemplate = new RedisTemplate<Object, Object>();
 		this.redisTemplate.setConnectionFactory(connectionFactory);
 		this.redisTemplate.afterPropertiesSet();
-	}
-
-	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		Assert.notNull(evaluationContext, "'evaluationContext' must not be null");
-		this.evaluationContext = evaluationContext;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -104,6 +97,12 @@ public class RedisOutboundGateway extends AbstractReplyProducingMessageHandler
 	@Override
 	public String getComponentType() {
 		return "redis:outbound-gateway";
+	}
+
+	@Override
+	protected void doInit() {
+		super.doInit();
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 	}
 
 	@Override

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisPublishingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisPublishingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2014 the original author or authors
+ * Copyright 2007-2015 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
+import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.support.converter.SimpleMessageConverter;
 import org.springframework.messaging.Message;
@@ -36,7 +36,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @since 2.1
  */
-public class RedisPublishingMessageHandler extends AbstractMessageHandler implements IntegrationEvaluationContextAware {
+public class RedisPublishingMessageHandler extends AbstractMessageHandler {
 
 	private final RedisTemplate<?, ?> template;
 
@@ -54,11 +54,6 @@ public class RedisPublishingMessageHandler extends AbstractMessageHandler implem
 		this.template.setConnectionFactory(connectionFactory);
 		this.template.setEnableDefaultSerializer(false);
 		this.template.afterPropertiesSet();
-	}
-
-	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		this.evaluationContext = evaluationContext;
 	}
 
 	public void setSerializer(RedisSerializer<?> serializer) {
@@ -101,8 +96,9 @@ public class RedisPublishingMessageHandler extends AbstractMessageHandler implem
 	protected void onInit() throws Exception {
 		Assert.notNull(topicExpression, "'topicExpression' must not be null.");
 		if (this.messageConverter instanceof BeanFactoryAware) {
-			((BeanFactoryAware) this.messageConverter).setBeanFactory(this.getBeanFactory());
+			((BeanFactoryAware) this.messageConverter).setBeanFactory(getBeanFactory());
 		}
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 	}
 
 	@Override

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisQueueOutboundChannelAdapter.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisQueueOutboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors
+ * Copyright 2013-2015 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
+import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
@@ -35,7 +35,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @since 3.0
  */
-public class RedisQueueOutboundChannelAdapter extends AbstractMessageHandler implements IntegrationEvaluationContextAware {
+public class RedisQueueOutboundChannelAdapter extends AbstractMessageHandler {
 
 	private final RedisSerializer<String> stringSerializer = new StringRedisSerializer();
 
@@ -67,11 +67,6 @@ public class RedisQueueOutboundChannelAdapter extends AbstractMessageHandler imp
 		this.template.afterPropertiesSet();
 	}
 
-	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		this.evaluationContext = evaluationContext;
-	}
-
 	public void setExtractPayload(boolean extractPayload) {
 		this.extractPayload = extractPayload;
 	}
@@ -85,6 +80,12 @@ public class RedisQueueOutboundChannelAdapter extends AbstractMessageHandler imp
 	@Override
 	public String getComponentType() {
 		return "redis:queue-outbound-channel-adapter";
+	}
+
+	@Override
+	protected void onInit() throws Exception {
+		super.onInit();
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 	}
 
 	@Override

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpInboundRemoteFileSystemSynchronizerTests.java
@@ -109,7 +109,9 @@ public class SftpInboundRemoteFileSystemSynchronizerTests {
 		filters.add(patternFilter);
 		CompositeFileListFilter<LsEntry> filter = new CompositeFileListFilter<LsEntry>(filters);
 		synchronizer.setFilter(filter);
-		synchronizer.setIntegrationEvaluationContext(ExpressionUtils.createStandardEvaluationContext());
+		synchronizer.setBeanFactory(mock(BeanFactory.class));
+		synchronizer.afterPropertiesSet();
+
 		SftpInboundFileSynchronizingMessageSource ms = new SftpInboundFileSynchronizingMessageSource(synchronizer);
 		ms.setAutoCreateLocalDirectory(true);
 		ms.setLocalDirectory(localDirectoy);

--- a/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/outbound/StompMessageHandler.java
+++ b/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/outbound/StompMessageHandler.java
@@ -21,7 +21,7 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.Lifecycle;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
+import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.mapping.HeaderMapper;
@@ -46,8 +46,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @since 4.2
  */
-public class StompMessageHandler extends AbstractMessageHandler implements IntegrationEvaluationContextAware,
-		ApplicationEventPublisherAware, Lifecycle {
+public class StompMessageHandler extends AbstractMessageHandler implements ApplicationEventPublisherAware, Lifecycle {
 
 	private final StompSessionHandler sessionHandler = new IntegrationOutboundStompSessionHandler();
 
@@ -86,13 +85,15 @@ public class StompMessageHandler extends AbstractMessageHandler implements Integ
 	}
 
 	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		this.evaluationContext = evaluationContext;
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
 	}
 
 	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
-		this.applicationEventPublisher = applicationEventPublisher;
+	protected void onInit() throws Exception {
+		super.onInit();
+
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 	}
 
 	@Override

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/outbound/StatusUpdatingMessageHandler.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/outbound/StatusUpdatingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors
+ * Copyright 2002-2015 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.TypeLocator;
 import org.springframework.expression.spel.support.StandardTypeLocator;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
+import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
@@ -37,8 +37,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @since 2.0
  */
-public class StatusUpdatingMessageHandler extends AbstractMessageHandler
-		implements IntegrationEvaluationContextAware {
+public class StatusUpdatingMessageHandler extends AbstractMessageHandler {
 
 	private final Twitter twitter;
 
@@ -49,18 +48,6 @@ public class StatusUpdatingMessageHandler extends AbstractMessageHandler
 	public StatusUpdatingMessageHandler(Twitter twitter) {
 		Assert.notNull(twitter, "twitter must not be null");
 		this.twitter = twitter;
-	}
-
-	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		TypeLocator typeLocator = evaluationContext.getTypeLocator();
-		if (typeLocator instanceof StandardTypeLocator) {
-			/*
-			 * Register the twitter api package so they don't need a FQCN for TweetData.
-			 */
-			((StandardTypeLocator) typeLocator).registerImport("org.springframework.social.twitter.api");
-		}
-		this.evaluationContext = evaluationContext;
 	}
 
 	@Override
@@ -79,6 +66,20 @@ public class StatusUpdatingMessageHandler extends AbstractMessageHandler
 	 */
 	public void setTweetDataExpression(Expression tweetDataExpression) {
 		this.tweetDataExpression = tweetDataExpression;
+	}
+
+	@Override
+	protected void onInit() throws Exception {
+		super.onInit();
+
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		TypeLocator typeLocator = this.evaluationContext.getTypeLocator();
+		if (typeLocator instanceof StandardTypeLocator) {
+			/*
+			 * Register the twitter api package so they don't need a FQCN for TweetData.
+			 */
+			((StandardTypeLocator) typeLocator).registerImport("org.springframework.social.twitter.api");
+		}
 	}
 
 	@Override

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/outbound/TwitterSearchOutboundGateway.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/outbound/TwitterSearchOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.TypeLocator;
 import org.springframework.expression.spel.support.StandardTypeLocator;
-import org.springframework.integration.expression.IntegrationEvaluationContextAware;
+import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.twitter.core.TwitterHeaders;
 import org.springframework.messaging.Message;
@@ -40,10 +40,8 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @since 4.0
- *
  */
-public class TwitterSearchOutboundGateway extends AbstractReplyProducingMessageHandler
-		implements IntegrationEvaluationContextAware {
+public class TwitterSearchOutboundGateway extends AbstractReplyProducingMessageHandler {
 
 	private static final int DEFAULT_PAGE_SIZE = 20;
 
@@ -56,18 +54,6 @@ public class TwitterSearchOutboundGateway extends AbstractReplyProducingMessageH
 	public TwitterSearchOutboundGateway(Twitter twitter) {
 		Assert.notNull(twitter, "'twitter' must not be null");
 		this.twitter = twitter;
-	}
-
-	@Override
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		TypeLocator typeLocator = evaluationContext.getTypeLocator();
-		if (typeLocator instanceof StandardTypeLocator) {
-			/*
-			 * Register the twitter api package so they don't need a FQCN for SearchParameters.
-			 */
-			((StandardTypeLocator) typeLocator).registerImport("org.springframework.social.twitter.api");
-		}
-		this.evaluationContext = evaluationContext;
 	}
 
 	/**
@@ -97,6 +83,19 @@ public class TwitterSearchOutboundGateway extends AbstractReplyProducingMessageH
 
 	protected Twitter getTwitter() {
 		return twitter;
+	}
+
+	@Override
+	protected void doInit() {
+		super.doInit();
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		TypeLocator typeLocator = this.evaluationContext.getTypeLocator();
+		if (typeLocator instanceof StandardTypeLocator) {
+			/*
+			 * Register the twitter api package so they don't need a FQCN for SearchParameters.
+			 */
+			((StandardTypeLocator) typeLocator).registerImport("org.springframework.social.twitter.api");
+		}
 	}
 
 	@Override


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3749

Since `IntegrationEvaluationContextAware` isn't so "context-free" resource like `BeanFactory`
 and `ApplicationContext`, but just a specific bean in the context, we can't follow with `BeanPostProcessor` logic - bad architecture by level of responsibility.
 Therefore we should follow with standard Dependency Injection mechanism to retrieve `evaluationContext` for the particular component.

 Since we can't rely on the `@Autowired` because SI can be used from the raw XML configuration,
 we use utility method instead. The pattern to get the proper `integrationEvaluationContext` is:

```
 @Override
 protected void onInit() throws Exception {
        super.onInit();
        this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 }
```
