### PR TITLE
INT-3783: Make JPA module compatible with IO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ subprojects { subproject ->
 		guavaVersion = '18.0'
 		hamcrestVersion = '1.3'
 		hazelcastVersion = '3.4.2'
-		hibernateVersion = '4.3.8.Final'
+		hibernateVersion = '4.3.10.Final'
 		hsqldbVersion = '2.3.2'
 		h2Version = '1.4.180'
 		jackson2Version = '2.5.1'
@@ -107,6 +107,7 @@ subprojects { subproject ->
 		jedisVersion = '2.7.3'
 		jmsApiVersion = '1.1-rev-1'
 		jpa21ApiVersion = '1.0.0.Final'
+		jpaApiVersion = '2.0.0'
 		jrubyVersion = '1.7.19'
 		jschVersion = '0.1.52'
 		jsonpathVersion = '2.0.0'
@@ -444,7 +445,8 @@ project('spring-integration-jpa') {
 	dependencies {
 		compile project(":spring-integration-core")
 		compile "org.springframework:spring-orm:$springVersion"
-		compile ("org.hibernate.javax.persistence:hibernate-jpa-2.1-api:$jpa21ApiVersion", optional)
+		compile ("org.eclipse.persistence:javax.persistence:$jpaApiVersion", optional)
+
 
 		testCompile "com.h2database:h2:$h2Version"
 		testCompile "org.hsqldb:hsqldb:$hsqldbVersion"
@@ -456,6 +458,7 @@ project('spring-integration-jpa') {
 			exclude group: 'org.apache.geronimo.specs'
 		}
 
+		testRuntime "org.hibernate.javax.persistence:hibernate-jpa-2.1-api:$jpa21ApiVersion"
 		testRuntime "org.eclipse.persistence:org.eclipse.persistence.jpa:$eclipseLinkVersion"
 		testRuntime "org.springframework:spring-instrument:$springVersion"
 	}

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
@@ -108,7 +108,7 @@ public class FeedInboundChannelAdapterParserTests {
 		latch = spy(new CountDownLatch(3));
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"FeedInboundChannelAdapterParserTests-file-usage-context.xml", this.getClass());
-		latch.await(5, TimeUnit.SECONDS);
+		latch.await(10, TimeUnit.SECONDS);
 		verify(latch, times(3)).countDown();
 		context.destroy();
 
@@ -135,7 +135,7 @@ public class FeedInboundChannelAdapterParserTests {
 				"FeedInboundChannelAdapterParserTests-http-context.xml", this.getClass());
 		DirectChannel feedChannel = context.getBean("feedChannel", DirectChannel.class);
 		feedChannel.subscribe(handler);
-		latch.await(5, TimeUnit.SECONDS);
+		latch.await(10, TimeUnit.SECONDS);
 		verify(handler, atLeast(3)).handleMessage(Mockito.any(Message.class));
 	}
 

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/inbound/JpaPollingChannelAdapterTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/inbound/JpaPollingChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.jpa.inbound;
 
 import static org.junit.Assert.assertEquals;
@@ -24,7 +25,6 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
 import javax.persistence.EntityManager;
 
 import org.junit.Test;
@@ -45,21 +45,24 @@ import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Integration tests for the Jpa Polling Channel Adapter {@link JpaPollingChannelAdapter}.
  *
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.2
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
-@TransactionConfiguration(transactionManager="transactionManager", defaultRollback=true)
+@Rollback
+@Transactional("transactionManager")
 public class JpaPollingChannelAdapterTests {
 
 	@Autowired
@@ -118,7 +121,6 @@ public class JpaPollingChannelAdapterTests {
 
 		assertNotNull(message);
 		assertNotNull(message.getPayload());
-		assertTrue(message.getPayload() instanceof Collection<?>);
 
 		Collection<?> primeNumbers = message.getPayload();
 
@@ -162,7 +164,6 @@ public class JpaPollingChannelAdapterTests {
 
 		assertNotNull(message);
 		assertNotNull(message.getPayload());
-		assertTrue(message.getPayload() instanceof Collection<?>);
 
 		Collection<?> primeNumbers = message.getPayload();
 
@@ -207,7 +208,6 @@ public class JpaPollingChannelAdapterTests {
 
 		assertNotNull(message);
 		assertNotNull(message.getPayload());
-		assertTrue(message.getPayload() instanceof Collection<?>);
 
 		Collection<?> primeNumbers = message.getPayload();
 
@@ -250,7 +250,6 @@ public class JpaPollingChannelAdapterTests {
 
 		assertNotNull(message);
 		assertNotNull(message.getPayload());
-		assertTrue(message.getPayload() instanceof Collection<?>);
 
 		Collection<?> students = message.getPayload();
 
@@ -301,7 +300,6 @@ public class JpaPollingChannelAdapterTests {
 
 		assertNotNull("Message is null.", message);
 		assertNotNull(message.getPayload());
-		assertTrue(message.getPayload() instanceof Collection<?>);
 
 		Collection<?> students = message.getPayload();
 
@@ -312,7 +310,7 @@ public class JpaPollingChannelAdapterTests {
 	}
 
 	private Long waitForDeletes(Collection<?> students) throws InterruptedException {
-		Long studentCount = Long.valueOf(students.size());
+		Long studentCount = (long) students.size();
 
 		int n = 0;
 
@@ -398,7 +396,6 @@ public class JpaPollingChannelAdapterTests {
 
 		assertNotNull("Message is null.", message);
 		assertNotNull(message.getPayload());
-		assertTrue(message.getPayload() instanceof Collection<?>);
 
 		final Collection<?> students = message.getPayload();
 
@@ -446,7 +443,6 @@ public class JpaPollingChannelAdapterTests {
 
 		assertNotNull(message);
 		assertNotNull(message.getPayload());
-		assertTrue(message.getPayload() instanceof Collection<?>);
 
 		Collection<?> students = message.getPayload();
 
@@ -490,7 +486,6 @@ public class JpaPollingChannelAdapterTests {
 
 		assertNotNull(message);
 		assertNotNull(message.getPayload());
-		assertTrue(message.getPayload() instanceof Collection<?>);
 
 		Collection<?> students = message.getPayload();
 

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundChannelAdapterTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,12 +10,12 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package org.springframework.integration.jpa.outbound;
 
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
-
 import javax.persistence.EntityManager;
 
 import org.junit.After;
@@ -33,12 +33,13 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 /**
@@ -51,7 +52,8 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
-@TransactionConfiguration(transactionManager="transactionManager", defaultRollback=true)
+@Rollback
+@Transactional("transactionManager")
 public class JpaOutboundChannelAdapterTests {
 
 	@Autowired
@@ -197,4 +199,5 @@ public class JpaOutboundChannelAdapterTests {
 
 		Assert.assertNotNull(testStudent.getRollNumber());
 	}
+
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3783
- Since IO doesn't have `hibernate-jpa-2.1-api` dependency and we need it only for testing,
  hence move it to the `testRuntime`.
- Revert `org.eclipse.persistence:javax.persistence` and make it as `optional`, since it is end-user
  responsibility to choose JPA implementation.
- Resolve deprecations since the latest Spring Framework changes.
- Increase `FeedInboundChannelAdapterParserTests` timeouts: https://build.spring.io/browse/INT-B41-353
