### PR TITLE
INT-3387: MessageGroupStore improvements

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageBarrier.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageBarrier.java
@@ -95,7 +95,7 @@ public class CorrelatingMessageBarrier extends AbstractMessageHandler implements
 		Object correlationKey = this.correlationStrategy.getCorrelationKey(message);
 		Object lock = getLock(correlationKey);
 		synchronized (lock) {
-			this.store.addMessageToGroup(correlationKey, message);
+			this.store.addMessagesToGroup(correlationKey, message);
 		}
 		if (log.isDebugEnabled()) {
 			log.debug(String.format("Handled message for key [%s]: %s.", correlationKey, message));

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -18,7 +18,6 @@ package org.springframework.integration.aggregator;
 
 import java.util.Collection;
 
-import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.SimpleMessageStore;
@@ -74,12 +73,9 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 
 	@Override
 	protected void afterRelease(MessageGroup messageGroup, Collection<Message<?>> completedMessages, boolean timeout) {
-		int size = messageGroup.getMessages().size();
-		int sequenceSize = 0;
-		Message<?> message = messageGroup.getOne();
-		if (message != null) {
-			sequenceSize = new IntegrationMessageHeaderAccessor(message).getSequenceSize();
-		}
+		int size = messageGroup.size();
+		int sequenceSize = messageGroup.getSequenceSize();
+
 		// If there is no sequence then it must be incomplete or unbounded
 		if (sequenceSize > 0 && sequenceSize == size) {
 			remove(messageGroup);

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/SequenceSizeReleaseStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/SequenceSizeReleaseStrategy.java
@@ -36,6 +36,7 @@ import org.springframework.messaging.Message;
  * @author Dave Syer
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  * @author Enrique Rodríguez
  */
 public class SequenceSizeReleaseStrategy implements ReleaseStrategy {
@@ -55,9 +56,9 @@ public class SequenceSizeReleaseStrategy implements ReleaseStrategy {
 	}
 
 	/**
-	 * Flag that determines if partial sequences are allowed. If true then as soon as enough messages arrive that can be
-	 * ordered they will be released, provided they all have sequence numbers greater than those already released.
-	 *
+	 * Flag that determines if partial sequences are allowed. If true then as soon as
+	 * enough messages arrive that can be ordered they will be released, provided they
+	 * all have sequence numbers greater than those already released.
 	 * @param releasePartialSequences true when partial sequences should be released.
 	 */
 	public void setReleasePartialSequences(boolean releasePartialSequences) {
@@ -69,13 +70,12 @@ public class SequenceSizeReleaseStrategy implements ReleaseStrategy {
 
 		boolean canRelease = false;
 
-		Collection<Message<?>> messages = messageGroup.getMessages();
-
-		if (this.releasePartialSequences && !messages.isEmpty()) {
-
+		int size = messageGroup.size();
+		if (this.releasePartialSequences && size > 0) {
 			if (logger.isTraceEnabled()) {
 				logger.trace("Considering partial release of group [" + messageGroup + "]");
 			}
+			Collection<Message<?>> messages = messageGroup.getMessages();
 			Message<?> minMessage = Collections.min(messages, this.comparator);
 
 			int nextSequenceNumber = new IntegrationMessageHeaderAccessor(minMessage).getSequenceNumber();
@@ -86,13 +86,11 @@ public class SequenceSizeReleaseStrategy implements ReleaseStrategy {
 			}
 		}
 		else {
-			int size = messages.size();
-
 			if (size == 0) {
 				canRelease = true;
 			}
 			else {
-				int sequenceSize = new IntegrationMessageHeaderAccessor(messageGroup.getOne()).getSequenceSize();
+				int sequenceSize = messageGroup.getSequenceSize();
 				// If there is no sequence then it must be incomplete....
 				if (sequenceSize == size) {
 					canRelease = true;

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
@@ -18,7 +18,6 @@ package org.springframework.integration.store;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -98,12 +97,11 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 		MessageGroupMetadata metadata = getGroupMetadata(groupId);
 		if (metadata != null) {
 
-			SimpleMessageGroup messageGroup = new SimpleMessageGroup(Collections.<Message<?>>emptyList(),
-					groupId, metadata.getTimestamp(), metadata.isComplete());
+			MessageGroup messageGroup = getMessageGroupFactory()
+					.create(this, groupId, metadata.getTimestamp(), metadata.isComplete());
 			messageGroup.setLastModified(metadata.getLastModified());
 			messageGroup.setLastReleasedMessageSequenceNumber(metadata.getLastReleasedMessageSequenceNumber());
-
-			return proxyMessageGroupForLazyLoad(messageGroup);
+			return messageGroup;
 		}
 		else {
 			return new SimpleMessageGroup(groupId);

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -57,8 +57,6 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 
 	private volatile boolean messageBuilderFactorySet;
 
-	private volatile boolean lazyLoadMessageGroups = true;
-
 	public AbstractMessageGroupStore() {
 		super();
 	}
@@ -114,7 +112,7 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 	 * @since 4.3
 	 */
 	public void setLazyLoadMessageGroups(boolean lazyLoadMessageGroups) {
-		this.lazyLoadMessageGroups = lazyLoadMessageGroups;
+		setMessageGroupFactory(new SimpleMessageGroupFactory(SimpleMessageGroupFactory.GroupType.PERSISTENT));
 	}
 
 	@Override
@@ -190,22 +188,6 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 	public MessageGroup addMessageToGroup(Object groupId, Message<?> message) {
 		addMessagesToGroup(groupId, message);
 		return getMessageGroup(groupId);
-	}
-
-	protected MessageGroup proxyMessageGroupForLazyLoad(MessageGroup original) {
-		if (this.lazyLoadMessageGroups) {
-			return new PersistentMessageGroup(this, original);
-		}
-		else {
-			Object groupId = original.getGroupId();
-			Collection<Message<?>> messagesForGroup = getMessagesForGroup(groupId);
-			MessageGroup messageGroup = getMessageGroupFactory().create(messagesForGroup, groupId,
-					original.getTimestamp(), original.isComplete());
-			messageGroup.setLastModified(original.getLastModified());
-			messageGroup.setLastReleasedMessageSequenceNumber(original.getLastReleasedMessageSequenceNumber());
-			return messageGroup;
-		}
-
 	}
 
 	private void expire(MessageGroup group) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -49,6 +49,9 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 
 	private final Collection<MessageGroupCallback> expiryCallbacks = new LinkedHashSet<MessageGroupCallback>();
 
+	private final MessageGroupFactory persistentMessageGroupFactory =
+			new SimpleMessageGroupFactory(SimpleMessageGroupFactory.GroupType.PERSISTENT);
+
 	private volatile boolean timeoutOnIdle;
 
 	private volatile BeanFactory beanFactory;
@@ -56,6 +59,8 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 
 	private volatile boolean messageBuilderFactorySet;
+
+	private boolean lazyLoadMessageGroups = true;
 
 	public AbstractMessageGroupStore() {
 		super();
@@ -75,6 +80,16 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 			this.messageBuilderFactorySet = true;
 		}
 		return this.messageBuilderFactory;
+	}
+
+	@Override
+	protected MessageGroupFactory getMessageGroupFactory() {
+		if (this.lazyLoadMessageGroups) {
+			return this.persistentMessageGroupFactory;
+		}
+		else {
+			return super.getMessageGroupFactory();
+		}
 	}
 
 	/**
@@ -108,11 +123,12 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 	 * Specify if the result of the {@link #getMessageGroup(Object)} should be wrapped
 	 * to the {@link PersistentMessageGroup} - a lazy-load proxy for messages in group
 	 * Defaults to {@code true}.
+	 * <p> The target logic is based on the {@link SimpleMessageGroupFactory.GroupType#PERSISTENT}.
 	 * @param lazyLoadMessageGroups the {@code boolean} flag to use.
 	 * @since 4.3
 	 */
 	public void setLazyLoadMessageGroups(boolean lazyLoadMessageGroups) {
-		setMessageGroupFactory(new SimpleMessageGroupFactory(SimpleMessageGroupFactory.GroupType.PERSISTENT));
+		this.lazyLoadMessageGroups = lazyLoadMessageGroups;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupFactory.java
@@ -36,4 +36,10 @@ public interface MessageGroupFactory {
 	MessageGroup create(Collection<? extends Message<?>> messages, Object groupId, long timestamp,
 						boolean complete);
 
+
+	MessageGroup create(MessageGroupStore messageGroupStore, Object groupId);
+
+	MessageGroup create(MessageGroupStore messageGroupStore, Object groupId, long timestamp,
+			boolean complete);
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupFactory.java
@@ -29,16 +29,56 @@ import org.springframework.messaging.Message;
  */
 public interface MessageGroupFactory {
 
+	/**
+	 * Create a {@link MessageGroup} instance based on the provided {@code groupId}.
+	 * @param groupId the group id to use.
+	 * @return the {@link MessageGroup} instance.
+	 */
 	MessageGroup create(Object groupId);
 
+	/**
+	 * Create a {@link MessageGroup} instance based on the provided {@code groupId}
+	 * and with the {@code messages} for the group.
+	 * @param messages the messages for the group.
+	 * @param groupId the group id to use.
+	 * @return the {@link MessageGroup} instance.
+	 */
 	MessageGroup create(Collection<? extends Message<?>> messages, Object groupId);
 
+	/**
+	 * Create a {@link MessageGroup} instance based on the provided {@code groupId}
+	 * and with the {@code messages} for the group.
+	 * In addition the creating {@code timestamp} and {@code complete} flag may be used to customize
+	 * the target {@link MessageGroup} object.
+	 * @param messages the messages for the group.
+	 * @param groupId the group id to use.
+	 * @param timestamp the creation time.
+	 * @param complete the {@code boolean} flag to indicate that group is completed.
+	 * @return the {@link MessageGroup} instance.
+	 */
 	MessageGroup create(Collection<? extends Message<?>> messages, Object groupId, long timestamp,
 						boolean complete);
 
-
+	/**
+	 * Create a {@link MessageGroup} instance based on the provided {@code groupId}.
+	 * The {@link MessageGroupStore} may be consulted for the messages and metadata for the {@link MessageGroup}.
+	 * @param messageGroupStore the {@link MessageGroupStore} for additional {@link MessageGroup} information.
+	 * @param groupId the group id to use.
+	 * @return the {@link MessageGroup} instance.
+	 */
 	MessageGroup create(MessageGroupStore messageGroupStore, Object groupId);
 
+	/**
+	 * Create a {@link MessageGroup} instance based on the provided {@code groupId}.
+	 * The {@link MessageGroupStore} may be consulted for the messages and metadata for the {@link MessageGroup}.
+	 * In addition the creating {@code timestamp} and {@code complete} flag may be used to customize
+	 * the target {@link MessageGroup} object.
+	 * @param messageGroupStore the {@link MessageGroupStore} for additional {@link MessageGroup} information.
+	 * @param groupId the group id to use.
+	 * @param timestamp the creation time.
+	 * @param complete the {@code boolean} flag to indicate that group is completed.
+	 * @return the {@link MessageGroup} instance.
+	 */
 	MessageGroup create(MessageGroupStore messageGroupStore, Object groupId, long timestamp,
 			boolean complete);
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
@@ -26,10 +26,11 @@ import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
 /**
- * Immutable Value Object holding metadata about a MessageGroup.
+ * Value Object holding metadata about a MessageGroup in the MessageGroupStore.
  *
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.1
  */
 public class MessageGroupMetadata implements Serializable {
@@ -40,47 +41,35 @@ public class MessageGroupMetadata implements Serializable {
 
 	private final List<UUID> messageIds = new LinkedList<UUID>();
 
-	private final boolean complete;
-
 	private final long timestamp;
+
+	private volatile boolean complete;
 
 	private volatile long lastModified;
 
-	private final int lastReleasedMessageSequenceNumber;
-
-	private final boolean hasMessages;
-
-	private final UUID first;
+	private volatile int lastReleasedMessageSequenceNumber;
 
 	public MessageGroupMetadata(MessageGroup messageGroup) {
-		this(messageGroup, true, null);
-	}
-
-	public MessageGroupMetadata(MessageGroup messageGroup, boolean hasMessages, UUID first) {
-
 		Assert.notNull(messageGroup, "'messageGroup' must not be null");
 		this.groupId = messageGroup.getGroupId();
-		if (hasMessages) {
-			for (Message<?> message : messageGroup.getMessages()) {
-				this.messageIds.add(message.getHeaders().getId());
-			}
+		for (Message<?> message : messageGroup.getMessages()) {
+			this.messageIds.add(message.getHeaders().getId());
 		}
 		this.complete = messageGroup.isComplete();
 		this.timestamp = messageGroup.getTimestamp();
 		this.lastReleasedMessageSequenceNumber = messageGroup.getLastReleasedMessageSequenceNumber();
 		this.lastModified = messageGroup.getLastModified();
-		this.hasMessages = hasMessages;
-		this.first = first;
 	}
 
 	public void remove(UUID messageId) {
-		if (!this.hasMessages) {
-			throw new IllegalStateException("Messages are not available, fetch the entire group");
-		}
 		this.messageIds.remove(messageId);
 	}
 
-	public void setLastModified(long lastModified) {
+	boolean add(UUID messageId) {
+		return !this.messageIds.contains(messageId) && this.messageIds.add(messageId);
+	}
+
+	void setLastModified(long lastModified) {
 		this.lastModified = lastModified;
 	}
 
@@ -89,9 +78,6 @@ public class MessageGroupMetadata implements Serializable {
 	}
 
 	public Iterator<UUID> messageIdIterator() {
-		if (!this.hasMessages) {
-			throw new IllegalStateException("Messages are not available, fetch the entire group");
-		}
 		return this.messageIds.iterator();
 	}
 
@@ -100,16 +86,14 @@ public class MessageGroupMetadata implements Serializable {
 	}
 
 	public UUID firstId() {
-		if (this.first != null) {
-			return this.first;
-		}
-		if (!this.hasMessages) {
-			throw new IllegalStateException("Messages are not available, fetch the entire group");
-		}
 		if (this.messageIds.size() > 0) {
-			return this.messageIds.iterator().next();
+			return this.messageIds.get(0);
 		}
 		return null;
+	}
+
+	void complete() {
+		this.complete = true;
 	}
 
 	public boolean isComplete() {
@@ -127,4 +111,9 @@ public class MessageGroupMetadata implements Serializable {
 	public int getLastReleasedMessageSequenceNumber() {
 		return this.lastReleasedMessageSequenceNumber;
 	}
+
+	void setLastReleasedMessageSequenceNumber(int lastReleasedMessageSequenceNumber) {
+		this.lastReleasedMessageSequenceNumber = lastReleasedMessageSequenceNumber;
+	}
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -29,6 +29,7 @@ import org.springframework.messaging.Message;
  * @author Dave Syer
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 2.0
  *
@@ -36,9 +37,8 @@ import org.springframework.messaging.Message;
 public interface MessageGroupStore extends BasicMessageGroupStore {
 
 	/**
-	 * Optional attribute giving the number of messages in the store over all groups. Implementations may decline to
-	 * respond by throwing an exception.
-	 *
+	 * Optional attribute giving the number of messages in the store over all groups.
+	 * Implementations may decline to respond by throwing an exception.
 	 * @return the number of messages
 	 * @throws UnsupportedOperationException if not implemented
 	 */
@@ -46,9 +46,8 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	int getMessageCountForAllMessageGroups();
 
 	/**
-	 * Optional attribute giving the number of  message groups. Implementations may decline
-	 * to respond by throwing an exception.
-	 *
+	 * Optional attribute giving the number of  message groups.
+	 * Implementations may decline to respond by throwing an exception.
 	 * @return the number message groups
 	 * @throws UnsupportedOperationException if not implemented
 	 */
@@ -56,9 +55,8 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	int getMessageGroupCount();
 
 	/**
-	 * Persist the deletion of a single message from the group. The group is modified to reflect that 'messageToRemove' is
-	 * no longer present in the group.
-	 *
+	 * Persist the deletion of a single message from the group.
+	 * The group is modified to reflect that 'messageToRemove' is no longer present in the group.
 	 * @param key The groupId for the group containing the message.
 	 * @param messageToRemove The message to be removed.
 	 * @return The message Group.
@@ -69,27 +67,22 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 
 	/**
 	 * Persist the deletion of messages from the group.
-	 *
 	 * @param key The groupId for the group containing the message(s).
 	 * @param messages The messages to be removed.
-	 *
 	 * @since 4.2
 	 */
 	void removeMessagesFromGroup(Object key, Collection<Message<?>> messages);
 
 	/**
 	 * Persist the deletion of messages from the group.
-	 *
 	 * @param key The groupId for the group containing the message(s).
 	 * @param messages The messages to be removed.
-	 *
 	 * @since 4.2
 	 */
 	void removeMessagesFromGroup(Object key, Message<?>... messages);
 
 	/**
 	 * Register a callback for when a message group is expired through {@link #expireMessageGroups(long)}.
-	 *
 	 * @param callback A callback to execute when a message group is cleaned up.
 	 */
 	void registerMessageGroupExpiryCallback(MessageGroupCallback callback);
@@ -99,10 +92,8 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	 * each of the registered callbacks on them in turn. For example: call with a timeout of 100 to expire all groups
 	 * that were created more than 100 milliseconds ago, and are not yet complete. Use a timeout of 0 (or negative to be
 	 * on the safe side) to expire all message groups.
-	 *
 	 * @param timeout the timeout threshold to use
 	 * @return the number of message groups expired
-	 *
 	 * @see #registerMessageGroupExpiryCallback(MessageGroupCallback)
 	 */
 	@ManagedOperation
@@ -110,7 +101,6 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 
 	/**
 	 * Allows you to set the sequence number of the last released Message. Used for Resequencing use cases
-	 *
 	 * @param groupId The group identifier.
 	 * @param sequenceNumber The sequence number.
 	 */
@@ -125,7 +115,6 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	 * Completes this MessageGroup. Completion of the MessageGroup generally means
 	 * that this group should not be allowing any more mutating operation to be performed on it.
 	 * For example any attempt to add/remove new Message form the group should not be allowed.
-	 *
 	 * @param groupId The group identifier.
 	 */
 	void completeGroup(Object groupId);
@@ -140,12 +129,29 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	MessageGroupMetadata getGroupMetadata(Object groupId);
 
 	/**
-	 * Return the one {@link org.springframework.messaging.Message} from {@link org.springframework.integration.store.MessageGroup}.
+	 * Return the one {@link Message} from {@link MessageGroup}.
 	 * @param groupId The group identifier.
-	 * @return the {@link org.springframework.messaging.Message}.
+	 * @return the {@link Message}.
 	 * @since 4.0
 	 */
 	Message<?> getOneMessageFromGroup(Object groupId);
+
+	/**
+	 * Store messages with an association to a group id.
+	 * This can be used to group messages together.
+	 * @param groupId The group id to store messages under.
+	 * @param messages The messages to add.
+	 * @since 4.3
+	 */
+	void addMessagesToGroup(Object groupId, Message<?>... messages);
+
+	/**
+	 * Retrieve messages for the provided group id.
+	 * @param groupId The group id to retrieve messages for.
+	 * @return the messages for group.
+	 * @since 4.3
+	 */
+	Collection<Message<?>> getMessagesForGroup(Object groupId);
 
 	/**
 	 * Invoked when a MessageGroupStore expires a group.

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/PersistentMessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/PersistentMessageGroup.java
@@ -82,7 +82,9 @@ class PersistentMessageGroup implements MessageGroup {
 		else {
 			Message<?> message = getOne();
 			if (message != null) {
-				return message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, Integer.class);
+				Integer sequenceSize = message.getHeaders()
+						.get(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, Integer.class);
+				return (sequenceSize != null ? sequenceSize : 0);
 			}
 			else {
 				return 0;

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/PersistentMessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/PersistentMessageGroup.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.store;
+
+import java.util.AbstractCollection;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.messaging.Message;
+
+/**
+ * @author Artem Bilan
+ * @since 4.3
+ */
+class PersistentMessageGroup implements MessageGroup {
+
+	private static final Log logger = LogFactory.getLog(PersistentMessageGroup.class);
+
+	private MessageGroupStore messageGroupStore;
+
+	private final Collection<Message<?>> messages = new PersistentCollection();
+
+	private final MessageGroup original;
+
+	private volatile Message<?> oneMessage;
+
+	private volatile int size;
+
+	PersistentMessageGroup(MessageGroupStore messageGroupStore, MessageGroup original) {
+		this.messageGroupStore = messageGroupStore;
+		this.original = original;
+	}
+
+	public void setSize(int size) {
+		this.size = size;
+	}
+
+	@Override
+	public Collection<Message<?>> getMessages() {
+		return Collections.unmodifiableCollection(this.messages);
+	}
+
+	@Override
+	public Message<?> getOne() {
+		if (this.oneMessage == null) {
+			synchronized (this) {
+				if (this.oneMessage == null) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Lazy loading of one message for messageGroup: " + this.original.getGroupId());
+					}
+					this.oneMessage = this.messageGroupStore.getOneMessageFromGroup(this.original.getGroupId());
+				}
+			}
+		}
+		return this.oneMessage;
+	}
+
+	@Override
+	public int getSequenceSize() {
+		if (size() == 0) {
+			return 0;
+		}
+		else {
+			Message<?> message = getOne();
+			if (message != null) {
+				return message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, Integer.class);
+			}
+			else {
+				return 0;
+			}
+		}
+	}
+
+	@Override
+	public int size() {
+		if (this.size == 0) {
+			synchronized (this) {
+				if (this.size == 0) {
+					if (logger.isDebugEnabled()) {
+						logger.debug("Lazy loading of group size for messageGroup: " + this.original.getGroupId());
+					}
+					this.size = this.messageGroupStore.messageGroupSize(this.original.getGroupId());
+				}
+			}
+		}
+		return this.size;
+	}
+
+	@Override
+	public Object getGroupId() {
+		return this.original.getGroupId();
+	}
+
+	@Override
+	public boolean canAdd(Message<?> message) {
+		return this.original.canAdd(message);
+	}
+
+	@Override
+	public int getLastReleasedMessageSequenceNumber() {
+		return this.original.getLastReleasedMessageSequenceNumber();
+	}
+
+	@Override
+	public boolean isComplete() {
+		return this.original.isComplete();
+	}
+
+	@Override
+	public void complete() {
+		this.original.complete();
+	}
+
+	@Override
+	public long getTimestamp() {
+		return this.original.getTimestamp();
+	}
+
+	@Override
+	public long getLastModified() {
+		return this.original.getLastModified();
+	}
+
+	@Override
+	public void setLastModified(long lastModified) {
+		this.original.setLastModified(lastModified);
+	}
+
+	@Override
+	public void add(Message<?> messageToAdd) {
+		this.original.add(messageToAdd);
+	}
+
+	@Override
+	public boolean remove(Message<?> messageToRemove) {
+		return this.original.remove(messageToRemove);
+	}
+
+	@Override
+	public void setLastReleasedMessageSequenceNumber(int sequenceNumber) {
+		this.original.setLastReleasedMessageSequenceNumber(sequenceNumber);
+	}
+
+	@Override
+	public void clear() {
+		this.original.clear();
+	}
+
+
+	private class PersistentCollection extends AbstractCollection<Message<?>> {
+
+		private volatile Collection<Message<?>> collection;
+
+		private void load() {
+			if (this.collection == null) {
+				synchronized (this) {
+					if (this.collection == null) {
+						Object groupId = PersistentMessageGroup.this.original.getGroupId();
+						if (logger.isDebugEnabled()) {
+							logger.debug("Lazy loading of messages for messageGroup: " + groupId);
+						}
+						this.collection = PersistentMessageGroup.this.messageGroupStore.getMessagesForGroup(groupId);
+					}
+				}
+			}
+		}
+
+		@Override
+		public boolean contains(Object o) {
+			load();
+			return this.collection.contains(o);
+		}
+
+		@Override
+		public Object[] toArray() {
+			load();
+			return this.collection.toArray();
+		}
+
+		@Override
+		public <T> T[] toArray(T[] a) {
+			load();
+			return this.collection.toArray(a);
+		}
+
+		@Override
+		public boolean containsAll(Collection<?> c) {
+			load();
+			return this.collection.containsAll(c);
+		}
+
+		@Override
+		public Iterator<Message<?>> iterator() {
+			load();
+			return this.collection.iterator();
+		}
+
+		@Override
+		public int size() {
+			return PersistentMessageGroup.this.size();
+		}
+
+	}
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandlerTests.java
@@ -293,9 +293,8 @@ public class AbstractCorrelatingMessageHandlerTests {
 		Method forceComplete =
 				AbstractCorrelatingMessageHandler.class.getDeclaredMethod("forceComplete", MessageGroup.class);
 		forceComplete.setAccessible(true);
-		mgs.addMessageToGroup("foo", new GenericMessage<String>("foo"));
 		GenericMessage<String> secondMessage = new GenericMessage<String>("bar");
-		mgs.addMessageToGroup("foo", secondMessage);
+		mgs.addMessagesToGroup("foo", new GenericMessage<String>("foo"), secondMessage);
 		MessageGroup group = mgs.getMessageGroup("foo");
 		// remove a message
 		mgs.removeMessagesFromGroup("foo", secondMessage);
@@ -324,7 +323,7 @@ public class AbstractCorrelatingMessageHandlerTests {
 		QueueChannel outputChannel = new QueueChannel();
 		handler.setOutputChannel(outputChannel);
 		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore", MessageGroupStore.class);
-		mgs.addMessageToGroup("foo", new GenericMessage<String>("foo"));
+		mgs.addMessagesToGroup("foo", new GenericMessage<String>("foo"));
 		mgs.completeGroup("foo");
 		mgs = spy(mgs);
 		new DirectFieldAccessor(handler).setPropertyValue("messageStore", mgs);
@@ -357,7 +356,7 @@ public class AbstractCorrelatingMessageHandlerTests {
 		QueueChannel outputChannel = new QueueChannel();
 		handler.setOutputChannel(outputChannel);
 		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore", MessageGroupStore.class);
-		mgs.addMessageToGroup("foo", new GenericMessage<String>("foo"));
+		mgs.addMessagesToGroup("foo", new GenericMessage<String>("foo"));
 		MessageGroup group = new SimpleMessageGroup(mgs.getMessageGroup("foo"));
 		mgs.completeGroup("foo");
 		mgs = spy(mgs);
@@ -393,7 +392,7 @@ public class AbstractCorrelatingMessageHandlerTests {
 		QueueChannel outputChannel = new QueueChannel();
 		handler.setOutputChannel(outputChannel);
 		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore", MessageGroupStore.class);
-		mgs.addMessageToGroup("foo", new GenericMessage<String>("foo"));
+		mgs.addMessagesToGroup("foo", new GenericMessage<String>("foo"));
 		MessageGroup group = new SimpleMessageGroup(mgs.getMessageGroup("foo"));
 		mgs = spy(mgs);
 		new DirectFieldAccessor(handler).setPropertyValue("messageStore", mgs);

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests.java
@@ -36,7 +36,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.logging.Log;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import reactor.rx.Promise;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanNameAware;
@@ -64,6 +63,8 @@ import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import reactor.rx.Promise;
 
 /**
  * @author Mark Fisher
@@ -173,7 +174,7 @@ public class GatewayParserTests {
 		this.startResponder(requestChannel, replyChannel);
 		TestService service = context.getBean("promise", TestService.class);
 		Promise<Message<?>> result = service.promise("foo");
-		Message<?> reply = result.await(1, TimeUnit.SECONDS);
+		Message<?> reply = result.await(10, TimeUnit.SECONDS);
 		assertEquals("foo", reply.getPayload());
 		assertNotNull(TestUtils.getPropertyValue(context.getBean("&promise"), "asyncExecutor"));
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageStoreTests.java
@@ -34,6 +34,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 /**
  * @author Dave Syer
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class MessageStoreTests {
 
@@ -80,7 +81,7 @@ public class MessageStoreTests {
 		assertEquals(1, store.getMessageCountForAllMessageGroups());
 	}
 
-	private static class TestMessageStore extends AbstractMessageGroupStore {
+	private static class TestMessageStore extends SimpleMessageStore  {
 
 		@SuppressWarnings("unchecked")
 		MessageGroup testMessages =
@@ -95,7 +96,7 @@ public class MessageStoreTests {
 		}
 
 		@Override
-		public MessageGroup addMessageToGroup(Object correlationKey, Message<?> message) {
+		public void addMessagesToGroup(Object groupId, Message<?>... messages) {
 			throw new UnsupportedOperationException();
 		}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/WatchServiceDirectoryScanner.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/WatchServiceDirectoryScanner.java
@@ -246,7 +246,7 @@ public class WatchServiceDirectoryScanner extends DefaultDirectoryScanner implem
 		if (logger.isDebugEnabled()) {
 			logger.debug("registering: " + dir + " for file creation events");
 		}
-		dir.register(this.watcher, StandardWatchEventKinds.ENTRY_CREATE);
+		dir.register(this.watcher, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
 	}
 
 }

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
@@ -163,7 +163,7 @@ public class GemfireGroupStoreTests {
 		GemfireMessageStore store = new GemfireMessageStore(this.region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
-		store.addMessageToGroup(messageGroup.getGroupId(), new GenericMessage<String>("1"));
+		store.addMessagesToGroup(messageGroup.getGroupId(), new GenericMessage<String>("1"));
 		store.removeMessagesFromGroup(1, new GenericMessage<String>("2"));
 	}
 
@@ -180,7 +180,7 @@ public class GemfireGroupStoreTests {
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> messageToMark = new GenericMessage<String>("1");
-		store.addMessageToGroup(messageGroup.getGroupId(), messageToMark);
+		store.addMessagesToGroup(messageGroup.getGroupId(), messageToMark);
 		store.completeGroup(messageGroup.getGroupId());
 		messageGroup = store.getMessageGroup(1);
 		assertTrue(messageGroup.isComplete());
@@ -192,7 +192,7 @@ public class GemfireGroupStoreTests {
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> messageToMark = new GenericMessage<String>("1");
-		store.addMessageToGroup(messageGroup.getGroupId(), messageToMark);
+		store.addMessagesToGroup(messageGroup.getGroupId(), messageToMark);
 		store.setLastReleasedSequenceNumberForGroup(messageGroup.getGroupId(), 5);
 		messageGroup = store.getMessageGroup(1);
 		assertEquals(5, messageGroup.getLastReleasedMessageSequenceNumber());
@@ -207,7 +207,7 @@ public class GemfireGroupStoreTests {
 		store2.afterPropertiesSet();
 
 		Message<?> message = new GenericMessage<String>("1");
-		store1.addMessageToGroup(1, message);
+		store1.addMessagesToGroup(1, message);
 		MessageGroup messageGroup = store2.addMessageToGroup(1, new GenericMessage<String>("2"));
 
 		assertEquals(2, messageGroup.getMessages().size());
@@ -236,7 +236,7 @@ public class GemfireGroupStoreTests {
 
 		message = MessageHistory.write(message, fooChannel);
 		message = MessageHistory.write(message, barChannel);
-		store.addMessageToGroup(1, message);
+		store.addMessagesToGroup(1, message);
 
 		message = store.getMessageGroup(1).getMessages().iterator().next();
 
@@ -255,10 +255,9 @@ public class GemfireGroupStoreTests {
 		GemfireMessageStore store2 = new GemfireMessageStore(this.region);
 		store2.afterPropertiesSet();
 
-		store1.addMessageToGroup(1, new GenericMessage<String>("1"));
-		store2.addMessageToGroup(2, new GenericMessage<String>("2"));
-		store1.addMessageToGroup(3, new GenericMessage<String>("3"));
-		store2.addMessageToGroup(3, new GenericMessage<String>("3A"));
+		store1.addMessagesToGroup(1, new GenericMessage<String>("1"));
+		store2.addMessagesToGroup(2, new GenericMessage<String>("2"));
+		store1.addMessagesToGroup(3, new GenericMessage<String>("3"), new GenericMessage<String>("3A"));
 
 		Iterator<MessageGroup> messageGroups = store1.iterator();
 		int counter = 0;

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
@@ -110,7 +110,7 @@ public class GemfireMessageStoreTests {
 		List<Message<?>> messages = new ArrayList<Message<?>>();
 		for (int i = 0; i < 25; i++) {
 			Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
-			messageStore.addMessageToGroup(groupId, message);
+			messageStore.addMessagesToGroup(groupId, message);
 			messages.add(message);
 		}
 		MessageGroup group = messageStore.getMessageGroup(groupId);

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageStore.java
@@ -616,8 +616,7 @@ public class JdbcMessageStore extends AbstractMessageGroupStore implements Messa
 
 	@Override
 	public Message<?> getOneMessageFromGroup(Object groupId) {
-		return this.jdbcTemplate.queryForObject(getQuery(Query.LIST_MESSAGES_BY_GROUP_KEY), this.mapper,
-				getKey(groupId), this.region);
+		return doPollForMessage(getKey(groupId));
 	}
 
 	@Override
@@ -683,8 +682,7 @@ public class JdbcMessageStore extends AbstractMessageGroupStore implements Messa
 
 	/**
 	 * This method executes a call to the DB to get the oldest Message in the MessageGroup
-	 * Override this method if need to. For example if you DB supports advanced function such as FIRST etc.
-	 *
+	 * Override this method if need to. For example if your DB supports advanced function such as FIRST etc.
 	 * @param groupIdKey String representation of message group ID
 	 * @return a message; could be null if query produced no Messages
 	 */

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageStore.java
@@ -23,7 +23,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -460,13 +459,11 @@ public class JdbcMessageStore extends AbstractMessageGroupStore implements Messa
 			return new SimpleMessageGroup(groupId);
 		}
 
-		SimpleMessageGroup messageGroup = new SimpleMessageGroup(Collections.<Message<?>>emptyList(), groupId,
-				createDate.get().getTime(), completeFlag.get());
-
+		MessageGroup messageGroup = getMessageGroupFactory()
+				.create(this, groupId, createDate.get().getTime(), completeFlag.get());
 		messageGroup.setLastModified(updateDate.get().getTime());
 		messageGroup.setLastReleasedMessageSequenceNumber(lastReleasedSequenceRef.get());
-
-		return proxyMessageGroupForLazyLoad(messageGroup);
+		return messageGroup;
 	}
 
 	@Override

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
@@ -7,7 +7,9 @@
 	http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<beans:bean id="messageStore"
-				class="org.springframework.integration.jdbc.DelayerHandlerRescheduleIntegrationTests$TestJdbcMessageStore"/>
+				class="org.springframework.integration.jdbc.DelayerHandlerRescheduleIntegrationTests$TestJdbcMessageStore">
+		<beans:property name="lazyLoadMessageGroups" value="false"/>
+	</beans:bean>
 
 	<beans:bean id="transactionManager"
 				class="org.springframework.jdbc.datasource.DataSourceTransactionManager"

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcMessageStoreTests.java
@@ -245,9 +245,9 @@ public class JdbcMessageStoreTests {
 		List<Message<?>> messages = new ArrayList<Message<?>>();
 		for (int i = 0; i < 25; i++) {
 			Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
-			messageStore.addMessagesToGroup(groupId, message);
 			messages.add(message);
 		}
+		messageStore.addMessagesToGroup(groupId, messages.toArray(new Message[messages.size()]));
 		MessageGroup group = messageStore.getMessageGroup(groupId);
 		assertEquals(25, group.size());
 		messageStore.removeMessagesFromGroup(groupId, messages);
@@ -314,7 +314,9 @@ public class JdbcMessageStoreTests {
 		String groupId = "X";
 
 		this.messageStore.addMessagesToGroup(groupId,
-				MessageBuilder.withPayload("foo").setCorrelationId(groupId).build(),
+				MessageBuilder.withPayload("foo").setCorrelationId(groupId).build());
+		Thread.sleep(1);
+		this.messageStore.addMessagesToGroup(groupId,
 				MessageBuilder.withPayload("bar").setCorrelationId(groupId).build());
 		MessageGroup group = this.messageStore.getMessageGroup(groupId);
 		assertEquals(2, group.size());

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
@@ -17,7 +17,9 @@
 package org.springframework.integration.mongodb.store;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -49,8 +51,9 @@ import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
-import org.springframework.integration.store.AbstractBatchingMessageGroupStore;
+import org.springframework.integration.store.AbstractMessageGroupStore;
 import org.springframework.integration.store.BasicMessageGroupStore;
+import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.utils.IntegrationUtils;
@@ -66,7 +69,7 @@ import org.springframework.util.Assert;
  * @since 4.0
  */
 
-public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractBatchingMessageGroupStore
+public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMessageGroupStore
 		implements BasicMessageGroupStore, InitializingBean, ApplicationContextAware {
 
 	public final static String SEQUENCE_NAME = "messagesSequence";
@@ -217,6 +220,47 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractBa
 
 	protected static Query groupIdQuery(Object groupId) {
 		return Query.query(Criteria.where(MessageDocumentFields.GROUP_ID).is(groupId));
+	}
+
+	@Override
+	@Deprecated
+	public MessageGroup removeMessageFromGroup(Object key, Message<?> messageToRemove) {
+		throw new UnsupportedOperationException("The operation isn't implemented for this class.");
+	}
+
+	@Override
+	public void removeMessagesFromGroup(Object key, Collection<Message<?>> messages) {
+		throw new UnsupportedOperationException("The operation isn't implemented for this class.");
+	}
+
+	@Override
+	public void setLastReleasedSequenceNumberForGroup(Object groupId, int sequenceNumber) {
+		throw new UnsupportedOperationException("The operation isn't implemented for this class.");
+	}
+
+	@Override
+	public Iterator<MessageGroup> iterator() {
+		throw new UnsupportedOperationException("The operation isn't implemented for this class.");
+	}
+
+	@Override
+	public void completeGroup(Object groupId) {
+		throw new UnsupportedOperationException("The operation isn't implemented for this class.");
+	}
+
+	@Override
+	public Message<?> getOneMessageFromGroup(Object groupId) {
+		throw new UnsupportedOperationException("The operation isn't implemented for this class.");
+	}
+
+	@Override
+	public void addMessagesToGroup(Object groupId, Message<?>... messages) {
+		throw new UnsupportedOperationException("The operation isn't implemented for this class.");
+	}
+
+	@Override
+	public Collection<Message<?>> getMessagesForGroup(Object groupId) {
+		throw new UnsupportedOperationException("The operation isn't implemented for this class.");
 	}
 
 	/**

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
@@ -64,10 +64,11 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 	public void testNonExistingEmptyMessageGroup() throws Exception {
 		this.cleanupCollections(new SimpleMongoDbFactory(new MongoClient(), "test"));
 		MessageGroupStore store = getMessageGroupStore();
+		store.addMessagesToGroup(1, new GenericMessage<Object>("foo"));
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		assertNotNull(messageGroup);
 		assertThat(messageGroup.getClass().getName(), containsString("PersistentMessageGroup"));
-		assertEquals(0, messageGroup.size());
+		assertEquals(1, messageGroup.size());
 	}
 
 	@Test

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
@@ -16,10 +16,12 @@
 
 package org.springframework.integration.mongodb.store;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -42,7 +44,6 @@ import org.springframework.integration.store.AbstractBatchingMessageGroupStore;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.MessageStore;
-import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -65,7 +66,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		MessageGroupStore store = getMessageGroupStore();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		assertNotNull(messageGroup);
-		assertTrue(messageGroup instanceof SimpleMessageGroup);
+		assertThat(messageGroup.getClass().getName(), containsString("PersistentMessageGroup"));
 		assertEquals(0, messageGroup.size());
 	}
 
@@ -78,7 +79,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> messageA = new GenericMessage<String>("A");
 		Message<?> messageB = new GenericMessage<String>("B");
-		store.addMessageToGroup(1, messageA);
+		store.addMessagesToGroup(1, messageA);
 		messageGroup = store.addMessageToGroup(1, messageB);
 		assertNotNull(messageGroup);
 		assertEquals(2, messageGroup.size());
@@ -101,7 +102,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		Message<?> messageA = MessageBuilder.withPayload("A").setHeader("foo", uuidA).build();
 		UUID uuidB = UUID.randomUUID();
 		Message<?> messageB = MessageBuilder.withPayload("B").setHeader("foo", uuidB).build();
-		store.addMessageToGroup(id, messageA);
+		store.addMessagesToGroup(id, messageA);
 		messageGroup = store.addMessageToGroup(id, messageB);
 		assertNotNull(messageGroup);
 		assertEquals(2, messageGroup.size());
@@ -122,8 +123,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		MessageGroupStore store = this.getMessageGroupStore();
 		Message<?> messageA = new GenericMessage<String>("A");
 		Message<?> messageB = new GenericMessage<String>("B");
-		store.addMessageToGroup(1, messageA);
-		store.addMessageToGroup(1, messageB);
+		store.addMessagesToGroup(1, messageA, messageB);
 		assertEquals(2, store.messageGroupSize(1));
 	}
 
@@ -134,9 +134,9 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		MessageGroupStore store = this.getMessageGroupStore();
 		Message<?> messageA = new GenericMessage<String>("A");
 		Message<?> messageB = new GenericMessage<String>("B");
-		store.addMessageToGroup(1, messageA);
+		store.addMessagesToGroup(1, messageA);
 		Thread.sleep(10);
-		store.addMessageToGroup(1, messageB);
+		store.addMessagesToGroup(1, messageB);
 		assertEquals(2, store.messageGroupSize(1));
 		Message<?> out = store.pollMessageFromGroup(1);
 		assertNotNull(out);
@@ -153,10 +153,10 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		this.cleanupCollections(new SimpleMongoDbFactory(new MongoClient(), "test"));
 		MessageGroupStore store = this.getMessageGroupStore();
 		Message<?> messageA = new GenericMessage<String>("A");
-		store.addMessageToGroup(1, messageA);
-		store.addMessageToGroup(2, messageA);
-		store.addMessageToGroup(3, messageA);
-		store.addMessageToGroup(4, messageA);
+		store.addMessagesToGroup(1, messageA);
+		store.addMessagesToGroup(2, messageA);
+		store.addMessagesToGroup(3, messageA);
+		store.addMessagesToGroup(4, messageA);
 		assertEquals(1, store.messageGroupSize(1));
 		assertEquals(1, store.messageGroupSize(2));
 		assertEquals(1, store.messageGroupSize(3));
@@ -190,10 +190,10 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		MessageGroupStore store = this.getMessageGroupStore();
 
 		Message<?> messageA = new GenericMessage<String>("A");
-		store.addMessageToGroup(1, messageA);
-		store.addMessageToGroup(2, messageA);
-		store.addMessageToGroup(3, messageA);
-		store.addMessageToGroup(4, messageA);
+		store.addMessagesToGroup(1, messageA);
+		store.addMessagesToGroup(2, messageA);
+		store.addMessagesToGroup(3, messageA);
+		store.addMessagesToGroup(4, messageA);
 		assertEquals(1, store.messageGroupSize(1));
 		assertEquals(1, store.messageGroupSize(2));
 		assertEquals(1, store.messageGroupSize(3));
@@ -258,7 +258,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> messageA = new GenericMessage<String>("A");
 		Message<?> messageB = new GenericMessage<String>("B");
-		store.addMessageToGroup(1, messageA);
+		store.addMessagesToGroup(1, messageA);
 		messageGroup = store.addMessageToGroup(1, messageB);
 		assertNotNull(messageGroup);
 		assertEquals(2, messageGroup.size());
@@ -306,7 +306,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		assertNotNull(messageGroup);
 		Message<?> message = new GenericMessage<String>("Hello");
-		store.addMessageToGroup(messageGroup.getGroupId(), message);
+		store.addMessagesToGroup(messageGroup.getGroupId(), message);
 		store.completeGroup(messageGroup.getGroupId());
 		messageGroup = store.getMessageGroup(1);
 		assertTrue(messageGroup.isComplete());
@@ -321,7 +321,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		assertNotNull(messageGroup);
 		Message<?> message = new GenericMessage<String>("Hello");
-		store.addMessageToGroup(messageGroup.getGroupId(), message);
+		store.addMessagesToGroup(messageGroup.getGroupId(), message);
 		store.setLastReleasedSequenceNumberForGroup(messageGroup.getGroupId(), 5);
 		messageGroup = store.getMessageGroup(1);
 		assertEquals(5, messageGroup.getLastReleasedMessageSequenceNumber());
@@ -335,8 +335,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("2");
-		store.addMessageToGroup(1, new GenericMessage<String>("1"));
-		store.addMessageToGroup(1, message);
+		store.addMessagesToGroup(1, new GenericMessage<String>("1"), message);
 		messageGroup = store.addMessageToGroup(1, new GenericMessage<String>("3"));
 		assertNotNull(messageGroup);
 		assertEquals(3, messageGroup.size());
@@ -355,9 +354,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		MessageGroupStore store2 = this.getMessageGroupStore();
 
 		Message<?> message = new GenericMessage<String>("1");
-		store1.addMessageToGroup(1, message);
-		store2.addMessageToGroup(1, new GenericMessage<String>("2"));
-		store1.addMessageToGroup(1, new GenericMessage<String>("3"));
+		store1.addMessagesToGroup(1, message, new GenericMessage<String>("2"), new GenericMessage<String>("3"));
 
 		MessageGroupStore store3 = this.getMessageGroupStore();
 
@@ -380,9 +377,9 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		MessageGroupStore store2 = this.getMessageGroupStore();
 
 		Message<?> message = new GenericMessage<String>("1");
-		store2.addMessageToGroup(1, message);
-		store1.addMessageToGroup(2, new GenericMessage<String>("2"));
-		store2.addMessageToGroup(3, new GenericMessage<String>("3"));
+		store2.addMessagesToGroup(1, message);
+		store1.addMessagesToGroup(2, new GenericMessage<String>("2"));
+		store2.addMessagesToGroup(3, new GenericMessage<String>("3"));
 
 		MessageGroupStore store3 = this.getMessageGroupStore();
 		Iterator<MessageGroup> iterator = store3.iterator();
@@ -415,7 +412,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		List<Message<?>> messages = new ArrayList<Message<?>>();
 		for (int i = 0; i < 25; i++) {
 			Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
-			messageStore.addMessageToGroup(groupId, message);
+			messageStore.addMessagesToGroup(groupId, message);
 			messages.add(message);
 		}
 		MessageGroup group = messageStore.getMessageGroup(groupId);
@@ -477,20 +474,41 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		MessageChannel input = context.getBean("inputChannel", MessageChannel.class);
 		QueueChannel output = context.getBean("outputChannel", QueueChannel.class);
 
-		Message<?> m1 = MessageBuilder.withPayload("1").setSequenceNumber(1).setSequenceSize(3).setCorrelationId(1).build();
-		Message<?> m2 = MessageBuilder.withPayload("2").setSequenceNumber(2).setSequenceSize(3).setCorrelationId(1).build();
+		Message<?> m1 = MessageBuilder.withPayload("1")
+				.setSequenceNumber(1)
+				.setSequenceSize(10)
+				.setCorrelationId(1)
+				.build();
+		Message<?> m2 = MessageBuilder.withPayload("2")
+				.setSequenceNumber(2)
+				.setSequenceSize(10)
+				.setCorrelationId(1)
+				.build();
 		input.send(m1);
 		assertNull(output.receive(1000));
 		input.send(m2);
 		assertNull(output.receive(1000));
+
+		for (int i = 3; i < 10; i++) {
+			input.send(MessageBuilder.withPayload("" + i)
+					.setSequenceNumber(i)
+					.setSequenceSize(10)
+					.setCorrelationId(1)
+					.build());
+		}
+
 		context.close();
 
 		context = new ClassPathXmlApplicationContext(config, this.getClass());
 		input = context.getBean("inputChannel", MessageChannel.class);
 		output = context.getBean("outputChannel", QueueChannel.class);
 
-		Message<?> m3 = MessageBuilder.withPayload("3").setSequenceNumber(3).setSequenceSize(3).setCorrelationId(1).build();
-		input.send(m3);
+		Message<?> m10 = MessageBuilder.withPayload("10")
+				.setSequenceNumber(10)
+				.setSequenceSize(10)
+				.setCorrelationId(1)
+				.build();
+		input.send(m10);
 		assertNotNull(output.receive(2000));
 		context.close();
 	}
@@ -511,7 +529,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 
 		message = MessageHistory.write(message, fooChannel);
 		message = MessageHistory.write(message, barChannel);
-		store.addMessageToGroup(1, message);
+		store.addMessagesToGroup(1, message);
 		MessageGroup group = store.getMessageGroup(1);
 		assertNotNull(group);
 		Collection<Message<?>> messages = group.getMessages();

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
@@ -56,6 +56,7 @@ public class ConfigurableMongoDbMessageGroupStoreTests extends AbstractMongoDbMe
 		GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
 		testApplicationContext.refresh();
 		mongoDbMessageStore.setApplicationContext(testApplicationContext);
+		mongoDbMessageStore.setLazyLoadMessageGroups(true);
 		mongoDbMessageStore.afterPropertiesSet();
 		return mongoDbMessageStore;
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 import java.util.Map;
 
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -34,10 +35,13 @@ import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.PriorityChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
+import org.springframework.integration.store.AbstractMessageGroupStore;
 import org.springframework.integration.store.MessageStore;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.util.StopWatch;
 
 import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
@@ -69,6 +73,48 @@ public class ConfigurableMongoDbMessageGroupStoreTests extends AbstractMongoDbMe
 	@MongoDbAvailable
 	public void testWithAggregatorWithShutdown() throws Exception {
 		super.testWithAggregatorWithShutdown("mongo-aggregator-confugurable-config.xml");
+	}
+
+	@Test
+	@Ignore("The performance test. Enough slow.")
+	@MongoDbAvailable
+	public void messageGroupStoreLazyLoadPerformance() throws Exception {
+		cleanupCollections(new SimpleMongoDbFactory(new MongoClient(), "test"));
+
+		StopWatch watch = new StopWatch("Lazy-Load Performance");
+
+		int sequenceSize = 1000;
+
+		performLazyLoadEagerTest(watch, sequenceSize, true);
+
+		performLazyLoadEagerTest(watch, sequenceSize, false);
+
+		System.out.println(watch.prettyPrint());
+	}
+
+	private void performLazyLoadEagerTest(StopWatch watch, int sequenceSize, boolean lazyLoad) {
+		ClassPathXmlApplicationContext context =
+				new ClassPathXmlApplicationContext("mongo-aggregator-confugurable-config.xml", getClass());
+		context.refresh();
+
+		AbstractMessageGroupStore messageGroupStore = context.getBean("mongoStore", AbstractMessageGroupStore.class);
+		messageGroupStore.setLazyLoadMessageGroups(lazyLoad);
+		MessageChannel input = context.getBean("inputChannel", MessageChannel.class);
+		QueueChannel output = context.getBean("outputChannel", QueueChannel.class);
+
+		watch.start(lazyLoad ? "Lazy-Load" : "Eager");
+
+		for (int i = 0; i < sequenceSize; i++) {
+			input.send(MessageBuilder.withPayload("" + i)
+					.setCorrelationId(1)
+					.build());
+		}
+
+		assertNotNull(output.receive(20000));
+
+		watch.stop();
+
+		context.close();
 	}
 
 	@Test

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
@@ -56,7 +56,6 @@ public class ConfigurableMongoDbMessageGroupStoreTests extends AbstractMongoDbMe
 		GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
 		testApplicationContext.refresh();
 		mongoDbMessageStore.setApplicationContext(testApplicationContext);
-		mongoDbMessageStore.setLazyLoadMessageGroups(true);
 		mongoDbMessageStore.afterPropertiesSet();
 		return mongoDbMessageStore;
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageGroupStoreTests.java
@@ -16,12 +16,13 @@
 
 package org.springframework.integration.mongodb.store;
 
-import com.mongodb.MongoClient;
 import org.junit.Test;
 
 import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
 import org.springframework.integration.store.MessageStore;
+
+import com.mongodb.MongoClient;
 
 /**
  * @author Oleg Zhurakousky
@@ -33,7 +34,9 @@ public class MongoDbMessageGroupStoreTests extends AbstractMongoDbMessageGroupSt
 
 	@Override
 	protected MongoDbMessageStore getMessageGroupStore() throws Exception {
-		MongoDbMessageStore mongoDbMessageStore = new MongoDbMessageStore(new SimpleMongoDbFactory(new MongoClient(), "test"));
+		MongoDbMessageStore mongoDbMessageStore =
+				new MongoDbMessageStore(new SimpleMongoDbFactory(new MongoClient(), "test"));
+		mongoDbMessageStore.setLazyLoadMessageGroups(true);
 		mongoDbMessageStore.afterPropertiesSet();
 		return mongoDbMessageStore;
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageGroupStoreTests.java
@@ -36,7 +36,6 @@ public class MongoDbMessageGroupStoreTests extends AbstractMongoDbMessageGroupSt
 	protected MongoDbMessageStore getMessageGroupStore() throws Exception {
 		MongoDbMessageStore mongoDbMessageStore =
 				new MongoDbMessageStore(new SimpleMongoDbFactory(new MongoClient(), "test"));
-		mongoDbMessageStore.setLazyLoadMessageGroups(true);
 		mongoDbMessageStore.afterPropertiesSet();
 		return mongoDbMessageStore;
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-config.xml
@@ -5,7 +5,8 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="mongoStore"/>
+	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="mongoStore"
+					release-strategy-expression="size() == 10"/>
 
 	<int:channel id="outputChannel">
 		<int:queue/>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-confugurable-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-confugurable-config.xml
@@ -5,7 +5,8 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="mongoStore"/>
+	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="mongoStore"
+					release-strategy-expression="size() == 10"/>
 
 	<int:channel id="outputChannel">
 		<int:queue/>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-confugurable-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-confugurable-config.xml
@@ -14,7 +14,6 @@
 
 	<bean id="mongoStore" class="org.springframework.integration.mongodb.store.ConfigurableMongoDbMessageStore">
 		<constructor-arg ref="mongoConnectionFactory"/>
-		<property name="lazyLoadMessageGroups" value="true"/>
 	</bean>
 
 	<bean id="mongoConnectionFactory" class="org.springframework.data.mongodb.core.SimpleMongoDbFactory">

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-confugurable-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-confugurable-config.xml
@@ -6,7 +6,7 @@
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="mongoStore"
-					release-strategy-expression="size() == 10"/>
+					release-strategy-expression="size() == 1000"/>
 
 	<int:channel id="outputChannel">
 		<int:queue/>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-confugurable-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-confugurable-config.xml
@@ -14,6 +14,7 @@
 
 	<bean id="mongoStore" class="org.springframework.integration.mongodb.store.ConfigurableMongoDbMessageStore">
 		<constructor-arg ref="mongoConnectionFactory"/>
+		<property name="lazyLoadMessageGroups" value="true"/>
 	</bean>
 
 	<bean id="mongoConnectionFactory" class="org.springframework.data.mongodb.core.SimpleMongoDbFactory">

--- a/spring-integration-mongodb/src/test/resources/log4j.properties
+++ b/spring-integration-mongodb/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+log4j.rootCategory=WARN, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss.SSS} %-5p [%t][%c] %m%n
+
+log4j.category.org.springframework.integration=WARN
+log4j.category.org.springframework.integration.mongodb=INFO

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
@@ -186,8 +186,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("2");
-		store.addMessageToGroup(messageGroup.getGroupId(), new GenericMessage<String>("1"));
-		store.addMessageToGroup(messageGroup.getGroupId(), message);
+		store.addMessagesToGroup(messageGroup.getGroupId(), new GenericMessage<String>("1"), message);
 		messageGroup = store.addMessageToGroup(messageGroup.getGroupId(), new GenericMessage<String>("3"));
 		assertEquals(3, messageGroup.size());
 
@@ -218,7 +217,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 
 		message = MessageHistory.write(message, fooChannel);
 		message = MessageHistory.write(message, barChannel);
-		store.addMessageToGroup(1, message);
+		store.addMessagesToGroup(1, message);
 
 		message = store.getMessageGroup(1).getMessages().iterator().next();
 
@@ -236,7 +235,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 		RedisMessageStore store = new RedisMessageStore(jcf);
 
 		MessageGroup messageGroup = store.getMessageGroup(1);
-		store.addMessageToGroup(messageGroup.getGroupId(), new GenericMessage<String>("1"));
+		store.addMessagesToGroup(messageGroup.getGroupId(), new GenericMessage<String>("1"));
 		store.removeMessagesFromGroup(1, new GenericMessage<String>("2"));
 	}
 
@@ -259,7 +258,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 		RedisMessageStore store2 = new RedisMessageStore(jcf);
 
 		Message<?> message = new GenericMessage<String>("1");
-		store1.addMessageToGroup(1, message);
+		store1.addMessagesToGroup(1, message);
 		MessageGroup messageGroup = store2.addMessageToGroup(1, new GenericMessage<String>("2"));
 
 		assertEquals(2, messageGroup.getMessages().size());
@@ -280,10 +279,9 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 		RedisMessageStore store2 = new RedisMessageStore(jcf);
 
 
-		store1.addMessageToGroup(1, new GenericMessage<String>("1"));
-		store2.addMessageToGroup(2, new GenericMessage<String>("2"));
-		store1.addMessageToGroup(3, new GenericMessage<String>("3"));
-		store2.addMessageToGroup(3, new GenericMessage<String>("3A"));
+		store1.addMessagesToGroup(1, new GenericMessage<String>("1"));
+		store2.addMessagesToGroup(2, new GenericMessage<String>("2"));
+		store1.addMessagesToGroup(3, new GenericMessage<String>("3"), new GenericMessage<String>("3A"));
 
 		Iterator<MessageGroup> messageGroups = store1.iterator();
 		int counter = 0;
@@ -394,7 +392,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 		List<Message<?>> messages = new ArrayList<Message<?>>();
 		for (int i = 0; i < 25; i++) {
 			Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
-			messageStore.addMessageToGroup(groupId, message);
+			messageStore.addMessagesToGroup(groupId, message);
 			messages.add(message);
 		}
 		MessageGroup group = messageStore.getMessageGroup(groupId);

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageStoreTests.java
@@ -169,7 +169,7 @@ public class RedisMessageStoreTests extends RedisAvailableTests {
 		List<Message<?>> messages = new ArrayList<Message<?>>();
 		for (int i = 0; i < 25; i++) {
 			Message<String> message = MessageBuilder.withPayload("foo").setCorrelationId(groupId).build();
-			messageStore.addMessageToGroup(groupId, message);
+			messageStore.addMessagesToGroup(groupId, message);
 			messages.add(message);
 		}
 		messageStore.removeMessagesFromGroup(groupId, messages);

--- a/src/reference/asciidoc/message-store.adoc
+++ b/src/reference/asciidoc/message-store.adoc
@@ -94,6 +94,7 @@ This defaults to a `SimpleMessageGroupFactory` which produces `SimpleMessageGrou
 (`LinkedHashSet`) internal collection.
 Other possible options are `SYNCHRONISED_SET` and `BLOCKING_QUEUE`, where the last one can be used to reinstate the
 previous `SimpleMessageGroup` behavior.
+Also the `PERSISTENT` option is available. See the next section for more information.
 
 [[lazy-load-message-group]]
 ==== Persistence MessageGroupStore and Lazy-Load
@@ -103,5 +104,6 @@ from the store with the _Lazy-Load_ manner.
 In most cases it is useful for the Correlation `MessageHandler` s (<<aggregator>> and <<resequencer>>),
 when it would be an overhead to load entire `MessageGroup` from the store on each correlation operation.
 
-To switch off the lazy-load behavior the `AbstractMessageGroupStore.setLazyLoadMessageGroups(false)` option
+To switch on the lazy-load behavior the `AbstractMessageGroupStore.setLazyLoadMessageGroups(true)` option
 can be used from the configuration.
+Or you can inject the `SimpleMessageGroupFactory` with the `SimpleMessageGroupFactory.GroupType.PERSISTENT` variant.

--- a/src/reference/asciidoc/message-store.adoc
+++ b/src/reference/asciidoc/message-store.adoc
@@ -104,6 +104,5 @@ from the store with the _Lazy-Load_ manner.
 In most cases it is useful for the Correlation `MessageHandler` s (<<aggregator>> and <<resequencer>>),
 when it would be an overhead to load entire `MessageGroup` from the store on each correlation operation.
 
-To switch on the lazy-load behavior the `AbstractMessageGroupStore.setLazyLoadMessageGroups(true)` option
+To switch off the lazy-load behavior the `AbstractMessageGroupStore.setLazyLoadMessageGroups(false)` option
 can be used from the configuration.
-Or you can inject the `SimpleMessageGroupFactory` with the `SimpleMessageGroupFactory.GroupType.PERSISTENT` variant.

--- a/src/reference/asciidoc/message-store.adoc
+++ b/src/reference/asciidoc/message-store.adoc
@@ -106,3 +106,28 @@ when it would be an overhead to load entire `MessageGroup` from the store on eac
 
 To switch off the lazy-load behavior the `AbstractMessageGroupStore.setLazyLoadMessageGroups(false)` option
 can be used from the configuration.
+
+Our performance tests for _lazy-load_ on MongoDB `MessageStore` (<<mongodb-message-store>>) and
+`<aggregator>` (<<aggregator>>)
+with custom `release-strategy` like:
+
+[source,xml]
+----
+<int:aggregator input-channel="inputChannel"
+                output-channel="outputChannel"
+                message-store="mongoStore"
+                release-strategy-expression="size() == 1000"/>
+
+----
+
+demonstrate this results for 1000 simple messages:
+
+....
+StopWatch 'Lazy-Load Performance': running time (millis) = 38918
+-----------------------------------------
+ms     %     Task name
+-----------------------------------------
+02652  007%  Lazy-Load
+36266  093%  Eager
+....
+

--- a/src/reference/asciidoc/message-store.adoc
+++ b/src/reference/asciidoc/message-store.adoc
@@ -94,3 +94,14 @@ This defaults to a `SimpleMessageGroupFactory` which produces `SimpleMessageGrou
 (`LinkedHashSet`) internal collection.
 Other possible options are `SYNCHRONISED_SET` and `BLOCKING_QUEUE`, where the last one can be used to reinstate the
 previous `SimpleMessageGroup` behavior.
+
+[[lazy-load-message-group]]
+==== Persistence MessageGroupStore and Lazy-Load
+
+Starting with _version 4.3_, all persistence `MessageGroupStore` s retrieve `MessageGroup` s and their `messages`
+from the store with the _Lazy-Load_ manner.
+In most cases it is useful for the Correlation `MessageHandler` s (<<aggregator>> and <<resequencer>>),
+when it would be an overhead to load entire `MessageGroup` from the store on each correlation operation.
+
+To switch off the lazy-load behavior the `AbstractMessageGroupStore.setLazyLoadMessageGroups(false)` option
+can be used from the configuration.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -24,7 +24,7 @@ See <<message-store>> for more information.
 ==== PersistentMessageGroup
 
 The `PersistentMessageGroup`, - lazy-load proxy, - implementation is provided for persistent `MessageGroupStore` s,
-which return this instance for the `getMessageGroup()` when their `lazyLoadMessageGroups` is `true` (defaults to `false`).
+which return this instance for the `getMessageGroup()` when their `lazyLoadMessageGroups` is `true` (defaults).
 See <<message-store>> for more information.
 
 [[x4.3-general]]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -24,7 +24,7 @@ See <<message-store>> for more information.
 ==== PersistentMessageGroup
 
 The `PersistentMessageGroup`, - lazy-load proxy, - implementation is provided for persistent `MessageGroupStore` s,
-which return this instance for the `getMessageGroup()` when their `lazyLoadMessageGroups` is `true` (defaults).
+which return this instance for the `getMessageGroup()` when their `lazyLoadMessageGroups` is `true` (defaults to `false`).
 See <<message-store>> for more information.
 
 [[x4.3-general]]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -21,6 +21,11 @@ The `SimpleMessageGroupFactory` is provided for the `SimpleMessageGroup` with th
 factory for the standard `MessageGroupStore` implementations.
 See <<message-store>> for more information.
 
+==== PersistentMessageGroup
+
+The `PersistentMessageGroup`, - lazy-load proxy, - implementation is provided for persistent `MessageGroupStore` s,
+which return this instance for the `getMessageGroup()` when their `lazyLoadMessageGroups` is `true` (defaults).
+See <<message-store>> for more information.
 
 [[x4.3-general]]
 === General Changes


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3387,
https://jira.spring.io/browse/INT-3806
- Introduce

```
MessageGroupStore

void addMessagesToGroup(Object groupId, Message<?>... messages);
```

And implement it in all stores.
- Use new `addMessagesToGroup` where it is reasonable, e.g. `DelayHandler`
- Optimize test-case to use a new store method (where it is possible)
- Fix timing delays in the `JdbcMessageStoreTests`
- Introduce `PersistentMessageGroup`
- Add `AbstractMessageGroupStore#proxyMessageGroupForLazyLoad` to wrap the raw `MessageGroup` to the `PersistentMessageGroup` for lazy-load
- Rework `MessageGroupMetadata` do not be `immutable` and allow to store/restore in the `AbstractKeyValueMessageStore` only the `MessageGroupMetadata`
- Refactor `ResequencingMessageHandler` and `SequenceSizeReleaseStrategy` a bit for better performance when interact with the `MessageGroup`
- Add `AbstractMessageGroupStore#setLazyLoadMessageGroups` to switch off the `lazy-load` behavior and restore the previous full `MessageGroup` logic
- Add `What's New` note and `message-store.adoc` paragraph for the lazy-load functionality
