### PR TITLE
TCP Connection Factory FactoryBean Improvements

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryParser.java
@@ -45,7 +45,7 @@ public class TcpConnectionFactoryParser extends AbstractBeanDefinitionParser {
 					" must be 'client' or 'server' for a TCP Connection Factory", element);
 		}
 		builder = BeanDefinitionBuilder.genericBeanDefinition(TcpConnectionFactoryFactoryBean.class);
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "type");
+		IpAdapterParserUtils.addConstructorValueIfAttributeDefined(builder, element, "type");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.HOST);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryTests.java
@@ -55,6 +55,7 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.ip.config.TcpConnectionFactoryFactoryBean;
 import org.springframework.integration.ip.event.IpIntegrationEvent;
 import org.springframework.integration.ip.tcp.TcpReceivingChannelAdapter;
 import org.springframework.integration.test.support.LogAdjustingTestSupport;
@@ -70,6 +71,16 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  *
  */
 public class ConnectionFactoryTests extends LogAdjustingTestSupport {
+
+	@Test
+	public void factoryBeanTests() {
+		TcpConnectionFactoryFactoryBean fb = new TcpConnectionFactoryFactoryBean("client");
+		assertEquals(AbstractClientConnectionFactory.class, fb.getObjectType());
+		fb = new TcpConnectionFactoryFactoryBean("server");
+		assertEquals(AbstractServerConnectionFactory.class, fb.getObjectType());
+		fb = new TcpConnectionFactoryFactoryBean();
+		assertEquals(AbstractConnectionFactory.class, fb.getObjectType());
+	}
 
 	@Test
 	public void testObtainConnectionIdsNet() throws Exception {


### PR DESCRIPTION
Add ctor argument so that early `getObjectType()` calls can return
a narrower type (server Vs. client CF).
