### PR TITLE
INT-3932: RedisQueueMessageDrivenEndpoint readFromLeft option to use …

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.util.StringUtils;
  * Parser for the &lt;queue-inbound-channel-adapter&gt; element of the 'redis' namespace.
  *
  * @author Artem Bilan
+ * @author Rainer Frey
  * @since 3.0
  */
 public class RedisQueueInboundChannelAdapterParser extends AbstractChannelAdapterParser {

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParser.java
@@ -52,7 +52,7 @@ public class RedisQueueInboundChannelAdapterParser extends AbstractChannelAdapte
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "expect-message");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "receive-timeout");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "recovery-interval");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "read-from-left");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "right-pop");
 		builder.addPropertyReference("outputChannel", channelName);
 
 		return builder.getBeanDefinition();

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParser.java
@@ -51,6 +51,7 @@ public class RedisQueueInboundChannelAdapterParser extends AbstractChannelAdapte
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "expect-message");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "receive-timeout");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "recovery-interval");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "read-from-left");
 		builder.addPropertyReference("outputChannel", channelName);
 
 		return builder.getBeanDefinition();

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisQueueOutboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisQueueOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.util.StringUtils;
  * Parser for the &lt;int-redis:queue-outbound-channel-adapter&gt; element.
  *
  * @author Artem Bilan
+ * @author Rainer Frey
  * @since 3.0
  */
 public class RedisQueueOutboundChannelAdapterParser extends AbstractOutboundChannelAdapterParser {
@@ -50,6 +51,7 @@ public class RedisQueueOutboundChannelAdapterParser extends AbstractOutboundChan
 
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "extract-payload");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "serializer");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "left-push");
 
 		return builder.getBeanDefinition();
 	}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
@@ -201,10 +201,10 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport impl
 		byte[] value = null;
 		try {
 			if (readFromLeft) {
-				value = this.boundListOperations.leftPop( this.receiveTimeout, TimeUnit.MILLISECONDS);
+				value = this.boundListOperations.leftPop(this.receiveTimeout, TimeUnit.MILLISECONDS);
 			}
 			else {
-				value = this.boundListOperations.rightPop( this.receiveTimeout, TimeUnit.MILLISECONDS);
+				value = this.boundListOperations.rightPop(this.receiveTimeout, TimeUnit.MILLISECONDS);
 			}
 		}
 		catch (Exception e) {

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
@@ -48,6 +48,7 @@ import org.springframework.util.Assert;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Rainer Frey
  * @since 3.0
  */
 @ManagedResource
@@ -162,9 +163,8 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport impl
 
 	/**
 	 * Should data from the Redis queue be read from the left end of the queue (using leftPop)?
-	 * This is useful when the queue is fed by a software that uses rightPush.
-	 * @since 4.3
 	 * @param readFromLeft Defaults to false
+	 * @since 4.3
 	 */
 	public void setReadFromLeft(boolean readFromLeft) {
 		this.readFromLeft = readFromLeft;
@@ -200,7 +200,7 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport impl
 
 		byte[] value = null;
 		try {
-			if (readFromLeft) {
+			if (this.readFromLeft) {
 				value = this.boundListOperations.leftPop(this.receiveTimeout, TimeUnit.MILLISECONDS);
 			}
 			else {
@@ -244,7 +244,7 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport impl
 				this.sendMessage(message);
 			}
 			else {
-				if (readFromLeft) {
+				if (this.readFromLeft) {
 					this.boundListOperations.leftPush(value);
 				}
 				else {

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
@@ -81,7 +81,7 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport impl
 
 	private volatile Runnable stopCallback;
 
-	private volatile boolean readFromLeft = false;
+	private volatile boolean rightPop = true;
 
 	/**
 	 * @param queueName         Must not be an empty String
@@ -162,12 +162,12 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport impl
 	}
 
 	/**
-	 * Should data from the Redis queue be read from the left end of the queue (using leftPop)?
-	 * @param readFromLeft Defaults to false
+	 * Should data from the Redis queue be read with a rightPop or leftPop operation?
+	 * @param rightPop Defaults to true
 	 * @since 4.3
 	 */
-	public void setReadFromLeft(boolean readFromLeft) {
-		this.readFromLeft = readFromLeft;
+	public void setRightPop(boolean rightPop) {
+		this.rightPop = rightPop;
 	}
 
 	@Override
@@ -200,11 +200,11 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport impl
 
 		byte[] value = null;
 		try {
-			if (this.readFromLeft) {
-				value = this.boundListOperations.leftPop(this.receiveTimeout, TimeUnit.MILLISECONDS);
+			if (this.rightPop) {
+				value = this.boundListOperations.rightPop(this.receiveTimeout, TimeUnit.MILLISECONDS);
 			}
 			else {
-				value = this.boundListOperations.rightPop(this.receiveTimeout, TimeUnit.MILLISECONDS);
+				value = this.boundListOperations.leftPop(this.receiveTimeout, TimeUnit.MILLISECONDS);
 			}
 		}
 		catch (Exception e) {
@@ -244,11 +244,11 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport impl
 				this.sendMessage(message);
 			}
 			else {
-				if (this.readFromLeft) {
-					this.boundListOperations.leftPush(value);
+				if (this.rightPop) {
+					this.boundListOperations.rightPush(value);
 				}
 				else {
-					this.boundListOperations.rightPush(value);
+					this.boundListOperations.leftPush(value);
 				}
 			}
 		}

--- a/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-4.3.xsd
+++ b/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-4.3.xsd
@@ -390,11 +390,11 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
-					<xsd:attribute name="read-from-left" type="xsd:string" default="false">
+					<xsd:attribute name="right-pop" type="xsd:string" default="true">
 						<xsd:annotation>
 							<xsd:documentation>
-								When true, specifies that data is read from the left end of the Redis queue
-								(default is right end).
+								When 'false', specifies that data is read using a 'left pop' operation instead of a 'right pop'.
+								Default is 'true'.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>

--- a/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-4.3.xsd
+++ b/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-4.3.xsd
@@ -618,6 +618,14 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="left-push" type="xsd:string" default="true">
+						<xsd:annotation>
+							<xsd:documentation>
+								When 'false', specifies that data is read using a 'right push' operation instead of a 'left push'.
+								Default is 'true'.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-4.3.xsd
+++ b/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-4.3.xsd
@@ -390,6 +390,15 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="read-from-left" type="xsd:string" default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+								When true, specifies that the next message is read from the left end of the Redis queue
+								(default is right end). Useful when the queue is fed on the right end (eg. by
+								non-SI software).
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="task-executor" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[

--- a/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-4.3.xsd
+++ b/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-4.3.xsd
@@ -393,9 +393,8 @@
 					<xsd:attribute name="read-from-left" type="xsd:string" default="false">
 						<xsd:annotation>
 							<xsd:documentation>
-								When true, specifies that the next message is read from the left end of the Redis queue
-								(default is right end). Useful when the queue is fed on the right end (eg. by
-								non-SI software).
+								When true, specifies that data is read from the left end of the Redis queue
+								(default is right end).
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests-context.xml
@@ -31,7 +31,8 @@
 											  recovery-interval="3000"
 											  task-executor="executor"
 											  auto-startup="false"
-											  phase="100"/>
+											  phase="100"
+											  read-from-left="true"/>
 
 	<bean id="executor" class="org.springframework.integration.util.ErrorHandlingTaskExecutor">
 		<constructor-arg ref="threadPoolTaskExecutor"/>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests-context.xml
@@ -32,7 +32,7 @@
 											  task-executor="executor"
 											  auto-startup="false"
 											  phase="100"
-											  read-from-left="true"/>
+											  right-pop="false"/>
 
 	<bean id="executor" class="org.springframework.integration.util.ErrorHandlingTaskExecutor">
 		<constructor-arg ref="threadPoolTaskExecutor"/>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Rainer Frey
  * @since 3.0
  */
 @ContextConfiguration

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests.java
@@ -104,7 +104,7 @@ public class RedisQueueInboundChannelAdapterParserTests {
 		assertTrue(TestUtils.getPropertyValue(this.defaultAdapter, "autoStartup", Boolean.class));
 		assertEquals(Integer.MAX_VALUE / 2, TestUtils.getPropertyValue(this.defaultAdapter, "phase"));
 		assertSame(this.defaultAdapterChannel, TestUtils.getPropertyValue(this.defaultAdapter, "outputChannel"));
-		assertFalse(TestUtils.getPropertyValue(this.defaultAdapter, "readFromLeft", Boolean.class));
+		assertTrue(TestUtils.getPropertyValue(this.defaultAdapter, "rightPop", Boolean.class));
 	}
 
 	@Test
@@ -121,7 +121,7 @@ public class RedisQueueInboundChannelAdapterParserTests {
 		assertFalse(TestUtils.getPropertyValue(this.customAdapter, "autoStartup", Boolean.class));
 		assertEquals(100, TestUtils.getPropertyValue(this.customAdapter, "phase"));
 		assertSame(this.sendChannel, TestUtils.getPropertyValue(this.customAdapter, "outputChannel"));
-		assertTrue(TestUtils.getPropertyValue(this.customAdapter, "readFromLeft", Boolean.class));
+		assertFalse(TestUtils.getPropertyValue(this.customAdapter, "rightPop", Boolean.class));
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests.java
@@ -103,6 +103,7 @@ public class RedisQueueInboundChannelAdapterParserTests {
 		assertTrue(TestUtils.getPropertyValue(this.defaultAdapter, "autoStartup", Boolean.class));
 		assertEquals(Integer.MAX_VALUE / 2, TestUtils.getPropertyValue(this.defaultAdapter, "phase"));
 		assertSame(this.defaultAdapterChannel, TestUtils.getPropertyValue(this.defaultAdapter, "outputChannel"));
+		assertFalse(TestUtils.getPropertyValue(this.defaultAdapter, "readFromLeft", Boolean.class));
 	}
 
 	@Test
@@ -119,6 +120,7 @@ public class RedisQueueInboundChannelAdapterParserTests {
 		assertFalse(TestUtils.getPropertyValue(this.customAdapter, "autoStartup", Boolean.class));
 		assertEquals(100, TestUtils.getPropertyValue(this.customAdapter, "phase"));
 		assertSame(this.sendChannel, TestUtils.getPropertyValue(this.customAdapter, "outputChannel"));
+		assertTrue(TestUtils.getPropertyValue(this.customAdapter, "readFromLeft", Boolean.class));
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueOutboundChannelAdapterParserTests-context.xml
@@ -26,7 +26,8 @@
 											  queue-expression="headers['redis_queue']"
 											  extract-payload="false"
 											  serializer="serializer"
-											  connection-factory="customRedisConnectionFactory"/>
+											  connection-factory="customRedisConnectionFactory"
+											  left-push="false"/>
 
 	<bean id="serializer" class="org.springframework.data.redis.serializer.StringRedisSerializer"/>
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Rainer Frey
  * @since 3.0
  */
 @ContextConfiguration
@@ -89,6 +90,7 @@ public class RedisQueueOutboundChannelAdapterParserTests {
 
 		assertThat(TestUtils.getPropertyValue(handler, "h.advised.advisors.first.item.advice"),
 				Matchers.instanceOf(RequestHandlerRetryAdvice.class));
+		assertTrue(TestUtils.getPropertyValue(this.defaultAdapter, "leftPush", Boolean.class));
 	}
 
 	@Test
@@ -98,6 +100,7 @@ public class RedisQueueOutboundChannelAdapterParserTests {
 		assertFalse(TestUtils.getPropertyValue(this.customAdapter, "extractPayload", Boolean.class));
 		assertTrue(TestUtils.getPropertyValue(this.customAdapter, "serializerExplicitlySet", Boolean.class));
 		assertSame(this.serializer, TestUtils.getPropertyValue(this.customAdapter, "serializer"));
+		assertFalse(TestUtils.getPropertyValue(this.customAdapter, "leftPush", Boolean.class));
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpointTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpointTests.java
@@ -73,6 +73,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Rainer Frey
  * @since 3.0
  */
 @ContextConfiguration

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpointTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpointTests.java
@@ -340,6 +340,49 @@ public class RedisQueueMessageDrivenEndpointTests extends RedisAvailableTests {
 		endpoint.stop();
 	}
 
+	@Test
+	@RedisAvailable
+	@SuppressWarnings("unchecked")
+	public void testInt3932ReadFromLeft() throws Exception {
+
+		String queueName = "si.test.redisQueueInboundChannelAdapterTests3932";
+
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<String, Object>();
+		redisTemplate.setConnectionFactory(this.connectionFactory);
+		redisTemplate.setEnableDefaultSerializer(false);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new JdkSerializationRedisSerializer());
+		redisTemplate.afterPropertiesSet();
+
+		String payload = "testing";
+
+		redisTemplate.boundListOps(queueName).rightPush(payload);
+
+		Date payload2 = new Date();
+
+		redisTemplate.boundListOps(queueName).rightPush(payload2);
+
+		PollableChannel channel = new QueueChannel();
+
+		RedisQueueMessageDrivenEndpoint endpoint = new RedisQueueMessageDrivenEndpoint(queueName, this.connectionFactory);
+		endpoint.setBeanFactory(Mockito.mock(BeanFactory.class));
+		endpoint.setOutputChannel(channel);
+		endpoint.setReceiveTimeout(1000);
+		endpoint.setReadFromLeft(true);
+		endpoint.afterPropertiesSet();
+		endpoint.start();
+
+		Message<Object> receive = (Message<Object>) channel.receive(2000);
+		assertNotNull(receive);
+		assertEquals(payload, receive.getPayload());
+
+		receive = (Message<Object>) channel.receive(2000);
+		assertNotNull(receive);
+		assertEquals(payload2, receive.getPayload());
+
+		endpoint.stop();
+	}
+
 	private void waitListening(RedisQueueMessageDrivenEndpoint endpoint) throws InterruptedException {
 		int n = 0;
 		do {

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpointTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpointTests.java
@@ -369,7 +369,7 @@ public class RedisQueueMessageDrivenEndpointTests extends RedisAvailableTests {
 		endpoint.setBeanFactory(Mockito.mock(BeanFactory.class));
 		endpoint.setOutputChannel(channel);
 		endpoint.setReceiveTimeout(1000);
-		endpoint.setReadFromLeft(true);
+		endpoint.setRightPop(false);
 		endpoint.afterPropertiesSet();
 		endpoint.start();
 

--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -170,7 +170,8 @@ These attributes are mutually exclusive.
 [[redis-queue-inbound-channel-adapter]]
 ==== Redis Queue Inbound Channel Adapter
 
-Since _Spring Integration 3.0_, a Queue Inbound Channel Adapter is available to 'right pop' messages from a Redis List.
+Since _Spring Integration 3.0_, a Queue Inbound Channel Adapter is available to 'pop' messages from a Redis List. By default it uses 'right pop', but
+it can be configured to use 'left pop' instead.
 The adapter is message-driven using an internal listener thread and does not use a poller.
 [source,xml]
 ----
@@ -185,7 +186,8 @@ The adapter is message-driven using an internal listener thread and does not use
                     receive-timeout=""  <9>
                     recovery-interval=""  <10>
                     expect-message=""  <11>
-                    task-executor=""/>  <12>
+                    task-executor=""  <12>
+                    right-pop=""/>  <13>
 
 ----
 
@@ -211,7 +213,7 @@ Default is `0`.
 Defaults to `redisConnectionFactory`.
 
 
-<6> The name of the Redis List on which the queue-based 'right pop' operation is performed to get Redis messages.
+<6> The name of the Redis List on which the queue-based 'pop' operation is performed to get Redis messages.
 
 
 <7> The `MessageChannel` to which to send `ErrorMessage` s with `Exception` s from the listening task of the Endpoint.
@@ -224,11 +226,11 @@ In this case the raw `byte[]` from the inbound Redis message is sent to the `cha
 By default it is a `JdkSerializationRedisSerializer`.
 
 
-<9> The timeout in milliseconds for 'right pop' operation to wait for a Redis message from the queue.
+<9> The timeout in milliseconds for 'pop' operation to wait for a Redis message from the queue.
 Default is 1 second.
 
 
-<10> The time in milliseconds for which the listener task should sleep after exceptions on the 'right pop' operation, before restarting the listener task.
+<10> The time in milliseconds for which the listener task should sleep after exceptions on the 'pop' operation, before restarting the listener task.
 
 
 <11> Specify if this Endpoint expects data from the Redis queue to contain entire `Message` s.
@@ -240,10 +242,17 @@ Default is `false`.
 It is used for the underlying listening task.
 By default a `SimpleAsyncTaskExecutor` is used.
 
+
+<13> Specify whether this Endpoint should use 'right pop' (when `true`) or 'left pop' (when `false`) to read messages from the Redis List.
+If `true`, the Redis List acts as a `FIFO` queue when used with a default _Redis Queue Outbound Channel Adapter_. Set to `false` to use with software
+that writes to the list with 'right push', or to achieve a stack-like message order.
+Default is `true`.
+
 [[redis-queue-outbound-channel-adapter]]
 ==== Redis Queue Outbound Channel Adapter
 
-Since _Spring Integration 3.0_, a Queue Outbound Channel Adapter is available to 'left push' to a Redis List from Spring Integration messages:
+Since _Spring Integration 3.0_, a Queue Outbound Channel Adapter is available to 'push' to a Redis List from Spring Integration messages. By default,
+it uses 'left push', but it can be configured to use 'right push' instead.
 [source,xml]
 ----
 <int-redis:queue-outbound-channel-adapter id=""  <1>
@@ -252,7 +261,8 @@ Since _Spring Integration 3.0_, a Queue Outbound Channel Adapter is available to
                     queue=""  <4>
                     queue-expression=""  <5>
                     serializer=""  <6>
-                    extract-payload="" /> <7>
+                    extract-payload=""  <7>
+                    left-push=""/>  <8>
 
 ----
 
@@ -270,7 +280,7 @@ In this case, the endpoint is registered with the bean name `id + '.adapter'`.
 Defaults to `redisConnectionFactory`.
 
 
-<4> The name of the Redis List on which the queue-based 'left push' operation is performed to send Redis messages.
+<4> The name of the Redis List on which the queue-based 'push' operation is performed to send Redis messages.
 This attribute is mutually exclusive with `queue-expression`.
 
 
@@ -285,6 +295,13 @@ However, for `String` payloads, a `StringRedisSerializer` is used, if a `seriali
 
 <7> Specify if this Endpoint should send just the _payload_ to the Redis queue, or the entire `Message`.
 Default is `true`.
+
+
+<8> Specify whether this Endpoint should use 'left push' (when `true`) or 'right push' (when `false`) to write messages to the Redis List.
+If `true`, the Redis List acts as a `FIFO` queue when used with a default _Redis Queue Inbound Channel Adapter_. Set to `false` to use with software
+that reads from the list with 'left pop', or to achieve a stack-like message order.
+Default is `true`.
+
 
 [[redis-application-events]]
 ==== Redis Application Events

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -66,3 +66,9 @@ See <<file-writing-file-names>> for more information.
 The outbound endpoints now support a `RabbitTemplate` configured with a `ContentTypeDelegatingMessageConverter` such
 that the converter can be chosen based on the message content type.
 See <<content-type-conversion-outbound>> for more information.
+
+==== Redis Changes
+
+Previously, the queue channel adapters always used the Redis List in a fixed direction, pushing to the left end and reading from the right end.
+It is now possible to configure the reading and writing direction.
+See <<redis-queue-inbound-channel-adapter>> and <<redis-queue-outbound-channel-adapter>> for more information.


### PR DESCRIPTION
…BLPOP instead of BRPOP

Also supported in the namespace as attribute `read-from-left`.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
