### PR TITLE
TCP: Tests: Let OS Choose Test Port

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/FactoryStopStartTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/FactoryStopStartTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 package org.springframework.integration.ip.tcp;
 
 import org.junit.Test;
+
 import org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.TcpNetServerConnectionFactory;
-import org.springframework.integration.test.util.SocketUtils;
 
 
 /**
@@ -30,8 +30,7 @@ public class FactoryStopStartTests {
 
 	@Test
 	public void testRestart() {
-		int port = SocketUtils.findAvailableServerSocket();
-		AbstractServerConnectionFactory factory = new TcpNetServerConnectionFactory(port);
+		AbstractServerConnectionFactory factory = new TcpNetServerConnectionFactory(0);
 		factory.setSoTimeout(10000);
 		factory.start();
 		factory.stop();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ServerSocketFactory;
 import javax.net.SocketFactory;
@@ -57,7 +58,6 @@ import org.springframework.integration.ip.tcp.connection.TcpNetServerConnectionF
 import org.springframework.integration.ip.tcp.connection.TcpNioServerConnectionFactory;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer;
 import org.springframework.integration.ip.util.TestingUtilities;
-import org.springframework.integration.test.util.SocketUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -69,8 +69,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 
 	@Test
 	public void testNet() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(port);
+		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(0);
 		noopPublisher(scf);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
@@ -79,6 +78,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		adapter.setConnectionFactory(scf);
 		scf.start();
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
 		adapter.setBeanFactory(mock(BeanFactory.class));
@@ -97,7 +97,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 
 	@Test
 	public void testNetClientMode() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch1 = new CountDownLatch(1);
 		final CountDownLatch latch2 = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
@@ -105,7 +105,8 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 			@Override
 			public void run() {
 				try {
-					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port, 10);
+					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0, 10);
+					serverSocket.set(server);;
 					latch1.countDown();
 					Socket socket = server.accept();
 					socket.getOutputStream().write("Test1\r\nTest2\r\n".getBytes());
@@ -120,7 +121,9 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 				}
 			}
 		});
-		AbstractClientConnectionFactory ccf = new TcpNetClientConnectionFactory("localhost", port);
+		assertTrue(latch1.await(10, TimeUnit.SECONDS));
+		AbstractClientConnectionFactory ccf = new TcpNetClientConnectionFactory("localhost",
+				serverSocket.get().getLocalPort());
 		noopPublisher(ccf);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		ccf.setSerializer(serializer);
@@ -133,7 +136,6 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		adapter.setOutputChannel(channel);
 		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
-		assertTrue(latch1.await(10, TimeUnit.SECONDS));
 		adapter.setRetryInterval(10000);
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 		taskScheduler.setPoolSize(1);
@@ -151,12 +153,12 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		adapter.stop();
 		latch2.countDown();
 		ccf.stop();
+		serverSocket.get().close();
 	}
 
 	@Test
 	public void testNio() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(port);
+		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
 		noopPublisher(scf);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
@@ -166,6 +168,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		adapter.setConnectionFactory(scf);
 		scf.start();
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
 		Socket socket = SocketFactory.getDefault().createSocket("localhost", port);
@@ -186,8 +189,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 
 	@Test
 	public void testNetShared() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(port);
+		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(0);
 		noopPublisher(scf);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
@@ -200,6 +202,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		Socket socket = SocketFactory.getDefault().createSocket("localhost", port);
 		socket.setSoTimeout(2000);
 		socket.getOutputStream().write("Test\r\n".getBytes());
@@ -220,8 +223,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 
 	@Test
 	public void testNioShared() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(port);
+		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
 		noopPublisher(scf);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
@@ -234,6 +236,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		Socket socket = SocketFactory.getDefault().createSocket("localhost", port);
 		socket.setSoTimeout(2000);
 		socket.getOutputStream().write("Test\r\n".getBytes());
@@ -254,8 +257,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 
 	@Test
 	public void testNetSingleNoOutbound() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(port);
+		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(0);
 		noopPublisher(scf);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
@@ -265,6 +267,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		adapter.setConnectionFactory(scf);
 		scf.start();
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
 		Socket socket = SocketFactory.getDefault().createSocket("localhost", port);
@@ -286,8 +289,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 
 	@Test
 	public void testNioSingleNoOutbound() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(port);
+		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
 		noopPublisher(scf);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
@@ -297,6 +299,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		adapter.setConnectionFactory(scf);
 		scf.start();
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
 		Socket socket = SocketFactory.getDefault().createSocket("localhost", port);
@@ -328,8 +331,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 
 	@Test
 	public void testNetSingleShared() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(port);
+		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(0);
 		noopPublisher(scf);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
@@ -343,6 +345,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		Socket socket1 = SocketFactory.getDefault().createSocket("localhost", port);
 		socket1.setSoTimeout(2000);
 		socket1.getOutputStream().write("Test1\r\n".getBytes());
@@ -365,8 +368,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 
 	@Test
 	public void testNioSingleShared() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(port);
+		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
 		noopPublisher(scf);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
@@ -380,6 +382,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		Socket socket1 = SocketFactory.getDefault().createSocket("localhost", port);
 		socket1.setSoTimeout(2000);
 		socket1.getOutputStream().write("Test1\r\n".getBytes());
@@ -402,8 +405,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 
 	@Test
 	public void testNioSingleSharedMany() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(port);
+		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
 		noopPublisher(scf);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
@@ -420,6 +422,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		List<Socket> sockets = new LinkedList<Socket>();
 		for (int i = 100; i < 200; i++) {
 			Socket socket1 = SocketFactory.getDefault().createSocket("localhost", port);
@@ -442,59 +445,53 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 
 	@Test
 	public void testNetInterceptors() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(port);
+		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(0);
 		noopPublisher(scf);
-		interceptorsGuts(port, scf);
+		interceptorsGuts(scf);
 		scf.stop();
 	}
 
 	@Test
 	public void testNetSingleNoOutboundInterceptors() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(port);
+		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(0);
 		noopPublisher(scf);
-		singleNoOutboundInterceptorsGuts(port, scf);
+		singleNoOutboundInterceptorsGuts(scf);
 		scf.stop();
 	}
 
 	@Test
 	public void testNetSingleSharedInterceptors() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(port);
+		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(0);
 		noopPublisher(scf);
-		singleSharedInterceptorsGuts(port, scf);
+		singleSharedInterceptorsGuts(scf);
 		scf.stop();
 	}
 
 	@Test
 	public void testNioInterceptors() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		AbstractServerConnectionFactory scf = new TcpNioServerConnectionFactory(port);
+		AbstractServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
 		noopPublisher(scf);
-		interceptorsGuts(port, scf);
+		interceptorsGuts(scf);
 		scf.stop();
 	}
 
 	@Test
 	public void testNioSingleNoOutboundInterceptors() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		AbstractServerConnectionFactory scf = new TcpNioServerConnectionFactory(port);
+		AbstractServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
 		noopPublisher(scf);
-		singleNoOutboundInterceptorsGuts(port, scf);
+		singleNoOutboundInterceptorsGuts(scf);
 		scf.stop();
 	}
 
 	@Test
 	public void testNioSingleSharedInterceptors() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		AbstractServerConnectionFactory scf = new TcpNioServerConnectionFactory(port);
+		AbstractServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
 		noopPublisher(scf);
-		singleSharedInterceptorsGuts(port, scf);
+		singleSharedInterceptorsGuts(scf);
 		scf.stop();
 	}
 
-	private void interceptorsGuts(final int port, AbstractServerConnectionFactory scf) throws Exception {
+	private void interceptorsGuts(AbstractServerConnectionFactory scf) throws Exception {
 		scf.setSerializer(new DefaultSerializer());
 		scf.setDeserializer(new DefaultDeserializer());
 		scf.setSingleUse(false);
@@ -509,6 +506,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		scf.setSoTimeout(10000);
 		scf.start();
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
 		Socket socket = SocketFactory.getDefault().createSocket("localhost", port);
@@ -530,7 +528,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		assertTrue(results.contains("Test2"));
 	}
 
-	private void singleNoOutboundInterceptorsGuts(final int port, AbstractServerConnectionFactory scf) throws Exception {
+	private void singleNoOutboundInterceptorsGuts(AbstractServerConnectionFactory scf) throws Exception {
 		scf.setSerializer(new DefaultSerializer());
 		scf.setDeserializer(new DefaultDeserializer());
 		scf.setSingleUse(true);
@@ -545,6 +543,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		adapter.setConnectionFactory(scf);
 		scf.start();
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
 		Socket socket = SocketFactory.getDefault().createSocket("localhost", port);
@@ -573,7 +572,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		assertTrue(results.contains("Test2"));
 	}
 
-	private void singleSharedInterceptorsGuts(final int port, AbstractServerConnectionFactory scf) throws Exception {
+	private void singleSharedInterceptorsGuts(AbstractServerConnectionFactory scf) throws Exception {
 		scf.setSerializer(new DefaultSerializer());
 		scf.setDeserializer(new DefaultDeserializer());
 		scf.setSingleUse(true);
@@ -592,6 +591,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		Socket socket1 = SocketFactory.getDefault().createSocket("localhost", port);
 		socket1.setSoTimeout(60000);
 		new ObjectOutputStream(socket1.getOutputStream()).writeObject("Hello");
@@ -621,8 +621,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 
 	@Test
 	public void testException() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
-		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(port);
+		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(0);
 		noopPublisher(scf);
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
@@ -631,6 +630,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		adapter.setConnectionFactory(scf);
 		scf.start();
 		TestingUtilities.waitListening(scf, null);
+		int port = scf.getPort();
 		SubscribableChannel channel = new DirectChannel();
 		adapter.setOutputChannel(channel);
 		ServiceActivatingHandler handler = new ServiceActivatingHandler(new FailingService());

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
@@ -311,8 +311,7 @@ public class FailoverClientConnectionFactoryTests {
 
 	@Test
 	public void testFailoverCachedRealClose() throws Exception {
-		int port1 = SocketUtils.findAvailableServerSocket();
-		TcpNetServerConnectionFactory server1 = new TcpNetServerConnectionFactory(port1);
+		TcpNetServerConnectionFactory server1 = new TcpNetServerConnectionFactory(0);
 		server1.setBeanName("server1");
 		final CountDownLatch latch1 = new CountDownLatch(3);
 		server1.registerListener(new TcpListener() {
@@ -325,8 +324,8 @@ public class FailoverClientConnectionFactoryTests {
 		});
 		server1.start();
 		TestingUtilities.waitListening(server1, 10000L);
-		int port2 = SocketUtils.findAvailableServerSocket();
-		TcpNetServerConnectionFactory server2 = new TcpNetServerConnectionFactory(port2);
+		int port1 = server1.getPort();
+		TcpNetServerConnectionFactory server2 = new TcpNetServerConnectionFactory(0);
 		server2.setBeanName("server2");
 		final CountDownLatch latch2 = new CountDownLatch(2);
 		server2.registerListener(new TcpListener() {
@@ -339,6 +338,7 @@ public class FailoverClientConnectionFactoryTests {
 		});
 		server2.start();
 		TestingUtilities.waitListening(server2, 10000L);
+		int port2 = server2.getPort();
 		AbstractClientConnectionFactory factory1 = new TcpNetClientConnectionFactory("localhost", port1);
 		factory1.setBeanName("client1");
 		factory1.registerListener(new TcpListener() {
@@ -407,8 +407,7 @@ public class FailoverClientConnectionFactoryTests {
 
 	@Test
 	public void testFailoverCachedRealBadHost() throws Exception {
-		int port1 = SocketUtils.findAvailableServerSocket();
-		TcpNetServerConnectionFactory server1 = new TcpNetServerConnectionFactory(port1);
+		TcpNetServerConnectionFactory server1 = new TcpNetServerConnectionFactory(0);
 		server1.setBeanName("server1");
 		final CountDownLatch latch1 = new CountDownLatch(3);
 		server1.registerListener(new TcpListener() {
@@ -421,8 +420,8 @@ public class FailoverClientConnectionFactoryTests {
 		});
 		server1.start();
 		TestingUtilities.waitListening(server1, 10000L);
-		int port2 = SocketUtils.findAvailableServerSocket();
-		TcpNetServerConnectionFactory server2 = new TcpNetServerConnectionFactory(port2);
+		int port1 = server1.getPort();
+		TcpNetServerConnectionFactory server2 = new TcpNetServerConnectionFactory(0);
 		server2.setBeanName("server2");
 		final CountDownLatch latch2 = new CountDownLatch(2);
 		server2.registerListener(new TcpListener() {
@@ -435,6 +434,7 @@ public class FailoverClientConnectionFactoryTests {
 		});
 		server2.start();
 		TestingUtilities.waitListening(server2, 10000L);
+		int port2 = server2.getPort();
 
 		AbstractClientConnectionFactory factory1 = new TcpNetClientConnectionFactory("junkjunk", port1);
 		factory1.setBeanName("client1");

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionWriteTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionWriteTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer
 import org.springframework.integration.ip.tcp.serializer.ByteArrayLengthHeaderSerializer;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayStxEtxSerializer;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.test.util.SocketUtils;
 
 /**
  * @author Gary Russell
@@ -56,10 +55,9 @@ public class TcpNioConnectionWriteTests {
 
 	@Test
 	public void testWriteLengthHeader() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
 		final String testString = "abcdef";
-		ServerSocket server = ServerSocketFactory.getDefault()
-				.createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		final int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
@@ -93,10 +91,9 @@ public class TcpNioConnectionWriteTests {
 
 	@Test
 	public void testWriteStxEtx() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
 		final String testString = "abcdef";
-		ServerSocket server = ServerSocketFactory.getDefault()
-				.createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		final int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
@@ -130,10 +127,9 @@ public class TcpNioConnectionWriteTests {
 
 	@Test
 	public void testWriteCrLf() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
 		final String testString = "abcdef";
-		ServerSocket server = ServerSocketFactory.getDefault()
-				.createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		final int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
@@ -167,10 +163,9 @@ public class TcpNioConnectionWriteTests {
 
 	@Test
 	public void testWriteLengthHeaderDirect() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
 		final String testString = "abcdef";
-		ServerSocket server = ServerSocketFactory.getDefault()
-				.createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		final int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
@@ -204,10 +199,9 @@ public class TcpNioConnectionWriteTests {
 
 	@Test
 	public void testWriteStxEtxDirect() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
 		final String testString = "abcdef";
-		ServerSocket server = ServerSocketFactory.getDefault()
-				.createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		final int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
@@ -241,10 +235,9 @@ public class TcpNioConnectionWriteTests {
 
 	@Test
 	public void testWriteCrLfDirect() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
 		final String testString = "abcdef";
-		ServerSocket server = ServerSocketFactory.getDefault()
-				.createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		final int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/DeserializationTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/DeserializationTests.java
@@ -38,7 +38,6 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.serializer.DefaultDeserializer;
 import org.springframework.integration.ip.util.SocketTestUtils;
-import org.springframework.integration.test.util.SocketUtils;
 
 /**
  * @author Gary Russell
@@ -49,8 +48,8 @@ public class DeserializationTests {
 
 	@Test
 	public void testReadLength() throws Exception {
-		int port = SocketUtils.findAvailableServerSocket();
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		CountDownLatch done = SocketTestUtils.testSendLength(port, null);
 		Socket socket = server.accept();
@@ -68,8 +67,8 @@ public class DeserializationTests {
 
 	@Test
 	public void testReadStxEtx() throws Exception {
-		int port = SocketUtils.findAvailableServerSocket();
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		CountDownLatch done = SocketTestUtils.testSendStxEtx(port, null);
 		Socket socket = server.accept();
@@ -87,8 +86,8 @@ public class DeserializationTests {
 
 	@Test
 	public void testReadCrLf() throws Exception {
-		int port = SocketUtils.findAvailableServerSocket();
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		CountDownLatch done = SocketTestUtils.testSendCrLf(port, null);
 		Socket socket = server.accept();
@@ -106,8 +105,8 @@ public class DeserializationTests {
 
 	@Test
 	public void testReadRaw() throws Exception {
-		int port = SocketUtils.findAvailableServerSocket();
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		SocketTestUtils.testSendRaw(port);
 		Socket socket = server.accept();
@@ -121,8 +120,8 @@ public class DeserializationTests {
 
 	@Test
 	public void testReadSerialized() throws Exception {
-		int port = SocketUtils.findAvailableServerSocket();
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		CountDownLatch done = SocketTestUtils.testSendSerialized(port);
 		Socket socket = server.accept();
@@ -138,8 +137,8 @@ public class DeserializationTests {
 
 	@Test
 	public void testReadLengthOverflow() throws Exception {
-		int port = SocketUtils.findAvailableServerSocket();
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		CountDownLatch done = SocketTestUtils.testSendLengthOverflow(port);
 		Socket socket = server.accept();
@@ -160,8 +159,8 @@ public class DeserializationTests {
 
 	@Test
 	public void testReadStxEtxTimeout() throws Exception {
-		int port = SocketUtils.findAvailableServerSocket();
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		CountDownLatch done = SocketTestUtils.testSendStxEtxOverflow(port);
 		Socket socket = server.accept();
@@ -182,8 +181,8 @@ public class DeserializationTests {
 
 	@Test
 	public void testReadStxEtxOverflow() throws Exception {
-		int port = SocketUtils.findAvailableServerSocket();
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		CountDownLatch done = SocketTestUtils.testSendStxEtxOverflow(port);
 		Socket socket = server.accept();
@@ -205,8 +204,8 @@ public class DeserializationTests {
 
 	@Test
 	public void testReadCrLfTimeout() throws Exception {
-		int port = SocketUtils.findAvailableServerSocket();
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		CountDownLatch latch = SocketTestUtils.testSendCrLfOverflow(port);
 		Socket socket = server.accept();
@@ -227,8 +226,8 @@ public class DeserializationTests {
 
 	@Test
 	public void testReadCrLfOverflow() throws Exception {
-		int port = SocketUtils.findAvailableServerSocket();
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		CountDownLatch latch = SocketTestUtils.testSendCrLfOverflow(port);
 		Socket socket = server.accept();
@@ -305,9 +304,9 @@ public class DeserializationTests {
 
 			@Override
 			public void publishEvent(Object event) {
-				
+
 			}
-			
+
 		}
 		Publisher publisher = new Publisher();
 		ByteArrayInputStream bais = new ByteArrayInputStream(data);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/SerializationTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/SerializationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import javax.net.SocketFactory;
 import org.junit.Test;
 
 import org.springframework.core.serializer.DefaultSerializer;
-import org.springframework.integration.test.util.SocketUtils;
 
 /**
  * @author Gary Russell
@@ -43,9 +42,9 @@ public class SerializationTests {
 
 	@Test
 	public void testWriteLengthHeader() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
 		final String testString = "abcdef";
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		final int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
@@ -80,9 +79,9 @@ public class SerializationTests {
 
 	@Test
 	public void testWriteStxEtx() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
 		final String testString = "abcdef";
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		final int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
@@ -117,9 +116,9 @@ public class SerializationTests {
 
 	@Test
 	public void testWriteCrLf() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
 		final String testString = "abcdef";
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		final int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
@@ -154,9 +153,9 @@ public class SerializationTests {
 
 	@Test
 	public void testWriteRaw() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
 		final String testString = "abcdef";
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		final int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {
@@ -191,9 +190,9 @@ public class SerializationTests {
 
 	@Test
 	public void testWriteSerialized() throws Exception {
-		final int port = SocketUtils.findAvailableServerSocket();
 		final String testString = "abcdef";
-		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(port);
+		ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
+		final int port = server.getLocalPort();
 		server.setSoTimeout(10000);
 		final CountDownLatch latch = new CountDownLatch(1);
 		Thread t = new Thread(new Runnable() {


### PR DESCRIPTION
https://build.spring.io/browse/INT-MJATS41-434

BindException.

Avoid using `findAvailableServerSocket()` where easily possible.

Some still remain, but they would require major rework of the tests.

Also fix a race in `TcpOutboundGatewayTests.testGoodNetGWTimeoutGuts()`. Although an
`AtomicBoolean` was used, both threads might still see the lower (500ms) timeout.
