### PR TITLE
INT-3827: ResettableFileListFilter

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentAcceptOnceFileListFilter.java
@@ -35,7 +35,7 @@ import org.springframework.util.Assert;
  *
  */
 public abstract class AbstractPersistentAcceptOnceFileListFilter<F> extends AbstractFileListFilter<F>
-		implements ReversibleFileListFilter<F>, Closeable {
+		implements ReversibleFileListFilter<F>, ResettableFileListFilter<F>,  Closeable {
 
 	protected final ConcurrentMetadataStore store;
 
@@ -102,10 +102,15 @@ public abstract class AbstractPersistentAcceptOnceFileListFilter<F> extends Abst
 				rollingBack = true;
 			}
 			if (rollingBack) {
-				this.store.remove(buildKey(fileToRollback));
-				flushIfNeeded();
+				remove(fileToRollback);
 			}
 		}
+	}
+
+	@Override
+	public void remove(F fileToRemove) {
+		this.store.remove(buildKey(fileToRemove));
+		flushIfNeeded();
 	}
 
 	@Override

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentAcceptOnceFileListFilter.java
@@ -108,9 +108,10 @@ public abstract class AbstractPersistentAcceptOnceFileListFilter<F> extends Abst
 	}
 
 	@Override
-	public void remove(F fileToRemove) {
-		this.store.remove(buildKey(fileToRemove));
+	public boolean remove(F fileToRemove) {
+		String removed = this.store.remove(buildKey(fileToRemove));
 		flushIfNeeded();
+		return removed != null;
 	}
 
 	@Override

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AcceptOnceFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AcceptOnceFileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,8 @@ import java.util.concurrent.LinkedBlockingQueue;
  * @author Gary Russell
  * @since 1.0.0
  */
-public class AcceptOnceFileListFilter<F> extends AbstractFileListFilter<F> implements ReversibleFileListFilter<F> {
+public class AcceptOnceFileListFilter<F> extends AbstractFileListFilter<F> implements ReversibleFileListFilter<F>,
+		ResettableFileListFilter<F> {
 
 	private final Queue<F> seen;
 
@@ -93,12 +94,17 @@ public class AcceptOnceFileListFilter<F> extends AbstractFileListFilter<F> imple
 					rollingBack = true;
 				}
 				if (rollingBack) {
-					this.seenSet.remove(fileToRollback);
-					if (this.seen != null) {
-						this.seen.remove(fileToRollback);
-					}
+					remove(fileToRollback);
 				}
 			}
+		}
+	}
+
+	@Override
+	public void remove(F fileToRemove) {
+		this.seenSet.remove(fileToRemove);
+		if (this.seen != null) {
+			this.seen.remove(fileToRemove);
 		}
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AcceptOnceFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AcceptOnceFileListFilter.java
@@ -101,11 +101,12 @@ public class AcceptOnceFileListFilter<F> extends AbstractFileListFilter<F> imple
 	}
 
 	@Override
-	public void remove(F fileToRemove) {
-		this.seenSet.remove(fileToRemove);
+	public boolean remove(F fileToRemove) {
+		boolean removed = this.seenSet.remove(fileToRemove);
 		if (this.seen != null) {
 			this.seen.remove(fileToRemove);
 		}
+		return removed;
 	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
  *
  * @param <F> The type that will be filtered.
  */
-public class CompositeFileListFilter<F> implements FileListFilter<F>, Closeable {
+public class CompositeFileListFilter<F> implements ReversibleFileListFilter<F>, Closeable {
 
 	private final Set<FileListFilter<F>> fileFilters;
 
@@ -109,6 +109,15 @@ public class CompositeFileListFilter<F> implements FileListFilter<F>, Closeable 
 			results.retainAll(currentResults);
 		}
 		return results;
+	}
+
+	@Override
+	public void rollback(F file, List<F> files) {
+		for (FileListFilter<F> fileFilter : this.fileFilters) {
+			if (fileFilter instanceof ReversibleFileListFilter) {
+				((ReversibleFileListFilter<F>) fileFilter).rollback(file, files);
+			}
+		}
 	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ResettableFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ResettableFileListFilter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.file.filters;
+
+/**
+ * A {@link FileListFilter} that can be reset by removing a specific file from its
+ * state.
+ * @author Gary Russell
+ * @since 4.1.7
+ *
+ */
+public interface ResettableFileListFilter<F> extends FileListFilter<F> {
+
+	/**
+	 * Remove the specified element from the filter so it will pass on the next attempt.
+	 * @param f the element to remove.
+	 */
+	void remove(F f);
+
+}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ResettableFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ResettableFileListFilter.java
@@ -25,9 +25,10 @@ package org.springframework.integration.file.filters;
 public interface ResettableFileListFilter<F> extends FileListFilter<F> {
 
 	/**
-	 * Remove the specified element from the filter so it will pass on the next attempt.
+	 * Remove the specified file from the filter so it will pass on the next attempt.
 	 * @param f the element to remove.
+	 * @return true if the file was removed as a result of this call.
 	 */
-	void remove(F f);
+	boolean remove(F f);
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/filters/AcceptOnceFileListFilterTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/filters/AcceptOnceFileListFilterTests.java
@@ -80,7 +80,8 @@ public class AcceptOnceFileListFilterTests {
 	@Test
 	public void testRollbackComposite() {
 		AcceptOnceFileListFilter<String> filter = new AcceptOnceFileListFilter<String>();
-		CompositeFileListFilter<String> composite = new CompositeFileListFilter<>(Collections.singletonList(filter));
+		CompositeFileListFilter<String> composite = new CompositeFileListFilter<String>(
+				Collections.singletonList(filter));
 		doTestRollback(composite);
 	}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/filters/AcceptOnceFileListFilterTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/filters/AcceptOnceFileListFilterTests.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
@@ -74,6 +75,13 @@ public class AcceptOnceFileListFilterTests {
 	public void testRollback() {
 		AcceptOnceFileListFilter<String> filter = new AcceptOnceFileListFilter<String>();
 		doTestRollback(filter);
+	}
+
+	@Test
+	public void testRollbackComposite() {
+		AcceptOnceFileListFilter<String> filter = new AcceptOnceFileListFilter<String>();
+		CompositeFileListFilter<String> composite = new CompositeFileListFilter<>(Collections.singletonList(filter));
+		doTestRollback(composite);
 	}
 
 	protected void doTestRollback(ReversibleFileListFilter<String> filter) {

--- a/spring-integration-sftp/.gitignore
+++ b/spring-integration-sftp/.gitignore
@@ -1,3 +1,4 @@
 local-test-dir/*.test
+local-test-dir/rollback/*.txt
 remote-target-dir/*foo*
 remote-target-dir/*test*

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/RollbackLocalFilterTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/RollbackLocalFilterTests-context.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-sftp="http://www.springframework.org/schema/integration/sftp"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/sftp http://www.springframework.org/schema/integration/sftp/spring-integration-sftp.xsd">
+
+	<int-sftp:inbound-channel-adapter id="sftpAdapterAutoCreate"
+			session-factory="sftpSessionFactory"
+			channel="requestChannel"
+			remote-directory-expression="'/sftpSource'"
+			local-directory="file:local-test-dir/rollback"
+			auto-create-local-directory="true"
+			filename-pattern="sftpSource1.txt"
+			local-filter="acceptOnceFilter">
+		<int:poller fixed-rate="1000" max-messages-per-poll="2" error-channel="nullChannel">
+			<int:transactional synchronization-factory="syncFactory" />
+		</int:poller>
+	</int-sftp:inbound-channel-adapter>
+
+	<int:channel id="requestChannel" />
+
+	<int:service-activator input-channel="requestChannel" ref="crash" method="handle" />
+
+	<bean id="crash" class="org.springframework.integration.sftp.inbound.RollbackLocalFilterTests$Crash" />
+
+	<bean id="acceptOnceFilter" class="org.springframework.integration.file.filters.AcceptOnceFileListFilter" />
+
+	<int:transaction-synchronization-factory id="syncFactory">
+		<int:after-rollback expression="@acceptOnceFilter.remove(payload)" />
+	</int:transaction-synchronization-factory>
+
+	<bean id="transactionManager" class="org.springframework.integration.transaction.PseudoTransactionManager" />
+
+	<bean id="sftpServerConfig" class="org.springframework.integration.sftp.TestSftpServerConfig" />
+
+</beans>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/RollbackLocalFilterTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/RollbackLocalFilterTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.sftp.inbound;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 4.2
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class RollbackLocalFilterTests {
+
+	@Autowired
+	private Crash crash;
+
+	@Test
+	public void testRollback() throws Exception {
+		assertTrue(this.crash.getLatch().await(10, TimeUnit.SECONDS));
+		assertEquals("sftpSource1.txt", this.crash.getFile().getName());
+	}
+
+	public static class Crash {
+
+		private final CountDownLatch latch = new CountDownLatch(2);
+
+		private final AtomicBoolean shouldCrash = new AtomicBoolean();
+
+		private volatile File file;
+
+		public CountDownLatch getLatch() {
+			return latch;
+		}
+
+		public File getFile() {
+			return file;
+		}
+
+		public void handle(File in) {
+			latch.countDown();
+			if (this.shouldCrash.compareAndSet(false, true)) {
+				throw new RuntimeException("foo");
+			}
+			this.
+			file = in;
+		}
+	}
+
+}

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/RollbackLocalFilterTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/RollbackLocalFilterTests.java
@@ -32,7 +32,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
- * @since 4.2
+ * @since 4.1.7
  *
  */
 @ContextConfiguration
@@ -69,8 +69,7 @@ public class RollbackLocalFilterTests {
 			if (this.shouldCrash.compareAndSet(false, true)) {
 				throw new RuntimeException("foo");
 			}
-			this.
-			file = in;
+			this.file = in;
 		}
 	}
 

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -274,6 +274,52 @@ Only then is the poll operation considered complete, and the poller will wait fo
 You can alternatively set the 'max-messages-per-poll' value to a positive value indicating the upward limit of Messages to be created from files with each poll.
 For example, a value of 10 means that on each poll it will attempt to process no more than 10 files.
 
+==== Recovering from Failures
+
+It is important to understand the architecture of the adapter.
+There is a file synchronizer which fetches the files, and a `FileReadingMessageSource` to emit a message for each
+synchronized file.
+As discussed above, there are two filters involved.
+The `filter` attribute (and patterns) refers to the remote (FTP) file list - to avoid fetching files that have already
+been fetched.
+The `local-filter` is used by the `FileReadingMessageSource` to determine which files are to be sent as messages.
+
+The synchronizer lists the remote files and consults its filter; the files are then transferred.
+If an IO error occurs during file transfer, any files that have already been added to the filter are removed so they
+are eligible to be re-fetched on the next poll.
+This only applies if the filter implements `ReversibleFileListFilter` (such as the `AcceptOnceFileListFilter`).
+
+If, after synchronizing the files, an error occurs on the downstream flow processing a file, there is __no__ automatic
+rollback of the filter so the failed file will __not__ be reprocessed by default.
+
+If you wish to reprocess such files after a failure, you can use configuration similar to the following to facilitate
+the removal of the failed file from the filter.
+This will work for any `ResettableFileListFilter`.
+
+[source, xml]
+----
+<int-ftp:inbound-channel-adapter id="ftpAdapter"
+		session-factory="ftpSessionFactory"
+		channel="requestChannel"
+		remote-directory-expression="'/sftpSource'"
+		local-directory="file:myLocalDir"
+		auto-create-local-directory="true"
+		filename-pattern="*.txt"
+		local-filter="acceptOnceFilter">
+	<int:poller fixed-rate="1000">
+		<int:transactional synchronization-factory="syncFactory" />
+	</int:poller>
+</int-ftp:inbound-channel-adapter>
+
+<bean id="acceptOnceFilter" class="org.springframework.integration.file.filters.AcceptOnceFileListFilter" />
+
+<int:transaction-synchronization-factory id="syncFactory">
+	<int:after-rollback expression="@acceptOnceFilter.remove(payload)" />
+</int:transaction-synchronization-factory>
+
+<bean id="transactionManager" class="org.springframework.integration.transaction.PseudoTransactionManager" />
+----
+
 [[ftp-outbound]]
 === FTP Outbound Channel Adapter
 

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -359,6 +359,52 @@ If you need a custom filter implementation simply include a reference in your ad
 
 ----
 
+==== Recovering from Failures
+
+It is important to understand the architecture of the adapter.
+There is a file synchronizer which fetches the files, and a `FileReadingMessageSource` to emit a message for each
+synchronized file.
+As discussed above, there are two filters involved.
+The `filter` attribute (and patterns) refers to the remote (SFTP) file list - to avoid fetching files that have already
+been fetched.
+The `local-filter` is used by the `FileReadingMessageSource` to determine which files are to be sent as messages.
+
+The synchronizer lists the remote files and consults its filter; the files are then transferred.
+If an IO error occurs during file transfer, any files that have already been added to the filter are removed so they
+are eligible to be re-fetched on the next poll.
+This only applies if the filter implements `ReversibleFileListFilter` (such as the `AcceptOnceFileListFilter`).
+
+If, after synchronizing the files, an error occurs on the downstream flow processing a file, there is _no_ automatic
+rollback of the filter so the failed file will _not_ be reprocessed by default.
+
+If you wish to reprocess such files after a failure, you can use configuration similar to the following to facilitate
+the removal of the failed file from the filter.
+This will work for any `ResettableFileListFilter`.
+
+[source, xml]
+----
+<int-sftp:inbound-channel-adapter id="sftpAdapter"
+		session-factory="sftpSessionFactory"
+		channel="requestChannel"
+		remote-directory-expression="'/sftpSource'"
+		local-directory="file:myLocalDir"
+		auto-create-local-directory="true"
+		filename-pattern="*.txt"
+		local-filter="acceptOnceFilter">
+	<int:poller fixed-rate="1000">
+		<int:transactional synchronization-factory="syncFactory" />
+	</int:poller>
+</int-sftp:inbound-channel-adapter>
+
+<bean id="acceptOnceFilter" class="org.springframework.integration.file.filters.AcceptOnceFileListFilter" />
+
+<int:transaction-synchronization-factory id="syncFactory">
+	<int:after-rollback expression="@acceptOnceFilter.remove(payload)" />
+</int:transaction-synchronization-factory>
+
+<bean id="transactionManager" class="org.springframework.integration.transaction.PseudoTransactionManager" />
+----
+
 [[sftp-outbound]]
 === SFTP Outbound Channel Adapter
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3827

Provide a hook to enable removing a file from an `AcceptOnceFileListFilter`,
for example after a message processing failure.

Make the `CompositeFileListFilter` a `ReversibleFileListFilter` so it can
delegate to any of its composed filters that are reversible.

**cherry-pick to 4.1.x**
