### PR TITLE
INT-3920: Handler Factory Bean Subclassing

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractStandardMessageHandlerFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractStandardMessageHandlerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -38,7 +38,8 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author David Liu
  */
-abstract class AbstractStandardMessageHandlerFactoryBean extends AbstractSimpleMessageHandlerFactoryBean<MessageHandler> {
+public abstract class AbstractStandardMessageHandlerFactoryBean
+		extends AbstractSimpleMessageHandlerFactoryBean<MessageHandler> {
 
 	private static final ExpressionParser expressionParser = new SpelExpressionParser(new SpelParserConfiguration(true,
 			true));
@@ -129,22 +130,22 @@ abstract class AbstractStandardMessageHandlerFactoryBean extends AbstractSimpleM
 	/**
 	 * Subclasses must implement this method to create the MessageHandler.
 	 */
-	abstract MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName);
+	protected abstract MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName);
 
-	MessageHandler createExpressionEvaluatingHandler(Expression expression) {
+	protected MessageHandler createExpressionEvaluatingHandler(Expression expression) {
 		throw new UnsupportedOperationException(this.getClass().getName() + " does not support expressions.");
 	}
 
-	<T> MessageHandler createMessageProcessingHandler(MessageProcessor<T> processor) {
+	protected <T> MessageHandler createMessageProcessingHandler(MessageProcessor<T> processor) {
 		return this.createMethodInvokingHandler(processor, null);
 	}
 
-	MessageHandler createDefaultHandler() {
+	protected MessageHandler createDefaultHandler() {
 		throw new IllegalArgumentException("Exactly one of the 'targetObject' or 'expression' property is required.");
 	}
 
 	@SuppressWarnings("unchecked")
-	<T> T extractTypeIfPossible(Object targetObject, Class<T> expectedType) {
+	protected <T> T extractTypeIfPossible(Object targetObject, Class<T> expectedType) {
 		if (targetObject == null) {
 			return null;
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/FilterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/FilterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public class FilterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 	}
 
 	@Override
-	MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName) {
+	protected MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName) {
 		MessageSelector selector = null;
 		if (targetObject instanceof MessageSelector) {
 			selector = (MessageSelector) targetObject;
@@ -88,17 +88,17 @@ public class FilterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 	}
 
 	@Override
-	MessageHandler createExpressionEvaluatingHandler(Expression expression) {
+	protected MessageHandler createExpressionEvaluatingHandler(Expression expression) {
 		return this.createFilter(new ExpressionEvaluatingSelector(expression));
 	}
 
-	private MessageFilter createFilter(MessageSelector selector) {
+	protected MessageFilter createFilter(MessageSelector selector) {
 		MessageFilter filter = new MessageFilter(selector);
 		postProcessReplyProducer(filter);
 		return filter;
 	}
 
-	private void postProcessFilter(MessageFilter filter) {
+	protected void postProcessFilter(MessageFilter filter) {
 		if (this.throwExceptionOnRejection != null) {
 			filter.setThrowExceptionOnRejection(this.throwExceptionOnRejection);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
@@ -90,7 +90,7 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 	}
 
 	@Override
-	MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName) {
+	protected MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName) {
 		Assert.notNull(targetObject, "target object must not be null");
 		AbstractMessageRouter router = this.extractTypeIfPossible(targetObject, AbstractMessageRouter.class);
 		if (router == null) {
@@ -113,17 +113,17 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 	}
 
 	@Override
-	MessageHandler createExpressionEvaluatingHandler(Expression expression) {
+	protected MessageHandler createExpressionEvaluatingHandler(Expression expression) {
 		return this.configureRouter(new ExpressionEvaluatingRouter(expression));
 	}
 
-	private AbstractMappingMessageRouter createMethodInvokingRouter(Object targetObject, String targetMethodName) {
+	protected AbstractMappingMessageRouter createMethodInvokingRouter(Object targetObject, String targetMethodName) {
 		return (StringUtils.hasText(targetMethodName))
 				? new MethodInvokingRouter(targetObject, targetMethodName)
 				: new MethodInvokingRouter(targetObject);
 	}
 
-	private AbstractMessageRouter configureRouter(AbstractMessageRouter router) {
+	protected AbstractMessageRouter configureRouter(AbstractMessageRouter router) {
 		if (this.defaultOutputChannel != null) {
 			router.setDefaultOutputChannel(this.defaultOutputChannel);
 		}
@@ -145,7 +145,7 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 		return router;
 	}
 
-	private void configureMappingRouter(AbstractMappingMessageRouter router) {
+	protected void configureMappingRouter(AbstractMappingMessageRouter router) {
 		if (this.channelMappings != null) {
 			router.setChannelMappings(this.channelMappings);
 		}
@@ -159,7 +159,7 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 		return noRouterAttributesProvided();
 	}
 
-	private boolean noRouterAttributesProvided() {
+	protected boolean noRouterAttributesProvided() {
 		return this.channelMappings == null && this.defaultOutputChannel == null
 				&& this.sendTimeout == null && this.resolutionRequired == null && this.applySequence == null
 				&& this.ignoreSendFailures == null;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ServiceActivatorFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ServiceActivatorFactoryBean.java
@@ -49,7 +49,7 @@ public class ServiceActivatorFactoryBean extends AbstractStandardMessageHandlerF
 	}
 
 	@Override
-	MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName) {
+	protected MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName) {
 		MessageHandler handler = null;
 		handler = createDirectHandlerIfPossible(targetObject, targetMethodName);
 		if (handler == null) {
@@ -65,7 +65,7 @@ public class ServiceActivatorFactoryBean extends AbstractStandardMessageHandlerF
 	 * If the target object is a {@link MessageHandler} and the method is 'handleMessage', return an
 	 * {@link AbstractMessageProducingHandler} that wraps it.
 	 */
-	private MessageHandler createDirectHandlerIfPossible(final Object targetObject, String targetMethodName) {
+	protected MessageHandler createDirectHandlerIfPossible(final Object targetObject, String targetMethodName) {
 		MessageHandler handler = null;
 		if (targetObject instanceof MessageHandler
 				&& this.methodIsHandleMessageOrEmpty(targetMethodName)) {
@@ -92,18 +92,18 @@ public class ServiceActivatorFactoryBean extends AbstractStandardMessageHandlerF
 	}
 
 	@Override
-	MessageHandler createExpressionEvaluatingHandler(Expression expression) {
+	protected MessageHandler createExpressionEvaluatingHandler(Expression expression) {
 		ExpressionEvaluatingMessageProcessor<Object> processor = new ExpressionEvaluatingMessageProcessor<Object>(expression);
 		processor.setBeanFactory(this.getBeanFactory());
 		return this.configureHandler(new ServiceActivatingHandler(processor));
 	}
 
 	@Override
-	<T> MessageHandler createMessageProcessingHandler(MessageProcessor<T> processor) {
+	protected <T> MessageHandler createMessageProcessingHandler(MessageProcessor<T> processor) {
 		return this.configureHandler(new ServiceActivatingHandler(processor));
 	}
 
-	private MessageHandler configureHandler(ServiceActivatingHandler handler) {
+	protected MessageHandler configureHandler(ServiceActivatingHandler handler) {
 		postProcessReplyProducer(handler);
 		return handler;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/SplitterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/SplitterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public class SplitterFactoryBean extends AbstractStandardMessageHandlerFactoryBe
 	}
 
 	@Override
-	MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName) {
+	protected MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName) {
 		Assert.notNull(targetObject, "targetObject must not be null");
 		AbstractMessageSplitter splitter = this.extractTypeIfPossible(targetObject, AbstractMessageSplitter.class);
 		if (splitter == null) {
@@ -86,23 +86,23 @@ public class SplitterFactoryBean extends AbstractStandardMessageHandlerFactoryBe
 		return splitter;
 	}
 
-	private AbstractMessageSplitter createMethodInvokingSplitter(Object targetObject, String targetMethodName) {
+	protected AbstractMessageSplitter createMethodInvokingSplitter(Object targetObject, String targetMethodName) {
 		return (StringUtils.hasText(targetMethodName))
 				? new MethodInvokingSplitter(targetObject, targetMethodName)
 				: new MethodInvokingSplitter(targetObject);
 	}
 
 	@Override
-	MessageHandler createExpressionEvaluatingHandler(Expression expression) {
+	protected MessageHandler createExpressionEvaluatingHandler(Expression expression) {
 		return this.configureSplitter(new ExpressionEvaluatingSplitter(expression));
 	}
 
 	@Override
-	MessageHandler createDefaultHandler() {
+	protected MessageHandler createDefaultHandler() {
 		return this.configureSplitter(new DefaultMessageSplitter());
 	}
 
-	private AbstractMessageSplitter configureSplitter(AbstractMessageSplitter splitter) {
+	protected AbstractMessageSplitter configureSplitter(AbstractMessageSplitter splitter) {
 		this.postProcessReplyProducer(splitter);
 		return splitter;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/TransformerFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/TransformerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public class TransformerFactoryBean extends AbstractStandardMessageHandlerFactor
 	}
 
 	@Override
-	MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName) {
+	protected MessageHandler createMethodInvokingHandler(Object targetObject, String targetMethodName) {
 		Assert.notNull(targetObject, "targetObject must not be null");
 		Transformer transformer = null;
 		if (targetObject instanceof Transformer) {
@@ -61,12 +61,12 @@ public class TransformerFactoryBean extends AbstractStandardMessageHandlerFactor
 	}
 
 	@Override
-	MessageHandler createExpressionEvaluatingHandler(Expression expression) {
+	protected MessageHandler createExpressionEvaluatingHandler(Expression expression) {
 		Transformer transformer = new ExpressionEvaluatingTransformer(expression);
 		return this.createHandler(transformer);
 	}
 
-	private MessageTransformingHandler createHandler(Transformer transformer) {
+	protected MessageTransformingHandler createHandler(Transformer transformer) {
 		MessageTransformingHandler handler = new MessageTransformingHandler(transformer);
 		this.postProcessReplyProducer(handler);
 		return handler;


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3920

Remove package and private protection from the message handler `FactoryBean` hierarchy.

Ease the creation of subclasses, for example, it was impossible to subclass
the `SplitterFactoryBean` to support default, expression, or file splitter here:

https://github.com/garyrussell/spring-cloud-stream-modules/commit/43c8c041d72883ae34e4a137b5effdd07c598748#diff-bb5468e093538789dcde1b222fe90693R62
