### PR TITLE
INT-3767: Fix JPA Parser for `parameter-source`

### DIFF
--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/JpaInboundChannelAdapterParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/JpaInboundChannelAdapterParser.java
@@ -70,6 +70,7 @@ public class JpaInboundChannelAdapterParser extends AbstractPollingInboundChanne
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaExecutorBuilder, element, "flush-after-delete", "flush");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaExecutorBuilder, element, "delete-in-batch");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaExecutorBuilder, element, "expect-single-result");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(jpaExecutorBuilder, element, "parameter-source");
 
 		final BeanDefinition jpaExecutorBuilderBeanDefinition = jpaExecutorBuilder.getBeanDefinition();
 		final String channelAdapterId = this.resolveId(element, jpaPollingChannelAdapterBuilder.getRawBeanDefinition(), parserContext);

--- a/spring-integration-jpa/src/main/resources/org/springframework/integration/jpa/config/xml/spring-integration-jpa-4.2.xsd
+++ b/spring-integration-jpa/src/main/resources/org/springframework/integration/jpa/config/xml/spring-integration-jpa-4.2.xsd
@@ -32,7 +32,7 @@
 				<xsd:annotation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.core.MessageChannel" />
+							<tool:expected-type type="org.springframework.messaging.MessageChannel" />
 						</tool:annotation>
 					</xsd:appinfo>
 				</xsd:annotation>
@@ -41,7 +41,8 @@
 				<xsd:annotation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.jpa.core.JpaQLParameterSource" />
+							<tool:expected-type
+									type="org.springframework.integration.jpa.support.parametersource.ParameterSource" />
 						</tool:annotation>
 					</xsd:appinfo>
 					<xsd:documentation>
@@ -336,7 +337,7 @@
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.integration.core.MessageChannel" />
+						<tool:expected-type type="org.springframework.messaging.MessageChannel" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -349,7 +350,7 @@
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.integration.core.MessageChannel" />
+						<tool:expected-type type="org.springframework.messaging.MessageChannel" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -381,7 +382,8 @@
 			<xsd:annotation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.integration.jpa.JPAQLParameterSourceFactory" />
+						<tool:expected-type
+								type="org.springframework.integration.jpa.support.parametersource.ParameterSourceFactory" />
 					</tool:annotation>
 				</xsd:appinfo>
 				<xsd:documentation>

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaInboundChannelAdapterParserTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package org.springframework.integration.jpa.config.xml;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
@@ -28,6 +29,7 @@ import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.jpa.core.JpaExecutor;
 import org.springframework.integration.jpa.core.JpaOperations;
+import org.springframework.integration.jpa.support.parametersource.ParameterSource;
 import org.springframework.integration.test.util.TestUtils;
 
 /**
@@ -66,7 +68,8 @@ public class JpaInboundChannelAdapterParserTests {
 		assertNotNull(jpaOperations);
 
 		assertTrue(TestUtils.getPropertyValue(jpaExecutor, "expectSingleResult", Boolean.class));
-
+		ParameterSource parameterSource = this.context.getBean(ParameterSource.class);
+		assertSame(parameterSource, TestUtils.getPropertyValue(jpaExecutor, "parameterSource"));
 	}
 
 	@Test

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaInboundChannelAdapterParserTests.xml
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaInboundChannelAdapterParserTests.xml
@@ -13,12 +13,16 @@
 
 	<int:channel id="out"/>
 
+	<bean id="jpaParameterSource" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.integration.jpa.support.parametersource.ParameterSource"/>
+	</bean>
+
 	<int-jpa:inbound-channel-adapter id="jpaInboundChannelAdapter1"
-		entity-manager-factory="entityManagerFactory"
-		entity-class="org.springframework.integration.jpa.test.entity.StudentDomain"
-		expect-single-result="true"
-									 parameter-source=""
-		channel="out">
+									 entity-manager-factory="entityManagerFactory"
+									 entity-class="org.springframework.integration.jpa.test.entity.StudentDomain"
+									 expect-single-result="true"
+									 parameter-source="jpaParameterSource"
+									 channel="out">
 		<int:poller fixed-rate="5000"/>
 	</int-jpa:inbound-channel-adapter>
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3767

The `JpaInboundChannelAdapterParser` has missed to parse `parameter-source`,
as well as the parser test-case has been missed.

In addition fix JPA xsd for wrong type references.
