### PR TITLE
INT-3977: Improve `LoggingHandler` for JavaConfig

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/LoggingChannelAdapterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/LoggingChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import org.springframework.util.StringUtils;
  * Parser for the 'logging-channel-adapter' element.
  *
  * @author Mark Fisher
+ * @author Artem Bilan
+ *
  * @since 1.0.1
  */
 public class LoggingChannelAdapterParser extends AbstractOutboundChannelAdapterParser {
@@ -47,7 +49,7 @@ public class LoggingChannelAdapterParser extends AbstractOutboundChannelAdapterP
 			builder.addPropertyValue("shouldLogFullMessage", logFullMessage);
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "logger-name");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "expression");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "expression", "logExpressionString");
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/LoggingHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/LoggingHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.handler;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -29,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
@@ -61,7 +63,7 @@ public class LoggingHandlerTests {
 	@Test
 	public void assertMutuallyExclusive() {
 		LoggingHandler loggingHandler = new LoggingHandler("INFO");
-		loggingHandler.setExpression("'foo'");
+		loggingHandler.setLogExpressionString("'foo'");
 		try {
 			loggingHandler.setShouldLogFullMessage(true);
 			fail("Expected IllegalArgumentException");
@@ -73,7 +75,7 @@ public class LoggingHandlerTests {
 		loggingHandler = new LoggingHandler("INFO");
 		loggingHandler.setShouldLogFullMessage(true);
 		try {
-			loggingHandler.setExpression("'foo'");
+			loggingHandler.setLogExpressionString("'foo'");
 			fail("Expected IllegalArgumentException");
 		}
 		catch (IllegalArgumentException e) {
@@ -84,6 +86,9 @@ public class LoggingHandlerTests {
 	@Test
 	public void testDontEvaluateIfNotEnabled() {
 		LoggingHandler loggingHandler = new LoggingHandler("INFO");
+		loggingHandler.setBeanFactory(mock(BeanFactory.class));
+		loggingHandler.afterPropertiesSet();
+
 		DirectFieldAccessor accessor = new DirectFieldAccessor(loggingHandler);
 		Log log = (Log) accessor.getPropertyValue("messageLogger");
 		log = spy(log);
@@ -102,7 +107,10 @@ public class LoggingHandlerTests {
 
 	@Test
 	public void testChangeLevel() {
-		LoggingHandler loggingHandler = new LoggingHandler("INFO");
+		LoggingHandler loggingHandler = new LoggingHandler(Level.INFO);
+		loggingHandler.setBeanFactory(mock(BeanFactory.class));
+		loggingHandler.afterPropertiesSet();
+
 		DirectFieldAccessor accessor = new DirectFieldAccessor(loggingHandler);
 		Log log = (Log) accessor.getPropertyValue("messageLogger");
 		log = spy(log);

--- a/src/reference/asciidoc/logging-adapter.adoc
+++ b/src/reference/asciidoc/logging-adapter.adoc
@@ -40,3 +40,44 @@ This attribute cannot be specified if `expression` is specified.
 <5> Specifies the _name_ of the logger (known as `category` in `log4j`) used for log messages created by this adapter.
 This enables setting the log name (in the logging subsystem) for individual adapters.
 By default, all adapters will log under the name `org.springframework.integration.handler.LoggingHandler`.
+
+==== Configuring with Java Configuration
+
+The following Spring Boot application provides an example of configuring the `LoggingHandler` using Java configuration:
+[source, java]
+----
+@SpringBootApplication
+public class LoggingJavaApplication {
+
+    public static void main(String[] args) {
+        ConfigurableApplicationContext context =
+             new SpringApplicationBuilder(LoggingJavaApplication.class)
+                    .web(false)
+                    .run(args);
+         MyGateway gateway = context.getBean(MyGateway.class);
+         gateway.sendToLogger("foo");
+    }
+
+    @Bean
+    public MessageChannel logInputChannel() {
+        return new DirectChannel();
+    }
+
+    @Bean
+    @ServiceActivator(inputChannel = "logChannel")
+    public LoggingHandler logging() {
+        LoggingHandler adapter = new LoggingHandler(LoggingHandler.Level.DEBUG);
+        adapter.setLoggerName("TEST_LOGGER");
+        adapter.setLogExpressionString("headers.id + ': ' + payload");
+        return adapter;
+    }
+
+    @MessagingGateway(defaultRequestChannel = "logChannel")
+    public interface MyGateway {
+
+        void sendToLogger(String data);
+
+    }
+
+}
+----


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3977
- Add `Level` ctor
- Add `setLogExpression(Expression)` and `setLogExpressionString(String)`
- Deprecate existing `setExpression(String)` in favor of those new
- Some refactor for redundant code around `evaluationContext`
- Fix tests according a new `LoggingHandler` logic
- Add JavaConfig sample to the Reference Manual
