### PR TITLE
INT-3794: SocketUtils - Bind to Loopback Adapter

### DIFF
--- a/spring-integration-test/src/main/java/org/springframework/integration/test/util/SocketUtils.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/util/SocketUtils.java
@@ -16,6 +16,7 @@
 package org.springframework.integration.test.util;
 
 import java.net.DatagramSocket;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.List;
@@ -103,7 +104,8 @@ public final class SocketUtils {
 
 		for (int i = seed; i < seed+200; i++) {
 			try {
-				ServerSocket sock = ServerSocketFactory.getDefault().createServerSocket(i);
+				ServerSocket sock = ServerSocketFactory.getDefault().createServerSocket(i, 1,
+						InetAddress.getByName("localhost"));
 				sock.close();
 				openPorts.add(i);
 
@@ -166,7 +168,7 @@ public final class SocketUtils {
 
 		for (int i = seed; i < seed+200; i++) {
 			try {
-				DatagramSocket sock = new DatagramSocket(i);
+				DatagramSocket sock = new DatagramSocket(i, InetAddress.getByName("localhost"));
 				sock.close();
 				Thread.sleep(100);
 

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/util/SocketUtilsTests.java
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/util/SocketUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,20 @@
  */
 package org.springframework.integration.test.util;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertNotEquals;
 
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+
+import javax.net.ServerSocketFactory;
+
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
  * @author Gunnar Hillert
+ * @author Gary Russell
  */
 public class SocketUtilsTests {
 
@@ -52,6 +60,23 @@ public class SocketUtilsTests {
 		}
 
 		Assert.fail("Expected an IllegalArgumentException to be thrown.");
+	}
+
+	@Test
+	public void testTcpLocalhost() throws Exception {
+		int available = SocketUtils.findAvailableServerSocket();
+		ServerSocket ss = ServerSocketFactory.getDefault().createServerSocket(available, 1,
+				InetAddress.getByName("localhost"));
+		assertNotEquals(available, SocketUtils.findAvailableServerSocket(available));
+		ss.close();
+	}
+
+	@Test
+	public void testUdpLocalhost() throws Exception {
+		int available = SocketUtils.findAvailableUdpSocket(2000);
+		DatagramSocket dgs = new DatagramSocket(available, InetAddress.getByName("localhost"));
+		assertNotEquals(available, SocketUtils.findAvailableUdpSocket(available));
+		dgs.close();
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3794

On OSX, if a server socket is in use on the loopback adapter, but not on others,
a BindException is not thrown; instead the socket is bound to other adapters.

This causes test failures because tests, generally, expect the socket to be bound to localhost.

Change SocketUtils to attempt to bind to localhost.
