### PR TITLE
Enable `RedundantModifier` checkstyle, add fixer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ subprojects { subproject ->
 	apply plugin: 'checkstyle'
 
 	apply from:   "${rootDir}/src/checkstyle/fixHeaders.gradle"
+	apply from:   "${rootDir}/src/checkstyle/fixModifiers.gradle"
 
 	if (project.hasProperty('platformVersion')) {
 		apply plugin: 'spring-io'

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -4,4 +4,6 @@
     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files="package-info\.java" checks=".*" />
+	<suppress files="[\\/]test[\\/]" checks="RequireThis" />
+	<suppress files="[\\/]test[\\/]" checks="Javadoc*" />
 </suppressions>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -125,7 +125,7 @@
 <!-- 		<module name="OuterTypeFilename" /> -->
 
 		<!-- Modifiers -->
-<!-- 		<module name="RedundantModifier" /> -->
+ 		<module name="RedundantModifier" />
 
 		<!-- Regexp -->
 <!--  		<module name="RegexpSinglelineJava"> -->

--- a/src/checkstyle/fixModifiers.gradle
+++ b/src/checkstyle/fixModifiers.gradle
@@ -1,0 +1,50 @@
+task fixModifiers << {
+	fileTree("${buildDir}/reports/checkstyle").include('*.xml').each { report ->
+		def xml = new XmlParser(false, false).parse(report)
+		xml.file.each { f ->
+			def errors = f.error
+			def modifierErrors = []
+			errors.each { error ->
+				if (error.@source == 'com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck') {
+					modifierErrors.add(error)
+				}
+			}
+			if (modifierErrors) {
+				def errorInx = 0
+				def error = modifierErrors[errorInx++]
+				def file = new File(f.@name)
+				println "Fixing file $file ..."
+				boolean headerFixed
+				def outSource = ''
+				file.eachLine { line, ln ->
+					if (!headerFixed) {
+						def matcher = line =~ /Copyright (20\d\d)(?:-20\d\d)?/
+						if (matcher.count) {
+							def years = matcher[0][1]
+							if (years != now) {
+								years = years + "-$now"
+							}
+							line = line.replaceFirst(/(20\d\d)(?:-20\d\d)?/, years)
+							headerFixed = true
+						}
+					}
+
+					while (error && ln == (error.@line as int)) {
+						def message = error.@message
+						def modifier = message.substring(message.indexOf('\'') + 1, message.lastIndexOf('\''))
+
+						line = line.replaceFirst(modifier + ' ', '')
+
+						println "Fixed line $line"
+
+						error = modifierErrors[errorInx++]
+					}
+
+					outSource += line + '\n'
+				}
+				file.write(outSource)
+				println()
+			}
+		}
+	}
+}

--- a/src/checkstyle/fixThis.gradle
+++ b/src/checkstyle/fixThis.gradle
@@ -1,0 +1,65 @@
+task fixThis << {
+	fileTree("${buildDir}/reports/checkstyle").include('*.xml').each { report ->
+		println "processing $report"
+		def xml = new XmlParser(false, false).parse(report)
+		xml.file.each { f ->
+			// println "processing $f"
+			def errors = f.error
+			def hasThisError = false
+			def thisErrors = []
+			errors.each { error ->
+				if (error.@source == 'com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck') {
+					thisErrors.add(error)
+					hasThisError = true
+				}
+			}
+			// println hasThisError
+			// println f.@name
+			if (hasThisError) {
+				def errorInx = 0
+				def error = thisErrors[errorInx++]
+				def lx = Integer.valueOf(error.@line)
+				println error
+				def file = new File(f.@name)
+				def outSource = ''
+				def ln = 0
+				file.eachLine { line ->
+					// println line
+					ln++
+					def matcher = line =~ /Copyright (20\d\d)(?:-20\d\d)?/
+					if (matcher.count) {
+						def years = matcher[0][1]
+						if (years != now) {
+							years = years + "-$now"
+						}
+						line.replaceFirst(/(20\d\d)(?:-20\d\d)?/, years)
+					}
+					if (error && ln == lx) {
+						// println line
+						def beforeIndex = Integer.valueOf(error.@column) - 1
+						def chars = line.toCharArray()
+						for (int i = 0; i < beforeIndex; i++) {
+							if (chars[i] == '\t') { // tabs before code == 8
+								beforeIndex -= 7;
+							}
+							else if (chars[i] != ' ') { // tabs after code start are only counted as 1
+								break;
+							}
+						}
+						line = line.substring(0, beforeIndex) + "this." + line.substring(beforeIndex)
+						// println line
+						error = thisErrors[errorInx++]
+						while (error && lx == Integer.valueOf(error.@line)) {
+							error = thisErrors[errorInx++]
+						}
+						if (error) {
+							lx = Integer.valueOf(error.@line)
+						}
+					}
+					outSource += line + '\n'
+				}
+				file.write(outSource)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add `fixModifiers.gradle` to run after `check` task.

The `RedundantModifierChecker` doesn't catch all errors at once.
We need run `check -> fixModifiers` pair several times to reach `SUCCESSFUL`.

The `fixThis` has been ported from the SA, but without applying.

Review for this first of all!
