### PR TITLE
INT-3852: Support ObjectName Customization

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationManagedResource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationManagedResource.java
@@ -22,11 +22,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.jmx.export.annotation.ManagedResource;
 
 /**
  * Clone of {@link ManagedResource} limiting beans thus annotated so that they
- * will only be exported by the {@code IntegrationMBeanExporter}.
+ * will only be exported by the {@code IntegrationMBeanExporter} and prevented
+ * from being exported by other MBeanExporters (if present).
  *
  * @author Gary Russell
  * @since 4.2
@@ -43,8 +45,10 @@ public @interface IntegrationManagedResource {
 	 * attribute, for simple default usage.
 	 * @return the value.
 	 */
+	@AliasFor("objectName")
 	String value() default "";
 
+	@AliasFor("value")
 	String objectName() default "";
 
 	String description() default "";

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/CustomObjectNameTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/CustomObjectNameTests-context.xml
@@ -4,9 +4,11 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:jmx="http://www.springframework.org/schema/integration/jmx"
 	xmlns:util="http://www.springframework.org/schema/util"
+	xmlns:tx="http://www.springframework.org/schema/tx"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:mbean-server id="mbs"/>
@@ -24,6 +26,8 @@
 		<prop key="customRouterName">custom:type=MessageRouter,name=foo</prop>
 	</util:properties>
 
+	<tx:annotation-driven />
+
 	<bean id="customChannel"
 		class="org.springframework.integration.jmx.config.CustomObjectNameTests.ChannelWithCustomObjectName"/>
 
@@ -38,5 +42,8 @@
 
 	<bean id="standardHandler"
 		class="org.springframework.integration.jmx.config.CustomObjectNameTests.HandlerWithStandardObjectName"/>
+
+	<bean id="txConfig"
+		class="org.springframework.integration.jmx.config.CustomObjectNameTests.TxConfig"/>
 
 </beans>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/CustomObjectNameTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/CustomObjectNameTests-context.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:jmx="http://www.springframework.org/schema/integration/jmx"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+	<context:mbean-server id="mbs"/>
+
+	<context:mbean-export server="mbs" default-domain="test.custom"/>
+
+	<jmx:mbean-export server="mbs" default-domain="test.custom"/>
+
+	<context:property-placeholder properties-ref="props" />
+
+	<util:properties id="props">
+		<prop key="customChannelName">custom:type=MessageChannel,name=foo</prop>
+		<prop key="customHandlerName">custom:type=MessageHandler,name=foo</prop>
+		<prop key="customSourceName">custom:type=MessageSource,name=foo</prop>
+		<prop key="customRouterName">custom:type=MessageRouter,name=foo</prop>
+	</util:properties>
+
+	<bean id="customChannel"
+		class="org.springframework.integration.jmx.config.CustomObjectNameTests.ChannelWithCustomObjectName"/>
+
+	<bean id="customHandler"
+		class="org.springframework.integration.jmx.config.CustomObjectNameTests.HandlerWithCustomObjectName"/>
+
+	<bean id="customSource"
+		class="org.springframework.integration.jmx.config.CustomObjectNameTests.SourceWithCustomObjectName"/>
+
+	<bean id="customRouter"
+		class="org.springframework.integration.jmx.config.CustomObjectNameTests.RouterWithCustomObjectName"/>
+
+	<bean id="standardHandler"
+		class="org.springframework.integration.jmx.config.CustomObjectNameTests.HandlerWithStandardObjectName"/>
+
+</beans>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/CustomObjectNameTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/CustomObjectNameTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.integration.jmx.config;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import javax.management.Descriptor;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.channel.AbstractMessageChannel;
+import org.springframework.integration.endpoint.AbstractMessageSource;
+import org.springframework.integration.handler.AbstractMessageHandler;
+import org.springframework.integration.router.AbstractMappingMessageRouter;
+import org.springframework.integration.support.management.IntegrationManagedResource;
+import org.springframework.messaging.Message;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ * @since 4.2.1
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
+public class CustomObjectNameTests {
+
+	@Autowired
+	private MBeanServer server;
+
+	@Test
+	public void testCustomMBeanRegistration() throws Exception {
+		Set<ObjectName> names = server.queryNames(new ObjectName("custom:type=MessageChannel,*"), null);
+		assertEquals(1, names.size());
+		ObjectName name = names.iterator().next();
+		assertEquals("custom:type=MessageChannel,name=foo", name.toString());
+		MBeanInfo mBeanInfo = server.getMBeanInfo(name);
+		assertEquals("custom channel", mBeanInfo.getDescription());
+		names = server.queryNames(new ObjectName("custom:type=MessageHandler,*"), null);
+		assertEquals(1, names.size());
+		name = names.iterator().next();
+		assertEquals("custom:type=MessageHandler,name=foo", name.toString());
+		mBeanInfo = server.getMBeanInfo(name);
+		assertEquals("custom handler", mBeanInfo.getDescription());
+		Descriptor descriptor = mBeanInfo.getDescriptor();
+		assertEquals("true", descriptor.getFieldValue("log"));
+		assertEquals("foo", descriptor.getFieldValue("logFile"));
+		assertEquals("1000", descriptor.getFieldValue("currencyTimeLimit"));
+		assertEquals("bar", descriptor.getFieldValue("persistLocation"));
+		assertEquals("baz", descriptor.getFieldValue("persistName"));
+		assertEquals("10", descriptor.getFieldValue("persistPeriod"));
+		assertEquals("Never", descriptor.getFieldValue("persistPolicy"));
+		names = server.queryNames(new ObjectName("custom:type=MessageSource,*"), null);
+		assertEquals(1, names.size());
+		name = names.iterator().next();
+		assertEquals("custom:type=MessageSource,name=foo", name.toString());
+		names = server.queryNames(new ObjectName("custom:type=MessageRouter,*"), null);
+		assertEquals(1, names.size());
+		name = names.iterator().next();
+		assertEquals("custom:type=MessageRouter,name=foo", name.toString());
+		names = server.queryNames(new ObjectName("test.custom:type=MessageHandler,*"), null);
+		assertEquals(2, names.size());
+		Iterator<ObjectName> iterator = names.iterator();
+		name = iterator.next();
+		assertEquals("test.custom:type=MessageHandler,name=standardHandler,bean=handler", name.toString());
+		name = iterator.next();
+		assertEquals("test.custom:type=MessageHandler,name=errorLogger,bean=internal", name.toString());
+	}
+
+	@IntegrationManagedResource(objectName="${customChannelName}", description="custom channel")
+	public static class ChannelWithCustomObjectName extends AbstractMessageChannel {
+
+		@Override
+		protected boolean doSend(Message<?> message, long timeout) {
+			return false;
+		}
+
+	}
+
+	@IntegrationManagedResource(objectName="${customHandlerName}", description="custom handler",
+			currencyTimeLimit=1000, log=true, logFile="foo", persistLocation="bar", persistName="baz", persistPeriod=10,
+			persistPolicy="Never")
+	public static class HandlerWithCustomObjectName extends AbstractMessageHandler {
+
+		@Override
+		protected void handleMessageInternal(Message<?> message) throws Exception {
+		}
+
+	}
+
+	@IntegrationManagedResource("${customSourceName}")
+	public static class SourceWithCustomObjectName extends AbstractMessageSource<String> {
+
+		@Override
+		public String getComponentType() {
+			return "foo";
+		}
+
+		@Override
+		protected Object doReceive() {
+			return null;
+		}
+
+	}
+
+	@IntegrationManagedResource("${customRouterName}")
+	public static class RouterWithCustomObjectName extends AbstractMappingMessageRouter {
+
+		@Override
+		protected List<Object> getChannelKeys(Message<?> message) {
+			return null;
+		}
+
+	}
+
+	@IntegrationManagedResource
+	public static class HandlerWithStandardObjectName extends AbstractMessageHandler {
+
+		@Override
+		protected void handleMessageInternal(Message<?> message) throws Exception {
+		}
+
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3852

Custom object names in `@IntegrationManagedResource` were ignored.

Some EIP objects were wrapped with their `Lifecycle` in order to expose
a single MBean with all attributes and operations.

This process "hid" the annotation so the object namer failed to detect the
presence of a custom object name or the other attributes.

Also, update the `@IntegrationManagedResource` to use the Spring 4.2 `@AliasFor` annotation.
