### PR TITLE
Add check `header` rule and `fixHeaders` task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ subprojects { subproject ->
 	apply plugin: 'jacoco'
 	apply plugin: 'checkstyle'
 
+	apply from:   "${rootDir}/src/checkstyle/fixHeaders.gradle"
+
 	if (project.hasProperty('platformVersion')) {
 		apply plugin: 'spring-io'
 
@@ -241,6 +243,7 @@ subprojects { subproject ->
 
 	checkstyle {
 		configFile = new File(rootDir, "src/checkstyle/checkstyle.xml")
+//		ignoreFailures = true
 	}
 
 	artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -243,7 +243,6 @@ subprojects { subproject ->
 
 	checkstyle {
 		configFile = new File(rootDir, "src/checkstyle/checkstyle.xml")
-//		ignoreFailures = true
 	}
 
 	artifacts {

--- a/src/checkstyle/checkstyle-header.txt
+++ b/src/checkstyle/checkstyle-header.txt
@@ -13,4 +13,5 @@
 ^\Q * See the License for the specific language governing permissions and\E$
 ^\Q * limitations under the License.\E$
 ^\Q */\E$
+^$
 ^.*$

--- a/src/checkstyle/checkstyle-header.txt
+++ b/src/checkstyle/checkstyle-header.txt
@@ -1,5 +1,5 @@
 ^\Q/*\E$
-^\Q * Copyright \E20\d\d\-20\d\d\Q the original author or authors.\E$
+^\Q * Copyright \E20\d\d(\-20\d\d)?\Q the original author or authors.\E$
 ^\Q *\E$
 ^\Q * Licensed under the Apache License, Version 2.0 (the "License");\E$
 ^\Q * you may not use this file except in compliance with the License.\E$
@@ -13,5 +13,4 @@
 ^\Q * See the License for the specific language governing permissions and\E$
 ^\Q * limitations under the License.\E$
 ^\Q */\E$
-^$
 ^.*$

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -3,4 +3,5 @@
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
+	<suppress files="package-info\.java" checks=".*" />
 </suppressions>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -2,11 +2,16 @@
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
 
+	<module name="SuppressionFilter">
+		<property name="file" value="src/checkstyle/checkstyle-suppressions.xml" />
+	</module>
+
 	<!-- Root Checks -->
-<!-- 	<module name="RegexpHeader"> -->
-<!-- 		<property name="headerFile" value="${checkstyle.header.file}" /> -->
-<!-- 		<property name="fileExtensions" value="java" /> -->
-<!-- 	</module> -->
+ 	<module name="RegexpHeader">
+ 		<property name="headerFile" value="src/checkstyle/checkstyle-header.txt" />
+ 		<property name="fileExtensions" value="java" />
+ 	</module>
+
 	<module name="NewlineAtEndOfFile">
 		<property name="lineSeparator" value="lf"/>
 	</module>

--- a/src/checkstyle/fixHeaders.gradle
+++ b/src/checkstyle/fixHeaders.gradle
@@ -1,25 +1,15 @@
+ext {
+	headerTemplate = new File('src/checkstyle/checkstyle-header.txt')
+			.text
+			.replaceAll(/\^\\Q|\\E\$|\^\$|\^\.\*\$/, '')
+			.replaceFirst(/\\E20\\d\\d\(\\-20\\d\\d\)\?\\Q/, '{year}')
+			.trim() + System.lineSeparator()  + System.lineSeparator()
+
+
+	now = Calendar.instance.get(Calendar.YEAR) as String
+}
+
 task fixHeaders << {
-
-	def headerTemplate =
-			'''/*
- * Copyright {year} the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-'''
-	def now = Calendar.instance.get(Calendar.YEAR) as String
-
 	fileTree("${buildDir}/reports/checkstyle").include('*.xml').each { report ->
 		def xml = new XmlParser(false, false).parse(report)
 		xml.file.each {
@@ -29,11 +19,11 @@ task fixHeaders << {
 				def line
 				file.withReader { reader ->
 					while (line = reader.readLine()) {
-						def matcher = line =~ /Copyright (20\d\d(?:-20\d\d)?)/
+						def matcher = line =~ /Copyright (20\d\d)(?:-20\d\d)?/
 						if (matcher.count) {
 							years = matcher[0][1]
 							if (years != now) {
-								years = years.take(4) + "-$now"
+								years = years + "-$now"
 							}
 							break
 						}
@@ -43,7 +33,8 @@ task fixHeaders << {
 				def header = headerTemplate.replaceFirst(/\{year}/, years)
 
 				def sourceCode = file.text
-				sourceCode = sourceCode.replaceFirst(/(?s)(?:.*)(package.*)/, "${header}\$1")
+				sourceCode = sourceCode.replaceFirst(/(?s)(?:.*)(package org\.springframework\.integration.*)/,
+						"${header}\$1")
 				file.write(sourceCode)
 				println "Header fixed for $file"
 			}

--- a/src/checkstyle/fixHeaders.gradle
+++ b/src/checkstyle/fixHeaders.gradle
@@ -1,0 +1,52 @@
+task fixHeaders << {
+
+	def headerTemplate =
+			'''/*
+ * Copyright {year} the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'''
+	def now = Calendar.instance.get(Calendar.YEAR) as String
+
+	fileTree("${buildDir}/reports/checkstyle").include('*.xml').each { report ->
+		def xml = new XmlParser(false, false).parse(report)
+		xml.file.each {
+			if (it.error.@source == ['com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck']) {
+				def years = now
+				def file = new File(it.@name)
+				def line
+				file.withReader { reader ->
+					while (line = reader.readLine()) {
+						def matcher = line =~ /Copyright (20\d\d(?:-20\d\d)?)/
+						if (matcher.count) {
+							years = matcher[0][1]
+							if (years != now) {
+								years = years.take(4) + "-$now"
+							}
+							break
+						}
+					}
+				}
+
+				def header = headerTemplate.replaceFirst(/\{year}/, years)
+
+				def sourceCode = file.text
+				sourceCode = sourceCode.replaceFirst(/(?s)(?:.*)(package.*)/, "${header}\$1")
+				file.write(sourceCode)
+				println "Header fixed for $file"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Copied/pasted `checkstyle-header` and its checkstyle rule from Spring AMQP.

Implemented `fixHeaders` Gradle task - `src/checkstyle/fixHeaders.gradle`.

The classes with violations (351) have been left without changes.
Just let you know to play with the script locally! :smile: 
1. uncomment `ignoreFailures = true` for `checkstyle` task in the `build.gradle`
2. run it like `gradlew clean check -x test --parallel` to get all reports
3. run the `fixHeaders` and enjoy its report in the console!

Any feedback welcome!

I wonder if there is better way to replace the part of file, rather than read and write the whole content...
