### PR TITLE
Consider exception's inheritors

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
@@ -38,11 +38,16 @@ public class ErrorMessageExceptionTypeRouter extends AbstractMappingMessageRoute
 		Object payload = message.getPayload();
 		if (payload instanceof Throwable) {
 			Throwable cause = (Throwable) payload;
-			while (cause != null) {
+			while (cause != null && mostSpecificCause == null) {
 				String causeName = cause.getClass().getName();
-				if (this.getChannelMappings().keySet().contains(causeName)) {
-					mostSpecificCause = causeName;
+				for (String channelMappingKey : this.getChannelMappings().keySet()) {
+					Class channelMappingKeyAsClass = Class.forName(channelMappingKey);
+					if (channelMappingKeyAsClass.isInstance(cause.getClass())) {
+						mostSpecificCause = causeName;
+						break;
+					}
 				}
+				
 				cause = cause.getCause();
 			}
 		}


### PR DESCRIPTION
E.g. we have hierarchy of exceptions:
com.test.ValidationException
com.test.ValidationException <- com.test.SpecificAValidationException
com.test.ValidationException <- com.test.SpecificBValidationException

In this case if I want to map all ValidationException exceptions to specific channel I have to specify all inheritors as keys.

I suggested consider inheritors also (look at my proposal changes).

P.S.:
I know that in such way we add new for-statement and performance becomes worse. Probably we can forget about new for-statement because usually router mapping is not so big.
