### PR TITLE
INT-3999: Avoid "hard" references from schedulers

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -426,43 +426,53 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		}
 	}
 
-	private void scheduleGroupToForceComplete(final MessageGroup messageGroup) {
-		final Long groupTimeout = this.obtainGroupTimeout(messageGroup);
+	private void scheduleGroupToForceComplete(MessageGroup messageGroup) {
+		final Long groupTimeout = obtainGroupTimeout(messageGroup);
 		/*
 		 * When 'groupTimeout' is evaluated to 'null' we do nothing.
 		 * The 'MessageGroupStoreReaper' can be used to 'forceComplete' message groups.
 		 */
 		if (groupTimeout != null && groupTimeout >= 0) {
 			if (groupTimeout > 0) {
-				final MessageGroupProcessor forceReleaseProcessor =
-						AbstractCorrelatingMessageHandler.this.forceReleaseProcessor;
-				ScheduledFuture<?> scheduledFuture = this.getTaskScheduler()
+				final Object groupId = messageGroup.getGroupId();
+				ScheduledFuture<?> scheduledFuture = getTaskScheduler()
 						.schedule(new Runnable() {
 
 							@Override
 							public void run() {
 								try {
-									forceReleaseProcessor.processMessageGroup(messageGroup);
+									processForceRelease(groupId);
 								}
 								catch (MessageDeliveryException e) {
 									if (logger.isDebugEnabled()) {
-										logger.debug("The MessageGroup [ " + messageGroup +
+										logger.debug("The MessageGroup [ " + groupId +
 												"] is rescheduled by the reason: " + e.getMessage());
 									}
-									scheduleGroupToForceComplete(messageGroup);
+									scheduleGroupToForceComplete(groupId);
 								}
 							}
+
 						}, new Date(System.currentTimeMillis() + groupTimeout));
 
 				if (logger.isDebugEnabled()) {
 					logger.debug("Schedule MessageGroup [ " + messageGroup + "] to 'forceComplete'.");
 				}
-				this.expireGroupScheduledFutures.put(UUIDConverter.getUUID(messageGroup.getGroupId()), scheduledFuture);
+				this.expireGroupScheduledFutures.put(UUIDConverter.getUUID(groupId), scheduledFuture);
 			}
 			else {
 				this.forceReleaseProcessor.processMessageGroup(messageGroup);
 			}
 		}
+	}
+
+	private void scheduleGroupToForceComplete(Object groupId) {
+		MessageGroup messageGroup = this.messageStore.getMessageGroup(groupId);
+		scheduleGroupToForceComplete(messageGroup);
+	}
+
+	private void processForceRelease(Object groupId) {
+		MessageGroup messageGroup = this.messageStore.getMessageGroup(groupId);
+		this.forceReleaseProcessor.processMessageGroup(messageGroup);
 	}
 
 	private void discardMessage(Message<?> message) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3999

Since the scheduled tasks may live for a long time it can finish
with the `OutOfMemory` if we use the direct reference to big objects, like `Message<?>`.
- Fix `AbstractCorrelatingMessageHandler` to deal only with the `groupId`
  from the `scheduleGroupToForceComplete()` when we `schedule` `Runnable` for the `forceRelease` logic.
- Fix `DelayHandler` to deal only with `messageId` in the `releaseMessageAfterDelay()`, when we
  `schedule` `Runnable` for the `releaseMessageAfterDelay`.
- Since the logic hasn't been changed for those components, there is no any new test.
  There is just enough to be sure that all existing tests are fine.

**Cherry-pick to 4.0.x, 4.1.x, 4.2.x**
