### PR TITLE
Fix Stomp Test Race Condition

### DIFF
--- a/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducer.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducer.java
@@ -56,6 +56,10 @@ public class ApplicationEventListeningMessageProducer extends ExpressionMessageP
 
 	private volatile long stoppedAt;
 
+	public ApplicationEventListeningMessageProducer() {
+		setPhase(Integer.MAX_VALUE / 2 - 1000);
+	}
+
 	/**
 	 * Set the list of event types (classes that extend ApplicationEvent) that
 	 * this adapter should send to the message channel. By default, all event


### PR DESCRIPTION
Message producers are started in phase `Integer.MAX_INT / 2`.

The test case has a stomp inbound adapter and an event producer.

Since they are both in the same phase, the event producer can miss the `StompReceiptEvent`.

Change the phase of the event producer to ensure it is started before other message producers.
