### PR TITLE
[3.0.x] INT-3837: TCP GW - Propagate Socket Timeout

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -582,8 +582,10 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 								logger.warn("Timing out TcpNioConnection " +
 										    connection.getConnectionId());
 							}
-							connection.publishConnectionExceptionEvent(new SocketTimeoutException("Timing out connection"));
+							SocketTimeoutException exception = new SocketTimeoutException("Timing out connection");
+							connection.publishConnectionExceptionEvent(exception);
 							connection.timeout();
+							connection.sendExceptionToListener(exception);
 						}
 					}
 				}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
@@ -247,8 +247,8 @@ public class TcpNetConnection extends TcpConnectionSupport {
 									 e.getClass().getSimpleName() +
 								     ":" + (e.getCause() != null ? e.getCause() + ":" : "") + e.getMessage());
 					}
-					this.sendExceptionToListener(e);
 				}
+				this.sendExceptionToListener(e);
 			}
 		}
 		return doClose;


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3837

INT-3103 introduced exception propagation to waiting gateway threads.

However, `SocketTimeoutException`s were not propagated (in all cases
since 4.2 and for single-use sockets since 3.0).

Conflicts:
    spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java

Resolved.

Remove beanfactory from backported test.
