### PR TITLE
INT-3821: Description for MessagingException ctor

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/MessageRejectedException.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/MessageRejectedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,11 @@ import org.springframework.messaging.MessageHandlingException;
 @SuppressWarnings("serial")
 public class MessageRejectedException extends MessageHandlingException {
 
+	/**
+	 * @param failedMessage the failed {@link Message}
+	 * @deprecated since 4.2 in favor of {@link MessageRejectedException(Message, String)}
+	 */
+	@Deprecated
 	public MessageRejectedException(Message<?> failedMessage) {
 		super(failedMessage);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/FixedSubscriberChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/FixedSubscriberChannel.java
@@ -72,7 +72,7 @@ public final class FixedSubscriberChannel implements SubscribableChannel, BeanNa
 		catch (RuntimeException e) {
 			if (e instanceof MessagingException &&
 					((MessagingException) e).getFailedMessage() == null) {
-				throw new MessagingException(message, e);
+				throw new MessagingException(message, "Failed to handle Message", e);
 			}
 			else {
 				throw e;

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CodecMessageConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CodecMessageConverter.java
@@ -50,7 +50,7 @@ public class CodecMessageConverter extends IntegrationObjectSupport implements M
 			return this.codec.encode(message);
 		}
 		catch (IOException e) {
-			throw new MessagingException(message, e);
+			throw new MessagingException(message, "Failed to encode Message", e);
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AbstractDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AbstractDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,7 +130,7 @@ public abstract class AbstractDispatcher implements MessageDispatcher {
 						"Dispatcher failed to deliver Message.", e);
 		if (e instanceof MessagingException &&
 				((MessagingException) e).getFailedMessage() == null) {
-			runtimeException = new MessagingException(message, e);
+			runtimeException = new MessagingException(message, "Dispatcher failed to deliver Message", e);
 		}
 		return runtimeException;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/BroadcastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/BroadcastingDispatcher.java
@@ -230,7 +230,7 @@ public class BroadcastingDispatcher extends AbstractDispatcher implements BeanFa
 		catch (RuntimeException e) {
 			if (!this.ignoreFailures) {
 				if (e instanceof MessagingException && ((MessagingException) e).getFailedMessage() == null) {
-					throw new MessagingException(message, e);
+					throw new MessagingException(message, "Failed to handle Message", e);
 				}
 				throw e;
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,7 +165,7 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 				throw (MessagingException) e;
 			}
 			else {
-				throw new MessagingException(message, e);
+				throw new MessagingException(message, "Failed to send Message", e);
 			}
 		}
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,8 @@ public class ErrorMessageSendingRecoverer implements RecoveryCallback<Object>, B
 					"RetryContext: " + context.toString());
 		}
 		else if (!(lastThrowable instanceof MessagingException)) {
-			lastThrowable = new MessagingException((Message<?>) context.getAttribute("message"), lastThrowable);
+			lastThrowable = new MessagingException((Message<?>) context.getAttribute("message"),
+					lastThrowable.getMessage(), lastThrowable);
 		}
 		if (logger.isDebugEnabled()) {
 			String supplement = ":failedMessage:" + ((MessagingException) lastThrowable).getFailedMessage();
@@ -89,5 +90,7 @@ public class ErrorMessageSendingRecoverer implements RecoveryCallback<Object>, B
 		public RetryExceptionNotAvailableException(Message<?> message, String description) {
 			super(message, description);
 		}
+
 	}
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformationException.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,9 @@ import org.springframework.messaging.MessagingException;
 
 /**
  * Base Exception type for Message transformation errors.
- * 
+ *
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 @SuppressWarnings("serial")
 public class MessageTransformationException extends MessagingException {
@@ -35,8 +36,14 @@ public class MessageTransformationException extends MessagingException {
 		super(message, description);
 	}
 
+	/**
+	 * @param message the failed {@link Message}
+	 * @param cause the cause {@link Throwable}
+	 * @deprecated since 4.2 in favor of {@link MessageTransformationException(Message, String, Throwable)}.
+	 */
+	@Deprecated
 	public MessageTransformationException(Message<?> message, Throwable cause) {
-		super(message, cause);
+		this(message, cause.getMessage(), cause);
 	}
 
 	public MessageTransformationException(String description, Throwable cause) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ public class MessageTransformingHandler extends AbstractReplyProducingMessageHan
 			if (e instanceof MessageTransformationException) {
 				throw (MessageTransformationException) e;
 			}
-			throw new MessageTransformationException(message, e);
+			throw new MessageTransformationException(message, "Failed to transform Message", e);
 		}
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpInboundGateway.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpInboundGateway.java
@@ -46,9 +46,9 @@ import org.springframework.util.Assert;
  * is not used, but multiple concurrent connections can be used if the connection factory uses
  * single-use connections. For true asynchronous bi-directional communication, a pair of
  * inbound / outbound channel adapters should be used.
+ *
  * @author Gary Russell
  * @since 2.0
- *
  */
 public class TcpInboundGateway extends MessagingGatewaySupport implements
 		TcpListener, TcpSender, ClientModeCapable, OrderlyShutdownCapable {
@@ -148,7 +148,8 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 		ApplicationEventPublisher applicationEventPublisher = cf.getApplicationEventPublisher();
 		if (applicationEventPublisher != null) {
 			applicationEventPublisher.publishEvent(
-				new TcpConnectionFailedCorrelationEvent(this, connectionId, new MessagingException(message)));
+				new TcpConnectionFailedCorrelationEvent(this, connectionId,
+						new MessagingException(message, "Connection not found to process reply.")));
 		}
 	}
 
@@ -156,8 +157,7 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 	 * @return true if the associated connection factory is listening.
 	 */
 	public boolean isListening() {
-		return this.serverConnectionFactory == null ? false
-				: this.serverConnectionFactory.isListening();
+		return this.serverConnectionFactory != null && this.serverConnectionFactory.isListening();
 	}
 
 	/**

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
@@ -106,7 +106,7 @@ public class TcpNetConnection extends TcpConnectionSupport implements Scheduling
 			this.socketOutputStream.flush();
 		}
 		catch (Exception e) {
-			this.publishConnectionExceptionEvent(new MessagingException(message, e));
+			this.publishConnectionExceptionEvent(new MessagingException(message, "Failed TCP serialization", e));
 			this.closeConnection(true);
 			throw e;
 		}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -151,7 +151,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 				this.bufferedOutputStream.flush();
 			}
 			catch (Exception e) {
-				this.publishConnectionExceptionEvent(new MessagingException(message, e));
+				this.publishConnectionExceptionEvent(new MessagingException(message, "Failed TCP serialization", e));
 				this.closeConnection(true);
 				throw e;
 			}

--- a/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/SyslogReceivingChannelAdapterSupport.java
+++ b/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/SyslogReceivingChannelAdapterSupport.java
@@ -93,7 +93,7 @@ public abstract class SyslogReceivingChannelAdapterSupport extends MessageProduc
 			}
 		}
 		catch (Exception e) {
-			throw new MessagingException(message, e);
+			throw new MessagingException(message, "Failed to send Message", e);
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3821

The `MessagingException` provides an empty String for its `NestedRuntimeException`
for those ctors which are without `description` argument.

The `NestedRuntimeException` uses `NestedExceptionUtils.buildMessage` for `getMessage()` implementation
and the algorithm there is based on the `message != null` condition to build the first part of the nested
cascade. In the case of empty String we end up with useless ";" part in the StackTrace logs.

Fix Framework classes to use the `MessagingException` ctor with particular description.
