### PR TITLE
INT-3848: ERROR log for the `null` `beanName`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
@@ -159,23 +159,30 @@ public class ConsumerEndpointFactoryBean
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		try {
-			if (!this.beanName.startsWith("org.springframework")) {
-				MessageHandler targetHandler = this.handler;
-				if (AopUtils.isAopProxy(targetHandler)) {
-					Object target = ((Advised) targetHandler).getTargetSource().getTarget();
-					if (target instanceof MessageHandler) {
-						targetHandler = (MessageHandler) target;
+		if (this.beanName == null) {
+			logger.error("The MessageHandler [" + this.handler + "] will be created without 'componentName'." +
+					"Consider to specify the 'beanName' property on this ConsumerEndpointFactoryBean.");
+		}
+		else {
+			try {
+				if (!this.beanName.startsWith("org.springframework")) {
+					MessageHandler targetHandler = this.handler;
+					if (AopUtils.isAopProxy(targetHandler)) {
+						Object target = ((Advised) targetHandler).getTargetSource().getTarget();
+						if (target instanceof MessageHandler) {
+							targetHandler = (MessageHandler) target;
+						}
+					}
+					if (targetHandler instanceof IntegrationObjectSupport) {
+						((IntegrationObjectSupport) targetHandler).setComponentName(this.beanName);
 					}
 				}
-				if (targetHandler instanceof IntegrationObjectSupport) {
-					((IntegrationObjectSupport) targetHandler).setComponentName(this.beanName);
-				}
 			}
-		} catch (Exception e) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("Could not set component name for handler "
-						+ this.handler + " for " + this.beanName + " :" + e.getMessage());
+			catch (Exception e) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Could not set component name for handler "
+							+ this.handler + " for " + this.beanName + " :" + e.getMessage());
+				}
 			}
 		}
 		if (!CollectionUtils.isEmpty(this.adviceChain)) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3848

When the `ConsumerEndpointFactoryBean` is created programmatically
the `beanName` property may be missed and the `catch` for the `NPE`
just hides an issue with the `DEBUG` log message.

Add check for the `null` on the `bean` and log the issue on ERROR level.

**Cherry-pick to the 4.1.x, 4.0.x and 3.0.x**
