### PR TITLE
INT-3917: Gemfire tests polishing

### DIFF
--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireCqInboundChannelAdapterParserTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireCqInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.integration.gemfire.inbound.ContinuousQueryMessageProducer;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -34,6 +35,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
+@DirtiesContext
 public class GemfireCqInboundChannelAdapterParserTests {
 
 	private GemfireCqInboundChannelAdapterParser underTest = new GemfireCqInboundChannelAdapterParser();

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireInboundChannelAdapterParserTests-context.xml
@@ -1,21 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:gfe="http://www.springframework.org/schema/gemfire"
 	   xmlns:int-gfe="http://www.springframework.org/schema/integration/gemfire"
 	   xsi:schemaLocation="http://www.springframework.org/schema/integration/gemfire
 		http://www.springframework.org/schema/integration/gemfire/spring-integration-gemfire.xsd
-		http://www.springframework.org/schema/gemfire
-		http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
 		http://www.springframework.org/schema/beans
 		http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<gfe:cache id="gemfire-cache-2"/>
-
-	<gfe:replicated-region id="region1" cache-ref="gemfire-cache-2"/>
+	<bean id="region" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="com.gemstone.gemfire.cache.Region"/>
+	</bean>
 
 	<int-gfe:inbound-channel-adapter id="channel1"
-									 region="region1"
+									 region="region"
 									 cache-events="CREATED"
 									 expression="newValue"
 									 auto-startup="false"

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireInboundChannelAdapterParserTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.integration.gemfire.inbound.CacheListeningMessageProducer;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -34,6 +35,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
+@DirtiesContext
 public class GemfireInboundChannelAdapterParserTests {
 
 	private GemfireInboundChannelAdapterParser underTest = new GemfireInboundChannelAdapterParser();
@@ -58,4 +60,5 @@ public class GemfireInboundChannelAdapterParserTests {
 	public void testAutoStart() {
 		assertEquals(false, adapter1.isAutoStartup());
 	}
+
 }

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/config/xml/GemfireOutboundChannelAdapterParserTests-context.xml
@@ -24,4 +24,5 @@
 	<bean id="region" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="com.gemstone.gemfire.cache.Region"/>
 	</bean>
+
 </beans>

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/inbound/CqInboundChannelAdapterTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/inbound/CqInboundChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -32,6 +32,7 @@ import org.springframework.integration.gemfire.fork.ForkUtil;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -41,12 +42,13 @@ import com.gemstone.gemfire.internal.cache.LocalRegion;
 /**
  * @author David Turanski
  * @author Gary Russell
+ * @author Artem Bilan
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
+@DirtiesContext
 public class CqInboundChannelAdapterTests {
-	static ConfigurableApplicationContext staticCtx;
 
 	@Autowired
 	LocalRegion region;
@@ -64,20 +66,15 @@ public class CqInboundChannelAdapterTests {
 	ContinuousQueryMessageProducer withDurable;
 
 	static OutputStream os;
+
 	@BeforeClass
 	public static void startUp() throws Exception {
 		os = ForkUtil.cacheServer();
 	}
 
-
-	@Before
-	public void setUp() {
-		staticCtx = applicationContext;
-		assertTrue(TestUtils.getPropertyValue(withDurable, "durable", Boolean.class));
-	}
-
 	@Test
 	public void testCqEvent()  throws InterruptedException {
+		assertTrue(TestUtils.getPropertyValue(withDurable, "durable", Boolean.class));
 		region.put("one",1);
 		Message<?> msg = outputChannel1.receive(10000);
 		assertNotNull(msg);
@@ -94,10 +91,6 @@ public class CqInboundChannelAdapterTests {
 
 	@AfterClass
 	public static void cleanUp()  {
-		/*
-		 * Avoid shutdown errors
-		 */
-		staticCtx.close();
 		sendSignal();
 	}
 

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/inbound/GemfireInboundChannelAdapterTests-context.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/inbound/GemfireInboundChannelAdapterTests-context.xml
@@ -11,11 +11,12 @@
 		http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<gfe:cache id="gemfire-cache-2"/>
-	<gfe:replicated-region id="region1" cache-ref="gemfire-cache-2"/>
 
-	<gfe:replicated-region id="region2" cache-ref="gemfire-cache-2"/>
+	<gfe:local-region id="region1" cache-ref="gemfire-cache-2"/>
 
-	<gfe:replicated-region id="region3" cache-ref="gemfire-cache-2"/>
+	<gfe:local-region id="region2" cache-ref="gemfire-cache-2"/>
+
+	<gfe:local-region id="region3" cache-ref="gemfire-cache-2"/>
 
 	<int-gfe:inbound-channel-adapter id="channel1" region="region1" cache-events="CREATED" expression="newValue"/>
 

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/inbound/GemfireInboundChannelAdapterTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/inbound/GemfireInboundChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -30,6 +30,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.gemstone.gemfire.cache.EntryEvent;
 import com.gemstone.gemfire.internal.cache.DistributedRegion;
+import com.gemstone.gemfire.internal.cache.LocalRegion;
 
 /**
  * @author David Turanski
@@ -53,13 +54,13 @@ public class GemfireInboundChannelAdapterTests {
 	SubscribableChannel errorChannel;
 
 	@Autowired
-	DistributedRegion region1;
+	LocalRegion region1;
 
 	@Autowired
-	DistributedRegion region2;
+	LocalRegion region2;
 
 	@Autowired
-	DistributedRegion region3;
+	LocalRegion region3;
 
 	@Test
 	public void testGemfireInboundChannelAdapterWithExpression() {

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.springframework.data.gemfire.GemfireTemplate;
-import org.springframework.integration.gemfire.metadata.GemfireMetadataStore;
 import org.springframework.integration.metadata.ConcurrentMetadataStore;
 import org.springframework.util.Assert;
 
@@ -53,8 +52,10 @@ public class GemfireMetadataStoreTests {
 
 	@AfterClass
 	public static void cleanUp() {
-		cache.close();
-		Assert.isTrue(cache.isClosed(), "Cache did not close after close() call");
+		if (cache != null) {
+			cache.close();
+			Assert.isTrue(cache.isClosed(), "Cache did not close after close() call");
+		}
 	}
 
 	@Before

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/outbound/CacheWritingMessageHandlerTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/outbound/CacheWritingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ public class CacheWritingMessageHandlerTests {
 		handler.handleMessage(message);
 		assertEquals(1, region.size());
 		assertEquals("bar", region.get("foo"));
+		cache.close();
 	}
 
 	@Test
@@ -105,6 +106,7 @@ public class CacheWritingMessageHandlerTests {
 		handler.handleMessage(new GenericMessage<String>("test"));
 		assertEquals(3, region.size());
 		assertEquals(10L, region.get("baz"));
+		cache.close();
 	}
 
 }

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/outbound/GemfireOutboundChannelAdapterTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/outbound/GemfireOutboundChannelAdapterTests.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2012 the original author or authors.
- * 
+ * Copyright 2002-2016 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -20,10 +20,12 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -37,17 +39,18 @@ import com.gemstone.gemfire.internal.cache.DistributedRegion;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
+@DirtiesContext
 public class GemfireOutboundChannelAdapterTests {
-	
+
 	@Autowired
 	MessageChannel cacheChannel1;
 
 	@Autowired
 	DistributedRegion region1;
-	
+
 	@Autowired
 	MessageChannel cacheChannel2;
-	
+
 	@Autowired
 	DistributedRegion region2;
 
@@ -60,36 +63,36 @@ public class GemfireOutboundChannelAdapterTests {
 		region1.clear();
 		region2.clear();
 	}
-	
+
 	@Test
 	public void testWriteMapPayload() {
-		Map<String,String> map = new HashMap<String,String>();
-		map.put("foo","bar");
-		
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("foo", "bar");
+
 		Message<?> message = MessageBuilder.withPayload(map).build();
 		cacheChannel1.send(message);
-		assertEquals(1,region1.size());
-		assertEquals("bar",region1.get("foo"));	
+		assertEquals(1, region1.size());
+		assertEquals("bar", region1.get("foo"));
 	}
-	
+
 	@Test
 	public void testWriteExpressions() {
 		Message<?> message = MessageBuilder.withPayload("Hello").build();
 		cacheChannel2.send(message);
-		assertEquals(2,region2.size());
-		assertEquals("hello",region2.get("HELLO"));	
-		assertEquals("bar",region2.get("foo"));	
+		assertEquals(2, region2.size());
+		assertEquals("hello", region2.get("HELLO"));
+		assertEquals("bar", region2.get("foo"));
 	}
 
 	@Test //INT-2275
 	public void testWriteWithinChain() {
-		Map<String,String> map = new HashMap<String,String>();
-		map.put("foo","bar");
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("foo", "bar");
 
 		Message<?> message = MessageBuilder.withPayload(map).build();
 		cacheChainChannel.send(message);
-		assertEquals(1,region1.size());
-		assertEquals("bar",region1.get("foo"));
+		assertEquals(1, region1.size());
+		assertEquals("bar", region1.get("foo"));
 	}
 
 }

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/DelayerHandlerRescheduleIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -66,8 +66,10 @@ public class DelayerHandlerRescheduleIntegrationTests {
 
 	@AfterClass
 	public static void cleanUp() {
-		cache.close();
-		Assert.isTrue(cache.isClosed(), "Cache did not close after close() call");
+		if (cache != null) {
+			cache.close();
+			Assert.isTrue(cache.isClosed(), "Cache did not close after close() call");
+		}
 	}
 
 	@Test

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -67,7 +68,7 @@ public class GemfireGroupStoreTests {
 
 	private Region<Object, Object> region;
 
-//	@Rule
+	@Rule
 	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Test
@@ -383,8 +384,10 @@ public class GemfireGroupStoreTests {
 
 	@After
 	public void cleanup() {
-		this.cache.close();
-		Assert.isTrue(this.cache.isClosed(), "Cache did not close after close() call");
+		if (this.cache != null) {
+			this.cache.close();
+			Assert.isTrue(this.cache.isClosed(), "Cache did not close after close() call");
+		}
 	}
 
 }

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
@@ -129,8 +129,10 @@ public class GemfireMessageStoreTests {
 
 	@After
 	public void cleanup() {
-		this.cache.close();
-		Assert.isTrue(this.cache.isClosed(), "Cache did not close after close() call");
+		if (this.cache != null) {
+			this.cache.close();
+			Assert.isTrue(this.cache.isClosed(), "Cache did not close after close() call");
+		}
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3917
- Add `@DirtiesContext` to tests with application contexts
- Add `cache.close()`
- Add NPE check around `cache` in the `@After` methods
- Change a parser test to use mocks, not real Gemfire objects

**Cherry-pick to 4.2.x**
