### PR TITLE
INT-4043: Fix ExecutorChannel with datatypes Attr.

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/ExecutorChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/ExecutorChannel.java
@@ -101,6 +101,12 @@ public class ExecutorChannel extends AbstractExecutorChannel {
 
 	@Override
 	public final void onInit() {
+		try {
+			super.onInit(); // TODO add throws clause in 5.0
+		}
+		catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
 		if (!(this.executor instanceof ErrorHandlingTaskExecutor)) {
 			ErrorHandler errorHandler = new MessagePublishingErrorHandler(
 					new BeanFactoryChannelResolver(this.getBeanFactory()));

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/converter/DefaultDatatypeChannelMessageConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/converter/DefaultDatatypeChannelMessageConverter.java
@@ -60,7 +60,10 @@ public class DefaultDatatypeChannelMessageConverter implements MessageConverter,
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		if (!this.conversionServiceSet && beanFactory != null) {
-			this.conversionService = IntegrationUtils.getConversionService(beanFactory);
+			ConversionService integrationConversionService = IntegrationUtils.getConversionService(beanFactory);
+			if (integrationConversionService != null) {
+				this.conversionService = integrationConversionService;
+			}
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelParserTests-context.xml
@@ -46,6 +46,10 @@
 		<queue capacity="10" />
 	</channel>
 
+	<channel id="executorChannel" datatype="java.lang.Byte[]">
+		<dispatcher task-executor="taskExecutor" />
+	</channel>
+
 	<beans:bean id="taskExecutor"
 		class="org.springframework.core.task.SimpleAsyncTaskExecutor" />
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelParserTests-no-converter-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelParserTests-no-converter-context.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:beans="http://www.springframework.org/schema/beans"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+			http://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/integration
+			http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<channel id="executorChannel" datatype="java.lang.Byte[]">
+		<dispatcher task-executor="taskExecutor" />
+	</channel>
+
+	<beans:bean id="taskExecutor"
+		class="org.springframework.core.task.SimpleAsyncTaskExecutor" />
+
+</beans:beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4043

The `ExecutorChannel` overrides `onInit()` but fails to call the super
which is where the message converter for datatype conversion is set up.

Also, when Jackson is not on the class path and there are no converters in the
context, the default integration conversion service is not registered.

The `DefaultDatatypeChannelMessageConverter` overwites its default conversion
service with this bean, unconditionally - setting it to null in this case.

Check for a null conversion service before replacing the default.

**cherry-pick to 4.2.x, 4.1.x**
