### PR TITLE
INT-3970: Fix `ScriptExecutor` for wrong `lang`

### DIFF
--- a/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/jsr223/AbstractScriptExecutor.java
+++ b/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/jsr223/AbstractScriptExecutor.java
@@ -53,16 +53,10 @@ public abstract class AbstractScriptExecutor implements ScriptExecutor {
 		Assert.hasText(language, "language must not be empty");
 		this.language = language;
 
-		scriptEngine = new ScriptEngineManager().getEngineByName(this.language);
-
+		this.scriptEngine = new ScriptEngineManager().getEngineByName(this.language);
+		Assert.notNull(this.scriptEngine, "There is no 'scriptEngine' for the 'language': " + this.language);
 		if (logger.isDebugEnabled()) {
-
-			if (scriptEngine == null) {
-				logger.error(invlalidLanguageMessage(this.language));
-			}
-			else {
-				logger.debug("using script engine : " + scriptEngine.getFactory().getEngineName());
-			}
+			logger.debug("Using script engine : " + scriptEngine.getFactory().getEngineName());
 		}
 	}
 

--- a/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/jsr223/AbstractScriptExecutor.java
+++ b/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/jsr223/AbstractScriptExecutor.java
@@ -54,7 +54,7 @@ public abstract class AbstractScriptExecutor implements ScriptExecutor {
 		this.language = language;
 
 		this.scriptEngine = new ScriptEngineManager().getEngineByName(this.language);
-		Assert.notNull(this.scriptEngine, "There is no 'scriptEngine' for the 'language': " + this.language);
+		Assert.notNull(this.scriptEngine, invalidLanguageMessage(this.language));
 		if (logger.isDebugEnabled()) {
 			logger.debug("Using script engine : " + scriptEngine.getFactory().getEngineName());
 		}
@@ -67,7 +67,7 @@ public abstract class AbstractScriptExecutor implements ScriptExecutor {
 
 	@Override
 	public Object executeScript(ScriptSource scriptSource, Map<String, Object> variables) {
-		Object result = null;
+		Object result;
 
 		try {
 			String script = scriptSource.getScriptAsString();
@@ -109,10 +109,10 @@ public abstract class AbstractScriptExecutor implements ScriptExecutor {
 	 */
 	protected abstract Object postProcess(Object result, ScriptEngine scriptEngine, String script, Bindings bindings);
 
-	private static String invlalidLanguageMessage(String language) {
-		return new StringBuilder().append(ScriptEngineManager.class.getName())
-				.append(" is unable to create a script engine for language '").append(language).append("'.\n")
-				.append("This may be due to a missing language implementation or an invalid language name.").toString();
+	private static String invalidLanguageMessage(String language) {
+		return ScriptEngineManager.class.getName() +
+				" is unable to create a script engine for language '" + language + "'.\n" +
+				"This may be due to a missing language implementation or an invalid language name.";
 	}
 
 }

--- a/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/jsr223/DefaultScriptExecutor.java
+++ b/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/jsr223/DefaultScriptExecutor.java
@@ -34,7 +34,7 @@ import org.springframework.integration.scripting.ScriptExecutor;
 	 * Create a DefaultScriptExecutor for the specified language name (JSR233
 	 * alias).
 	 */
-	DefaultScriptExecutor(String language) {
+	public DefaultScriptExecutor(String language) {
 		super(language);
 	}
 

--- a/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/jsr223/Jsr223ScriptExecutorTests.java
+++ b/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/jsr223/Jsr223ScriptExecutorTests.java
@@ -24,14 +24,14 @@ import java.util.Map;
 import org.junit.Test;
 
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 import org.springframework.integration.scripting.ScriptExecutor;
-import org.springframework.integration.scripting.ScriptingException;
 import org.springframework.scripting.support.ResourceScriptSource;
 import org.springframework.scripting.support.StaticScriptSource;
 
 /**
  * @author David Turanski
- *
+ * @author Artem Bilan
  */
 public class Jsr223ScriptExecutorTests {
 
@@ -41,9 +41,9 @@ public class Jsr223ScriptExecutorTests {
 		executor.executeScript(new StaticScriptSource("'hello, world'"));
 		executor.executeScript(new StaticScriptSource("'hello, again'"));
 
-		Map<String,Object> variables = new HashMap<String,Object>();
+		Map<String, Object> variables = new HashMap<String, Object>();
 
-		Map<String,Object> headers = new HashMap<String,Object>();
+		Map<String, Object> headers = new HashMap<String, Object>();
 		headers.put("one", 1);
 		headers.put("two", "two");
 		headers.put("three", 3);
@@ -51,33 +51,32 @@ public class Jsr223ScriptExecutorTests {
 		variables.put("payload", "payload");
 		variables.put("headers", headers);
 
-		String result = (String)executor.executeScript(
-				new ResourceScriptSource(new ClassPathResource("/org/springframework/integration/scripting/jsr223/print_message.rb")),
-				variables
-		);
+		Resource resource = new ClassPathResource("/org/springframework/integration/scripting/jsr223/print_message.rb");
+		String result = (String) executor.executeScript(new ResourceScriptSource(resource), variables);
 
 		assertEquals("payload modified", result.substring(0, "payload modified".length()));
 	}
+
 	@Test
-	public void testJs(){
+	public void testJs() {
 		ScriptExecutor executor = ScriptExecutorFactory.getScriptExecutor("js");
 		Object obj = executor.executeScript(new StaticScriptSource("function js(){ return 'js';} js();"));
-		assertEquals("js",obj.toString());
+		assertEquals("js", obj.toString());
 	}
 
 	@Test
 	public void testPython() {
 		ScriptExecutor executor = ScriptExecutorFactory.getScriptExecutor("python");
-		Object obj = executor.executeScript(new StaticScriptSource("x=2") );
-		assertEquals(2,obj);
+		Object obj = executor.executeScript(new StaticScriptSource("x=2"));
+		assertEquals(2, obj);
 
-		obj =  executor.executeScript(new StaticScriptSource("def foo(y):\n\tx=y\n\treturn y\nz=foo(2)") );
-		assertEquals(2,obj);
+		obj = executor.executeScript(new StaticScriptSource("def foo(y):\n\tx=y\n\treturn y\nz=foo(2)"));
+		assertEquals(2, obj);
 	}
 
-	@Test(expected = ScriptingException.class)
-	public void testInvalidLanguageThrowsScriptingException() {
-		ScriptExecutor executor = ScriptExecutorFactory.getScriptExecutor("foo");
-		executor.executeScript(new StaticScriptSource("x=2"));
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidLanguageThrowsIllegalArgumentException() {
+		ScriptExecutorFactory.getScriptExecutor("foo");
 	}
+
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3970

NOTE: Don't see reason to back-port, because we have catched `ScriptingException` for the same reason at runtime.
