### PR TITLE
INT-3919: FTP: allow `null` for remote directory

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileInboundChannelAdapterParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileInboundChannelAdapterParser.java
@@ -46,7 +46,7 @@ public abstract class AbstractRemoteFileInboundChannelAdapterParser extends Abst
 
 		// configure the InboundFileSynchronizer properties
 		BeanDefinition expressionDef = IntegrationNamespaceUtils.createExpressionDefinitionFromValueOrExpression(
-				"remote-directory", "remote-directory-expression", parserContext, element, true);
+				"remote-directory", "remote-directory-expression", parserContext, element, false);
 		synchronizerBuilder.addPropertyValue("remoteDirectoryExpression", expressionDef);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(synchronizerBuilder, element, "delete-remote-files");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(synchronizerBuilder, element, "preserve-timestamp");

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileInboundChannelAdapterParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.util.StringUtils;
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.0
  */
 public abstract class AbstractRemoteFileInboundChannelAdapterParser extends AbstractPollingInboundChannelAdapterParser {
@@ -47,7 +48,9 @@ public abstract class AbstractRemoteFileInboundChannelAdapterParser extends Abst
 		// configure the InboundFileSynchronizer properties
 		BeanDefinition expressionDef = IntegrationNamespaceUtils.createExpressionDefinitionFromValueOrExpression(
 				"remote-directory", "remote-directory-expression", parserContext, element, false);
-		synchronizerBuilder.addPropertyValue("remoteDirectoryExpression", expressionDef);
+		if (expressionDef != null) {
+			synchronizerBuilder.addPropertyValue("remoteDirectoryExpression", expressionDef);
+		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(synchronizerBuilder, element, "delete-remote-files");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(synchronizerBuilder, element, "preserve-timestamp");
 
@@ -57,7 +60,8 @@ public abstract class AbstractRemoteFileInboundChannelAdapterParser extends Abst
 		this.configureFilter(synchronizerBuilder, element, parserContext);
 
 		// build the MessageSource
-		BeanDefinitionBuilder messageSourceBuilder = BeanDefinitionBuilder.genericBeanDefinition(this.getMessageSourceClassname());
+		BeanDefinitionBuilder messageSourceBuilder =
+				BeanDefinitionBuilder.genericBeanDefinition(getMessageSourceClassname());
 		messageSourceBuilder.addConstructorArgValue(synchronizerBuilder.getBeanDefinition());
 		String comparator = element.getAttribute("comparator");
 		if (StringUtils.hasText(comparator)) {
@@ -65,17 +69,21 @@ public abstract class AbstractRemoteFileInboundChannelAdapterParser extends Abst
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(messageSourceBuilder, element, "local-filter");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(messageSourceBuilder, element, "local-directory");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(messageSourceBuilder, element, "auto-create-local-directory");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(messageSourceBuilder, element,
+				"auto-create-local-directory");
 		String localFileGeneratorExpression = element.getAttribute("local-filename-generator-expression");
 		if (StringUtils.hasText(localFileGeneratorExpression)) {
-			BeanDefinitionBuilder localFileGeneratorExpressionBuilder = BeanDefinitionBuilder.genericBeanDefinition(ExpressionFactoryBean.class);
+			BeanDefinitionBuilder localFileGeneratorExpressionBuilder =
+					BeanDefinitionBuilder.genericBeanDefinition(ExpressionFactoryBean.class);
 			localFileGeneratorExpressionBuilder.addConstructorArgValue(localFileGeneratorExpression);
-			synchronizerBuilder.addPropertyValue("localFilenameGeneratorExpression", localFileGeneratorExpressionBuilder.getBeanDefinition());
+			synchronizerBuilder.addPropertyValue("localFilenameGeneratorExpression",
+					localFileGeneratorExpressionBuilder.getBeanDefinition());
 		}
 		return messageSourceBuilder.getBeanDefinition();
 	}
 
-	private void configureFilter(BeanDefinitionBuilder synchronizerBuilder, Element element, ParserContext parserContext) {
+	private void configureFilter(BeanDefinitionBuilder synchronizerBuilder, Element element,
+	                             ParserContext parserContext) {
 		String filter = element.getAttribute("filter");
 		String fileNamePattern = element.getAttribute("filename-pattern");
 		String fileNameRegex = element.getAttribute("filename-regex");

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,9 @@ public abstract class AbstractRemoteFileOutboundGatewayParser extends AbstractCo
 		}
 		else {
 			builder.addConstructorArgValue(element.getAttribute("command"));
-			builder.addConstructorArgValue(element.getAttribute(EXPRESSION_ATTRIBUTE));
+			if (element.hasAttribute(EXPRESSION_ATTRIBUTE)) {
+				builder.addConstructorArgValue(element.getAttribute(EXPRESSION_ATTRIBUTE));
+			}
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "command-options", "options");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,6 +160,10 @@ public abstract class AbstractInboundFileSynchronizer<F>
 		this.remoteDirectoryExpression = remoteDirectoryExpression;
 	}
 
+	protected Expression getRemoteDirectoryExpression() {
+		return this.remoteDirectoryExpression;
+	}
+
 	/**
 	 * Set the filter to be applied to the remote files before transferring.
 	 * @param filter the file list filter.
@@ -195,7 +199,7 @@ public abstract class AbstractInboundFileSynchronizer<F>
 	}
 
 	@Override
-	public final void afterPropertiesSet() {
+	public void afterPropertiesSet() {
 		Assert.state(this.remoteDirectoryExpression != null, "'remoteDirectoryExpression' must not be null");
 		if (this.evaluationContext == null) {
 			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
@@ -271,7 +275,9 @@ public abstract class AbstractInboundFileSynchronizer<F>
 			Session<F> session) throws IOException {
 		String remoteFileName = this.getFilename(remoteFile);
 		String localFileName = this.generateLocalFileName(remoteFileName);
-		String remoteFilePath = remoteDirectoryPath + remoteFileSeparator + remoteFileName;
+		String remoteFilePath = remoteDirectoryPath != null
+				? (remoteDirectoryPath + remoteFileSeparator + remoteFileName)
+				: remoteFileName;
 		if (!this.isFile(remoteFile)) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("cannot copy, not a file: " + remoteFilePath);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -199,7 +199,7 @@ public abstract class AbstractInboundFileSynchronizer<F>
 	}
 
 	@Override
-	public void afterPropertiesSet() {
+	public final void afterPropertiesSet() {
 		Assert.state(this.remoteDirectoryExpression != null, "'remoteDirectoryExpression' must not be null");
 		if (this.evaluationContext == null) {
 			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -189,8 +189,10 @@ public class RemoteFileOutboundGatewayTests {
 			}
 
 			@Override
-			public String[] listNames(String path) throws IOException {
-				return new String[] { path1, path2 };
+			public TestLsEntry[] list(String path) throws IOException {
+				return new TestLsEntry[] {
+						new TestLsEntry(path1.replaceFirst("testremote/", ""), 123, false, false, 1234, "-r--r--r--"),
+						new TestLsEntry(path2.replaceFirst("testremote/", ""), 123, false, false, 1234, "-r--r--r--")};
 			}
 
 		});
@@ -221,8 +223,8 @@ public class RemoteFileOutboundGatewayTests {
 			}
 
 			@Override
-			public String[] listNames(String path) throws IOException {
-				return new String[]{"f1"};
+			public TestLsEntry[] list(String path) throws IOException {
+				return new TestLsEntry[]{new TestLsEntry("f1", 123, false, false, 1234, "-r--r--r--")};
 			}
 
 		});

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -621,10 +622,8 @@ public class RemoteFileOutboundGatewayTests {
 		assertEquals(outFile, out.getPayload());
 		assertTrue(outFile.exists());
 		outFile.delete();
-		assertEquals("/",
-				out.getHeaders().get(FileHeaders.REMOTE_DIRECTORY));
-		assertEquals("f1",
-				out.getHeaders().get(FileHeaders.REMOTE_FILE));
+		assertNull(out.getHeaders().get(FileHeaders.REMOTE_DIRECTORY));
+		assertEquals("f1", out.getHeaders().get(FileHeaders.REMOTE_FILE));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +80,32 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 	 */
 	public FtpOutboundGateway(RemoteFileTemplate<FTPFile> remoteFileTemplate, String command, String expression) {
 		super(remoteFileTemplate, command, expression);
+	}
+
+	/**
+	 * Construct an instance with the supplied session factory, a command ('ls', 'get'
+	 * etc).
+	 * <p> The {@code remoteDirectory} expression is {@code null} assuming to use
+	 * the {@code workingDirectory} from the FTP Client.
+	 * @param sessionFactory the session factory.
+	 * @param command the command.
+	 * @since 4.3
+	 */
+	public FtpOutboundGateway(SessionFactory<FTPFile> sessionFactory, String command) {
+		this(sessionFactory, command, null);
+	}
+
+	/**
+	 * Construct an instance with the supplied remote file template, a command ('ls',
+	 * 'get' etc).
+	 * <p> The {@code remoteDirectory} expression is {@code null} assuming to use
+	 * the {@code workingDirectory} from the FTP Client.
+	 * @param remoteFileTemplate the remote file template.
+	 * @param command the command.
+	 * @since 4.3
+	 */
+	public FtpOutboundGateway(RemoteFileTemplate<FTPFile> remoteFileTemplate, String command) {
+		this(remoteFileTemplate, command, null);
 	}
 
 	@Override

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpInboundFileSynchronizer.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpInboundFileSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.ftp.inbound;
 
 import org.apache.commons.net.ftp.FTPFile;
 
+import org.springframework.expression.Expression;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.remote.synchronizer.AbstractInboundFileSynchronizer;
@@ -42,6 +43,20 @@ public class FtpInboundFileSynchronizer extends AbstractInboundFileSynchronizer<
 		super(sessionFactory);
 	}
 
+	@Override
+	public void setRemoteDirectoryExpression(Expression remoteDirectoryExpression) {
+		if (remoteDirectoryExpression != null) {
+			super.setRemoteDirectoryExpression(remoteDirectoryExpression);
+		}
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		if (getRemoteDirectoryExpression() == null) {
+			setRemoteDirectory(null);
+		}
+		super.afterPropertiesSet();
+	}
 
 	@Override
 	protected boolean isFile(FTPFile file) {

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpInboundFileSynchronizer.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpInboundFileSynchronizer.java
@@ -18,7 +18,7 @@ package org.springframework.integration.ftp.inbound;
 
 import org.apache.commons.net.ftp.FTPFile;
 
-import org.springframework.expression.Expression;
+import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.remote.synchronizer.AbstractInboundFileSynchronizer;
@@ -41,21 +41,7 @@ public class FtpInboundFileSynchronizer extends AbstractInboundFileSynchronizer<
 	 */
 	public FtpInboundFileSynchronizer(SessionFactory<FTPFile> sessionFactory) {
 		super(sessionFactory);
-	}
-
-	@Override
-	public void setRemoteDirectoryExpression(Expression remoteDirectoryExpression) {
-		if (remoteDirectoryExpression != null) {
-			super.setRemoteDirectoryExpression(remoteDirectoryExpression);
-		}
-	}
-
-	@Override
-	public void afterPropertiesSet() {
-		if (getRemoteDirectoryExpression() == null) {
-			setRemoteDirectory(null);
-		}
-		super.afterPropertiesSet();
+		setRemoteDirectoryExpression(new LiteralExpression(null));
 	}
 
 	@Override

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/AbstractFtpSessionFactory.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/AbstractFtpSessionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.springframework.integration.ftp.session;
 
 import java.io.IOException;
-import java.net.SocketException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -39,8 +38,6 @@ import org.springframework.util.Assert;
  * @since 2.0
  */
 public abstract class AbstractFtpSessionFactory<T extends FTPClient> implements SessionFactory<FTPFile> {
-
-	public static final String DEFAULT_REMOTE_WORKING_DIRECTORY = "/";
 
 	private final Log logger = LogFactory.getLog(this.getClass());
 
@@ -172,7 +169,7 @@ public abstract class AbstractFtpSessionFactory<T extends FTPClient> implements 
 		}
 	}
 
-	private T createClient() throws SocketException, IOException {
+	private T createClient() throws IOException {
 		final T client = this.createClientInstance();
 		Assert.notNull(client, "client must not be null");
 		client.configure(this.config);
@@ -200,7 +197,7 @@ public abstract class AbstractFtpSessionFactory<T extends FTPClient> implements 
 
 		// Login
 		if (!client.login(username, password)) {
-			throw new IllegalStateException("Login failed. The respponse from the server is: " +
+			throw new IllegalStateException("Login failed. The response from the server is: " +
 					client.getReplyString());
 		}
 

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.0
  */
 public class FtpSession implements Session<FTPFile> {
@@ -55,22 +56,21 @@ public class FtpSession implements Session<FTPFile> {
 	@Override
 	public boolean remove(String path) throws IOException {
 		Assert.hasText(path, "path must not be null");
-		boolean completed = this.client.deleteFile(path);
-	 	if (!completed) {
+	 	if (!this.client.deleteFile(path)) {
 			throw new IOException("Failed to delete '" + path + "'. Server replied with: " + client.getReplyString());
 		}
-		return completed;
+		else {
+		    return true;
+	    }
 	}
 
 	@Override
 	public FTPFile[] list(String path) throws IOException {
-		Assert.hasText(path, "path must not be null");
 		return this.client.listFiles(path);
 	}
 
 	@Override
 	public String[] listNames(String path) throws IOException {
-		Assert.hasText(path, "path must not be null");
 		return this.client.listNames(path);
 	}
 
@@ -83,7 +83,7 @@ public class FtpSession implements Session<FTPFile> {
 			throw new IOException("Failed to copy '" + path +
 					"'. Server replied with: " + this.client.getReplyString());
 		}
-		logger.info("File has been successfully transfered from: " + path);
+		logger.info("File has been successfully transferred from: " + path);
 	}
 
 	@Override
@@ -93,7 +93,8 @@ public class FtpSession implements Session<FTPFile> {
 		}
 		InputStream inputStream = this.client.retrieveFileStream(source);
 		if (inputStream == null) {
-			throw new IOException("Failed to obtain InputStream for remote file " + source + ": " + this.client.getReplyCode());
+			throw new IOException("Failed to obtain InputStream for remote file " + source + ": "
+					+ this.client.getReplyCode());
 		}
 		return inputStream;
 	}
@@ -123,7 +124,7 @@ public class FtpSession implements Session<FTPFile> {
 					+ "'. Server replied with: " + this.client.getReplyString());
 		}
 		if (logger.isInfoEnabled()) {
-			logger.info("File has been successfully transfered to: " + path);
+			logger.info("File has been successfully transferred to: " + path);
 		}
 	}
 
@@ -196,7 +197,8 @@ public class FtpSession implements Session<FTPFile> {
 		Assert.hasText(path, "'path' must not be empty");
 
 		String currentWorkingPath = this.client.printWorkingDirectory();
-		Assert.state(currentWorkingPath != null, "working directory cannot be determined, therefore exists check can not be completed");
+		Assert.state(currentWorkingPath != null,
+				"working directory cannot be determined, therefore exists check can not be completed");
 		boolean exists = false;
 
 		try {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -41,8 +41,9 @@
 	<int-ftp:outbound-gateway session-factory="ftpSessionFactory"
 							  request-channel="inboundMGet"
 							  command="mget"
+							  command-options="-f"
 							  expression="payload"
-							  local-directory-expression="@ftpServer.targetLocalDirectoryName + #remoteDirectory"
+							  local-directory-expression="@ftpServer.targetLocalDirectoryName + (#remoteDirectory ?: '')"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('ftpSource', 'localTarget')"
 							  reply-channel="output"/>
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -169,5 +169,22 @@
 	<bean id="messageSessionCallback"
 		  class="org.springframework.integration.ftp.outbound.FtpServerOutboundTests$TestMessageSessionCallback"/>
 
+	<int-ftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="inboundLs"
+							  command="ls"
+							  command-options="-1"
+							  reply-channel="output"/>
+
+	<int-ftp:inbound-channel-adapter id="ftpInbound"
+									 channel="output"
+									 auto-startup="false"
+									 session-factory="ftpSessionFactory"
+									 auto-create-local-directory="true"
+									 delete-remote-files="false"
+									 filename-pattern="*.txt"
+									 temporary-file-suffix=".foo"
+									 local-directory="#{T (System).getProperty('java.io.tmpdir') + T (java.util.UUID).randomUUID().toString()}">
+		<int:poller fixed-delay="100"/>
+	</int-ftp:inbound-channel-adapter>
 
 </beans>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,15 @@
 package org.springframework.integration.ftp.outbound;
 
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -44,6 +47,7 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -57,6 +61,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.InputStreamCallback;
@@ -139,6 +144,12 @@ public class FtpServerOutboundTests {
 	@Autowired
 	private DirectChannel inboundCallback;
 
+	@Autowired
+	private DirectChannel inboundLs;
+
+	@Autowired
+	private SourcePollingChannelAdapter ftpInbound;
+
 	@Before
 	public void setup() {
 		this.ftpServer.recursiveDelete(ftpServer.getTargetLocalDirectory());
@@ -183,7 +194,7 @@ public class FtpServerOutboundTests {
 	@SuppressWarnings("unchecked")
 	public void testInt2866LocalDirectoryExpressionMGET() {
 		String dir = "ftpSource/";
-		this.inboundMGet.send(new GenericMessage<Object>(dir + "*.txt"));
+		this.inboundMGet.send(new GenericMessage<Object>("*.txt"));
 		Message<?> result = this.output.receive(1000);
 		assertNotNull(result);
 		List<File> localFiles = (List<File>) result.getPayload();
@@ -209,7 +220,7 @@ public class FtpServerOutboundTests {
 	@SuppressWarnings("unchecked")
 	public void testInt3172LocalDirectoryExpressionMGETRecursive() {
 		String dir = "ftpSource/";
-		this.inboundMGetRecursive.send(new GenericMessage<Object>(dir + "*"));
+		this.inboundMGetRecursive.send(new GenericMessage<Object>("*"));
 		Message<?> result = this.output.receive(1000);
 		assertNotNull(result);
 		List<File> localFiles = (List<File>) result.getPayload();
@@ -545,6 +556,51 @@ public class FtpServerOutboundTests {
 		Message<?> receive = this.output.receive(10000);
 		assertNotNull(receive);
 		assertEquals("FOO", receive.getPayload());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testLsForNullDir() throws IOException {
+		Session<FTPFile> session = ftpSessionFactory.getSession();
+		((FTPClient) session.getClientInstance()).changeWorkingDirectory("ftpSource");
+		session.close();
+
+		this.inboundLs.send(new GenericMessage<String>("foo"));
+		Message<?> receive = this.output.receive(10000);
+		assertNotNull(receive);
+		assertThat(receive.getPayload(), instanceOf(List.class));
+		List<String> files = (List<String>) receive.getPayload();
+		assertEquals(2, files.size());
+		assertThat(files, containsInAnyOrder("ftpSource1.txt", "ftpSource2.txt"));
+
+		FTPFile[] ftpFiles = ftpSessionFactory.getSession().list(null);
+		for (FTPFile ftpFile : ftpFiles) {
+			if (!ftpFile.isDirectory()) {
+				assertTrue(files.contains(ftpFile.getName()));
+			}
+		}
+	}
+
+	@Test
+	public void testInboundChannelAdapterWithNullDir() throws IOException {
+		Session<FTPFile> session = ftpSessionFactory.getSession();
+		((FTPClient) session.getClientInstance()).changeWorkingDirectory("ftpSource");
+		session.close();
+		this.ftpInbound.start();
+
+		Message<?> message = this.output.receive(10000);
+		assertNotNull(message);
+		assertThat(message.getPayload(), instanceOf(File.class));
+		assertEquals("ftpSource1.txt", ((File) message.getPayload()).getName());
+
+		message = this.output.receive(10000);
+		assertNotNull(message);
+		assertThat(message.getPayload(), instanceOf(File.class));
+		assertEquals("ftpSource2.txt", ((File) message.getPayload()).getName());
+
+		assertNull(this.output.receive(10));
+
+		this.ftpInbound.stop();
 	}
 
 	public static class SortingFileListFilter implements FileListFilter<File> {

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -191,6 +191,9 @@ Starting with _version 4.2_, you can specify `remote-directory-expression` inste
 you to dynamically determine the directory on each poll.
 e.g `remote-directory-expression="@myBean.determineRemoteDir()"`.
 
+Starting with _version 4.3_, the `remote-directory` attributes can be omitted assuming `null`.
+However, according to the FTP Client logic, the working directory is used as a default remote directory for the `LS` command.
+
 Sometimes file filtering based on the simple pattern specified via `filename-pattern` attribute might not be sufficient.
 If this is the case, you can use the `filename-regex` attribute to specify a Regular Expression (e.g.
 `filename-regex=".*\.test$"`).
@@ -255,7 +258,10 @@ Here is an example that uses a custom Filter implementation.
 
 _Poller configuration notes for the inbound FTP adapter_
 
-The job of the inbound FTP adapter consists of two tasks: _1) Communicate with a remote server in order to transfer files from a remote directory to a local directory.__2) For each transferred file, generate a Message with that file as a payload and send it to the channel identified by the 'channel' attribute._ That is why they are called 'channel-adapters' rather than just 'adapters'.
+The job of the inbound FTP adapter consists of two tasks:
+_1) Communicate with a remote server in order to transfer files from a remote directory to a local directory._
+_2) For each transferred file, generate a Message with that file as a payload and send it to the channel identified by the 'channel' attribute._
+That is why they are called 'channel-adapters' rather than just 'adapters'.
 The main job of such an adapter is to generate a Message to be sent to a Message Channel.
 Essentially, the second task mentioned above takes precedence in such a way that *IF* your local directory already has one or more files it will first generate Messages from those, and *ONLY* when all local files have been processed, will it initiate the remote communication to retrieve more files.
 
@@ -406,6 +412,13 @@ When using the recursive option (`-R`), the `fileName` includes any subdirectory
 If the `-dirs` option is included, each recursive directory is also returned as an element in the list.
 In this case, it is recommended that the `-1` is not used because you would not be able to determine files Vs.
 directories, which is achievable using the `FileInfo` objects.
+
+Starting with _version 4.3_, the `FtpSession` supports `null` for the `list()` and `listNames()` method,
+therefore the `expression` attribute can be omitted.
+From Java perspective there are two new constructor without `expression` argument for convenience.
+The `null` for `LS` command is treated as an FTP Client working directory.
+The working directory can be set via the `FTPClient.changeWorkingDirectory()` function when you extend the
+`DefaultFtpSessionFactory` and implement `postProcessClientBeforeConnect()` callback.
 
 *get*
 

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -191,8 +191,8 @@ Starting with _version 4.2_, you can specify `remote-directory-expression` inste
 you to dynamically determine the directory on each poll.
 e.g `remote-directory-expression="@myBean.determineRemoteDir()"`.
 
-Starting with _version 4.3_, the `remote-directory` attributes can be omitted assuming `null`.
-However, according to the FTP Client logic, the working directory is used as a default remote directory for the `LS` command.
+Starting with _version 4.3_, the `remote-directory`/`remote-directory-expression` attributes can be omitted assuming `null`.
+However, according to the FTP protocol, the Client working directory is used as a default remote directory.
 
 Sometimes file filtering based on the simple pattern specified via `filename-pattern` attribute might not be sufficient.
 If this is the case, you can use the `filename-regex` attribute to specify a Regular Expression (e.g.
@@ -416,7 +416,7 @@ directories, which is achievable using the `FileInfo` objects.
 Starting with _version 4.3_, the `FtpSession` supports `null` for the `list()` and `listNames()` method,
 therefore the `expression` attribute can be omitted.
 From Java perspective there are two new constructor without `expression` argument for convenience.
-The `null` for `LS` command is treated as an FTP Client working directory.
+The `null` for `LS` command is treated as an Client working directory according to the FTP protocol.
 The working directory can be set via the `FTPClient.changeWorkingDirectory()` function when you extend the
 `DefaultFtpSessionFactory` and implement `postProcessClientBeforeConnect()` callback.
 

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -192,7 +192,7 @@ you to dynamically determine the directory on each poll.
 e.g `remote-directory-expression="@myBean.determineRemoteDir()"`.
 
 Starting with _version 4.3_, the `remote-directory`/`remote-directory-expression` attributes can be omitted assuming `null`.
-However, according to the FTP protocol, the Client working directory is used as a default remote directory.
+In this case, according to the FTP protocol, the Client working directory is used as a default remote directory.
 
 Sometimes file filtering based on the simple pattern specified via `filename-pattern` attribute might not be sufficient.
 If this is the case, you can use the `filename-regex` attribute to specify a Regular Expression (e.g.
@@ -413,7 +413,7 @@ If the `-dirs` option is included, each recursive directory is also returned as 
 In this case, it is recommended that the `-1` is not used because you would not be able to determine files Vs.
 directories, which is achievable using the `FileInfo` objects.
 
-Starting with _version 4.3_, the `FtpSession` supports `null` for the `list()` and `listNames()` method,
+Starting with _version 4.3_, the `FtpSession` supports `null` for the `list()` and `listNames()` methods,
 therefore the `expression` attribute can be omitted.
 From Java perspective there are two new constructor without `expression` argument for convenience.
 The `null` for `LS` command is treated as an Client working directory according to the FTP protocol.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -106,6 +106,14 @@ See <<http-inbound>> for more information.
 A new factory bean is provided to simplify the configuration of Jsch proxies for SFTP.
 See <<sftp-proxy-factory-bean>> for more information.
 
+==== FTP Changes
+
+The `FtpSession` now supports `null` for the `list()` and `listNames()` method, since it is possible by the
+underlying FTP Client.
+With that the `FtpOutboundGateway` can now be configured without `remoteDirectory` expression.
+And the `<int-ftp:inbound-channel-adapter>` can be configured without `remote-directory`/`remote-directory-expression`.
+See <<ftp>> for more information.
+
 ==== Routers Changes
 
 The `ErrorMessageExceptionTypeRouter` supports now the `Exception` superclass mappings to avoid duplication


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3919

Since `FtpClient` supports `null` for the `LS` command, treating it as a current `working directory`,
there is no reason to forbid `null` from the FTP adapters end-user perspective.
- Allow `null` for the `FtpSession` `list()` and `listNames()` methods
- Allow `null` in the `remote-directory` for the `<int-ftp:inbound-channel-adapter>`
- Allow `null` in the `expression` for the `FtpOutboundGateway`
- In both cases the final directory is enhanced as a client's `working directory` to avoid unexpected NPEe.
  Plus don't lose the `REMOTE_DIRECTORY` header feature.
