### PR TITLE
INT-3859: Fix `NPE` in the `ImapMailReceiver`

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package org.springframework.integration.mail;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ScheduledFuture;
 
@@ -197,7 +199,15 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 		SearchTerm searchTerm = this.compileSearchTerms(supportedFlags);
 		Folder folder = this.getFolder();
 		if (folder.isOpen()) {
-			return searchTerm != null ? folder.search(searchTerm) : folder.getMessages();
+			Message[] messageArray = searchTerm != null ? folder.search(searchTerm) : folder.getMessages();
+			// INT-3859
+			List<Message> messages = new ArrayList<Message>();
+			for (Message message : messageArray) {
+				if (message != null) {
+					messages.add(message);
+				}
+			}
+			return messages.toArray(new Message[messages.size()]);
 		}
 		throw new MessagingException("Folder is closed");
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3859

The Java Mail `MessageCache.getMessageBySeqnum()` has the code:

``` java
if (msgnum < 0) {       // XXX - < 1 ?
    if (logger.isLoggable(Level.FINE))
    logger.fine("no message seqnum " + seqnum);
        return null;
}
```

about which the `IMAPFolder.search` doesn't care:

``` java
matchMsgs[i] = getMessageBySeqNumber(matches[i]);
```

therefore pops `null`s to the top for the `ImapMailReceiver`
- Fix `NPE` filtering the `Message[]` from `null` items

Note: its enough difficult to reproduce it because it isn't clear how we can end up with:

``` java
if (seqnums[msgnum-1] > seqnum)
        break;      // message doesn't exist
```

in the `MessageCache`.
That's why there is no test-cases on the matter.

**Cherry-pick to 4.1.x**
