### PR TITLE
INT-4024: TcpNetConnection Do Not Cache Listener

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
@@ -154,7 +154,6 @@ public class TcpNetConnection extends TcpConnectionSupport implements Scheduling
 	 */
 	@Override
 	public void run() {
-		TcpListener listener = getListener();
 		boolean okToRun = true;
 		if (logger.isDebugEnabled()) {
 			logger.debug(this.getConnectionId() + " Reading...");
@@ -176,6 +175,7 @@ public class TcpNetConnection extends TcpConnectionSupport implements Scheduling
 					logger.debug("Message received " + message);
 				}
 				try {
+					TcpListener listener = getListener();
 					if (listener == null) {
 						throw new NoListenerException("No listener");
 					}


### PR DESCRIPTION
JIRA; https://jira.spring.io/browse/INT-4024

When the `FailOverClientConnectionFactory` is used on top of a
`CachingClientConnectionFactory`, the underlying connection's listener
is changed to the new `CachedConnection` which in turn has its
listener set to the new `FailoverTcpConnection`.

Since the caching connection factory implies single-use (so the connection
is "closed" - returned to the cache), the `FOCCF`
is also forced to have single-use = true - hence the new ultimate listener.

The `TcpNetConnection` obtained its listener (`getListner()`) in the outer
block of its read loop and hence did not detect the listener change.

This caused the old listener (cached connection) to be invoked and when
the result was ultimately passed back to the `TcpOutboundGateway`, the
connection id did not match and the reply eventually timed out.

Change the `TcpNetConnection` to call `getListener()` for every message.

This was already the case in `TcpNioConnection`.

**cherry-pick to 4.2.x**
