### PR TITLE
INT-2787: Map `correlationId` to JMS Property

### DIFF
--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/SplitterAggregatorTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/SplitterAggregatorTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.jms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.aggregator.AggregatingMessageHandler;
+import org.springframework.integration.aggregator.DefaultAggregatingMessageGroupProcessor;
+import org.springframework.integration.annotation.InboundChannelAdapter;
+import org.springframework.integration.annotation.Poller;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.annotation.Splitter;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.core.MessageSource;
+import org.springframework.integration.splitter.DefaultMessageSplitter;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Artem Bilan
+ * @since 4.2.1
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
+public class SplitterAggregatorTests extends ActiveMQMultiContextTests {
+
+	@Autowired
+	private MessageChannel splitChannel;
+
+	@Autowired
+	private PollableChannel resultChannel;
+
+	@Test
+	public void testSplitterAggregatorOverJms() {
+		List<Integer> payload = Arrays.asList(1, 2, 3, 4, 5, 6);
+		this.splitChannel.send(new GenericMessage<List<Integer>>(payload));
+		Message<?> message = this.resultChannel.receive(10000);
+		assertNotNull(message);
+		assertEquals(payload, message.getPayload());
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class ContextConfiguration {
+
+		@Bean
+		@Splitter(inputChannel = "splitChannel")
+		public MessageHandler splitter() {
+			DefaultMessageSplitter splitter = new DefaultMessageSplitter();
+			splitter.setOutputChannelName("toJmsChannel");
+			return splitter;
+		}
+
+		@Bean
+		@ServiceActivator(inputChannel = "toJmsChannel")
+		public MessageHandler toJms() {
+			JmsSendingMessageHandler handler = new JmsSendingMessageHandler(new JmsTemplate(amqFactory));
+			handler.setDestinationName("test");
+			return handler;
+		}
+
+		@Bean
+		@InboundChannelAdapter(value = "aggregateChannel",
+				poller = @Poller(fixedDelay = "1000", maxMessagesPerPoll = "10"))
+		public MessageSource<Object> fromJms() {
+			JmsDestinationPollingSource source = new JmsDestinationPollingSource(new JmsTemplate(amqFactory));
+			source.setDestinationName("test");
+			return source;
+		}
+
+		@Bean
+		public MessageChannel aggregateChannel() {
+			return new DirectChannel();
+		}
+
+		@Bean
+		@ServiceActivator(inputChannel = "aggregateChannel")
+		public MessageHandler aggregator() {
+			AggregatingMessageHandler handler =
+					new AggregatingMessageHandler(new DefaultAggregatingMessageGroupProcessor());
+			handler.setOutputChannel(resultChannel());
+			return handler;
+		}
+
+		@Bean
+		public PollableChannel resultChannel() {
+			return new QueueChannel();
+		}
+
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-2787

The `correlationId` is `UUID` object by default Framework behavior.
This type isn't allowed for JMS Message properties mapping.

Add the mapping for the `IntegrationMessageHeaderAccessor.CORRELATION_ID` header as a `String`,
since on the other side it simply can be converted to the `UUID` object back.
For example `AbstractCorrelatingMessageHandler` does that automatically on the correlation function using `UUIDConverter`.

The provided `SplitterAggregatorTests` demonstrates the scenario when we weren't be able to aggregate by the unsupported `UUID` type.

I don't consider this as back-port fix, because the same can be simply achieved with the custom `JmsHeaderMapper`.
From other side this fix maybe like some side-effect breaking change.

I don't consider any `UUID` message header as a candidate to be converted to String and mapped, because to do that unconditionally
may cause some undesired issues. From other side it can be done with the custom `JmsHeaderMapper` in the end-application.
