### PR TITLE
INT-3849: Fix File Inbound Adapter Regression

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileInboundChannelAdapterParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileInboundChannelAdapterParser.java
@@ -84,23 +84,26 @@ public class FileInboundChannelAdapterParser extends AbstractPollingInboundChann
 		String filenameRegex = element.getAttribute("filename-regex");
 		String preventDuplicates = element.getAttribute("prevent-duplicates");
 		String ignoreHidden = element.getAttribute("ignore-hidden");
-		if (!StringUtils.hasText(filenamePattern) && !StringUtils.hasText(filenameRegex)
+		String filter = element.getAttribute("filter");
+		if (!StringUtils.hasText(filter) && !StringUtils.hasText(filenamePattern) && !StringUtils.hasText(filenameRegex)
 				&& !StringUtils.hasText(preventDuplicates) && !StringUtils.hasText(ignoreHidden)) {
 			return null;
 		}
 		BeanDefinitionBuilder factoryBeanBuilder =
 				BeanDefinitionBuilder.genericBeanDefinition(FileListFilterFactoryBean.class);
 		factoryBeanBuilder.setRole(BeanDefinition.ROLE_SUPPORT);
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(factoryBeanBuilder, element, "filter");
+		if (StringUtils.hasText(filter)) {
+			factoryBeanBuilder.addPropertyReference("filter", filter);
+		}
 		if (StringUtils.hasText(filenamePattern)) {
-			if (element.hasAttribute("filter")) {
+			if (StringUtils.hasText(filter)) {
 				parserContext.getReaderContext().error(
 						"At most one of 'filter' and 'filename-pattern' may be provided.", element);
 			}
 			factoryBeanBuilder.addPropertyValue("filenamePattern", filenamePattern);
 		}
 		if (StringUtils.hasText(filenameRegex)) {
-			if (element.hasAttribute("filter")) {
+			if (StringUtils.hasText(filter)) {
 				parserContext.getReaderContext().error(
 						"At most one of 'filter' and 'filename-regex' may be provided.", element);
 			}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests-context.xml
@@ -21,6 +21,13 @@
 		</integration:poller>
 	</inbound-channel-adapter>
 
+	<inbound-channel-adapter id="inboundWithJustFilter"
+							 directory="${java.io.tmpdir}"
+							 filter="filter"
+							 auto-startup="false">
+		<integration:poller fixed-rate="5000" />
+	</inbound-channel-adapter>
+
 	<integration:channel id="successChannel" />
 
 	<beans:bean id="filter" class="org.springframework.integration.file.config.FileListFilterFactoryBean">


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3849

A file inbound adapter with just a `filter` attribute (no implied filter attributes)
did not get its filter injected.

The parser took an early exit from the filter configuration if none of the implied
filter attributes were specified.

Work around is to explicitly set `ignore-hidden="true"`.
