### PR TITLE
INT-3932: Redis: add `rightPop` and `leftPush` backport

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisQueueOutboundChannelAdapter.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisQueueOutboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors
+ * Copyright 2013-2016 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Rainer Frey
  * @since 3.0
  */
 public class RedisQueueOutboundChannelAdapter extends AbstractMessageHandler {
@@ -50,6 +51,8 @@ public class RedisQueueOutboundChannelAdapter extends AbstractMessageHandler {
 	private volatile RedisSerializer<?> serializer = new JdkSerializationRedisSerializer();
 
 	private volatile boolean serializerExplicitlySet;
+
+	private volatile boolean leftPush = true;
 
 	public RedisQueueOutboundChannelAdapter(String queueName, RedisConnectionFactory connectionFactory) {
 		this(new LiteralExpression(queueName), connectionFactory);
@@ -75,6 +78,15 @@ public class RedisQueueOutboundChannelAdapter extends AbstractMessageHandler {
 		Assert.notNull(serializer, "'serializer' must not be null");
 		this.serializer = serializer;
 		this.serializerExplicitlySet = true;
+	}
+
+	/**
+	 * Specify if {@code PUSH} operation to Redis List should be {@code LPUSH} or {@code RPUSH}.
+	 * @param leftPush the {@code LPUSH} flag. Defaults to {@code true}.
+	 * @since 4.2.5
+	 */
+	public void setLeftPush(boolean leftPush) {
+		this.leftPush = leftPush;
 	}
 
 	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
@@ -113,7 +125,12 @@ public class RedisQueueOutboundChannelAdapter extends AbstractMessageHandler {
 		}
 
 		String queueName = this.queueNameExpression.getValue(this.evaluationContext, message, String.class);
-		this.template.boundListOps(queueName).leftPush(value);
+		if (this.leftPush) {
+			this.template.boundListOps(queueName).leftPush(value);
+		}
+		else {
+			this.template.boundListOps(queueName).rightPush(value);
+		}
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3932

Backport to 4.2.x branch.
As discussed in #1685 setters and logic only, no namespace changes, no tests and no docs
