### PR TITLE
INT-3846: Some fixes for the `SimpleMessageStore`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -13,11 +13,12 @@
 
 package org.springframework.integration.aggregator;
 
-import java.util.ArrayList;
 import java.util.Collection;
 
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
+import org.springframework.integration.store.SimpleMessageGroup;
+import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.messaging.Message;
 
 /**
@@ -66,8 +67,13 @@ public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler
 			remove(messageGroup);
 		}
 		else {
-			this.messageStore.removeMessagesFromGroup(messageGroup.getGroupId(),
-					new ArrayList<Message<?>>(messageGroup.getMessages()));
+			if (this.messageStore instanceof SimpleMessageStore) {
+				((SimpleMessageGroup) messageGroup).clear();
+				((SimpleMessageGroup) messageGroup).setLastModified(System.currentTimeMillis());
+			}
+			else {
+				this.messageStore.removeMessagesFromGroup(messageGroup.getGroupId(), messageGroup.getMessages());
+			}
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -13,6 +13,7 @@
 
 package org.springframework.integration.aggregator;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 import org.springframework.integration.store.MessageGroup;
@@ -65,7 +66,8 @@ public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler
 			remove(messageGroup);
 		}
 		else {
-			this.messageStore.removeMessagesFromGroup(messageGroup.getGroupId(), messageGroup.getMessages());
+			this.messageStore.removeMessagesFromGroup(messageGroup.getGroupId(),
+					new ArrayList<Message<?>>(messageGroup.getMessages()));
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -17,7 +17,6 @@ import java.util.Collection;
 
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
-import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.messaging.Message;
 
@@ -61,18 +60,18 @@ public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler
 
 	@Override
 	protected void afterRelease(MessageGroup messageGroup, Collection<Message<?>> completedMessages) {
-		this.messageStore.completeGroup(messageGroup.getGroupId());
+		Object groupId = messageGroup.getGroupId();
+		this.messageStore.completeGroup(groupId);
 
 		if (this.expireGroupsUponCompletion) {
 			remove(messageGroup);
 		}
 		else {
 			if (this.messageStore instanceof SimpleMessageStore) {
-				((SimpleMessageGroup) messageGroup).clear();
-				((SimpleMessageGroup) messageGroup).setLastModified(System.currentTimeMillis());
+				((SimpleMessageStore) this.messageStore).clearMessageGroup(groupId);
 			}
 			else {
-				this.messageStore.removeMessagesFromGroup(messageGroup.getGroupId(), messageGroup.getMessages());
+				this.messageStore.removeMessagesFromGroup(groupId, messageGroup.getMessages());
 			}
 		}
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -28,6 +28,7 @@ import org.springframework.messaging.Message;
  *
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.1
  */
 public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandler {
@@ -87,7 +88,7 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 				int lastReleasedSequenceNumber = findLastReleasedSequenceNumber(groupId, completedMessages);
 				this.messageStore.setLastReleasedSequenceNumberForGroup(groupId, lastReleasedSequenceNumber);
 				if (this.messageStore instanceof SimpleMessageStore
-						&& completedMessages.containsAll(messageGroup.getMessages())) {
+						&& completedMessages.size() == messageGroup.size()) {
 					((SimpleMessageGroup) messageGroup).clear();
 					((SimpleMessageGroup) messageGroup).setLastModified(System.currentTimeMillis());
 				}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -18,7 +18,6 @@ import java.util.Collection;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
-import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.messaging.Message;
 
@@ -89,8 +88,7 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 				this.messageStore.setLastReleasedSequenceNumberForGroup(groupId, lastReleasedSequenceNumber);
 				if (this.messageStore instanceof SimpleMessageStore
 						&& completedMessages.size() == messageGroup.size()) {
-					((SimpleMessageGroup) messageGroup).clear();
-					((SimpleMessageGroup) messageGroup).setLastModified(System.currentTimeMillis());
+					((SimpleMessageStore) this.messageStore).clearMessageGroup(groupId);
 				}
 				else {
 					this.messageStore.removeMessagesFromGroup(groupId, completedMessages);

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -13,6 +13,7 @@
 
 package org.springframework.integration.aggregator;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
@@ -84,7 +85,8 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 			if (completedMessages != null){
 				int lastReleasedSequenceNumber = this.findLastReleasedSequenceNumber(messageGroup.getGroupId(), completedMessages);
 				messageStore.setLastReleasedSequenceNumberForGroup(messageGroup.getGroupId(), lastReleasedSequenceNumber);
-				this.messageStore.removeMessagesFromGroup(messageGroup.getGroupId(), completedMessages);
+				this.messageStore.removeMessagesFromGroup(messageGroup.getGroupId(),
+						new ArrayList<Message<?>>(completedMessages));
 			}
 			if (timeout) {
 				this.messageStore.completeGroup(messageGroup.getGroupId());

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -349,7 +349,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 			synchronized (this.messageGroupId) {
 				Collection<Message<?>> messages = this.messageStore.getMessageGroup(this.messageGroupId).getMessages();
 				if (messages.contains(message)) {
-					this.messageStore.removeMessageFromGroup(this.messageGroupId, message);
+					this.messageStore.removeMessagesFromGroup(this.messageGroupId, message);
 					return true;
 				}
 				else {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -86,8 +86,6 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 
 	private static final ExpressionParser expressionParser = new SpelExpressionParser();
 
-	private final Object simpleMessageStoreMonitor = new Object();
-
 	private final String messageGroupId;
 
 	private volatile long defaultDelay;
@@ -348,7 +346,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 
 	private boolean removeDelayedMessageFromMessageStore(Message<?> message) {
 		if (this.messageStore instanceof SimpleMessageStore) {
-			synchronized (this.simpleMessageStoreMonitor) {
+			synchronized (this.messageGroupId) {
 				Collection<Message<?>> messages = this.messageStore.getMessageGroup(this.messageGroupId).getMessages();
 				if (messages.contains(message)) {
 					this.messageStore.removeMessageFromGroup(this.messageGroupId, message);

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractBatchingMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractBatchingMessageGroupStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractBatchingMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractBatchingMessageGroupStore.java
@@ -49,7 +49,7 @@ public abstract class AbstractBatchingMessageGroupStore implements BasicMessageG
 	}
 
 	/**
-	 * Specify the {@link MessageGroupFactory} to create {@link MessageGroup) object where
+	 * Specify the {@link MessageGroupFactory} to create {@link MessageGroup} object where
 	 * it is necessary.
 	 * Defaults to {@link SimpleMessageGroupFactory}.
 	 * @param messageGroupFactory the {@link MessageGroupFactory} to use.

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractBatchingMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractBatchingMessageGroupStore.java
@@ -48,6 +48,13 @@ public abstract class AbstractBatchingMessageGroupStore implements BasicMessageG
 		return removeBatchSize;
 	}
 
+	/**
+	 * Specify the {@link MessageGroupFactory} to create {@link MessageGroup) object where
+	 * it is necessary.
+	 * Defaults to {@link SimpleMessageGroupFactory}.
+	 * @param messageGroupFactory the {@link MessageGroupFactory} to use.
+	 * @since 4.3
+	 */
 	public void setMessageGroupFactory(MessageGroupFactory messageGroupFactory) {
 		Assert.notNull(messageGroupFactory, "'messageGroupFactory' must not be null");
 		this.messageGroupFactory = messageGroupFactory;

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractBatchingMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractBatchingMessageGroupStore.java
@@ -13,11 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.store;
 
 
+import org.springframework.util.Assert;
+
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 4.2
  *
  */
@@ -26,6 +30,8 @@ public abstract class AbstractBatchingMessageGroupStore implements BasicMessageG
 	private static final int DEFAULT_REMOVE_BATCH_SIZE = 100;
 
 	private volatile int removeBatchSize = DEFAULT_REMOVE_BATCH_SIZE;
+
+	private volatile MessageGroupFactory messageGroupFactory = new SimpleMessageGroupFactory();
 
 	/**
 	 * Set the batch size when bulk removing messages from groups for message stores
@@ -40,6 +46,15 @@ public abstract class AbstractBatchingMessageGroupStore implements BasicMessageG
 
 	public int getRemoveBatchSize() {
 		return removeBatchSize;
+	}
+
+	public void setMessageGroupFactory(MessageGroupFactory messageGroupFactory) {
+		Assert.notNull(messageGroupFactory, "'messageGroupFactory' must not be null");
+		this.messageGroupFactory = messageGroupFactory;
+	}
+
+	protected MessageGroupFactory getMessageGroupFactory() {
+		return this.messageGroupFactory;
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
@@ -329,8 +329,8 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 				}
 			}
 
-			SimpleMessageGroup messageGroup = new SimpleMessageGroup(messages,
-						groupId, messageGroupMetadata.getTimestamp(), messageGroupMetadata.isComplete());
+			SimpleMessageGroup messageGroup = getSimpleMessageGroupFactory()
+					.create(messages, groupId, messageGroupMetadata.getTimestamp(), messageGroupMetadata.isComplete());
 			messageGroup.setLastModified(messageGroupMetadata.getLastModified());
 			messageGroup.setLastReleasedMessageSequenceNumber(messageGroupMetadata.getLastReleasedMessageSequenceNumber());
 			return messageGroup;
@@ -345,12 +345,12 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 			return (SimpleMessageGroup) messageGroup;
 		}
 		else {
-			return new SimpleMessageGroup(messageGroup);
+			return getSimpleMessageGroupFactory().create(messageGroup);
 		}
 	}
 
 	private SimpleMessageGroup normalizeSimpleMessageGroup(SimpleMessageGroup messageGroup){
-		SimpleMessageGroup normalizedGroup = new SimpleMessageGroup(messageGroup.getGroupId());
+		SimpleMessageGroup normalizedGroup = getSimpleMessageGroupFactory().create(messageGroup.getGroupId());
 		for (Message<?> message : messageGroup.getMessages()) {
 			Message<?> normalizedMessage = normalizeMessage(message);
 			normalizedGroup.add(normalizedMessage);

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors
+ * Copyright 2002-2016 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
@@ -132,6 +132,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	 * Remove a Message from the group with the provided group ID.
 	 */
 	@Override
+	@Deprecated
 	public MessageGroup removeMessageFromGroup(Object groupId, Message<?> messageToRemove) {
 		Assert.notNull(groupId, "'groupId' must not be null");
 		Assert.notNull(messageToRemove, "'messageToRemove' must not be null");

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -28,7 +28,6 @@ import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.messaging.Message;
-import org.springframework.util.Assert;
 
 /**
  * @author Dave Syer
@@ -51,8 +50,6 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 	private volatile BeanFactory beanFactory;
 
 	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
-
-	private volatile SimpleMessageGroupFactory simpleMessageGroupFactory = new SimpleMessageGroupFactory();
 
 	private volatile boolean messageBuilderFactorySet;
 
@@ -104,18 +101,9 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 		this.timeoutOnIdle = timeoutOnIdle;
 	}
 
-	public void setSimpleMessageGroupFactory(SimpleMessageGroupFactory simpleMessageGroupFactory) {
-		Assert.notNull(simpleMessageGroupFactory, "'simpleMessageGroupFactory' must not be null");
-		this.simpleMessageGroupFactory = simpleMessageGroupFactory;
-	}
-
-	protected SimpleMessageGroupFactory getSimpleMessageGroupFactory() {
-		return simpleMessageGroupFactory;
-	}
-
 	@Override
 	public void registerMessageGroupExpiryCallback(MessageGroupCallback callback) {
-		expiryCallbacks.add(callback);
+		this.expiryCallbacks.add(callback);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -107,7 +107,7 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 	}
 
 	@Override
-	public int expireMessageGroups(long timeout) {
+	public synchronized int expireMessageGroups(long timeout) {
 		int count = 0;
 		long threshold = System.currentTimeMillis() - timeout;
 		for (MessageGroup group : this) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -28,6 +28,7 @@ import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
 
 /**
  * @author Dave Syer
@@ -50,6 +51,8 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 	private volatile BeanFactory beanFactory;
 
 	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
+
+	private volatile SimpleMessageGroupFactory simpleMessageGroupFactory = new SimpleMessageGroupFactory();
 
 	private volatile boolean messageBuilderFactorySet;
 
@@ -99,6 +102,15 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 	 */
 	public void setTimeoutOnIdle(boolean timeoutOnIdle) {
 		this.timeoutOnIdle = timeoutOnIdle;
+	}
+
+	public void setSimpleMessageGroupFactory(SimpleMessageGroupFactory simpleMessageGroupFactory) {
+		Assert.notNull(simpleMessageGroupFactory, "'simpleMessageGroupFactory' must not be null");
+		this.simpleMessageGroupFactory = simpleMessageGroupFactory;
+	}
+
+	protected SimpleMessageGroupFactory getSimpleMessageGroupFactory() {
+		return simpleMessageGroupFactory;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.messaging.Message;
  * @author Dave Syer
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public interface MessageGroup {
 
@@ -39,6 +40,21 @@ public interface MessageGroup {
 	 * @return true if the message can be added.
 	 */
 	boolean canAdd(Message<?> message);
+
+	/**
+	 * Add the message to this group.
+	 * @param messageToAdd the message to add.
+	 * @since 4.3
+	 */
+	void add(Message<?> messageToAdd);
+
+	/**
+	 * Remove the message from this group.
+	 * @param messageToRemove the message to remove.
+	 * @return {@code true} if a message was removed.
+	 * @since 4.3
+	 */
+	boolean remove(Message<?> messageToRemove);
 
 	/**
 	 * Returns all available Messages from the group at the time of invocation
@@ -56,6 +72,8 @@ public interface MessageGroup {
 	 * @return the sequenceNumber of the last released message. Used in Resequencer use cases only
 	 */
 	int getLastReleasedMessageSequenceNumber();
+
+	void setLastReleasedMessageSequenceNumber(int sequenceNumber);
 
 	/**
 	 * @return true if the group is complete (i.e. no more messages are expected to be added)
@@ -91,5 +109,9 @@ public interface MessageGroup {
 	 * @return the timestamp (milliseconds since epoch) associated with the time this group was last updated
 	 */
 	long getLastModified();
+
+	void setLastModified(long lastModified);
+
+	void clear();
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupFactory.java
@@ -21,6 +21,9 @@ import java.util.Collection;
 import org.springframework.messaging.Message;
 
 /**
+ * The {@link MessageGroup} factory strategy.
+ * This strategy is used from the {@link MessageGroup}-aware components, e.g. {@code MessageGroupStore}.
+ *
  * @author Artem Bilan
  * @since 4.3
  */

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.integration.store;
+
+import java.util.Collection;
+
+import org.springframework.messaging.Message;
+
+/**
+ * @author Artem Bilan
+ * @since 4.3
+ */
+public interface MessageGroupFactory {
+
+	MessageGroup create(Object groupId);
+
+	MessageGroup create(Collection<? extends Message<?>> messages, Object groupId);
+
+	MessageGroup create(Collection<? extends Message<?>> messages, Object groupId, long timestamp,
+						boolean complete);
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package org.springframework.integration.store;
 
 import java.util.Collection;

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -57,7 +57,9 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	 * @param key The groupId for the group containing the message.
 	 * @param messageToRemove The message to be removed.
 	 * @return The message Group.
+	 * @deprecated in favor of {@link #removeMessagesFromGroup}
 	 */
+	@Deprecated
 	MessageGroup removeMessageFromGroup(Object key, Message<?> messageToRemove);
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
@@ -101,8 +101,8 @@ public class SimpleMessageGroup implements MessageGroup {
 		return true;
 	}
 
-	public void add(Message<?> message) {
-		addMessage(message);
+	public void add(Message<?> messageToAdd) {
+		addMessage(messageToAdd);
 	}
 
 	public boolean remove(Message<?> message) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroupFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroupFactory.java
@@ -21,6 +21,10 @@ import java.util.concurrent.LinkedBlockingQueue;
 import org.springframework.messaging.Message;
 
 /**
+ * The {@link MessageGroupFactory} implementation to produce {@link SimpleMessageGroup} instances.
+ * The {@link GroupType} modificator specifies the internal collection for the {@link SimpleMessageGroup}.
+ * The {@link GroupType#HASH_SET} is the default type.
+ *
  * @author Artem Bilan
  * @since 4.3
  */

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroupFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroupFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.integration.store;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.springframework.messaging.Message;
+
+/**
+ * @author Artem Bilan
+ * @since 4.3
+ */
+public class SimpleMessageGroupFactory {
+
+	private final GroupType type;
+
+	public SimpleMessageGroupFactory() {
+		this(GroupType.HASH_SET);
+	}
+
+	public SimpleMessageGroupFactory(GroupType type) {
+		this.type = type;
+	}
+
+	public SimpleMessageGroup create(Object groupId) {
+		return create(Collections.<Message<?>> emptyList(), groupId);
+	}
+
+	public SimpleMessageGroup create(Collection<? extends Message<?>> messages, Object groupId) {
+		return create(messages, groupId, System.currentTimeMillis(), false);
+	}
+
+	public SimpleMessageGroup create(Collection<? extends Message<?>> messages, Object groupId, long timestamp,
+	                                 boolean complete) {
+		return new SimpleMessageGroup(this.type.get(), messages, groupId, timestamp, complete);
+	}
+
+	public enum GroupType {
+
+		BLOCKING_QUEUE {
+
+			@Override
+			Collection<Message<?>> get() {
+				return new LinkedBlockingQueue<Message<?>>();
+			}
+
+		},
+		HASH_SET {
+
+			@Override
+			Collection<Message<?>> get() {
+				return new LinkedHashSet<Message<?>>();
+			}
+
+		},
+		SYNCHRONISED_SET {
+
+			@Override
+			Collection<Message<?>> get() {
+				return Collections.<Message<?>>synchronizedSet(new LinkedHashSet<Message<?>>());
+			}
+
+		};
+
+		abstract Collection<Message<?>> get();
+
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroupFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroupFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroupFactory.java
@@ -24,7 +24,7 @@ import org.springframework.messaging.Message;
  * @author Artem Bilan
  * @since 4.3
  */
-public class SimpleMessageGroupFactory {
+public class SimpleMessageGroupFactory implements MessageGroupFactory {
 
 	private final GroupType type;
 
@@ -36,16 +36,19 @@ public class SimpleMessageGroupFactory {
 		this.type = type;
 	}
 
-	public SimpleMessageGroup create(Object groupId) {
+	@Override
+	public MessageGroup create(Object groupId) {
 		return create(Collections.<Message<?>> emptyList(), groupId);
 	}
 
-	public SimpleMessageGroup create(Collection<? extends Message<?>> messages, Object groupId) {
+	@Override
+	public MessageGroup create(Collection<? extends Message<?>> messages, Object groupId) {
 		return create(messages, groupId, System.currentTimeMillis(), false);
 	}
 
-	public SimpleMessageGroup create(Collection<? extends Message<?>> messages, Object groupId, long timestamp,
-	                                 boolean complete) {
+	@Override
+	public MessageGroup create(Collection<? extends Message<?>> messages, Object groupId, long timestamp,
+							   boolean complete) {
 		return new SimpleMessageGroup(this.type.get(), messages, groupId, timestamp, complete);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
@@ -255,7 +255,7 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 					return;
 				}
 
-				this.groupToUpperBound.remove(groupId).release(this.groupCapacity);
+				this.groupToUpperBound.remove(groupId);
 				this.groupIdToMessageGroup.remove(groupId);
 			}
 			finally {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
@@ -202,7 +202,7 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 
 		SimpleMessageGroup group = groupIdToMessageGroup.get(groupId);
 		if (group == null) {
-			return new SimpleMessageGroup(groupId, true);
+			return getSimpleMessageGroupFactory().create(groupId);
 		}
 		if (this.copyOnGet) {
 			return copy(group);
@@ -218,7 +218,7 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 		try {
 			lock.lockInterruptibly();
 			try {
-				SimpleMessageGroup simpleMessageGroup = new SimpleMessageGroup(group, true);
+				SimpleMessageGroup simpleMessageGroup = getSimpleMessageGroupFactory().create(group);
 				simpleMessageGroup.setLastModified(group.getLastModified());
 				return simpleMessageGroup;
 			}
@@ -242,7 +242,7 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 				UpperBound upperBound;
 				SimpleMessageGroup group = this.groupIdToMessageGroup.get(groupId);
 				if (group == null) {
-					group = new SimpleMessageGroup(groupId, true);
+					group = getSimpleMessageGroupFactory().create(groupId);
 					this.groupIdToMessageGroup.putIfAbsent(groupId, group);
 					upperBound = new UpperBound(this.groupCapacity);
 					upperBound.tryAcquire(-1);
@@ -413,7 +413,7 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 
 	@Override
 	public Message<?> pollMessageFromGroup(Object groupId) {
-		Collection<Message<?>> messageList = this.getMessageGroup(groupId).getMessages();
+		Collection<Message<?>> messageList = getMessageGroup(groupId).getMessages();
 		Message<?> message = null;
 		if (!CollectionUtils.isEmpty(messageList)) {
 			message = messageList.iterator().next();
@@ -426,17 +426,17 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 
 	@Override
 	public int messageGroupSize(Object groupId) {
-		return this.getMessageGroup(groupId).size();
+		return getMessageGroup(groupId).size();
 	}
 
 	@Override
 	public MessageGroupMetadata getGroupMetadata(Object groupId) {
-		return new MessageGroupMetadata(this.getMessageGroup(groupId));
+		return new MessageGroupMetadata(getMessageGroup(groupId));
 	}
 
 	@Override
 	public Message<?> getOneMessageFromGroup(Object groupId) {
-		return this.getMessageGroup(groupId).getOne();
+		return getMessageGroup(groupId).getOne();
 	}
 
 	public void clearMessageGroup(Object groupId) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
@@ -88,7 +88,7 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 	 * @param groupCapacity      The capacity of each group.
 	 * @param upperBoundTimeout  The time to wait if the store is at max capacity.
 	 * @see #SimpleMessageStore(int, int)
-	 * @since 3.0.8
+	 * @since 4.3
 	 */
 	public SimpleMessageStore(int individualCapacity, int groupCapacity, long upperBoundTimeout) {
 		this(individualCapacity, groupCapacity, upperBoundTimeout, new DefaultLockRegistry());
@@ -115,7 +115,7 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 	 * @param groupCapacity      The capacity of each group.
 	 * @param upperBoundTimeout  The time to wait if the store is at max capacity
 	 * @param lockRegistry       The lock registry.
-	 * @since 3.0.8
+	 * @since 4.3
 	 */
 	public SimpleMessageStore(int individualCapacity, int groupCapacity, long upperBoundTimeout,
 	                          LockRegistry lockRegistry) {
@@ -303,6 +303,7 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 	}
 
 	@Override
+	@Deprecated
 	public MessageGroup removeMessageFromGroup(Object groupId, Message<?> messageToRemove) {
 		Lock lock = this.lockRegistry.obtain(groupId);
 		try {

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/UpperBound.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/UpperBound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/UpperBound.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/UpperBound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ public final class UpperBound {
 	 * indefinitely.
 	 *
 	 * @param timeoutInMilliseconds The time to wait until a permit is available.
-	 * @return true if a permit is aquired.
+	 * @return true if a permit is acquired.
 	 */
 	public boolean tryAcquire(long timeoutInMilliseconds) {
 		if (this.semaphore != null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/UpperBound.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/UpperBound.java
@@ -25,6 +25,8 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Mark Fisher
  * @author Iwein Fuld
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public final class UpperBound {
@@ -97,4 +99,9 @@ public final class UpperBound {
 		}
 	}
 
+	@Override
+	public String toString() {
+		return super.toString() + "[Permits = " +
+				(this.semaphore != null ? this.semaphore.availablePermits() : "UNLIMITED") + "]";
+	}
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -290,7 +290,7 @@ public class AbstractCorrelatingMessageHandlerTests {
 		mgs.addMessageToGroup("foo", secondMessage);
 		MessageGroup group = mgs.getMessageGroup("foo");
 		// remove a message
-		mgs.removeMessageFromGroup("foo", secondMessage);
+		mgs.removeMessagesFromGroup("foo", secondMessage);
 		// force lastModified to be the same
 		MessageGroup groupNow = mgs.getMessageGroup("foo");
 		new DirectFieldAccessor(group).setPropertyValue("lastModified", groupNow.getLastModified());

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ public class AbstractCorrelatingMessageHandlerTests {
 	@Test // INT-2751
 	public void testReaperDoesntReapAProcessingGroup() throws Exception {
 		final MessageGroupStore groupStore = new SimpleMessageStore();
-		final CountDownLatch waitForSendlatch = new CountDownLatch(1);
+		final CountDownLatch waitForSendLatch = new CountDownLatch(1);
 		final CountDownLatch waitReapStartLatch = new CountDownLatch(1);
 		final CountDownLatch waitReapCompleteLatch = new CountDownLatch(1);
 		AbstractCorrelatingMessageHandler handler = new AbstractCorrelatingMessageHandler(
@@ -85,7 +85,7 @@ public class AbstractCorrelatingMessageHandlerTests {
 				catch (InterruptedException e) {
 					Thread.currentThread().interrupt();
 				}
-				waitForSendlatch.countDown();
+				waitForSendLatch.countDown();
 				try {
 					Thread.sleep(100);
 				}
@@ -95,6 +95,7 @@ public class AbstractCorrelatingMessageHandlerTests {
 				groupStore.expireMessageGroups(50);
 				waitReapCompleteLatch.countDown();
 			}
+
 		});
 
 		final List<Message<?>> outputMessages = new ArrayList<Message<?>>();
@@ -109,7 +110,7 @@ public class AbstractCorrelatingMessageHandlerTests {
 				// wake reaper
 				waitReapStartLatch.countDown();
 				try {
-					waitForSendlatch.await(10, TimeUnit.SECONDS);
+					waitForSendLatch.await(10, TimeUnit.SECONDS);
 					// wait a little longer for reaper to grab groups
 					Thread.sleep(2000);
 					// simulate tx commit
@@ -132,6 +133,7 @@ public class AbstractCorrelatingMessageHandlerTests {
 			public boolean canRelease(MessageGroup group) {
 				return group.size() == 2;
 			}
+
 		});
 
 		QueueChannel discards = new QueueChannel();

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
@@ -27,6 +27,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
@@ -38,9 +41,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
-import org.junit.Before;
-import org.junit.Test;
-
 /**
  * @author Marius Bogoevici
  * @author Alex Peters
@@ -48,6 +48,7 @@ import org.junit.Test;
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class ResequencerTests {
 
@@ -166,6 +167,8 @@ public class ResequencerTests {
 	@Test
 	public void testResequencingWithIncompleteSequenceRelease() throws InterruptedException {
 		this.resequencer.setReleaseStrategy(new SequenceSizeReleaseStrategy(true));
+		// INT-3846
+		this.resequencer.setMessageStore(new SimpleMessageStore(2));
 		QueueChannel replyChannel = new QueueChannel();
 		Message<?> message1 = createMessage("123", "ABC", 4, 2, replyChannel);
 		Message<?> message2 = createMessage("456", "ABC", 4, 1, replyChannel);

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ResequencerTests.java
@@ -16,11 +16,13 @@
 
 package org.springframework.integration.aggregator;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
@@ -39,6 +41,7 @@ import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
@@ -168,11 +171,11 @@ public class ResequencerTests {
 	public void testResequencingWithIncompleteSequenceRelease() throws InterruptedException {
 		this.resequencer.setReleaseStrategy(new SequenceSizeReleaseStrategy(true));
 		// INT-3846
-		this.resequencer.setMessageStore(new SimpleMessageStore(2));
+		this.resequencer.setMessageStore(new SimpleMessageStore(3));
 		QueueChannel replyChannel = new QueueChannel();
-		Message<?> message1 = createMessage("123", "ABC", 4, 2, replyChannel);
-		Message<?> message2 = createMessage("456", "ABC", 4, 1, replyChannel);
-		Message<?> message3 = createMessage("789", "ABC", 4, 4, replyChannel);
+		Message<?> message1 = createMessage("123", "ABC", 4, 4, replyChannel);
+		Message<?> message2 = createMessage("456", "ABC", 4, 2, replyChannel);
+		Message<?> message3 = createMessage("789", "ABC", 4, 1, replyChannel); // release 2 after this one
 		Message<?> message4 = createMessage("XYZ", "ABC", 4, 3, replyChannel);
 		this.resequencer.handleMessage(message1);
 		this.resequencer.handleMessage(message2);
@@ -194,6 +197,26 @@ public class ResequencerTests {
 		assertEquals(new Integer(3), new IntegrationMessageHeaderAccessor(reply3).getSequenceNumber());
 		assertNotNull(reply4);
 		assertEquals(new Integer(4), new IntegrationMessageHeaderAccessor(reply4).getSequenceNumber());
+	}
+
+	@Test
+	public void testResequencingWithCapacity() throws InterruptedException {
+		this.resequencer.setReleaseStrategy(new SequenceSizeReleaseStrategy(true));
+		// INT-3846
+		this.resequencer.setMessageStore(new SimpleMessageStore(3, 2));
+		QueueChannel replyChannel = new QueueChannel();
+		Message<?> message1 = createMessage("123", "ABC", 4, 4, replyChannel);
+		Message<?> message2 = createMessage("456", "ABC", 4, 2, replyChannel);
+		Message<?> message3 = createMessage("789", "ABC", 4, 1, replyChannel);
+		this.resequencer.handleMessage(message1);
+		this.resequencer.handleMessage(message2);
+		try {
+			this.resequencer.handleMessage(message3);
+			fail("Expected exception");
+		}
+		catch (MessagingException e) {
+			assertThat(e.getMessage(), containsString("out of capacity (2) for group 'ABC'"));
+		}
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageGroupQueueTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageGroupQueueTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageGroupQueueTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageGroupQueueTests.java
@@ -16,6 +16,11 @@
 
 package org.springframework.integration.store;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -27,15 +32,10 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Ignore;
 import org.junit.Test;
+
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Dave Syer
@@ -92,17 +92,15 @@ public class MessageGroupQueueTests {
 	}
 
 	@Test
-	@Ignore
 	public void testConcurrentAccess() throws Exception {
 		doTestConcurrentAccess(50, 20, new HashSet<String>());
 	}
 
 	@Test
-	@Ignore
 	public void testConcurrentAccessUniqueResults() throws Exception {
 		doTestConcurrentAccess(50, 20, null);
 	}
-	
+
 	private void doTestConcurrentAccess(int concurrency, final int maxPerTask, final Set<String> set) throws Exception {
 
 		SimpleMessageStore messageGroupStore = new SimpleMessageStore();
@@ -163,7 +161,7 @@ public class MessageGroupQueueTests {
 		assertEquals(0, queue.size());
 		messageGroupStore.expireMessageGroups(-10000);
 		assertEquals(Integer.MAX_VALUE, queue.remainingCapacity());
-		
+
 		executorService.shutdown();
 
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package org.springframework.integration.store;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -40,7 +40,8 @@ public class MessageStoreTests {
 	@Test
 	public void shouldRegisterCallbacks() throws Exception {
 		TestMessageStore store = new TestMessageStore();
-		store.setExpiryCallbacks(Arrays.<MessageGroupCallback> asList(new MessageGroupStore.MessageGroupCallback() {
+		store.setExpiryCallbacks(Collections.<MessageGroupCallback>singletonList(new MessageGroupCallback() {
+
 			@Override
 			public void execute(MessageGroupStore messageGroupStore, MessageGroup group) {
 			}
@@ -82,14 +83,15 @@ public class MessageStoreTests {
 	private static class TestMessageStore extends AbstractMessageGroupStore {
 
 		@SuppressWarnings("unchecked")
-		MessageGroup testMessages = new SimpleMessageGroup(Arrays.asList(new GenericMessage<String>("foo")), "bar");
+		MessageGroup testMessages =
+				new SimpleMessageGroup(Collections.singletonList(new GenericMessage<String>("foo")), "bar");
 
 		private boolean removed = false;
 
 
 		@Override
 		public Iterator<MessageGroup> iterator() {
-			return Arrays.asList(testMessages).iterator();
+			return Collections.singletonList(testMessages).iterator();
 		}
 
 		@Override

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
@@ -103,6 +103,7 @@ public class MessageStoreTests {
 		}
 
 		@Override
+		@Deprecated
 		public MessageGroup removeMessageFromGroup(Object key, Message<?> messageToRemove) {
 			throw new UnsupportedOperationException();
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageGroupTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageGroupTests.java
@@ -94,7 +94,7 @@ public class SimpleMessageGroupTests {
 		for (int i = 0; i < 100000; i++) {
 			messages.add(new GenericMessage<Object>("foo"));
 		}
-		SimpleMessageGroup group = new SimpleMessageGroup(messages, this.key, System.currentTimeMillis(), false, true);
+		SimpleMessageGroup group = new SimpleMessageGroup(messages, this.key);
 		StopWatch watch = new StopWatch();
 		watch.start();
 		for (Message<?> message : messages) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageGroupTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageGroupTests.java
@@ -36,7 +36,7 @@ import org.springframework.util.StopWatch;
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
  * @author Dave Syer
- * @author Artenm Bilan
+ * @author Artem Bilan
  */
 public class SimpleMessageGroupTests {
 
@@ -75,7 +75,7 @@ public class SimpleMessageGroupTests {
 		assertThat(group.canAdd(message1), is(true));
 	}
 
-	@Test // shoud not fail with NPE (see INT-2666)
+	@Test // should not fail with NPE (see INT-2666)
 	public void shouldIgnoreNullValuesWhenInitializedWithCollectionContainingNulls() throws Exception{
 		Message<?> m1 = mock(Message.class);
 		Message<?> m2 = mock(Message.class);

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageGroupTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageGroupTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2015 the original author or authors.
+ * Copyright 2009-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageGroupTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageGroupTests.java
@@ -94,7 +94,7 @@ public class SimpleMessageGroupTests {
 		for (int i = 0; i < 100000; i++) {
 			messages.add(new GenericMessage<Object>("foo"));
 		}
-		SimpleMessageGroup group = new SimpleMessageGroup(messages, this.key);
+		SimpleMessageGroup group = new SimpleMessageGroup(messages, this.key, System.currentTimeMillis(), false, true);
 		StopWatch watch = new StopWatch();
 		watch.start();
 		for (Message<?> message : messages) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageGroupTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageGroupTests.java
@@ -1,24 +1,42 @@
+/*
+ * Copyright 2009-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package org.springframework.integration.store;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
 
-import org.springframework.messaging.Message;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.util.StopWatch;
 
 /**
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
  * @author Dave Syer
+ * @author Artenm Bilan
  */
 public class SimpleMessageGroupTests {
 
@@ -57,7 +75,7 @@ public class SimpleMessageGroupTests {
 		assertThat(group.canAdd(message1), is(true));
 	}
 
-	@Test // shoudl not fail with NPE (see INT-2666)
+	@Test // shoud not fail with NPE (see INT-2666)
 	public void shouldIgnoreNullValuesWhenInitializedWithCollectionContainingNulls() throws Exception{
 		Message<?> m1 = mock(Message.class);
 		Message<?> m2 = mock(Message.class);
@@ -68,4 +86,22 @@ public class SimpleMessageGroupTests {
 		SimpleMessageGroup grp = new SimpleMessageGroup(messages, 1);
 		assertEquals(2, grp.getMessages().size());
 	}
+
+	@Test
+	// This test used to take 2 min and half to run; now ~200 milliseconds.
+	public void testPerformance_INT3846() {
+		Collection<Message<?>> messages = new ArrayList<>();
+		for (int i = 0; i < 100000; i++) {
+			messages.add(new GenericMessage<Object>("foo"));
+		}
+		SimpleMessageGroup group = new SimpleMessageGroup(messages, this.key);
+		StopWatch watch = new StopWatch();
+		watch.start();
+		for (Message<?> message : messages) {
+			group.getMessages().contains(message);
+		}
+		watch.stop();
+		assertTrue(watch.getTotalTimeMillis() < 5000);
+	}
+
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageStoreTests.java
@@ -175,7 +175,7 @@ public class SimpleMessageStoreTests {
 
 	@Test(expected = MessagingException.class)
 	public void shouldTimeoutAfterWaitIfGroupCapacity() {
-		SimpleMessageStore store2 = new SimpleMessageStore(1, 1, 10);
+		SimpleMessageStore store2 = new SimpleMessageStore(1, 1, 1);
 		store2.addMessageToGroup("foo", MessageBuilder.withPayload("foo").build());
 		// This should throw
 		store2.addMessageToGroup("foo", MessageBuilder.withPayload("bar").build());

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageStoreTests.java
@@ -147,7 +147,7 @@ public class SimpleMessageStoreTests {
 
 	@Test
 	public void shouldWaitIfGroupCapacity() throws InterruptedException {
-		final SimpleMessageStore store2 = new SimpleMessageStore(1, 2, 1000);
+		final SimpleMessageStore store2 = new SimpleMessageStore(1, 1, 1000);
 		final Message<String> testMessage1 = MessageBuilder.withPayload("foo").build();
 		final Message<String> testMessage2 = MessageBuilder.withPayload("bar").build();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageStoreTests.java
@@ -166,7 +166,7 @@ public class SimpleMessageStoreTests {
 		});
 		// Simulate a blocked consumer
 		Thread.sleep(10);
-		store2.removeMessageFromGroup("foo", testMessage1);
+		store2.removeMessagesFromGroup("foo", testMessage1);
 
 		assertTrue(message2Latch.await(10, TimeUnit.SECONDS));
 		MessageGroup messageGroup = store2.getMessageGroup("foo");
@@ -206,7 +206,7 @@ public class SimpleMessageStoreTests {
 			assertThat(e, instanceOf(MessagingException.class));
 			assertThat(e.getMessage(), containsString("was out of capacity (1) for group 'foo'"));
 		}
-		store.removeMessageFromGroup("foo", testMessage2);
+		store.removeMessagesFromGroup("foo", testMessage2);
 		try {
 			store.addMessageToGroup("foo", testMessage2);
 			fail("Should have thrown");
@@ -215,7 +215,7 @@ public class SimpleMessageStoreTests {
 			assertThat(e, instanceOf(MessagingException.class));
 			assertThat(e.getMessage(), containsString("was out of capacity (1) for group 'foo'"));
 		}
-		store.removeMessageFromGroup("foo", testMessage1);
+		store.removeMessagesFromGroup("foo", testMessage1);
 		store.addMessageToGroup("foo", testMessage2);
 	}
 
@@ -234,7 +234,8 @@ public class SimpleMessageStoreTests {
 		Message<String> testMessage1 = MessageBuilder.withPayload("foo").build();
 		store.addMessageToGroup("bar", testMessage1);
 		Message<?> testMessage2 = store.getMessageGroup("bar").getOne();
-		MessageGroup group = store.removeMessageFromGroup("bar", testMessage2);
+		store.removeMessagesFromGroup("bar", testMessage2);
+		MessageGroup group = store.getMessageGroup("bar");
 		assertEquals(0, group.size());
 		assertEquals(0, store.getMessageGroup("bar").size());
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageStoreTests.java
@@ -81,7 +81,7 @@ public class SimpleMessageStoreTests {
 		}
 		catch (Exception e) {
 			assertThat(e, instanceOf(MessagingException.class));
-			assertThat(e.getMessage(), containsString("was out of capacity at"));
+			assertThat(e.getMessage(), containsString("was out of capacity (1)"));
 		}
 		store.removeMessage(testMessage2.getHeaders().getId());
 		try {
@@ -90,7 +90,7 @@ public class SimpleMessageStoreTests {
 		}
 		catch (Exception e) {
 			assertThat(e, instanceOf(MessagingException.class));
-			assertThat(e.getMessage(), containsString("was out of capacity at"));
+			assertThat(e.getMessage(), containsString("was out of capacity (1)"));
 		}
 		store.removeMessage(testMessage1.getHeaders().getId());
 		store.addMessage(testMessage2);
@@ -204,7 +204,7 @@ public class SimpleMessageStoreTests {
 		}
 		catch (Exception e) {
 			assertThat(e, instanceOf(MessagingException.class));
-			assertThat(e.getMessage(), containsString("was out of capacity at"));
+			assertThat(e.getMessage(), containsString("was out of capacity (1) for group 'foo'"));
 		}
 		store.removeMessageFromGroup("foo", testMessage2);
 		try {
@@ -213,7 +213,7 @@ public class SimpleMessageStoreTests {
 		}
 		catch (Exception e) {
 			assertThat(e, instanceOf(MessagingException.class));
-			assertThat(e.getMessage(), containsString("was out of capacity at"));
+			assertThat(e.getMessage(), containsString("was out of capacity (1) for group 'foo'"));
 		}
 		store.removeMessageFromGroup("foo", testMessage1);
 		store.addMessageToGroup("foo", testMessage2);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -307,7 +307,7 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 				if (!resultFile.exists() &&
 						generatedFileName.replaceAll("/", Matcher.quoteReplacement(File.separator))
 								.contains(File.separator)) {
-					resultFile.getParentFile().mkdirs();
+					resultFile.getParentFile().mkdirs(); //NOSONAR - will fail on the writing below
 				}
 				if (payload instanceof File) {
 					resultFile = handleFileMessage((File) payload, tempFile, resultFile);

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
@@ -13,6 +13,7 @@
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
  */
+
 package org.springframework.integration.gemfire.store;
 
 import static org.junit.Assert.assertEquals;
@@ -29,6 +30,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import com.gemstone.gemfire.cache.Cache;
+import com.gemstone.gemfire.cache.Region;
+import com.gemstone.gemfire.cache.Scope;
+import junit.framework.AssertionFailedError;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -49,16 +54,11 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.Assert;
 
-import com.gemstone.gemfire.cache.Cache;
-import com.gemstone.gemfire.cache.Region;
-import com.gemstone.gemfire.cache.Scope;
-
-import junit.framework.AssertionFailedError;
-
 /**
  * @author Oleg Zhurakousky
  * @author David Turanski
  * @author Gary Russell
+ * @author Artem Bilan
  *
  */
 public class GemfireGroupStoreTests {
@@ -119,7 +119,7 @@ public class GemfireGroupStoreTests {
 		messageGroup = store.getMessageGroup(1);
 		assertEquals(3, messageGroup.size());
 
-		messageGroup = store.removeMessageFromGroup(messageGroup.getGroupId(), message);
+		store.removeMessagesFromGroup(messageGroup.getGroupId(), message);
 		messageGroup = store.getMessageGroup(1);
 		assertEquals(2, messageGroup.size());
 
@@ -163,14 +163,14 @@ public class GemfireGroupStoreTests {
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		store.addMessageToGroup(messageGroup.getGroupId(), new GenericMessage<String>("1"));
-		store.removeMessageFromGroup(1, new GenericMessage<String>("2"));
+		store.removeMessagesFromGroup(1, new GenericMessage<String>("2"));
 	}
 
 	@Test
 	public void testRemoveNonExistingMessageFromNonExistingTheGroup() throws Exception {
 		GemfireMessageStore store = new GemfireMessageStore(this.region);
 		store.afterPropertiesSet();
-		store.removeMessageFromGroup(1, new GenericMessage<String>("2"));
+		store.removeMessagesFromGroup(1, new GenericMessage<String>("2"));
 	}
 
 	@Test
@@ -214,7 +214,8 @@ public class GemfireGroupStoreTests {
 		GemfireMessageStore store3 = new GemfireMessageStore(this.region);
 		store3.afterPropertiesSet();
 
-		messageGroup = store3.removeMessageFromGroup(1, message);
+		store3.removeMessagesFromGroup(1, message);
+		messageGroup = store3.getMessageGroup(1);
 
 		assertEquals(1, messageGroup.getMessages().size());
 	}
@@ -308,7 +309,8 @@ public class GemfireGroupStoreTests {
 			executor.execute(new Runnable() {
 				@Override
 				public void run() {
-					MessageGroup group = store2.removeMessageFromGroup(1, message);
+					store2.removeMessagesFromGroup(1, message);
+					MessageGroup group = store2.getMessageGroup(1);
 					if (group.getMessages().size() != 0) {
 						failures.add("REMOVE");
 						throw new AssertionFailedError("Failed on Remove");
@@ -318,7 +320,7 @@ public class GemfireGroupStoreTests {
 
 			executor.shutdown();
 			executor.awaitTermination(10, TimeUnit.SECONDS);
-			store2.removeMessageFromGroup(1, message); // ensures that if ADD thread executed after REMOVE, the store is empty for the next cycle
+			store2.removeMessagesFromGroup(1, message); // ensures that if ADD thread executed after REMOVE, the store is empty for the next cycle
 		}
 		assertTrue(failures.size() == 0);
 	}

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2015 the original author or authors
+ * Copyright 2007-2016 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
@@ -30,14 +30,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import com.gemstone.gemfire.cache.Cache;
-import com.gemstone.gemfire.cache.Region;
-import com.gemstone.gemfire.cache.Scope;
-import junit.framework.AssertionFailedError;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -54,6 +49,11 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.Assert;
 
+import com.gemstone.gemfire.cache.Cache;
+import com.gemstone.gemfire.cache.Region;
+import com.gemstone.gemfire.cache.Scope;
+import junit.framework.AssertionFailedError;
+
 /**
  * @author Oleg Zhurakousky
  * @author David Turanski
@@ -67,7 +67,7 @@ public class GemfireGroupStoreTests {
 
 	private Region<Object, Object> region;
 
-	@Rule
+//	@Rule
 	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Test

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageStore.java
@@ -449,13 +449,14 @@ public class JdbcMessageStore extends AbstractMessageGroupStore implements Messa
 					logger.warn("Missing group row for message id: " + message.getHeaders().getId());
 				}
 			}
-			return new SimpleMessageGroup(groupId);
+			return getSimpleMessageGroupFactory().create(groupId);
 		}
 
 		long timestamp = createDate.get().getTime();
 		boolean complete = completeFlag.get();
 
-		SimpleMessageGroup messageGroup = new SimpleMessageGroup(messages, groupId, timestamp, complete);
+		SimpleMessageGroup messageGroup = getSimpleMessageGroupFactory()
+				.create(messages, groupId, timestamp, complete);
 		messageGroup.setLastModified(updateDate.get().getTime());
 
 		int lastReleasedSequenceNumber = lastReleasedSequenceRef.get();

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageStore.java
@@ -465,6 +465,7 @@ public class JdbcMessageStore extends AbstractMessageGroupStore implements Messa
 	}
 
 	@Override
+	@Deprecated
 	public MessageGroup removeMessageFromGroup(Object groupId, Message<?> messageToRemove) {
 		final String groupKey = getKey(groupId);
 		final String messageId = getKey(messageToRemove.getHeaders().getId());

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -362,6 +362,13 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 		return this.priorityEnabled;
 	}
 
+	/**
+	 * Specify the {@link MessageGroupFactory} to create {@link MessageGroup) object where
+	 * it is necessary.
+	 * Defaults to {@link SimpleMessageGroupFactory}.
+	 * @param messageGroupFactory the {@link MessageGroupFactory} to use.
+	 * @since 4.3
+	 */
 	public void setMessageGroupFactory(MessageGroupFactory messageGroupFactory) {
 		Assert.notNull(messageGroupFactory, "'messageGroupFactory' must not be null");
 		this.messageGroupFactory = messageGroupFactory;

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -363,7 +363,7 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 	}
 
 	/**
-	 * Specify the {@link MessageGroupFactory} to create {@link MessageGroup) object where
+	 * Specify the {@link MessageGroupFactory} to create {@link MessageGroup} object where
 	 * it is necessary.
 	 * Defaults to {@link SimpleMessageGroupFactory}.
 	 * @param messageGroupFactory the {@link MessageGroupFactory} to use.

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
@@ -49,10 +48,11 @@ import org.springframework.integration.jdbc.store.channel.MySqlChannelMessageSto
 import org.springframework.integration.jdbc.store.channel.OracleChannelMessageStoreQueryProvider;
 import org.springframework.integration.jdbc.store.channel.PostgresChannelMessageStoreQueryProvider;
 import org.springframework.integration.store.MessageGroup;
+import org.springframework.integration.store.MessageGroupFactory;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.MessageStore;
 import org.springframework.integration.store.PriorityCapableChannelMessageStore;
-import org.springframework.integration.store.SimpleMessageGroup;
+import org.springframework.integration.store.SimpleMessageGroupFactory;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.utils.IntegrationUtils;
@@ -150,6 +150,8 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 	private volatile MessageRowMapper messageRowMapper;
 
 	private volatile Map<String, String> queryCache = new HashMap<String, String>();
+
+	private volatile MessageGroupFactory messageGroupFactory = new SimpleMessageGroupFactory();
 
 	private boolean usingIdCache = false;
 
@@ -360,6 +362,15 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 		return this.priorityEnabled;
 	}
 
+	public void setMessageGroupFactory(MessageGroupFactory messageGroupFactory) {
+		Assert.notNull(messageGroupFactory, "'messageGroupFactory' must not be null");
+		this.messageGroupFactory = messageGroupFactory;
+	}
+
+	protected MessageGroupFactory getMessageGroupFactory() {
+		return this.messageGroupFactory;
+	}
+
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		this.beanFactory = beanFactory;
@@ -468,7 +479,7 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 	 */
 	@Override
 	public MessageGroup getMessageGroup(Object groupId) {
-		return new SimpleMessageGroup(groupId);
+		return getMessageGroupFactory().create(groupId);
 	}
 
 	/**

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -243,7 +243,7 @@ public class JdbcMessageStoreTests {
 		String groupId = "X";
 		Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
 		messageStore.addMessageToGroup(groupId, message);
-		messageStore.removeMessageFromGroup(groupId, message);
+		messageStore.removeMessagesFromGroup(groupId, message);
 		MessageGroup group = messageStore.getMessageGroup(groupId);
 		assertEquals(0, group.size());
 	}
@@ -532,14 +532,12 @@ public class JdbcMessageStoreTests {
 		messageStore.completeGroup(messageGroup.getGroupId());
 		//now clear the messages
 		for (Message<?> message : messageGroup.getMessages()) {
-			messageStore.removeMessageFromGroup(groupId, message);
+			messageStore.removeMessagesFromGroup(groupId, message);
 		}//end for
 		//'add' the other message --> emulated by getting the messageGroup
 		messageGroup = messageStore.getMessageGroup(groupId);
 		//should be marked 'complete' --> old behavior it would not
 		assertTrue(messageGroup.isComplete());
 	}
-
-
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlJdbcMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlJdbcMessageStoreTests.java
@@ -277,7 +277,7 @@ public class MySqlJdbcMessageStoreTests {
 		String groupId = "X";
 		Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
 		messageStore.addMessageToGroup(groupId, message);
-		messageStore.removeMessageFromGroup(groupId, message);
+		messageStore.removeMessagesFromGroup(groupId, message);
 		MessageGroup group = messageStore.getMessageGroup(groupId);
 		assertEquals(0, group.size());
 	}

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlJdbcMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlJdbcMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.serializer.Deserializer;
 import org.springframework.core.serializer.Serializer;
@@ -84,10 +85,11 @@ import org.springframework.transaction.support.TransactionTemplate;
  * schema-mysql-5_6_4.sql
  *
  * @author Gunnar Hillert
+ * @author Artem Bilan
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
-@DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 @Ignore
 public class MySqlJdbcMessageStoreTests {
 
@@ -111,16 +113,17 @@ public class MySqlJdbcMessageStoreTests {
 	public void afterTest() {
 		final JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 		new TransactionTemplate(this.transactionManager).execute(new TransactionCallback<Void>() {
-		public Void doInTransaction(TransactionStatus status) {
-			final int deletedGroupToMessageRows = jdbcTemplate.update("delete from INT_GROUP_TO_MESSAGE");
-			final int deletedMessages = jdbcTemplate.update("delete from INT_MESSAGE");
-			final int deletedMessageGroups = jdbcTemplate.update("delete from INT_MESSAGE_GROUP");
 
-			LOG.info(String.format("Cleaning Database - Deleted Messages: %s, " +
-					"Deleted GroupToMessage Rows: %s, Deleted Message Groups: %s",
-					deletedMessages, deletedGroupToMessageRows, deletedMessageGroups));
-			return null;
-		}
+			public Void doInTransaction(TransactionStatus status) {
+				final int deletedGroupToMessageRows = jdbcTemplate.update("delete from INT_GROUP_TO_MESSAGE");
+				final int deletedMessages = jdbcTemplate.update("delete from INT_MESSAGE");
+				final int deletedMessageGroups = jdbcTemplate.update("delete from INT_MESSAGE_GROUP");
+
+				LOG.info(String.format("Cleaning Database - Deleted Messages: %s, " +
+								"Deleted GroupToMessage Rows: %s, Deleted Message Groups: %s",
+						deletedMessages, deletedGroupToMessageRows, deletedMessageGroups));
+				return null;
+			}
 		});
 	}
 
@@ -146,7 +149,7 @@ public class MySqlJdbcMessageStoreTests {
 
 	@Test
 	@Transactional
-	public void testWithMessageHistory() throws Exception{
+	public void testWithMessageHistory() throws Exception {
 
 		Message<?> message = new GenericMessage<String>("Hello");
 		DirectChannel fooChannel = new DirectChannel();
@@ -179,12 +182,14 @@ public class MySqlJdbcMessageStoreTests {
 	public void testSerializer() throws Exception {
 		// N.B. these serializers are not realistic (just for test purposes)
 		messageStore.setSerializer(new Serializer<Message<?>>() {
+
 			public void serialize(Message<?> object, OutputStream outputStream) throws IOException {
 				outputStream.write(((Message<?>) object).getPayload().toString().getBytes());
 				outputStream.flush();
 			}
 		});
 		messageStore.setDeserializer(new Deserializer<GenericMessage<String>>() {
+
 			public GenericMessage<String> deserialize(InputStream inputStream) throws IOException {
 				BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
 				return new GenericMessage<String>(reader.readLine());
@@ -297,7 +302,7 @@ public class MySqlJdbcMessageStoreTests {
 
 		String uuidGroupId = UUIDConverter.getUUID(groupId).toString();
 		assertTrue(template.queryForList(
-				"SELECT * from INT_GROUP_TO_MESSAGE where GROUP_KEY = '"  + uuidGroupId + "'").size() == 0);
+				"SELECT * from INT_GROUP_TO_MESSAGE where GROUP_KEY = '" + uuidGroupId + "'").size() == 0);
 	}
 
 	@Test
@@ -362,6 +367,7 @@ public class MySqlJdbcMessageStoreTests {
 		Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
 		messageStore.addMessageToGroup(groupId, message);
 		messageStore.registerMessageGroupExpiryCallback(new MessageGroupCallback() {
+
 			public void execute(MessageGroupStore messageGroupStore, MessageGroup group) {
 				messageGroupStore.removeMessageGroup(group.getGroupId());
 			}
@@ -385,6 +391,7 @@ public class MySqlJdbcMessageStoreTests {
 		messageStore.setTimeoutOnIdle(true);
 		messageStore.addMessageToGroup(groupId, message);
 		messageStore.registerMessageGroupExpiryCallback(new MessageGroupCallback() {
+
 			public void execute(MessageGroupStore messageGroupStore, MessageGroup group) {
 				messageGroupStore.removeMessageGroup(group.getGroupId());
 			}
@@ -511,10 +518,11 @@ public class MySqlJdbcMessageStoreTests {
 		assertNotNull(messageFromRegion2);
 
 		LOG.info("messageFromRegion1: " + messageFromRegion1.getHeaders().getId() + "; Sequence #: " + new IntegrationMessageHeaderAccessor(messageFromRegion1).getSequenceNumber());
-		LOG.info("messageFromRegion2: " + messageFromRegion2.getHeaders().getId() + "; Sequence #: " +new IntegrationMessageHeaderAccessor(messageFromRegion2).getSequenceNumber());
+		LOG.info("messageFromRegion2: " + messageFromRegion2.getHeaders().getId() + "; Sequence #: " + new IntegrationMessageHeaderAccessor(messageFromRegion2).getSequenceNumber());
 
 		assertEquals(Integer.valueOf(1), (Integer) messageFromRegion1.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER));
 		assertEquals(Integer.valueOf(2), (Integer) messageFromRegion2.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER));
 
 	}
+
 }

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
@@ -35,7 +35,6 @@ import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupMetadata;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.MessageStore;
-import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
@@ -161,7 +160,7 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 		for (MessageDocument document : messageDocuments) {
 			messages.add(document.getMessage());
 		}
-		SimpleMessageGroup group = new SimpleMessageGroup(messages, groupId, createdTime, complete);
+		MessageGroup group = getMessageGroupFactory().create(messages, groupId, createdTime, complete);
 		group.setLastReleasedMessageSequenceNumber(lastReleasedSequence);
 		group.setLastModified(lastModifiedTime);
 

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
@@ -201,6 +201,7 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 	}
 
 	@Override
+	@Deprecated
 	public MessageGroup removeMessageFromGroup(final Object groupId, final Message<?> messageToRemove) {
 		Assert.notNull(groupId, "'groupId' must not be null");
 		Assert.notNull(messageToRemove, "'messageToRemove' must not be null");

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.PriorityCapableChannelMessageStore;
-import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
@@ -119,7 +118,7 @@ public class MongoDbChannelMessageStore extends AbstractConfigurableMongoDbMessa
 	 */
 	@Override
 	public MessageGroup getMessageGroup(Object groupId) {
-		return new SimpleMessageGroup(groupId);
+		return getMessageGroupFactory().create(groupId);
 	}
 
 	@Override

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -28,6 +28,11 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.BulkWriteOperation;
+import com.mongodb.DBObject;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanClassLoaderAware;
@@ -74,11 +79,6 @@ import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
-
-import com.mongodb.BasicDBList;
-import com.mongodb.BasicDBObject;
-import com.mongodb.BulkWriteOperation;
-import com.mongodb.DBObject;
 
 
 /**
@@ -305,6 +305,7 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 	}
 
 	@Override
+	@Deprecated
 	public MessageGroup removeMessageFromGroup(final Object groupId, final Message<?> messageToRemove) {
 		Assert.notNull(groupId, "'groupId' must not be null");
 		Assert.notNull(messageToRemove, "'messageToRemove' must not be null");

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -264,7 +264,7 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 			messages.add(messageWrapper.getMessage());
 		}
 
-		SimpleMessageGroup messageGroup = new SimpleMessageGroup(messages, groupId, timestamp, completeGroup);
+		SimpleMessageGroup messageGroup = getSimpleMessageGroupFactory().create(messages, groupId, timestamp, completeGroup);
 		messageGroup.setLastModified(lastModified);
 		if (lastReleasedSequenceNumber > 0){
 			messageGroup.setLastReleasedMessageSequenceNumber(lastReleasedSequenceNumber);

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -28,11 +28,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 
-import com.mongodb.BasicDBList;
-import com.mongodb.BasicDBObject;
-import com.mongodb.BulkWriteOperation;
-import com.mongodb.DBObject;
-
 import org.springframework.beans.BeansException;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanClassLoaderAware;
@@ -69,7 +64,6 @@ import org.springframework.integration.store.AbstractMessageGroupStore;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.MessageStore;
-import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MutableMessageBuilder;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.messaging.Message;
@@ -79,6 +73,11 @@ import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
+
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.BulkWriteOperation;
+import com.mongodb.DBObject;
 
 
 /**
@@ -264,7 +263,7 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 			messages.add(messageWrapper.getMessage());
 		}
 
-		SimpleMessageGroup messageGroup = getSimpleMessageGroupFactory().create(messages, groupId, timestamp, completeGroup);
+		MessageGroup messageGroup = getMessageGroupFactory().create(messages, groupId, timestamp, completeGroup);
 		messageGroup.setLastModified(lastModified);
 		if (lastReleasedSequenceNumber > 0){
 			messageGroup.setLastReleasedMessageSequenceNumber(lastReleasedSequenceNumber);

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.mongodb.store;
 
 import static org.junit.Assert.assertEquals;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 
+import com.mongodb.MongoClient;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -47,13 +49,11 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 
-import com.mongodb.MongoClient;
-
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Amol Nayak
- *
+ * @author Artem Bilan
  */
 public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvailableTests {
 
@@ -197,22 +197,22 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		assertEquals(1, store.messageGroupSize(2));
 		assertEquals(1, store.messageGroupSize(3));
 		assertEquals(1, store.messageGroupSize(4));
-		store.removeMessageFromGroup(3, messageA);
+		store.removeMessagesFromGroup(3, messageA);
 		assertEquals(1, store.messageGroupSize(1));
 		assertEquals(1, store.messageGroupSize(2));
 		assertEquals(0, store.messageGroupSize(3));
 		assertEquals(1, store.messageGroupSize(4));
-		store.removeMessageFromGroup(4, messageA);
+		store.removeMessagesFromGroup(4, messageA);
 		assertEquals(1, store.messageGroupSize(1));
 		assertEquals(1, store.messageGroupSize(2));
 		assertEquals(0, store.messageGroupSize(3));
 		assertEquals(0, store.messageGroupSize(4));
-		store.removeMessageFromGroup(2, messageA);
+		store.removeMessagesFromGroup(2, messageA);
 		assertEquals(1, store.messageGroupSize(1));
 		assertEquals(0, store.messageGroupSize(2));
 		assertEquals(0, store.messageGroupSize(3));
 		assertEquals(0, store.messageGroupSize(4));
-		store.removeMessageFromGroup(1, messageA);
+		store.removeMessagesFromGroup(1, messageA);
 		assertEquals(0, store.messageGroupSize(1));
 		assertEquals(0, store.messageGroupSize(2));
 		assertEquals(0, store.messageGroupSize(3));
@@ -262,7 +262,8 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		assertNotNull(messageGroup);
 		assertEquals(2, messageGroup.size());
 
-		messageGroup = store.removeMessageFromGroup(1, messageA);
+		store.removeMessagesFromGroup(1, messageA);
+		messageGroup = store.getMessageGroup(1);
 		assertEquals(1, messageGroup.size());
 
 		// validate that the updates were propagated to Mongo as well
@@ -339,7 +340,8 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		assertNotNull(messageGroup);
 		assertEquals(3, messageGroup.size());
 
-		messageGroup = store.removeMessageFromGroup(1, message);
+		store.removeMessagesFromGroup(1, message);
+		messageGroup = store.getMessageGroup(1);
 		assertEquals(2, messageGroup.size());
 	}
 
@@ -363,7 +365,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		assertNotNull(messageGroup);
 		assertEquals(3, messageGroup.size());
 
-		store3.removeMessageFromGroup(1, message);
+		store3.removeMessagesFromGroup(1, message);
 
 		messageGroup = store2.getMessageGroup(1);
 		assertEquals(2, messageGroup.size());
@@ -391,7 +393,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		}
 		assertEquals(3, counter);
 
-		store2.removeMessageFromGroup(1, message);
+		store2.removeMessagesFromGroup(1, message);
 
 		iterator = store3.iterator();
 		counter = 0;

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 
-import com.mongodb.MongoClient;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -48,6 +47,8 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
+
+import com.mongodb.MongoClient;
 
 /**
  * @author Oleg Zhurakousky

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelMessageStore.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelMessageStore.java
@@ -76,6 +76,13 @@ public class RedisChannelMessageStore implements ChannelMessageStore, BeanNameAw
 		this.redisTemplate.setValueSerializer(valueSerializer);
 	}
 
+	/**
+	 * Specify the {@link MessageGroupFactory} to create {@link MessageGroup) object where
+	 * it is necessary.
+	 * Defaults to {@link SimpleMessageGroupFactory}.
+	 * @param messageGroupFactory the {@link MessageGroupFactory} to use.
+	 * @since 4.3
+	 */
 	public void setMessageGroupFactory(MessageGroupFactory messageGroupFactory) {
 		Assert.notNull(messageGroupFactory, "'messageGroupFactory' must not be null");
 		this.messageGroupFactory = messageGroupFactory;

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelMessageStore.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelMessageStore.java
@@ -77,7 +77,7 @@ public class RedisChannelMessageStore implements ChannelMessageStore, BeanNameAw
 	}
 
 	/**
-	 * Specify the {@link MessageGroupFactory} to create {@link MessageGroup) object where
+	 * Specify the {@link MessageGroupFactory} to create {@link MessageGroup} object where
 	 * it is necessary.
 	 * Defaults to {@link SimpleMessageGroupFactory}.
 	 * @param messageGroupFactory the {@link MessageGroupFactory} to use.

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelMessageStore.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.integration.store.ChannelMessageStore;
 import org.springframework.integration.store.MessageGroup;
-import org.springframework.integration.store.SimpleMessageGroup;
+import org.springframework.integration.store.MessageGroupFactory;
+import org.springframework.integration.store.SimpleMessageGroupFactory;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
@@ -38,12 +39,15 @@ import org.springframework.util.Assert;
  * Requires {@link #setBeanName(String)} which is used as part of the key.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 4.0
  *
  */
 public class RedisChannelMessageStore implements ChannelMessageStore, BeanNameAware, InitializingBean {
 
 	private final RedisTemplate<Object, Message<?>> redisTemplate;
+
+	private volatile MessageGroupFactory messageGroupFactory = new SimpleMessageGroupFactory();
 
 	private String beanName;
 
@@ -71,6 +75,15 @@ public class RedisChannelMessageStore implements ChannelMessageStore, BeanNameAw
 		this.redisTemplate.setValueSerializer(valueSerializer);
 	}
 
+	public void setMessageGroupFactory(MessageGroupFactory messageGroupFactory) {
+		Assert.notNull(messageGroupFactory, "'messageGroupFactory' must not be null");
+		this.messageGroupFactory = messageGroupFactory;
+	}
+
+	protected MessageGroupFactory getMessageGroupFactory() {
+		return this.messageGroupFactory;
+	}
+
 	@Override
 	public void setBeanName(String name) {
 		Assert.notNull(name, "'beanName' must not be null");
@@ -78,11 +91,11 @@ public class RedisChannelMessageStore implements ChannelMessageStore, BeanNameAw
 	}
 
 	protected String getBeanName() {
-		return beanName;
+		return this.beanName;
 	}
 
 	protected RedisTemplate<Object, Message<?>> getRedisTemplate() {
-		return redisTemplate;
+		return this.redisTemplate;
 	}
 
 	@Override
@@ -99,7 +112,7 @@ public class RedisChannelMessageStore implements ChannelMessageStore, BeanNameAw
 	@Override
 	public MessageGroup getMessageGroup(Object groupId) {
 		List<Message<?>> messages = this.redisTemplate.boundListOps(groupId).range(0, -1);
-		return new SimpleMessageGroup(messages, groupId);
+		return getMessageGroupFactory().create(messages, groupId);
 	}
 
 	@Override

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelMessageStore.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.redis.store;
 
 import java.util.List;

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelPriorityMessageStore.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelPriorityMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelPriorityMessageStore.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisChannelPriorityMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.PriorityCapableChannelMessageStore;
-import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
@@ -41,10 +40,12 @@ import org.springframework.util.Assert;
  * Requires that groupId is a String.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 4.0
  *
  */
-public class RedisChannelPriorityMessageStore extends RedisChannelMessageStore implements PriorityCapableChannelMessageStore {
+public class RedisChannelPriorityMessageStore extends RedisChannelMessageStore
+		implements PriorityCapableChannelMessageStore {
 
 	private final Comparator<String> keysComparator = new Comparator<String>() {
 
@@ -85,7 +86,7 @@ public class RedisChannelPriorityMessageStore extends RedisChannelMessageStore i
 			List<Message<?>> messages = this.getRedisTemplate().boundListOps(key).range(0, -1);
 			allMessages.addAll(messages);
 		}
-		return new SimpleMessageGroup(allMessages, groupId);
+		return getMessageGroupFactory().create(allMessages, groupId);
 	}
 
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisChannelMessageStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisChannelMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.redis.store;
 
 import static org.junit.Assert.assertEquals;

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisChannelMessageStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisChannelMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,9 +118,9 @@ public class RedisChannelMessageStoreTests extends RedisAvailableTests {
 	@RedisAvailable
 	public void testPriority() {
 		for (int i = 0; i < 10; i++) {
-			Message<Integer> message = MessageBuilder.withPayload(i).setPriority(i).build();
-			this.testChannel3.send(message);
-			this.testChannel3.send(message);
+			this.testChannel3.send(MessageBuilder.withPayload(i).setPriority(i).build());
+			//We need unique messages
+			this.testChannel3.send(MessageBuilder.withPayload(i).setPriority(i).build());
 		}
 		this.testChannel3.send(MessageBuilder.withPayload(99).setPriority(199).build());
 		this.testChannel3.send(MessageBuilder.withPayload(98).build());

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2015 the original author or authors
+ * Copyright 2007-2016 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.AssertionFailedError;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -50,6 +49,8 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
+
+import junit.framework.AssertionFailedError;
 
 /**
  * @author Oleg Zhurakousky

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
@@ -13,6 +13,7 @@
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
  */
+
 package org.springframework.integration.redis.store;
 
 import static org.junit.Assert.assertEquals;
@@ -54,7 +55,6 @@ import org.springframework.messaging.support.GenericMessage;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gary Russell
- *
  */
 public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 
@@ -190,7 +190,8 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 		messageGroup = store.addMessageToGroup(messageGroup.getGroupId(), new GenericMessage<String>("3"));
 		assertEquals(3, messageGroup.size());
 
-		messageGroup = store.removeMessageFromGroup(1, message);
+		store.removeMessagesFromGroup(1, message);
+		messageGroup = store.getMessageGroup(1);
 		assertEquals(2, messageGroup.size());
 
 		// make sure the store is properly rebuild from Redis
@@ -235,7 +236,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		store.addMessageToGroup(messageGroup.getGroupId(), new GenericMessage<String>("1"));
-		store.removeMessageFromGroup(1, new GenericMessage<String>("2"));
+		store.removeMessagesFromGroup(1, new GenericMessage<String>("2"));
 	}
 
 	@Test
@@ -243,7 +244,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 	public void testRemoveNonExistingMessageFromNonExistingTheGroup() throws Exception{
 		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
-		store.removeMessageFromGroup(1, new GenericMessage<String>("2"));
+		store.removeMessagesFromGroup(1, new GenericMessage<String>("2"));
 	}
 
 
@@ -264,7 +265,8 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 
 		RedisMessageStore store3 = new RedisMessageStore(jcf);
 
-		messageGroup = store3.removeMessageFromGroup(1, message);
+		store3.removeMessagesFromGroup(1, message);
+		messageGroup = store3.getMessageGroup(1);
 
 		assertEquals(1, messageGroup.getMessages().size());
 	}
@@ -340,7 +342,8 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 			executor.execute(new Runnable() {
 				@Override
 				public void run() {
-					MessageGroup group = store2.removeMessageFromGroup(1, message);
+					store2.removeMessagesFromGroup(1, message);
+					MessageGroup group = store2.getMessageGroup(1);
 					if (group.getMessages().size() != 0){
 						failures.add("REMOVE");
 						throw new AssertionFailedError("Failed on Remove");
@@ -350,7 +353,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 
 			executor.shutdown();
 			executor.awaitTermination(10, TimeUnit.SECONDS);
-			store2.removeMessageFromGroup(1, message); // ensures that if ADD thread executed after REMOVE, the store is empty for the next cycle
+			store2.removeMessagesFromGroup(1, message); // ensures that if ADD thread executed after REMOVE, the store is empty for the next cycle
 		}
 		assertTrue(failures.size() == 0);
 	}

--- a/src/reference/asciidoc/message-store.adoc
+++ b/src/reference/asciidoc/message-store.adoc
@@ -84,3 +84,13 @@ Manipulation of the group outside of the aggregator may cause unpredictable resu
 
 For this reason, users should not perform such manipulation, or set the `copyOnGet` property to `true`.
 =====
+
+[[message-group-factory]]
+===== MessageGroupFactory
+
+Starting with _version 4.3_, some `MessageGroupStore` implementations can be injected with the custom
+`MessageGroupFactory` strategy to create/customize the `MessageGroup` instances in the `MessageGroupStore` logic.
+The defaults to `SimpleMessageGroupFactory` which produces `SimpleMessageGroup` s based on the `GroupType.HASH_SET`
+(`LinkedHashSet`) internal collection.
+Other possible options are `SYNCHRONISED_SET` and `BLOCKING_QUEUE`, where the last one can be used to reinstate the
+previous `SimpleMessageGroup` behavior.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -9,6 +9,14 @@ development process.
 [[x4.3-new-components]]
 === New Components
 
+==== MessageGroupFactory
+
+The new `MessageGroupFactory` strategy has been introduced to allow a control over `MessageGroup` instances
+in the `MessageGroupStore` logic.
+The `SimpleMessageGroupFactory` is provided for the `SimpleMessageGroup` with the `GroupType.HASH_SET` as default
+factory for the particular `MessageGroupStore` implementations.
+See <<message-store>> for more information.
+
 
 [[x4.3-general]]
 === General Changes


### PR DESCRIPTION
JIRAs:
https://jira.spring.io/browse/INT-3830
https://jira.spring.io/browse/INT-3523
https://jira.spring.io/browse/INT-3846
- Fix the OOM condition, when we `release()` `UpperBound` independently of the previous `remove` result (https://jira.spring.io/browse/INT-3846)
- Fix "confuse" around `groupCapacity`, when we really didn't care about individual groups (https://jira.spring.io/browse/INT-3523)
- Add `upperBoundTimeout` to have a hook to wait some time for the empty slot in the store (https://jira.spring.io/browse/INT-3830)
- Fix some JavaDocs warnings
- Fix some typos
