### PR TITLE
INT-3777: Reference guide still mentions SI 4.1.x version in the Requirements paragraph

### DIFF
--- a/src/reference/asciidoc/preface.adoc
+++ b/src/reference/asciidoc/preface.adoc
@@ -10,15 +10,15 @@ This section details the compatible http://www.oracle.com/technetwork/java/javas
 [[supported-java-versions]]
 === Compatible Java Versions
 
-For _Spring Integration_*4.1.x*, the *minimum* compatible Java version is *Java SE 6*.
+For _Spring Integration_ *4.2.x*, the *minimum* compatible Java version is *Java SE 6*.
 Older versions of Java are not supported.
 
-_Spring Integration_*4.1.x* is also compatible with *Java SE 7* as well as *Java SE 8*.
+_Spring Integration_ *4.2.x* is also compatible with *Java SE 7* as well as *Java SE 8*.
 
 [[supported-spring-versions]]
 === Compatible Versions of the Spring Framework
 
-_Spring Integration_*4.1.x* requires _Spring Framework_*4.1.4* or later.
+_Spring Integration_ *4.2.x* requires _Spring Framework_ *4.2.0* or later.
 
 [[code-conventions]]
 === Code Conventions


### PR DESCRIPTION
I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.

In addition to the problem described in the JIRA ticket, I also took the liberty to add a space between the Spring library names and versions because I think it's more readable.
Also, looking at the build.gradle file, it seems like the minimum required version of the Spring Framework was increased to 4.2.0, so I changed it too.
