### PR TITLE
INT-3978 Fix `MessageHistory` for `Message` types

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ExpressionEvaluatingRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ExpressionEvaluatingRequestHandlerAdvice.java
@@ -164,7 +164,7 @@ public class ExpressionEvaluatingRequestHandlerAdvice extends AbstractRequestHan
 			evaluationFailed = true;
 		}
 		if (evalResult != null && this.successChannel != null) {
-			AdviceMessage resultMessage = new AdviceMessage(evalResult, message);
+			AdviceMessage<?> resultMessage = new AdviceMessage<Object>(evalResult, message);
 			this.messagingTemplate.send(this.successChannel, resultMessage);
 		}
 		if (evaluationFailed && this.propagateOnSuccessEvaluationFailures) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/message/AdviceMessage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/message/AdviceMessage.java
@@ -29,20 +29,22 @@ import org.springframework.messaging.support.GenericMessage;
  * handler.
  * .
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.2
  */
-public class AdviceMessage extends GenericMessage<Object> {
+public class AdviceMessage<T> extends GenericMessage<T> {
 
 	private static final long serialVersionUID = 1L;
 
 	private final Message<?> inputMessage;
 
-	public AdviceMessage(Object payload, Message<?> inputMessage) {
+	public AdviceMessage(T payload, Message<?> inputMessage) {
 		super(payload);
 		this.inputMessage = inputMessage;
 	}
 
-	public AdviceMessage(Object payload, Map<String, Object> headers, Message<?> inputMessage) {
+	public AdviceMessage(T payload, Map<String, Object> headers, Message<?> inputMessage) {
 		super(payload, headers);
 		this.inputMessage = inputMessage;
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/core/MessageHistoryTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/core/MessageHistoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,30 @@
 
 package org.springframework.integration.core;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 
 import java.util.Properties;
 
 import org.junit.Test;
 
 import org.springframework.integration.history.MessageHistory;
-import org.springframework.messaging.support.GenericMessage;
+import org.springframework.integration.message.AdviceMessage;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.support.MutableMessage;
 import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  * @since 2.0
  */
 public class MessageHistoryTests {
@@ -55,6 +63,69 @@ public class MessageHistoryTests {
 		Message<?> message = MessageHistory.write(MessageBuilder.withPayload("test").build(), new TestComponent(1));
 		MessageHistory history = MessageHistory.read(message);
 		history.add(new Properties());
+	}
+
+	@Test
+	public void testCorrectMutableMessageAfterWrite() {
+		MutableMessage<String> original = new MutableMessage<>("foo");
+		assertNull(MessageHistory.read(original));
+		Message<String> result1 = MessageHistory.write(original, new TestComponent(1));
+		assertThat(result1, instanceOf(MutableMessage.class));
+		assertSame(original, result1);
+		MessageHistory history1 = MessageHistory.read(result1);
+		assertNotNull(history1);
+		assertEquals("testComponent-1", history1.toString());
+		Message<String> result2 = MessageHistory.write(result1, new TestComponent(2));
+		assertSame(original, result2);
+		MessageHistory history2 = MessageHistory.read(result2);
+		assertNotNull(history2);
+		assertEquals("testComponent-1,testComponent-2", history2.toString());
+	}
+
+	@Test
+	public void testCorrectErrorMessageAfterWrite() {
+		RuntimeException payload = new RuntimeException();
+		ErrorMessage original = new ErrorMessage(payload);
+		assertNull(MessageHistory.read(original));
+		Message<Throwable> result1 = MessageHistory.write(original, new TestComponent(1));
+		assertThat(result1, instanceOf(ErrorMessage.class));
+		assertNotSame(original, result1);
+		assertSame(original.getPayload(), result1.getPayload());
+		MessageHistory history1 = MessageHistory.read(result1);
+		assertNotNull(history1);
+		assertEquals("testComponent-1", history1.toString());
+		Message<Throwable> result2 = MessageHistory.write(result1, new TestComponent(2));
+		assertThat(result2, instanceOf(ErrorMessage.class));
+		assertNotSame(original, result2);
+		assertNotSame(result1, result2);
+		assertSame(original.getPayload(), result2.getPayload());
+		MessageHistory history2 = MessageHistory.read(result2);
+		assertNotNull(history2);
+		assertEquals("testComponent-1,testComponent-2", history2.toString());
+	}
+
+	@Test
+	public void testCorrectAdviceMessageAfterWrite() {
+		Message<?> inputMessage = new GenericMessage<>("input");
+		AdviceMessage<String> original = new AdviceMessage<>("foo", inputMessage);
+		assertNull(MessageHistory.read(original));
+		Message<String> result1 = MessageHistory.write(original, new TestComponent(1));
+		assertThat(result1, instanceOf(AdviceMessage.class));
+		assertNotSame(original, result1);
+		assertSame(original.getPayload(), result1.getPayload());
+		assertSame(original.getInputMessage(), ((AdviceMessage) result1).getInputMessage());
+		MessageHistory history1 = MessageHistory.read(result1);
+		assertNotNull(history1);
+		assertEquals("testComponent-1", history1.toString());
+		Message<String> result2 = MessageHistory.write(result1, new TestComponent(2));
+		assertThat(result2, instanceOf(AdviceMessage.class));
+		assertNotSame(original, result2);
+		assertSame(original.getPayload(), result2.getPayload());
+		assertSame(original.getInputMessage(), ((AdviceMessage) result2).getInputMessage());
+		assertNotSame(result1, result2);
+		MessageHistory history2 = MessageHistory.read(result2);
+		assertNotNull(history2);
+		assertEquals("testComponent-1,testComponent-2", history2.toString());
 	}
 
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -164,7 +164,7 @@ public class AdvisedMessageHandlerTests {
 
 		Message<?> success = successChannel.receive(1000);
 		assertNotNull(success);
-		assertEquals("Hello, world!", ((AdviceMessage) success).getInputMessage().getPayload());
+		assertEquals("Hello, world!", ((AdviceMessage<?>) success).getInputMessage().getPayload());
 		assertEquals("foo", success.getPayload());
 
 		// advice with failure, not trapped
@@ -244,7 +244,7 @@ public class AdvisedMessageHandlerTests {
 
 		Message<?> success = successChannel.receive(1000);
 		assertNotNull(success);
-		assertEquals("Hello, world!", ((AdviceMessage) success).getInputMessage().getPayload());
+		assertEquals("Hello, world!", ((AdviceMessage<?>) success).getInputMessage().getPayload());
 		assertEquals(ArithmeticException.class, success.getPayload().getClass());
 		assertEquals("/ by zero", ((Exception) success.getPayload()).getMessage());
 
@@ -262,7 +262,7 @@ public class AdvisedMessageHandlerTests {
 
 		success = successChannel.receive(1000);
 		assertNotNull(success);
-		assertEquals("Hello, world!", ((AdviceMessage) success).getInputMessage().getPayload());
+		assertEquals("Hello, world!", ((AdviceMessage<?>) success).getInputMessage().getPayload());
 		assertEquals(ArithmeticException.class, success.getPayload().getClass());
 		assertEquals("/ by zero", ((Exception) success.getPayload()).getMessage());
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageStoreTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.mongodb.store;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -38,6 +39,7 @@ import org.springframework.integration.mongodb.rules.MongoDbAvailable;
 import org.springframework.integration.mongodb.rules.MongoDbAvailableTests;
 import org.springframework.integration.store.MessageStore;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.support.MutableMessage;
 import org.springframework.integration.support.MutableMessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
@@ -186,7 +188,7 @@ public abstract class AbstractMongoDbMessageStoreTests extends MongoDbAvailableT
 		p.setFname("John");
 		p.setLname("Doe");
 		Message<Person> inputMessage = MessageBuilder.withPayload(p).build();
-		Message<?> messageToStore = new AdviceMessage("foo", inputMessage);
+		Message<?> messageToStore = new AdviceMessage<String>("foo", inputMessage);
 		store.addMessage(messageToStore);
 		Message<?> retrievedMessage = store.getMessage(messageToStore.getHeaders().getId());
 		assertNotNull(retrievedMessage);
@@ -205,12 +207,12 @@ public abstract class AbstractMongoDbMessageStoreTests extends MongoDbAvailableT
 		p.setFname("John");
 		p.setLname("Doe");
 		Message<Person> inputMessage = MessageBuilder.withPayload(p).build();
-		Message<?> messageToStore = new GenericMessage<Message<?>>(new AdviceMessage("foo", inputMessage));
+		Message<?> messageToStore = new GenericMessage<Message<?>>(new AdviceMessage<String>("foo", inputMessage));
 		store.addMessage(messageToStore);
 		Message<?> retrievedMessage = store.getMessage(messageToStore.getHeaders().getId());
 		assertNotNull(retrievedMessage);
 		assertTrue(retrievedMessage.getPayload() instanceof AdviceMessage);
-		AdviceMessage adviceMessage = (AdviceMessage) retrievedMessage.getPayload();
+		AdviceMessage<?> adviceMessage = (AdviceMessage<?>) retrievedMessage.getPayload();
 		assertEquals("foo", adviceMessage.getPayload());
 		assertEquals(messageToStore.getHeaders(), retrievedMessage.getHeaders());
 		assertEquals(inputMessage, adviceMessage.getInputMessage());
@@ -228,7 +230,7 @@ public abstract class AbstractMongoDbMessageStoreTests extends MongoDbAvailableT
 		store.addMessage(messageToStore);
 		Message<?> retrievedMessage = store.getMessage(messageToStore.getHeaders().getId());
 		assertNotNull(retrievedMessage);
-		assertEquals("org.springframework.integration.support.MutableMessage", retrievedMessage.getPayload().getClass().getName());
+		assertThat(retrievedMessage.getPayload(), instanceOf(MutableMessage.class));
 		assertEquals(messageToStore.getPayload(), retrievedMessage.getPayload());
 		assertEquals(messageToStore.getHeaders(), retrievedMessage.getHeaders());
 		assertEquals(((Message<?>) messageToStore.getPayload()).getPayload(), p);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3978

Previously the `MessageHistory.write()` always used `MessageBuilder` to populated the `history` header.
Since the `MessageBuilder` doesn't care about the `source` message type, we might lose some important information,
like `AdviceMessage.inputMessage`
- Add conditional logic into the `MessageHistory` for all known `Message<?>` implementations
- Provide appropriate tests in the `MessageHistoryTests` for known `Message<?>` implementations
- Make `AdviceMessage` generic and fix all affected code on the matter
- Since `MutableMessage` is public already, fix `MongoDbMessageStore.DBObjectToMutableMessageConverter` to use
  `MutableMessage` type directly.
