### PR TITLE
INT-3765: Fix BeanFactory usage from BPP

### DIFF
--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/JmxIntegrationConfigurationInitializer.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/JmxIntegrationConfigurationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class JmxIntegrationConfigurationInitializer implements IntegrationConfig
 	}
 
 	private void registerMBeanExporterHelperIfNecessary(ConfigurableListableBeanFactory beanFactory) {
-		if (beanFactory.getBeanNamesForType(IntegrationMBeanExporter.class).length > 0) {
+		if (beanFactory.getBeanNamesForType(IntegrationMBeanExporter.class, false, false).length > 0) {
 			((BeanDefinitionRegistry) beanFactory).registerBeanDefinition(MBEAN_EXPORTER_HELPER_BEAN_NAME,
 					new RootBeanDefinition(MBeanExporterHelper.class));
 		}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3765

The `beanFactory.getBeanNamesForType(Class<?> aClass)`
has eager `FactoryBean` loading logic and using it from the `BeanPostProcessor`
may cause an issue with late-binding beans like auto-created `MessageChannel`.

The change that code to the

```
beanFactory.getBeanNamesForType(IntegrationMBeanExporter.class, false, false)
```

to bypass `FactoryBean`s eager initialization.

All other similar usage throughout the project are OK, because they are already outside of any `BPP`

**Cherry-pick to 4.1.x and 4.0.x**
