### PR TITLE
INT-3956 use Deque.peekLast() for timeSinceLastSend on channel metrics.

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRate.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRate.java
@@ -53,9 +53,9 @@ public class ExponentialMovingAverageRate {
 
 	private final double period;
 
-	private final Deque<Long> times = new ArrayDeque<Long>();
+	final Deque<Long> times = new ArrayDeque<Long>();
 
-	private final int retention;
+	final int retention;
 
 	private final int window;
 
@@ -205,7 +205,7 @@ public class ExponentialMovingAverageRate {
 
 	private synchronized double lastTime() {
 		if (this.times.size() > 0) {
-			return this.times.peekFirst() / this.factor;
+			return this.times.peekLast() / this.factor;
 		}
 		else {
 			 return this.t0;

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRate.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRate.java
@@ -53,9 +53,9 @@ public class ExponentialMovingAverageRate {
 
 	private final double period;
 
-	final Deque<Long> times = new ArrayDeque<Long>();
+	private final Deque<Long> times = new ArrayDeque<Long>();
 
-	final int retention;
+	private final int retention;
 
 	private final int window;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRatio.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRatio.java
@@ -51,11 +51,11 @@ public class ExponentialMovingAverageRatio {
 
 	private final double lapse;
 
-	private final Deque<Long> times = new ArrayDeque<Long>();
+	final Deque<Long> times = new ArrayDeque<Long>();
 
 	private final Deque<Integer> values = new ArrayDeque<Integer>();
 
-	private final int retention;
+	final int retention;
 
 	private final int window;
 
@@ -224,7 +224,7 @@ public class ExponentialMovingAverageRatio {
 
 	private synchronized double lastTime() {
 		if (this.times.size() > 0) {
-			return this.times.peekFirst();
+			return this.times.peekLast();
 		}
 		else {
 			return this.t0 * this.factor;

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRatio.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/ExponentialMovingAverageRatio.java
@@ -51,11 +51,11 @@ public class ExponentialMovingAverageRatio {
 
 	private final double lapse;
 
-	final Deque<Long> times = new ArrayDeque<Long>();
+	private final Deque<Long> times = new ArrayDeque<Long>();
 
 	private final Deque<Integer> values = new ArrayDeque<Integer>();
 
-	final int retention;
+	private final int retention;
 
 	private final int window;
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/ExponentialMovingAverageRateTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/ExponentialMovingAverageRateTests.java
@@ -17,12 +17,12 @@ import java.util.Deque;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -65,7 +65,7 @@ public class ExponentialMovingAverageRateTests {
 
 		//increment just so we'll have a different value between first and last
 		history.increment(System.nanoTime());
-		Assert.assertNotEquals(times.peekFirst(), times.peekLast());
+		assertNotEquals(times.peekFirst(), times.peekLast());
 
 		Thread.sleep(sleepTime);
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/ExponentialMovingAverageRateTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/ExponentialMovingAverageRateTests.java
@@ -12,6 +12,8 @@
  */
 package org.springframework.integration.support.management;
 
+import java.util.Deque;
+
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -24,6 +26,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.util.StopWatch;
 
 /**
@@ -45,22 +48,24 @@ public class ExponentialMovingAverageRateTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testGetTimeSinceLastMeasurement() throws Exception {
 		long sleepTime = 20L;
 
 		// fill history with the same value.
 		long now = System.nanoTime();
-		for (int i=0; i< history.retention; i++) {
+		for (int i=0; i< TestUtils.getPropertyValue(history, "retention", Integer.class); i++) {
 			history.increment(now);
 		}
-		assertEquals(Long.valueOf(now), history.times.peekFirst());
-		assertEquals(Long.valueOf(now), history.times.peekLast());
+		final Deque<Long> times = TestUtils.getPropertyValue(history, "times", Deque.class);
+		assertEquals(Long.valueOf(now), times.peekFirst());
+		assertEquals(Long.valueOf(now), times.peekLast());
 
 		Thread.sleep(sleepTime);
 
 		//increment just so we'll have a different value between first and last
 		history.increment(System.nanoTime());
-		Assert.assertNotEquals(history.times.peekFirst(), history.times.peekLast());
+		Assert.assertNotEquals(times.peekFirst(), times.peekLast());
 
 		Thread.sleep(sleepTime);
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/ExponentialMovingAverageRatioTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/ExponentialMovingAverageRatioTests.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.integration.support.management;
 
+import java.util.Deque;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
@@ -24,6 +26,8 @@ import static org.junit.Assert.assertThat;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import org.springframework.integration.test.util.TestUtils;
 
 /**
  * @author Dave Syer
@@ -44,21 +48,23 @@ public class ExponentialMovingAverageRatioTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testGetTimeSinceLastMeasurement() throws Exception {
 		long sleepTime = 20L;
 		// fill history with the same value.
 		long now = System.nanoTime();
-		for (int i=0; i< history.retention; i++) {
+		for (int i=0; i< TestUtils.getPropertyValue(history,"retention", Integer.class); i++) {
 			history.success(now);
 		}
-		assertEquals(Long.valueOf(now), history.times.peekFirst());
-		assertEquals(Long.valueOf(now), history.times.peekLast());
+		final Deque<Long> times = TestUtils.getPropertyValue(history, "times", Deque.class);
+		assertEquals(Long.valueOf(now), times.peekFirst());
+		assertEquals(Long.valueOf(now), times.peekLast());
 
 		Thread.sleep(sleepTime);
 
 		//increment just so we'll have a different value between first and last
 		history.success(System.nanoTime());
-		assertNotEquals(history.times.peekFirst(), history.times.peekLast());
+		assertNotEquals(times.peekFirst(), times.peekLast());
 
 		Thread.sleep(sleepTime);
 


### PR DESCRIPTION
I had to change the visibility modifiers of a couple of internal fields in order to make the tests accurate. Hope that's okay.
