### PR TITLE
INT-3904: Fix NPE in the `JsonPropertyAccessor`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPropertyAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPropertyAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ public class JsonPropertyAccessor implements PropertyAccessor {
 				return new TypedValue(wrap(json));
 			}
 			else {
-				return null;
+				return TypedValue.NULL;
 			}
 		}
 	}
@@ -155,6 +155,9 @@ public class JsonPropertyAccessor implements PropertyAccessor {
 
 		@Override
 		public String toString() {
+			if (node == null) {
+				return "null";
+			}
 			if (node.isValueNode()) {
 				// This is to avoid quotes around a TextNode for example
 				return node.asText();
@@ -166,14 +169,15 @@ public class JsonPropertyAccessor implements PropertyAccessor {
 
 		@Override
 		public boolean equals(Object o) {
-			return this == o
-					|| (!(o == null || getClass() != o.getClass())
-							&& this.node.equals(((ToStringFriendlyJsonNode) o).node));
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			ToStringFriendlyJsonNode that = (ToStringFriendlyJsonNode) o;
+			return (this.node == that.node) || (this.node != null && this.node.equals(that.node));
 		}
 
 		@Override
 		public int hashCode() {
-			return this.node.toString().hashCode();
+			return this.node != null ? this.node.toString().hashCode() : 0;
 		}
 
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/JsonPropertyAccessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/JsonPropertyAccessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,19 @@
 package org.springframework.integration.json;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.expression.Expression;
 import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Tests for {@link JsonPropertyAccessor}.
@@ -117,6 +118,18 @@ public class JsonPropertyAccessorTests {
 	public void testUnsupportedJson() throws Exception {
 		String json = "\"literal\"";
 		evaluate(json, "foo", Object.class);
+	}
+
+	@Test
+	public void testNoNullPointerWithCachedReadAccessor() throws Exception {
+		Expression expression = parser.parseExpression("foo");
+		Object json = mapper.readTree("{\"foo\": \"bar\"}");
+		Object value = expression.getValue(this.context, json);
+		assertThat(value, Matchers.instanceOf(JsonPropertyAccessor.ToStringFriendlyJsonNode.class));
+		assertEquals("bar", value.toString());
+		Object json2 = mapper.readTree("{}");
+		Object value2 = expression.getValue(this.context, json2);
+		assertNull(value2);
 	}
 
 	private <T> T evaluate(Object target, String expression, Class<T> expectedType) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3904

When we use the same expression several times, the SpEL engine cache an `accessor` after the first use.
The next evaluation just bypass `canRead()` and in case of JSON that mean that we don't check that the income has the field or not.
For this case the `read()` must return `TypedValue.NULL` instead of just `null`.

**Cherry-pick to ALL**
