### PR TITLE
INT-3950: Fix `Aggregator` documentation

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -26,6 +26,7 @@ import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.messaging.Message;
 
@@ -107,6 +108,7 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 	}
 
 	@Override
+	@ManagedOperation
 	public synchronized int expireMessageGroups(long timeout) {
 		int count = 0;
 		long threshold = System.currentTimeMillis() - timeout;

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.Iterator;
 
 import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.messaging.Message;
 
 /**
@@ -101,6 +102,7 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	 *
 	 * @see #registerMessageGroupExpiryCallback(MessageGroupCallback)
 	 */
+	@ManagedOperation
 	int expireMessageGroups(long timeout);
 
 	/**
@@ -145,7 +147,7 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	/**
 	 * Invoked when a MessageGroupStore expires a group.
 	 */
-	public interface MessageGroupCallback {
+	interface MessageGroupCallback {
 
 		void execute(MessageGroupStore messageGroupStore, MessageGroup group);
 

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration-4.3.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration-4.3.xsd
@@ -3739,7 +3739,7 @@
 						Specifies whether messages that expired should be aggregated and sent to the 'output-channel' or 'replyChannel'.
 						Messages are expired when their containing MessageGroup expires. One of the ways of expiring MessageGroups is by
 						configuring a MessageGroupStoreReaper. However MessageGroups can alternatively be expired by simply calling
-						MessageGroupStore.expireMessageGroup(groupId). That could be accomplished via a ControlBus operation
+						MessageGroupStore.expireMessageGroups(timeout). That could be accomplished via a ControlBus operation
 						or by simply invoking that method if you have a reference to the MessageGroupStore instance.
 						</xsd:documentation>
 					</xsd:annotation>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorWithMessageStoreParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorWithMessageStoreParserTests-context.xml
@@ -14,10 +14,12 @@
 
 	<aggregator id="aggregator" ref="aggregatorBean"
 		input-channel="input" output-channel="output" message-store="messageStore" send-partial-result-on-expiry="true"/>
-		
+
 	<beans:bean id="messageStore" class="org.springframework.integration.store.SimpleMessageStore"/>
 
 	<beans:bean id="aggregatorBean"
 		class="org.springframework.integration.config.TestAggregatorBean" />
+
+	<control-bus input-channel="controlBusChannel" output-channel="nullChannel"/>
 
 </beans:beans>

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
@@ -36,6 +36,7 @@ import org.springframework.integration.store.MessageGroupMetadata;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.MessageStore;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
@@ -289,6 +290,7 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 	}
 
 	@Override
+	@ManagedOperation
 	public int expireMessageGroups(long timeout) {
 		int count = 0;
 		long threshold = System.currentTimeMillis() - timeout;

--- a/src/reference/asciidoc/aggregator.adoc
+++ b/src/reference/asciidoc/aggregator.adoc
@@ -356,13 +356,13 @@ _Optional_, by default a volatile in-memory store.
 
 <8> Indicates that expired messages should be aggregated and sent to the 'output-channel' or 'replyChannel' once their containing `MessageGroup` is expired (see `MessageGroupStore.expireMessageGroups(long)`).
 One way of expiring `MessageGroup` s is by configuring a `MessageGroupStoreReaper`.
-However `MessageGroup` s can alternatively be expired by simply calling `MessageGroupStore.expireMessageGroup(groupId)`.
+However `MessageGroup` s can alternatively be expired by simply calling `MessageGroupStore.expireMessageGroups(timeout)`.
 That could be accomplished via a Control Bus operation or by simply invoking that method if you have a reference to the `MessageGroupStore` instance.
 Otherwise by itself this attribute has no behavior.
 It only serves as an indicator of what to do (discard or send to the output/reply channel) with Messages that are still in the `MessageGroup` that is about to be expired.
 _Optional_.
-_Default - 'false'_.
-*NOTE:* This attribute is more properly 'send-partial-result-on-timeout' because the group may not actually expire if
+_Default - false_.
+*NOTE:* This attribute is more properly `send-partial-result-on-timeout` because the group may not actually expire if
 `expire-groups-upon-timeout` is set to `false`.
 
 
@@ -381,8 +381,7 @@ _Optional_.
 <10> A reference to a bean that implements the message correlation (grouping) algorithm.
 The bean can be an implementation of the `CorrelationStrategy` interface or a POJO.
 In the latter case the correlation-strategy-method attribute must be defined as well.
-_Optional (by default, the aggregator will use
-        the `IntegrationMessageHeaderAccessor.CORRELATION_ID` header) _.
+_Optional (by default, the aggregator will use the `IntegrationMessageHeaderAccessor.CORRELATION_ID` header)_.
 
 
 

--- a/src/reference/asciidoc/resequencer.adoc
+++ b/src/reference/asciidoc/resequencer.adoc
@@ -96,8 +96,7 @@ _Optional_.
 <9> A reference to a bean that implements the message correlation (grouping) algorithm.
 The bean can be an implementation of the `CorrelationStrategy` interface or a POJO.
 In the latter case the correlation-strategy-method attribute must be defined as well.
-_Optional (by default, the aggregator will use
-          the `IntegrationMessageHeaderAccessor.CORRELATION_ID` header) _.
+_Optional (by default, the aggregator will use the `IntegrationMessageHeaderAccessor.CORRELATION_ID` header)_.
 
 
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3950

Previously there was a mention of the `MessageGroupStore.expireMessageGroup(groupId)` which just doesn't existing
in the Framework and never has been there.
- Fix the documentation for the existing `MessageGroupStore.expireMessageGroups(timeout)`.
  Although the mention there of `Control Bus` requires to have `@ManagedOperation` on the method.
- Add `@ManagedOperation` for the `MessageGroupStore.expireMessageGroups(timeout)` and confirm with the test-case: `AggregatorWithMessageStoreParserTests`
- Fix the same docs in the XSD for `<aggregator>`
- Fix other typos in the `aggregator.adoc` and `resequencer.adoc`
