### PR TITLE
INT-3896: JMX: Fix Double Router MBean Export

### DIFF
--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/MBeanExporterHelper.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/MBeanExporterHelper.java
@@ -62,6 +62,11 @@ class MBeanExporterHelper implements BeanPostProcessor, Ordered {
 			}
 		}
 
+		return bean;
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
 		if (AnnotatedElementUtils.isAnnotated(AopUtils.getTargetClass(bean),
 				IntegrationManagedResource.class.getName())) {
 			this.siBeanNames.add(beanName);
@@ -80,11 +85,6 @@ class MBeanExporterHelper implements BeanPostProcessor, Ordered {
 			}
 		}
 
-		return bean;
-	}
-
-	@Override
-	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
 		return bean;
 	}
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/RouterMBeanTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/RouterMBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -90,6 +90,9 @@ public class RouterMBeanTests {
 		// System.err.println(server.queryNames(new ObjectName("*:type=MessageHandler,*"), null));
 		Set<ObjectName> names = server.queryNames(new ObjectName("test.RouterMBean:type=MessageHandler,name=ptRouter,*"), null);
 		assertEquals(1, names.size());
+		// INT-3896
+		names = server.queryNames(new ObjectName("test.RouterMBean:type=ExpressionEvaluatingRouter,*"), null);
+		assertEquals(0, names.size());
 	}
 
 	public static interface Service {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3896

Routers created by the `RouterFactoryBean` were not suppressed from being exported
by the context exporter when an `IMBE` is present.

Move the suppression logic to `postProcessAfterInitialization()` so the annotation on
the bean created by the factory bean is detected. The annotation is not detected on
the factory bean itself in `postProcessBeforeInitialization()`.
