### PR TITLE
INT-3975: AMQP Channels: Support extract-payload

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/AbstractAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/AbstractAmqpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,11 @@
 package org.springframework.integration.amqp.channel;
 
 import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.core.MessageDeliveryMode;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.integration.amqp.support.AmqpHeaderMapper;
+import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
+import org.springframework.integration.amqp.support.MappingUtils;
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
@@ -29,11 +34,48 @@ public abstract class AbstractAmqpChannel extends AbstractMessageChannel {
 
 	private final AmqpTemplate amqpTemplate;
 
+	private final RabbitTemplate rabbitTemplate;
+
+	private final AmqpHeaderMapper outboundHeaderMapper;
+
+	private final AmqpHeaderMapper inboundHeaderMapper;
+
+	private volatile boolean extractPayload;
+
 	private volatile boolean loggingEnabled = true;
 
+	private MessageDeliveryMode defaultDeliveryMode;
+
+	/**
+	 * Construct an instance with the supplied template and default header mappers
+	 * used if the template is a {@link RabbitTemplate} and the message is mapped.
+	 * @param amqpTemplate the template.
+	 * @see #setExtractPayload(boolean)
+	 */
 	AbstractAmqpChannel(AmqpTemplate amqpTemplate) {
+		this(amqpTemplate, DefaultAmqpHeaderMapper.outboundMapper(), DefaultAmqpHeaderMapper.inboundMapper());
+	}
+
+	/**
+	 * Construct an instance with the supplied template and header mappers, used
+	 * when the message is mapped.
+	 * @param amqpTemplate the template.
+	 * @param outboundMapper the outbound mapper.
+	 * @param inboundMapper the inbound mapper.
+	 * @see #setExtractPayload(boolean)
+	 * @since 4.3
+	 */
+	AbstractAmqpChannel(AmqpTemplate amqpTemplate, AmqpHeaderMapper outboundMapper, AmqpHeaderMapper inboundMapper) {
 		Assert.notNull(amqpTemplate, "amqpTemplate must not be null");
 		this.amqpTemplate = amqpTemplate;
+		if (amqpTemplate instanceof RabbitTemplate) {
+			this.rabbitTemplate = (RabbitTemplate) amqpTemplate;
+		}
+		else {
+			this.rabbitTemplate = null;
+		}
+		this.outboundHeaderMapper = outboundMapper;
+		this.inboundHeaderMapper = inboundMapper;
 	}
 
 	@Override
@@ -44,6 +86,41 @@ public abstract class AbstractAmqpChannel extends AbstractMessageChannel {
 	@Override
 	public void setLoggingEnabled(boolean loggingEnabled) {
 		this.loggingEnabled = loggingEnabled;
+	}
+
+	/**
+	 * Set the delivery mode to use if the message has no
+	 * {@value org.springframework.amqp.support.AmqpHeaders#DELIVERY_MODE}
+	 * header and the message property was not set by the {@code MessagePropertiesConverter}.
+	 * @param defaultDeliveryMode the default delivery mode.
+	 * @since 4.3
+	 */
+	public void setDefaultDeliveryMode(MessageDeliveryMode defaultDeliveryMode) {
+		this.defaultDeliveryMode = defaultDeliveryMode;
+	}
+
+	/**
+	 * Set to true to extract the payload and map the headers; otherwise
+	 * the entire message is converted and sent. Default false.
+	 * @param extractPayload true to extract and map.
+	 * @since 4.3
+	 */
+	public void setExtractPayload(boolean extractPayload) {
+		if (extractPayload) {
+			Assert.isTrue(this.rabbitTemplate != null, "amqpTemplate must be a RabbitTemplate for 'extractPayload'");
+			Assert.state(this.outboundHeaderMapper != null && this.inboundHeaderMapper != null,
+					"'extractPayload' requires both inbound and outbound header mappers");
+		}
+		this.extractPayload = extractPayload;
+	}
+
+	/**
+	 * @return the extract payload.
+	 * @see #setExtractPayload(boolean)
+	 * @since 4.3
+	 */
+	protected boolean isExtractPayload() {
+		return this.extractPayload;
 	}
 
 	/**
@@ -66,13 +143,27 @@ public abstract class AbstractAmqpChannel extends AbstractMessageChannel {
 		return "";
 	}
 
-	AmqpTemplate getAmqpTemplate() {
+	protected AmqpHeaderMapper getInboundHeaderMapper() {
+		return this.inboundHeaderMapper;
+	}
+
+	protected AmqpTemplate getAmqpTemplate() {
 		return this.amqpTemplate;
+	}
+
+	protected RabbitTemplate getRabbitTemplate() {
+		return this.rabbitTemplate;
 	}
 
 	@Override
 	protected boolean doSend(Message<?> message, long timeout) {
-		this.amqpTemplate.convertAndSend(this.getExchangeName(), this.getRoutingKey(), message);
+		if (this.extractPayload) {
+			this.amqpTemplate.send(getExchangeName(), getRoutingKey(), MappingUtils.mapMessage(message,
+					this.rabbitTemplate.getMessageConverter(), this.outboundHeaderMapper, this.defaultDeliveryMode));
+		}
+		else {
+			this.amqpTemplate.convertAndSend(getExchangeName(), getRoutingKey(), message);
+		}
 		return true;
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PointToPointSubscribableAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PointToPointSubscribableAmqpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.dispatcher.AbstractDispatcher;
 import org.springframework.integration.dispatcher.RoundRobinLoadBalancingStrategy;
 import org.springframework.integration.dispatcher.UnicastingDispatcher;
@@ -34,9 +35,34 @@ public class PointToPointSubscribableAmqpChannel extends AbstractSubscribableAmq
 	private volatile String queueName;
 
 
+	/**
+	 * Construct an instance with the supplied name, container and template; default header
+	 * mappers will be used if the message is mapped.
+	 * @param channelName the channel name.
+	 * @param container the container.
+	 * @param amqpTemplate the template.
+	 * @see #setExtractPayload(boolean)
+	 */
 	public PointToPointSubscribableAmqpChannel(String channelName, SimpleMessageListenerContainer container,
 			AmqpTemplate amqpTemplate) {
 		super(channelName, container, amqpTemplate);
+	}
+
+
+	/**
+	 * Construct an instance with the supplied name, container and template; default header
+	 * mappers will be used if the message is mapped.
+	 * @param channelName the channel name.
+	 * @param container the container.
+	 * @param amqpTemplate the template.
+	 * @param outboundMapper the outbound mapper.
+	 * @param inboundMapper the inbound mapper.
+	 * @see #setExtractPayload(boolean)
+	 * @since 4.3
+	 */
+	public PointToPointSubscribableAmqpChannel(String channelName, SimpleMessageListenerContainer container,
+			AmqpTemplate amqpTemplate, AmqpHeaderMapper outboundMapper, AmqpHeaderMapper inboundMapper) {
+		super(channelName, container, amqpTemplate, outboundMapper, inboundMapper);
 	}
 
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PollableAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PollableAmqpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,14 @@ package org.springframework.integration.amqp.channel;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.channel.ExecutorChannelInterceptorAware;
 import org.springframework.integration.support.management.PollableChannelManagement;
 import org.springframework.messaging.Message;
@@ -54,8 +56,31 @@ public class PollableAmqpChannel extends AbstractAmqpChannel
 
 	private volatile int executorInterceptorsSize;
 
+	/**
+	 * Construct an instance with the suppleid name, template and defaule header mappers
+	 * used if the template is a {@link RabbitTemplate} and the message is mapped.
+	 * @param channelName the channel name.
+	 * @param amqpTemplate the template.
+	 * @see #setExtractPayload(boolean)
+	 */
 	public PollableAmqpChannel(String channelName, AmqpTemplate amqpTemplate) {
 		super(amqpTemplate);
+		Assert.hasText(channelName, "channel name must not be empty");
+		this.channelName = channelName;
+	}
+
+	/**
+	 * Construct an instance with the supplied name, template and header mappers.
+	 * @param channelName the channel name.
+	 * @param amqpTemplate the template.
+	 * @param outboundMapper the outbound mapper.
+	 * @param inboundMapper the inbound mapper.
+	 * @see #setExtractPayload(boolean)
+	 * @since 4.3
+	 */
+	public PollableAmqpChannel(String channelName, AmqpTemplate amqpTemplate, AmqpHeaderMapper outboundMapper,
+			AmqpHeaderMapper inboundMapper) {
+		super(amqpTemplate, inboundMapper, outboundMapper);
 		Assert.hasText(channelName, "channel name must not be empty");
 		this.channelName = channelName;
 	}
@@ -141,7 +166,7 @@ public class PollableAmqpChannel extends AbstractAmqpChannel
 					 return null;
 				}
 			}
-			Object object = getAmqpTemplate().receiveAndConvert(this.queueName);
+			Object object = doReceive();
 			if (object == null) {
 				if (isLoggingEnabled() && logger.isTraceEnabled()) {
 					logger.trace("postReceive on channel '" + this + "', message is null");
@@ -176,6 +201,26 @@ public class PollableAmqpChannel extends AbstractAmqpChannel
 				interceptorList.afterReceiveCompletion(null, this, e, interceptorStack);
 			}
 			throw e;
+		}
+	}
+
+
+	protected Object doReceive() {
+		if (!isExtractPayload()) {
+			return getAmqpTemplate().receiveAndConvert(this.queueName);
+		}
+		else {
+			RabbitTemplate rabbitTemplate = getRabbitTemplate();
+			org.springframework.amqp.core.Message message = rabbitTemplate.receive(this.queueName);
+			if (message != null) {
+				Object payload = rabbitTemplate.getMessageConverter().fromMessage(message);
+				Map<String, Object> headers =
+						getInboundHeaderMapper().toHeadersFromRequest(message.getMessageProperties());
+				return getMessageBuilderFactory().withPayload(payload).copyHeaders(headers).build();
+			}
+			else {
+				return null;
+			}
 		}
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PollableAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PollableAmqpChannel.java
@@ -57,7 +57,7 @@ public class PollableAmqpChannel extends AbstractAmqpChannel
 	private volatile int executorInterceptorsSize;
 
 	/**
-	 * Construct an instance with the suppleid name, template and defaule header mappers
+	 * Construct an instance with the supplied name, template and default header mappers
 	 * used if the template is a {@link RabbitTemplate} and the message is mapped.
 	 * @param channelName the channel name.
 	 * @param amqpTemplate the template.

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.dispatcher.AbstractDispatcher;
 import org.springframework.integration.dispatcher.BroadcastingDispatcher;
 
@@ -46,9 +47,33 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 
 	private volatile boolean initialized;
 
+	/**
+	 * Construct an instance with the supplied name, container and template; default header
+	 * mappers will be used if the message is mapped.
+	 * @param channelName the channel name.
+	 * @param container the container.
+	 * @param amqpTemplate the template.
+	 * @see #setExtractPayload(boolean)
+	 */
 	public PublishSubscribeAmqpChannel(String channelName, SimpleMessageListenerContainer container,
 			AmqpTemplate amqpTemplate) {
 		super(channelName, container, amqpTemplate, true);
+	}
+
+	/**
+	 * Construct an instance with the supplied name, container and template; default header
+	 * mappers will be used if the message is mapped.
+	 * @param channelName the channel name.
+	 * @param container the container.
+	 * @param amqpTemplate the template
+	 * @param outboundMapper the outbound mapper.
+	 * @param inboundMapper the inbound mapper.
+	 * @see #setExtractPayload(boolean)
+	 * @since 4.3
+	 */
+	public PublishSubscribeAmqpChannel(String channelName, SimpleMessageListenerContainer container,
+			AmqpTemplate amqpTemplate, AmqpHeaderMapper outboundMapper, AmqpHeaderMapper inboundMapper) {
+		super(channelName, container, amqpTemplate, true, outboundMapper, inboundMapper);
 	}
 
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpChannelParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpChannelParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,10 @@ public class AmqpChannelParser extends AbstractChannelParser {
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "transaction-attribute");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "transaction-manager");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "tx-size");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "default-delivery-mode");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "extract-payload");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "outbound-header-mapper");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "inbound-header-mapper");
 		return builder;
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
@@ -20,12 +20,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.amqp.core.MessageDeliveryMode;
-import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.support.CorrelationData;
 import org.springframework.amqp.support.AmqpHeaders;
-import org.springframework.amqp.support.converter.ContentTypeDelegatingMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.Lifecycle;
@@ -365,28 +363,6 @@ public abstract class AbstractAmqpOutboundEndpoint extends AbstractReplyProducin
 			routingKey = this.routingKeyGenerator.processMessage(requestMessage);
 		}
 		return routingKey;
-	}
-
-	protected org.springframework.amqp.core.Message mapMessage(Message<?> requestMessage, MessageConverter converter) {
-		MessageProperties amqpMessageProperties = new MessageProperties();
-		org.springframework.amqp.core.Message amqpMessage;
-		if (converter instanceof ContentTypeDelegatingMessageConverter) {
-			getHeaderMapper().fromHeadersToRequest(requestMessage.getHeaders(), amqpMessageProperties);
-			amqpMessage = converter.toMessage(requestMessage.getPayload(), amqpMessageProperties);
-		}
-		else { // See INT-3002 - map headers last if we're not using a CTDMC
-			amqpMessage = converter.toMessage(requestMessage.getPayload(), amqpMessageProperties);
-			getHeaderMapper().fromHeadersToRequest(requestMessage.getHeaders(), amqpMessageProperties);
-		}
-		checkDeliveryMode(requestMessage, amqpMessageProperties);
-		return amqpMessage;
-	}
-
-	private void checkDeliveryMode(Message<?> requestMessage, MessageProperties messageProperties) {
-		if (this.defaultDeliveryMode != null &&
-				requestMessage.getHeaders().get(AmqpHeaders.DELIVERY_MODE) == null) {
-			messageProperties.setDeliveryMode(this.defaultDeliveryMode);
-		}
 	}
 
 	protected Message<?> buildReplyMessage(MessageConverter converter,

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
@@ -25,6 +25,7 @@ import org.springframework.amqp.rabbit.support.CorrelationData;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.Lifecycle;
 import org.springframework.expression.Expression;
+import org.springframework.integration.amqp.support.MappingUtils;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
@@ -127,7 +128,8 @@ public class AmqpOutboundEndpoint extends AbstractAmqpOutboundEndpoint
 			final Message<?> requestMessage, CorrelationData correlationData) {
 		if (this.amqpTemplate instanceof RabbitTemplate) {
 			MessageConverter converter = ((RabbitTemplate) this.amqpTemplate).getMessageConverter();
-			org.springframework.amqp.core.Message amqpMessage = mapMessage(requestMessage, converter);
+			org.springframework.amqp.core.Message amqpMessage = MappingUtils.mapMessage(requestMessage, converter,
+					getHeaderMapper(), this.getDefaultDeliveryMode());
 			((RabbitTemplate) this.amqpTemplate).send(exchangeName, routingKey, amqpMessage, correlationData);
 		}
 		else {
@@ -149,7 +151,8 @@ public class AmqpOutboundEndpoint extends AbstractAmqpOutboundEndpoint
 		Assert.isInstanceOf(RabbitTemplate.class, this.amqpTemplate,
 				"RabbitTemplate implementation is required for publisher confirms");
 		MessageConverter converter = ((RabbitTemplate) this.amqpTemplate).getMessageConverter();
-		org.springframework.amqp.core.Message amqpMessage = mapMessage(requestMessage, converter);
+		org.springframework.amqp.core.Message amqpMessage = MappingUtils.mapMessage(requestMessage, converter, getHeaderMapper(),
+				getDefaultDeliveryMode());
 		org.springframework.amqp.core.Message amqpReplyMessage =
 				((RabbitTemplate) this.amqpTemplate).sendAndReceive(exchangeName, routingKey, amqpMessage,
 						correlationData);

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
@@ -129,7 +129,7 @@ public class AmqpOutboundEndpoint extends AbstractAmqpOutboundEndpoint
 		if (this.amqpTemplate instanceof RabbitTemplate) {
 			MessageConverter converter = ((RabbitTemplate) this.amqpTemplate).getMessageConverter();
 			org.springframework.amqp.core.Message amqpMessage = MappingUtils.mapMessage(requestMessage, converter,
-					getHeaderMapper(), this.getDefaultDeliveryMode());
+					getHeaderMapper(), getDefaultDeliveryMode());
 			((RabbitTemplate) this.amqpTemplate).send(exchangeName, routingKey, amqpMessage, correlationData);
 		}
 		else {

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AsyncAmqpOutboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AsyncAmqpOutboundGateway.java
@@ -22,6 +22,7 @@ import org.springframework.amqp.rabbit.AsyncRabbitTemplate;
 import org.springframework.amqp.rabbit.AsyncRabbitTemplate.RabbitMessageFuture;
 import org.springframework.amqp.rabbit.support.CorrelationData;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.integration.amqp.support.MappingUtils;
 import org.springframework.integration.handler.ReplyRequiredException;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
@@ -60,7 +61,8 @@ public class AsyncAmqpOutboundGateway extends AbstractAmqpOutboundEndpoint {
 	@Override
 	protected Object handleRequestMessage(Message<?> requestMessage) {
 		RabbitMessageFuture future = this.template.sendAndReceive(generateExchangeName(requestMessage),
-				generateRoutingKey(requestMessage), mapMessage(requestMessage, this.messageConverter));
+				generateRoutingKey(requestMessage),
+				MappingUtils.mapMessage(requestMessage, this.messageConverter, getHeaderMapper(), getDefaultDeliveryMode()));
 		future.addCallback(new FutureCallback(requestMessage));
 		CorrelationData correlationData = generateCorrelationData(requestMessage);
 		if (correlationData != null && future.getConfirm() != null) {

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -429,31 +429,31 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 	 * @return the default request headers for an inbound mapper.
 	 */
 	public static String[] inboundRequestHeaders() {
-		return safeInboundHeaders();
+		return new String[] { "*" };
 	}
 
 	/**
 	 * @return the default reply headers for an inbound mapper.
 	 */
 	public static String[] inboundReplyHeaders() {
-		return new String[] { "*" };
+		return safeOutboundHeaders();
 	}
 
 	/**
 	 * @return the default request headers for an outbound mapper.
 	 */
 	public static String[] outboundRequestHeaders() {
-		return new String[] { "*" };
+		return safeOutboundHeaders();
 	}
 
 	/**
 	 * @return the default reply headers for an outbound mapper.
 	 */
 	public static String[] outboundReplyHeaders() {
-		return safeInboundHeaders();
+		return new String[] { "*" };
 	}
 
-	private static String[] safeInboundHeaders() {
+	private static String[] safeOutboundHeaders() {
 		return new String[] { "!x-*", "*" };
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -119,7 +119,17 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 	 */
 	@Deprecated
 	public DefaultAmqpHeaderMapper() {
+		this(null, null);
+	}
+
+	private DefaultAmqpHeaderMapper(String[] requestHeaderNames, String[] replyHeaderNames) {
 		super(AmqpHeaders.PREFIX, STANDARD_HEADER_NAMES, STANDARD_HEADER_NAMES);
+		if (requestHeaderNames != null) {
+			setRequestHeaderNames(requestHeaderNames);
+		}
+		if (replyHeaderNames != null) {
+			setReplyHeaderNames(replyHeaderNames);
+		}
 	}
 
 	/**
@@ -411,22 +421,33 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 		}
 	}
 
+	/**
+	 * Construct a default inbound header mapper.
+	 * @return the mapper.
+	 * @see #inboundRequestHeaders()
+	 * @see #inboundReplyHeaders()
+	 * @since 4.3
+	 */
 	public static DefaultAmqpHeaderMapper inboundMapper() {
-		DefaultAmqpHeaderMapper mapper = new DefaultAmqpHeaderMapper();
-		mapper.setRequestHeaderNames(inboundRequestHeaders());
-		mapper.setReplyHeaderNames(inboundReplyHeaders());
+		DefaultAmqpHeaderMapper mapper = new DefaultAmqpHeaderMapper(inboundRequestHeaders(), inboundReplyHeaders());
 		return mapper;
 	}
 
+	/**
+	 * Construct a default outbound header mapper.
+	 * @return the mapper.
+	 * @see #outboundRequestHeaders()
+	 * @see #outboundReplyHeaders()
+	 * @since 4.3
+	 */
 	public static DefaultAmqpHeaderMapper outboundMapper() {
-		DefaultAmqpHeaderMapper mapper = new DefaultAmqpHeaderMapper();
-		mapper.setRequestHeaderNames(outboundRequestHeaders());
-		mapper.setReplyHeaderNames(outboundReplyHeaders());
+		DefaultAmqpHeaderMapper mapper = new DefaultAmqpHeaderMapper(outboundRequestHeaders(), outboundReplyHeaders());
 		return mapper;
 	}
 
 	/**
 	 * @return the default request headers for an inbound mapper.
+	 * @since 4.3
 	 */
 	public static String[] inboundRequestHeaders() {
 		return new String[] { "*" };
@@ -434,6 +455,7 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 
 	/**
 	 * @return the default reply headers for an inbound mapper.
+	 * @since 4.3
 	 */
 	public static String[] inboundReplyHeaders() {
 		return safeOutboundHeaders();
@@ -441,6 +463,7 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 
 	/**
 	 * @return the default request headers for an outbound mapper.
+	 * @since 4.3
 	 */
 	public static String[] outboundRequestHeaders() {
 		return safeOutboundHeaders();
@@ -448,6 +471,7 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 
 	/**
 	 * @return the default reply headers for an outbound mapper.
+	 * @since 4.3
 	 */
 	public static String[] outboundReplyHeaders() {
 		return new String[] { "*" };

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/MappingUtils.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/MappingUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.amqp.support;
+
+import org.springframework.amqp.core.MessageDeliveryMode;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.amqp.support.converter.ContentTypeDelegatingMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.messaging.Message;
+
+/**
+ * Utility methods used during message mapping.
+ *
+ * @author Gary Russell
+ * @since 4.3
+ *
+ */
+public class MappingUtils {
+
+	/**
+	 * Map an o.s.Message to an o.s.a.core.Message.
+	 * @param requestMessage the request message.
+	 * @param converter the message converter to use.
+	 * @param headerMapper the header mapper to use.
+	 * @param defaultDeliveryMode the default delivery mode.
+	 * @return the mapped Message.
+	 */
+	public static org.springframework.amqp.core.Message mapMessage(Message<?> requestMessage,
+			MessageConverter converter, AmqpHeaderMapper headerMapper, MessageDeliveryMode defaultDeliveryMode) {
+		MessageProperties amqpMessageProperties = new MessageProperties();
+		org.springframework.amqp.core.Message amqpMessage;
+		if (converter instanceof ContentTypeDelegatingMessageConverter) {
+			headerMapper.fromHeadersToRequest(requestMessage.getHeaders(), amqpMessageProperties);
+			amqpMessage = converter.toMessage(requestMessage.getPayload(), amqpMessageProperties);
+		}
+		else { // See INT-3002 - map headers last if we're not using a CTDMC
+			amqpMessage = converter.toMessage(requestMessage.getPayload(), amqpMessageProperties);
+			headerMapper.fromHeadersToRequest(requestMessage.getHeaders(), amqpMessageProperties);
+		}
+		checkDeliveryMode(requestMessage, amqpMessageProperties, defaultDeliveryMode);
+		return amqpMessage;
+	}
+
+	/**
+	 * Check the delivery mode and update with the default if not already present.
+	 * @param requestMessage the request message.
+	 * @param messageProperties the mapped message properties.
+	 * @param defaultDeliveryMode the default delivery mode.
+	 */
+	public static void checkDeliveryMode(Message<?> requestMessage, MessageProperties messageProperties,
+			MessageDeliveryMode defaultDeliveryMode) {
+		if (defaultDeliveryMode != null &&
+				requestMessage.getHeaders().get(AmqpHeaders.DELIVERY_MODE) == null) {
+			messageProperties.setDeliveryMode(defaultDeliveryMode);
+		}
+	}
+
+}

--- a/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-4.3.xsd
+++ b/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-4.3.xsd
@@ -344,6 +344,45 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="default-delivery-mode">
+			<xsd:annotation>
+				<xsd:documentation>
+	The default delivery mode for messages; 'PERSISTENT' or 'NON_PERSISTENT'. Overridden if the 'header-mapper'
+	sets the delivery mode. The 'DefaultHeaderMapper' sets the value if the
+	Spring Integration message header 'amqp_deliveryMode' is present. If this attribute is not supplied and
+	the header mapper doesn't set it, the default depends on the underlying spring-amqp 'MessagePropertiesConverter'
+	used by the 'RabbitTemplate'. If that is not customized at all, the default is 'PERSISTENT'.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="deliveryModeEnumeration xsd:string" />
+			</xsd:simpleType>
+		</xsd:attribute>
+		<xsd:attribute name="extract-payload">
+			<xsd:annotation>
+				<xsd:documentation>
+	Set to 'true' to extract the message payload and map the o.s.messaging.Message to an o.s.amqp.core.Message in
+	a similar manner to a pair of channel adapters. When 'false' the entire message is converted requiring either
+	Java serializable contents or a custom message converter. Also see inbound and outbound mapped headers.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="outbound-header-mapper">
+			<xsd:annotation>
+				<xsd:documentation>
+	The header mapper to use when sending and 'extract-payload' is true. The default mapper is
+	DefaultAmqpHeaderMapper.outboundMapper() which maps all headers except 'x-*'.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="inbound-header-mapper">
+			<xsd:annotation>
+				<xsd:documentation>
+	The header mapper to use when receiving and 'extract-payload' is true. The default mapper is
+	DefaultAmqpHeaderMapper.inboundMapper() which maps all headers.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attributeGroup ref="containerAndTemplateAttributes"/>
 		<xsd:attributeGroup ref="integration:subscribersAttributeGroup" />
 	</xsd:complexType>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/ChannelTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/ChannelTests-context.xml
@@ -9,8 +9,24 @@
 		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<int-amqp:publish-subscribe-channel id="foo" />
+	<int-amqp:publish-subscribe-channel id="channel" />
 
 	<rabbit:connection-factory id="rabbitConnectionFactory" host="localhost" />
+
+	<int-amqp:channel id="withEP" extract-payload="true" message-converter="jackson" />
+
+	<int-amqp:channel id="pollableWithEP" extract-payload="true" message-driven="false" message-converter="jackson" />
+
+	<int-amqp:publish-subscribe-channel id="pubSubWithEP" extract-payload="true" message-converter="jackson" />
+
+	<int:bridge input-channel="withEP" output-channel="out" />
+
+	<int:bridge input-channel="pubSubWithEP" output-channel="out" />
+
+	<int:channel id="out">
+		<int:queue />
+	</int:channel>
+
+	<bean id="jackson" class="org.springframework.amqp.support.converter.Jackson2JsonMessageConverter" />
 
 </beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests-context.xml
@@ -22,4 +22,21 @@
 
 	<amqp:publish-subscribe-channel id="pubSub" />
 
+	<amqp:channel id="withEP" extract-payload="true" default-delivery-mode="NON_PERSISTENT"
+		inbound-header-mapper="inMapper" outbound-header-mapper="outMapper" />
+
+	<amqp:channel id="pollableWithEP" extract-payload="true" message-driven="false"
+		inbound-header-mapper="inMapper" outbound-header-mapper="outMapper" />
+
+	<amqp:publish-subscribe-channel id="pubSubWithEP" extract-payload="true"
+		inbound-header-mapper="inMapper" outbound-header-mapper="outMapper" />
+
+	<bean id="inMapper" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.integration.amqp.support.AmqpHeaderMapper" />
+	</bean>
+
+	<bean id="outMapper" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.integration.amqp.support.AmqpHeaderMapper" />
+	</bean>
+
 </beans>

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
@@ -264,24 +264,28 @@ public class DefaultAmqpHeaderMapperTests {
 		assertNull(headers.get(AmqpHeaders.DELIVERY_MODE));
 		assertEquals(MessageDeliveryMode.NON_PERSISTENT, headers.get(AmqpHeaders.RECEIVED_DELIVERY_MODE));
 		assertEquals("bar", headers.get("foo"));
-		assertNull(headers.get("x-foo"));
+		assertEquals("bar", headers.get("x-foo"));
 
+		amqpProperties = new MessageProperties();
 		headers.put(AmqpHeaders.DELIVERY_MODE, MessageDeliveryMode.NON_PERSISTENT);
 		mapper.fromHeadersToReply(new MessageHeaders(headers), amqpProperties);
 		assertEquals(MessageDeliveryMode.NON_PERSISTENT, amqpProperties.getDeliveryMode());
 		assertEquals("bar", amqpProperties.getHeaders().get("foo"));
-
+		assertNull(amqpProperties.getHeaders().get("x-foo"));
 
 		mapper = DefaultAmqpHeaderMapper.outboundMapper();
 		mapper.fromHeadersToRequest(new MessageHeaders(headers), amqpProperties);
 		assertEquals(MessageDeliveryMode.NON_PERSISTENT, amqpProperties.getDeliveryMode());
 		assertEquals("bar", amqpProperties.getHeaders().get("foo"));
+		assertNull(amqpProperties.getHeaders().get("x-foo"));
 
 		amqpProperties.setReceivedDeliveryMode(MessageDeliveryMode.NON_PERSISTENT);
+		amqpProperties.setHeader("x-death", "foo");
 		headers = mapper.toHeadersFromReply(amqpProperties);
 		assertEquals(MessageDeliveryMode.NON_PERSISTENT, headers.get(AmqpHeaders.RECEIVED_DELIVERY_MODE));
 		assertNull(headers.get(AmqpHeaders.DELIVERY_MODE));
 		assertEquals("bar", headers.get("foo"));
+		assertEquals("foo", headers.get("x-death"));
 	}
 
 }

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1142,7 +1142,8 @@ This applies to both the outbound channel adapter and gateway.
 
 There are two Message Channel implementations available.
 One is point-to-point, and the other is publish/subscribe.
-Both of these channels provide a wide range of configuration attributes for the underlying AmqpTemplate and SimpleMessageListenerContainer as you have seen on the Channel Adapters and Gateways.
+Both of these channels provide a wide range of configuration attributes for the underlying AmqpTemplate and
+SimpleMessageListenerContainer as you have seen on the Channel Adapters and Gateways.
 However, the examples we'll show here are going to have minimal configuration.
 Explore the XML schema to view the available attributes.
 
@@ -1154,7 +1155,9 @@ A point-to-point channel would look like this:
 
 Under the covers a Queue named "si.p2pChannel" would be declared, and this channel will send to that Queue (technically by sending to the no-name Direct Exchange with a routing key that matches this Queue's name).
 This channel will also register a consumer on that Queue.
-If for some reason, you want the Queue to be "pollable" instead of message-driven, then simply provide the "message-driven" flag with a value of false:
+If you want the channel to be "pollable" instead of message-driven, then simply provide the "message-driven" flag with
+a value of `false`:
+
 [source,xml]
 ----
 <int-amqp:channel id="p2pPollableChannel"  message-driven="false"/>
@@ -1166,12 +1169,35 @@ A publish/subscribe channel would look like this:
 <int-amqp:publish-subscribe-channel id="pubSubChannel"/>
 ----
 
-Under the covers a Fanout Exchange named "si.fanout.pubSubChannel" would be declared, and this channel will send to that Fanout Exchange.
-This channel will also declare a server-named exclusive, auto-delete, non-durable Queue and bind that to the Fanout Exchange while registering a consumer on that Queue to receive Messages.
+Under the covers a Fanout Exchange named "si.fanout.pubSubChannel" would be declared, and this channel will send to that
+Fanout Exchange.
+This channel will also declare a server-named exclusive, auto-delete, non-durable Queue and bind that to the Fanout
+Exchange while registering a consumer on that Queue to receive Messages.
 There is no "pollable" option for a publish-subscribe-channel; it must be message-driven.
 
-Starting with _version 4.1_ AMQP Backed Message Channels, alongside with `channel-transacted`, support `template-channel-transacted` to separate `transactional` configuration for the `AbstractMessageListenerContainer` and for the `RabbitTemplate`.
-Note, previously, the `channel-transacted` was `true` by default, now it changed to `false` as standard default value for the `AbstractMessageListenerContainer`.
+Starting with _version 4.1_ AMQP Backed Message Channels, alongside with `channel-transacted`, support
+`template-channel-transacted` to separate `transactional` configuration for the `AbstractMessageListenerContainer` and
+for the `RabbitTemplate`.
+Note, previously, the `channel-transacted` was `true` by default, now it changed to `false` as standard default value
+for the `AbstractMessageListenerContainer`.
+
+Prior to _version 4.3_, AMQP-backed channels only supported messages with `Serializable` payloads and headers.
+The entire message was converted (serialized) and sent to RabbitMQ.
+Now, you can set the `extract-payload` attribute (or `setExtractPayload()` when using Java configuration) to true.
+When this flag is `true`, the message payload is converted and the headers mapped, in a similar manner to when using
+channel adapters.
+This allows AMQP-backed channels to be used with non-serializable payloads (perhaps with another message converter
+such as the `Jackson2JsonMessageConverter`).
+The default mapped headers are discussed in <<amqp-message-headers>>.
+You can modify the mapping by providing custom mappers using the `outbound-header-mapper` and `inbound-header-mapper`
+attributes.
+You can now also specify a `default-delivery-mode`, used to set the delivery mode when there is no
+`amqp_deliveryMode` header.
+By default, Spring AMQP `MessageProperties` uses `PERSISTENT` delivery mode.
+
+IMPORTANT: Just as with other persistence-backed channels, AMQP-backed channels are intended to provide message
+persistence to avoid message loss.
+They are not intended to distribute work to other peer applications; for that purpose, use channel adapters instead.
 
 ==== Configuring with Java Configuration
 
@@ -1258,7 +1284,7 @@ properties to support that.
 Any user-defined headers within the AMQP http://docs.spring.io/spring-amqp/api/org/springframework/amqp/core/MessageProperties.html[MessageProperties] WILL
 be copied to or from an AMQP Message, unless explicitly negated by the _requestHeaderNames_ and/or
 _replyHeaderNames_ properties of the `DefaultAmqpHeaderMapper`.
-For an inbound mapper, all `x-*` headers are not mapped by default.
+For an outbound mapper, no `x-*` headers are mapped by default; see the caution below for the reason why.
 
 To override the default, and revert to the pre-4.3 behavior, use `STANDARD_REQUEST_HEADERS` and
 `STANDARD_REPLY_HEADERS` in the properties.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -109,6 +109,11 @@ Spring AMQP 1.6 adds support for
 https://www.rabbitmq.com/blog/2015/04/16/scheduling-messages-with-rabbitmq/[Delayed Message Exchanges].
 Header mapping now supports the headers (`amqp_delay` and `amqp_receivedDelay`) used by this feature.
 
+===== AMQP-Backed Channels
+
+AMQP-backed channels now support message mapping.
+See <<amqp-channels>> for more information.
+
 ==== Redis Changes
 
 ===== List Push/Pop Direction


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3975

Also, switch the default mapping to map all inbound headers, but
don't map `x-*` on outbound (by default).

This will provide apps access to important headers such as `x-death` by
default, while not propagating dangerous headers outbound.
