### PR TITLE
INT-4020: Fix `unnamed` global wire-taps

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GlobalWireTapParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GlobalWireTapParser.java
@@ -25,8 +25,10 @@ import org.springframework.beans.factory.xml.ParserContext;
 
 /**
  * Parser for the top level 'wire-tap' element
+ *
  * @author David Turanski
  * @author Artem Bilan
+ *
  * @since 2.1
  *
  */
@@ -41,7 +43,14 @@ public class GlobalWireTapParser extends GlobalChannelInterceptorParser {
 	@Override
 	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
 			throws BeanDefinitionStoreException {
-		return super.resolveId(element, definition, parserContext) + ".globalChannelInterceptor";
+		RuntimeBeanReference wireTapBean =
+				(RuntimeBeanReference) definition.getConstructorArgumentValues()
+						.getIndexedArgumentValues()
+						.values()
+						.iterator()
+						.next()
+						.getValue();
+		return wireTapBean.getBeanName() + ".globalChannelInterceptor";
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalWireTapTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalWireTapTests-context.xml
@@ -27,6 +27,7 @@
 	<channel id="random-channel"/>
 
 	<bridge input-channel="channel" output-channel="output"/>
+
 	<bridge input-channel="random-channel" output-channel="output"/>
 
 	<!-- This wiretap targets a single channel -->
@@ -42,5 +43,10 @@
 	<!-- This wiretap targets all channels -->
 	<wire-tap id="wiretap-all-channels" channel="wiretap-all"/>
 
+	<publish-subscribe-channel id="unnamedGlobalWireTaps"/>
+
+	<wire-tap channel="unnamedGlobalWireTaps" pattern="channel"/>
+
+	<wire-tap channel="unnamedGlobalWireTaps" pattern="channel"/>
 
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalWireTapTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalWireTapTests.java
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.integration.channel.DirectChannel;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
@@ -47,7 +48,7 @@ public class GlobalWireTapTests {
 
 	@Autowired
 	@Qualifier("channel")
-	MessageChannel channel;
+	DirectChannel channel;
 
 	@Autowired
 	@Qualifier("random-channel")
@@ -74,8 +75,8 @@ public class GlobalWireTapTests {
 		Message<?> wireTapMessage = this.wiretapSingle.receive(100);
 		assertNotNull(wireTapMessage);
 
-		// There should be three messages on this channel.
-		// One for 'channel', one for 'output', and one for 'wiretapSingle'.
+		// There should be 5 messages on this channel:
+		// 'channel', 'output', 'wiretapSingle', and too for 'unnamedGlobalWireTaps'.
 		wireTapMessage = this.wiretapAll.receive(100);
 		int msgCount = 0;
 		while (wireTapMessage != null) {
@@ -84,9 +85,11 @@ public class GlobalWireTapTests {
 			wireTapMessage = this.wiretapAll.receive(100);
 		}
 
-		assertEquals(3, msgCount);
+		assertEquals(5, msgCount);
 
 		assertNull(this.wiretapAll2.receive(1));
+
+		assertEquals(4, this.channel.getChannelInterceptors().size());
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4020

The fix for `named` global `wire-tap`s (INT-2230) didn't covered testing for `unnamed`.
Therefore the fix unconditionally didn't picked up the issue that we used a wrong `BeanDefinition` to determine the current `id`
- Fix `WireTapParser` to use `wireTapBeanName` from the `resolveId()` when the `GlobalChannelInterceptorParser` invokes it.
- Add tests to demonstrate the issue and confirm the fix

**Cherry-pick to 4.2.x**
