### PR TITLE
INT-3755: Separate Stats Enablement from JMX

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
@@ -100,7 +100,7 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 	}
 
 	@Override
-	public void enableCounts(boolean countsEnabled) {
+	public void setCountsEnabled(boolean countsEnabled) {
 		this.countsEnabled = countsEnabled;
 		if (!countsEnabled) {
 			this.statsEnabled = false;
@@ -113,7 +113,7 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 	}
 
 	@Override
-	public void enableStats(boolean statsEnabled) {
+	public void setStatsEnabled(boolean statsEnabled) {
 		if (statsEnabled) {
 			this.countsEnabled = true;
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/NullChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/NullChannel.java
@@ -95,7 +95,7 @@ public class NullChannel implements PollableChannel, MessageChannelMetrics,
 	}
 
 	@Override
-	public void enableCounts(boolean countsEnabled) {
+	public void setCountsEnabled(boolean countsEnabled) {
 		this.countsEnabled = countsEnabled;
 		if (!countsEnabled) {
 			this.statsEnabled = false;
@@ -108,7 +108,7 @@ public class NullChannel implements PollableChannel, MessageChannelMetrics,
 	}
 
 	@Override
-	public void enableStats(boolean statsEnabled) {
+	public void setStatsEnabled(boolean statsEnabled) {
 		if (statsEnabled) {
 			this.countsEnabled = true;
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AggregatorFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AggregatorFactoryBean.java
@@ -102,11 +102,11 @@ public class AggregatorFactoryBean extends AbstractSimpleMessageHandlerFactoryBe
 		this.aggregator.setChannelResolver(channelResolver);
 	}
 
-	public void enableStats(boolean statsEnabled) {
+	public void setStatsEnabled(boolean statsEnabled) {
 		this.aggregator.setStatsEnabled(statsEnabled);
 	}
 
-	public void enableCounts(boolean countsEnabled) {
+	public void setCountsEnabled(boolean countsEnabled) {
 		this.aggregator.setCountsEnabled(countsEnabled);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AggregatorFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AggregatorFactoryBean.java
@@ -103,11 +103,11 @@ public class AggregatorFactoryBean extends AbstractSimpleMessageHandlerFactoryBe
 	}
 
 	public void enableStats(boolean statsEnabled) {
-		this.aggregator.enableStats(statsEnabled);
+		this.aggregator.setStatsEnabled(statsEnabled);
 	}
 
 	public void enableCounts(boolean countsEnabled) {
-		this.aggregator.enableCounts(countsEnabled);
+		this.aggregator.setCountsEnabled(countsEnabled);
 	}
 
 	public void setLockRegistry(LockRegistry lockRegistry) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/EnableIntegrationManagement.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/EnableIntegrationManagement.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.integration.support.management.IntegrationManagement;
+import org.springframework.integration.support.management.IntegrationManagementConfigurer;
+
+/**
+ * Enables default configuring of management in Spring Integration components in an existing application.
+ *
+ * <p>The resulting {@link IntegrationManagementConfigurer}
+ * bean is defined under the name {@code integrationManagementConfigurer}.
+ *
+ * @author Gary Russell
+ * @since 4.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(IntegrationManagementConfiguration.class)
+public @interface EnableIntegrationManagement {
+
+	/**
+	 * A list of simple patterns for component names for which message counts will be
+	 * enabled (defaults to '*'). Enables message
+	 * counting (`sendCount`, `errorCount`, `receiveCount`) for those components that
+	 * support counters (channels, message handlers, etc). This is the initial setting
+	 * only, individual components can have counts enabled/disabled at runtime. May be
+	 * overridden by an entry in {@link #statsEnabled() statsEnabled} which is additional
+	 * functionality over simple counts. If a pattern starts with `!`, counts are disabled
+	 * for matches. For components that match multiple patterns, the first pattern wins.
+	 * Disabling counts at runtime also disables stats. Overrides
+	 * @return the patterns.
+	 * @since 4.2
+	 */
+	String[] countsEnabled() default "";
+
+	/**
+	 * A list of simple patterns for component names for which message statistics will be
+	 * enabled (response times, rates etc), as well as counts (a positive match here
+	 * overrides {@link #countsEnabled() countsEnabled}, you can't have statistics without
+	 * counts). (defaults to '*'). Enables
+	 * statistics for those components that support statistics (channels - when sending,
+	 * message handlers, etc). This is the initial setting only, individual components can
+	 * have stats enabled/disabled at runtime. If a pattern starts with `!`, stats (and
+	 * counts) are disabled for matches. Note: this means that '!foo' here will disable
+	 * stats and counts for 'foo' even if counts are enabled for 'foo' in
+	 * {@link #countsEnabled() countsEnabled}. For components
+	 * that match multiple patterns, the first pattern wins. Enabling stats at runtime
+	 * also enables counts.
+	 * Defaults to no components, unless JMX is enabled in which case, defaults to all
+	 * components.
+	 * @return the patterns.
+	 * @since 4.2
+	 */
+	String[] statsEnabled() default "";
+
+	/**
+	 * The default setting for enabling counts when a bean name is not matched by
+	 * {@link #countsEnabled() countsEnabled}.
+	 * @return the value; false by default, or true when JMX is enabled.
+	 */
+	String defaultCountsEnabled() default "false";
+
+	/**
+	 * The default setting for enabling statistics when a bean name is not matched by
+	 * {@link #statsEnabled() statsEnabled}.
+	 * @return the value; false by default, or true when JMX is enabled.
+	 */
+	String defaultStatsEnabled() default "false";
+
+	/**
+	 * Use to disable all logging in the main message flow in framework components. When 'false', such logging will be
+	 * skipped, regardless of logging level. When 'true', the logging is controlled as normal by the logging
+	 * subsystem log level configuration.
+	 * <p>
+	 * It has been found that in high-volume messaging environments, calls to methods such as
+	 * {@code logger.isDebuggingEnabled()} can be quite expensive and account for an inordinate amount of CPU
+	 * time.
+	 * <p>
+	 * Set this to false to disable logging by default in all framework components that implement
+	 * {@link IntegrationManagement} (channels, message handlers etc). This turns off logging such as
+	 * "PreSend on channel", "Received message" etc.
+	 * <p>
+	 * After the context is initialized, individual components can have their setting changed by invoking
+	 * {@link IntegrationManagement#setLoggingEnabled(boolean)}.
+	 * @return the value; true by default.
+	 */
+	String defaultLoggingEnabled() default "true";
+
+	/**
+	 * The bean name of a {@code MetricsFactory}. The {@code DefaultMetricsFactory} is used
+	 * if omitted.
+	 * @return the bean name.
+	 */
+	String metricsFactory() default "";
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/EnableIntegrationManagement.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/EnableIntegrationManagement.java
@@ -33,7 +33,7 @@ import org.springframework.integration.support.management.IntegrationManagementC
  * bean is defined under the name {@code integrationManagementConfigurer}.
  *
  * @author Gary Russell
- * @since 4.0
+ * @since 4.2
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -50,7 +50,9 @@ public @interface EnableIntegrationManagement {
 	 * overridden by an entry in {@link #statsEnabled() statsEnabled} which is additional
 	 * functionality over simple counts. If a pattern starts with `!`, counts are disabled
 	 * for matches. For components that match multiple patterns, the first pattern wins.
-	 * Disabling counts at runtime also disables stats. Overrides
+	 * Disabling counts at runtime also disables stats.
+	 * Defaults to no components, unless JMX is enabled in which case, defaults to all
+	 * components. Overrides {@link #defaultCountsEnabled()} for matching bean names.
 	 * @return the patterns.
 	 * @since 4.2
 	 */

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfiguration.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfiguration.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.config;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportAware;
+import org.springframework.context.annotation.Role;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.integration.support.management.IntegrationManagementConfigurer;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@code @Configuration} class that registers a {@link IntegrationManagementConfigurer} bean.
+ *
+ * <p>This configuration class is automatically imported when using the
+ * {@link EnableIntegrationManagement} annotation. See its javadoc for complete usage details.
+ *
+ * @author Artem Bilan
+ * @author Gary Russell
+ * @since 4.2
+ */
+@Configuration
+public class IntegrationManagementConfiguration implements ImportAware, EnvironmentAware {
+
+	private AnnotationAttributes attributes;
+
+	private Environment environment;
+
+	@Override
+	public void setEnvironment(Environment environment) {
+		this.environment = environment;
+	}
+
+	@Override
+	public void setImportMetadata(AnnotationMetadata importMetadata) {
+		Map<String, Object> map = importMetadata.getAnnotationAttributes(EnableIntegrationManagement.class.getName());
+		this.attributes = AnnotationAttributes.fromMap(map);
+		Assert.notNull(this.attributes,
+				"@EnableIntegrationManagement is not present on importing class " + importMetadata.getClassName());
+	}
+
+	@Bean(name = IntegrationManagementConfigurer.MANAGEMENT_CONFIGURER_NAME)
+	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+	public IntegrationManagementConfigurer managementConfigurer() {
+		IntegrationManagementConfigurer configurer = new IntegrationManagementConfigurer();
+		setupCountsEnabledNamePatterns(configurer);
+		setupStatsEnabledNamePatterns(configurer);
+		configurer.setDefaultLoggingEnabled(
+				Boolean.parseBoolean(this.environment.resolvePlaceholders(
+						(String) this.attributes.get("defaultLoggingEnabled"))));
+		configurer.setDefaultCountsEnabled(
+				Boolean.parseBoolean(this.environment.resolvePlaceholders(
+						(String) this.attributes.get("defaultCountsEnabled"))));
+		configurer.setDefaultStatsEnabled(
+				Boolean.parseBoolean(this.environment.resolvePlaceholders(
+						(String) this.attributes.get("defaultStatsEnabled"))));
+		configurer.setMetricsFactoryBeanName((String) this.attributes.get("metricsFactory"));
+		return configurer;
+	}
+
+	private void setupCountsEnabledNamePatterns(IntegrationManagementConfigurer exporter) {
+		List<String> patterns = new ArrayList<String>();
+		String[] countsEnabled = this.attributes.getStringArray("countsEnabled");
+		for (String managedComponent : countsEnabled) {
+			String pattern = this.environment.resolvePlaceholders(managedComponent);
+			patterns.addAll(Arrays.asList(StringUtils.commaDelimitedListToStringArray(pattern)));
+		}
+		exporter.setEnabledCountsPatterns(patterns.toArray(new String[patterns.size()]));
+	}
+
+	private void setupStatsEnabledNamePatterns(IntegrationManagementConfigurer exporter) {
+		List<String> patterns = new ArrayList<String>();
+		String[] statsEnabled = this.attributes.getStringArray("statsEnabled");
+		for (String managedComponent : statsEnabled) {
+			String pattern = this.environment.resolvePlaceholders(managedComponent);
+			patterns.addAll(Arrays.asList(StringUtils.commaDelimitedListToStringArray(pattern)));
+		}
+		exporter.setEnabledStatsPatterns(patterns.toArray(new String[patterns.size()]));
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfiguration.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfiguration.java
@@ -83,14 +83,14 @@ public class IntegrationManagementConfiguration implements ImportAware, Environm
 		return configurer;
 	}
 
-	private void setupCountsEnabledNamePatterns(IntegrationManagementConfigurer exporter) {
+	private void setupCountsEnabledNamePatterns(IntegrationManagementConfigurer configurer) {
 		List<String> patterns = new ArrayList<String>();
 		String[] countsEnabled = this.attributes.getStringArray("countsEnabled");
 		for (String managedComponent : countsEnabled) {
 			String pattern = this.environment.resolvePlaceholders(managedComponent);
 			patterns.addAll(Arrays.asList(StringUtils.commaDelimitedListToStringArray(pattern)));
 		}
-		exporter.setEnabledCountsPatterns(patterns.toArray(new String[patterns.size()]));
+		configurer.setEnabledCountsPatterns(patterns.toArray(new String[patterns.size()]));
 	}
 
 	private void setupStatsEnabledNamePatterns(IntegrationManagementConfigurer exporter) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationManagementParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationManagementParser.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.config.xml;
+
+import org.w3c.dom.Element;
+
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.support.management.IntegrationManagementConfigurer;
+
+/**
+ * Parser for the &lt;management/&gt; element.
+ *
+ * @author Gary Russell
+ * @since 4.2
+ */
+public class IntegrationManagementParser extends AbstractBeanDefinitionParser {
+
+
+	@Override
+	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
+			throws BeanDefinitionStoreException {
+		return IntegrationManagementConfigurer.MANAGEMENT_CONFIGURER_NAME;
+	}
+
+	@Override
+	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(IntegrationManagementConfigurer.class);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "default-logging-enabled");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "default-counts-enabled");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "default-stats-enabled");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "counts-enabled-patterns",
+				"enabledCountsPatterns");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "stats-enabled-patterns",
+				"enabledStatsPatterns");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "metrics-factory");
+		AbstractBeanDefinition interceptorBeanDefinition = builder.getBeanDefinition();
+		return interceptorBeanDefinition;
+	}
+
+	@Override
+	protected boolean shouldFireEvents() {
+		return false;
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceHandler.java
@@ -83,6 +83,7 @@ public class IntegrationNamespaceHandler extends AbstractIntegrationNamespaceHan
 		registerBeanDefinitionParser("retry-advice", retryParser);
 		registerBeanDefinitionParser("scatter-gather", new ScatterGatherParser());
 		registerBeanDefinitionParser("idempotent-receiver", new IdempotentReceiverInterceptorParser());
+		registerBeanDefinitionParser("management", new IntegrationManagementParser());
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractMessageSource.java
@@ -24,10 +24,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.expression.Expression;
 import org.springframework.integration.core.MessageSource;
-import org.springframework.integration.endpoint.management.MessageSourceMetrics;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.integration.support.management.IntegrationManagedResource;
+import org.springframework.integration.support.management.MessageSourceMetrics;
 import org.springframework.integration.util.AbstractExpressionEvaluator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
@@ -98,7 +98,7 @@ public abstract class AbstractMessageSource<T> extends AbstractExpressionEvaluat
 	}
 
 	@Override
-	public void enableCounts(boolean countsEnabled) {
+	public void setCountsEnabled(boolean countsEnabled) {
 		this.countsEnabled = countsEnabled;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageHandler.java
@@ -21,11 +21,11 @@ import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.context.Orderable;
 import org.springframework.integration.handler.management.AbstractMessageHandlerMetrics;
 import org.springframework.integration.handler.management.DefaultMessageHandlerMetrics;
-import org.springframework.integration.handler.management.MessageHandlerMetrics;
 import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.history.TrackableComponent;
 import org.springframework.integration.support.management.ConfigurableMetricsAware;
 import org.springframework.integration.support.management.IntegrationManagedResource;
+import org.springframework.integration.support.management.MessageHandlerMetrics;
 import org.springframework.integration.support.management.MetricsContext;
 import org.springframework.integration.support.management.Statistics;
 import org.springframework.messaging.Message;
@@ -203,7 +203,7 @@ public abstract class AbstractMessageHandler extends IntegrationObjectSupport im
 	}
 
 	@Override
-	public void enableStats(boolean statsEnabled) {
+	public void setStatsEnabled(boolean statsEnabled) {
 		if (statsEnabled) {
 			this.countsEnabled = true;
 		}
@@ -219,7 +219,7 @@ public abstract class AbstractMessageHandler extends IntegrationObjectSupport im
 	}
 
 	@Override
-	public void enableCounts(boolean countsEnabled) {
+	public void setCountsEnabled(boolean countsEnabled) {
 		this.countsEnabled = countsEnabled;
 		if (!countsEnabled) {
 			this.statsEnabled = false;

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/management/AggregatingMessageHandlerMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/management/AggregatingMessageHandlerMetrics.java
@@ -20,7 +20,8 @@ import org.springframework.integration.support.management.ExponentialMovingAvera
 import org.springframework.integration.support.management.MetricsContext;
 
 /**
- * An implementation of {@link MessageHandlerMetrics} that aggregates the total response
+ * An implementation of {@link org.springframework.integration.support.management.MessageHandlerMetrics}
+ * that aggregates the total response
  * time over a sample, to avoid fetching the system time twice for every message.
  *
  * @author Gary Russell

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
+import org.springframework.integration.support.management.MappingMessageRouterManagement;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.messaging.Message;

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/AggregatingMetricsFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/AggregatingMetricsFactory.java
@@ -13,32 +13,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.integration.monitor;
+package org.springframework.integration.support.management;
 
 import org.springframework.integration.channel.management.AbstractMessageChannelMetrics;
-import org.springframework.integration.channel.management.DefaultMessageChannelMetrics;
+import org.springframework.integration.channel.management.AggregatingMessageChannelMetrics;
 import org.springframework.integration.handler.management.AbstractMessageHandlerMetrics;
-import org.springframework.integration.handler.management.DefaultMessageHandlerMetrics;
+import org.springframework.integration.handler.management.AggregatingMessageHandlerMetrics;
 
 
 
 /**
- * Default implementation.
+ * Implementation that returns aggregating metrics.
  *
  * @author Gary Russell
  * @since 4.2
  *
  */
-public class DefaultMetricsFactory implements MetricsFactory {
+public class AggregatingMetricsFactory implements MetricsFactory {
+
+	private final int sampleSize;
+
+	/**
+	 * @param sampleSize the number of messages over which to aggregate the elapsed time.
+	 */
+	public AggregatingMetricsFactory(int sampleSize) {
+		this.sampleSize = sampleSize;
+	}
 
 	@Override
 	public AbstractMessageChannelMetrics createChannelMetrics(String name) {
-		return new DefaultMessageChannelMetrics(name);
+		return new AggregatingMessageChannelMetrics(name, this.sampleSize);
 	}
 
 	@Override
 	public AbstractMessageHandlerMetrics createHandlerMetrics(String name) {
-		return new DefaultMessageHandlerMetrics(name);
+		return new AggregatingMessageHandlerMetrics(name, this.sampleSize);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/DefaultMetricsFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/DefaultMetricsFactory.java
@@ -13,41 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.integration.monitor;
+package org.springframework.integration.support.management;
 
 import org.springframework.integration.channel.management.AbstractMessageChannelMetrics;
-import org.springframework.integration.channel.management.AggregatingMessageChannelMetrics;
+import org.springframework.integration.channel.management.DefaultMessageChannelMetrics;
 import org.springframework.integration.handler.management.AbstractMessageHandlerMetrics;
-import org.springframework.integration.handler.management.AggregatingMessageHandlerMetrics;
+import org.springframework.integration.handler.management.DefaultMessageHandlerMetrics;
 
 
 
 /**
- * Implementation that returns aggregating metrics.
+ * Default implementation.
  *
  * @author Gary Russell
  * @since 4.2
  *
  */
-public class AggregatingMetricsFactory implements MetricsFactory {
-
-	private final int sampleSize;
-
-	/**
-	 * @param sampleSize the number of messages over which to aggregate the elapsed time.
-	 */
-	public AggregatingMetricsFactory(int sampleSize) {
-		this.sampleSize = sampleSize;
-	}
+public class DefaultMetricsFactory implements MetricsFactory {
 
 	@Override
 	public AbstractMessageChannelMetrics createChannelMetrics(String name) {
-		return new AggregatingMessageChannelMetrics(name, this.sampleSize);
+		return new DefaultMessageChannelMetrics(name);
 	}
 
 	@Override
 	public AbstractMessageHandlerMetrics createHandlerMetrics(String name) {
-		return new AggregatingMessageHandlerMetrics(name, this.sampleSize);
+		return new DefaultMessageHandlerMetrics(name);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationManagement.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationManagement.java
@@ -36,8 +36,8 @@ public interface IntegrationManagement {
 	@ManagedOperation
 	void reset();
 
-	@ManagedOperation(description = "Enable message counting statistics")
-	void enableCounts(boolean countsEnabled);
+	@ManagedAttribute(description = "Enable message counting statistics")
+	void setCountsEnabled(boolean countsEnabled);
 
 	@ManagedAttribute
 	boolean isCountsEnabled();

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationManagementConfigurer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationManagementConfigurer.java
@@ -88,9 +88,8 @@ public class IntegrationManagementConfigurer implements SmartInitializingSinglet
 
 	/**
 	 * Set the array of simple patterns for component names for which message counts will
-	 * be enabled (defaults to '*'). Only patterns that also match
-	 * {@link #setComponentNamePatterns(String[]) componentNamePatterns} will be
-	 * considered. Enables message counting (`sendCount`, `errorCount`, `receiveCount`)
+	 * be enabled (defaults to '*').
+	 * Enables message counting (`sendCount`, `errorCount`, `receiveCount`)
 	 * for those components that support counters (channels, message handlers, etc).
 	 * This is the initial setting only, individual components can have counts
 	 * enabled/disabled at runtime. May be overridden by an entry in
@@ -110,9 +109,8 @@ public class IntegrationManagementConfigurer implements SmartInitializingSinglet
 	 * Set the array of simple patterns for component names for which message statistics
 	 * will be enabled (response times, rates etc), as well as counts (a positive match
 	 * here overrides {@link #setEnabledCountsPatterns(String[]) enabledCountsPatterns},
-	 * you can't have statistics without counts). (defaults to '*'). Only patterns that
-	 * also match {@link #setComponentNamePatterns(String[]) componentNamePatterns} will
-	 * be considered. Enables statistics for those components that support statistics
+	 * you can't have statistics without counts). (defaults to '*').
+	 * Enables statistics for those components that support statistics
 	 * (channels - when sending, message handlers, etc). This is the initial setting only,
 	 * individual components can have stats enabled/disabled at runtime. If a pattern
 	 * starts with `!`, stats (and counts) are disabled for matches. Note: this means that
@@ -144,7 +142,7 @@ public class IntegrationManagementConfigurer implements SmartInitializingSinglet
 	/**
 	 * Set whether managed components maintain message statistics by default.
 	 * Defaults to false, unless an Integration MBean Exporter is configured.
-	 * @param defaultCountsEnabled true to enable.
+	 * @param defaultStatsEnabled true to enable.
 	 */
 	public void setDefaultStatsEnabled(Boolean defaultStatsEnabled) {
 		this.defaultStatsEnabled = defaultStatsEnabled;

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationStatsManagement.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationStatsManagement.java
@@ -16,7 +16,6 @@
 package org.springframework.integration.support.management;
 
 import org.springframework.jmx.export.annotation.ManagedAttribute;
-import org.springframework.jmx.export.annotation.ManagedOperation;
 
 
 /**
@@ -28,8 +27,8 @@ import org.springframework.jmx.export.annotation.ManagedOperation;
  */
 public interface IntegrationStatsManagement extends IntegrationManagement {
 
-	@ManagedOperation(description = "Enable all statistics")
-	void enableStats(boolean statsEnabled);
+	@ManagedAttribute(description = "Enable all statistics")
+	void setStatsEnabled(boolean statsEnabled);
 
 	@ManagedAttribute
 	boolean isStatsEnabled();

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/LifecycleMessageHandlerMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/LifecycleMessageHandlerMetrics.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.monitor;
+package org.springframework.integration.support.management;
 
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.handler.management.AbstractMessageHandlerMetrics;
-import org.springframework.integration.handler.management.MessageHandlerMetrics;
-import org.springframework.integration.support.management.ConfigurableMetricsAware;
-import org.springframework.integration.support.management.IntegrationManagedResource;
-import org.springframework.integration.support.management.Statistics;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 
@@ -144,13 +140,13 @@ public class LifecycleMessageHandlerMetrics implements MessageHandlerMetrics, Li
 	}
 
 	@Override
-	public void enableStats(boolean statsEnabled) {
-		this.delegate.enableStats(statsEnabled);
+	public void setStatsEnabled(boolean statsEnabled) {
+		this.delegate.setStatsEnabled(statsEnabled);
 	}
 
 	@Override
-	public void enableCounts(boolean countsEnabled) {
-		this.delegate.enableCounts(countsEnabled);
+	public void setCountsEnabled(boolean countsEnabled) {
+		this.delegate.setCountsEnabled(countsEnabled);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/LifecycleMessageSourceMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/LifecycleMessageSourceMetrics.java
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.monitor;
+package org.springframework.integration.support.management;
 
 import org.springframework.context.Lifecycle;
-import org.springframework.integration.endpoint.management.MessageSourceMetrics;
-import org.springframework.integration.support.management.IntegrationManagedResource;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 
@@ -89,8 +87,8 @@ public class LifecycleMessageSourceMetrics implements MessageSourceMetrics, Life
 	}
 
 	@Override
-	public void enableCounts(boolean countsEnabled) {
-		delegate.enableCounts(countsEnabled);
+	public void setCountsEnabled(boolean countsEnabled) {
+		delegate.setCountsEnabled(countsEnabled);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/LifecycleTrackableMessageHandlerMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/LifecycleTrackableMessageHandlerMetrics.java
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.monitor;
+package org.springframework.integration.support.management;
 
 import org.springframework.context.Lifecycle;
-import org.springframework.integration.handler.management.MessageHandlerMetrics;
 import org.springframework.integration.history.TrackableComponent;
-import org.springframework.integration.support.management.IntegrationManagedResource;
 import org.springframework.util.Assert;
 
 /**

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/LifecycleTrackableMessageSourceMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/LifecycleTrackableMessageSourceMetrics.java
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.monitor;
+package org.springframework.integration.support.management;
 
 import org.springframework.context.Lifecycle;
-import org.springframework.integration.endpoint.management.MessageSourceMetrics;
 import org.springframework.integration.history.TrackableComponent;
-import org.springframework.integration.support.management.IntegrationManagedResource;
 import org.springframework.util.Assert;
 
 /**

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/MappingMessageRouterManagement.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/MappingMessageRouterManagement.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.integration.router;
+package org.springframework.integration.support.management;
 
 import java.util.Map;
 import java.util.Properties;

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/MessageHandlerMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/MessageHandlerMetrics.java
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.handler.management;
+package org.springframework.integration.support.management;
 
-import org.springframework.integration.support.management.IntegrationStatsManagement;
-import org.springframework.integration.support.management.Statistics;
 import org.springframework.jmx.export.annotation.ManagedMetric;
 import org.springframework.jmx.support.MetricType;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/MessageSourceMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/MessageSourceMetrics.java
@@ -11,9 +11,8 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package org.springframework.integration.endpoint.management;
+package org.springframework.integration.support.management;
 
-import org.springframework.integration.support.management.IntegrationManagement;
 import org.springframework.jmx.export.annotation.ManagedMetric;
 import org.springframework.jmx.support.MetricType;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/MetricsFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/MetricsFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.integration.monitor;
+package org.springframework.integration.support.management;
 
 import org.springframework.integration.channel.management.AbstractMessageChannelMetrics;
 import org.springframework.integration.handler.management.AbstractMessageHandlerMetrics;

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/RouterMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/RouterMetrics.java
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.integration.monitor;
+package org.springframework.integration.support.management;
 
 import java.util.Map;
 import java.util.Properties;
 
 import org.springframework.context.Lifecycle;
-import org.springframework.integration.handler.management.MessageHandlerMetrics;
-import org.springframework.integration.router.MappingMessageRouterManagement;
 
 /**
  * Allows Router operations to appear in the same MBean as statistics.

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/TrackableRouterMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/TrackableRouterMetrics.java
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.monitor;
+package org.springframework.integration.support.management;
 
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.history.TrackableComponent;
-import org.springframework.integration.router.MappingMessageRouterManagement;
 import org.springframework.util.Assert;
 
 /**

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.2.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/xml/spring-integration-4.2.xsd
@@ -4482,6 +4482,82 @@ The list of component name patterns you want to track (e.g.,  tracked-components
 		</xsd:complexType>
 	</xsd:element>
 
+	<xsd:element name="management">
+		<xsd:complexType>
+			<xsd:attribute name="default-logging-enabled" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						Set false, to disable all main-path debug logging for components that implement
+						'IntegrationManagement' (channels, message handlers etc). For high-volume environments
+						avoiding calls to 'isDebuggingEnabled()` can improve performance.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="default-counts-enabled" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The default value for components that don't match 'counts-enabled-patterns'.
+						Defaults to false, or true when an Integration MBean Exporter is provided.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="default-stats-enabled" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						The default value for components that don't match 'stats-enabled-patterns'.
+						Defaults to false, or true when an Integration MBean Exporter is provided.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="counts-enabled-patterns" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						Comma separated list of simple patterns for component names for which message counts
+						will be enabled (defaults to '*'). Only patterns that also match 'managed-components'
+						will be considered. Enables message counting (`sendCount`, `errorCount`, `receiveCount`)
+						for those components that support counters (channels, message handlers, etc).
+						This is the initial setting only, individual components can have counts enabled/disabled
+						at runtime. May be overridden by an entry in 'stats-enabled' which is additional
+						functionality over simple counts. If a pattern starts with `!`, counts are disabled
+						for matches. For components with names that match multiple patterns, the first pattern wins.
+						Disabling counts at runtime also disables stats.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="stats-enabled-patterns" use="optional">
+				<xsd:annotation>
+					<xsd:documentation>
+						Comma separated list of simple patterns for component names for which message statistics
+						will be enabled (response times, rates etc), as well as counts (a positive match here
+						overrides `counts-enabled`, you can't have statistics without counts).
+						(defaults to '*'). Only patterns that also match 'managed-components'
+						will be considered. Enables statistics for those components that support
+						statistics (channels - when sending, message handlers, etc).
+						This is the initial setting only, individual components can have stats enabled/disabled
+						at runtime. If a pattern starts with `!`, stats (and counts) are disabled
+						for matches. Note: this means that '!foo' here will disable stats
+						and counts for 'foo' even if counts are enabled for 'foo' in 'counts-enabled'.
+						For components with names that match multiple patterns, the first pattern wins.
+						Enabling stats at runtime also enables counts.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="metrics-factory" use="optional">
+				<xsd:annotation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="org.springframework.integration.support.management.MetricsFactory" />
+						</tool:annotation>
+					</xsd:appinfo>
+					<xsd:documentation>
+						A MetricsFactory responsible for creating objects that maintain metrics for message
+						channels and message handlers.
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+		</xsd:complexType>
+	</xsd:element>
+
 	<xsd:complexType name="control-bus-type">
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/IntegrationManagementConfigurerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/IntegrationManagementConfigurerTests.java
@@ -64,6 +64,7 @@ public class IntegrationManagementConfigurerTests {
 		beans.put("baz", source);
 		when(ctx.getBeansOfType(IntegrationManagement.class)).thenReturn(beans);
 		IntegrationManagementConfigurer configurer = new IntegrationManagementConfigurer();
+		configurer.setBeanName(IntegrationManagementConfigurer.MANAGEMENT_CONFIGURER_NAME);
 		configurer.setApplicationContext(ctx);
 		configurer.setDefaultLoggingEnabled(false);
 		configurer.afterSingletonsInstantiated();

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/EnableIntegrationMBeanExport.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/EnableIntegrationMBeanExport.java
@@ -84,39 +84,4 @@ public @interface EnableIntegrationMBeanExport {
 	 */
 	String[] managedComponents() default "*";
 
-	/**
-	 * A list of simple patterns for component names for which message counts will be
-	 * enabled (defaults to '*'). Only patterns that also match
-	 * {@link #managedComponents() managedComponents} will be considered. Enables message
-	 * counting (`sendCount`, `errorCount`, `receiveCount`) for those components that
-	 * support counters (channels, message handlers, etc). This is the initial setting
-	 * only, individual components can have counts enabled/disabled at runtime. May be
-	 * overridden by an entry in {@link #statsEnabled() statsEnabled} which is additional
-	 * functionality over simple counts. If a pattern starts with `!`, counts are disabled
-	 * for matches. For components that match multiple patterns, the first pattern wins.
-	 * Disabling counts at runtime also disables stats.
-	 * @return the patterns.
-	 * @since 4.2
-	 */
-	String[] countsEnabled() default "*";
-
-	/**
-	 * A list of simple patterns for component names for which message statistics will be
-	 * enabled (response times, rates etc), as well as counts (a positive match here
-	 * overrides {@link #countsEnabled() countsEnabled}, you can't have statistics without
-	 * counts). (defaults to '*'). Only patterns that also match
-	 * {@link #managedComponents() managedComponents} will be considered. Enables
-	 * statistics for those components that support statistics (channels - when sending,
-	 * message handlers, etc). This is the initial setting only, individual components can
-	 * have stats enabled/disabled at runtime. If a pattern starts with `!`, stats (and
-	 * counts) are disabled for matches. Note: this means that '!foo' here will disable
-	 * stats and counts for 'foo' even if counts are enabled for 'foo' in
-	 * {@link #countsEnabled() countsEnabled}. For components
-	 * that match multiple patterns, the first pattern wins. Enabling stats at runtime
-	 * also enables counts.
-	 * @return the patterns.
-	 * @since 4.2
-	 */
-	String[] statsEnabled() default "*";
-
 }

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/MBeanExporterParser.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/MBeanExporterParser.java
@@ -58,9 +58,6 @@ public class MBeanExporterParser extends AbstractSingleBeanDefinitionParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "default-domain");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "object-name-static-properties");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "managed-components", "componentNamePatterns");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "counts-enabled", "enabledCountsPatterns");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "stats-enabled", "enabledStatsPatterns");
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "metrics-factory");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "object-naming-strategy", "namingStrategy");
 
 		builder.addPropertyValue("server", mbeanServer);

--- a/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-4.2.xsd
+++ b/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-4.2.xsd
@@ -188,52 +188,6 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
-					<xsd:attribute name="counts-enabled" use="optional">
-						<xsd:annotation>
-							<xsd:documentation>
-								Comma separated list of simple patterns for component names for which message counts
-								will be enabled (defaults to '*'). Only patterns that also match 'managed-components'
-								will be considered. Enables message counting (`sendCount`, `errorCount`, `receiveCount`)
-								for those components that support counters (channels, message handlers, etc).
-								This is the initial setting only, individual components can have counts enabled/disabled
-								at runtime. May be overridden by an entry in 'stats-enabled' which is additional
-								functionality over simple counts. If a pattern starts with `!`, counts are disabled
-								for matches. For components with names that match multiple patterns, the first pattern wins.
-								Disabling counts at runtime also disables stats.
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
-					<xsd:attribute name="stats-enabled" use="optional">
-						<xsd:annotation>
-							<xsd:documentation>
-								Comma separated list of simple patterns for component names for which message statistics
-								will be enabled (response times, rates etc), as well as counts (a positive match here
-								overrides `counts-enabled`, you can't have statistics without counts).
-								(defaults to '*'). Only patterns that also match 'managed-components'
-								will be considered. Enables statistics for those components that support
-								statistics (channels - when sending, message handlers, etc).
-								This is the initial setting only, individual components can have stats enabled/disabled
-								at runtime. If a pattern starts with `!`, stats (and counts) are disabled
-								for matches. Note: this means that '!foo' here will disable stats
-								and counts for 'foo' even if counts are enabled for 'foo' in 'counts-enabled'.
-								For components with names that match multiple patterns, the first pattern wins.
-								Enabling stats at runtime also enables counts.
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
-					<xsd:attribute name="metrics-factory" use="optional">
-						<xsd:annotation>
-							<xsd:appinfo>
-								<tool:annotation kind="ref">
-									<tool:expected-type type="org.springframework.integration.monitor.MetricsFactory" />
-								</tool:annotation>
-							</xsd:appinfo>
-							<xsd:documentation>
-								A MetricsFactory responsible for creating objects that maintain metrics for message
-								channels and message handlers.
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
 					<xsd:attribute name="object-naming-strategy" use="optional">
 						<xsd:annotation>
 							<xsd:appinfo>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanExporterParserTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanExporterParserTests-context.xml
@@ -20,11 +20,16 @@
 					  default-domain="tests.MBeanExpoerterParser"
 					  object-name-static-properties="appProperties"
 					  object-naming-strategy="keyNamer"
-					  counts-enabled="foo, !baz, ba*"
-					  stats-enabled="fiz, buz" 
-					  managed-components="\!excluded, f*, b*, q*, t*"
-					  metrics-factory="mf" />
-					  
+					  managed-components="\!excluded, f*, b*, q*, t*" />
+
+	<si:management
+		default-logging-enabled="false"
+		default-counts-enabled="false"
+		default-stats-enabled="false"
+		counts-enabled-patterns="foo, !baz, ba*"
+		stats-enabled-patterns="fiz, buz"
+		metrics-factory="mf" />
+						  
 	<util:properties id="appProperties">
 		<prop key="foo">foo</prop>
 		<prop key="bar">bar</prop>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanExporterParserTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanExporterParserTests.java
@@ -36,12 +36,13 @@ import org.springframework.integration.channel.management.DefaultMessageChannelM
 import org.springframework.integration.channel.management.MessageChannelMetrics;
 import org.springframework.integration.handler.management.AbstractMessageHandlerMetrics;
 import org.springframework.integration.handler.management.DefaultMessageHandlerMetrics;
-import org.springframework.integration.handler.management.MessageHandlerMetrics;
 import org.springframework.integration.monitor.IntegrationMBeanExporter;
-import org.springframework.integration.monitor.MetricsFactory;
 import org.springframework.integration.support.management.ExponentialMovingAverage;
 import org.springframework.integration.support.management.ExponentialMovingAverageRate;
 import org.springframework.integration.support.management.ExponentialMovingAverageRatio;
+import org.springframework.integration.support.management.IntegrationManagementConfigurer;
+import org.springframework.integration.support.management.MessageHandlerMetrics;
+import org.springframework.integration.support.management.MetricsFactory;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -99,11 +100,13 @@ public class MBeanExporterParserTests {
 		assertFalse(metrics.isStatsEnabled());
 		checkCustomized(metrics);
 		MetricsFactory factory = context.getBean(MetricsFactory.class);
-		assertSame(factory, TestUtils.getPropertyValue(exporter, "metricsFactory"));
+		IntegrationManagementConfigurer configurer = context.getBean(IntegrationManagementConfigurer.class);
+		assertSame(factory, TestUtils.getPropertyValue(configurer, "metricsFactory"));
 		exporter.destroy();
 	}
 
 	private void checkCustomized(MessageChannelMetrics metrics) {
+		assertFalse(metrics.isLoggingEnabled());
 		assertEquals(20, TestUtils.getPropertyValue(metrics, "channelMetrics.sendDuration.window"));
 		assertEquals(1000000., TestUtils.getPropertyValue(metrics, "channelMetrics.sendDuration.factor", Double.class),
 				.01);

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/AggregatingMetricsTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/AggregatingMetricsTests-context.xml
@@ -11,7 +11,9 @@
 
 	<context:mbean-server />
 
-	<int-jmx:mbean-export metrics-factory="aggregatingMetricsFactory" />
+	<int-jmx:mbean-export />
+
+	<int:management metrics-factory="aggregatingMetricsFactory" default-counts-enabled="true" default-stats-enabled="true" />
 
 	<int:channel id="input" />
 
@@ -21,7 +23,8 @@
 		<int:queue />
 	</int:channel>
 
-	<bean id="aggregatingMetricsFactory" class="org.springframework.integration.monitor.AggregatingMetricsFactory">
+	<bean id="aggregatingMetricsFactory"
+			class="org.springframework.integration.support.management.AggregatingMetricsFactory">
 		<constructor-arg value="1000" />
 	</bean>
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/AggregatingMetricsTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/AggregatingMetricsTests.java
@@ -80,9 +80,9 @@ public class AggregatingMetricsTests {
 	public void testElapsed() {
 		int sampleSize = 2;
 		this.delay.configureMetrics(new AggregatingMessageChannelMetrics("foo", sampleSize));
-		this.delay.enableStats(true);
+		this.delay.setStatsEnabled(true);
 		this.delayer.configureMetrics(new AggregatingMessageHandlerMetrics("bar", sampleSize));
-		this.delayer.enableStats(true);
+		this.delayer.setStatsEnabled(true);
 		GenericMessage<String> message = new GenericMessage<String>("foo");
 		int count = 4;
 		for (int i = 0; i < count; i++) {

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/ChannelIntegrationTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/ChannelIntegrationTests.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.integration.handler.management.MessageHandlerMetrics;
+import org.springframework.integration.support.management.MessageHandlerMetrics;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.PollableChannel;

--- a/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/Int2307Tests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/Int2307Tests.java
@@ -54,11 +54,11 @@ public class Int2307Tests {
 		int count = 0;
 		for (ObjectInstance mbean : mbeans) {
 			Thread.sleep(500); //Added in order to pass test with Java 8
-			if (mbean.toString().startsWith("org.springframework.integration.monitor.LifecycleTrackableMessageHandlerMetrics[test.domain:type=MessageHandler,name=rlr,bean=endpoint,random=")) {
+			if (mbean.toString().startsWith("org.springframework.integration.support.management.LifecycleTrackableMessageHandlerMetrics[test.domain:type=MessageHandler,name=rlr,bean=endpoint,random=")) {
 				bits |= 2;
 				count++;
 			}
-			else if (mbean.toString().startsWith("org.springframework.integration.monitor.TrackableRouterMetrics[test.domain:type=MessageHandler,name=hvr,bean=endpoint,random=")) {
+			else if (mbean.toString().startsWith("org.springframework.integration.support.management.TrackableRouterMetrics[test.domain:type=MessageHandler,name=hvr,bean=endpoint,random=")) {
 				bits |= 8;
 				count++;
 			}

--- a/src/reference/asciidoc/jmx.adoc
+++ b/src/reference/asciidoc/jmx.adoc
@@ -301,107 +301,6 @@ NOTE: The default naming strategy is a http://docs.spring.io/spring/docs/current
 The exporter propagates the `default-domain` to that object to allow it to generate a fallback object name if parsing of the bean key fails.
 If your custom naming strategy is a `MetadataNamingStrategy` (or subclass), the exporter will *not* propagate the `default-domain`; you will need to configure it on your strategy bean.
 
-[[jmx-channel-features]]
-===== MessageChannel MBean Features
-
-Message channels report metrics according to their concrete type.
-If you are looking at a `DirectChannel`, you will see statistics for the send operation.
-If it is a `QueueChannel`, you will also see statistics for the receive operation, as well as the count of messages that are currently buffered by this `QueueChannel`.
-In both cases there are some metrics that are simple counters (message count and error count), and some that are estimates of averages of interesting quantities.
-The algorithms used to calculate these estimates are described briefly in the section below.
-
-.MessageChannel Metrics
-
-
-[cols="1,2,3", options="header"]
-|===
-| Metric Type
-| Example
-| Algorithm
-
-| Count
-| Send Count
-| Simple incrementer.
-Increases by one when an event occurs.
-
-| Error Count
-| Send Error Count
-| Simple incrementer.
-Increases by one when an send results in an error.
-
-| Duration
-| Send Duration (method execution time in milliseconds)
-| Exponential Moving Average with decay factor (10 by default).
-Average of the method execution time over roughly the last 10 (default) measurements.
-
-| Rate
-| Send Rate (number of operations per second)
-| Inverse of Exponential Moving Average of the interval between events with decay in time (lapsing over 60 seconds by default) and per measurement (last 10 events by default).
-
-| Error Rate
-| Send Error Rate (number of errors per second)
-| Inverse of Exponential Moving Average of the interval between error events with decay in time (lapsing over 60 seconds by default) and per measurement (last 10 events by default).
-
-| Ratio
-| Send Success Ratio (ratio of successful to total sends)
-| Estimate the success ratio as the Exponential Moving Average of the series composed of values 1 for success and 0 for failure (decaying as per the rate measurement over time and events by default).
-Error ratio is 1 - success ratio.
-
-|===
-
-[[jmx-handler-features]]
-===== MessageHandler MBean Features
-
-The following table shows the statistics maintained for message handlers.
-Some metrics are simple counters (message count and error count), and one is an estimate of averages of send duration.
-The algorithms used to calculate these estimates are described briefly in the table below:
-
-.MessageHandlerMetrics
-
-[cols="1,2,3", options="header"]
-|===
-| Metric Type
-| Example
-| Algorithm
-
-| Count
-| Handle Count
-| Simple incrementer.
-Increases by one when an event occurs.
-
-| Error Count
-| Handler Error Count
-| Simple incrementer.
-Increases by one when an invocation results in an error.
-
-| Active Count
-| Handler Active Count
-| Indicates the number of currently active threads currently invoking the handler (or any downstream synchronous flow).
-
-| Duration
-| Handle Duration (method execution time in milliseconds)
-| Exponential Moving Average with decay factor (10 by default).
-Average of the method execution time over roughly the last 10 (default) measurements.
-
-|===
-
-[[jmx-statistics]]
-===== Time-Based Average Estimates
-
-A feature of the time-based average estimates is that they decay with time if no new measurements arrive.
-To help interpret the behaviour over time, the time (in seconds) since the last measurement is also exposed as a metric.
-
-There are two basic exponential models: decay per measurement (appropriate for duration and anything where the number of measurements is part of the metric), and decay per time unit (more suitable for rate measurements where the time in between measurements is part of the metric).
-Both models depend on the fact that
-
-`S(n) = sum(i=0,i=n) w(i) x(i)`has a special form when `w(i) = r^i`, with `r=constant`:
-
-`S(n) = x(n) + r S(n-1)`(so you only have to store `S(n-1)`, not the whole series `x(i)`, to generate a new metric estimate from the last measurement).
-The algorithms used in the duration metrics use `r=exp(-1/M)` with `M=10`.
-The net effect is that the estimate `S(n)` is more heavily weighted to recent measurements and is composed roughly of the last `M` measurements.
-So `M` is the "window" or lapse rate of the estimate In the case of the vanilla moving average, `i` is a counter over the number of measurements.
-In the case of the rate we interpret `i` as the elapsed time, or a combination of elapsed time and a counter (so the metric estimate contains contributions roughly from the last `M` measurements and the last `T` seconds).
-
 [[jmx-42-improvements]]
 ===== JMX Improvements
 
@@ -414,7 +313,7 @@ These changes are detailed below, with a *caution* where necessary.
 Previously, `MessageSource`, `MessageChannel` and `MessageHandler` metrics were captured by wrapping the object in a JDK dynamic proxy to intercept appropriate method calls and capture the statistics.
 The proxy was added when an integration MBean exporter was declared in the context.
 
-Now, the statistics are captured by the beans themselves; but they are still enabled (by default) only if the integration MBean exporter is declared.
+Now, the statistics are captured by the beans themselves; see <<metrics-management>> for more information.
 
 WARNING: This change means that you no longer automatically get an MBean or statistics for custom `MessageHandler` implementations, unless those custom handlers extend `AbstractMessageHandler`.
 The simplest way to resolve this is to extend `AbstractMessageHandler`.
@@ -441,17 +340,7 @@ It is now possible to control whether the statisics are enabled on an individual
 Further, it is possible to capture simple counts on `MessageChannel` s and `MessageHandler` s instead of the complete time-based statistics.
 This can have significant performance implications because you can selectively configure where you need detailed statistics, as well as enable/disable at runtime.
 
-Two new attributes have been added to the `<int-jmx:mbean-exporter/>`.
-`counts-enabled` is a list of bean name patterns where simple message counts will be enabled.
-`stats-enabled` is a list of bean name patterns where full time-based statistics will be enabled.
-These are initial settings only and each component can have its settings changed at runtime, using JMX or a <control-bus/> using the `enableCounts()` and `enableStats()` operations.
-*Note:* stats is a superset of counts, enabling stats will enable counts (this is true for the initial setting via the patterns and at runtime).
-Disabling counts at runtime will also disable stats.
-
-A pattern can be negated by preceding it with `!`; patterns are evaluated left to right; the first match (positive or negative) wins and the remaining patterns won't be evaluated against that bean.
-If your bean name begins with `!`, the `!` in the pattern can be escaped.
-`"\!foo"` will positively match a bean named `"!foo"`.
-
+See <<metrics-management>>.
 
 * *@IntegrationManagedResource*
 
@@ -501,89 +390,10 @@ If you have a bean `"!foo"`*and* you included a pattern `"!foo"` in your MBean e
 In this case, you can escape the `!` in the pattern with `\`.
 The pattern `"\!foo"` means match a bean named `"!foo"`.
 
-
-* *Replacing the Default Channel/Handler Statistics*
-
-A new strategy interface `MetricsFactory` has been introduced allowing you to provide custom channel metrics for your `MessageChannel` s and `MessageHandler` s.
-By default, a `DefaultMetricsFactory` provides default implementation of `MessageChannelMetrics` and `MessageHandlerMetrics` which are described in the next bullet.
-To override the default `MetricsFactory` use the MBean exporter's `metrics-factory` attribute to provide a reference to your `MetricsFactory` bean instance.
-You can either customize the default implementations as described in the next bullet, or provide completely different implementations by overriding `AbstractMessageChannelMetrics` and/or `AbstractMessageHandlerMetrics`.
-
-In addition to the default metrics factory described above, the framework provides the `AggregatingMetricsFactory`.
-This factory creates `AggregatingMessageChannelMetrics` and `AggregatingMessageHandlerMetrics`.
-In very high volume scenarios, the cost of capturing statistics can be prohibitive (2 calls to the system time and
-storing the data).
-The aggregating metrics aggregate the response time over a sample of messages.
-This can save significant CPU time.
-
-CAUTION: The statistics will be skewed if messages arrive in bursts.
-These metrics are intended for use with high, constant-volume, message rates.
-
-[source, xml]
-----
-<context:mbean-server />
-
-<int-jmx:mbean-export metrics-factory="aggregatingMetricsFactory" />
-
-<bean id="aggregatingMetricsFactory" class="org.springframework.integration.monitor.AggregatingMetricsFactory">
-    <constructor-arg value="1000" /> <!-- sample size -->
-</bean>
-----
-
-The above configuration aggregates the response time over 1000 messages.
-Counts (send, error) are maintained per-message but the statistics are per 1000 messages.
-
-* *Customizing the Default Channel/Handler Statistics*
-
-See <<jmx-statistics>> and the Javadocs for the `ExponentialMovingAverage*` classes for more information about these values.
-
-By default, the `DefaultMessageChannelMetrics` and `DefaultMessageHandlerMetrics` use a `window` of 10 measurements, a rate period of 1 second (rate per second) and a decay lapse period of 1 minute.
-
-If you wish to override these defaults, you can provide a custom `MetricsFactory` that returns appropriately configured metrics and provide a reference to it to the MBean exporter as described above.
-
-Example:
-
-[source,java]
-----
-public static class CustomMetrics implements MetricsFactory {
-
-    @Override
-    public AbstractMessageChannelMetrics createChannelMetrics(String name) {
-        return new DefaultMessageChannelMetrics(name,
-                new ExponentialMovingAverage(20, 1000000.),
-                new ExponentialMovingAverageRate(2000, 120000, 30, true),
-                new ExponentialMovingAverageRatio(130000, 40, true),
-                new ExponentialMovingAverageRate(3000, 140000, 50, true));
-    }
-
-    @Override
-    public AbstractMessageHandlerMetrics createHandlerMetrics(String name) {
-        return new DefaultMessageHandlerMetrics(name, new ExponentialMovingAverage(20, 1000000.));
-    }
-
-}
-----
-
-
-* *Advanced Customization*
-
-The customizations described above are wholesale and will apply to all appropriate beans exported by the MBean exporter.
-This is the extent of customization available using XML configuration.
-
-Individual beans can be provided with different implementations using java `@Configuration` or programmatically at runtime, after the application context has been refreshed, by invoking the `configureMetrics` methods on `AbstractMessageChannel` and `AbstractMessageHandler`.
-
-
-* *Performance Improvement*
-
-Previously, the time-based metrics (see <<jmx-statistics>>) were calculated in real time.
-The statistics are now calculated when retrieved instead.
-This resulted in a significant performance improvement, at the expense of a small amount of additional memory for each statistic.
-As discussed in the bullet above, the statistics can be disabled altogether, while retaining the MBean allowing the invocation of `Lifecycle` methods.
-
-
 * *IntegrationMBeanExporter changes*
 
-The `IntegrationMBeanExporter` no longer implements `SmartLifecycle`; this means that `start()` and `stop()` operations are no longer available to register/unregister MBeans.
+The `IntegrationMBeanExporter` no longer implements `SmartLifecycle`; this means that `start()` and `stop()` operations
+are no longer available to register/unregister MBeans.
 The MBeans are now registered during context initialization and unregistered when the context is destroyed.
 
 

--- a/src/reference/asciidoc/metrics.adoc
+++ b/src/reference/asciidoc/metrics.adoc
@@ -174,9 +174,9 @@ To help interpret the behaviour over time, the time (in seconds) since the last 
 There are two basic exponential models: decay per measurement (appropriate for duration and anything where the number of measurements is part of the metric), and decay per time unit (more suitable for rate measurements where the time in between measurements is part of the metric).
 Both models depend on the fact that
 
-`S(n) = sum(i=0,i=n) w(i) x(i)`has a special form when `w(i) = r^i`, with `r=constant`:
+`S(n) = sum(i=0,i=n) w(i) x(i)` has a special form when `w(i) = r^i`, with `r=constant`:
 
-`S(n) = x(n) + r S(n-1)`(so you only have to store `S(n-1)`, not the whole series `x(i)`, to generate a new metric estimate from the last measurement).
+`S(n) = x(n) + r S(n-1)` (so you only have to store `S(n-1)`, not the whole series `x(i)`, to generate a new metric estimate from the last measurement).
 The algorithms used in the duration metrics use `r=exp(-1/M)` with `M=10`.
 The net effect is that the estimate `S(n)` is more heavily weighted to recent measurements and is composed roughly of the last `M` measurements.
 So `M` is the "window" or lapse rate of the estimate In the case of the vanilla moving average, `i` is a counter over the number of measurements.

--- a/src/reference/asciidoc/metrics.adoc
+++ b/src/reference/asciidoc/metrics.adoc
@@ -1,0 +1,269 @@
+[[metrics-management]]
+=== Metrics and Management
+
+==== Configuring Metrics Capture
+
+NOTE: Prior to _version 4.2_ metrics were only available when JMX was enabled.
+See <<jmx>>.
+
+To enable `MessageSource`, `MessageChannel` and `MessageHandler` metrics, add an `<int:management/>` bean to the
+application context, or annotate one of your `@Configuration` classes with `@EnableIntegrationManagement`.
+`MessageSource` s only maintain counts, `MessageChannel` s and `MessageHandler` s maintain duration statistics in
+addition to counts.
+See <<mgmt-channel-features>> and <<mgmt-handler-features>> below.
+
+This causes the automatic registration of the `IntegrationManagementConfigurer` bean in the application context.
+Only one such bean can exist in the context and it must have the bean name `integrationManagementConfigurer`
+if registered manually via a `<bean/>` definition.
+
+In addition to metrics, you can control *debug* logging in the main message flow.
+It has been found that in very high volume applications, even calls to `isDebugEnabled()` can be quite expensive with
+some logging subsystems.
+You can disable all such logging to avoid this overhead; exception logging (debug or otherwise) are not affected
+by this setting.
+
+A number of options are available:
+
+[source, xml]
+----
+<int:management
+    default-logging-enabled="false" <1>
+    default-counts-enabled="false" <2>
+    default-stats-enabled="false" <3>
+    counts-enabled-patterns="foo, !baz, ba*" <4>
+    stats-enabled-patterns="fiz, buz" <5>
+    metrics-factory="myMetricsFactory" /> <6>
+----
+
+[source, java]
+----
+@Configuration
+@EnableIntegration
+@EnableIntegrationManagement(
+		defaultLoggingEnabled = "false", <1>
+		defaultCountsEnabled = "false", <2>
+		defaultStatsEnabled = "false", <3>
+		countsEnabled = { "foo", "${count.patterns}" }, <4>
+		statsEnabled = { "qux", "!*" }, <5>
+		MetricsFactory = "myMetricsFactory") <6>
+public static class ContextConfiguration {
+...
+}
+----
+
+<1> Set to `false` to disable all logging in the main message flow, regardless of the log system category settings.
+Set to 'true' to enable debug logging (if also enabled by the logging subsystem).
+
+<2> Enable or disable count metrics for components not matching one of the patterns in <4>.
+
+<3> Enable or disable statistical metrics for components not matching one of the patterns in <5>.
+
+<4> A comma-delimited list of patterns for beans for which counts should be enabled; negate the pattern with `!`.
+First match wins (positive or negative).
+In the unlikely event that you have a bean name starting with `!`, escape the `!` in the pattern: `\!foo` positively
+matches a bean named `!foo`.
+
+<5> A comma-delimited list of patterns for beans for which statistical metrics should be enabled; negate the pattern
+with `!`.
+First match wins (positive or negative).
+In the unlikely event that you have a bean name starting with `!`, escape the `!` in the pattern: `\!foo` positively
+matches a bean named `!foo`.
+Stats implies counts.
+
+<6> A reference to a `MetricsFactory`.
+See <<mgmt-metrics-factory>>.
+
+At runtime, counts and statistics can be obtained by calling `IntegrationManagementConfigurer` `getChannelMetrics`,
+`getHandlerMetrics` and `getSourceMetrics`, returning `MessageChannelMetrics`, `MessageHandlerMetrics` and
+`MessageSourceMetrics` respectively.
+
+See the javadocs for complete information about these classes.
+
+When JMX is enabled (see <<jmx>>), these metrics are also exposed by the `IntegrationMBeanExporter`.
+
+[[mgmt-channel-features]]
+==== MessageChannel Metric Features
+
+Message channels report metrics according to their concrete type.
+If you are looking at a `DirectChannel`, you will see statistics for the send operation.
+If it is a `QueueChannel`, you will also see statistics for the receive operation, as well as the count of messages that are currently buffered by this `QueueChannel`.
+In both cases there are some metrics that are simple counters (message count and error count), and some that are estimates of averages of interesting quantities.
+The algorithms used to calculate these estimates are described briefly in the section below.
+
+.MessageChannel Metrics
+
+
+[cols="1,2,3", options="header"]
+|===
+| Metric Type
+| Example
+| Algorithm
+
+| Count
+| Send Count
+| Simple incrementer.
+Increases by one when an event occurs.
+
+| Error Count
+| Send Error Count
+| Simple incrementer.
+Increases by one when an send results in an error.
+
+| Duration
+| Send Duration (method execution time in milliseconds)
+| Exponential Moving Average with decay factor (10 by default).
+Average of the method execution time over roughly the last 10 (default) measurements.
+
+| Rate
+| Send Rate (number of operations per second)
+| Inverse of Exponential Moving Average of the interval between events with decay in time (lapsing over 60 seconds by default) and per measurement (last 10 events by default).
+
+| Error Rate
+| Send Error Rate (number of errors per second)
+| Inverse of Exponential Moving Average of the interval between error events with decay in time (lapsing over 60 seconds by default) and per measurement (last 10 events by default).
+
+| Ratio
+| Send Success Ratio (ratio of successful to total sends)
+| Estimate the success ratio as the Exponential Moving Average of the series composed of values 1 for success and 0 for failure (decaying as per the rate measurement over time and events by default).
+Error ratio is 1 - success ratio.
+
+|===
+
+[[mgmt-handler-features]]
+==== MessageHandler Metric Features
+
+The following table shows the statistics maintained for message handlers.
+Some metrics are simple counters (message count and error count), and one is an estimate of averages of send duration.
+The algorithms used to calculate these estimates are described briefly in the table below:
+
+.MessageHandlerMetrics
+
+[cols="1,2,3", options="header"]
+|===
+| Metric Type
+| Example
+| Algorithm
+
+| Count
+| Handle Count
+| Simple incrementer.
+Increases by one when an event occurs.
+
+| Error Count
+| Handler Error Count
+| Simple incrementer.
+Increases by one when an invocation results in an error.
+
+| Active Count
+| Handler Active Count
+| Indicates the number of currently active threads currently invoking the handler (or any downstream synchronous flow).
+
+| Duration
+| Handle Duration (method execution time in milliseconds)
+| Exponential Moving Average with decay factor (10 by default).
+Average of the method execution time over roughly the last 10 (default) measurements.
+
+|===
+
+[[mgmt-statistics]]
+==== Time-Based Average Estimates
+
+A feature of the time-based average estimates is that they decay with time if no new measurements arrive.
+To help interpret the behaviour over time, the time (in seconds) since the last measurement is also exposed as a metric.
+
+There are two basic exponential models: decay per measurement (appropriate for duration and anything where the number of measurements is part of the metric), and decay per time unit (more suitable for rate measurements where the time in between measurements is part of the metric).
+Both models depend on the fact that
+
+`S(n) = sum(i=0,i=n) w(i) x(i)`has a special form when `w(i) = r^i`, with `r=constant`:
+
+`S(n) = x(n) + r S(n-1)`(so you only have to store `S(n-1)`, not the whole series `x(i)`, to generate a new metric estimate from the last measurement).
+The algorithms used in the duration metrics use `r=exp(-1/M)` with `M=10`.
+The net effect is that the estimate `S(n)` is more heavily weighted to recent measurements and is composed roughly of the last `M` measurements.
+So `M` is the "window" or lapse rate of the estimate In the case of the vanilla moving average, `i` is a counter over the number of measurements.
+In the case of the rate we interpret `i` as the elapsed time, or a combination of elapsed time and a counter (so the metric estimate contains contributions roughly from the last `M` measurements and the last `T` seconds).
+
+
+[[mgmt-metrics-factory]]
+==== Metrics Factory
+
+A new strategy interface `MetricsFactory` has been introduced allowing you to provide custom channel metrics for your
+`MessageChannel` s and `MessageHandler` s.
+By default, a `DefaultMetricsFactory` provides default implementation of `MessageChannelMetrics` and
+`MessageHandlerMetrics` which are described in the next bullet.
+To override the default `MetricsFactory` configure it as described above, by providing a reference to your
+`MetricsFactory` bean instance.
+You can either customize the default implementations as described in the next bullet, or provide completely different
+implementations by extending `AbstractMessageChannelMetrics` and/or `AbstractMessageHandlerMetrics`.
+
+In addition to the default metrics factory described above, the framework provides the `AggregatingMetricsFactory`.
+This factory creates `AggregatingMessageChannelMetrics` and `AggregatingMessageHandlerMetrics`.
+In very high volume scenarios, the cost of capturing statistics can be prohibitive (2 calls to the system time and
+storing the data for each message).
+The aggregating metrics aggregate the response time over a sample of messages.
+This can save significant CPU time.
+
+CAUTION: The statistics will be skewed if messages arrive in bursts.
+These metrics are intended for use with high, constant-volume, message rates.
+
+[source, xml]
+----
+<bean id="aggregatingMetricsFactory"
+            class="org.springframework.integration.support.management.AggregatingMetricsFactory">
+    <constructor-arg value="1000" /> <!-- sample size -->
+</bean>
+----
+
+The above configuration aggregates the duration over 1000 messages.
+Counts (send, error) are maintained per-message but the statistics are per 1000 messages.
+
+* *Customizing the Default Channel/Handler Statistics*
+
+See <<mgmt-statistics>> and the Javadocs for the `ExponentialMovingAverage*` classes for more information about these
+values.
+
+By default, the `DefaultMessageChannelMetrics` and `DefaultMessageHandlerMetrics` use a `window` of 10 measurements,
+a rate period of 1 second (rate per second) and a decay lapse period of 1 minute.
+
+If you wish to override these defaults, you can provide a custom `MetricsFactory` that returns appropriately configured
+metrics and provide a reference to it to the MBean exporter as described above.
+
+Example:
+
+[source,java]
+----
+public static class CustomMetrics implements MetricsFactory {
+
+    @Override
+    public AbstractMessageChannelMetrics createChannelMetrics(String name) {
+        return new DefaultMessageChannelMetrics(name,
+                new ExponentialMovingAverage(20, 1000000.),
+                new ExponentialMovingAverageRate(2000, 120000, 30, true),
+                new ExponentialMovingAverageRatio(130000, 40, true),
+                new ExponentialMovingAverageRate(3000, 140000, 50, true));
+    }
+
+    @Override
+    public AbstractMessageHandlerMetrics createHandlerMetrics(String name) {
+        return new DefaultMessageHandlerMetrics(name, new ExponentialMovingAverage(20, 1000000.));
+    }
+
+}
+----
+
+
+* *Advanced Customization*
+
+The customizations described above are wholesale and will apply to all appropriate beans exported by the MBean exporter.
+This is the extent of customization available using XML configuration.
+
+Individual beans can be provided with different implementations using java `@Configuration` or programmatically at
+runtime, after the application context has been refreshed, by invoking the `configureMetrics` methods on
+`AbstractMessageChannel` and `AbstractMessageHandler`.
+
+
+* *Performance Improvement*
+
+Previously, the time-based metrics (see <<mgmt-statistics>>) were calculated in real time.
+The statistics are now calculated when retrieved instead.
+This resulted in a significant performance improvement, at the expense of a small amount of additional memory for each statistic.
+As discussed in the bullet above, the statistics can be disabled altogether, while retaining the MBean allowing the invocation of `Lifecycle` methods.

--- a/src/reference/asciidoc/system-management.adoc
+++ b/src/reference/asciidoc/system-management.adoc
@@ -2,6 +2,8 @@
 == System Management
 
 // BE SURE TO PRECEDE ALL include:: with a blank line - see https://github.com/asciidoctor/asciidoctor/issues/1297
+include::./metrics.adoc[]
+
 include::./jmx.adoc[]
 
 include::./message-history.adoc[]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -8,14 +8,15 @@ If you are interested in more details, please see the Issue Tracker tickets that
 === New Components
 
 [[x4.2-JMX]]
-==== Major JMX Rework
+==== Major Management/JMX Rework
 
 A new `MetricsFactory` strategy interface has been introduced.
-This, together with other changes in the JMX infrastructure provides much more control over JMX configuration and runtime performance.
+This, together with other changes in the JMX and management infrastructure provides much more control over management
+configuration and runtime performance.
 
 However, this has some important implications for (some) user environments.
 
-For complete details, see <<jmx-42-improvements>>.
+For complete details, see <<metrics-management>> and <<jmx-42-improvements>>.
 
 [[x4.2-mongodb-metadata-store]]
 ==== MongodDB Metadata Store


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3755
JIRA: https://jira.spring.io/browse/INT-3756

Previously JMX was required to enable capturing message counts and statistics.

This is now a separate operation from JMX and can be enabled independently.

For backwards compatibility, enabling JMX will automatically enable statistics
(unless separately configured).
