### PR TITLE
INT-3968: Map JmsDestination Header (Inbound)

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.jms.support.JmsHeaders;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.StringUtils;
 
@@ -111,7 +112,7 @@ public class DefaultJmsHeaderMapper implements JmsHeaderMapper {
 		try {
 			Object jmsCorrelationId = headers.get(JmsHeaders.CORRELATION_ID);
 			if (jmsCorrelationId instanceof Number) {
-				jmsCorrelationId = ((Number) jmsCorrelationId).toString();
+				jmsCorrelationId = jmsCorrelationId.toString();
 			}
 			if (jmsCorrelationId instanceof String) {
 				try {
@@ -190,6 +191,15 @@ public class DefaultJmsHeaderMapper implements JmsHeaderMapper {
 			}
 			catch (Exception e) {
 				logger.info("failed to read JMSMessageID property, skipping", e);
+			}
+			try {
+				Destination destination = jmsMessage.getJMSDestination();
+				if (destination != null) {
+					headers.put(JmsHeaders.DESTINATION, destination);
+				}
+			}
+			catch (Exception ex) {
+				logger.info("failed to read JMSDestination property, skipping", ex);
 			}
 			try {
 				String correlationId = jmsMessage.getJMSCorrelationID();

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsHeaders.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,13 @@ package org.springframework.integration.jms;
 /**
  * Pre-defined names and prefixes to be used for setting and/or retrieving JMS
  * attributes from/to integration Message Headers.
- * 
+ *
+ * @deprecated - use {@link org.springframework.jms.support.JmsHeaders.JmsHeaders}.
+ *
  * @author Mark Fisher
+ * @author Gary Russell
  */
+@Deprecated
 public abstract class JmsHeaders {
 
 	/**
@@ -29,18 +33,18 @@ public abstract class JmsHeaders {
 	 * user-defined headers and other internal headers (e.g. correlationId).
 	 * @see DefaultJmsHeaderMapper
 	 */
-	public static final String PREFIX = "jms_";
+	public static final String PREFIX = org.springframework.jms.support.JmsHeaders.PREFIX;
 
-	public static final String MESSAGE_ID = PREFIX + "messageId";
+	public static final String MESSAGE_ID = org.springframework.jms.support.JmsHeaders.MESSAGE_ID;
 
-	public static final String CORRELATION_ID = PREFIX + "correlationId";
+	public static final String CORRELATION_ID = org.springframework.jms.support.JmsHeaders.CORRELATION_ID;
 
-	public static final String REPLY_TO = PREFIX + "replyTo";
+	public static final String REPLY_TO = org.springframework.jms.support.JmsHeaders.REPLY_TO;
 
-	public static final String REDELIVERED = PREFIX + "redelivered";
+	public static final String REDELIVERED = org.springframework.jms.support.JmsHeaders.REDELIVERED;
 
-	public static final String TYPE = PREFIX + "type";
+	public static final String TYPE = org.springframework.jms.support.JmsHeaders.TYPE;
 
-	public static final String TIMESTAMP = PREFIX + "timestamp";
+	public static final String TIMESTAMP = org.springframework.jms.support.JmsHeaders.TIMESTAMP;
 
 }

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsHeaderEnricherParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsHeaderEnricherParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2009 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@
 package org.springframework.integration.jms.config;
 
 import org.springframework.integration.config.xml.HeaderEnricherParserSupport;
-import org.springframework.integration.jms.JmsHeaders;
+import org.springframework.jms.support.JmsHeaders;
 
 /**
  * Header enricher for JMS specific values.
- * 
+ *
  * @author Mark Fisher
  * @since 2.0
  */

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/DefaultJmsHeaderMapperTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/DefaultJmsHeaderMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.mockito.stubbing.Answer;
 
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.jms.support.JmsHeaders;
 import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
 import org.springframework.jms.support.converter.MessageType;
 import org.springframework.messaging.Message;

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsHeaderEnricherTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsHeaderEnricherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.jms.DefaultJmsHeaderMapper;
+import org.springframework.integration.jms.StubTextMessage;
+import org.springframework.jms.support.JmsHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
-import org.springframework.integration.jms.DefaultJmsHeaderMapper;
-import org.springframework.integration.jms.JmsHeaders;
-import org.springframework.integration.jms.StubTextMessage;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -37,6 +37,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Gary Russell
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCorrelationKeyProvidedTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCorrelationKeyProvidedTests.java
@@ -26,12 +26,12 @@ import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.gateway.RequestReplyExchanger;
 import org.springframework.integration.jms.ActiveMQMultiContextTests;
-import org.springframework.integration.jms.JmsHeaders;
 import org.springframework.integration.jms.JmsOutboundGateway;
 import org.springframework.integration.jms.config.ActiveMqTestUtils;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.jms.support.JmsHeaders;
 import org.springframework.messaging.Message;
 /**
  * @author Oleg Zhurakousky


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3968

Also deprecate `o.s.i.jms.JmsHeaders` in favor of the `o.s.jms.support` version.
