### PR TITLE
INT-3425: Deprecate TCP Event Channel Adapter

### DIFF
--- a/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducer.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public class ApplicationEventListeningMessageProducer extends ExpressionMessageP
 	 * @see ApplicationEventMulticaster#addApplicationListener
 	 * @see #supportsEventType
 	 */
-	public void setEventTypes(Class<? extends ApplicationEvent>... eventTypes) {
+	public void setEventTypes(@SuppressWarnings("unchecked") Class<? extends ApplicationEvent>... eventTypes) {
 		Set<Class<? extends ApplicationEvent>> eventSet = new HashSet<Class<? extends ApplicationEvent>>(
 				Arrays.asList(eventTypes));
 		eventSet.remove(null);

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionEventInboundChannelAdapterParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionEventInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,10 @@ import org.springframework.integration.ip.tcp.connection.TcpConnectionEventListe
 /**
  * @author Gary Russell
  * @since 3.0
+ *
+ * @deprecated in favor of the generic event adapter.
  */
+@Deprecated
 public class TcpConnectionEventInboundChannelAdapterParser extends AbstractChannelAdapterParser {
 
 	@Override

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionEventListeningMessageProducer.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionEventListeningMessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,12 @@ import org.springframework.util.CollectionUtils;
  * @author Gary Russell
  * @since 3.0
  *
+ * @deprecated in favor of using the generic {@code ApplicationEventListeningMessageProducer} which
+ * can now more efficiently filter required events. Configure the adapter to handle
+ * {@link TcpConnectionEvent}.
+ *
  */
+@Deprecated
 public class TcpConnectionEventListeningMessageProducer extends MessageProducerSupport
 	implements ApplicationListener<TcpConnectionEvent> {
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -55,7 +55,6 @@ import org.springframework.integration.ip.tcp.connection.DefaultTcpNetSSLSocketF
 import org.springframework.integration.ip.tcp.connection.DefaultTcpNioSSLConnectionSupport;
 import org.springframework.integration.ip.tcp.connection.DefaultTcpSSLContextSupport;
 import org.springframework.integration.ip.tcp.connection.TcpConnectionEvent;
-import org.springframework.integration.ip.tcp.connection.TcpConnectionEventListeningMessageProducer;
 import org.springframework.integration.ip.tcp.connection.TcpConnectionOpenEvent;
 import org.springframework.integration.ip.tcp.connection.TcpConnectionSupport;
 import org.springframework.integration.ip.tcp.connection.TcpMessageMapper;
@@ -268,8 +267,9 @@ public class ParserUnitTests {
 	@Autowired
 	TcpMessageMapper mapper;
 
+	@SuppressWarnings("deprecation")
 	@Autowired
-	TcpConnectionEventListeningMessageProducer eventAdapter;
+	org.springframework.integration.ip.tcp.connection.TcpConnectionEventListeningMessageProducer eventAdapter;
 
 	@Autowired
 	QueueChannel eventChannel;
@@ -664,7 +664,7 @@ public class ParserUnitTests {
 		assertSame(socketSupport, dfa.getPropertyValue("tcpSocketSupport"));
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "deprecation" })
 	@Test
 	public void testEventAdapter() {
 		Set<?> eventTypes = TestUtils.getPropertyValue(this.eventAdapter, "eventTypes", Set.class);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpConnectionEventListenerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpConnectionEventListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.messaging.Message;
  */
 public class TcpConnectionEventListenerTests {
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testNoFilter() {
 		TcpConnectionEventListeningMessageProducer eventProducer = new TcpConnectionEventListeningMessageProducer();
@@ -62,7 +63,7 @@ public class TcpConnectionEventListenerTests {
 		assertNull(message);
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "deprecation" })
 	@Test
 	public void testFilter() {
 		TcpConnectionEventListeningMessageProducer eventProducer = new TcpConnectionEventListeningMessageProducer();

--- a/src/reference/asciidoc/content-enrichment.adoc
+++ b/src/reference/asciidoc/content-enrichment.adoc
@@ -5,7 +5,7 @@
 ==== Introduction
 
 At times you may have a requirement to enhance a request with more information than was provided by the target system.
-Thehttp://www.eaipatterns.com/DataEnricher.html[Content Enricher] pattern describes various scenarios as well as the component (Enricher), which allows you to address such requirements.
+The http://www.eaipatterns.com/DataEnricher.html[Content Enricher] pattern describes various scenarios as well as the component (Enricher), which allows you to address such requirements.
 
 The Spring Integration `Core` module includes 2 enrichers:
 

--- a/src/reference/asciidoc/ip.adoc
+++ b/src/reference/asciidoc/ip.adoc
@@ -355,12 +355,19 @@ Configuring a connection interceptor factory chain.
 Beginning with version 3.0, changes to `TcpConnection` s are reported by `TcpConnectionEvent` s.
 `TcpConnectionEvent` is a subclass of `ApplicationEvent` and thus can be received by any `ApplicationListener` defined in the `ApplicationContext`.
 
+[NOTE]
+=====
+The following is deprecated as of _version 4.2_; use the generic Event Inbound Channel Adapter instead.
+See <<applicationevent-inbound>>.
+
 For convenience, a `<int-ip:tcp-connection-event-inbound-channel-adapter/>` is provided.
 This adapter will receive all `TcpConnectionEvent` s (by default), and send them to its `channel`.
 The adapter accepts an `event-type` attribute, which is a list of class names for events that should be sent.
 This can be used if an application subclasses `TcpConnectionEvent` for some reason, and wishes to only receive those events.
 Omitting this attribute will mean that all `TcpConnectionEvent` s will be sent.
 You can also use this to limit which `TcpConnectionEvent` s you are interested in ( `TcpConnectionOpenEvent`, `TcpConnectionCloseEvent`, or `TcpConnectionExceptionEvent`).
+=====
+
 
 `TcpConnectionEvents` have the following properties:
 

--- a/src/reference/asciidoc/transformer.adoc
+++ b/src/reference/asciidoc/transformer.adoc
@@ -367,18 +367,19 @@ Also see <<advising-with-annotations>>.
 ==== Header Filter
 
 Some times your transformation use case might be as simple as removing a few headers.
-  	For such a use case, Spring Integration provides a _Header Filter_which allows you to specify certain header names
-    that should be removed from the output Message (e.g.
-for security reasons or a value that was only needed temporarily).Basically the _Header Filter_is the opposite  of the _Header Enricher_.
-  	The latter is discussed in <<header-enricher>>[source,xml]
+For such a use case, Spring Integration provides a _Header Filter_ which allows you to specify certain header names
+that should be removed from the output Message (e.g. for security reasons or a value that was only needed temporarily).
+Basically, the _Header Filter_ is the opposite  of the _Header Enricher_.
+The latter is discussed in <<header-enricher>>.
+
+[source,xml]
 ----
 <int:header-filter input-channel="inputChannel"
 		output-channel="outputChannel" header-names="lastName, state"/>
 ----
 
-As you can see, configuration of a _Header Filter_is quite simple.
-It is a typical endpoint with input/output channels
-	and a `header-names` attribute.
+As you can see, configuration of a _Header Filter_ is quite simple.
+It is a typical endpoint with input/output channels and a `header-names` attribute.
 That attribute accepts the names of the header(s) (delimited by commas if there are multiple)
-	that need to be removed.
+that need to be removed.
 So, in the above example the headers named 'lastName' and 'state' will not be present on the outbound Message.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -114,7 +114,11 @@ See <<ip-msg-headers>> for more information.
 ===== TCP Events
 
 New events are now published whenever a correlation exception occurs - for example sending a message to a
-non-existent socket. See <<tcp-events>> for more information.
+non-existent socket.
+
+The `TcpConnectionEventListeningMessageProducer` is deprecated; use the generic event adapter instead.
+
+See <<tcp-events>> for more information.
 
 [[x4.2-inbound-channel-adapter-annotation]]
 ==== @InboundChannelAdapter


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3425

Deprecate `TcpConnectionEventListeningMessageProducer` in favor
of using a generic event inbound channel adapter.
