### PR TITLE
INT-3979: Properly handle `MBuilder` in splitter

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractAggregatingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractAggregatingMessageGroupProcessor.java
@@ -47,6 +47,7 @@ import org.springframework.util.Assert;
  * @author Dave Syer
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 public abstract class AbstractAggregatingMessageGroupProcessor implements MessageGroupProcessor,
@@ -83,13 +84,18 @@ public abstract class AbstractAggregatingMessageGroupProcessor implements Messag
 		Object payload = this.aggregatePayloads(group, headers);
 		AbstractIntegrationMessageBuilder<?> builder;
 		if (payload instanceof Message<?>) {
-			builder = getMessageBuilderFactory().fromMessage((Message<?>) payload).copyHeadersIfAbsent(headers);
+			builder = getMessageBuilderFactory().fromMessage((Message<?>) payload);
+		}
+		else if (payload instanceof AbstractIntegrationMessageBuilder) {
+			builder = (AbstractIntegrationMessageBuilder<?>) payload;
 		}
 		else {
-			builder = getMessageBuilderFactory().withPayload(payload).copyHeadersIfAbsent(headers);
+			builder = getMessageBuilderFactory().withPayload(payload);
 		}
 
-		return builder.popSequenceDetails().build();
+		return builder.copyHeadersIfAbsent(headers)
+				.popSequenceDetails()
+				.build();
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageSplitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,12 +112,15 @@ public abstract class AbstractMessageSplitter extends AbstractReplyProducingMess
 			Object correlationId, int sequenceNumber, int sequenceSize) {
 		AbstractIntegrationMessageBuilder<?> builder;
 		if (item instanceof Message) {
-			builder = this.getMessageBuilderFactory().fromMessage((Message<?>) item);
+			builder = getMessageBuilderFactory().fromMessage((Message<?>) item);
+		}
+		else if (item instanceof AbstractIntegrationMessageBuilder) {
+			builder = (AbstractIntegrationMessageBuilder<?>) item;
 		}
 		else {
-			builder = this.getMessageBuilderFactory().withPayload(item);
-			builder.copyHeaders(headers);
+			builder = getMessageBuilderFactory().withPayload(item);
 		}
+		builder.copyHeadersIfAbsent(headers);
 		if (this.applySequence) {
 			builder.pushSequenceDetails(correlationId, sequenceNumber, sequenceSize);
 		}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3979

Previously we had a to instantiate all messages from the `MessageBuilder`
if we would like to return messages as splitted items.
For example to populate some item-specific headers.

From other hand the `MessageBuilder` as an item incorrectly remained as a `payload`.
- Add condition logic to the `AbstractMessageSplitter` to properly handle `AbstractIntegrationMessageBuilder`
  and don't create an extra `Message`
- Apply the same logic to the `AbstractAggregatingMessageGroupProcessor`

(We may consider to backport it later)
