### PR TITLE
INT-3802: Spring AMQP 1.5.0.RC1, Reactor 2.0.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ subprojects { subproject ->
 		openJpaVersion = '2.3.0'
 		pahoMqttClientVersion = '1.0.2'
 		postgresVersion = '9.1-901-1.jdbc4'
-		reactorVersion = '2.0.1.RELEASE'
+		reactorVersion = '2.0.5.RELEASE'
 		reactorSpringVersion = '2.0.1.RELEASE'
 		romeToolsVersion = '1.5.0'
 		saajApiVersion = '1.3.5'
@@ -131,7 +131,7 @@ subprojects { subproject ->
 		tomcatVersion = "8.0.18"
 		smack3Version = '3.2.1'
 		smackVersion = '4.0.6'
-		springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '1.5.0.M1'
+		springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '1.5.0.RC1'
 //		springCloudClusterVersion = '1.0.0.BUILD-SNAPSHOT'
 		springDataMongoVersion = '1.7.2.RELEASE'
 		springDataRedisVersion = '1.5.2.RELEASE'

--- a/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-4.2.xsd
+++ b/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-4.2.xsd
@@ -501,6 +501,7 @@ property set to TRUE.
 				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attributeGroup ref="integration:smartLifeCycleAttributeGroup"/>
 	</xsd:complexType>
 
 	<xsd:simpleType name="deliveryModeEnumeration">

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/StubRabbitConnectionFactory.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/StubRabbitConnectionFactory.java
@@ -147,6 +147,7 @@ public class StubRabbitConnectionFactory implements ConnectionFactory {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public boolean flowBlocked() {
 			return false;
 		}
@@ -482,15 +483,18 @@ public class StubRabbitConnectionFactory implements ConnectionFactory {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public void addFlowListener(FlowListener listener) {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public boolean removeFlowListener(FlowListener listener) {
 			return false;
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public void clearFlowListeners() {
 		}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests-context.xml
@@ -46,6 +46,7 @@
 	<amqp:outbound-channel-adapter id="withPublisherConfirms" channel="pcRequestChannel"
 								   exchange-name="outboundchanneladapter.test.1"
 								   mapped-request-headers="foo*"
+								   auto-startup="false"
 								   amqp-template="amqpTemplateConfirms"
 								   confirm-correlation-expression="headers['amqp_confirmCorrelationData']"
 								   confirm-ack-channel="ackChannel"/>
@@ -53,20 +54,6 @@
 	<int:channel id="pcRequestChannel"/>
 
 	<int:channel id="ackChannel">
-		<int:queue/>
-	</int:channel>
-
-	<rabbit:template id="amqpTemplateReturns" connection-factory="connectionFactory" mandatory="true" />
-
-	<amqp:outbound-channel-adapter id="withReturns" channel="returnRequestChannel"
-								   exchange-name="outboundchanneladapter.test.1"
-								   mapped-request-headers="foo*"
-								   amqp-template="amqpTemplateReturns"
-								   return-channel="returnChannel"/>
-
-	<int:channel id="returnRequestChannel"/>
-
-	<int:channel id="returnChannel">
 		<int:queue/>
 	</int:channel>
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests-context.xml
@@ -15,6 +15,7 @@
 		exchange-name="si.test.exchange"
 		routing-key="si.test.binding"
 		amqp-template="amqpTemplate"
+		auto-startup="false"
 		order="5"
 		return-channel="returnChannel"/>
 
@@ -79,35 +80,5 @@
 							   mapped-request-headers=""
 							   mapped-reply-headers=""/>
 	</int:chain>
-
-	<rabbit:template id="amqpTemplateConfirms" connection-factory="connectionFactory" reply-timeout="10"/>
-
-	<amqp:outbound-gateway request-channel="pcRequestChannel"
-						   reply-channel="fromRabbit"
-						   exchange-name="si.test.exchange"
-						   mapped-request-headers="foo*"
-						   requires-reply="false"
-						   amqp-template="amqpTemplateConfirms"
-						   confirm-correlation-expression="headers['amqp_confirmCorrelationData']"
-						   confirm-ack-channel="ackChannel"/>
-
-	<int:channel id="pcRequestChannel"/>
-
-	<rabbit:template id="amqpTemplateConfirmsMC" connection-factory="connectionFactory" reply-timeout="10"/>
-
-	<amqp:outbound-gateway request-channel="pcMessageCorrelationRequestChannel"
-						   reply-channel="fromRabbit"
-						   exchange-name="si.test.exchange"
-						   mapped-request-headers="foo*"
-						   requires-reply="false"
-						   amqp-template="amqpTemplateConfirmsMC"
-						   confirm-correlation-expression="#this"
-						   confirm-ack-channel="ackChannel"/>
-
-	<int:channel id="pcMessageCorrelationRequestChannel"/>
-
-	<int:channel id="ackChannel">
-		<int:queue/>
-	</int:channel>
 
 </beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests-context.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:amqp="http://www.springframework.org/schema/integration/amqp"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<int:channel id="fromRabbit">
+		<int:queue />
+	</int:channel>
+
+	<rabbit:template id="amqpTemplateConfirms" connection-factory="connectionFactory" reply-timeout="10" />
+
+	<amqp:outbound-gateway id="pcGateway"
+						   request-channel="pcRequestChannel"
+						   reply-channel="fromRabbit"
+						   exchange-name=""
+						   routing-key="#{queue.name}"
+						   mapped-request-headers="foo*"
+						   requires-reply="false"
+						   amqp-template="amqpTemplateConfirms"
+						   confirm-correlation-expression="headers['amqp_confirmCorrelationData']"
+						   confirm-ack-channel="ackChannel" />
+
+	<int:channel id="pcRequestChannel"/>
+
+	<rabbit:template id="amqpTemplateConfirmsMC" connection-factory="connectionFactory" reply-timeout="10" />
+
+	<amqp:outbound-gateway request-channel="pcMessageCorrelationRequestChannel"
+						   reply-channel="fromRabbit"
+						   exchange-name=""
+						   routing-key="#{queue.name}"
+						   mapped-request-headers="foo*"
+						   requires-reply="false"
+						   amqp-template="amqpTemplateConfirmsMC"
+						   confirm-correlation-expression="#this"
+						   confirm-ack-channel="ackChannel" />
+
+	<int:channel id="pcMessageCorrelationRequestChannel" />
+
+	<int:channel id="ackChannel">
+		<int:queue />
+	</int:channel>
+
+	<rabbit:template id="amqpTemplateConfirmsAdapter" connection-factory="connectionFactory"/>
+
+	<amqp:outbound-channel-adapter id="withPublisherConfirms" channel="pcRequestChannelAdapter"
+								   exchange-name=""
+								   routing-key="#{queue.name}"
+								   mapped-request-headers="foo*"
+								   amqp-template="amqpTemplateConfirmsAdapter"
+								   confirm-correlation-expression="headers['amqp_confirmCorrelationData']"
+								   confirm-ack-channel="ackChannel" />
+
+	<int:channel id="pcRequestChannelAdapter"/>
+
+	<rabbit:template id="amqpTemplateReturns" connection-factory="connectionFactory" mandatory="true" />
+
+	<amqp:outbound-channel-adapter id="withReturns" channel="returnRequestChannel"
+								   exchange-name=""
+								   routing-key="#{queue.name + queue.name}"
+								   mapped-request-headers="foo*"
+								   amqp-template="amqpTemplateReturns"
+								   return-channel="returnChannel" />
+
+	<int:channel id="returnRequestChannel"/>
+
+	<int:channel id="returnChannel">
+		<int:queue />
+	</int:channel>
+
+	<rabbit:connection-factory id="connectionFactory" 
+		host="localhost" publisher-returns="true" publisher-confirms="true" />
+
+	<rabbit:admin connection-factory="connectionFactory" />
+
+	<rabbit:queue id="queue" />
+	
+</beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.amqp.outbound;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.amqp.rule.BrokerRunning;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Oleg Zhurakousky
+ * @author Gary Russell
+ * @author Artem Bilan
+ * @author Gunnar Hillert
+ *
+ * @since 2.1
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
+public class AmqpOutboundEndpointTests {
+
+	@Rule
+	public BrokerRunning brokerRunning = BrokerRunning.isRunning();
+
+	@Autowired
+	private MessageChannel pcRequestChannel;
+
+	@Autowired
+	private MessageChannel pcMessageCorrelationRequestChannel;
+
+	@Autowired
+	private RabbitTemplate amqpTemplateConfirms;
+
+	@Autowired
+	private Queue queue;
+
+	@Autowired
+	private PollableChannel ackChannel;
+
+	@Autowired
+	private MessageChannel pcRequestChannelAdapter;
+
+	@Autowired
+	private MessageChannel returnRequestChannel;
+
+	@Autowired
+	private PollableChannel returnChannel;
+
+	@Test
+	public void testGatewayPublisherConfirms() throws Exception {
+
+		Message<?> message = MessageBuilder.withPayload("hello")
+				.setHeader("amqp_confirmCorrelationData", "foo")
+				.build();
+		this.pcRequestChannel.send(message);
+		Message<?> ack = this.ackChannel.receive(10000);
+		assertNotNull(ack);
+		assertEquals("foo", ack.getPayload());
+		assertEquals(Boolean.TRUE, ack.getHeaders().get(AmqpHeaders.PUBLISH_CONFIRM));
+
+		// test whole message is correlation
+		message = MessageBuilder.withPayload("hello")
+				.build();
+		this.pcMessageCorrelationRequestChannel.send(message);
+		ack = ackChannel.receive(10000);
+		assertNotNull(ack);
+		assertSame(message.getPayload(), ack.getPayload());
+		assertEquals(Boolean.TRUE, ack.getHeaders().get(AmqpHeaders.PUBLISH_CONFIRM));
+
+		this.amqpTemplateConfirms.receive(this.queue.getName()); // so queue is deleted
+
+	}
+
+	@Test
+	public void adapterWithPublisherConfirms() throws Exception {
+		Message<?> message = MessageBuilder.withPayload("hello")
+				.setHeader("amqp_confirmCorrelationData", "foo")
+				.build();
+		this.pcRequestChannelAdapter.send(message);
+		Message<?> ack = this.ackChannel.receive(10000);
+		assertNotNull(ack);
+		assertEquals("foo", ack.getPayload());
+		assertEquals(Boolean.TRUE, ack.getHeaders().get(AmqpHeaders.PUBLISH_CONFIRM));
+	}
+
+	@Test
+	public void adapterWithReturns() throws Exception {
+		Message<?> message = MessageBuilder.withPayload("hello").build();
+		this.returnRequestChannel.send(message);
+		Message<?> returned = returnChannel.receive(10000);
+		assertNotNull(returned);
+		assertEquals(message.getPayload(), returned.getPayload());
+	}
+
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3802

For publisher confirms and returns, the `RabbitTemplate` now checks for a
`CachingConnectionFactory` which can't be mocked/stubbed.

Convert the mock tests for these features to real broker tests.

Also see AMQP-524.

Also, the lifecyle attributes were missing from the AMQP outbound endpoints.
