### PR TITLE
INT-3910: MessageProducerSupport.outputChannelName

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/MessageProducerSupportTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/MessageProducerSupportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.endpoint;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -25,11 +26,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
+
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.handler.ServiceActivatingHandler;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.integration.test.util.TestUtils.TestApplicationContext;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
@@ -117,6 +120,20 @@ public class MessageProducerSupportTests {
 		assertEquals(MessageDeliveryException.class, errorMessage.getPayload().getClass());
 		MessageDeliveryException exception = (MessageDeliveryException) errorMessage.getPayload();
 		assertEquals(message, exception.getFailedMessage());
+	}
+
+	@Test
+	public void testWithChannelName() {
+		DirectChannel outChannel = new DirectChannel();
+		MessageProducerSupport mps = new MessageProducerSupport() {};
+		mps.setOutputChannelName("foo");
+		TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
+		testApplicationContext.registerBean("foo", outChannel);
+		testApplicationContext.refresh();
+		mps.setBeanFactory(testApplicationContext);
+		mps.afterPropertiesSet();
+		mps.start();
+		assertSame(outChannel, TestUtils.getPropertyValue(mps, "outputChannel"));
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3910
- Support channel name on `MessageProducerSupport`.
- Defer validation until the endpoint is `start()`ed.
