### PR TITLE
Fix Amqp Header Mapper MimeType

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -348,8 +348,7 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 
 	/**
 	 * Will extract Content-Type from MessageHeaders and convert it to String if possible
-	 * Required since Content-Type can be represented as org.springframework.http.MediaType
-	 * see INT-2713 for more details
+	 * Required since Content-Type can be represented as org.springframework.util.MimeType.
 	 *
 	 */
 	private String extractContentTypeAsString(Map<String, Object> headers) {
@@ -360,8 +359,7 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 		if (contentType != null) {
 			String contentTypeClassName = contentType.getClass().getName();
 
-			if (contentType instanceof MimeType ||
-					contentTypeClassName.equals("org.springframework.http.MediaType")) { // see INT-2713
+			if (contentType instanceof MimeType) {
 				contentTypeStringValue = contentType.toString();
 			}
 			else if (contentType instanceof String) {

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.http.MediaType;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
 
 /**
  * @author Mark Fisher
@@ -121,6 +122,13 @@ public class DefaultAmqpHeaderMapperTests {
 		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
 
 		assertEquals("text/html", amqpProperties.getContentType());
+
+		headerMap.put(AmqpHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON);
+		integrationHeaders = new MessageHeaders(headerMap);
+		amqpProperties = new MessageProperties();
+		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
+
+		assertEquals(MimeTypeUtils.APPLICATION_JSON_VALUE, amqpProperties.getContentType());
 	}
 
 	@Test


### PR DESCRIPTION
Remove unnecessary class name comparison; `MediaType` is a subclass of `MimeType`.
