### PR TITLE
INT-3984: Fix the `BFPP`s order

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -735,7 +735,7 @@ public class EnableIntegrationTests {
 
 
 		@Bean
-		@GlobalChannelInterceptor(patterns = "input")
+		@GlobalChannelInterceptor(patterns = "${global.wireTap.pattern}")
 		public WireTap wireTap() {
 			return new WireTap(this.wireTapChannel());
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.properties
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.properties
@@ -1,3 +1,4 @@
 message.history.tracked.components=input, publishedChannel, annotationTestService*
 poller.maxMessagesPerPoll=10
 poller.interval=100
+global.wireTap.pattern=input

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreChannelIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreChannelIntegrationTests.java
@@ -94,7 +94,7 @@ public class JdbcMessageStoreChannelIntegrationTests {
 	@Test
 	public void testSendAndActivate() throws Exception {
 		input.send(new GenericMessage<String>("foo"));
-		Service.await(1000);
+		Service.await(10000);
 		assertEquals(1, Service.messages.size());
 	}
 
@@ -102,7 +102,7 @@ public class JdbcMessageStoreChannelIntegrationTests {
 	public void testSendAndActivateWithRollback() throws Exception {
 		Service.fail = true;
 		input.send(new GenericMessage<String>("foo"));
-		Service.await(1000);
+		Service.await(10000);
 		assertThat(Service.messages.size(), Matchers.greaterThanOrEqualTo(1));
 		// After a rollback in the poller the message is still waiting to be delivered
 		// but unless we use a transaction here there is a chance that the queue will
@@ -252,6 +252,7 @@ public class JdbcMessageStoreChannelIntegrationTests {
 	}
 
 	public static class Service {
+
 		private static boolean fail = false;
 
 		private static List<String> messages = new CopyOnWriteArrayList<String>();
@@ -278,6 +279,7 @@ public class JdbcMessageStoreChannelIntegrationTests {
 			}
 			return input;
 		}
+
 	}
 
 }

--- a/spring-integration-security/src/test/java/org/springframework/integration/security/config/ChannelSecurityInterceptorSecuredChannelAnnotationTests.java
+++ b/spring-integration-security/src/test/java/org/springframework/integration/security/config/ChannelSecurityInterceptorSecuredChannelAnnotationTests.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.integration.annotation.BridgeTo;
 import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.channel.DirectChannel;
@@ -208,6 +209,11 @@ public class ChannelSecurityInterceptorSecuredChannelAnnotationTests {
 	public static class ContextConfiguration {
 
 		@Bean
+		public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+			return new PropertySourcesPlaceholderConfigurer();
+		}
+
+		@Bean
 		@SecuredChannel(interceptor = "channelSecurityInterceptor", sendAccess = {"ROLE_ADMIN", "ROLE_PRESIDENT"})
 		public SubscribableChannel securedChannel() {
 			return new DirectChannel();
@@ -225,7 +231,7 @@ public class ChannelSecurityInterceptorSecuredChannelAnnotationTests {
 		}
 
 		@Bean
-		@GlobalChannelInterceptor(patterns = {"queueChannel", "executorChannel"})
+		@GlobalChannelInterceptor(patterns = {"#{'queueChannel'}", "${security.channel:executorChannel}"})
 		public ChannelInterceptor securityContextPropagationInterceptor() {
 			return new SecurityContextPropagationChannelInterceptor();
 		}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3984

The `PropertySourcesPlaceholderConfigurer implements BeanFactoryPostProcessor, PriorityOrdered`
meaning that it is run before any other regular `BeanFactoryPostProcessor`,
like the `IntegrationConfigurationBeanFactoryPostProcessor` has been before.
With such an order any `BeanDefinition` declaration from the `IntegrationConfigurationBeanFactoryPostProcessor` process
ended up without `PP` resolutions.
- Rework `IntegrationConfigurationBeanFactoryPostProcessor` to the `BeanDefinitionRegistryPostProcessor`,
  which makes it be loaded as early as possible. See `PostProcessorRegistrationDelegate`:

``` java
// Now, invoke the postProcessBeanFactory callback of all processors handled so far.
invokeBeanFactoryPostProcessors(registryPostProcessors, beanFactory);
invokeBeanFactoryPostProcessors(regularPostProcessors, beanFactory);
```
- Modify `EnableIntegrationTests` and `ChannelSecurityInterceptorSecuredChannelAnnotationTests` to ensure that the change
  meets the `PP` and `SpEL` resolutions during bean definition phase.
- Fix the timing issue in the `JdbcMessageStoreChannelIntegrationTests`
