### PR TITLE
INT-2541: Fix `@ManagedResource` JMX registration

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/WireTap.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/WireTap.java
@@ -22,7 +22,6 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.channel.ChannelInterceptorAware;
 import org.springframework.integration.core.MessageSelector;
-import org.springframework.integration.support.management.IntegrationManagedResource;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedResource;
@@ -40,7 +39,6 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  */
 @ManagedResource
-@IntegrationManagedResource
 public class WireTap extends ChannelInterceptorAdapter implements Lifecycle, VetoCapableInterceptor {
 
 	private static final Log logger = LogFactory.getLog(WireTap.class);

--- a/spring-integration-core/src/main/java/org/springframework/integration/metadata/MetadataStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/metadata/MetadataStore.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.metadata;
 
-import org.springframework.integration.support.management.IntegrationManagedResource;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
 
@@ -31,7 +30,6 @@ import org.springframework.jmx.export.annotation.ManagedResource;
  * @since 2.0
  */
 @ManagedResource
-@IntegrationManagedResource
 public interface MetadataStore {
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -24,7 +24,6 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
-import org.springframework.integration.support.management.IntegrationManagedResource;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
@@ -39,7 +38,6 @@ import org.springframework.messaging.Message;
  * @since 2.0
  */
 @ManagedResource
-@IntegrationManagedResource
 public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageGroupStore
 		implements MessageGroupStore, Iterable<MessageGroup>, BeanFactoryAware {
 

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/StoredProcExecutor.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/StoredProcExecutor.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.BeanFactory;
@@ -33,7 +34,6 @@ import org.springframework.expression.common.LiteralExpression;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.jdbc.storedproc.ProcedureParameter;
-import org.springframework.integration.support.management.IntegrationManagedResource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.SqlInOutParameter;
@@ -68,7 +68,6 @@ import com.google.common.cache.LoadingCache;
  *
  */
 @ManagedResource
-@IntegrationManagedResource
 public class StoredProcExecutor implements BeanFactoryAware, InitializingBean {
 
 	private static final boolean guavaPresent = ClassUtils.isPresent("com.google.common.cache.LoadingCache",

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -55,7 +55,6 @@ import org.springframework.integration.store.PriorityCapableChannelMessageStore;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
-import org.springframework.integration.support.management.IntegrationManagedResource;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.integration.transaction.TransactionSynchronizationFactory;
 import org.springframework.integration.util.UUIDConverter;
@@ -97,7 +96,6 @@ import org.springframework.util.StringUtils;
  * @since 2.2
  */
 @ManagedResource
-@IntegrationManagedResource
 public class JdbcChannelMessageStore implements PriorityCapableChannelMessageStore, InitializingBean, BeanFactoryAware {
 
 	private static final Log logger = LogFactory.getLog(JdbcChannelMessageStore.class);

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/MBeanExporterHelper.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/MBeanExporterHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,27 +10,24 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package org.springframework.integration.jmx.config;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.DirectFieldAccessor;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanPostProcessor;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.core.Ordered;
-import org.springframework.core.type.StandardMethodMetadata;
-import org.springframework.integration.config.IntegrationConfigUtils;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.integration.monitor.IntegrationMBeanExporter;
+import org.springframework.integration.support.management.IntegrationManagedResource;
 import org.springframework.jmx.export.MBeanExporter;
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * Most likely a temporary class mainly needed to address issue described in INT-2307.
@@ -43,56 +40,43 @@ import org.springframework.util.StringUtils;
  * @since 2.1
  *
  */
-class MBeanExporterHelper implements BeanPostProcessor, Ordered, BeanFactoryAware, InitializingBean {
+class MBeanExporterHelper implements BeanPostProcessor, Ordered {
+
+	private final List<MBeanExporter> mBeanExportersForExcludes = new ArrayList<MBeanExporter>();
 
 	private final Set<String> siBeanNames = new HashSet<String>();
 
-	private volatile DefaultListableBeanFactory beanFactory;
-
-	private volatile boolean capturedAutoChannelCandidates;
-
 	@Override
-	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-		Assert.isInstanceOf(DefaultListableBeanFactory.class, beanFactory);
-		this.beanFactory = (DefaultListableBeanFactory) beanFactory;
-	}
-
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		if (this.beanFactory != null) {
-			String[] beanNames = this.beanFactory.getBeanDefinitionNames();
-			for (String beanName : beanNames) {
-				BeanDefinition def = this.beanFactory.getBeanDefinition(beanName);
-				String className = def.getBeanClassName();
-				if (className == null && def.getSource() instanceof StandardMethodMetadata) {
-					className = ((StandardMethodMetadata) def.getSource()).getIntrospectedMethod().getReturnType().getName();
-				}
-				if (StringUtils.hasText(className)){
-					if (className.startsWith(IntegrationConfigUtils.BASE_PACKAGE)
-							&& !(className.endsWith(IntegrationMBeanExporter.class.getName()))){
-						siBeanNames.add(beanName);
+	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+		if ("$autoCreateChannelCandidates".equals(beanName)) {
+			@SuppressWarnings("unchecked")
+			Collection<String> autoCreateChannelCandidatesNames = (Collection<String>) new DirectFieldAccessor(bean)
+							.getPropertyValue("channelNames");
+			this.siBeanNames.addAll(autoCreateChannelCandidatesNames);
+			if (!this.mBeanExportersForExcludes.isEmpty()) {
+				for (String autoCreateChannelCandidatesName : autoCreateChannelCandidatesNames) {
+					for (MBeanExporter mBeanExporter : this.mBeanExportersForExcludes) {
+						mBeanExporter.addExcludedBean(autoCreateChannelCandidatesName);
 					}
 				}
 			}
 		}
-	}
 
-	@Override
-	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
-		if (!this.capturedAutoChannelCandidates && this.beanFactory != null) {
-			Object autoCreateChannelCandidates = beanFactory.getBean("$autoCreateChannelCandidates");
-			if (autoCreateChannelCandidates != null){
-					@SuppressWarnings("unchecked")
-					Collection<String> autoCreateChannelCandidatesNames =
-									(Collection<String>) new DirectFieldAccessor(autoCreateChannelCandidates).getPropertyValue("channelNames");
-					this.siBeanNames.addAll(autoCreateChannelCandidatesNames);
+		if (AnnotatedElementUtils.isAnnotated(AopUtils.getTargetClass(bean),
+				IntegrationManagedResource.class.getName())){
+			this.siBeanNames.add(beanName);
+			if (!this.mBeanExportersForExcludes.isEmpty()) {
+				for (MBeanExporter mBeanExporter : this.mBeanExportersForExcludes) {
+					mBeanExporter.addExcludedBean(beanName);
+				}
 			}
-			this.capturedAutoChannelCandidates = true;
 		}
+
 		if (bean instanceof MBeanExporter && !(bean instanceof IntegrationMBeanExporter)) {
-			MBeanExporter mbeanExporter = (MBeanExporter) bean;
-			for (String siBean : this.siBeanNames) {
-				mbeanExporter.addExcludedBean(siBean);
+			MBeanExporter mBeanExporter = (MBeanExporter) bean;
+			this.mBeanExportersForExcludes.add(mBeanExporter);
+			for (String siBeanName : this.siBeanNames) {
+				mBeanExporter.addExcludedBean(siBeanName);
 			}
 		}
 

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
@@ -114,7 +114,6 @@ import org.springframework.util.StringValueResolver;
  * @author Artem Bilan
  */
 @ManagedResource
-@IntegrationManagedResource
 public class IntegrationMBeanExporter extends MBeanExporter implements ApplicationContextAware,
 		EmbeddedValueResolverAware {
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MessageStoreTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MessageStoreTests-context.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:int="http://www.springframework.org/schema/integration"
-	xmlns:jmx="http://www.springframework.org/schema/integration/jmx"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xmlns:jmx="http://www.springframework.org/schema/integration/jmx"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
 			http://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/context
 			http://www.springframework.org/schema/context/spring-context.xsd
-			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd
 			http://www.springframework.org/schema/integration/jmx
 			http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd">
 
-	<context:mbean-server id="mbs" />
-	
+	<context:mbean-server id="mbs"/>
+
 	<context:mbean-export server="mbs" default-domain="test.MessageStore"/>
 
+	<jmx:mbean-export server="mbs" default-domain="test.MessageStore"/>
+
 	<bean id="messageStore" class="org.springframework.integration.store.SimpleMessageStore"/>
-	
+
 </beans>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/NotificationPublishingChannelAdapterParserTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/NotificationPublishingChannelAdapterParserTests-context.xml
@@ -13,8 +13,10 @@
 			http://www.springframework.org/schema/integration/jmx
 			http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd">
 
-	<context:mbean-export default-domain="#{T(java.util.UUID).randomUUID().toString()}"/>
 	<context:mbean-server/>
+
+	<context:mbean-export default-domain="#{T(java.util.UUID).randomUUID().toString()}"/>
+
 	<jmx:mbean-export default-domain="#{T(java.util.UUID).randomUUID().toString()}"/>
 
 	<si:message-history/>
@@ -26,7 +28,7 @@
 			object-name="test.publisher:name=publisher"
 			default-notification-type="default.type">
 		<jmx:request-handler-advice-chain>
-			<bean class="org.springframework.integration.jmx.config.NotificationPublishingChannelAdapterParserTests$FooADvice"/>
+			<bean class="org.springframework.integration.jmx.config.NotificationPublishingChannelAdapterParserTests.FooAdvice"/>
 		</jmx:request-handler-advice-chain>
 	</jmx:notification-publishing-channel-adapter>
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/NotificationPublishingChannelAdapterParserTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/NotificationPublishingChannelAdapterParserTests.java
@@ -173,14 +173,14 @@ public class NotificationPublishingChannelAdapterParserTests {
 
 	}
 
-	public static class FooADvice extends AbstractRequestHandlerAdvice {
+	public static class FooAdvice extends AbstractRequestHandlerAdvice {
 
 		@Override
 		protected Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) throws Exception {
 			adviceCalled++;
-			new RuntimeException("foo").printStackTrace();
 			return callback.execute();
 		}
 
 	}
+
 }

--- a/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/Int2307Tests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/Int2307Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,6 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package org.springframework.integration_.mbeanexporterhelper;
 
 import static org.junit.Assert.assertEquals;
@@ -23,11 +24,9 @@ import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
 import javax.management.ObjectInstance;
 
-import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.jmx.export.MBeanExporter;
 
@@ -35,17 +34,13 @@ import org.springframework.jmx.export.MBeanExporter;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
- *
  */
 public class Int2307Tests {
 
-	@Rule
-	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
-
 	@SuppressWarnings("unchecked")
 	@Test
-	public void testInt2307_DefaultMBeanExporter() throws Exception{
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("single-config.xml", this.getClass());
+	public void testInt2307_DefaultMBeanExporter() throws Exception {
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("single-config.xml", getClass());
 		List<MBeanServer> servers = MBeanServerFactory.findMBeanServer(null);
 		assertEquals(1, servers.size());
 		MBeanServer server = servers.get(0);
@@ -53,12 +48,13 @@ public class Int2307Tests {
 		int bits = 0;
 		int count = 0;
 		for (ObjectInstance mbean : mbeans) {
-			Thread.sleep(500); //Added in order to pass test with Java 8
-			if (mbean.toString().startsWith("org.springframework.integration.support.management.LifecycleTrackableMessageHandlerMetrics[test.domain:type=MessageHandler,name=rlr,bean=endpoint,random=")) {
+			if (mbean.toString()
+					.startsWith("org.springframework.integration.support.management.LifecycleTrackableMessageHandlerMetrics[test.domain:type=MessageHandler,name=rlr,bean=endpoint,random=")) {
 				bits |= 2;
 				count++;
 			}
-			else if (mbean.toString().startsWith("org.springframework.integration.support.management.TrackableRouterMetrics[test.domain:type=MessageHandler,name=hvr,bean=endpoint,random=")) {
+			else if (mbean.toString()
+					.startsWith("org.springframework.integration.support.management.TrackableRouterMetrics[test.domain:type=MessageHandler,name=hvr,bean=endpoint,random=")) {
 				bits |= 8;
 				count++;
 			}
@@ -67,7 +63,8 @@ public class Int2307Tests {
 		assertEquals(2, count);
 
 		Class<?> clazz = Class.forName("org.springframework.integration.jmx.config.MBeanExporterHelper");
-		List<Object> beanPostProcessors = TestUtils.getPropertyValue(context, "beanFactory.beanPostProcessors", List.class);
+		List<Object> beanPostProcessors =
+				TestUtils.getPropertyValue(context, "beanFactory.beanPostProcessors", List.class);
 		Object mBeanExporterHelper = null;
 		for (Object beanPostProcessor : beanPostProcessors) {
 			if (clazz.isAssignableFrom(beanPostProcessor.getClass())) {
@@ -78,24 +75,22 @@ public class Int2307Tests {
 		assertNotNull(mBeanExporterHelper);
 		assertTrue(TestUtils.getPropertyValue(mBeanExporterHelper, "siBeanNames", Set.class).contains("z"));
 		assertTrue(TestUtils.getPropertyValue(mBeanExporterHelper, "siBeanNames", Set.class).contains("zz"));
-
-		// make sure there are no duplicate MBean ObjectNames if 2 contexts loaded from same config
-		new ClassPathXmlApplicationContext("single-config.xml", this.getClass()).close();
+		context.close();
 	}
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void testInt2307_CustomMBeanExporter() throws Exception{
-		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("single-config-custom-exporter.xml", this.getClass());
+	public void testInt2307_CustomMBeanExporter() throws Exception {
+		ClassPathXmlApplicationContext context =
+				new ClassPathXmlApplicationContext("single-config-custom-exporter.xml", getClass());
 		MBeanExporter exporter = context.getBean("myExporter", MBeanExporter.class);
 		Set<String> excludedBeanNames = TestUtils.getPropertyValue(exporter, "excludedBeans", Set.class);
-		assertTrue(excludedBeanNames.contains("rlr"));
-		assertTrue(excludedBeanNames.contains("hvr"));
 		assertTrue(excludedBeanNames.contains("x"));
 		assertTrue(excludedBeanNames.contains("y"));
 		assertTrue(excludedBeanNames.contains("foo")); // non SI bean
 		Class<?> clazz = Class.forName("org.springframework.integration.jmx.config.MBeanExporterHelper");
-		List<Object> beanPostProcessors = TestUtils.getPropertyValue(context, "beanFactory.beanPostProcessors", List.class);
+		List<Object> beanPostProcessors =
+				TestUtils.getPropertyValue(context, "beanFactory.beanPostProcessors", List.class);
 		Object mBeanExporterHelper = null;
 		for (Object beanPostProcessor : beanPostProcessors) {
 			if (clazz.isAssignableFrom(beanPostProcessor.getClass())) {
@@ -105,7 +100,11 @@ public class Int2307Tests {
 		}
 		assertNotNull(mBeanExporterHelper);
 		assertTrue(TestUtils.getPropertyValue(mBeanExporterHelper, "siBeanNames", Set.class).contains("z"));
+		context.close();
 	}
 
-	public static class Foo{}
+	public static class Foo {
+
+	}
+
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-2541

The `IntegrationMBeanExporter` doesn't register any `@ManagedResource` automatically.
Its `autoDetection` is disabled by default.
Hence such a components like `AbstractMessageGroupStore`
or `WireTap` aren't exposed to the JMX by the `IntegrationMBeanExporter`.
From other side `MBeanExporterHelper` aims to help to avoid duplicate exposing if
an `MBeanExporter` is presented in the CTX.
But `MBeanExporterHelper` did that unconditionally just for the whole `org.springframework.integration` package.
Therefore components which aren't EIP ones aren't exposed to the JMX at all.
- Fix `MBeanExporterHelper` to deal for exclusion based on the `@IntegrationManagedResource` annotation.
- Remove `@IntegrationManagedResource` from those components which aren't EIP.
- Make some polishing in the JMX tests.
