### PR TITLE
Move `BigMGetTests` out of the `main`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -341,6 +341,7 @@ project('spring-integration-ftp') {
 		compile "org.springframework:spring-context-support:$springVersion"
 		compile("javax.activation:activation:$javaxActivationVersion", optional)
 		testCompile "org.apache.ftpserver:ftpserver-core:$ftpServerVersion"
+		testCompile project(":spring-integration-file").sourceSets.test.output
 	}
 }
 
@@ -562,6 +563,7 @@ project('spring-integration-sftp') {
 		compile "org.springframework:spring-context-support:$springVersion"
 		compile("javax.activation:activation:$javaxActivationVersion", optional)
 		testCompile "org.apache.sshd:sshd-core:$apacheSshdVersion"
+		testCompile project(":spring-integration-file").sourceSets.test.output
 	}
 }
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/test/package-info.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/test/package-info.java
@@ -1,5 +1,0 @@
-/**
- * Provides classes used to support common test cases in modules
- * that are dependent on the file module.
- */
-package org.springframework.integration.file.test;

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/BigMGetTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/BigMGetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.integration.file.test;
+
+package org.springframework.integration.file;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -29,6 +30,7 @@ import org.springframework.messaging.support.GenericMessage;
  * Created this test because a customer reported hanging with large mget.
  *
  * Could not reproduce; code is checked in, but test is @Ignored.
+ *
  * @author Gary Russell
  * @since 2.2
  *
@@ -61,4 +63,5 @@ public abstract class BigMGetTests {
 		Message<List<File>> results = (Message<List<File>>) resultChannel.receive(600000);
 		return results;
 	}
+
 }

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/BigMGetTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/BigMGetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,11 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
-public class BigMGetTests extends org.springframework.integration.file.test.BigMGetTests {
+public class BigMGetTests extends org.springframework.integration.file.BigMGetTests {
 
 	@Test @Ignore // needs directories and server (FTP and SFTP)
 	public void doTest() throws Exception {
 		assertEquals(FILES, this.mgetManyFiles().getPayload().size());
 	}
+
 }

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/BigMGetTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/BigMGetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.integration.sftp.outbound;
 
 import static org.junit.Assert.assertEquals;
@@ -30,10 +31,11 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
-public class BigMGetTests extends org.springframework.integration.file.test.BigMGetTests {
+public class BigMGetTests extends org.springframework.integration.file.BigMGetTests {
 
 	@Test @Ignore // needs directories and server (FTP and SFTP)
 	public void doTest() throws Exception {
 		assertEquals(FILES, this.mgetManyFiles().getPayload().size());
 	}
+
 }


### PR DESCRIPTION
Even it isn't harmful, the one useless class in the `.file.test` package looks confusing.

Move it out to the `test` scope and change the dependant projects respectively.
