### PR TITLE
INT-3958: Groovy Compiler customization support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,7 @@ subprojects { subproject ->
 		springSecurityVersion = project.hasProperty('springSecurityVersion') ? project.springSecurityVersion : '4.0.3.RELEASE'
 		springSocialTwitterVersion = '1.1.1.RELEASE'
 		springRetryVersion = '1.1.2.RELEASE'
-		springVersion = project.hasProperty('springVersion') ? project.springVersion : '4.2.4.RELEASE'
+		springVersion = project.hasProperty('springVersion') ? project.springVersion : '4.3.0.BUILD-SNAPSHOT'
 		springWsVersion = '2.2.4.RELEASE'
 		xmlUnitVersion = '1.6'
 		xstreamVersion = '1.4.7'

--- a/spring-integration-groovy/src/main/java/org/springframework/integration/groovy/config/GroovyScriptParser.java
+++ b/spring-integration-groovy/src/main/java/org/springframework/integration/groovy/config/GroovyScriptParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,15 @@
 
 package org.springframework.integration.groovy.config;
 
-import groovy.lang.Script;
+import org.w3c.dom.Element;
+
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.groovy.GroovyScriptExecutingMessageProcessor;
 import org.springframework.integration.scripting.config.AbstractScriptParser;
-import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
-import org.w3c.dom.Element;
+
+import groovy.lang.Script;
 
 /**
  * Parser for the &lt;groovy:script/&gt; element.
@@ -51,6 +53,8 @@ public class GroovyScriptParser extends AbstractScriptParser {
 
 	protected void postProcess(BeanDefinitionBuilder builder, Element element, ParserContext parserContext) {
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "customizer");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "compiler-configuration");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "compile-static");
 	}
 
 

--- a/spring-integration-groovy/src/main/resources/org/springframework/integration/groovy/config/spring-integration-groovy-4.3.xsd
+++ b/spring-integration-groovy/src/main/resources/org/springframework/integration/groovy/config/spring-integration-groovy-4.3.xsd
@@ -36,6 +36,30 @@
 						</xsd:appinfo>
 					</xsd:annotation>
 				</xsd:attribute>
+				<xsd:attribute name="compile-static" default="false">
+					<xsd:annotation>
+						<xsd:documentation>
+							Indicates if the target Groovy script should be compiled statically.
+							The @CompileStatic hint is applied for the Groovy compiler.
+							This attribute is ignored if the 'compiler-configuration' reference is specified.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:union memberTypes="xsd:boolean xsd:string" />
+					</xsd:simpleType>
+				</xsd:attribute>
+				<xsd:attribute name="compiler-configuration">
+					<xsd:annotation>
+						<xsd:documentation>
+							Reference to a CompilerConfiguration bean to be applied to the underlying GroovyClassLoader
+							for this script compilation.
+						</xsd:documentation>
+						<xsd:appinfo>
+							<tool:expected-type
+									type="org.codehaus.groovy.control.CompilerConfiguration" />
+						</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyFilterTests-context.xml
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyFilterTests-context.xml
@@ -1,20 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans xmlns="http://www.springframework.org/schema/integration"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:beans="http://www.springframework.org/schema/beans"
-	xmlns:groovy="http://www.springframework.org/schema/integration/groovy"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			 xmlns:beans="http://www.springframework.org/schema/beans"
+			 xmlns:groovy="http://www.springframework.org/schema/integration/groovy"
+			 xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/integration/groovy http://www.springframework.org/schema/integration/groovy/spring-integration-groovy.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
+	<beans:bean class="org.springframework.integration.groovy.config.GroovyFilterTests.TestConfig"/>
+
 	<filter id="groovyFilter" input-channel="referencedScriptInput">
-		<groovy:script location="org/springframework/integration/groovy/config/GroovyFilterTests.groovy"/>
+		<groovy:script location="org/springframework/integration/groovy/config/GroovyFilterTests.groovy"
+					   compiler-configuration="compilerConfiguration"/>
 	</filter>
 
 	<filter input-channel="inlineScriptInput">
 		<groovy:script><![CDATA[
-				return payload == 'good'
-		]]></groovy:script>
+			return payload == 'good'
+			]]></groovy:script>
+	</filter>
+
+	<filter input-channel="compileStaticFailScriptInput">
+		<groovy:script compile-static="true"><![CDATA[
+			payload == 'good'
+			]]></groovy:script>
 	</filter>
 
 </beans:beans>

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyFilterTests.groovy
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyFilterTests.groovy
@@ -1,1 +1,2 @@
-headers.type == 'good'
+// org.springframework.integration.groovy.config.GroovyFilterTests.TestConfig
+headers.type == pi

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyRefreshTests-context.xml
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyRefreshTests-context.xml
@@ -6,7 +6,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/integration/groovy http://www.springframework.org/schema/integration/groovy/spring-integration-groovy.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
-		
+
 	<bean class="org.springframework.beans.factory.config.CustomEditorConfigurer" xmlns="http://www.springframework.org/schema/beans">
 		<property name="customEditors">
 			<map>
@@ -16,7 +16,7 @@
 	</bean>
 
 	<transformer input-channel="referencedScriptInput">
-		<groovy:script location="GroovyRefreshTests.groovy" refresh-check-delay="0"/>
+		<groovy:script location="GroovyRefreshTests.groovy" refresh-check-delay="0" compile-static="true"/>
 	</transformer>
 
 </beans:beans>

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyRefreshTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyRefreshTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  * @since 2.0
  */
 @ContextConfiguration
@@ -66,7 +67,8 @@ public class GroovyRefreshTests {
 	private static class CycleResource extends AbstractResource {
 
 		private int count = -1;
-		private String[] scripts = {"\"groovy-$payload-0\"", "\"groovy-$payload-1\""};
+		private String[] scripts = {"\"groovy-${binding.variables['payload']}-0\"",
+				"\"groovy-${binding.variables['payload']}-1\""};
 
 		public String getDescription() {
 			return "CycleResource";

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovySplitterTests-context.xml
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovySplitterTests-context.xml
@@ -12,8 +12,8 @@
 	</splitter>
 
 	<splitter input-channel="inlineScriptInput">
-		<groovy:script><![CDATA[
-				return payload.split('\\s+')
+		<groovy:script compile-static="true"><![CDATA[
+			((String) binding.variables.payload).split('\\s+')
 		]]></groovy:script>
 	</splitter>
 

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyTransformerTests.groovy
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyTransformerTests.groovy
@@ -1,1 +1,6 @@
-"groovy-$payload"
+@groovy.transform.CompileStatic
+String transform(Object payload) {
+	"groovy-$payload"
+}
+
+transform(payload)

--- a/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/RefreshableResourceScriptSource.java
+++ b/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/RefreshableResourceScriptSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class RefreshableResourceScriptSource implements ScriptSource {
 	}
 
 	public String suggestedClassName() {
-		return this.source.suggestedClassName();
+		return this.source.getResource().getFilename();
 	}
 
 	public boolean isModified() {

--- a/src/reference/asciidoc/groovy.adoc
+++ b/src/reference/asciidoc/groovy.adoc
@@ -2,7 +2,7 @@
 === Groovy support
 
 In Spring Integration 2.0 we added Groovy support allowing you to use the Groovy scripting language to provide the logic for various integration components similar to the way the Spring Expression Language (SpEL) is supported for routing, transformation and other integration concerns.
-For more information about Groovy please refer to the Groovy documentation which you can find on the http://groovy.codehaus.org[project website]
+For more information about Groovy please refer to the Groovy documentation which you can find on the http://www.groovy-lang.org/[project website].
 
 [[groovy-config]]
 ==== Groovy configuration
@@ -32,7 +32,7 @@ Also note that the `lang` attribute on the `<script>` tag is not valid in this n
 _Groovy object customization_
 
 If you need to customize the Groovy object itself, beyond setting variables, you can reference a bean that implements `org.springframework.scripting.groovy.GroovyObjectCustomizer` via the `customizer` attribute.
-For example, this might be useful if you want to implement a domain-specific language (DSL) by modifying the MetaClass and registering functions to be available within the script:
+For example, this might be useful if you want to implement a domain-specific language (DSL) by modifying the `MetaClass` and registering functions to be available within the script:
 [source,xml]
 ----
 <int:service-activator input-channel="groovyChannel">
@@ -46,7 +46,7 @@ Setting a custom GroovyObjectCustomizer is not mutually exclusive with `<variabl
 It can also be provided when defining an inline script.
 
 With _Spring Integration 3.0_, in addition to the `variable` sub-element, the `variables` attribute has been introduced.
-Also, groovy scripts have the ability to resolve a variable to a bean in the`BeanFactory`, if a binding variable was not provided with the name:
+Also, groovy scripts have the ability to resolve a variable to a bean in the `BeanFactory`, if a binding variable was not provided with the name:
 [source,xml]
 ----
 <int-groovy:script>
@@ -60,6 +60,53 @@ Also, groovy scripts have the ability to resolve a variable to a bean in the`Bea
 where variable `entityManager` is an appropriate bean in the application context.
 
 For more information regarding `<variable>`, `variables`, and `script-variable-generator`, see the paragraph '_Script variable bindings_' of <<scripting-config>>.
+
+_Groovy Script Compiler Customization_
+
+The `@CompileStatic` hint is the most popular and enough powerful Groovy compiler customization option,
+which can be used on the class or method level.
+See more information in the Groovy http://docs.groovy-lang.org/latest/html/documentation/index.html#_static_compilation[Reference Manual].
+Therefore for the short scripts, used in the integration scenarios, we are forced to change something like this
+(a `<filter>` script):
+
+[source,groovy]
+----
+headers.type == 'good'
+----
+
+into the more Java-friendly code:
+
+[source,groovy]
+----
+@groovy.transform.CompileStatic
+String filter(Map headers) {
+	headers.type == 'good'
+}
+
+filter(headers)
+----
+
+With that the `filter()` method will be transformed and compiled to static Java code bypassing the Groovy
+dynamic phases of invocation.
+
+Starting with _version 4.3_ the Groovy components can be configured with the `compile-static` `boolean` option,
+specifying that `ASTTransformationCustomizer` for the `@CompileStatic` should be added to the internal
+`CompilerConfiguration`.
+With that we can omit the method declaration with `@CompileStatic` in our script code and still get a gain from
+its purpose through the manual Groovy Script compiler customization.
+In this case our script can still be short but should be changed to the Java code style a bit:
+[source,groovy]
+----
+binding.variables.headers.type == 'good'
+----
+Where we can get access to our `headers` and `payload` (or any other) variables only through the `groovy.lang.Script`
+`binding` property, since with the `@CompileStatic` we don't have the  dynamic `GroovyObject.getProperty()` nature any more.
+
+In addition, the `compiler-configuration` bean reference has been introduced, too.
+Alongside with the `@CompileStatic` over `ASTTransformationCustomizer`, using `compilerConfiguration`
+you can provide any other required Groovy compiler customizations, e.g. `ImportCustomizer`.
+For more information about this feature, please, refer to the Groovy Documentation:
+http://groovy.jmiguel.eu/groovy.codehaus.org/Advanced+compiler+configuration.html[Advanced compiler configuration ].
 
 [[groovy-control-bus]]
 ==== Control Bus

--- a/src/reference/asciidoc/groovy.adoc
+++ b/src/reference/asciidoc/groovy.adoc
@@ -63,10 +63,12 @@ For more information regarding `<variable>`, `variables`, and `script-variable-g
 
 _Groovy Script Compiler Customization_
 
-The `@CompileStatic` hint is the most popular and enough powerful Groovy compiler customization option,
+The `@CompileStatic` hint is the most popular Groovy compiler customization option,
 which can be used on the class or method level.
-See more information in the Groovy http://docs.groovy-lang.org/latest/html/documentation/index.html#_static_compilation[Reference Manual].
-Therefore for the short scripts, used in the integration scenarios, we are forced to change something like this
+See more information in the Groovy
+http://docs.groovy-lang.org/latest/html/documentation/index.html#_static_compilation[Reference Manual] and,
+specifically, http://docs.groovy-lang.org/latest/html/documentation/index.html#compilestatic-annotation[@CompileStatic].
+To utilize this feature for short scripts (in integration scenarios), we are forced to change a simple script like this
 (a `<filter>` script):
 
 [source,groovy]
@@ -74,7 +76,7 @@ Therefore for the short scripts, used in the integration scenarios, we are force
 headers.type == 'good'
 ----
 
-into the more Java-friendly code:
+to more Java-like code:
 
 [source,groovy]
 ----
@@ -86,27 +88,29 @@ String filter(Map headers) {
 filter(headers)
 ----
 
-With that the `filter()` method will be transformed and compiled to static Java code bypassing the Groovy
+With that, the `filter()` method will be transformed and compiled to static bytecode, bypassing the Groovy
 dynamic phases of invocation.
 
-Starting with _version 4.3_ the Groovy components can be configured with the `compile-static` `boolean` option,
-specifying that `ASTTransformationCustomizer` for the `@CompileStatic` should be added to the internal
+Starting with _version 4.3_, Spring Integration Groovy components can be configured with the `compile-static` `boolean`
+option, specifying that `ASTTransformationCustomizer` for `@CompileStatic` should be added to the internal
 `CompilerConfiguration`.
-With that we can omit the method declaration with `@CompileStatic` in our script code and still get a gain from
-its purpose through the manual Groovy Script compiler customization.
-In this case our script can still be short but should be changed to the Java code style a bit:
+With that in place, we can omit the method declaration with `@CompileStatic` in our script code and still get compiled
+bytecode.
+In this case our script can still be short but still needs to be a little more verbose than interpreted script:
+
 [source,groovy]
 ----
 binding.variables.headers.type == 'good'
 ----
-Where we can get access to our `headers` and `payload` (or any other) variables only through the `groovy.lang.Script`
-`binding` property, since with the `@CompileStatic` we don't have the  dynamic `GroovyObject.getProperty()` nature any more.
+Where we can access the `headers` and `payload` (or any other) variables only through the `groovy.lang.Script`
+`binding` property since, with `@CompileStatic`, we don't have the  dynamic `GroovyObject.getProperty()` capability.
 
-In addition, the `compiler-configuration` bean reference has been introduced, too.
-Alongside with the `@CompileStatic` over `ASTTransformationCustomizer`, using `compilerConfiguration`
-you can provide any other required Groovy compiler customizations, e.g. `ImportCustomizer`.
+In addition, the `compiler-configuration` bean reference has been introduced.
+With this attribute, you can provide any other required Groovy compiler customizations, e.g. `ImportCustomizer`.
 For more information about this feature, please, refer to the Groovy Documentation:
-http://groovy.jmiguel.eu/groovy.codehaus.org/Advanced+compiler+configuration.html[Advanced compiler configuration ].
+http://groovy.jmiguel.eu/groovy.codehaus.org/Advanced+compiler+configuration.html[Advanced compiler configuration].
+
+NOTE: Using `compilerConfiguration` does not automatically add a `ASTTransformationCustomizer` for `@CompileStatic`.
 
 [[groovy-control-bus]]
 ==== Control Bus

--- a/src/reference/asciidoc/groovy.adoc
+++ b/src/reference/asciidoc/groovy.adoc
@@ -42,7 +42,7 @@ For example, this might be useful if you want to implement a domain-specific lan
 <beans:bean id="groovyCustomizer" class="org.foo.MyGroovyObjectCustomizer"/>
 ----
 
-Setting a custom GroovyObjectCustomizer is not mutually exclusive with `<variable>` sub-elements or the `script-variable-generator` attribute.
+Setting a custom `GroovyObjectCustomizer` is not mutually exclusive with `<variable>` sub-elements or the `script-variable-generator` attribute.
 It can also be provided when defining an inline script.
 
 With _Spring Integration 3.0_, in addition to the `variable` sub-element, the `variables` attribute has been introduced.
@@ -88,14 +88,14 @@ String filter(Map headers) {
 filter(headers)
 ----
 
-With that, the `filter()` method will be transformed and compiled to static bytecode, bypassing the Groovy
-dynamic phases of invocation.
+With that, the `filter()` method will be transformed and compiled to static Java code, bypassing the Groovy
+dynamic phases of invocation, like `getProperty()` factories and `CallSite` proxies.
 
 Starting with _version 4.3_, Spring Integration Groovy components can be configured with the `compile-static` `boolean`
 option, specifying that `ASTTransformationCustomizer` for `@CompileStatic` should be added to the internal
 `CompilerConfiguration`.
 With that in place, we can omit the method declaration with `@CompileStatic` in our script code and still get compiled
-bytecode.
+plain Java code.
 In this case our script can still be short but still needs to be a little more verbose than interpreted script:
 
 [source,groovy]
@@ -110,7 +110,13 @@ With this attribute, you can provide any other required Groovy compiler customiz
 For more information about this feature, please, refer to the Groovy Documentation:
 http://groovy.jmiguel.eu/groovy.codehaus.org/Advanced+compiler+configuration.html[Advanced compiler configuration].
 
-NOTE: Using `compilerConfiguration` does not automatically add a `ASTTransformationCustomizer` for `@CompileStatic`.
+NOTE: Using `compilerConfiguration` does not automatically add a `ASTTransformationCustomizer` for `@CompileStatic`
+and overrides the `compileStatic` option.
+If `CompileStatic` is still requirement, a `new ASTTransformationCustomizer(CompileStatic.class)` should be manually
+added into the `CompilationCustomizers` of that custom `compilerConfiguration`.
+
+NOTE: The Groovy compiler customization does not have any effect to the `refresh-check-delay` option
+and reloadable scripts can be statically compiled, too.
 
 [[groovy-control-bus]]
 ==== Control Bus

--- a/src/reference/asciidoc/scripting.adoc
+++ b/src/reference/asciidoc/scripting.adoc
@@ -10,7 +10,7 @@ Sun developed a JSR223 reference implementation which works with Java 5 but it i
 
 In order to use a JVM scripting language, a JSR223 implementation for that language must be included in your class path.
 Java 6 natively supports Javascript.
-The http://groovy.codehaus.org[Groovy] and http://jruby.org/[JRuby] projects provide JSR233 support in their standard distribution.
+The http://www.groovy-lang.org/[Groovy] and http://jruby.org/[JRuby] projects provide JSR233 support in their standard distribution.
 Other language implementations may be available or under development.
 Please refer to the appropriate project website for more information.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -136,3 +136,8 @@ See <<router>> for more information.
 AMQP, WS and XMPP header mappings (e.g. `request-header-mapping`, `reply-header-mapping`) now support negated
 patterns.
 See <<amqp-message-headers>>, <<ws-message-headers>>, and <<xmpp-message-headers>> for more information.
+
+==== Groovy Scripts
+
+Groovy scripts can now be configured with the `compile-static` hint or any other `CompilerConfiguration` options.
+See <<groovy-config>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3958
- Introduce `compileStatic` and `compilerConfiguration` properties for the `GroovyScriptExecutingMessageProcessor`,
  to allow to customize the Groovy Script compilation
- Introduce `compile-static` and `compiler-configuration` options on the `<int-groovy:script>` component
- Change `RefreshableResourceScriptSource.suggestedClassName()` to return the **full** file name together with the
  extension. That may be useful during the filtering phase for Compiler customization
- Modify tests to demonstrate different Compiler customization tricks
- Since Spring Boot 1.4 is already based on the SF-4.3, make an appropriate upgrade, too
