### PR TITLE
INT-4028: Fix ClientWebSocketContainer start/stop

### DIFF
--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/ClientWebSocketContainer.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/ClientWebSocketContainer.java
@@ -54,7 +54,7 @@ public final class ClientWebSocketContainer extends IntegrationWebSocketContaine
 
 	private final WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
 
-	private final ConnectionManagerSupport connectionManager;
+	private final IntegrationWebSocketConnectionManager connectionManager;
 
 	private volatile CountDownLatch connectionLatch;
 
@@ -108,6 +108,11 @@ public final class ClientWebSocketContainer extends IntegrationWebSocketContaine
 	@Override
 	public WebSocketSession getSession(String sessionId) {
 		if (isRunning()) {
+			if (!isConnected()) {
+				stop();
+				start();
+			}
+
 			try {
 				this.connectionLatch.await(this.connectionTimeout, TimeUnit.SECONDS);
 			}
@@ -115,11 +120,18 @@ public final class ClientWebSocketContainer extends IntegrationWebSocketContaine
 				logger.error("'clientSession' has not been established during 'openConnection'");
 			}
 		}
-		if (this.openConnectionException != null) {
-			throw new IllegalStateException(this.openConnectionException);
+
+		try {
+			if (this.openConnectionException != null) {
+				throw new IllegalStateException(this.openConnectionException);
+			}
+			Assert.state(this.clientSession != null,
+					"'clientSession' has not been established. Consider to 'start' this container.");
 		}
-		Assert.state(this.clientSession != null,
-				"'clientSession' has not been established. Consider to 'start' this container.");
+		catch (IllegalStateException e){
+			stop();
+			throw e;
+		}
 		return this.clientSession;
 	}
 
@@ -129,6 +141,15 @@ public final class ClientWebSocketContainer extends IntegrationWebSocketContaine
 
 	public void setPhase(int phase) {
 		this.connectionManager.setPhase(phase);
+	}
+
+	/**
+	 * Return {@code true} if the {@link #clientSession} is opened.
+	 * @return the {@link WebSocketSession#isOpen()} state.
+	 * @since 4.2.6
+	 */
+	public boolean isConnected() {
+		return this.connectionManager.isConnected();
 	}
 
 	@Override
@@ -149,6 +170,8 @@ public final class ClientWebSocketContainer extends IntegrationWebSocketContaine
 	@Override
 	public synchronized void start() {
 		if (!isRunning()) {
+			this.clientSession = null;
+			this.openConnectionException = null;
 			this.connectionLatch = new CountDownLatch(1);
 			this.connectionManager.start();
 		}
@@ -178,7 +201,8 @@ public final class ClientWebSocketContainer extends IntegrationWebSocketContaine
 
 		private final boolean syncClientLifecycle;
 
-		private IntegrationWebSocketConnectionManager(WebSocketClient client, String uriTemplate, Object... uriVariables) {
+		private IntegrationWebSocketConnectionManager(WebSocketClient client, String uriTemplate,
+				Object... uriVariables) {
 			super(uriTemplate, uriVariables);
 			this.client = client;
 			this.syncClientLifecycle = ((client instanceof Lifecycle) && !((Lifecycle) client).isRunning());
@@ -202,14 +226,14 @@ public final class ClientWebSocketContainer extends IntegrationWebSocketContaine
 			}
 			finally {
 				ClientWebSocketContainer.this.clientSession = null;
+				ClientWebSocketContainer.this.openConnectionException = null;
 			}
 		}
 
 		@Override
 		protected void openConnection() {
-
 			logger.info("Connecting to WebSocket at " + getUri());
-			ClientWebSocketContainer.this.headers.setSecWebSocketProtocol(ClientWebSocketContainer.this.getSubProtocols());
+			ClientWebSocketContainer.this.headers.setSecWebSocketProtocol(getSubProtocols());
 			ListenableFuture<WebSocketSession> future =
 					this.client.doHandshake(ClientWebSocketContainer.this.webSocketHandler,
 							ClientWebSocketContainer.this.headers, getUri());
@@ -229,6 +253,7 @@ public final class ClientWebSocketContainer extends IntegrationWebSocketContaine
 					ClientWebSocketContainer.this.openConnectionException = t;
 					ClientWebSocketContainer.this.connectionLatch.countDown();
 				}
+
 			});
 		}
 

--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/client/StompIntegrationTests.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/client/StompIntegrationTests.java
@@ -128,7 +128,7 @@ public class StompIntegrationTests extends LogAdjustingTestSupport {
 	private QueueChannel webSocketEvents;
 
 	public StompIntegrationTests() {
-		super("org.springframework", "org.springframework.integration");
+		super("org.springframework", "org.springframework.integration", "org.apache.catalina");
 	}
 
 
@@ -137,7 +137,7 @@ public class StompIntegrationTests extends LogAdjustingTestSupport {
 		StompHeaderAccessor headers = StompHeaderAccessor.create(StompCommand.CONNECT);
 		this.webSocketOutputChannel.send(MessageBuilder.withPayload(new byte[0]).setHeaders(headers).build());
 
-		Message<?> receive = this.webSocketEvents.receive(10000);
+		Message<?> receive = this.webSocketEvents.receive(20000);
 		assertNotNull(receive);
 		Object event = receive.getPayload();
 		assertThat(event, instanceOf(SessionConnectedEvent.class));
@@ -153,7 +153,7 @@ public class StompIntegrationTests extends LogAdjustingTestSupport {
 		this.webSocketOutputChannel.send(message);
 
 		SimpleController controller = this.serverContext.getBean(SimpleController.class);
-		assertTrue(controller.latch.await(10, TimeUnit.SECONDS));
+		assertTrue(controller.latch.await(20, TimeUnit.SECONDS));
 	}
 
 	@Test
@@ -169,7 +169,7 @@ public class StompIntegrationTests extends LogAdjustingTestSupport {
 
 		this.webSocketOutputChannel.send(message);
 
-		Message<?> receive = this.webSocketEvents.receive(10000);
+		Message<?> receive = this.webSocketEvents.receive(20000);
 		assertNotNull(receive);
 		Object event = receive.getPayload();
 		assertThat(event, instanceOf(ReceiptEvent.class));
@@ -187,7 +187,7 @@ public class StompIntegrationTests extends LogAdjustingTestSupport {
 
 		this.webSocketOutputChannel.send(message2);
 
-		receive = webSocketInputChannel.receive(10000);
+		receive = webSocketInputChannel.receive(20000);
 		assertNotNull(receive);
 		assertEquals("6", receive.getPayload());
 	}
@@ -213,7 +213,7 @@ public class StompIntegrationTests extends LogAdjustingTestSupport {
 
 		this.webSocketOutputChannel.send(message2);
 
-		Message<?> receive = webSocketInputChannel.receive(10000);
+		Message<?> receive = webSocketInputChannel.receive(20000);
 		assertNotNull(receive);
 		assertEquals("10", receive.getPayload());
 	}
@@ -232,7 +232,7 @@ public class StompIntegrationTests extends LogAdjustingTestSupport {
 
 		this.webSocketOutputChannel.send(message);
 
-		Message<?> receive = webSocketInputChannel.receive(10000);
+		Message<?> receive = webSocketInputChannel.receive(20000);
 		assertNotNull(receive);
 
 		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.wrap(receive);
@@ -268,7 +268,7 @@ public class StompIntegrationTests extends LogAdjustingTestSupport {
 		this.webSocketOutputChannel.send(message2);
 
 
-		Message<?> receive = webSocketInputChannel.receive(10000);
+		Message<?> receive = webSocketInputChannel.receive(20000);
 		assertNotNull(receive);
 
 		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.wrap(receive);
@@ -300,7 +300,7 @@ public class StompIntegrationTests extends LogAdjustingTestSupport {
 
 		this.webSocketOutputChannel.send(message2);
 
-		Message<?> receive = webSocketInputChannel.receive(10000);
+		Message<?> receive = webSocketInputChannel.receive(20000);
 		assertNotNull(receive);
 		assertEquals("Hello Bob", receive.getPayload());
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4028

Previously the `ClientWebSocketContainer` after the connection failure couldn't be restored even after `stop()/start()`
because the `openConnectionException` property hasn't been clear on `stop()`
- Add `openConnectionException = null` to `stopInternal()` logic
- Also clear `openConnectionException` and `clientSession` on `start()`
- Plus add recovery (restart) logic into the `getSession()` if the `!clientSession.isOpen()`

**Cherry-pick to 4.2.x**
