### PR TITLE
INT-3766: Fix Reactor Promise Detection

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -86,7 +86,7 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 
 	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
 
-	private static final boolean reactorPresent = ClassUtils.isPresent("reactor.Environment",
+	private static final boolean reactorPresent = ClassUtils.isPresent("reactor.rx.Promise",
 			GatewayProxyFactoryBean.class.getClassLoader());
 
 	private volatile Class<?> serviceInterface;


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3766

Previously the `GatewayProxyFactoryBean` detected the presence of `Environment` before
looking for `Promise` return types. This caused initialization failures if
`reactor-core` was on the classpath, but not `reactor-stream`.

Change `reactorPresent` to look for the `Promise` class intead of `Environment`.
