### PR TITLE
INT-3795: TCP: Combo Failover and Cached CFs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ services:
   - redis-server
 env:
   - TERM=dumb SI_FATAL_WHEN_NO_BEANFACTORY=true
-#script:
-#  - ./gradlew build --parallel
+script:
+  - ./gradlew :spring-integration-ip:build -d -Dtest.single=FailoverClientConnectionFactoryTests

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
@@ -111,7 +111,7 @@ public class TcpNetConnection extends TcpConnectionSupport implements Scheduling
 			throw e;
 		}
 		if (logger.isDebugEnabled()) {
-			logger.debug("Message sent " + message);
+			logger.debug(getConnectionId() + " Message sent " + message);
 		}
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -156,7 +156,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 				throw e;
 			}
 			if (logger.isDebugEnabled()) {
-				logger.debug("Message sent " + message);
+				logger.debug(getConnectionId() + " Message sent " + message);
 			}
 		}
 	}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -642,6 +642,7 @@ public class CachingClientConnectionFactoryTests {
 		assertTrue(latch1.await(10, TimeUnit.SECONDS));
 		server1.stop();
 		TestingUtilities.waitStopListening(server1, 10000L);
+		TestingUtilities.waitUntilFactoryHasThisNumberOfConnections(factory1, 0);
 		conn1 = cachingFactory.getConnection();
 		conn2 = cachingFactory.getConnection();
 		conn1.send(message);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -75,6 +75,7 @@ import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer
 import org.springframework.integration.ip.util.TestingUtilities;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.integration.util.SimplePool;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
@@ -565,6 +566,169 @@ public class CachingClientConnectionFactoryTests {
 		conn1 = cachingFactory.getConnection();
 		conn1.send(message);
 		Mockito.verify(mockConn2).send(message);
+	}
+
+	@Test
+	public void testCachedFailoverRealClose() throws Exception {
+		int port1 = SocketUtils.findAvailableTcpPort();
+		TcpNetServerConnectionFactory server1 = new TcpNetServerConnectionFactory(port1);
+		server1.setBeanName("server1");
+		final CountDownLatch latch1 = new CountDownLatch(3);
+		server1.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				latch1.countDown();
+				return false;
+			}
+		});
+		server1.start();
+		TestingUtilities.waitListening(server1, 10000L);
+		int port2 = SocketUtils.findAvailableTcpPort();
+		TcpNetServerConnectionFactory server2 = new TcpNetServerConnectionFactory(port2);
+		server1.setBeanName("server2");
+		final CountDownLatch latch2 = new CountDownLatch(2);
+		server2.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				latch2.countDown();
+				return false;
+			}
+		});
+		server2.start();
+		TestingUtilities.waitListening(server2, 10000L);
+		// Failover
+		AbstractClientConnectionFactory factory1 = new TcpNetClientConnectionFactory("localhost", port1);
+		factory1.setBeanName("client1");
+		factory1.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				return false;
+			}
+		});
+		AbstractClientConnectionFactory factory2 = new TcpNetClientConnectionFactory("localhost", port2);
+		factory2.setBeanName("client2");
+		factory2.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				return false;
+			}
+		});
+		List<AbstractClientConnectionFactory> factories = new ArrayList<AbstractClientConnectionFactory>();
+		factories.add(factory1);
+		factories.add(factory2);
+		FailoverClientConnectionFactory failoverFactory = new FailoverClientConnectionFactory(factories);
+
+		// Cache
+		CachingClientConnectionFactory cachingFactory = new CachingClientConnectionFactory(failoverFactory, 2);
+		cachingFactory.start();
+		TcpConnection conn1 = cachingFactory.getConnection();
+		GenericMessage<String> message = new GenericMessage<String>("foo");
+		conn1.send(message);
+		conn1.close();
+		TcpConnection conn2 = cachingFactory.getConnection();
+		assertSame(((TcpConnectionInterceptorSupport) conn1).getTheConnection(),
+				((TcpConnectionInterceptorSupport) conn2).getTheConnection());
+		conn2.send(message);
+		conn1 = cachingFactory.getConnection();
+		assertNotSame(((TcpConnectionInterceptorSupport) conn1).getTheConnection(),
+				((TcpConnectionInterceptorSupport) conn2).getTheConnection());
+		conn1.send(message);
+		conn1.close();
+		conn2.close();
+		assertTrue(latch1.await(10, TimeUnit.SECONDS));
+		server1.stop();
+		TestingUtilities.waitStopListening(server1, 10000L);
+		conn1 = cachingFactory.getConnection();
+		conn2 = cachingFactory.getConnection();
+		conn1.send(message);
+		conn2.send(message);
+		conn1.close();
+		conn2.close();
+		assertTrue(latch2.await(10, TimeUnit.SECONDS));
+		SimplePool<?> pool = TestUtils.getPropertyValue(cachingFactory, "pool", SimplePool.class);
+		assertEquals(2, pool.getIdleCount());
+		server2.stop();
+	}
+
+	@Test
+	public void testCachedFailoverRealBadHost() throws Exception {
+		int port1 = SocketUtils.findAvailableTcpPort();
+		TcpNetServerConnectionFactory server1 = new TcpNetServerConnectionFactory(port1);
+		server1.setBeanName("server1");
+		final CountDownLatch latch1 = new CountDownLatch(3);
+		server1.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				latch1.countDown();
+				return false;
+			}
+		});
+		server1.start();
+		TestingUtilities.waitListening(server1, 10000L);
+		int port2 = SocketUtils.findAvailableTcpPort();
+		TcpNetServerConnectionFactory server2 = new TcpNetServerConnectionFactory(port2);
+		server1.setBeanName("server2");
+		final CountDownLatch latch2 = new CountDownLatch(2);
+		server2.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				latch2.countDown();
+				return false;
+			}
+		});
+		server2.start();
+		TestingUtilities.waitListening(server2, 10000L);
+		// Failover
+		AbstractClientConnectionFactory factory1 = new TcpNetClientConnectionFactory("junkjunk", port1);
+		factory1.setBeanName("client1");
+		factory1.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				return false;
+			}
+		});
+		AbstractClientConnectionFactory factory2 = new TcpNetClientConnectionFactory("localhost", port2);
+		factory2.setBeanName("client2");
+		factory2.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				return false;
+			}
+		});
+		List<AbstractClientConnectionFactory> factories = new ArrayList<AbstractClientConnectionFactory>();
+		factories.add(factory1);
+		factories.add(factory2);
+		FailoverClientConnectionFactory failoverFactory = new FailoverClientConnectionFactory(factories);
+
+		// Cache
+		CachingClientConnectionFactory cachingFactory = new CachingClientConnectionFactory(failoverFactory, 2);
+		cachingFactory.start();
+		TcpConnection conn1 = cachingFactory.getConnection();
+		GenericMessage<String> message = new GenericMessage<String>("foo");
+		conn1.send(message);
+		conn1.close();
+		TcpConnection conn2 = cachingFactory.getConnection();
+		assertSame(((TcpConnectionInterceptorSupport) conn1).getTheConnection(),
+				((TcpConnectionInterceptorSupport) conn2).getTheConnection());
+		conn2.send(message);
+		conn1 = cachingFactory.getConnection();
+		assertNotSame(((TcpConnectionInterceptorSupport) conn1).getTheConnection(),
+				((TcpConnectionInterceptorSupport) conn2).getTheConnection());
+		conn1.send(message);
+		conn1.close();
+		conn2.close();
+		assertTrue(latch2.await(10, TimeUnit.SECONDS));
+		assertEquals(3, latch1.getCount());
+		server1.stop();
+		server2.stop();
 	}
 
 	@Test //INT-3650

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
@@ -16,7 +16,10 @@
 
 package org.springframework.integration.ip.tcp.connection;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doAnswer;
@@ -30,8 +33,10 @@ import java.net.Socket;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -55,6 +60,7 @@ import org.springframework.integration.ip.util.TestingUtilities;
 import org.springframework.integration.test.rule.Log4jLevelAdjuster;
 import org.springframework.integration.test.util.SocketUtils;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.integration.util.SimplePool;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
@@ -301,6 +307,186 @@ public class FailoverClientConnectionFactoryTests {
 		client1.setSingleUse(true);
 		client2.setSingleUse(true);
 		testRealGuts(client1, client2, server1, server2);
+	}
+
+	@Test
+	public void testFailoverCachedRealClose() throws Exception {
+		int port1 = SocketUtils.findAvailableServerSocket();
+		TcpNetServerConnectionFactory server1 = new TcpNetServerConnectionFactory(port1);
+		server1.setBeanName("server1");
+		final CountDownLatch latch1 = new CountDownLatch(3);
+		server1.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				latch1.countDown();
+				return false;
+			}
+		});
+		server1.start();
+		TestingUtilities.waitListening(server1, 10000L);
+		int port2 = SocketUtils.findAvailableServerSocket();
+		TcpNetServerConnectionFactory server2 = new TcpNetServerConnectionFactory(port2);
+		server1.setBeanName("server2");
+		final CountDownLatch latch2 = new CountDownLatch(2);
+		server2.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				latch2.countDown();
+				return false;
+			}
+		});
+		server2.start();
+		TestingUtilities.waitListening(server2, 10000L);
+		AbstractClientConnectionFactory factory1 = new TcpNetClientConnectionFactory("localhost", port1);
+		factory1.setBeanName("client1");
+		factory1.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				return false;
+			}
+		});
+		AbstractClientConnectionFactory factory2 = new TcpNetClientConnectionFactory("localhost", port2);
+		factory2.setBeanName("client2");
+		factory2.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				return false;
+			}
+		});
+		// Cache
+		CachingClientConnectionFactory cachingFactory1 = new CachingClientConnectionFactory(factory1, 2);
+		CachingClientConnectionFactory cachingFactory2 = new CachingClientConnectionFactory(factory2, 2);
+
+		// Failover
+		List<AbstractClientConnectionFactory> factories = new ArrayList<AbstractClientConnectionFactory>();
+		factories.add(cachingFactory1);
+		factories.add(cachingFactory2);
+		FailoverClientConnectionFactory failoverFactory = new FailoverClientConnectionFactory(factories);
+
+		failoverFactory.start();
+		TcpConnection conn1 = failoverFactory.getConnection();
+		GenericMessage<String> message = new GenericMessage<String>("foo");
+		conn1.send(message);
+		conn1.close();
+		TcpConnection conn2 = failoverFactory.getConnection();
+		assertSame(
+				(TestUtils.getPropertyValue(conn1, "delegate", TcpConnectionInterceptorSupport.class))
+						.getTheConnection(),
+				(TestUtils.getPropertyValue(conn2, "delegate", TcpConnectionInterceptorSupport.class))
+						.getTheConnection());
+		conn2.send(message);
+		conn1 = failoverFactory.getConnection();
+		assertNotSame(
+				(TestUtils.getPropertyValue(conn1, "delegate", TcpConnectionInterceptorSupport.class))
+						.getTheConnection(),
+				(TestUtils.getPropertyValue(conn2, "delegate", TcpConnectionInterceptorSupport.class))
+						.getTheConnection());
+		conn1.send(message);
+		conn1.close();
+		conn2.close();
+		assertTrue(latch1.await(10, TimeUnit.SECONDS));
+		server1.stop();
+		TestingUtilities.waitStopListening(server1, 10000L);
+		conn1 = failoverFactory.getConnection();
+		conn2 = failoverFactory.getConnection();
+		conn1.send(message);
+		conn2.send(message);
+		conn1.close();
+		conn2.close();
+		assertTrue(latch2.await(10, TimeUnit.SECONDS));
+		SimplePool<?> pool = TestUtils.getPropertyValue(cachingFactory2, "pool", SimplePool.class);
+		assertEquals(2, pool.getIdleCount());
+		server2.stop();
+	}
+
+	@Test
+	public void testFailoverCachedRealBadHost() throws Exception {
+		int port1 = SocketUtils.findAvailableServerSocket();
+		TcpNetServerConnectionFactory server1 = new TcpNetServerConnectionFactory(port1);
+		server1.setBeanName("server1");
+		final CountDownLatch latch1 = new CountDownLatch(3);
+		server1.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				latch1.countDown();
+				return false;
+			}
+		});
+		server1.start();
+		TestingUtilities.waitListening(server1, 10000L);
+		int port2 = SocketUtils.findAvailableServerSocket();
+		TcpNetServerConnectionFactory server2 = new TcpNetServerConnectionFactory(port2);
+		server1.setBeanName("server2");
+		final CountDownLatch latch2 = new CountDownLatch(2);
+		server2.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				latch2.countDown();
+				return false;
+			}
+		});
+		server2.start();
+		TestingUtilities.waitListening(server2, 10000L);
+
+		AbstractClientConnectionFactory factory1 = new TcpNetClientConnectionFactory("junkjunk", port1);
+		factory1.setBeanName("client1");
+		factory1.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				return false;
+			}
+		});
+		AbstractClientConnectionFactory factory2 = new TcpNetClientConnectionFactory("localhost", port2);
+		factory2.setBeanName("client2");
+		factory2.registerListener(new TcpListener() {
+
+			@Override
+			public boolean onMessage(Message<?> message) {
+				return false;
+			}
+		});
+
+		// Cache
+		CachingClientConnectionFactory cachingFactory1 = new CachingClientConnectionFactory(factory1, 2);
+		CachingClientConnectionFactory cachingFactory2 = new CachingClientConnectionFactory(factory2, 2);
+
+		// Failover
+		List<AbstractClientConnectionFactory> factories = new ArrayList<AbstractClientConnectionFactory>();
+		factories.add(cachingFactory1);
+		factories.add(cachingFactory2);
+		FailoverClientConnectionFactory failoverFactory = new FailoverClientConnectionFactory(factories);
+		failoverFactory.start();
+		TcpConnection conn1 = failoverFactory.getConnection();
+		GenericMessage<String> message = new GenericMessage<String>("foo");
+		conn1.send(message);
+		conn1.close();
+		TcpConnection conn2 = failoverFactory.getConnection();
+		assertSame(
+				(TestUtils.getPropertyValue(conn1, "delegate", TcpConnectionInterceptorSupport.class))
+						.getTheConnection(),
+				(TestUtils.getPropertyValue(conn2, "delegate", TcpConnectionInterceptorSupport.class))
+						.getTheConnection());
+		conn2.send(message);
+		conn1 = failoverFactory.getConnection();
+		assertNotSame(
+				(TestUtils.getPropertyValue(conn1, "delegate", TcpConnectionInterceptorSupport.class))
+						.getTheConnection(),
+				(TestUtils.getPropertyValue(conn2, "delegate", TcpConnectionInterceptorSupport.class))
+						.getTheConnection());
+		conn1.send(message);
+		conn1.close();
+		conn2.close();
+		assertTrue(latch2.await(10, TimeUnit.SECONDS));
+		assertEquals(3, latch1.getCount());
+		server1.stop();
+		server2.stop();
 	}
 
 	private void testRealGuts(AbstractClientConnectionFactory client1, AbstractClientConnectionFactory client2,


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3795

Previously, a `CachingClientConnectionFactory` could wrap `FailoverClientConnectionFactory` instances.

It was not possible to wrap `CachingClientConnectionFactory` instances in a `FailoverClientConnectionFactory`.

The failover logic only failed over when an `IOException` occurred, whereas the CCCF wrapped the IOException
in a `MessagingException`.
- Catch all exceptions in the failover logic
- Add real TCP test cases for both scenarios
  - test failover when a connection is closed
  - test failover when the first factory cannot connect at all
