### PR TITLE
INT-4006: Upgrade to `rometools-1.6.0`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ subprojects { subproject ->
 		pahoMqttClientVersion = '1.0.2'
 		postgresVersion = '9.1-901-1.jdbc4'
 		reactorVersion = '2.0.8.RELEASE'
-		romeToolsVersion = '1.5.0'
+		romeToolsVersion = '1.6.0'
 		servletApiVersion = '3.1.0'
 		slf4jVersion = "1.7.21"
 		tomcatVersion = "8.0.33"

--- a/spring-integration-feed/src/main/java/org/springframework/integration/feed/inbound/FeedEntryMessageSource.java
+++ b/spring-integration-feed/src/main/java/org/springframework/integration/feed/inbound/FeedEntryMessageSource.java
@@ -55,6 +55,7 @@ import com.rometools.rome.feed.synd.SyndFeed;
  * @author Aaron Loes
  * @since 2.0
  */
+@SuppressWarnings("deprecation")
 public class FeedEntryMessageSource extends IntegrationObjectSupport implements MessageSource<SyndEntry> {
 
 	private final URL feedUrl;

--- a/spring-integration-feed/src/main/resources/org/springframework/integration/feed/config/spring-integration-feed-4.3.xsd
+++ b/spring-integration-feed/src/main/resources/org/springframework/integration/feed/config/spring-integration-feed-4.3.xsd
@@ -56,13 +56,13 @@
 			<xsd:attribute name="feed-fetcher" use="optional" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>
-						Reference to a FeedFetcher instance for retrieveing Feeds from the provided URL.
+						Reference to a FeedFetcher instance for retrieving Feeds from the provided URL.
 						By default, the HTTP protocol is supported. For any other protocols or general
 						customizations, provide a reference to a different implementation.
 					</xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
-							<tool:expected-type type="com.sun.syndication.fetcher.FeedFetcher" />
+							<tool:expected-type type="com.rometools.fetcher.FeedFetcher" />
 						</tool:annotation>
 					</xsd:appinfo>
 				</xsd:annotation>

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
@@ -47,8 +47,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 
-import com.rometools.fetcher.impl.AbstractFeedFetcher;
-import com.rometools.fetcher.impl.HttpURLFeedFetcher;
 import com.rometools.rome.feed.synd.SyndEntry;
 
 /**
@@ -56,6 +54,7 @@ import com.rometools.rome.feed.synd.SyndEntry;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Gunnar Hillert
+ * @author Artem Bilan
  * @since 2.0
  */
 public class FeedInboundChannelAdapterParserTests {
@@ -64,7 +63,8 @@ public class FeedInboundChannelAdapterParserTests {
 
 	@Before
 	public void prepare() {
-		File persisterFile = new File(System.getProperty("java.io.tmpdir") + "/spring-integration/", "feedAdapter.last.entry");
+		File persisterFile = new File(System.getProperty("java.io.tmpdir") + "/spring-integration/",
+				"feedAdapter.last.entry");
 		if (persisterFile.exists()) {
 			persisterFile.delete();
 		}
@@ -79,28 +79,29 @@ public class FeedInboundChannelAdapterParserTests {
 		MetadataStore metadataStore = (MetadataStore) TestUtils.getPropertyValue(source, "metadataStore");
 		assertTrue(metadataStore instanceof SampleMetadataStore);
 		assertEquals(metadataStore, context.getBean("customMetadataStore"));
-		AbstractFeedFetcher fetcher = (AbstractFeedFetcher) TestUtils.getPropertyValue(source, "feedFetcher");
+		Object fetcher = TestUtils.getPropertyValue(source, "feedFetcher");
 		assertEquals("FileUrlFeedFetcher", fetcher.getClass().getSimpleName());
 		context.destroy();
 	}
 
 
+	@SuppressWarnings("deprecation")
+	@Test
 	public void validateSuccessfulHttpConfigurationWithCustomMetadataStore() {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"FeedInboundChannelAdapterParserTests-http-context.xml", this.getClass());
 		SourcePollingChannelAdapter adapter = context.getBean("feedAdapter", SourcePollingChannelAdapter.class);
 		FeedEntryMessageSource source = (FeedEntryMessageSource) TestUtils.getPropertyValue(adapter, "source");
 		MetadataStore metadataStore = (MetadataStore) TestUtils.getPropertyValue(source, "metadataStore");
-		assertTrue(metadataStore instanceof SampleMetadataStore);
-		assertEquals(metadataStore, context.getBean("customMetadataStore"));
-		AbstractFeedFetcher fetcher = (AbstractFeedFetcher) TestUtils.getPropertyValue(source, "feedFetcher");
-		assertTrue(fetcher instanceof HttpURLFeedFetcher);
+		Object fetcher = TestUtils.getPropertyValue(source, "feedFetcher");
+		assertTrue(fetcher instanceof com.rometools.fetcher.impl.HttpURLFeedFetcher);
 		context.destroy();
 	}
 
 	@Test
 	public void validateSuccessfulNewsRetrievalWithFileUrlAndMessageHistory() throws Exception {
-		File persisterFile = new File(System.getProperty("java.io.tmpdir") + "/spring-integration/", "metadata-store.properties");
+		File persisterFile = new File(System.getProperty("java.io.tmpdir") + "/spring-integration/",
+				"metadata-store.properties");
 		if (persisterFile.exists()) {
 			persisterFile.delete();
 		}

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FeedEntryMessageSourceTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FeedEntryMessageSourceTests.java
@@ -31,7 +31,6 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.integration.metadata.PropertiesPersistingMetadataStore;
 import org.springframework.messaging.Message;
 
-import com.rometools.fetcher.FeedFetcher;
 import com.rometools.rome.feed.synd.SyndEntry;
 
 /**
@@ -39,11 +38,13 @@ import com.rometools.rome.feed.synd.SyndEntry;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Aaron Loes
+ * @author Artem Bilan
  * @since 2.0
  */
+@SuppressWarnings("deprecation")
 public class FeedEntryMessageSourceTests {
 
-	private final FeedFetcher feedFetcher = new FileUrlFeedFetcher();
+	private final com.rometools.fetcher.FeedFetcher feedFetcher = new FileUrlFeedFetcher();
 
 	@Before
 	public void prepare() {

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FileUrlFeedFetcher.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FileUrlFeedFetcher.java
@@ -25,11 +25,6 @@ import java.util.zip.GZIPInputStream;
 
 import org.springframework.util.Assert;
 
-import com.rometools.fetcher.FeedFetcher;
-import com.rometools.fetcher.FetcherEvent;
-import com.rometools.fetcher.FetcherException;
-import com.rometools.fetcher.impl.AbstractFeedFetcher;
-import com.rometools.fetcher.impl.SyndFeedInfo;
 import com.rometools.rome.feed.synd.SyndFeed;
 import com.rometools.rome.io.FeedException;
 import com.rometools.rome.io.SyndFeedInput;
@@ -40,29 +35,32 @@ import com.rometools.rome.io.XmlReader;
  * @author Mark Fisher
  * @author Artem Bilan
  * @since 2.0
+ * @deprecated since 4.3 because 'rome-fetcher-1.6.0' is deprecated.
+ * Will be revised in 5.0 in favor of ROME 2.0
+ *
  */
-class FileUrlFeedFetcher extends AbstractFeedFetcher {
+@SuppressWarnings("deprecation")
+@Deprecated
+class FileUrlFeedFetcher extends com.rometools.fetcher.impl.AbstractFeedFetcher {
 
-	/**
-	 * Retrieve a SyndFeed for the given URL.
-	 * @see FeedFetcher#retrieveFeed(java.net.URL)
-	 */
 	@Override
-	public SyndFeed retrieveFeed(URL feedUrl) throws IOException, FeedException, FetcherException {
+	public SyndFeed retrieveFeed(URL feedUrl)
+			throws IOException, FeedException, com.rometools.fetcher.FetcherException {
 		Assert.notNull(feedUrl, "feedUrl must not be null");
 		URLConnection connection = feedUrl.openConnection();
-		SyndFeedInfo syndFeedInfo = new SyndFeedInfo();
+		com.rometools.fetcher.impl.SyndFeedInfo syndFeedInfo = new com.rometools.fetcher.impl.SyndFeedInfo();
 		this.refreshFeedInfo(feedUrl, syndFeedInfo, connection);
 		return syndFeedInfo.getSyndFeed();
 	}
 
 	@Override
 	public SyndFeed retrieveFeed(String userAgent, URL url)
-			throws IllegalArgumentException, IOException, FeedException, FetcherException {
+			throws IllegalArgumentException, IOException, FeedException, com.rometools.fetcher.FetcherException {
 		return retrieveFeed(url);
 	}
 
-	private void refreshFeedInfo(URL feedUrl, SyndFeedInfo syndFeedInfo, URLConnection connection)
+	private void refreshFeedInfo(URL feedUrl, com.rometools.fetcher.impl.SyndFeedInfo syndFeedInfo,
+			URLConnection connection)
 			throws IOException, FeedException {
 		// need to always set the URL because this may have changed due to 3xx redirects
 		syndFeedInfo.setUrl(connection.getURL());
@@ -111,7 +109,7 @@ class FileUrlFeedFetcher extends AbstractFeedFetcher {
 		SyndFeedInput syndFeedInput = new SyndFeedInput();
 		syndFeedInput.setPreserveWireFeed(isPreserveWireFeed());
 		SyndFeed feed = syndFeedInput.build(reader);
-		fireEvent(FetcherEvent.EVENT_TYPE_FEED_RETRIEVED, connection, feed);
+		fireEvent(com.rometools.fetcher.FetcherEvent.EVENT_TYPE_FEED_RETRIEVED, connection, feed);
 		return feed;
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4006
- Upgrade to `rometools-1.6.0`
- Fix `FeedFetcher` typo in the XSD
- Since the `FeedFetcher` (and the whole `feed-fetcher` jar) is deprecated, provide an appropriate `@SupressWarning("deprecation")`
- Deprecate `FileUrlFeedFetcher` as well
