### PR TITLE
INT-3899: Defer Poller Creation Until start()

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,13 +149,7 @@ public abstract class AbstractPollingEndpoint extends AbstractEndpoint implement
 					this.taskExecutor = new ErrorHandlingTaskExecutor(this.taskExecutor, this.errorHandler);
 				}
 			}
-			try {
-				this.poller = this.createPoller();
-				this.initialized = true;
-			}
-			catch (Exception e) {
-				throw new MessagingException("Failed to create Poller", e);
-			}
+			this.initialized = true;
 		}
 	}
 
@@ -204,6 +198,13 @@ public abstract class AbstractPollingEndpoint extends AbstractEndpoint implement
 		}
 		Assert.state(this.getTaskScheduler() != null,
 				"unable to start polling, no taskScheduler available");
+		try {
+			this.poller = createPoller();
+		}
+		catch (Exception e) {
+			this.initialized = false;
+			throw new MessagingException("Failed to create Poller", e);
+		}
 		this.runningTask = this.getTaskScheduler().schedule(this.poller, this.trigger);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.integration.handler.advice;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -82,6 +81,7 @@ import org.springframework.retry.RetryState;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.DefaultRetryState;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -896,6 +896,8 @@ public class AdvisedMessageHandlerTests {
 				}));
 		consumer.setBeanFactory(mock(BeanFactory.class));
 		consumer.afterPropertiesSet();
+		consumer.setTaskScheduler(mock(TaskScheduler.class));
+		consumer.start();
 
 		Callable<?> pollingTask = TestUtils.getPropertyValue(consumer, "poller.pollingTask", Callable.class);
 		assertTrue(AopUtils.isAopProxy(pollingTask));
@@ -919,6 +921,7 @@ public class AdvisedMessageHandlerTests {
 		assertTrue(logMessage.get().endsWith("can only be used for MessageHandlers; " +
 				"an attempt to advise method 'call' in " +
 				"'org.springframework.integration.endpoint.AbstractPollingEndpoint$1' is ignored"));
+		consumer.stop();
 	}
 
 	public void filterDiscardNoAdvice() {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,6 @@ public class FtpInboundChannelAdapterParserTests {
 		assertNotNull(comparator);
 		assertEquals("ftpInbound", ftpInbound.getComponentName());
 		assertEquals("ftp:inbound-channel-adapter", ftpInbound.getComponentType());
-		assertNotNull(TestUtils.getPropertyValue(ftpInbound, "poller"));
 		assertEquals(context.getBean("ftpChannel"), TestUtils.getPropertyValue(ftpInbound, "outputChannel"));
 		FtpInboundFileSynchronizingMessageSource inbound =
 			(FtpInboundFileSynchronizingMessageSource) TestUtils.getPropertyValue(ftpInbound, "source");


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3899

Previously, within `AbstractPollingEndpoint`, the `Poller` object was
created from `afterPropertiesSet()` as well as `start()` if previously `stopped()`
(`this.initialized == false`).

This precluded modification of the advice chain (e.g. in tests when using
`autoStartup == false`).

Move the poller creation to `start()` so that it is always created then, and does
not require a previous `stop()` to change the advice chain.
