### PR TITLE
INT-3996: Fix JdbcChannelMessageStore Javadoc

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -46,11 +46,8 @@ import org.springframework.core.serializer.support.SerializingConverter;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.jdbc.JdbcMessageStore;
 import org.springframework.integration.jdbc.store.channel.ChannelMessageStoreQueryProvider;
-import org.springframework.integration.jdbc.store.channel.DerbyChannelMessageStoreQueryProvider;
 import org.springframework.integration.jdbc.store.channel.MessageRowMapper;
-import org.springframework.integration.jdbc.store.channel.MySqlChannelMessageStoreQueryProvider;
 import org.springframework.integration.jdbc.store.channel.OracleChannelMessageStoreQueryProvider;
-import org.springframework.integration.jdbc.store.channel.PostgresChannelMessageStoreQueryProvider;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupFactory;
 import org.springframework.integration.store.MessageGroupStore;
@@ -252,23 +249,14 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 	}
 
 	/**
+	 * Sets the database specific {@code ChannelMessageStoreQueryProvider} to use. The
+	 * {@link JdbcChannelMessageStore} provides the SQL queries to retrieve messages from
+	 * the database. See the javadocs {@code ChannelMessageStoreQueryProvider} (all known
+	 * implementing classes) to see those implementations provided by the framework.
 	 * <p>
-	 * Sets the database specific {@link ChannelMessageStoreQueryProvider} to use. The {@link JdbcChannelMessageStore}
-	 * provides the SQL queries to retrieve messages from the database. The
-	 * following {@link ChannelMessageStoreQueryProvider} are provided:
+	 * You can provide your own query implementations, if you need to support additional
+	 * databases and/or need to fine-tune the queries for your requirements.
 	 * </p>
-	 * <ul>
-	 *     <li>{@link DerbyChannelMessageStoreQueryProvider}</li>
-	 *     <li>{@link MySqlChannelMessageStoreQueryProvider}</li>
-	 *     <li>{@link OracleChannelMessageStoreQueryProvider}</li>
-	 *     <li>{@link PostgresChannelMessageStoreQueryProvider}</li>
-	 * </ul>
-	 * <p>
-	 * Beyond, you can provide your own query implementations, in case you need
-	 * to support additional databases and/or need to fine-tune the queries for
-	 * your requirements.
-	 * </p>
-	 *
 	 * @param channelMessageStoreQueryProvider Must not be null.
 	 */
 	public void setChannelMessageStoreQueryProvider(ChannelMessageStoreQueryProvider channelMessageStoreQueryProvider) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3996

One of the query provider implementations was missing. To avoid a maintenance
nightmare, simply reference the interface's javadoc which lists all known
implementations.

**cherry-pick to 4.2.x**
