### PR TITLE
INT-3888: Fix STOMP test for race condition

### DIFF
--- a/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/AbstractStompSessionManager.java
+++ b/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/AbstractStompSessionManager.java
@@ -32,7 +32,6 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.integration.stomp.event.StompConnectionFailedEvent;
 import org.springframework.integration.stomp.event.StompSessionConnectedEvent;
-import org.springframework.messaging.simp.stomp.ConnectionLostException;
 import org.springframework.messaging.simp.stomp.StompClientSupport;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaders;
@@ -352,10 +351,8 @@ public abstract class AbstractStompSessionManager implements StompSessionManager
 		@Override
 		public void handleTransportError(StompSession session, Throwable exception) {
 			logger.error("STOMP transport error for session: [" + session + "]", exception);
-			if (exception instanceof ConnectionLostException) {
-				this.session = null;
-				scheduleReconnect(exception);
-			}
+			this.session = null;
+			scheduleReconnect(exception);
 			synchronized (this.delegates) {
 				for (StompSessionHandler delegate : this.delegates) {
 					delegate.handleTransportError(session, exception);

--- a/spring-integration-stomp/src/test/java/org/springframework/integration/stomp/client/StompServerIntegrationTests.java
+++ b/spring-integration-stomp/src/test/java/org/springframework/integration/stomp/client/StompServerIntegrationTests.java
@@ -214,7 +214,7 @@ public class StompServerIntegrationTests extends LogAdjustingTestSupport {
 		activeMQBroker.start(false);
 
 		do {
-			eventMessage = stompEvents1.receive(10000);
+			eventMessage = stompEvents1.receive(20000);
 			assertNotNull(eventMessage);
 		}
 		while (!(eventMessage.getPayload() instanceof StompReceiptEvent));


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3888

Note sure yet what race condition we have in the `DefaultSubscriptionRegistry`,
but that looks for me better to follow with the standard `SubscriptionRegistry.findSubscriptions()`
to check subscription present, unless fail during `send()` because of `destinationLookup` early exit.

**Cherry-pick to 4.2.x**
