### PR TITLE
Fix TCP Cache Race Condition

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -442,7 +442,7 @@ public class TcpOutboundGatewayTests extends LogAdjustingTestSupport {
 				}
 				else {
 					assertNotNull(e.getCause());
-					assertTrue(e.getCause() instanceof MessageTimeoutException);
+					assertThat(e.getCause(), instanceOf(MessageTimeoutException.class));
 				}
 				timeouts++;
 				continue;


### PR DESCRIPTION
On a gateway remote timeout, there's a race between the reader and writer
thread to close the connection.

Change the `released` boolean to an `AtomicBoolean` to avoid the unexpected
exception when the other thread attempts to return a non-existent connection
to the pool.

**cherry-pick to 4.2.x**
