### PR TITLE
INT-3961: Add channel late-binding for `@ICA`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/InboundChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/InboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
 
 /**
  * Indicates that a method is capable of producing a {@link org.springframework.messaging.Message}
@@ -53,9 +55,18 @@ import java.lang.annotation.Target;
 public @interface InboundChannelAdapter {
 
 	/**
+	 * Alias for the {@link #channel()} attribute.
 	 * @return the 'channel' bean name to send the {@link org.springframework.messaging.Message}.
 	 */
-	String value();
+	@AliasFor("channel")
+	String value() default "";
+
+	/**
+	 * @return the 'channel' bean name to send the {@link org.springframework.messaging.Message}.
+	 * @since 4.2.6
+	 */
+	@AliasFor("value")
+	String channel() default "";
 
 	/*
 	 {@code SmartLifecycle} options.

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.endpoint.MethodInvokingMessageSource;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.util.MessagingAnnotationUtils;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.util.Assert;
 
@@ -72,10 +71,8 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 			return null;
 		}
 
-		MessageChannel channel = this.channelResolver.resolveDestination(channelName);
-
 		SourcePollingChannelAdapter adapter = new SourcePollingChannelAdapter();
-		adapter.setOutputChannel(channel);
+		adapter.setOutputChannelName(channelName);
 		adapter.setSource(messageSource);
 		configurePollingEndpoint(adapter, annotations);
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,8 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 
 	private volatile MessageChannel outputChannel;
 
+	private volatile String outputChannelName;
+
 	private volatile boolean shouldTrack;
 
 	private final MessagingTemplate messagingTemplate = new MessagingTemplate();
@@ -73,6 +75,11 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 	 */
 	public void setOutputChannel(MessageChannel outputChannel) {
 		this.outputChannel = outputChannel;
+	}
+
+	public void setOutputChannelName(String outputChannelName) {
+		Assert.hasText(outputChannelName, "'outputChannelName' must not be empty");
+		this.outputChannelName = outputChannelName;
 	}
 
 	/**
@@ -145,11 +152,25 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 	@Override
 	protected void onInit() {
 		Assert.notNull(this.source, "source must not be null");
-		Assert.notNull(this.outputChannel, "outputChannel must not be null");
+		Assert.state((this.outputChannelName == null && this.outputChannel != null)
+				|| (this.outputChannelName != null && this.outputChannel == null),
+				"One and only one of 'requestChannelName' or 'requestChannel' is required.");
 		super.onInit();
 		if (this.getBeanFactory() != null) {
 			this.messagingTemplate.setBeanFactory(this.getBeanFactory());
 		}
+	}
+
+	public MessageChannel getOutputChannel() {
+		if (this.outputChannelName != null) {
+			synchronized (this) {
+				if (this.outputChannelName != null) {
+					this.outputChannel = getChannelResolver().resolveDestination(this.outputChannelName);
+					this.outputChannelName = null;
+				}
+			}
+		}
+		return this.outputChannel;
 	}
 
 	@Override
@@ -158,7 +179,7 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 			message = MessageHistory.write(message, this, this.getMessageBuilderFactory());
 		}
 		try {
-			this.messagingTemplate.send(this.outputChannel, message);
+			this.messagingTemplate.send(getOutputChannel(), message);
 		}
 		catch (Exception e) {
 			if (e instanceof MessagingException) {

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -438,6 +438,14 @@ public String foo() {
 }
 ----
 
+Starting with _version 4.3_ the `channel` alias for the `value` annotation attribute has been introduced for better
+source code readability.
+Also the target `MessageChannel` bean is resolved in the `SourcePollingChannelAdapter` by the provided name
+(`outputChannelName` options) on the first `receive()` call, not during
+initialization phase.
+It allows the 'late binding' logic, when the target `MessageChannel` bean from the consumer perspective
+is created and registered a bit later than the `@InboundChannelAdapter` parsing phase.
+
 The first example requires that the default poller has been declared elsewhere in the application context.
 
 *@MessagingGateway*

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -141,3 +141,10 @@ See <<amqp-message-headers>>, <<ws-message-headers>>, and <<xmpp-message-headers
 
 Groovy scripts can now be configured with the `compile-static` hint or any other `CompilerConfiguration` options.
 See <<groovy-config>> for more information.
+
+==== @InboundChannelAdapter
+
+The `@InboundChannelAdapter` has now an alias `channel` attribute for regular `value`.
+In addition the target `SourcePollingChannelAdapter` components can now resolve the target `outputChannel` bean
+from its provided name (`outputChannelName` options) in late-binding manner.
+See <<annotations>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3961

The `@InboundChannelAdapter` may be initialized by its `MessagingAnnotationPostProcessor` a bit earlier than the
provided channel is created and registered in the context - via some other more late `BPP`, e.g. `IntegrationFlowBeanPostProcessor` from Java DSL.
- Add channel late-binding logic to the `InboundChannelAdapterAnnotationPostProcessor` and `SourcePollingChannelAdapter` by the provided `outputChannelName` option.
- Add the `channel` alias for the `value` annotation attribute in the `@InboundChannelAdapter`
- Add the `@InboundChannelAdapter` configuration into the `EnableIntegrationTests` without the channel declaration to be sure that the fix provide the expected results without `DestinationResolutionException`
- Mention both changes in the `configuration.adoc` and `whats-new.adoc`
