### PR TITLE
INT-3994: Add Option to Map MimeMessage

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -369,7 +369,7 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 			content = message.getContent();
 			if (content instanceof String) {
 				String mailContentType = (String) headers.get(MailHeaders.CONTENT_TYPE);
-				if (mailContentType != null && mailContentType.startsWith("text")) {
+				if (mailContentType != null && mailContentType.toLowerCase().startsWith("text")) {
 					headers.put(MessageHeaders.CONTENT_TYPE, mailContentType);
 				}
 				else {

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailHeaders.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailHeaders.java
@@ -21,8 +21,9 @@ package org.springframework.integration.mail;
  * Message attributes from/to integration Message Headers.
  *
  * @author Mark Fisher
+ * @author Gary Russell
  */
-public abstract class MailHeaders {
+public final class MailHeaders {
 
 	public static final String PREFIX = "mail_";
 
@@ -43,5 +44,22 @@ public abstract class MailHeaders {
 	public static final String ATTACHMENT_FILENAME = PREFIX + "attachmentFilename";
 
 	public static final String CONTENT_TYPE = PREFIX + "contentType";
+
+	public static final String RAW_HEADERS = PREFIX + "raw";
+
+	public static final String FLAGS = PREFIX + "flags";
+
+	public static final String LINE_COUNT = PREFIX + "lineCount";
+
+	public static final String RECEIVED_DATE = PREFIX + "receivedDate";
+
+	public static final String SIZE = PREFIX + "size";
+
+	public static final String EXPUNGED = PREFIX + "expunged";
+
+	private MailHeaders() {
+		// empty
+	}
+
 
 }

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailReceiver.java
@@ -16,12 +16,6 @@
 
 package org.springframework.integration.mail;
 
-import javax.mail.Folder;
-import javax.mail.Message;
-
-import org.springframework.util.Assert;
-
-
 /**
  * Strategy interface for receiving mail {@link javax.mail.Message Messages}.
  *
@@ -30,30 +24,6 @@ import org.springframework.util.Assert;
  */
 public interface MailReceiver {
 
-	javax.mail.Message[] receive() throws javax.mail.MessagingException;
-
-	class MailReceiverContext {
-
-		private final Folder folder;
-
-		private volatile Message[] messages = new Message[0];
-
-		MailReceiverContext(Folder folder) {
-			this.folder = folder;
-		}
-
-		Message[] getMessages() {
-			return this.messages;
-		}
-
-		void setMessages(Message[] messages) {
-			Assert.noNullElements(messages, "messages cannot be null");
-			this.messages = messages;
-		}
-
-		Folder getFolder() {
-			return this.folder;
-		}
-	}
+	Object[] receive() throws javax.mail.MessagingException;
 
 }

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParser.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParser.java
@@ -97,7 +97,7 @@ public class ImapIdleChannelAdapterParser extends AbstractChannelAdapterParser {
 			receiverBuilder.addPropertyValue("selectorExpression", expressionDef);
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(receiverBuilder, element, "header-mapper");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(receiverBuilder, element, "multipart-as-bytes");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(receiverBuilder, element, "embedded-parts-as-bytes");
 
 		return receiverBuilder.getBeanDefinition();
 	}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParser.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParser.java
@@ -78,7 +78,8 @@ public class ImapIdleChannelAdapterParser extends AbstractChannelAdapterParser {
 		}
 		else {
 			IntegrationNamespaceUtils.setReferenceIfAttributeDefined(receiverBuilder, element, "java-mail-properties");
-			IntegrationNamespaceUtils.setReferenceIfAttributeDefined(receiverBuilder, element, "authenticator", "javaMailAuthenticator");
+			IntegrationNamespaceUtils.setReferenceIfAttributeDefined(receiverBuilder, element, "authenticator",
+					"javaMailAuthenticator");
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(receiverBuilder, element, "max-fetch-size");
 		receiverBuilder.addPropertyValue("shouldDeleteMessages", element.getAttribute("should-delete-messages"));
@@ -95,6 +96,8 @@ public class ImapIdleChannelAdapterParser extends AbstractChannelAdapterParser {
 			expressionDef.getConstructorArgumentValues().addGenericArgumentValue(selectorExpression);
 			receiverBuilder.addPropertyValue("selectorExpression", expressionDef);
 		}
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(receiverBuilder, element, "header-mapper");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(receiverBuilder, element, "multipart-as-bytes");
 
 		return receiverBuilder.getBeanDefinition();
 	}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/MailInboundChannelAdapterParser.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/MailInboundChannelAdapterParser.java
@@ -94,7 +94,7 @@ public class MailInboundChannelAdapterParser extends AbstractPollingInboundChann
 			receiverBuilder.addPropertyValue("selectorExpression", expressionDef);
 		}
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(receiverBuilder, element, "header-mapper");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(receiverBuilder, element, "multipart-as-bytes");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(receiverBuilder, element, "embedded-parts-as-bytes");
 
 		return receiverBuilder.getBeanDefinition();
 	}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/MailInboundChannelAdapterParser.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/MailInboundChannelAdapterParser.java
@@ -93,6 +93,8 @@ public class MailInboundChannelAdapterParser extends AbstractPollingInboundChann
 			expressionDef.getConstructorArgumentValues().addGenericArgumentValue(selectorExpression);
 			receiverBuilder.addPropertyValue("selectorExpression", expressionDef);
 		}
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(receiverBuilder, element, "header-mapper");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(receiverBuilder, element, "multipart-as-bytes");
 
 		return receiverBuilder.getBeanDefinition();
 	}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/MailReceiverFactoryBean.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/MailReceiverFactoryBean.java
@@ -83,7 +83,7 @@ public class MailReceiverFactoryBean implements FactoryBean<MailReceiver>, Dispo
 
 	private volatile HeaderMapper<MimeMessage> headerMapper;
 
-	private Boolean multipartAsBytes;
+	private Boolean embeddedPartsAsBytes;
 
 	public void setStoreUri(String storeUri) {
 		this.storeUri = storeUri;
@@ -137,8 +137,8 @@ public class MailReceiverFactoryBean implements FactoryBean<MailReceiver>, Dispo
 		this.headerMapper = headerMapper;
 	}
 
-	public void setMultipartAsBytes(Boolean multipartAsBytes) {
-		this.multipartAsBytes = multipartAsBytes;
+	public void setEmbeddedPartsAsBytes(Boolean embeddedPartsAsBytes) {
+		this.embeddedPartsAsBytes = embeddedPartsAsBytes;
 	}
 
 	@Override
@@ -227,8 +227,8 @@ public class MailReceiverFactoryBean implements FactoryBean<MailReceiver>, Dispo
 		if (this.headerMapper != null) {
 			receiver.setHeaderMapper(this.headerMapper);
 		}
-		if (this.multipartAsBytes != null) {
-			receiver.setMultipartAsBytes(this.multipartAsBytes);
+		if (this.embeddedPartsAsBytes != null) {
+			receiver.setEmbeddedPartsAsBytes(this.embeddedPartsAsBytes);
 		}
 		receiver.afterPropertiesSet();
 		return receiver;

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/MailReceiverFactoryBean.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/MailReceiverFactoryBean.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import javax.mail.Authenticator;
 import javax.mail.Session;
 import javax.mail.URLName;
+import javax.mail.internet.MimeMessage;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -36,6 +37,7 @@ import org.springframework.integration.mail.ImapMailReceiver;
 import org.springframework.integration.mail.MailReceiver;
 import org.springframework.integration.mail.Pop3MailReceiver;
 import org.springframework.integration.mail.SearchTermStrategy;
+import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -78,6 +80,10 @@ public class MailReceiverFactoryBean implements FactoryBean<MailReceiver>, Dispo
 	private volatile String userFlag;
 
 	private volatile BeanFactory beanFactory;
+
+	private volatile HeaderMapper<MimeMessage> headerMapper;
+
+	private Boolean multipartAsBytes;
 
 	public void setStoreUri(String storeUri) {
 		this.storeUri = storeUri;
@@ -125,6 +131,14 @@ public class MailReceiverFactoryBean implements FactoryBean<MailReceiver>, Dispo
 
 	public void setUserFlag(String userFlag) {
 		this.userFlag = userFlag;
+	}
+
+	public void setHeaderMapper(HeaderMapper<MimeMessage> headerMapper) {
+		this.headerMapper = headerMapper;
+	}
+
+	public void setMultipartAsBytes(Boolean multipartAsBytes) {
+		this.multipartAsBytes = multipartAsBytes;
 	}
 
 	@Override
@@ -209,6 +223,12 @@ public class MailReceiverFactoryBean implements FactoryBean<MailReceiver>, Dispo
 		}
 		if (this.beanFactory != null) {
 			receiver.setBeanFactory(this.beanFactory);
+		}
+		if (this.headerMapper != null) {
+			receiver.setHeaderMapper(this.headerMapper);
+		}
+		if (this.multipartAsBytes != null) {
+			receiver.setMultipartAsBytes(this.multipartAsBytes);
 		}
 		receiver.afterPropertiesSet();
 		return receiver;

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/DefaultMailHeaderMapper.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/DefaultMailHeaderMapper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mail.support;
+
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.Map;
+
+import javax.mail.Header;
+import javax.mail.internet.MimeMessage;
+
+import org.springframework.integration.mail.MailHeaders;
+import org.springframework.integration.mapping.HeaderMapper;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.MessagingException;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * Maps an inbound {@link MimeMessage} to a {@link Map}.
+ *
+ * @author Gary Russell
+ * @since 4.3
+ *
+ */
+public class DefaultMailHeaderMapper implements HeaderMapper<MimeMessage> {
+
+	@Override
+	public void fromHeaders(MessageHeaders headers, MimeMessage target) {
+		throw new UnsupportedOperationException("Mapping to a mail message is not currently supported");
+	}
+
+	@Override
+	public Map<String, Object> toHeaders(MimeMessage source) {
+		Map<String, Object> headers = MailUtils.extractStandardHeaders(source);
+		try {
+			Enumeration<?> allHeaders = source.getAllHeaders();
+			MultiValueMap<String, String> rawHeaders = new LinkedMultiValueMap<String, String>();
+			while (allHeaders.hasMoreElements()) {
+				Object headerInstance = allHeaders.nextElement();
+				if (headerInstance instanceof Header) {
+					Header header = (Header) headerInstance;
+					rawHeaders.add(header.getName(), header.getValue());
+				}
+			}
+			headers.put(MailHeaders.RAW_HEADERS, rawHeaders);
+			headers.put(MailHeaders.FLAGS, source.getFlags());
+			int lineCount = source.getLineCount();
+			if (lineCount > 0) {
+				headers.put(MailHeaders.LINE_COUNT, lineCount);
+			}
+			Date receivedDate = source.getReceivedDate();
+			if (receivedDate != null) {
+				headers.put(MailHeaders.RECEIVED_DATE, receivedDate);
+			}
+			int size = source.getSize();
+			if (size > 0) {
+				headers.put(MailHeaders.SIZE, size);
+			}
+			headers.put(MailHeaders.EXPUNGED, source.isExpunged());
+		}
+		catch (Exception e) {
+			throw new MessagingException("Failed to map message headers", e);
+		}
+		return headers;
+	}
+
+}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/DefaultMailHeaderMapper.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/DefaultMailHeaderMapper.java
@@ -72,6 +72,7 @@ public class DefaultMailHeaderMapper implements HeaderMapper<MimeMessage> {
 				headers.put(MailHeaders.SIZE, size);
 			}
 			headers.put(MailHeaders.EXPUNGED, source.isExpunged());
+			headers.put(MailHeaders.CONTENT_TYPE, source.getContentType());
 		}
 		catch (Exception e) {
 			throw new MessagingException("Failed to map message headers", e);

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/MailUtils.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/MailUtils.java
@@ -34,7 +34,7 @@ import org.springframework.util.Assert;
  */
 public final class MailUtils {
 
-	private MailUtils () {
+	private MailUtils() {
 		// empty
 	}
 

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/MailUtils.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/MailUtils.java
@@ -28,7 +28,7 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
 
 /**
- * Utilites for handling mail messages.
+ * Utilities for handling mail messages.
  *
  * @author Gary Russell
  * @since 4.3

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/MailUtils.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/MailUtils.java
@@ -28,6 +28,8 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
 
 /**
+ * Utilites for handling mail messages.
+ *
  * @author Gary Russell
  * @since 4.3
  *
@@ -38,6 +40,12 @@ public final class MailUtils {
 		// empty
 	}
 
+	/**
+	 * Map the message headers to a Map using {@link MailHeaders} keys; specifically
+	 * maps the address headers and the subject.
+	 * @param source the message.
+	 * @return the map.
+	 */
 	public static Map<String, Object> extractStandardHeaders(Message source) {
 		Map<String, Object> headers = new HashMap<String, Object>();
 		try {
@@ -54,7 +62,7 @@ public final class MailUtils {
 		}
 	}
 
-	public static String convertToString(Address[] addresses) {
+	private static String convertToString(Address[] addresses) {
 		if (addresses == null || addresses.length == 0) {
 			return null;
 		}
@@ -62,7 +70,7 @@ public final class MailUtils {
 		return addresses[0].toString();
 	}
 
-	public static String[] convertToStringArray(Address[] addresses) {
+	private static String[] convertToStringArray(Address[] addresses) {
 		if (addresses != null) {
 			String[] addressStrings = new String[addresses.length];
 			for (int i = 0; i < addresses.length; i++) {

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/MailUtils.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/MailUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mail.support;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.mail.Address;
+import javax.mail.Message;
+import javax.mail.Message.RecipientType;
+
+import org.springframework.integration.mail.MailHeaders;
+import org.springframework.messaging.MessagingException;
+import org.springframework.util.Assert;
+
+/**
+ * @author Gary Russell
+ * @since 4.3
+ *
+ */
+public final class MailUtils {
+
+	private MailUtils () {
+		// empty
+	}
+
+	public static Map<String, Object> extractStandardHeaders(Message source) {
+		Map<String, Object> headers = new HashMap<String, Object>();
+		try {
+			headers.put(MailHeaders.FROM, convertToString(source.getFrom()));
+			headers.put(MailHeaders.BCC, convertToStringArray(source.getRecipients(RecipientType.BCC)));
+			headers.put(MailHeaders.CC, convertToStringArray(source.getRecipients(RecipientType.CC)));
+			headers.put(MailHeaders.TO, convertToStringArray(source.getRecipients(RecipientType.TO)));
+			headers.put(MailHeaders.REPLY_TO, convertToString(source.getReplyTo()));
+			headers.put(MailHeaders.SUBJECT, source.getSubject());
+			return headers;
+		}
+		catch (Exception e) {
+			throw new MessagingException("conversion of MailMessage headers failed", e);
+		}
+	}
+
+	public static String convertToString(Address[] addresses) {
+		if (addresses == null || addresses.length == 0) {
+			return null;
+		}
+		Assert.state(addresses.length == 1, "expected a single value but received an Array");
+		return addresses[0].toString();
+	}
+
+	public static String[] convertToStringArray(Address[] addresses) {
+		if (addresses != null) {
+			String[] addressStrings = new String[addresses.length];
+			for (int i = 0; i < addresses.length; i++) {
+				addressStrings[i] = addresses[i].toString();
+			}
+			return addressStrings;
+		}
+		return new String[0];
+	}
+
+}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/package-info.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/support/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides classes to support email.
+ */
+package org.springframework.integration.mail.support;

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/AbstractMailMessageTransformer.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/AbstractMailMessageTransformer.java
@@ -16,18 +16,14 @@
 
 package org.springframework.integration.mail.transformer;
 
-import java.util.HashMap;
 import java.util.Map;
-
-import javax.mail.Address;
-import javax.mail.Message.RecipientType;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
-import org.springframework.integration.mail.MailHeaders;
+import org.springframework.integration.mail.support.MailUtils;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
@@ -35,8 +31,6 @@ import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.integration.transformer.MessageTransformationException;
 import org.springframework.integration.transformer.Transformer;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessagingException;
-import org.springframework.util.Assert;
 
 /**
  * Base class for Transformers that convert from a JavaMail Message to a
@@ -99,38 +93,7 @@ public abstract class AbstractMailMessageTransformer<T> implements Transformer,
 
 
 	private Map<String, Object> extractHeaderMapFromMailMessage(javax.mail.Message mailMessage) {
-		try {
-			Map<String, Object> headers = new HashMap<String, Object>();
-			headers.put(MailHeaders.FROM, this.convertToString(mailMessage.getFrom()));
-			headers.put(MailHeaders.BCC, this.convertToStringArray(mailMessage.getRecipients(RecipientType.BCC)));
-			headers.put(MailHeaders.CC, this.convertToStringArray(mailMessage.getRecipients(RecipientType.CC)));
-			headers.put(MailHeaders.TO, this.convertToStringArray(mailMessage.getRecipients(RecipientType.TO)));
-			headers.put(MailHeaders.REPLY_TO, this.convertToString(mailMessage.getReplyTo()));
-			headers.put(MailHeaders.SUBJECT, mailMessage.getSubject());
-			return headers;
-		}
-		catch (Exception e) {
-			throw new MessagingException("conversion of MailMessage headers failed", e);
-		}
-	}
-
-	private String convertToString(Address[] addresses) {
-		if (addresses == null || addresses.length == 0) {
-			return null;
-		}
-		Assert.state(addresses.length == 1, "expected a single value but received an Array");
-		return addresses[0].toString();
-	}
-
-	private String[] convertToStringArray(Address[] addresses) {
-		if (addresses != null) {
-			String[] addressStrings = new String[addresses.length];
-			for (int i = 0; i < addresses.length; i++) {
-				addressStrings[i] = addresses[i].toString();
-			}
-			return addressStrings;
-		}
-		return new String[0];
+		return MailUtils.extractStandardHeaders(mailMessage);
 	}
 
 }

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/MailToStringTransformer.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/MailToStringTransformer.java
@@ -20,15 +20,16 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.Charset;
 
 import javax.mail.Multipart;
+import javax.mail.Part;
 
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.util.Assert;
 
 /**
- * Transforms a Message payload of type {@link javax.mail.Message} to a String.
- * If the mail message's content is a String, it will be the payload of the
- * result Message. If the content is a Multipart, a String will be created from
- * an output stream of bytes using the provided charset (or UTF-8 by default).
+ * Transforms a Message payload of type {@link javax.mail.Message} to a String. If the
+ * mail message's content is a String, it will be the payload of the result Message. If
+ * the content is a Part or Multipart, a String will be created from an output stream of
+ * bytes using the provided charset (or UTF-8 by default).
  *
  * @author Mark Fisher
  * @author Gary Russell
@@ -59,6 +60,12 @@ public class MailToStringTransformer extends AbstractMailMessageTransformer<Stri
 		if (content instanceof Multipart) {
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 			((Multipart) content).writeTo(outputStream);
+			return this.getMessageBuilderFactory().withPayload(
+					new String(outputStream.toByteArray(), this.charset));
+		}
+		else if (content instanceof Part) {
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			((Part) content).writeTo(outputStream);
 			return this.getMessageBuilderFactory().withPayload(
 					new String(outputStream.toByteArray(), this.charset));
 		}

--- a/spring-integration-mail/src/main/resources/org/springframework/integration/mail/config/spring-integration-mail-4.3.xsd
+++ b/spring-integration-mail/src/main/resources/org/springframework/integration/mail/config/spring-integration-mail-4.3.xsd
@@ -171,6 +171,7 @@
 							</xsd:appinfo>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attributeGroup ref="inboundMappingGroup" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -269,6 +270,7 @@
 				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attributeGroup ref="inboundMappingGroup" />
 	</xsd:complexType>
 
 	<xsd:element name="mail-to-string-transformer">
@@ -362,5 +364,38 @@
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
+
+	<xsd:attributeGroup name="inboundMappingGroup">
+		<xsd:attribute name="header-mapper" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+	A reference to a `org.springframework.integration.mapping.HeaderMapper<MimeMessage>` bean.
+	When not supplied, the message payload will be the raw MimeMessage with no header mapping.
+	When a mapper is provided, the mail headers are mapped to 'MessageHeaders' and the payload
+	will depend on the email contents, and the setting of 'multipart-as-bytes'. The framework
+	provides a `DefaultMailHeaderMappe`; see the reference manual regarding the headers mapped
+	and the payload types.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.mapping.HeaderMapper" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="multipart-as-bytes">
+			<xsd:annotation>
+				<xsd:documentation>
+	When a 'header-mapper' is provided, and the 'MimeMessage' has 'MultiPart' contents, the message
+	payload will be a byte[] containing the raw multipart data. Set this boolean to 'false' for the
+	payload to be a decoded 'Multipart' object. Note that 'Multipart' is not 'Serializable', nor is it
+	suitable for serialization using other technologies such as Kryo. Default true (payload is 'byte[]').
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="xsd:boolean xsd:string"/>
+			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
 
 </xsd:schema>

--- a/spring-integration-mail/src/main/resources/org/springframework/integration/mail/config/spring-integration-mail-4.3.xsd
+++ b/spring-integration-mail/src/main/resources/org/springframework/integration/mail/config/spring-integration-mail-4.3.xsd
@@ -171,7 +171,6 @@
 							</xsd:appinfo>
 						</xsd:annotation>
 					</xsd:attribute>
-					<xsd:attributeGroup ref="inboundMappingGroup" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -369,11 +368,11 @@
 		<xsd:attribute name="header-mapper" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-	A reference to a `org.springframework.integration.mapping.HeaderMapper<MimeMessage>` bean.
+	A reference to a 'org.springframework.integration.mapping.HeaderMapper<MimeMessage>' bean.
 	When not supplied, the message payload will be the raw MimeMessage with no header mapping.
 	When a mapper is provided, the mail headers are mapped to 'MessageHeaders' and the payload
-	will depend on the email contents, and the setting of 'multipart-as-bytes'. The framework
-	provides a `DefaultMailHeaderMappe`; see the reference manual regarding the headers mapped
+	will depend on the email contents, and the setting of 'embedded-parts-as-bytes'. The framework
+	provides a 'DefaultMailHeaderMapper'; see the reference manual regarding the headers mapped
 	and the payload types.
 				]]></xsd:documentation>
 				<xsd:appinfo>
@@ -383,13 +382,14 @@
 				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
-		<xsd:attribute name="multipart-as-bytes">
+		<xsd:attribute name="embedded-parts-as-bytes">
 			<xsd:annotation>
 				<xsd:documentation>
-	When a 'header-mapper' is provided, and the 'MimeMessage' has 'MultiPart' contents, the message
-	payload will be a byte[] containing the raw multipart data. Set this boolean to 'false' for the
-	payload to be a decoded 'Multipart' object. Note that 'Multipart' is not 'Serializable', nor is it
-	suitable for serialization using other technologies such as Kryo. Default true (payload is 'byte[]').
+	When a 'header-mapper' is provided, and the 'MimeMessage' has embedded 'Part' (e.g. 'Message' or
+	'Multipart') contents, the message payload will be a byte[] containing the raw data. Set this
+	boolean to 'false' for the payload to be a decoded 'Part' object. Note that 'Part's are not
+	'Serializable', nor are they suitable for serialization using other technologies such as Kryo.
+	Default 'true' (payload is 'byte[]').
 				</xsd:documentation>
 			</xsd:annotation>
 			<xsd:simpleType>

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.mail;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -85,6 +86,7 @@ import org.springframework.integration.mail.config.ImapIdleChannelAdapterParserT
 import org.springframework.integration.mail.support.DefaultMailHeaderMapper;
 import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -189,6 +191,10 @@ public class ImapMailReceiverTests {
 			org.springframework.messaging.Message<?> received = channel.receive(10000);
 			assertNotNull(received);
 			assertNotNull(received.getHeaders().get(MailHeaders.RAW_HEADERS));
+			assertThat((String) received.getHeaders().get(MailHeaders.CONTENT_TYPE),
+					equalTo("TEXT/PLAIN; charset=ISO-8859-1"));
+			assertThat((String) received.getHeaders().get(MessageHeaders.CONTENT_TYPE),
+					equalTo("TEXT/PLAIN; charset=ISO-8859-1"));
 		}
 		assertNotNull(channel.receive(10000)); // new message after idle
 		assertNull(channel.receive(10000)); // no new message after second and third idle
@@ -870,8 +876,13 @@ public class ImapMailReceiverTests {
 		testAttachmentsGuts(receiver);
 		org.springframework.messaging.Message<?>[] messages = (org.springframework.messaging.Message<?>[]) receiver
 				.receive();
-		Object content = messages[0].getPayload();
+		org.springframework.messaging.Message<?> received = messages[0];
+		Object content = received.getPayload();
 		assertThat(content, instanceOf(byte[].class));
+		assertThat((String) received.getHeaders().get(MailHeaders.CONTENT_TYPE),
+				equalTo("multipart/mixed;\r\n boundary=\"------------040903000701040401040200\""));
+		assertThat((String) received.getHeaders().get(MessageHeaders.CONTENT_TYPE),
+				equalTo("application/octet-stream"));
 	}
 
 	@Test

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
@@ -878,7 +878,7 @@ public class ImapMailReceiverTests {
 	public void testAttachmentsWithMapping() throws Exception {
 		final ImapMailReceiver receiver = new ImapMailReceiver("imap://foo");
 		receiver.setHeaderMapper(new DefaultMailHeaderMapper());
-		receiver.setMultipartAsBytes(false);
+		receiver.setEmbeddedPartsAsBytes(false);
 		testAttachmentsGuts(receiver);
 		org.springframework.messaging.Message<?>[] messages = (org.springframework.messaging.Message<?>[]) receiver
 				.receive();

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/MailReceivingMessageSourceTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/MailReceivingMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ public class MailReceivingMessageSourceTests {
 
 		private final ConcurrentLinkedQueue<javax.mail.Message[]> messages = new ConcurrentLinkedQueue<javax.mail.Message[]>();
 
+		@Override
 		public javax.mail.Message[] receive() {
 			return messages.poll();
 		}
@@ -72,16 +73,6 @@ public class MailReceivingMessageSourceTests {
 		}
 
 		public void stop() {
-		}
-
-		public MailReceiverContext getTransactionContext() {
-			return null;
-		}
-
-		public void closeContextAfterSuccess(MailReceiverContext context) {
-		}
-
-		public void closeContextAfterFailure(MailReceiverContext context) {
 		}
 
 	}

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/MailTestsHelper.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/MailTestsHelper.java
@@ -16,13 +16,7 @@
 
 package org.springframework.integration.mail;
 
-import static org.mockito.Mockito.mock;
-
-import javax.mail.Folder;
-
-import org.springframework.integration.mail.MailReceiver.MailReceiverContext;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.test.util.TestUtils;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.messaging.Message;
 
@@ -75,15 +69,6 @@ public class MailTestsHelper {
 				.setHeader(MailHeaders.FROM, MailTestsHelper.FROM)
 				.setHeader(MailHeaders.REPLY_TO, MailTestsHelper.REPLY_TO)
 				.build();
-	}
-
-	public static MailReceiverContext setupContextHolder(AbstractMailReceiver receiver) {
-		@SuppressWarnings("unchecked")
-		ThreadLocal<MailReceiverContext> contextHolder = TestUtils.getPropertyValue(receiver, "contextHolder", ThreadLocal.class);
-		Folder folder = mock(Folder.class);
-		MailReceiverContext context = new MailReceiverContext(folder);
-		contextHolder.set(context);
-		return context;
 	}
 
 }

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests-context.xml
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests-context.xml
@@ -36,7 +36,7 @@
 			channel="channel"
 			auto-startup="false"
 			header-mapper="mapper"
-			multipart-as-bytes="false"
+			embedded-parts-as-bytes="false"
 			should-delete-messages="true"/>
 
 	<bean id="mapper" class="org.springframework.integration.mail.support.DefaultMailHeaderMapper" />

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests-context.xml
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests-context.xml
@@ -35,7 +35,11 @@
 			store-uri="imap:foo"
 			channel="channel"
 			auto-startup="false"
+			header-mapper="mapper"
+			multipart-as-bytes="false"
 			should-delete-messages="true"/>
+
+	<bean id="mapper" class="org.springframework.integration.mail.support.DefaultMailHeaderMapper" />
 
 	<mail:imap-idle-channel-adapter id="simpleAdapterWithErrorChannel"
 			store-uri="imap:foo"

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests.java
@@ -84,7 +84,7 @@ public class ImapIdleChannelAdapterParserTests {
 		assertEquals(Boolean.TRUE, receiverAccessor.getPropertyValue("shouldMarkMessagesAsRead"));
 		assertNull(adapterAccessor.getPropertyValue("errorChannel"));
 		assertNull(adapterAccessor.getPropertyValue("adviceChain"));
-		assertEquals(Boolean.FALSE, receiverAccessor.getPropertyValue("multipartAsBytes"));
+		assertEquals(Boolean.FALSE, receiverAccessor.getPropertyValue("embeddedPartsAsBytes"));
 		assertNotNull(receiverAccessor.getPropertyValue("headerMapper"));
 	}
 
@@ -107,7 +107,7 @@ public class ImapIdleChannelAdapterParserTests {
 		assertEquals(Boolean.TRUE, receiverAccessor.getPropertyValue("shouldDeleteMessages"));
 		assertEquals(Boolean.TRUE, receiverAccessor.getPropertyValue("shouldMarkMessagesAsRead"));
 		assertSame(context.getBean("errorChannel"), adapterAccessor.getPropertyValue("errorChannel"));
-		assertEquals(Boolean.TRUE, receiverAccessor.getPropertyValue("multipartAsBytes"));
+		assertEquals(Boolean.TRUE, receiverAccessor.getPropertyValue("embeddedPartsAsBytes"));
 		assertNull(receiverAccessor.getPropertyValue("headerMapper"));
 	}
 

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import org.springframework.integration.mail.ImapMailReceiver;
 import org.springframework.integration.mail.SearchTermStrategy;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -51,6 +52,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
+@DirtiesContext
 public class ImapIdleChannelAdapterParserTests {
 
 	@Autowired
@@ -82,7 +84,10 @@ public class ImapIdleChannelAdapterParserTests {
 		assertEquals(Boolean.TRUE, receiverAccessor.getPropertyValue("shouldMarkMessagesAsRead"));
 		assertNull(adapterAccessor.getPropertyValue("errorChannel"));
 		assertNull(adapterAccessor.getPropertyValue("adviceChain"));
+		assertEquals(Boolean.FALSE, receiverAccessor.getPropertyValue("multipartAsBytes"));
+		assertNotNull(receiverAccessor.getPropertyValue("headerMapper"));
 	}
+
 	@Test
 	public void simpleAdapterWithErrorChannel() {
 		Object adapter = context.getBean("simpleAdapterWithErrorChannel");
@@ -102,7 +107,10 @@ public class ImapIdleChannelAdapterParserTests {
 		assertEquals(Boolean.TRUE, receiverAccessor.getPropertyValue("shouldDeleteMessages"));
 		assertEquals(Boolean.TRUE, receiverAccessor.getPropertyValue("shouldMarkMessagesAsRead"));
 		assertSame(context.getBean("errorChannel"), adapterAccessor.getPropertyValue("errorChannel"));
+		assertEquals(Boolean.TRUE, receiverAccessor.getPropertyValue("multipartAsBytes"));
+		assertNull(receiverAccessor.getPropertyValue("headerMapper"));
 	}
+
 	@Test
 	public void simpleAdapterWithMarkeMessagesAsRead() {
 		Object adapter = context.getBean("simpleAdapterMarkAsRead");

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests-context.xml
@@ -15,7 +15,7 @@
 
 	<mail:inbound-channel-adapter id="pop3ShouldDeleteTrue"
 		store-uri="pop3:test" channel="testChannel" should-delete-messages="true"
-		header-mapper="mapper" multipart-as-bytes="false"
+		header-mapper="mapper" embedded-parts-as-bytes="false"
 		auto-startup="false" />
 
 	<mail:inbound-channel-adapter id="pop3ShouldDeleteFalse"

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests-context.xml
@@ -13,14 +13,24 @@
 
 	<!-- INT-982 -->
 
-	<mail:inbound-channel-adapter id="pop3ShouldDeleteTrue" store-uri="pop3:test" channel="testChannel" should-delete-messages="true" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="pop3ShouldDeleteTrue"
+		store-uri="pop3:test" channel="testChannel" should-delete-messages="true"
+		header-mapper="mapper" multipart-as-bytes="false"
+		auto-startup="false" />
 
-	<mail:inbound-channel-adapter id="pop3ShouldDeleteFalse" store-uri="pop3:test" channel="testChannel" should-delete-messages="false" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="pop3ShouldDeleteFalse"
+		store-uri="pop3:test" channel="testChannel" should-delete-messages="false"
+		auto-startup="false" />
 
-	<mail:inbound-channel-adapter id="imapShouldDeleteTrue" store-uri="imap:test" channel="testChannel" should-delete-messages="true" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="imapShouldDeleteTrue"
+		store-uri="imap:test" channel="testChannel" should-delete-messages="true"
+		auto-startup="false" />
 
-	<mail:inbound-channel-adapter id="imapShouldDeleteFalse" store-uri="imap:test" channel="testChannel" should-delete-messages="false" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="imapShouldDeleteFalse"
+		store-uri="imap:test" channel="testChannel" should-delete-messages="false"
+		auto-startup="false" />
 
+	<bean id="mapper" class="org.springframework.integration.mail.support.DefaultMailHeaderMapper" />
 
 	<!-- INT-1158 -->
 
@@ -31,46 +41,75 @@
 		<prop key="mail.delete.false">false</prop>
 	</util:properties>
 
-	<mail:inbound-channel-adapter id="pop3ShouldDeleteTrueProperty" store-uri="pop3:test" channel="testChannel" should-delete-messages="${mail.delete.true}" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="pop3ShouldDeleteTrueProperty"
+		store-uri="pop3:test" channel="testChannel" should-delete-messages="${mail.delete.true}"
+		auto-startup="false" />
 
-	<mail:inbound-channel-adapter id="pop3ShouldDeleteFalseProperty" store-uri="pop3:test" channel="testChannel" should-delete-messages="${mail.delete.false}" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="pop3ShouldDeleteFalseProperty"
+		store-uri="pop3:test" channel="testChannel" should-delete-messages="${mail.delete.false}"
+		auto-startup="false" />
 
-	<mail:inbound-channel-adapter id="imapShouldDeleteTrueProperty" store-uri="imap:test" channel="testChannel" should-delete-messages="${mail.delete.true}" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="imapShouldDeleteTrueProperty"
+		store-uri="imap:test" channel="testChannel" should-delete-messages="${mail.delete.true}"
+		auto-startup="false" />
 
-	<mail:inbound-channel-adapter id="imapShouldDeleteFalseProperty" store-uri="imap:test" channel="testChannel" should-delete-messages="${mail.delete.false}" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="imapShouldDeleteFalseProperty"
+		store-uri="imap:test" channel="testChannel" should-delete-messages="${mail.delete.false}"
+		auto-startup="false" />
 
 
 	<!-- INT-1159 -->
 
-	<mail:inbound-channel-adapter id="pop3WithAuthenticator" store-uri="pop3:test" authenticator="testAuthenticator" channel="testChannel" should-delete-messages="false" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="pop3WithAuthenticator"
+		store-uri="pop3:test" authenticator="testAuthenticator" channel="testChannel"
+		should-delete-messages="false" auto-startup="false" />
 
-	<mail:inbound-channel-adapter id="imapWithAuthenticator" store-uri="imap:test" authenticator="testAuthenticator" channel="testChannel" should-delete-messages="false" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="imapWithAuthenticator"
+		store-uri="imap:test" authenticator="testAuthenticator" channel="testChannel"
+		should-delete-messages="false" auto-startup="false" />
 
-	<mail:imap-idle-channel-adapter id="imapIdleWithAuthenticator" store-uri="imap:test" authenticator="testAuthenticator" channel="testChannel" should-delete-messages="false" auto-startup="false"/>
+	<mail:imap-idle-channel-adapter id="imapIdleWithAuthenticator"
+		store-uri="imap:test" authenticator="testAuthenticator" channel="testChannel"
+		should-delete-messages="false" auto-startup="false" />
 
-	<bean id="testAuthenticator" class="org.springframework.integration.mail.config.InboundChannelAdapterParserTests$TestAuthenticator"/>
+	<bean id="testAuthenticator"
+		class="org.springframework.integration.mail.config.InboundChannelAdapterParserTests$TestAuthenticator" />
 
 
 	<!-- INT-1160 -->
 
-	<mail:inbound-channel-adapter id="pop3WithMaxFetchSize" store-uri="pop3:test" max-fetch-size="11" channel="testChannel" should-delete-messages="false" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="pop3WithMaxFetchSize"
+		store-uri="pop3:test" max-fetch-size="11" channel="testChannel"
+		should-delete-messages="false" auto-startup="false" />
 
-	<mail:inbound-channel-adapter id="pop3WithMaxFetchSizeFallsBackToPollerMax" store-uri="pop3:test" channel="testChannel" should-delete-messages="false" auto-startup="false">
-		<si:poller max-messages-per-poll="99" fixed-rate="30000"/>
+	<mail:inbound-channel-adapter
+		id="pop3WithMaxFetchSizeFallsBackToPollerMax" store-uri="pop3:test"
+		channel="testChannel" should-delete-messages="false" auto-startup="false">
+		<si:poller max-messages-per-poll="99" fixed-rate="30000" />
 	</mail:inbound-channel-adapter>
 
-	<mail:inbound-channel-adapter id="imapWithMaxFetchSize" store-uri="imap:test" max-fetch-size="22" channel="testChannel" should-delete-messages="false" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="imapWithMaxFetchSize"
+		store-uri="imap:test" max-fetch-size="22" channel="testChannel"
+		should-delete-messages="false" auto-startup="false" />
 
-	<mail:imap-idle-channel-adapter id="imapIdleWithMaxFetchSize" store-uri="imap:test" max-fetch-size="33" channel="testChannel" should-delete-messages="false" auto-startup="false"/>
+	<mail:imap-idle-channel-adapter id="imapIdleWithMaxFetchSize"
+		store-uri="imap:test" max-fetch-size="33" channel="testChannel"
+		should-delete-messages="false" auto-startup="false" />
 
 
 	<!-- INT-1161 -->
 
-	<mail:inbound-channel-adapter id="pop3WithSession" store-uri="pop3:test" session="testSession" channel="testChannel" should-delete-messages="false" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="pop3WithSession"
+		store-uri="pop3:test" session="testSession" channel="testChannel"
+		should-delete-messages="false" auto-startup="false" />
 
-	<mail:inbound-channel-adapter id="imapWithSession" store-uri="imap:test" session="testSession" channel="testChannel" should-delete-messages="false" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="imapWithSession"
+		store-uri="imap:test" session="testSession" channel="testChannel"
+		should-delete-messages="false" auto-startup="false" />
 
-	<mail:imap-idle-channel-adapter id="imapIdleWithSession" store-uri="imap:test" session="testSession" channel="testChannel" should-delete-messages="false" auto-startup="false"/>
+	<mail:imap-idle-channel-adapter id="imapIdleWithSession"
+		store-uri="imap:test" session="testSession" channel="testChannel"
+		should-delete-messages="false" auto-startup="false" />
 
 	<bean id="testSession" class="javax.mail.Session" factory-method="getInstance">
 		<constructor-arg>
@@ -86,17 +125,28 @@
 
 	<!-- INT-1162 -->
 
-	<mail:inbound-channel-adapter id="pop3WithoutStoreUri" channel="testChannel" protocol="pop3" should-delete-messages="false" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="pop3WithoutStoreUri"
+		channel="testChannel" protocol="pop3" should-delete-messages="false"
+		auto-startup="false" />
 
-	<mail:inbound-channel-adapter id="imapWithoutStoreUri" channel="testChannel" protocol="imap" should-delete-messages="false" auto-startup="false"/>
+	<mail:inbound-channel-adapter id="imapWithoutStoreUri"
+		channel="testChannel" protocol="imap" should-delete-messages="false"
+		auto-startup="false" />
 
-	<mail:imap-idle-channel-adapter id="imapIdleWithoutStoreUri" channel="testChannel" should-delete-messages="false" auto-startup="false"/>
+	<mail:imap-idle-channel-adapter id="imapIdleWithoutStoreUri"
+		channel="testChannel" should-delete-messages="false" auto-startup="false" />
 
-	<mail:inbound-channel-adapter id="pop3ShouldMarkAsReadTrue" channel="testChannel" protocol="pop3" should-delete-messages="false" auto-startup="false" should-mark-messages-as-read="true"/>
+	<mail:inbound-channel-adapter id="pop3ShouldMarkAsReadTrue"
+		channel="testChannel" protocol="pop3" should-delete-messages="false"
+		auto-startup="false" should-mark-messages-as-read="true" />
 
-	<mail:inbound-channel-adapter id="pop3ShouldMarkAsReadFalse" channel="testChannel" protocol="pop3" should-delete-messages="false" auto-startup="false" should-mark-messages-as-read="false"/>
+	<mail:inbound-channel-adapter id="pop3ShouldMarkAsReadFalse"
+		channel="testChannel" protocol="pop3" should-delete-messages="false"
+		auto-startup="false" should-mark-messages-as-read="false" />
 
-    <mail:inbound-channel-adapter id="imapShouldMarkAsReadTrue" channel="testChannel" protocol="imap" should-delete-messages="false" auto-startup="false" should-mark-messages-as-read="true"/>
+	<mail:inbound-channel-adapter id="imapShouldMarkAsReadTrue"
+		channel="testChannel" protocol="imap" should-delete-messages="false"
+		auto-startup="false" should-mark-messages-as-read="true" />
 
 	<!-- INT-2407 -->
 

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests.java
@@ -78,7 +78,7 @@ public class InboundChannelAdapterParserTests {
 		DirectFieldAccessor receiverAccessor = new DirectFieldAccessor(receiver);
 		Boolean value = (Boolean) receiverAccessor.getPropertyValue("shouldDeleteMessages");
 		assertTrue(value);
-		assertEquals(Boolean.FALSE, receiverAccessor.getPropertyValue("multipartAsBytes"));
+		assertEquals(Boolean.FALSE, receiverAccessor.getPropertyValue("embeddedPartsAsBytes"));
 		assertNotNull(receiverAccessor.getPropertyValue("headerMapper"));
 	}
 
@@ -89,7 +89,7 @@ public class InboundChannelAdapterParserTests {
 		DirectFieldAccessor receiverAccessor = new DirectFieldAccessor(receiver);
 		Boolean value = (Boolean) receiverAccessor.getPropertyValue("shouldMarkMessagesAsRead");
 		assertTrue(value);
-		assertEquals(Boolean.TRUE, receiverAccessor.getPropertyValue("multipartAsBytes"));
+		assertEquals(Boolean.TRUE, receiverAccessor.getPropertyValue("embeddedPartsAsBytes"));
 		assertNull(receiverAccessor.getPropertyValue("headerMapper"));
 	}
 

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests.java
@@ -45,6 +45,7 @@ import org.springframework.integration.mail.Pop3MailReceiver;
 import org.springframework.integration.mail.SearchTermStrategy;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -56,6 +57,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
 public class InboundChannelAdapterParserTests {
 
 	@Autowired
@@ -73,16 +75,22 @@ public class InboundChannelAdapterParserTests {
 	public void pop3ShouldDeleteTrue() {
 		AbstractMailReceiver receiver = this.getReceiver("pop3ShouldDeleteTrue");
 		assertEquals(Pop3MailReceiver.class, receiver.getClass());
-		Boolean value = (Boolean) new DirectFieldAccessor(receiver).getPropertyValue("shouldDeleteMessages");
+		DirectFieldAccessor receiverAccessor = new DirectFieldAccessor(receiver);
+		Boolean value = (Boolean) receiverAccessor.getPropertyValue("shouldDeleteMessages");
 		assertTrue(value);
+		assertEquals(Boolean.FALSE, receiverAccessor.getPropertyValue("multipartAsBytes"));
+		assertNotNull(receiverAccessor.getPropertyValue("headerMapper"));
 	}
 
 	@Test
 	public void imapShouldMarkMessagesAsRead() {
 		AbstractMailReceiver receiver = this.getReceiver("imapShouldMarkAsReadTrue");
 		assertEquals(ImapMailReceiver.class, receiver.getClass());
-		Boolean value = (Boolean) new DirectFieldAccessor(receiver).getPropertyValue("shouldMarkMessagesAsRead");
+		DirectFieldAccessor receiverAccessor = new DirectFieldAccessor(receiver);
+		Boolean value = (Boolean) receiverAccessor.getPropertyValue("shouldMarkMessagesAsRead");
 		assertTrue(value);
+		assertEquals(Boolean.TRUE, receiverAccessor.getPropertyValue("multipartAsBytes"));
+		assertNull(receiverAccessor.getPropertyValue("headerMapper"));
 	}
 
 	@Test

--- a/src/reference/asciidoc/mail.adoc
+++ b/src/reference/asciidoc/mail.adoc
@@ -20,7 +20,7 @@ However, a few simple Message mapping strategies are supported out-of-the-box.
 For example, if the message payload is a byte array, then that will be mapped to an attachment.
 For simple text-based emails, you can provide a String-based Message payload.
 In that case, a MailMessage will be created with that String as the text content.
-If you are working with a Message payload type whose `toString()`` method returns appropriate mail text content, then consider adding Spring Integration's _ObjectToStringTransformer_ prior to the outbound Mail adapter (see the example within <<transformer-namespace>> for more detail).
+If you are working with a Message payload type whose `toString()` method returns appropriate mail text content, then consider adding Spring Integration's _ObjectToStringTransformer_ prior to the outbound Mail adapter (see the example within <<transformer-namespace>> for more detail).
 
 The outbound MailMessage may also be configured with certain values from the `MessageHeaders`.
 If available, values will be mapped to the outbound mail's properties, such as the recipients (TO, CC, and BCC), the from/reply-to, and the subject.
@@ -82,15 +82,25 @@ When message mapping is enabled, the payload depends on the mail message and its
 Email contents are usually rendered by a `DataHandler` within the `MimeMessage`.
 - For a simple `text/*` email, the payload will be a String and the `contentType` header will be the same as
 `mail_contentType`.
-- For a multipart message, the `DataHandler` usually renders a `Multipart` object - these objects are not
-`Serializable`, and are not suitable for serialization using alternative technologies such as `Kryo`.
+- For a messages with embedded `javax.mail.Part` s, the `DataHandler` usually renders a `Part` object - these objects
+are not `Serializable`, and are not suitable for serialization using alternative technologies such as `Kryo`.
 For this reason, by default, when mapping is enabled, such payloads are rendered as a raw `byte[]` containing the
-multipart data.
+`Part` data.
+Examples of `Part` are `Message` and `MultiPart`.
 The `contentType` header is `application/octet-stream` in this case.
-To change this behavior, and receive a `Multipart` object payload, set `multipartAsByetes` to `false` on the
+To change this behavior, and receive a `Multipart` object payload, set `embeddedPartsAsBytes` to `false` on the
 `MailReceiver`.
 For content types that are unknown to the `DataHandler`, the contents are rendered as a `byte[]` with a `contentType`
 header of `application/octet-stream`.
+
+When you do not provide a header mapper, the message payload is the `MimeMessage` presented by `javax.mail`.
+The framework provides a `MailToStringTransformer` which can be used to convert the message using a simple strategy
+to convert the mail contents to a String.
+Starting with _version 4.3_, the transformer will handle embedded `Part` as well as `Multipart` which was handled
+previously.
+The transformer is a subclass of `AbstractMailTransformer` which maps the address and subject headers from the list
+above.
+If you wish to perform some other transformation on the message, consider subclassing `AbstractMailTransformer`.
 
 [[mail-namespace]]
 === Mail Namespace Support

--- a/src/reference/asciidoc/mail.adoc
+++ b/src/reference/asciidoc/mail.adoc
@@ -75,7 +75,7 @@ This maps the following headers:
 - `mail_size` - The mail size (if available).
 - `mail_expunged` - A boolen indicating if the message is expunged.
 - `mail_raw` - A `MultiValueMap` containing all the mail headers and their values.
-- `mail_contentTYpe` - The content type of the original mail message.
+- `mail_contentType` - The content type of the original mail message.
 - `contentType` - The payload content type (see below).
 
 When message mapping is enabled, the payload depends on the mail message and its implementation.
@@ -86,7 +86,7 @@ Email contents are usually rendered by a `DataHandler` within the `MimeMessage`.
 are not `Serializable`, and are not suitable for serialization using alternative technologies such as `Kryo`.
 For this reason, by default, when mapping is enabled, such payloads are rendered as a raw `byte[]` containing the
 `Part` data.
-Examples of `Part` are `Message` and `MultiPart`.
+Examples of `Part` are `Message` and `Multipart`.
 The `contentType` header is `application/octet-stream` in this case.
 To change this behavior, and receive a `Multipart` object payload, set `embeddedPartsAsBytes` to `false` on the
 `MailReceiver`.
@@ -96,6 +96,33 @@ header of `application/octet-stream`.
 When you do not provide a header mapper, the message payload is the `MimeMessage` presented by `javax.mail`.
 The framework provides a `MailToStringTransformer` which can be used to convert the message using a simple strategy
 to convert the mail contents to a String.
+This is also available using the XML namespace:
+
+[source, xml]
+----
+<int-mail:mail-to-string-transformer ... >
+----
+
+and with Java configuration:
+
+[source, java]
+----
+@Bean
+@Transformer(inputChannel="...", outputChannel="...")
+public Transformer transformer() {
+    return new MailToStringTransformer();
+}
+----
+
+and with the Java DSL:
+
+[source, java]
+----
+   ...
+   .transform(new MailToStringTransformer())
+   ...
+----
+
 Starting with _version 4.3_, the transformer will handle embedded `Part` as well as `Multipart` which was handled
 previously.
 The transformer is a subclass of `AbstractMailTransformer` which maps the address and subject headers from the list

--- a/src/reference/asciidoc/mail.adoc
+++ b/src/reference/asciidoc/mail.adoc
@@ -55,6 +55,43 @@ Spring Integration provides the `ImapIdleChannelAdapter` which is itself a Messa
 It delegates to an instance of the `ImapMailReceiver` but enables asynchronous reception of Mail Messages.
 There are examples in the next section of configuring both types of inbound Channel Adapter with Spring Integration's namespace support in the 'mail' schema.
 
+[[mail-mapping]]
+=== Inbound Mail Message Mapping
+
+By default, the payload of messages produced by the inbound adapters is the raw `MimeMessage`; you can interrogate
+the headers and content using that object.
+Starting with _version 4.3_, you can provide a `HeaderMapper<MimeMessage>` to map the headers to `MessageHeaders`; for
+convenience, a `DefaultMailHeaderMapper` is provided for this purpose.
+This maps the following headers:
+
+- `mail_from` - A String representation of the `from` address.
+- `mail_bcc` - A String array containing the `bcc` addresses.
+- `mail_cc` - A String array containing the `cc` addresses.
+- `mail_to` - A String array containing the `to` addresses.
+- `mail_replyTo` - A String representation of the `replyTo` address.
+- `mail_subject` - The mail subject.
+- `mail_lineCount` - A line count (if available).
+- `mail_receivedDate` - The received date (if available).
+- `mail_size` - The mail size (if available).
+- `mail_expunged` - A boolen indicating if the message is expunged.
+- `mail_raw` - A `MultiValueMap` containing all the mail headers and their values.
+- `mail_contentTYpe` - The content type of the original mail message.
+- `contentType` - The payload content type (see below).
+
+When message mapping is enabled, the payload depends on the mail message and its implementation.
+Email contents are usually rendered by a `DataHandler` within the `MimeMessage`.
+- For a simple `text/*` email, the payload will be a String and the `contentType` header will be the same as
+`mail_contentType`.
+- For a multipart message, the `DataHandler` usually renders a `Multipart` object - these objects are not
+`Serializable`, and are not suitable for serialization using alternative technologies such as `Kryo`.
+For this reason, by default, when mapping is enabled, such payloads are rendered as a raw `byte[]` containing the
+multipart data.
+The `contentType` header is `application/octet-stream` in this case.
+To change this behavior, and receive a `Multipart` object payload, set `multipartAsByetes` to `false` on the
+`MailReceiver`.
+For content types that are unknown to the `DataHandler`, the contents are rendered as a `byte[]` with a `contentType`
+header of `application/octet-stream`.
+
 [[mail-namespace]]
 === Mail Namespace Support
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -55,9 +55,18 @@ See <<global-properties>> and <<annotations>> for more information.
 
 ==== Mail Changes
 
+===== Customizable User Flag
+
 The customizable `userFlag` added in 4.2.2 to provide customization of the flag used to denote that the mail has been
 seen is now available using the XML namespace.
 See <<imap-seen>> for more information.
+
+===== Mail Message Mapping
+
+There is now an option to map inbound mail messages with the `MessageHeaders` containing the mail headers and the
+payload containing the email content.
+Previously, the payload was always the raw `MimeMessage`.
+See <<mail-mapping>> for more information.
 
 ==== JMS Changes
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3994

If a header mapper is injected into the mail receiver, a mapped
message is result instead of a message with the raw `MimeMessage`.

`MimeMessage` properties are mapped as discrete headers; in addition
the raw email headers are provided as a multivalue map in the headers.
