### PR TITLE
Fix `feed` module and downgrade to curator-2.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ allprojects {
 
 	repositories {
 		if (version.endsWith('BUILD-SNAPSHOT') || project.hasProperty('platformVersion')) {
+			mavenLocal()
 			maven { url 'https://repo.spring.io/libs-snapshot' }
 		}
 		maven { url 'https://repo.spring.io/libs-milestone' }
@@ -96,7 +97,7 @@ subprojects { subproject ->
 		commonsDbcpVersion = '1.4'
 		commonsIoVersion = '2.4'
 		commonsNetVersion = '3.4'
-		curatorVersion = '3.1.0'
+		curatorVersion = '2.10.0'
 		derbyVersion = '10.11.1.1'
 		eclipseLinkVersion = '2.5.2'
 		ftpServerVersion = '1.0.6'
@@ -146,7 +147,6 @@ subprojects { subproject ->
 		springWsVersion = '2.3.0.RELEASE'
 		xmlUnitVersion = '1.6'
 		xstreamVersion = '1.4.7'
-		zookeeperVersion = '3.4.8'
 	}
 
 	eclipse {
@@ -713,15 +713,10 @@ project('spring-integration-zookeeper') {
 	description = 'Spring Integration Zookeeper Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile ("org.apache.zookeeper:zookeeper:$zookeeperVersion") {
-			exclude group: 'io.netty', module: 'netty'
-			exclude group: 'junit', module: 'junit'
-			exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-			exclude group: 'log4j', module: 'log4j'
-		}
-//		compile "org.springframework.cloud:spring-cloud-cluster-zookeeper:$springCloudClusterVersion"
+
 		compile("org.apache.curator:curator-recipes:$curatorVersion") {
-			exclude group: 'org.apache.zookeeper', module: 'zookeeper'
+			exclude group: 'io.netty', module: 'netty'
+			exclude group: 'log4j', module: 'log4j'
 		}
 
 		testCompile "org.apache.curator:curator-test:$curatorVersion"

--- a/spring-integration-feed/src/main/java/org/springframework/integration/feed/inbound/FeedEntryMessageSource.java
+++ b/spring-integration-feed/src/main/java/org/springframework/integration/feed/inbound/FeedEntryMessageSource.java
@@ -36,11 +36,6 @@ import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
-import com.rometools.fetcher.FeedFetcher;
-import com.rometools.fetcher.FetcherEvent;
-import com.rometools.fetcher.FetcherListener;
-import com.rometools.fetcher.impl.HashMapFeedInfoCache;
-import com.rometools.fetcher.impl.HttpURLFeedFetcher;
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 
@@ -60,7 +55,7 @@ public class FeedEntryMessageSource extends IntegrationObjectSupport implements 
 
 	private final URL feedUrl;
 
-	private final FeedFetcher feedFetcher;
+	private final com.rometools.fetcher.FeedFetcher feedFetcher;
 
 	private final Queue<SyndEntry> entries = new ConcurrentLinkedQueue<SyndEntry>();
 
@@ -82,12 +77,14 @@ public class FeedEntryMessageSource extends IntegrationObjectSupport implements 
 	/**
 	 * Creates a FeedEntryMessageSource that will use a HttpURLFeedFetcher to read feeds from the given URL.
 	 * If the feed URL has a protocol other than http*, consider providing a custom implementation of the
-	 * {@link FeedFetcher} via the alternate constructor.
+	 * {@link com.rometools.fetcher.FeedFetcher} via the alternate constructor.
 	 * @param feedUrl The URL.
 	 * @param metadataKey The metadata key.
 	 */
 	public FeedEntryMessageSource(URL feedUrl, String metadataKey) {
-		this(feedUrl, metadataKey, new HttpURLFeedFetcher(HashMapFeedInfoCache.getInstance()));
+		this(feedUrl, metadataKey,
+				new com.rometools.fetcher.impl.HttpURLFeedFetcher(
+						com.rometools.fetcher.impl.HashMapFeedInfoCache.getInstance()));
 	}
 
 	/**
@@ -96,7 +93,7 @@ public class FeedEntryMessageSource extends IntegrationObjectSupport implements 
 	 * @param metadataKey The metadata key.
 	 * @param feedFetcher The feed fetcher.
 	 */
-	public FeedEntryMessageSource(URL feedUrl, String metadataKey, FeedFetcher feedFetcher) {
+	public FeedEntryMessageSource(URL feedUrl, String metadataKey, com.rometools.fetcher.FeedFetcher feedFetcher) {
 		Assert.notNull(feedUrl, "feedUrl must not be null");
 		Assert.notNull(metadataKey, "metadataKey must not be null");
 		Assert.notNull(feedFetcher, "feedFetcher must not be null");
@@ -243,20 +240,17 @@ public class FeedEntryMessageSource extends IntegrationObjectSupport implements 
 	}
 
 
-	private class FeedQueueUpdatingFetcherListener implements FetcherListener {
+	private class FeedQueueUpdatingFetcherListener implements com.rometools.fetcher.FetcherListener {
 
-		/**
-		 * @see FetcherListener#fetcherEvent(FetcherEvent)
-		 */
 		@Override
-		public void fetcherEvent(final FetcherEvent event) {
+		public void fetcherEvent(final com.rometools.fetcher.FetcherEvent event) {
 			String eventType = event.getEventType();
-			if (FetcherEvent.EVENT_TYPE_FEED_POLLED.equals(eventType)) {
+			if (com.rometools.fetcher.FetcherEvent.EVENT_TYPE_FEED_POLLED.equals(eventType)) {
 				if (logger.isDebugEnabled()) {
 					logger.debug("\tEVENT: Feed Polled. URL = " + event.getUrlString());
 				}
 			}
-			else if (FetcherEvent.EVENT_TYPE_FEED_UNCHANGED.equals(eventType)) {
+			else if (com.rometools.fetcher.FetcherEvent.EVENT_TYPE_FEED_UNCHANGED.equals(eventType)) {
 				if (logger.isDebugEnabled()) {
 					logger.debug("\tEVENT: Feed Unchanged. URL = " + event.getUrlString());
 				}


### PR DESCRIPTION
1. The fix for `SI-feed` module wasn't proper and we still see a `deprecation` warns during testing with Gradle.
- Move all deprecated `com.rometools.fetcher` imports directly to their classes declaration in the `FeedEntryMessageSource`.
  That allows `@SuppressWarnings("deprecation")` to work properly
1. The latest nightly tests against IO demonstrate that upgrading to the `curator-3.1.0` has been hasty.
   And it pulls as transitive `ZK-3.5.1-alpha`. The last one isn't appropriate for our stable IO dependencies.
   But on the other hand the first one isn't compatible with `ZK-3.4.x`:

> The are currently two released versions of Curator, 2.x.x and 3.x.x:
> 
>  Curator 2.x.x - compatible with both ZooKeeper 3.4.x and ZooKeeper 3.5.x
>  Curator 3.x.x - compatible only with ZooKeeper 3.5.x and includes support for new features such as dynamic reconfiguration, etc.
- The consolidate decision with Spring Cloud team to stay with the latest curator version which pull the latest stable ZK version.
  Therefore downgrade to `curator-2.10.0`
- Additional decision is always to rely on the curator's transitive dependency for ZK and don't provide explicit to avoid versions incompatibility.
