### PR TITLE
INT-3749: Revert setters for `EC`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -185,6 +185,10 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		this.forceReleaseAdviceChain = forceReleaseAdviceChain;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	public void setTaskScheduler(TaskScheduler taskScheduler) {
 		super.setTaskScheduler(taskScheduler);
@@ -224,7 +228,9 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 			((SequenceSizeReleaseStrategy) this.releaseStrategy).setReleasePartialSequences(releasePartialSequences);
 		}
 
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		}
 
 		/*
 		 * Disallow any further changes to the lock registry

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ExpressionMessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ExpressionMessageProducerSupport.java
@@ -56,10 +56,16 @@ public abstract class ExpressionMessageProducerSupport extends MessageProducerSu
 		this.payloadExpression = payloadExpression;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	protected void onInit() {
 		super.onInit();
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());
+		}
 	}
 
 	protected Object evaluatePayloadExpression(Object payload){

--- a/spring-integration-core/src/main/java/org/springframework/integration/routingslip/ExpressionEvaluatingRoutingSlipRouteStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/routingslip/ExpressionEvaluatingRoutingSlipRouteStrategy.java
@@ -79,6 +79,10 @@ public class ExpressionEvaluatingRoutingSlipRouteStrategy
 		this.expression = expression;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		this.beanFactory = beanFactory;
@@ -86,7 +90,9 @@ public class ExpressionEvaluatingRoutingSlipRouteStrategy
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
+		}
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/transaction/ExpressionEvaluatingTransactionSynchronizationProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transaction/ExpressionEvaluatingTransactionSynchronizationProcessor.java
@@ -71,6 +71,10 @@ public class ExpressionEvaluatingTransactionSynchronizationProcessor extends Int
 
 	private volatile MessageChannel afterRollbackChannel = new NullChannel();
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	public void setBeforeCommitChannel(MessageChannel beforeCommitChannel) {
 		Assert.notNull(beforeCommitChannel, "'beforeCommitChannel' must not be null");
 		this.beforeCommitChannel = beforeCommitChannel;
@@ -104,7 +108,9 @@ public class ExpressionEvaluatingTransactionSynchronizationProcessor extends Int
 	@Override
 	protected void onInit() throws Exception {
 		super.onInit();
-		this.evaluationContext = createEvaluationContext();
+		if (this.evaluationContext == null) {
+			this.evaluationContext = createEvaluationContext();
+		}
 	}
 
 	public void processBeforeCommit(IntegrationResourceHolder holder) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ContentEnricher.java
@@ -244,6 +244,10 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler
 		this.shouldClonePayload = shouldClonePayload;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.sourceEvaluationContext = evaluationContext;
+	}
+
 	@Override
 	public String getComponentType() {
 		return "enricher";
@@ -303,7 +307,9 @@ public class ContentEnricher extends AbstractReplyProducingMessageHandler
 			this.gateway.afterPropertiesSet();
 		}
 
-		this.sourceEvaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		if (this.sourceEvaluationContext == null) {
+			this.sourceEvaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		}
 
 		StandardEvaluationContext targetContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 		// bean resolution is NOT allowed for the target of the enrichment

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -173,6 +173,10 @@ public abstract class AbstractInboundFileSynchronizer<F>
 		this.preserveTimestamp = preserveTimestamp;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		this.beanFactory = beanFactory;
@@ -181,7 +185,9 @@ public abstract class AbstractInboundFileSynchronizer<F>
 	@Override
 	public final void afterPropertiesSet() {
 		Assert.notNull(this.remoteDirectory, "remoteDirectory must not be null");
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
+		}
 	}
 
 	protected final List<F> filterFiles(F[] files) {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpOutboundGateway.java
@@ -96,11 +96,17 @@ public class TcpOutboundGateway extends AbstractReplyProducingMessageHandler
 		this.remoteTimeoutExpression = remoteTimeoutExpression;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	protected void doInit() {
 		super.doInit();
 
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		}
 	}
 
 	@Override

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/core/JpaExecutor.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/core/JpaExecutor.java
@@ -151,6 +151,10 @@ public class JpaExecutor implements InitializingBean, BeanFactoryAware {
 		this.jpaOperations = jpaOperations;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		this.beanFactory = beanFactory;
@@ -206,7 +210,9 @@ public class JpaExecutor implements InitializingBean, BeanFactoryAware {
 			this.flushSize = 1;
 		}
 
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
+		}
 	}
 
 	/**

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/ExpressionArgumentsStrategy.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/ExpressionArgumentsStrategy.java
@@ -63,6 +63,10 @@ public class ExpressionArgumentsStrategy implements ArgumentsStrategy, BeanFacto
 		this.useCommandVariable = useCommandVariable;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		this.beanFactory = beanFactory;
@@ -70,7 +74,9 @@ public class ExpressionArgumentsStrategy implements ArgumentsStrategy, BeanFacto
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
+		}
 	}
 
 	@Override

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisOutboundGateway.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisOutboundGateway.java
@@ -94,6 +94,10 @@ public class RedisOutboundGateway extends AbstractReplyProducingMessageHandler {
 		this.argumentsStrategy = argumentsStrategy;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	public String getComponentType() {
 		return "redis:outbound-gateway";
@@ -102,7 +106,9 @@ public class RedisOutboundGateway extends AbstractReplyProducingMessageHandler {
 	@Override
 	protected void doInit() {
 		super.doInit();
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		}
 	}
 
 	@Override

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisPublishingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisPublishingMessageHandler.java
@@ -87,6 +87,10 @@ public class RedisPublishingMessageHandler extends AbstractMessageHandler {
 		this.topicExpression = topicExpression;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	public String getComponentType() {
 		return "redis:outbound-channel-adapter";
@@ -98,7 +102,9 @@ public class RedisPublishingMessageHandler extends AbstractMessageHandler {
 		if (this.messageConverter instanceof BeanFactoryAware) {
 			((BeanFactoryAware) this.messageConverter).setBeanFactory(getBeanFactory());
 		}
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		}
 	}
 
 	@Override

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisQueueOutboundChannelAdapter.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisQueueOutboundChannelAdapter.java
@@ -77,6 +77,10 @@ public class RedisQueueOutboundChannelAdapter extends AbstractMessageHandler {
 		this.serializerExplicitlySet = true;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	public String getComponentType() {
 		return "redis:queue-outbound-channel-adapter";
@@ -85,7 +89,9 @@ public class RedisQueueOutboundChannelAdapter extends AbstractMessageHandler {
 	@Override
 	protected void onInit() throws Exception {
 		super.onInit();
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		}
 	}
 
 	@Override

--- a/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/outbound/StompMessageHandler.java
+++ b/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/outbound/StompMessageHandler.java
@@ -84,6 +84,10 @@ public class StompMessageHandler extends AbstractMessageHandler implements Appli
 		this.headerMapper = headerMapper;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
 		this.applicationEventPublisher = applicationEventPublisher;
@@ -93,7 +97,9 @@ public class StompMessageHandler extends AbstractMessageHandler implements Appli
 	protected void onInit() throws Exception {
 		super.onInit();
 
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		}
 	}
 
 	@Override

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/outbound/StatusUpdatingMessageHandler.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/outbound/StatusUpdatingMessageHandler.java
@@ -68,17 +68,24 @@ public class StatusUpdatingMessageHandler extends AbstractMessageHandler {
 		this.tweetDataExpression = tweetDataExpression;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	protected void onInit() throws Exception {
 		super.onInit();
 
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
-		TypeLocator typeLocator = this.evaluationContext.getTypeLocator();
-		if (typeLocator instanceof StandardTypeLocator) {
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+
+			TypeLocator typeLocator = this.evaluationContext.getTypeLocator();
+			if (typeLocator instanceof StandardTypeLocator) {
 			/*
 			 * Register the twitter api package so they don't need a FQCN for TweetData.
 			 */
-			((StandardTypeLocator) typeLocator).registerImport("org.springframework.social.twitter.api");
+				((StandardTypeLocator) typeLocator).registerImport("org.springframework.social.twitter.api");
+			}
 		}
 	}
 

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/outbound/TwitterSearchOutboundGateway.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/outbound/TwitterSearchOutboundGateway.java
@@ -76,6 +76,10 @@ public class TwitterSearchOutboundGateway extends AbstractReplyProducingMessageH
 		this.searchArgsExpression = searchArgsExpression;
 	}
 
+	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+		this.evaluationContext = evaluationContext;
+	}
+
 	@Override
 	public String getComponentType() {
 		return "twitter:search-outbound-gateway";
@@ -88,13 +92,15 @@ public class TwitterSearchOutboundGateway extends AbstractReplyProducingMessageH
 	@Override
 	protected void doInit() {
 		super.doInit();
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
-		TypeLocator typeLocator = this.evaluationContext.getTypeLocator();
-		if (typeLocator instanceof StandardTypeLocator) {
-			/*
-			 * Register the twitter api package so they don't need a FQCN for SearchParameters.
-			 */
-			((StandardTypeLocator) typeLocator).registerImport("org.springframework.social.twitter.api");
+		if (this.evaluationContext == null) {
+			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+			TypeLocator typeLocator = this.evaluationContext.getTypeLocator();
+			if (typeLocator instanceof StandardTypeLocator) {
+				/*
+				 * Register the twitter api package so they don't need a FQCN for SearchParameters.
+				 */
+				((StandardTypeLocator) typeLocator).registerImport("org.springframework.social.twitter.api");
+			}
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3749

Since some target application could inject there is `EvaluationContext` before, removal of
 `setIntegrationEvaluationContext()` is breaking change.

 This fix reverts all those setters.
