### PR TITLE
Add missing 'InputStream' in comment on FileWritingMessageHandler

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -51,9 +51,9 @@ import org.springframework.util.StringUtils;
 /**
  * A {@link MessageHandler} implementation that writes the Message payload to a
  * file. If the payload is a File object, it will copy the File to the specified
- * destination directory. If the payload is a byte array or String, it will write
- * it directly. Otherwise, the payload type is unsupported, and an Exception
- * will be thrown.
+ * destination directory. If the payload is a byte array, a String or an
+ * InputStream it will write it directly. Otherwise, the payload type is
+ * unsupported, and an Exception will be thrown.
  * <p>
  * To append a new-line after each write, set the
  * {@link #setAppendNewLine(boolean) appendNewLine} flag to 'true'. It is 'false' by default.


### PR DESCRIPTION
InputStream has been supported since 247232bdde24b81814a82100743f77d881aaf06b.
