### PR TITLE
INT-3829: Care about `@Profile` on the `@Bean`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/SimpleActiveIdleMessageSourceAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/SimpleActiveIdleMessageSourceAdvice.java
@@ -67,7 +67,7 @@ public class SimpleActiveIdleMessageSourceAdvice extends AbstractMessageSourceAd
 	}
 
 	@Override
-	public Message<?> afterReceive(Message<?> result, MessageSource<?> aource) {
+	public Message<?> afterReceive(Message<?> result, MessageSource<?> source) {
 		if (result == null) {
 			this.trigger.setPeriod(this.idlePollPeriod);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -31,6 +31,7 @@ import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.DefaultBeanFactoryPointcutAdvisor;
 import org.springframework.aop.support.NameMatchMethodPointcut;
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionValidationException;
 import org.springframework.context.annotation.Bean;
@@ -122,6 +123,16 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 	@Override
 	public Object postProcess(Object bean, String beanName, Method method, List<Annotation> annotations) {
+		if (this.beanAnnotationAware() && AnnotatedElementUtils.isAnnotated(method, Bean.class.getName())) {
+			try {
+				resolveTargetBeanFromMethodWithBeanAnnotation(method);
+			}
+			catch (NoSuchBeanDefinitionException e) {
+				// Skip the @Bean for farther endpoint processing.
+				// Mainly by the @Conditional reason.
+				return null;
+			}
+		}
 		MessageHandler handler = createHandler(bean, method, annotations);
 		setAdviceChainIfPresent(beanName, annotations, handler);
 		if (handler instanceof Orderable) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -24,6 +24,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.aopalliance.aop.Advice;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.aop.TargetSource;
 import org.springframework.aop.framework.Advised;
@@ -88,6 +90,8 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 	protected static final String SEND_TIMEOUT_ATTRIBUTE = "sendTimeout";
 
+	protected final Log logger = LogFactory.getLog(this.getClass());
+
 	protected final List<String> messageHandlerAttributes = new ArrayList<String>();
 
 	protected final ConfigurableListableBeanFactory beanFactory;
@@ -130,6 +134,10 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 			catch (NoSuchBeanDefinitionException e) {
 				// Skip the @Bean for farther endpoint processing.
 				// Mainly by the @Conditional reason.
+				if (this.logger.isDebugEnabled()) {
+					this.logger.debug("The bean for method [" + method + "] doesn't exist. " +
+							"Mainly by the @Conditional reason.");
+				}
 				return null;
 			}
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
@@ -67,6 +67,10 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 		catch (NoSuchBeanDefinitionException e) {
 			// Skip the @Bean for farther endpoint processing.
 			// Mainly by the @Conditional reason.
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug("The bean for method [" + method + "] doesn't exist. " +
+						"Mainly by the @Conditional reason.");
+			}
 			return null;
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -59,7 +60,15 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 		String channelName = MessagingAnnotationUtils.resolveAttribute(annotations, AnnotationUtils.VALUE, String.class);
 		Assert.hasText(channelName, "The channel ('value' attribute of @InboundChannelAdapter) can't be empty.");
 
-		MessageSource<?> messageSource = this.createMessageSource(bean, beanName, method);
+		MessageSource<?> messageSource = null;
+		try {
+			messageSource = createMessageSource(bean, beanName, method);
+		}
+		catch (NoSuchBeanDefinitionException e) {
+			// Skip the @Bean for farther endpoint processing.
+			// Mainly by the @Conditional reason.
+			return null;
+		}
 
 		MessageChannel channel = this.channelResolver.resolveDestination(channelName);
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyFactoryBeanTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,7 +206,7 @@ public class GatewayProxyFactoryBeanTests {
 				}
 			});
 		}
-		latch.await(10, TimeUnit.SECONDS);
+		latch.await(30, TimeUnit.SECONDS);
 		for (int i = 0; i < numRequests; i++) {
 			assertEquals("test-" + i + "!!!", results[i]);
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/gatewayWithResponseCorrelator.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/gatewayWithResponseCorrelator.xml
@@ -22,8 +22,8 @@
 		<beans:property name="serviceInterface" value="org.springframework.integration.gateway.TestService"/>
 		<beans:property name="defaultRequestChannel" ref="requestChannel"/>
 		<beans:property name="defaultReplyChannel" ref="replyChannel"/>
-		<beans:property name="defaultRequestTimeout" value="5000"/>
-		<beans:property name="defaultReplyTimeout" value="5000"/>
+		<beans:property name="defaultRequestTimeout" value="10000"/>
+		<beans:property name="defaultReplyTimeout" value="10000"/>
 	</beans:bean>
 
 	<beans:bean id="handler" class="org.springframework.integration.gateway.TestHandler"/>

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -16,7 +16,7 @@ Direct usage of the API is of course always an option, but we expect that most u
 === Namespace Support
 
 Spring Integration components can be configured with XML elements that map directly to the terminology and concepts of enterprise integration.
-In many cases, the element names match those of thehttp://www.eaipatterns.com[Enterprise Integration Patterns].
+In many cases, the element names match those of the http://www.eaipatterns.com[Enterprise Integration Patterns].
 
 To enable Spring Integration's core namespace support within your Spring configuration files, add the following namespace reference and schema mapping in your top-level 'beans' element:
 
@@ -531,6 +531,20 @@ For example the endpoint (`SourcePollingChannelAdapter`) for the `consoleSource(
 `myFlowConfiguration.consoleSource.inboundChannelAdapter`.
 
 IMPORTANT: When using these annotations on `@Bean` definitions, the `inputChannel` must reference a declared bean; channels are not automatically declared in this case.
+
+NOTE: With Java & Annotation configuration we can use any `@Conditional` (e.g. `@Profile`) definition on the `@Bean`
+method level, meaning to skip the bean registration by some condition reason:
+[source,java]
+----
+@Bean
+@ServiceActivator(inputChannel = "skippedChannel")
+@Profile("foo")
+public MessageHandler skipped() {
+	return System.out::println;
+}
+----
+Together with the existing Spring Container logic, the Messaging Endpoint bean, based on the `@ServiceActivator`
+ annotation, won't be registered as well.
 
 ==== Creating a Bridge with Annotations
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3829

Alongside with the `@Bean` definition we can use for example `@Profile` `@Conditional` annotation.
And the final bean won't be populated to the context.

Previously the `MessagingAnnotationPostProcessor` did take care about that infrastructure outcome,
hence we ended up with the `NoSuchBeanDefinitionException`
- Add appropriate `try...catch(NoSuchBeanDefinitionException)` to the `AbstractMethodAnnotationPostProcessor` and
  `InboundChannelAdapterAnnotationPostProcessor` to skip further endpoint processing if there is the target bean
  by the condition reason.
