### PR TITLE
INT-3898: Fix `<xsd:all>` usage

### DIFF
--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration-4.3.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration-4.3.xsd
@@ -4239,8 +4239,8 @@ unless bean with this name is already registered.
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
-			<xsd:all minOccurs="0" maxOccurs="1">
-				<xsd:element ref="beans:bean" />
+			<xsd:all>
+				<xsd:element ref="beans:bean" minOccurs="0" maxOccurs="1"/>
 			</xsd:all>
 			<xsd:attribute name="ref" type="xsd:string" use="optional">
 				<xsd:annotation>
@@ -4285,7 +4285,7 @@ The list of component name patterns you want to track (e.g.,  tracked-components
 		<xsd:complexType>
 			<xsd:complexContent>
 				<xsd:extension base="control-bus-type">
-					<xsd:all minOccurs="0" maxOccurs="1">
+					<xsd:all>
 						<xsd:element name="poller" type="basePollerType" minOccurs="0" maxOccurs="1" />
 					</xsd:all>
 					<xsd:attributeGroup ref="inputOutputChannelGroup" />

--- a/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-4.3.xsd
+++ b/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-4.3.xsd
@@ -140,6 +140,7 @@
 			<xsd:complexContent>
 				<xsd:extension base="adapterType">
 					<xsd:all>
+						<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1" />
 						<xsd:element name="request-handler-advice-chain" type="integration:handlerAdviceChainType" minOccurs="0" maxOccurs="1" />
 					</xsd:all>
 					<xsd:attribute name="default-notification-type" type="xsd:string" use="optional" />
@@ -156,7 +157,7 @@
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:complexContent>
-				<xsd:extension base="mbeanServerIdentifyerType">
+				<xsd:extension base="mbeanServerIdentifierType">
 					<xsd:attribute name="default-domain" use="optional">
 						<xsd:annotation>
 							<xsd:documentation>
@@ -215,7 +216,7 @@
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="mbeanServerIdentifyerType">
+			<xsd:extension base="mbeanServerIdentifierType">
 				<xsd:attribute name="channel" type="xsd:string" />
 				<xsd:attribute name="query-name" type="xsd:string" use="optional">
 					<xsd:annotation>
@@ -283,7 +284,7 @@
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="mbeanServerIdentifyerType">
+			<xsd:extension base="mbeanServerIdentifierType">
 				<xsd:attribute name="channel" type="xsd:string" />
 				<xsd:attribute name="object-name" type="xsd:string" use="required" />
 				<xsd:attributeGroup ref="integration:smartLifeCycleAttributeGroup"/>
@@ -298,14 +299,14 @@
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="mbeanServerIdentifyerType">
+			<xsd:extension base="mbeanServerIdentifierType">
 				<xsd:attribute name="object-name" type="xsd:string" use="required" />
 				<xsd:attribute name="operation-name" type="xsd:string" use="required" />
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 
-	<xsd:complexType name="mbeanServerIdentifyerType">
+	<xsd:complexType name="mbeanServerIdentifierType">
 		<xsd:attribute name="id" type="xsd:string" use="optional" />
 		<xsd:attribute name="server" type="xsd:string" default="mbeanServer">
 			<xsd:annotation>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3898

Some XML validator like `xercesImpl` doesn't allow `minOccurs` and `maxOccurs` on the `<xsd:all`.
- Remove them in favor of `minOccurs`/`maxOccurs` on the nested elements.
- Add `<poller>` for the `<int-jmx:notification-publishing-channel-adapter>`
