### PR TITLE
INT-4023: Fix MongoDB MGSs timing issue

### DIFF
--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
@@ -176,7 +176,7 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 		Query query = groupOrderQuery(groupId);
 		MessageDocument messageDocument = this.mongoTemplate.findOne(query, MessageDocument.class, this.collectionName);
 
-		long createdTime = 0;
+		long createdTime = System.currentTimeMillis();
 		int lastReleasedSequence = 0;
 		boolean complete = false;
 
@@ -191,8 +191,8 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 			document.setGroupId(groupId);
 			document.setComplete(complete);
 			document.setLastReleasedSequence(lastReleasedSequence);
-			document.setCreatedTime(createdTime == 0 ? System.currentTimeMillis() : createdTime);
-			document.setLastModifiedTime(System.currentTimeMillis());
+			document.setCreatedTime(createdTime);
+			document.setLastModifiedTime(messageDocument == null ? createdTime : System.currentTimeMillis());
 			document.setSequence(getNextId());
 
 			addMessageDocument(document);

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -270,7 +270,7 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 		Query query = whereGroupIdOrder(groupId);
 		MessageWrapper messageDocument = this.template.findOne(query, MessageWrapper.class, this.collectionName);
 
-		long createdTime = 0;
+		long createdTime = System.currentTimeMillis();
 		int lastReleasedSequence = 0;
 		boolean complete = false;
 
@@ -283,8 +283,8 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 		for (Message<?> message : messages) {
 			MessageWrapper wrapper = new MessageWrapper(message);
 			wrapper.set_GroupId(groupId);
-			wrapper.set_Group_timestamp(createdTime == 0 ? System.currentTimeMillis() : createdTime);
-			wrapper.set_Group_update_timestamp(System.currentTimeMillis());
+			wrapper.set_Group_timestamp(createdTime);
+			wrapper.set_Group_update_timestamp(messageDocument == null ? createdTime : System.currentTimeMillis());
 			wrapper.set_Group_complete(complete);
 			wrapper.set_LastReleasedSequenceNumber(lastReleasedSequence);
 			wrapper.setSequence(getNextId());

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
@@ -235,7 +235,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 		long createdTimestamp = messageGroup.getTimestamp();
 		long updatedTimestamp = messageGroup.getLastModified();
 		assertEquals(createdTimestamp, updatedTimestamp);
-		Thread.sleep(1000);
+		Thread.sleep(10);
 		message = new GenericMessage<String>("Hello again");
 		messageGroup = store.addMessageToGroup(1, message);
 		createdTimestamp = messageGroup.getTimestamp();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4023

There is no guaranty that following `System.currentTimeMillis()` return the same value.
That is how the `assertEquals()` test for `created` and `modified` value may fail sporadically.
- Fix `MongoDbMessageStore` and `ConfigurableMongoDbMessageStore` do not use a new `System.currentTimeMillis()`
  in case of `group create`

**Cherry-pick to 4.2.x**
