### PR TITLE
INT-4011: Fix `jdbc.adoc` for wrong `m-s` attr

### DIFF
--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -446,7 +446,7 @@ To configure that scenario, simply extend one message store bean from the other:
 </bean>
 
 <int:channel id="queueChannel">
-    <int:queue message-store="store"/>
+    <int:queue message-store="channelStore"/>
 </int:channel>
 
 <bean id="priorityStore" parent="channelStore">


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4011
- The `jdbc.adoc` has an incorrect reference in a snippet code about
  _Priority Channel_. The correct attribute value must be `channelStore`
