### PR TITLE
INT-3980: Don't require @Component for messaging

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -363,8 +363,11 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar, Bean
 	 */
 	private void registerMessagingAnnotationPostProcessors(AnnotationMetadata meta, BeanDefinitionRegistry registry) {
 		if (!registry.containsBeanDefinition(IntegrationContextUtils.MESSAGING_ANNOTATION_POSTPROCESSOR_NAME)) {
+			String requireComponentAnnotationExpression =
+					IntegrationProperties.getExpressionFor(IntegrationProperties.REQUIRE_COMPONENT_ANNOTATION);
 			BeanDefinitionBuilder builder =
 					BeanDefinitionBuilder.genericBeanDefinition(MessagingAnnotationPostProcessor.class)
+							.addPropertyValue("requireComponentAnnotation", requireComponentAnnotationExpression)
 							.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 
 			registry.registerBeanDefinition(IntegrationContextUtils.MESSAGING_ANNOTATION_POSTPROCESSOR_NAME,

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessor.java
@@ -55,7 +55,6 @@ import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.support.SmartLifecycleRoleController;
 import org.springframework.integration.util.MessagingAnnotationUtils;
-import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.LinkedMultiValueMap;
@@ -133,11 +132,8 @@ public class MessagingAnnotationPostProcessor implements BeanPostProcessor, Bean
 	@Override
 	public Object postProcessAfterInitialization(final Object bean, final String beanName) throws BeansException {
 		Assert.notNull(this.beanFactory, "BeanFactory must not be null");
-		final Class<?> beanClass = this.getBeanClass(bean);
-		if (AnnotationUtils.findAnnotation(beanClass, Component.class) == null) {
-			// we only post-process stereotype components
-			return bean;
-		}
+
+		final Class<?> beanClass = getBeanClass(bean);
 
 		ReflectionUtils.doWithMethods(beanClass, new ReflectionUtils.MethodCallback() {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationProperties.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
  */
 public final class IntegrationProperties {
 
-	public static final String INTEGRATION_PROPERTIES_PREFIX = "spring.integraton.";
+	public static final String INTEGRATION_PROPERTIES_PREFIX = "spring.integration.";
 
 	/**
 	 * Specifies whether to allow create automatically {@link org.springframework.integration.channel.DirectChannel}
@@ -65,6 +65,11 @@ public final class IntegrationProperties {
 	 * Specifies the value of {@link org.springframework.messaging.core.GenericMessagingTemplate#throwExceptionOnLateReply}.
 	 */
 	public static final String THROW_EXCEPTION_ON_LATE_REPLY = INTEGRATION_PROPERTIES_PREFIX + "messagingTemplate.throwExceptionOnLateReply";
+
+	/**
+	 * Specifies the value of {@link org.springframework.integration.config.annotation.MessagingAnnotationPostProcessor#requireComponentAnnotation}.
+	 */
+	public static final String REQUIRE_COMPONENT_ANNOTATION = INTEGRATION_PROPERTIES_PREFIX + "messagingAnnotations.require.componentAnnotation";
 
 	private static Properties defaults;
 

--- a/spring-integration-core/src/main/resources/META-INF/spring.integration.default.properties
+++ b/spring-integration-core/src/main/resources/META-INF/spring.integration.default.properties
@@ -1,5 +1,6 @@
-spring.integraton.channels.autoCreate=true
-spring.integraton.channels.maxUnicastSubscribers=0x7fffffff
-spring.integraton.channels.maxBroadcastSubscribers=0x7fffffff
-spring.integraton.taskScheduler.poolSize=10
-spring.integraton.messagingTemplate.throwExceptionOnLateReply=false
+spring.integration.channels.autoCreate=true
+spring.integration.channels.maxUnicastSubscribers=0x7fffffff
+spring.integration.channels.maxBroadcastSubscribers=0x7fffffff
+spring.integration.taskScheduler.poolSize=10
+spring.integration.messagingTemplate.throwExceptionOnLateReply=false
+spring.integration.messagingAnnotations.require.componentAnnotation=false

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/AnnotatedEndpointActivationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/AnnotatedEndpointActivationTests-context.xml
@@ -1,17 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans xmlns="http://www.springframework.org/schema/integration"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:beans="http://www.springframework.org/schema/beans"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans
+			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			 xmlns:beans="http://www.springframework.org/schema/beans"
+			 xmlns:util="http://www.springframework.org/schema/util"
+			 xsi:schemaLocation="http://www.springframework.org/schema/beans
 			http://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
-			http://www.springframework.org/schema/integration/spring-integration.xsd">
+			http://www.springframework.org/schema/integration/spring-integration.xsd
+			http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
 	<annotation-config/>
 
-	<annotation-config/>	<!-- Second declaration should not be a problem - see INT-3445 -->
+	<annotation-config/>    <!-- Second declaration should not be a problem - see INT-3445 -->
 
-	<beans:bean class="org.springframework.integration.config.annotation.AnnotatedEndpointActivationTests.AnnotatedEndpoint"/>
+	<util:properties id="integrationGlobalProperties">
+		<beans:prop key="spring.integration.messagingAnnotations.require.componentAnnotation">true</beans:prop>
+	</util:properties>
+
+	<beans:bean id="annotatedEndpoint"
+			class="org.springframework.integration.config.annotation.AnnotatedEndpointActivationTests.AnnotatedEndpoint"/>
+
+	<beans:bean id="annotatedEndpoint2"
+			class="org.springframework.integration.config.annotation.AnnotatedEndpointActivationTests.AnnotatedEndpoint2"/>
 
 	<channel id="input"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/AnnotatedEndpointActivationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/AnnotatedEndpointActivationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.config.annotation;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -27,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -70,17 +72,15 @@ public class AnnotatedEndpointActivationTests {
 	}
 
 	@Test
-	public void configCheck() {
-		assertTrue(true);
-	}
-
-	@Test
 	public void sendAndReceive() {
 		this.input.send(new GenericMessage<String>("foo"));
 		Message<?> message = this.output.receive(100);
 		assertNotNull(message);
 		assertEquals("foo: 1", message.getPayload());
 		assertEquals(1, count);
+
+		assertTrue(this.applicationContext.containsBean("annotatedEndpoint.process.serviceActivator"));
+		assertFalse(this.applicationContext.containsBean("annotatedEndpoint2.process.serviceActivator"));
 	}
 
 	@Test
@@ -112,6 +112,7 @@ public class AnnotatedEndpointActivationTests {
 		assertEquals(1, count);
 	}
 
+	@MessageEndpoint
 	private static class AnnotatedEndpoint {
 
 		@ServiceActivator(inputChannel = "input", outputChannel = "output")
@@ -127,5 +128,16 @@ public class AnnotatedEndpointActivationTests {
 		}
 
 	}
+
+	private static class AnnotatedEndpoint2 {
+
+		@ServiceActivator(inputChannel = "input", outputChannel = "output")
+		public String process(String message) {
+			count++;
+			return message + ": " + count;
+		}
+
+	}
+
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/AnnotatedEndpointActivationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/AnnotatedEndpointActivationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.support.AbstractApplicationContext;
-import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -113,7 +112,6 @@ public class AnnotatedEndpointActivationTests {
 		assertEquals(1, count);
 	}
 
-	@MessageEndpoint
 	private static class AnnotatedEndpoint {
 
 		@ServiceActivator(inputChannel = "input", outputChannel = "output")

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DispatcherMaxSubscribersOverrideDefaultTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DispatcherMaxSubscribersOverrideDefaultTests-context.xml
@@ -8,8 +8,8 @@
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
 	<util:properties id="integrationGlobalProperties">
-		<prop key="spring.integraton.channels.maxUnicastSubscribers">456</prop>
-		<prop key="spring.integraton.channels.maxBroadcastSubscribers">789</prop>
+		<prop key="spring.integration.channels.maxUnicastSubscribers">456</prop>
+		<prop key="spring.integration.channels.maxBroadcastSubscribers">789</prop>
 	</util:properties>
 
 	<import resource="DispatcherMaxSubscribersDefaultConfigurationTests-context.xml" />

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -74,7 +74,6 @@ import org.springframework.integration.annotation.Gateway;
 import org.springframework.integration.annotation.GatewayHeader;
 import org.springframework.integration.annotation.InboundChannelAdapter;
 import org.springframework.integration.annotation.IntegrationComponentScan;
-import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.annotation.Publisher;
@@ -137,8 +136,8 @@ import reactor.rx.Streams;
  * @since 4.0
  */
 @ContextConfiguration(loader = AnnotationConfigContextLoader.class,
-		classes = {EnableIntegrationTests.ContextConfiguration.class,
-				EnableIntegrationTests.ContextConfiguration2.class})
+		classes = { EnableIntegrationTests.ContextConfiguration.class,
+				EnableIntegrationTests.ContextConfiguration2.class })
 @RunWith(SpringJUnit4ClassRunner.class)
 @DirtiesContext
 public class EnableIntegrationTests {
@@ -414,14 +413,14 @@ public class EnableIntegrationTests {
 	@DirtiesContext
 	public void testChangePatterns() {
 		try {
-			this.configurer.setComponentNamePatterns(new String[] {"*"});
+			this.configurer.setComponentNamePatterns(new String[] { "*" });
 			fail("ExpectedException");
 		}
 		catch (IllegalStateException e) {
 			assertThat(e.getMessage(), containsString("cannot be changed"));
 		}
 		this.configurer.stop();
-		this.configurer.setComponentNamePatterns(new String[] {"*"});
+		this.configurer.setComponentNamePatterns(new String[] { "*" });
 		assertEquals("*", TestUtils.getPropertyValue(this.configurer, "componentNamePatterns", String[].class)[0]);
 	}
 
@@ -665,7 +664,7 @@ public class EnableIntegrationTests {
 	@IntegrationComponentScan
 	@EnableIntegration
 //	INT-3853 @PropertySource("classpath:org/springframework/integration/configuration/EnableIntegrationTests.properties")
-	@EnableMessageHistory({"input", "publishedChannel", "annotationTestService*"})
+	@EnableMessageHistory({ "input", "publishedChannel", "annotationTestService*" })
 	public static class ContextConfiguration {
 
 		@Bean
@@ -1045,6 +1044,11 @@ public class EnableIntegrationTests {
 			return new DirectChannel();
 		}
 
+		@Bean
+		public AnnotationTestService annotationTestService() {
+			return new AnnotationTestServiceImpl();
+		}
+
 	}
 
 	@Configuration
@@ -1112,7 +1116,6 @@ public class EnableIntegrationTests {
 
 	}
 
-	@MessageEndpoint("annotationTestService")
 	public static class AnnotationTestServiceImpl implements Lifecycle, AnnotationTestService {
 
 		private final AtomicInteger counter = new AtomicInteger();
@@ -1239,7 +1242,7 @@ public class EnableIntegrationTests {
 
 		@Override
 		@MyServiceActivator1(inputChannel = "annInput1", autoStartup = "true",
-				adviceChain = {"annAdvice1"}, poller = @Poller(fixedRate = "2000"))
+				adviceChain = { "annAdvice1" }, poller = @Poller(fixedRate = "2000"))
 		public Integer annCount1() {
 			return 0;
 		}
@@ -1324,7 +1327,7 @@ public class EnableIntegrationTests {
 
 	}
 
-	@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+	@Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@MessagingGateway(defaultRequestChannel = "gatewayChannel",
 			defaultRequestTimeout = "${default.request.timeout:12300}", defaultReplyTimeout = "#{13400}",
@@ -1344,13 +1347,13 @@ public class EnableIntegrationTests {
 
 	}
 
-	@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@ServiceActivator(autoStartup = "false",
 			phase = "23",
 			inputChannel = "annInput",
 			outputChannel = "annOutput",
-			adviceChain = {"annAdvice"},
+			adviceChain = { "annAdvice" },
 			poller = @Poller(fixedDelay = "1000"))
 	public @interface MyServiceActivator {
 
@@ -1358,16 +1361,16 @@ public class EnableIntegrationTests {
 
 		String outputChannel() default "";
 
-		String[] adviceChain() default {};
+		String[] adviceChain() default { };
 
 		String autoStartup() default "";
 
 		String phase() default "";
 
-		Poller[] poller() default {};
+		Poller[] poller() default { };
 	}
 
-	@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@MyServiceActivator
 	public @interface MyServiceActivator1 {
@@ -1376,16 +1379,16 @@ public class EnableIntegrationTests {
 
 		String outputChannel() default "";
 
-		String[] adviceChain() default {};
+		String[] adviceChain() default { };
 
 		String autoStartup() default "";
 
 		String phase() default "";
 
-		Poller[] poller() default {};
+		Poller[] poller() default { };
 	}
 
-	@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@MyServiceActivator1
 	public @interface MyServiceActivator2 {
@@ -1394,7 +1397,7 @@ public class EnableIntegrationTests {
 
 	}
 
-	@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@MyServiceActivator2
 	public @interface MyServiceActivator3 {
@@ -1403,7 +1406,7 @@ public class EnableIntegrationTests {
 
 	}
 
-	@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@MyServiceActivator3(inputChannel = "annInput3")
 	public @interface MyServiceActivator4 {
@@ -1412,7 +1415,7 @@ public class EnableIntegrationTests {
 
 	}
 
-	@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@MyServiceActivator4
 	public @interface MyServiceActivator5 {
@@ -1423,7 +1426,7 @@ public class EnableIntegrationTests {
 
 	// Test prevent infinite recursion
 
-	@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@MyServiceActivator5
 	public @interface MyServiceActivator6 {
@@ -1432,7 +1435,7 @@ public class EnableIntegrationTests {
 
 	}
 
-	@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@MyServiceActivator8
 	public @interface MyServiceActivator7 {
@@ -1441,7 +1444,7 @@ public class EnableIntegrationTests {
 
 	}
 
-	@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@MyServiceActivator7
 	public @interface MyServiceActivator8 {
@@ -1457,7 +1460,7 @@ public class EnableIntegrationTests {
 			phase = "23",
 			inputChannel = "annInput",
 			outputChannel = "annOutput",
-			adviceChain = {"annAdvice"},
+			adviceChain = { "annAdvice" },
 			poller = @Poller(fixedDelay = "1000"))
 	public @interface MyServiceActivatorNoLocalAtts {
 
@@ -1487,7 +1490,7 @@ public class EnableIntegrationTests {
 
 		String phase() default "";
 
-		Poller[] poller() default {};
+		Poller[] poller() default { };
 	}
 
 	@Target(ElementType.METHOD)
@@ -1508,7 +1511,7 @@ public class EnableIntegrationTests {
 
 	}
 
-	@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@InboundChannelAdapter(value = "counterChannel", autoStartup = "false", phase = "23")
 	public @interface MyInboundChannelAdapter {
@@ -1519,7 +1522,7 @@ public class EnableIntegrationTests {
 
 		String phase() default "";
 
-		Poller[] poller() default {};
+		Poller[] poller() default { };
 
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/splitter/MethodInvokingSplitterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/splitter/MethodInvokingSplitterTests.java
@@ -511,9 +511,9 @@ public class MethodInvokingSplitterTests {
 			return messages;
 		}
 
-		public List<AbstractIntegrationMessageBuilder> messageToMessageBuilderList(Message<?> input) {
+		public List<AbstractIntegrationMessageBuilder<String>> messageToMessageBuilderList(Message<?> input) {
 			String[] strings = input.getPayload().toString().split("\\.");
-			List<AbstractIntegrationMessageBuilder> messageBuilders = new ArrayList<>();
+			List<AbstractIntegrationMessageBuilder<String>> messageBuilders = new ArrayList<>();
 			for (String s : strings) {
 				MessageBuilder<String> builder = MessageBuilder.withPayload(s)
 						.setHeader("foo", "bar");

--- a/spring-integration-core/src/test/resources/META-INF/spring.integration.properties
+++ b/spring-integration-core/src/test/resources/META-INF/spring.integration.properties
@@ -1,5 +1,5 @@
-#spring.integraton.channels.autoCreate=false
-#spring.integraton.channels.maxUnicastSubscribers=1
-#spring.integraton.channels.maxBroadcastSubscribers=1
-spring.integraton.taskScheduler.poolSize=20
-spring.integraton.messagingTemplate.throwExceptionOnLateReply=true
+#spring.integration.channels.autoCreate=false
+#spring.integration.channels.maxUnicastSubscribers=1
+#spring.integration.channels.maxBroadcastSubscribers=1
+spring.integration.taskScheduler.poolSize=20
+spring.integration.messagingTemplate.throwExceptionOnLateReply=true

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -193,15 +193,17 @@ Certain global framework properties can be overridden by providing a properties 
 
 The default properties can be found in `/META-INF/spring.integration.default.properties` in the `spring-integration-core`
 jar.
-You can see them on GitHub https://github.com/spring-projects/spring-integration/blob/master/spring-integration-core/src/main/resources/META-INF/spring.integration.default.properties[here], but here are the current default values:
+You can see them on GitHub https://github.com/spring-projects/spring-integration/blob/master/spring-integration-core/src/main/resources/META-INF/spring.integration.default.properties[here],
+but here are the current default values:
 
 [source]
 ----
-spring.integraton.channels.autoCreate=true <1>
-spring.integraton.channels.maxUnicastSubscribers=0x7fffffff <2>
-spring.integraton.channels.maxBroadcastSubscribers=0x7fffffff <3>
-spring.integraton.taskScheduler.poolSize=10 <4>
-spring.integraton.messagingTemplate.throwExceptionOnLateReply=false <5>
+spring.integration.channels.autoCreate=true <1>
+spring.integration.channels.maxUnicastSubscribers=0x7fffffff <2>
+spring.integration.channels.maxBroadcastSubscribers=0x7fffffff <3>
+spring.integration.taskScheduler.poolSize=10 <4>
+spring.integration.messagingTemplate.throwExceptionOnLateReply=false <5>
+spring.integration.messagingAnnotations.require.componentAnnotation=false <6>
 ----
 
 <1> When true, `input-channel` s will be automatically declared as `DirectChannel` s when not explicitly found in the
@@ -217,8 +219,11 @@ This can be overridden on individual channels with the `max-subscribers` attribu
 
 <4> The number of threads available in the default `taskScheduler` bean; see <<namespace-taskscheduler>>.
 
-<5> When true, messages that arrive at a gateway reply channel will throw an exception, when the gateway is not
+<5> When `true`, messages that arrive at a gateway reply channel will throw an exception, when the gateway is not
 expecting a reply - because the sending thread has timed out, or already received a reply.
+
+<5> When `true`, the Messaging Annotation Support (<<annotations>>) requires a declaration of the
+`@MessageEndpoint` (or any other `@Component`) annotation on the class level.
 
 These properties can be overridden by adding a file `/META-INF/spring.integration.properties` to the classpath.
 It is not necessary to provide all the properties, just those that you want to override.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -40,6 +40,14 @@ If you have such configuration, simply remove the `reply-channel`.
 An option to make the Service Asynchronous has been added.
 See <<async-service-activator>> for more information.
 
+===== Messaging Annotation Support changes
+
+The Messaging Annotation Support doesn't require any more `@MessageEndpoint` (or any other `@Component`) annotation
+declaration on the class level.
+To restore the previous behaviour specify the `spring.integration.messagingAnnotations.require.componentAnnotation` of
+`spring.integration.properties` as `true`.
+See <<global-properties>> and <<annotations>> for more information.
+
 ==== Mail Changes
 
 The customizable `userFlag` added in 4.2.2 to provide customization of the flag used to denote that the mail has been


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3980

When we declare our components via `@Bean` (or `<bean>`) the requirements for
the `@Component` (`@MessageEndpoint`) looks redundant and sometimes even dangerous,
when we use `@ComponentScan`, too.
- Remove the `@Component` restriction logic from the `MessagingAnnotationPostProcessor`
- Ensure that tests pass

(We may consider to backport afterwards)
