### PR TITLE
INT-3916: Don't use CTOR injection in FactoryBean

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ReleaseStrategyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ReleaseStrategyFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.config;
 
 import java.lang.reflect.Method;
@@ -21,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.integration.aggregator.MethodInvokingReleaseStrategy;
 import org.springframework.integration.aggregator.ReleaseStrategy;
 import org.springframework.integration.aggregator.SequenceSizeReleaseStrategy;
@@ -28,55 +30,83 @@ import org.springframework.integration.util.MessagingAnnotationUtils;
 import org.springframework.util.StringUtils;
 
 /**
- * Convenience factory for XML configuration of a {@link ReleaseStrategy}. Encapsulates the knowledge of the default
- * strategy and search algorithms for POJO and annotated methods.
+ * Convenience factory for XML configuration of a {@link ReleaseStrategy}.
+ * Encapsulates the knowledge of the default strategy and search algorithms for POJO and annotated methods.
  *
  * @author Dave Syer
  * @author Gary Russell
+ * @author Artem Bilan
  *
  */
-public class ReleaseStrategyFactoryBean implements FactoryBean<ReleaseStrategy> {
+public class ReleaseStrategyFactoryBean implements FactoryBean<ReleaseStrategy>, InitializingBean {
 
 	private static final Log logger = LogFactory.getLog(ReleaseStrategyFactoryBean.class);
 
-	private ReleaseStrategy delegate = new SequenceSizeReleaseStrategy();
+	private Object target;
 
-	/**
-	 * Create a factory and set up the delegate which clients of the factory will see as its product.
-	 *
-	 * @param target the target object (null if default strategy is acceptable)
-	 */
-	public ReleaseStrategyFactoryBean(Object target) {
-		this(target, null);
+	private String methodName;
+
+	private ReleaseStrategy strategy = new SequenceSizeReleaseStrategy();
+
+	public ReleaseStrategyFactoryBean() {
 	}
 
 	/**
-	 * Create a factory and set up the delegate which clients of the factory will see as its product.
-	 *
+	 * Create a factory and set up the strategy which clients of the factory will see as its product.
+	 * @param target the target object (null if default strategy is acceptable)
+	 * @deprecated since {@literal 4.2.5} in favor of appropriate setters
+	 * to avoid {@code BeanCurrentlyInCreationException}
+	 * during {@code AbstractAutowireCapableBeanFactory.getSingletonFactoryBeanForTypeCheck()}
+	 */
+	@Deprecated
+	public ReleaseStrategyFactoryBean(Object target) {
+		this.target = target;
+	}
+
+	/**
+	 * Create a factory and set up the strategy which clients of the factory will see as its product.
 	 * @param target the target object (null if default strategy is acceptable)
 	 * @param methodName the method name to invoke in the target (null if it can be inferred)
+	 * @deprecated since {@literal 4.2.5} in favor of appropriate setters
+	 * to avoid {@code BeanCurrentlyInCreationException}
+	 * during {@code AbstractAutowireCapableBeanFactory.getSingletonFactoryBeanForTypeCheck()}
 	 */
+	@Deprecated
 	public ReleaseStrategyFactoryBean(Object target, String methodName) {
-		if (target instanceof ReleaseStrategy && !StringUtils.hasText(methodName)) {
-			this.delegate = (ReleaseStrategy) target;
+		this.target = target;
+		this.methodName = methodName;
+	}
+
+	public void setTarget(Object target) {
+		this.target = target;
+	}
+
+	public void setMethodName(String methodName) {
+		this.methodName = methodName;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		if (this.target instanceof ReleaseStrategy && !StringUtils.hasText(this.methodName)) {
+			this.strategy = (ReleaseStrategy) this.target;
 			return;
 		}
-		if (target != null) {
-			if (StringUtils.hasText(methodName)) {
-				this.delegate = new MethodInvokingReleaseStrategy(target, methodName);
+		if (this.target != null) {
+			if (StringUtils.hasText(this.methodName)) {
+				this.strategy = new MethodInvokingReleaseStrategy(this.target, this.methodName);
 			}
 			else {
-				Method method = MessagingAnnotationUtils.findAnnotatedMethod(target,
+				Method method = MessagingAnnotationUtils.findAnnotatedMethod(this.target,
 						org.springframework.integration.annotation.ReleaseStrategy.class);
 				if (method != null) {
-					this.delegate = new MethodInvokingReleaseStrategy(target, method);
+					this.strategy = new MethodInvokingReleaseStrategy(this.target, method);
 				}
 				else {
 					if (logger.isWarnEnabled()) {
 						logger.warn("No ReleaseStrategy annotated method found on "
-								+ target.getClass().getSimpleName()
+								+ this.target.getClass().getSimpleName()
 								+ "; falling back to SequenceSizeReleaseStrategy, target:"
-								+ target + ", methodName:" + methodName);
+								+ this.target + ", methodName:" + this.methodName);
 					}
 				}
 			}
@@ -90,7 +120,7 @@ public class ReleaseStrategyFactoryBean implements FactoryBean<ReleaseStrategy> 
 
 	@Override
 	public ReleaseStrategy getObject() throws Exception {
-		return this.delegate;
+		return this.strategy;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -266,15 +266,16 @@ public abstract class IntegrationNamespaceUtils {
 	}
 
 	/**
-	 * Get a text value from a named attribute if it exists, otherwise check for a nested element of the same name. If
-	 * both are specified it is an error, but if neither is specified, just returns null.
+	 * Get a text value from a named attribute if it exists, otherwise check for a nested element of the same name.
+	 * If both are specified it is an error, but if neither is specified, just returns null.
 	 *
 	 * @param element a DOM node
 	 * @param name the name of the property (attribute or child element)
 	 * @param parserContext the current context
-	 * @return the text from the attribite or element or null
+	 * @return the text from the attribute or element or null
 	 */
-	public static String getTextFromAttributeOrNestedElement(Element element, String name, ParserContext parserContext) {
+	public static String getTextFromAttributeOrNestedElement(Element element, String name,
+	                                                         ParserContext parserContext) {
 		String attr = element.getAttribute(name);
 		Element childElement = DomUtils.getChildElementByTagName(element, name);
 		if (StringUtils.hasText(attr) && childElement != null) {
@@ -305,7 +306,8 @@ public abstract class IntegrationNamespaceUtils {
 			parserContext.getReaderContext().error(
 				"Ambiguous definition. Inner bean " + (innerComponentDefinition.getBeanDefinition().getBeanClassName())
 						+ " declaration and \"ref\" " + ref + " are not allowed together on element " +
-					IntegrationNamespaceUtils.createElementDescription(element) + ".", parserContext.extractSource(element));
+					IntegrationNamespaceUtils.createElementDescription(element) + ".",
+					parserContext.extractSource(element));
 		}
 		return innerComponentDefinition;
 	}
@@ -616,13 +618,14 @@ public abstract class IntegrationNamespaceUtils {
 		return adapter;
 	}
 
-	private static BeanMetadataElement createAdapter(BeanMetadataElement ref, String method, String unqualifiedClassName) {
+	private static BeanMetadataElement createAdapter(BeanMetadataElement ref, String method,
+	                                                 String unqualifiedClassName) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder
 				.genericBeanDefinition(IntegrationConfigUtils.BASE_PACKAGE + ".config." + unqualifiedClassName
 						+ "FactoryBean");
-		builder.addConstructorArgValue(ref);
+		builder.addPropertyValue("target", ref);
 		if (StringUtils.hasText(method)) {
-			builder.addConstructorArgValue(method);
+			builder.addPropertyValue("methodName", method);
 		}
 		return builder.getBeanDefinition();
 	}

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/AbstractJpaOutboundGatewayParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/AbstractJpaOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/AbstractJpaOutboundGatewayParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/AbstractJpaOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.jpa.config.xml;
+
+import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -24,7 +27,6 @@ import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.jpa.outbound.JpaOutboundGatewayFactoryBean;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
-import org.w3c.dom.Element;
 
 /**
  * The Abstract Parser for the JPA Outbound Gateways.
@@ -42,14 +44,13 @@ public abstract class AbstractJpaOutboundGatewayParser extends AbstractConsumerE
 
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element gatewayElement, ParserContext parserContext) {
-
-		final BeanDefinitionBuilder jpaOutboundGatewayBuilder = BeanDefinitionBuilder
-				.genericBeanDefinition(JpaOutboundGatewayFactoryBean.class);
+		final BeanDefinitionBuilder jpaOutboundGatewayBuilder =
+				BeanDefinitionBuilder.genericBeanDefinition(JpaOutboundGatewayFactoryBean.class);
 
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaOutboundGatewayBuilder, gatewayElement, "reply-timeout");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaOutboundGatewayBuilder, gatewayElement, "requires-reply");
 
-		final String replyChannel = gatewayElement.getAttribute("reply-channel");
+		String replyChannel = gatewayElement.getAttribute("reply-channel");
 
 		if (StringUtils.hasText(replyChannel)) {
 			jpaOutboundGatewayBuilder.addPropertyReference("outputChannel", replyChannel);
@@ -58,7 +59,8 @@ public abstract class AbstractJpaOutboundGatewayParser extends AbstractConsumerE
 		final Element transactionalElement = DomUtils.getChildElementByTagName(gatewayElement, "transactional");
 
 		if (transactionalElement != null) {
-			BeanDefinition txAdviceDefinition = IntegrationNamespaceUtils.configureTransactionAttributes(transactionalElement);
+			BeanDefinition txAdviceDefinition =
+					IntegrationNamespaceUtils.configureTransactionAttributes(transactionalElement);
 			ManagedList<BeanDefinition> adviceChain = new ManagedList<BeanDefinition>();
 			adviceChain.add(txAdviceDefinition);
 			jpaOutboundGatewayBuilder.addPropertyValue("txAdviceChain", adviceChain);

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/JpaOutboundChannelAdapterParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/JpaOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
-   * Copyright 2002-2012 the original author or authors.
+   * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.jpa.config.xml;
 
 import org.w3c.dom.Element;
@@ -33,6 +34,7 @@ import org.springframework.util.xml.DomUtils;
  *
  * @author Amol Nayak
  * @author Gunnar Hillert
+ * @author Artem Bilan
  *
  * @since 2.2
  *
@@ -52,7 +54,8 @@ public class JpaOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 	@Override
 	protected AbstractBeanDefinition parseConsumer(Element element, ParserContext parserContext) {
 
-		final BeanDefinitionBuilder jpaOutboundChannelAdapterBuilder = BeanDefinitionBuilder.genericBeanDefinition(JpaOutboundGatewayFactoryBean.class);
+		final BeanDefinitionBuilder jpaOutboundChannelAdapterBuilder =
+				BeanDefinitionBuilder.genericBeanDefinition(JpaOutboundGatewayFactoryBean.class);
 		final BeanDefinitionBuilder jpaExecutorBuilder = JpaParserUtils.getJpaExecutorBuilder(element, parserContext);
 
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaExecutorBuilder, element, "persist-mode");
@@ -60,21 +63,25 @@ public class JpaOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaExecutorBuilder, element, "flush-size");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaExecutorBuilder, element, "clear-on-flush");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaExecutorBuilder, element, "parameter-source-factory");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaExecutorBuilder, element, "use-payload-as-parameter-source");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaExecutorBuilder, element,
+				"use-payload-as-parameter-source");
 
 		final BeanDefinition jpaExecutorBuilderBeanDefinition = jpaExecutorBuilder.getBeanDefinition();
-		final String channelAdapterId = this.resolveId(element, jpaOutboundChannelAdapterBuilder.getRawBeanDefinition(), parserContext);
+		final String channelAdapterId = resolveId(element, jpaOutboundChannelAdapterBuilder.getRawBeanDefinition(),
+				parserContext);
 		final String jpaExecutorBeanName = channelAdapterId + ".jpaExecutor";
 
-		parserContext.registerBeanComponent(new BeanComponentDefinition(jpaExecutorBuilderBeanDefinition, jpaExecutorBeanName));
+		parserContext.registerBeanComponent(
+				new BeanComponentDefinition(jpaExecutorBuilderBeanDefinition, jpaExecutorBeanName));
 
-		jpaOutboundChannelAdapterBuilder.addConstructorArgReference(jpaExecutorBeanName);
-		jpaOutboundChannelAdapterBuilder.addPropertyValue("producesReply", Boolean.FALSE);
+		jpaOutboundChannelAdapterBuilder.addPropertyReference("jpaExecutor", jpaExecutorBeanName)
+				.addPropertyValue("producesReply", Boolean.FALSE);
 
 		final Element transactionalElement = DomUtils.getChildElementByTagName(element, "transactional");
 
 		if(transactionalElement != null) {
-			BeanDefinition txAdviceDefinition = IntegrationNamespaceUtils.configureTransactionAttributes(transactionalElement);
+			BeanDefinition txAdviceDefinition =
+					IntegrationNamespaceUtils.configureTransactionAttributes(transactionalElement);
 			ManagedList<BeanDefinition> adviceChain = new ManagedList<BeanDefinition>();
 			adviceChain.add(txAdviceDefinition);
 			jpaOutboundChannelAdapterBuilder.addPropertyValue("txAdviceChain", adviceChain);

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/JpaOutboundChannelAdapterParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/JpaOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
-   * Copyright 2002-2015 the original author or authors.
+   * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/RetrievingJpaOutboundGatewayParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/RetrievingJpaOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/RetrievingJpaOutboundGatewayParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/RetrievingJpaOutboundGatewayParser.java
@@ -60,8 +60,7 @@ public class RetrievingJpaOutboundGatewayParser extends AbstractJpaOutboundGatew
 			jpaExecutorBuilder.addPropertyValue("maxResultsExpression", maxResultsExpression);
 		}
 
-		String idExpression = gatewayElement.getAttribute("id-expression");
-		if (StringUtils.hasText(idExpression)) {
+		if (StringUtils.hasText(gatewayElement.getAttribute("id-expression"))) {
 			String[] otherAttributes = {"jpa-query", "native-query", "named-query", "first-result",
 					"first-result-expression", "max-results", "max-results-expression", "delete-in-batch",
 					"expect-single-result", "parameter-source-factory", "use-payload-as-parameter-source"};

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/UpdatingJpaOutboundGatewayParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/UpdatingJpaOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/UpdatingJpaOutboundGatewayParser.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/config/xml/UpdatingJpaOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.integration.jpa.support.OutboundGatewayType;
  *
  * @author Amol Nayak
  * @author Gunnar Hillert
+ * @author Artem Bilan
  *
  * @since 2.2
  *
@@ -37,10 +38,10 @@ public class UpdatingJpaOutboundGatewayParser extends AbstractJpaOutboundGateway
 
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element gatewayElement, ParserContext parserContext) {
+		BeanDefinitionBuilder jpaOutboundGatewayBuilder = super.parseHandler(gatewayElement, parserContext);
 
-		final BeanDefinitionBuilder jpaOutboundGatewayBuilder = super.parseHandler(gatewayElement, parserContext);
-
-		final BeanDefinitionBuilder jpaExecutorBuilder = JpaParserUtils.getOutboundGatewayJpaExecutorBuilder(gatewayElement, parserContext);
+		BeanDefinitionBuilder jpaExecutorBuilder =
+				JpaParserUtils.getOutboundGatewayJpaExecutorBuilder(gatewayElement, parserContext);
 
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaExecutorBuilder, gatewayElement, "persist-mode");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaExecutorBuilder, gatewayElement, "flush");
@@ -48,15 +49,15 @@ public class UpdatingJpaOutboundGatewayParser extends AbstractJpaOutboundGateway
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(jpaExecutorBuilder, gatewayElement, "clear-on-flush");
 
 		final BeanDefinition jpaExecutorBuilderBeanDefinition = jpaExecutorBuilder.getBeanDefinition();
-		final String gatewayId = this.resolveId(gatewayElement, jpaOutboundGatewayBuilder.getRawBeanDefinition(), parserContext);
+		final String gatewayId = resolveId(gatewayElement, jpaOutboundGatewayBuilder.getRawBeanDefinition(),
+				parserContext);
 		final String jpaExecutorBeanName = gatewayId + ".jpaExecutor";
 
-		parserContext.registerBeanComponent(new BeanComponentDefinition(jpaExecutorBuilderBeanDefinition, jpaExecutorBeanName));
+		parserContext.registerBeanComponent(
+				new BeanComponentDefinition(jpaExecutorBuilderBeanDefinition, jpaExecutorBeanName));
 
-		jpaOutboundGatewayBuilder.addConstructorArgReference(jpaExecutorBeanName);
-		jpaOutboundGatewayBuilder.addPropertyValue("gatewayType", OutboundGatewayType.UPDATING);
-		return jpaOutboundGatewayBuilder;
-
+		return  jpaOutboundGatewayBuilder.addPropertyReference("jpaExecutor", jpaExecutorBeanName)
+				.addPropertyValue("gatewayType", OutboundGatewayType.UPDATING);
 	}
 
 }

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import org.springframework.integration.jpa.support.OutboundGatewayType;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
-import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 
@@ -47,21 +46,21 @@ import org.springframework.util.CollectionUtils;
  */
 public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHandler> {
 
-	private final JpaExecutor jpaExecutor;
+	private JpaExecutor jpaExecutor;
 
 	private OutboundGatewayType gatewayType = OutboundGatewayType.UPDATING;
 
 	/**
 	 * &lt;transactional /&gt; element applies to entire flow from this point
 	 */
-	private volatile List<Advice> txAdviceChain;
+	private List<Advice> txAdviceChain;
 
 	/**
 	 * &lt;request-handler-advice-chain /&gt; only applies to the handleRequestMessage.
 	 */
-	private volatile List<Advice> adviceChain;
+	private List<Advice> adviceChain;
 
-	private volatile ClassLoader beanClassLoader = ClassUtils.getDefaultClassLoader();
+	private ClassLoader beanClassLoader = ClassUtils.getDefaultClassLoader();
 
 	private boolean producesReply = true;
 
@@ -71,18 +70,11 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 
 	private long replyTimeout;
 
-	private volatile boolean requiresReply = false;
+	private boolean requiresReply = false;
 
-	private volatile String componentName;
+	private String componentName;
 
-	/**
-	 * Constructor taking an {@link JpaExecutor} that wraps all JPA Operations.
-	 *
-	 * @param jpaExecutor Must not be null
-	 *
-	 */
-	public JpaOutboundGatewayFactoryBean(JpaExecutor jpaExecutor) {
-		Assert.notNull(jpaExecutor, "jpaExecutor must not be null.");
+	public void setJpaExecutor(JpaExecutor jpaExecutor) {
 		this.jpaExecutor = jpaExecutor;
 	}
 
@@ -112,9 +104,9 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 
 	/**
 	 * Specifies the time the gateway will wait to send the result to the reply channel.
-	 * Only applies when the reply channel itself might block the send (for example a bounded QueueChannel that is currently full).
+	 * Only applies when the reply channel itself might block the send
+	 * (for example a bounded QueueChannel that is currently full).
 	 * By default the Gateway will wait indefinitely.
-	 *
 	 * @param replyTimeout The timeout in milliseconds
 	 */
 	public void setReplyTimeout(long replyTimeout) {
@@ -127,11 +119,16 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 
 	/**
 	 * Sets the name of the handler component.
-	 *
 	 * @param componentName The component name.
 	 */
 	public void setComponentName(String componentName) {
 		this.componentName = componentName;
+	}
+
+	@Override
+	public void setBeanClassLoader(ClassLoader classLoader) {
+		super.setBeanClassLoader(classLoader);
+		this.beanClassLoader = classLoader;
 	}
 
 	@Override
@@ -141,7 +138,6 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 
 	@Override
 	protected MessageHandler createInstance() {
-
 		JpaOutboundGateway jpaOutboundGateway = new JpaOutboundGateway(jpaExecutor);
 		jpaOutboundGateway.setGatewayType(this.gatewayType);
 		jpaOutboundGateway.setProducesReply(this.producesReply);
@@ -169,4 +165,5 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 
 		return jpaOutboundGateway;
 	}
+
 }

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,21 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 	private boolean requiresReply = false;
 
 	private String componentName;
+
+	public JpaOutboundGatewayFactoryBean() {
+	}
+
+	/**
+	 * Constructor taking an {@link JpaExecutor} that wraps all JPA Operations.
+	 * @param jpaExecutor Must not be null
+	 * @deprecated since {@literal 4.2.5} in favor of {@link #setJpaExecutor(JpaExecutor)}
+	 * to avoid {@code BeanCurrentlyInCreationException}
+	 * during {@code AbstractAutowireCapableBeanFactory.getSingletonFactoryBeanForTypeCheck()}
+	 */
+	@Deprecated
+	public JpaOutboundGatewayFactoryBean(JpaExecutor jpaExecutor) {
+		setJpaExecutor(jpaExecutor);
+	}
 
 	public void setJpaExecutor(JpaExecutor jpaExecutor) {
 		this.jpaExecutor = jpaExecutor;

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
@@ -86,7 +86,7 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<MessageHa
 	 */
 	@Deprecated
 	public JpaOutboundGatewayFactoryBean(JpaExecutor jpaExecutor) {
-		setJpaExecutor(jpaExecutor);
+		this.jpaExecutor = jpaExecutor;
 	}
 
 	public void setJpaExecutor(JpaExecutor jpaExecutor) {

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/WebSocketIntegrationConfigurationInitializer.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/WebSocketIntegrationConfigurationInitializer.java
@@ -115,7 +115,7 @@ public class WebSocketIntegrationConfigurationInitializer implements Integration
 
 		private ApplicationContext applicationContext;
 
-		private void setSockJsTaskScheduler(ThreadPoolTaskScheduler sockJsTaskScheduler) {
+		public void setSockJsTaskScheduler(ThreadPoolTaskScheduler sockJsTaskScheduler) {
 			this.registry = new ServletWebSocketHandlerRegistry(sockJsTaskScheduler);
 		}
 

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/WebSocketIntegrationConfigurationInitializer.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/WebSocketIntegrationConfigurationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public class WebSocketIntegrationConfigurationInitializer implements Integration
 				BeanDefinitionBuilder enableWebSocketBuilder =
 						BeanDefinitionBuilder.genericBeanDefinition(WebSocketHandlerMappingFactoryBean.class)
 								.setRole(BeanDefinition.ROLE_INFRASTRUCTURE)
-								.addConstructorArgReference("defaultSockJsTaskScheduler");
+								.addPropertyReference("sockJsTaskScheduler", "defaultSockJsTaskScheduler");
 
 				registry.registerBeanDefinition(WEB_SOCKET_HANDLER_MAPPING_BEAN_NAME,
 						enableWebSocketBuilder.getBeanDefinition());
@@ -111,11 +111,11 @@ public class WebSocketIntegrationConfigurationInitializer implements Integration
 	private static class WebSocketHandlerMappingFactoryBean extends AbstractFactoryBean<HandlerMapping>
 			implements ApplicationContextAware {
 
-		private final ServletWebSocketHandlerRegistry registry;
+		private ServletWebSocketHandlerRegistry registry;
 
 		private ApplicationContext applicationContext;
 
-		private WebSocketHandlerMappingFactoryBean(ThreadPoolTaskScheduler sockJsTaskScheduler) {
+		private void setSockJsTaskScheduler(ThreadPoolTaskScheduler sockJsTaskScheduler) {
 			this.registry = new ServletWebSocketHandlerRegistry(sockJsTaskScheduler);
 		}
 
@@ -140,6 +140,7 @@ public class WebSocketIntegrationConfigurationInitializer implements Integration
 		public Class<?> getObjectType() {
 			return HandlerMapping.class;
 		}
+
 	}
 
 }

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBean.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBean.java
@@ -79,8 +79,9 @@ public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnectio
 	 * to avoid {@code BeanCurrentlyInCreationException}
 	 * during {@code AbstractAutowireCapableBeanFactory.getSingletonFactoryBeanForTypeCheck()}
 	 */
+	@Deprecated
 	public XmppConnectionFactoryBean(XMPPTCPConnectionConfiguration connectionConfiguration) {
-		setConnectionConfiguration(connectionConfiguration);
+		this.connectionConfiguration = connectionConfiguration;
 	}
 
 	/**
@@ -155,6 +156,7 @@ public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnectio
 		return this.connection;
 	}
 
+	@Override
 	public void start() {
 		synchronized (this.lifecycleMonitor) {
 			if (this.running) {
@@ -176,6 +178,7 @@ public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnectio
 		}
 	}
 
+	@Override
 	public void stop() {
 		synchronized (this.lifecycleMonitor) {
 			if (this.isRunning()) {
@@ -185,19 +188,23 @@ public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnectio
 		}
 	}
 
+	@Override
 	public void stop(Runnable callback) {
 		stop();
 		callback.run();
 	}
 
+	@Override
 	public boolean isRunning() {
 		return this.running;
 	}
 
+	@Override
 	public int getPhase() {
 		return this.phase;
 	}
 
+	@Override
 	public boolean isAutoStartup() {
 		return this.autoStartup;
 	}
@@ -205,22 +212,27 @@ public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnectio
 
 	private class LoggingConnectionListener implements ConnectionListener {
 
+		@Override
 		public void reconnectionSuccessful() {
 			logger.debug("Reconnection successful");
 		}
 
+		@Override
 		public void reconnectionFailed(Exception e) {
 			logger.debug("Reconnection failed", e);
 		}
 
+		@Override
 		public void reconnectingIn(int seconds) {
 			logger.debug("Reconnecting in " + seconds + " seconds");
 		}
 
+		@Override
 		public void connectionClosedOnError(Exception e) {
 			logger.debug("Connection closed on error", e);
 		}
 
+		@Override
 		public void connectionClosed() {
 			logger.debug("Connection closed");
 		}

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBean.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import org.jxmpp.util.XmppStringUtils;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.context.SmartLifecycle;
-import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -44,9 +43,9 @@ import org.springframework.util.StringUtils;
  */
 public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnection> implements SmartLifecycle {
 
-	private final XMPPTCPConnectionConfiguration connectionConfiguration;
-
 	private final Object lifecycleMonitor = new Object();
+
+	private XMPPTCPConnectionConfiguration connectionConfiguration;
 
 	private volatile String resource; // server will generate resource if not provided
 
@@ -72,11 +71,23 @@ public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnectio
 
 
 	public XmppConnectionFactoryBean() {
-		this.connectionConfiguration = null;
 	}
 
+	/**
+	 * @param connectionConfiguration the {@link XMPPTCPConnectionConfiguration} to use.
+	 * @deprecated since {@literal 4.2.5} in favor of {@link #setConnectionConfiguration(XMPPTCPConnectionConfiguration)}
+	 * to avoid {@code BeanCurrentlyInCreationException}
+	 * during {@code AbstractAutowireCapableBeanFactory.getSingletonFactoryBeanForTypeCheck()}
+	 */
 	public XmppConnectionFactoryBean(XMPPTCPConnectionConfiguration connectionConfiguration) {
-		Assert.notNull(connectionConfiguration, "'connectionConfiguration' must not be null");
+		setConnectionConfiguration(connectionConfiguration);
+	}
+
+	/**
+	 * @param connectionConfiguration the {@link XMPPTCPConnectionConfiguration} to use.
+	 * @since 4.2.5
+	 */
+	public void setConnectionConfiguration(XMPPTCPConnectionConfiguration connectionConfiguration) {
 		this.connectionConfiguration = connectionConfiguration;
 	}
 

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBeanTests-context.xml
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBeanTests-context.xml
@@ -13,9 +13,9 @@
 	</bean>
 
 	<bean id="xmppConnection" class="org.springframework.integration.xmpp.config.XmppConnectionFactoryBean">
-		<constructor-arg>
+		<property name="connectionConfiguration">
 			<bean factory-bean="xmppConnectionConfigurationBuilder" factory-method="build"/>
-		</constructor-arg>
+		</property>
 		<property name="autoStartup" value="false"/>
 	</bean>
 

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBeanTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,13 +28,14 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 /**
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
+ * @author Artem Bilan
  */
 public class XmppConnectionFactoryBeanTests {
 
 	@Test
 	public void testXmppConnectionFactoryBean() throws Exception {
-		XmppConnectionFactoryBean xmppConnectionFactoryBean =
-				new XmppConnectionFactoryBean(mock(XMPPTCPConnectionConfiguration.class));
+		XmppConnectionFactoryBean xmppConnectionFactoryBean = new XmppConnectionFactoryBean();
+		xmppConnectionFactoryBean.setConnectionConfiguration(mock(XMPPTCPConnectionConfiguration.class));
 		XMPPConnection connection = xmppConnectionFactoryBean.createInstance();
 		assertNotNull(connection);
 	}

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/LeaderInitiatorFactoryBean.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/LeaderInitiatorFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,17 +33,18 @@ import org.springframework.integration.zookeeper.leader.LeaderInitiator;
  * Creates a {@link LeaderInitiator}.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 4.2
  *
  */
 public class LeaderInitiatorFactoryBean
 		implements FactoryBean<LeaderInitiator>, SmartLifecycle, InitializingBean, ApplicationEventPublisherAware {
 
-	private final CuratorFramework client;
+	private CuratorFramework client;
 
-	private final Candidate candidate;
+	private Candidate candidate;
 
-	private final String path;
+	private String path;
 
 	private LeaderInitiator leaderInitiator;
 
@@ -53,16 +54,37 @@ public class LeaderInitiatorFactoryBean
 
 	private ApplicationEventPublisher applicationEventPublisher;
 
+	public LeaderInitiatorFactoryBean() {
+	}
+
 	/**
 	 * Construct the instance.
 	 * @param client the {@link CuratorFramework}.
 	 * @param path the path in zookeeper.
 	 * @param role the role of the leader.
+	 * @deprecated since {@literal 4.2.5} in favor of appropriate setters
+	 * to avoid {@code BeanCurrentlyInCreationException}
+	 * during {@code AbstractAutowireCapableBeanFactory.getSingletonFactoryBeanForTypeCheck()}
 	 */
 	public LeaderInitiatorFactoryBean(CuratorFramework client, String path, String role) {
+		setClient(client);
+		setPath(path);
+		setRole(role);
+	}
+
+	public LeaderInitiatorFactoryBean setClient(CuratorFramework client) {
 		this.client = client;
-		this.candidate = new DefaultCandidate(UUID.randomUUID().toString(), role);
+		return this;
+	}
+
+	public LeaderInitiatorFactoryBean setPath(String path) {
 		this.path = path;
+		return this;
+	}
+
+	public LeaderInitiatorFactoryBean setRole(String role) {
+		this.candidate = new DefaultCandidate(UUID.randomUUID().toString(), role);
+		return this;
 	}
 
 	@Override

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/LeaderInitiatorFactoryBean.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/LeaderInitiatorFactoryBean.java
@@ -66,10 +66,11 @@ public class LeaderInitiatorFactoryBean
 	 * to avoid {@code BeanCurrentlyInCreationException}
 	 * during {@code AbstractAutowireCapableBeanFactory.getSingletonFactoryBeanForTypeCheck()}
 	 */
+	@Deprecated
 	public LeaderInitiatorFactoryBean(CuratorFramework client, String path, String role) {
-		setClient(client);
-		setPath(path);
-		setRole(role);
+		this.client = client;
+		this.path = path;
+		this.candidate = new DefaultCandidate(UUID.randomUUID().toString(), role);
 	}
 
 	public LeaderInitiatorFactoryBean setClient(CuratorFramework client) {

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/config/LeaderInitiatorFactoryBeanTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/config/LeaderInitiatorFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 4.2
  *
  */
@@ -85,7 +86,10 @@ public class LeaderInitiatorFactoryBeanTests extends ZookeeperTestSupport {
 
 		@Bean
 		public LeaderInitiatorFactoryBean leaderInitiator(CuratorFramework client) {
-			return new LeaderInitiatorFactoryBean(client, "/siTest/", "foo");
+			return new LeaderInitiatorFactoryBean()
+					.setClient(client)
+					.setPath("/siTest/")
+					.setRole("foo");
 		}
 
 		@Bean


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3916

The `JpaOutboundGatewayFactoryBean` used CTOR injection for the `JpaExecutor`.
That one, in turn, uses CTOR injection for the `EntityManagerFactory`.

Such a dependency may cause the `early bean instantiating` in case of `AbstractAutowireCapableBeanFactory.getSingletonFactoryBeanForTypeCheck()`.
And we end up with the `BeanCurrentlyInCreationException`.

Therefore no one `FactoryBean` should use CTOR injection if there is a potential hierarchical dependency.

NOTE: there is no tests on the matter, since we don't change the components behavior.
The `JPA` sample application will be changed to the Boot to track this fix.

**Cherry-pick to 4.2.x**
