### PR TITLE
INT-3816: Superclass mapping for EMExcTypeRouter

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.support.management.MappingMessageRouterManagement;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedOperation;
@@ -52,7 +51,7 @@ import org.springframework.util.StringUtils;
  */
 public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter implements MappingMessageRouterManagement {
 
-	private volatile Map<String, String> channelMappings = new ConcurrentHashMap<String, String>();
+	protected final Map<String, String> channelMappings = new ConcurrentHashMap<String, String>();
 
 	private volatile String prefix;
 
@@ -173,11 +172,13 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 	}
 
 	private void doSetChannelMappings(Map<String, String> newChannelMappings) {
-		Map<String, String> oldChannelMappings = this.channelMappings;
-		this.channelMappings = newChannelMappings;
+		Map<String, String> oldChannelMappings = new HashMap<String, String>(this.channelMappings);
+		synchronized (this.channelMappings) {
+			this.channelMappings.clear();
+			this.channelMappings.putAll(newChannelMappings);
+		}
 		if (logger.isDebugEnabled()) {
-			logger.debug("Channel mappings:" + oldChannelMappings
-					+ " replaced with:" + newChannelMappings);
+			logger.debug("Channel mappings: " + oldChannelMappings + " replaced with: " + newChannelMappings);
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
@@ -19,7 +19,6 @@ package org.springframework.integration.router;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +50,7 @@ import org.springframework.util.StringUtils;
  */
 public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter implements MappingMessageRouterManagement {
 
-	protected final Map<String, String> channelMappings = new ConcurrentHashMap<String, String>();
+	protected volatile Map<String, String> channelMappings = new ConcurrentHashMap<String, String>();
 
 	private volatile String prefix;
 
@@ -107,7 +106,7 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 	@Override
 	@ManagedAttribute
 	public Map<String, String> getChannelMappings() {
-		return Collections.unmodifiableMap(this.channelMappings);
+		return new HashMap<String, String>(this.channelMappings);
 	}
 
 	/**
@@ -172,11 +171,8 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 	}
 
 	private void doSetChannelMappings(Map<String, String> newChannelMappings) {
-		Map<String, String> oldChannelMappings = new HashMap<String, String>(this.channelMappings);
-		synchronized (this.channelMappings) {
-			this.channelMappings.clear();
-			this.channelMappings.putAll(newChannelMappings);
-		}
+		Map<String, String> oldChannelMappings = this.channelMappings;
+		this.channelMappings = newChannelMappings;
 		if (logger.isDebugEnabled()) {
 			logger.debug("Channel mappings: " + oldChannelMappings + " replaced with: " + newChannelMappings);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
@@ -68,9 +68,8 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 	@ManagedAttribute
 	public void setChannelMappings(Map<String, String> channelMappings) {
 		Assert.notNull(channelMappings, "'channelMappings' must not be null");
-		Map<String, String> newChannelMappings = new ConcurrentHashMap<String, String>();
-		newChannelMappings.putAll(channelMappings);
-		this.doSetChannelMappings(newChannelMappings);
+		Map<String, String> newChannelMappings = new ConcurrentHashMap<String, String>(channelMappings);
+		doSetChannelMappings(newChannelMappings);
 	}
 
 	/**
@@ -117,7 +116,9 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 	@Override
 	@ManagedOperation
 	public void setChannelMapping(String key, String channelName) {
-		this.channelMappings.put(key, channelName);
+		Map<String, String> newChannelMappings = new ConcurrentHashMap<String, String>(this.channelMappings);
+		newChannelMappings.put(key, channelName);
+		this.channelMappings = newChannelMappings;
 	}
 
 	/**
@@ -127,7 +128,9 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 	@Override
 	@ManagedOperation
 	public void removeChannelMapping(String key) {
-		this.channelMappings.remove(key);
+		Map<String, String> newChannelMappings = new ConcurrentHashMap<String, String>(this.channelMappings);
+		newChannelMappings.remove(key);
+		this.channelMappings = newChannelMappings;
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
@@ -57,7 +57,6 @@ public class ErrorMessageExceptionTypeRouter extends AbstractMappingMessageRoute
 	}
 
 	private void populateClassNameMapping(Set<String> classNames) {
-		Map<String, Class<?>> newMappings = new ConcurrentHashMap<String, Class<?>>();
 		synchronized (this.classNameMappings) {
 			this.classNameMappings.clear();
 			for (String className : classNames) {
@@ -93,13 +92,13 @@ public class ErrorMessageExceptionTypeRouter extends AbstractMappingMessageRoute
 	@ManagedOperation
 	public void replaceChannelMappings(Properties channelMappings) {
 		super.replaceChannelMappings(channelMappings);
-		populateClassNameMapping(getChannelMappings().keySet());
+		populateClassNameMapping(this.channelMappings.keySet());
 	}
 
 	@Override
 	protected void onInit() throws Exception {
 		super.onInit();
-		populateClassNameMapping(getChannelMappings().keySet());
+		populateClassNameMapping(this.channelMappings.keySet());
 		this.initialized = true;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
@@ -77,14 +77,18 @@ public class ErrorMessageExceptionTypeRouter extends AbstractMappingMessageRoute
 	@ManagedOperation
 	public void setChannelMapping(String key, String channelName) {
 		super.setChannelMapping(key, channelName);
-		this.classNameMappings.put(key, resolveClassFromName(key));
+		Map<String, Class<?>> newClassNameMappings = new ConcurrentHashMap<String, Class<?>>(this.classNameMappings);
+		newClassNameMappings.put(key, resolveClassFromName(key));
+		this.classNameMappings = newClassNameMappings;
 	}
 
 	@Override
 	@ManagedOperation
 	public void removeChannelMapping(String key) {
 		super.removeChannelMapping(key);
-		this.classNameMappings.remove(key);
+		Map<String, Class<?>> newClassNameMappings = new ConcurrentHashMap<String, Class<?>>(this.classNameMappings);
+		newClassNameMappings.remove(key);
+		this.classNameMappings = newClassNameMappings;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class PayloadTypeRouter extends AbstractMappingMessageRouter {
 	 */
 	@Override
 	protected List<Object> getChannelKeys(Message<?> message) {
-		if (CollectionUtils.isEmpty(this.getChannelMappings())) {
+		if (CollectionUtils.isEmpty(this.channelMappings)) {
 			return null;
 		}
 		Class<?> type = message.getPayload().getClass();
@@ -63,32 +63,35 @@ public class PayloadTypeRouter extends AbstractMappingMessageRouter {
 	private String findClosestMatch(Class<?> type, boolean isArray) {
 		int minTypeDiffWeight = Integer.MAX_VALUE;
 		List<String> matches = new ArrayList<String>();
-		for (String candidate : this.getChannelMappings().keySet()) {
-			if (isArray) {
-				if (!candidate.endsWith(ARRAY_SUFFIX)) {
+		synchronized (this.channelMappings) {
+			for (String candidate : this.channelMappings.keySet()) {
+				if (isArray) {
+					if (!candidate.endsWith(ARRAY_SUFFIX)) {
+						continue;
+					}
+					// trim the suffix
+					candidate = candidate.substring(0, candidate.length() - ARRAY_SUFFIX.length());
+				}
+				else if (candidate.endsWith(ARRAY_SUFFIX)) {
 					continue;
 				}
-				// trim the suffix
-				candidate = candidate.substring(0, candidate.length() - ARRAY_SUFFIX.length());
-			}
-			else if (candidate.endsWith(ARRAY_SUFFIX)) {
-				continue;
-			}
-			int typeDiffWeight = determineTypeDifferenceWeight(candidate, type, 0);
-			if (typeDiffWeight < minTypeDiffWeight) {
-				minTypeDiffWeight = typeDiffWeight;
-				// new winner, start accumulating matches from scratch
-				matches.clear();
-				matches.add((isArray) ? candidate + ARRAY_SUFFIX : candidate);
-			}
-			else if (typeDiffWeight == minTypeDiffWeight && typeDiffWeight != Integer.MAX_VALUE) {
-				// candidate tied with current winner, keep track
-				matches.add(candidate);
+				int typeDiffWeight = determineTypeDifferenceWeight(candidate, type, 0);
+				if (typeDiffWeight < minTypeDiffWeight) {
+					minTypeDiffWeight = typeDiffWeight;
+					// new winner, start accumulating matches from scratch
+					matches.clear();
+					matches.add((isArray) ? candidate + ARRAY_SUFFIX : candidate);
+				}
+				else if (typeDiffWeight == minTypeDiffWeight && typeDiffWeight != Integer.MAX_VALUE) {
+					// candidate tied with current winner, keep track
+					matches.add(candidate);
+				}
 			}
 		}
 		if (matches.size() > 1) { // ambiguity
 			throw new IllegalStateException(
-					"Unresolvable ambiguity while attempting to find closest match for [" + type.getName() + "]. Found: " + matches);
+					"Unresolvable ambiguity while attempting to find closest match for [" + type.getName() + "]. " +
+							"Found: " + matches);
 		}
 		if (CollectionUtils.isEmpty(matches)) { // no match
 			return null;

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
@@ -63,29 +63,27 @@ public class PayloadTypeRouter extends AbstractMappingMessageRouter {
 	private String findClosestMatch(Class<?> type, boolean isArray) {
 		int minTypeDiffWeight = Integer.MAX_VALUE;
 		List<String> matches = new ArrayList<String>();
-		synchronized (this.channelMappings) {
-			for (String candidate : this.channelMappings.keySet()) {
-				if (isArray) {
-					if (!candidate.endsWith(ARRAY_SUFFIX)) {
-						continue;
-					}
-					// trim the suffix
-					candidate = candidate.substring(0, candidate.length() - ARRAY_SUFFIX.length());
-				}
-				else if (candidate.endsWith(ARRAY_SUFFIX)) {
+		for (String candidate : this.channelMappings.keySet()) {
+			if (isArray) {
+				if (!candidate.endsWith(ARRAY_SUFFIX)) {
 					continue;
 				}
-				int typeDiffWeight = determineTypeDifferenceWeight(candidate, type, 0);
-				if (typeDiffWeight < minTypeDiffWeight) {
-					minTypeDiffWeight = typeDiffWeight;
-					// new winner, start accumulating matches from scratch
-					matches.clear();
-					matches.add((isArray) ? candidate + ARRAY_SUFFIX : candidate);
-				}
-				else if (typeDiffWeight == minTypeDiffWeight && typeDiffWeight != Integer.MAX_VALUE) {
-					// candidate tied with current winner, keep track
-					matches.add(candidate);
-				}
+				// trim the suffix
+				candidate = candidate.substring(0, candidate.length() - ARRAY_SUFFIX.length());
+			}
+			else if (candidate.endsWith(ARRAY_SUFFIX)) {
+				continue;
+			}
+			int typeDiffWeight = determineTypeDifferenceWeight(candidate, type, 0);
+			if (typeDiffWeight < minTypeDiffWeight) {
+				minTypeDiffWeight = typeDiffWeight;
+				// new winner, start accumulating matches from scratch
+				matches.clear();
+				matches.add((isArray) ? candidate + ARRAY_SUFFIX : candidate);
+			}
+			else if (typeDiffWeight == minTypeDiffWeight && typeDiffWeight != Integer.MAX_VALUE) {
+				// candidate tied with current winner, keep track
+				matches.add(candidate);
 			}
 		}
 		if (matches.size() > 1) { // ambiguity

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouterTests.java
@@ -236,4 +236,19 @@ public class ErrorMessageExceptionTypeRouterTests {
 		assertNull(defaultChannel.receive(0));
 	}
 
+	@Test
+	public void testInvalidMapping() {
+		ErrorMessageExceptionTypeRouter router = new ErrorMessageExceptionTypeRouter();
+		router.setBeanFactory(beanFactory);
+		router.setApplicationContext(TestUtils.createTestApplicationContext());
+		try {
+			router.setChannelMapping("foo", "fooChannel");
+			fail("IllegalStateException expected");
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(IllegalStateException.class));
+			assertThat(e.getCause(), instanceOf(ClassNotFoundException.class));
+		}
+	}
+
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouterTests.java
@@ -23,9 +23,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -76,13 +73,11 @@ public class ErrorMessageExceptionTypeRouterTests {
 		MessageHandlingException error = new MessageHandlingException(failedMessage, "failed", middleCause);
 		ErrorMessage message = new ErrorMessage(error);
 		ErrorMessageExceptionTypeRouter router = new ErrorMessageExceptionTypeRouter();
-		Map<String, String> exceptionTypeChannelMap = new HashMap<String, String>();
-		exceptionTypeChannelMap.put(IllegalArgumentException.class.getName(), "illegalArgumentChannel");
-		exceptionTypeChannelMap.put(RuntimeException.class.getName(), "runtimeExceptionChannel");
-		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
-		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		router.setApplicationContext(TestUtils.createTestApplicationContext());
+		router.setChannelMapping(IllegalArgumentException.class.getName(), "illegalArgumentChannel");
+		router.setChannelMapping(RuntimeException.class.getName(), "runtimeExceptionChannel");
+		router.setChannelMapping(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
 		router.setDefaultOutputChannel(defaultChannel);
 
 		router.handleMessage(message);
@@ -101,12 +96,10 @@ public class ErrorMessageExceptionTypeRouterTests {
 		MessageHandlingException error = new MessageHandlingException(failedMessage, "failed", middleCause);
 		ErrorMessage message = new ErrorMessage(error);
 		ErrorMessageExceptionTypeRouter router = new ErrorMessageExceptionTypeRouter();
-		Map<String, String> exceptionTypeChannelMap = new HashMap<String, String>();
-		exceptionTypeChannelMap.put(RuntimeException.class.getName(), "runtimeExceptionChannel");
-		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "runtimeExceptionChannel");
-		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		router.setApplicationContext(TestUtils.createTestApplicationContext());
+		router.setChannelMapping(RuntimeException.class.getName(), "runtimeExceptionChannel");
+		router.setChannelMapping(MessageHandlingException.class.getName(), "runtimeExceptionChannel");
 		router.setDefaultOutputChannel(defaultChannel);
 
 		router.handleMessage(message);
@@ -125,11 +118,9 @@ public class ErrorMessageExceptionTypeRouterTests {
 		MessageHandlingException error = new MessageHandlingException(failedMessage, "failed", middleCause);
 		ErrorMessage message = new ErrorMessage(error);
 		ErrorMessageExceptionTypeRouter router = new ErrorMessageExceptionTypeRouter();
-		Map<String, String> exceptionTypeChannelMap = new HashMap<String, String>();
-		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
-		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		router.setApplicationContext(TestUtils.createTestApplicationContext());
+		router.setChannelMapping(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
 		router.setDefaultOutputChannel(defaultChannel);
 
 		router.handleMessage(message);
@@ -148,8 +139,8 @@ public class ErrorMessageExceptionTypeRouterTests {
 		MessageHandlingException error = new MessageHandlingException(failedMessage, "failed", middleCause);
 		ErrorMessage message = new ErrorMessage(error);
 		ErrorMessageExceptionTypeRouter router = new ErrorMessageExceptionTypeRouter();
-		router.setDefaultOutputChannel(defaultChannel);
 		router.setApplicationContext(TestUtils.createTestApplicationContext());
+		router.setDefaultOutputChannel(defaultChannel);
 
 		router.handleMessage(message);
 
@@ -167,11 +158,9 @@ public class ErrorMessageExceptionTypeRouterTests {
 		MessageHandlingException error = new MessageHandlingException(failedMessage, "failed", middleCause);
 		ErrorMessage message = new ErrorMessage(error);
 		ErrorMessageExceptionTypeRouter router = new ErrorMessageExceptionTypeRouter();
-		Map<String, String> exceptionTypeChannelMap = new HashMap<String, String>();
-		exceptionTypeChannelMap.put(MessageDeliveryException.class.getName(), "messageDeliveryExceptionChannel");
-		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		router.setApplicationContext(TestUtils.createTestApplicationContext());
+		router.setChannelMapping(MessageDeliveryException.class.getName(), "messageDeliveryExceptionChannel");
 		router.setResolutionRequired(true);
 		router.setBeanName("fooRouter");
 
@@ -193,13 +182,11 @@ public class ErrorMessageExceptionTypeRouterTests {
 		MessageHandlingException error = new MessageHandlingException(failedMessage, "failed", middleCause);
 		Message<?> message = new GenericMessage<Exception>(error);
 		ErrorMessageExceptionTypeRouter router = new ErrorMessageExceptionTypeRouter();
-		Map<String, String> exceptionTypeChannelMap = new HashMap<String, String>();
-		exceptionTypeChannelMap.put(IllegalArgumentException.class.getName(), "illegalArgumentChannel");
-		exceptionTypeChannelMap.put(RuntimeException.class.getName(), "runtimeExceptionChannel");
-		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
-		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		router.setApplicationContext(TestUtils.createTestApplicationContext());
+		router.setChannelMapping(IllegalArgumentException.class.getName(), "illegalArgumentChannel");
+		router.setChannelMapping(RuntimeException.class.getName(), "runtimeExceptionChannel");
+		router.setChannelMapping(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
 		router.setDefaultOutputChannel(defaultChannel);
 
 		router.handleMessage(message);
@@ -218,12 +205,10 @@ public class ErrorMessageExceptionTypeRouterTests {
 		MessageHandlingException error = new MessageHandlingException(failedMessage, "failed", middleCause);
 		ErrorMessage message = new ErrorMessage(error);
 		ErrorMessageExceptionTypeRouter router = new ErrorMessageExceptionTypeRouter();
-		Map<String, String> exceptionTypeChannelMap = new HashMap<String, String>();
-		exceptionTypeChannelMap.put(IllegalArgumentException.class.getName(), "illegalArgumentChannel");
-		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
-		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		router.setApplicationContext(TestUtils.createTestApplicationContext());
+		router.setChannelMapping(IllegalArgumentException.class.getName(), "illegalArgumentChannel");
+		router.setChannelMapping(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
 		router.setDefaultOutputChannel(defaultChannel);
 
 		router.handleMessage(message);
@@ -240,11 +225,9 @@ public class ErrorMessageExceptionTypeRouterTests {
 		MessageHandlingException error = new MessageRejectedException(new GenericMessage<Object>("foo"), "failed", rootCause);
 		ErrorMessage message = new ErrorMessage(error);
 		ErrorMessageExceptionTypeRouter router = new ErrorMessageExceptionTypeRouter();
-		Map<String, String> exceptionTypeChannelMap = new HashMap<String, String>();
-		exceptionTypeChannelMap.put(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
-		router.setChannelMappings(exceptionTypeChannelMap);
 		router.setBeanFactory(beanFactory);
 		router.setApplicationContext(TestUtils.createTestApplicationContext());
+		router.setChannelMapping(MessageHandlingException.class.getName(), "messageHandlingExceptionChannel");
 		router.setDefaultOutputChannel(defaultChannel);
 
 		router.handleMessage(message);

--- a/src/reference/asciidoc/router.adoc
+++ b/src/reference/asciidoc/router.adoc
@@ -963,6 +963,9 @@ The only difference is that while `PayloadTypeRouter` navigates the instance hie
 the `ErrorMessageExceptionTypeRouter` navigates the hierarchy of 'exception causes' (e.g., `payload.getCause()`)
 to find the most specific `Throwable` type/channel mappings and uses `mappingClass.isInstance(cause)` to match the `cause` to its supper class.
 
+NOTE: Since _version 4.3_ the `ErrorMessageExceptionTypeRouter` loads all mapping classes during the initialization
+phase to fail-fast for the `ClassNotFoundException`.
+
 Below is a sample configuration for `ErrorMessageExceptionTypeRouter`.
 
 [source,xml]

--- a/src/reference/asciidoc/router.adoc
+++ b/src/reference/asciidoc/router.adoc
@@ -959,7 +959,9 @@ As such, please read chapter _<<xml-xpath-routing>>_
 Spring Integration also provides a special type-based router called `ErrorMessageExceptionTypeRouter` for routing Error Messages (Messages whose `payload` is a `Throwable` instance).
 `ErrorMessageExceptionTypeRouter` is very similar to the `PayloadTypeRouter`.
 In fact they are almost identical.
-The only difference is that while `PayloadTypeRouter` navigates the instance hierarchy of a payload instance (e.g., `payload.getClass().getSuperclass()`) to find the most specific type/channel mappings, the `ErrorMessageExceptionTypeRouter` navigates the hierarchy of 'exception causes' (e.g., `payload.getCause()`) to find the most specific `Throwable` type/channel mappings.
+The only difference is that while `PayloadTypeRouter` navigates the instance hierarchy of a payload instance (e.g., `payload.getClass().getSuperclass()`) to find the most specific type/channel mappings,
+the `ErrorMessageExceptionTypeRouter` navigates the hierarchy of 'exception causes' (e.g., `payload.getCause()`)
+to find the most specific `Throwable` type/channel mappings and uses `mappingClass.isInstance(cause)` to match the `cause` to its supper class.
 
 Below is a sample configuration for `ErrorMessageExceptionTypeRouter`.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -97,3 +97,12 @@ See <<http-inbound>> for more information.
 
 A new factory bean is provided to simplify the configuration of Jsch proxies for SFTP.
 See <<sftp-proxy-factory-bean>> for more information.
+
+==== Routers Changes
+
+The `ErrorMessageExceptionTypeRouter` supports now the `Exception` superclass mappings to avoid duplication
+for the same channel in case of several inheritors.
+For this purpose the `ErrorMessageExceptionTypeRouter` loads mapping classes during initialization to fail-fast
+for the `ClassNotFoundException`.
+
+See <<router>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3816

Add `cause` `supperclass` mapping ability to the `ErrorMessageExceptionTypeRouter`
