### PR TITLE
INT-4051: Add PublisherAnnBPP when `@EnableInt`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationBeanPostProcessor.java
@@ -82,7 +82,6 @@ public class PublisherAnnotationBeanPostProcessor extends ProxyConfig
 		return this.order;
 	}
 
-	@SuppressWarnings("deprecation")
 	@Override
 	public void afterPropertiesSet() {
 		this.advisor = new PublisherAnnotationAdvisor();

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/PublisherRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/PublisherRegistrar.java
@@ -46,10 +46,8 @@ public class PublisherRegistrar implements ImportBeanDefinitionRegistrar {
 	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
 		Map<String, Object> annotationAttributes =
 				importingClassMetadata.getAnnotationAttributes(EnablePublisher.class.getName());
-		if (annotationAttributes == null) {
-			return;
-		}
-		String value = (String) annotationAttributes.get("value");
+
+		String value = (annotationAttributes == null ? null : (String) annotationAttributes.get("value"));
 		if (!registry.containsBeanDefinition(IntegrationContextUtils.PUBLISHER_ANNOTATION_POSTPROCESSOR_NAME)) {
 			BeanDefinitionBuilder builder =
 					BeanDefinitionBuilder.genericBeanDefinition(PublisherAnnotationBeanPostProcessor.class)

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/PublisherRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/PublisherRegistrar.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.integration.aop.PublisherAnnotationBeanPostProcessor;
 import org.springframework.integration.context.IntegrationContextUtils;
@@ -47,7 +48,9 @@ public class PublisherRegistrar implements ImportBeanDefinitionRegistrar {
 		Map<String, Object> annotationAttributes =
 				importingClassMetadata.getAnnotationAttributes(EnablePublisher.class.getName());
 
-		String value = (annotationAttributes == null ? null : (String) annotationAttributes.get("value"));
+		String value = (annotationAttributes == null
+				? (String) AnnotationUtils.getDefaultValue(EnablePublisher.class)
+				: (String) annotationAttributes.get("value"));
 		if (!registry.containsBeanDefinition(IntegrationContextUtils.PUBLISHER_ANNOTATION_POSTPROCESSOR_NAME)) {
 			BeanDefinitionBuilder builder =
 					BeanDefinitionBuilder.genericBeanDefinition(PublisherAnnotationBeanPostProcessor.class)

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -54,7 +54,6 @@ import org.springframework.integration.annotation.BridgeTo;
 import org.springframework.integration.annotation.Filter;
 import org.springframework.integration.annotation.InboundChannelAdapter;
 import org.springframework.integration.annotation.Poller;
-import org.springframework.integration.annotation.Publisher;
 import org.springframework.integration.annotation.Router;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.annotation.Splitter;
@@ -76,7 +75,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
-import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -121,9 +119,6 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 	@Qualifier("skippedMessageSource")
 	private MessageSource<?> skippedMessageSource;
 
-	@Autowired
-	private PollableChannel publisherChannel;
-
 	@Test
 	public void testMessagingAnnotationsFlow() {
 		this.sourcePollingChannelAdapter.start();
@@ -150,8 +145,6 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 		assertNull(this.skippedChannel);
 		assertNull(this.skippedChannel2);
 		assertNull(this.skippedMessageSource);
-
-		assertNotNull(this.publisherChannel.receive(10000));
 	}
 
 	@Test
@@ -264,19 +257,12 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 		}
 
 		@Bean
-		public PollableChannel publisherChannel() {
-			return new QueueChannel();
-		}
-
-		@Bean
 		@ServiceActivator(inputChannel = "serviceChannel")
 		public MessageHandler service() {
 			final List<Message<?>> collector = this.collector();
 			return new MessageHandler() {
 
 				@Override
-				@Publisher(channel = "publisherChannel")
-				@Payload("#args[0]")
 				public void handleMessage(Message<?> message) throws MessagingException {
 					collector.add(message);
 				}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -54,6 +54,7 @@ import org.springframework.integration.annotation.BridgeTo;
 import org.springframework.integration.annotation.Filter;
 import org.springframework.integration.annotation.InboundChannelAdapter;
 import org.springframework.integration.annotation.Poller;
+import org.springframework.integration.annotation.Publisher;
 import org.springframework.integration.annotation.Router;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.annotation.Splitter;
@@ -75,6 +76,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -119,6 +121,9 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 	@Qualifier("skippedMessageSource")
 	private MessageSource<?> skippedMessageSource;
 
+	@Autowired
+	private PollableChannel publisherChannel;
+
 	@Test
 	public void testMessagingAnnotationsFlow() {
 		this.sourcePollingChannelAdapter.start();
@@ -145,6 +150,8 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 		assertNull(this.skippedChannel);
 		assertNull(this.skippedChannel2);
 		assertNull(this.skippedMessageSource);
+
+		assertNotNull(this.publisherChannel.receive(10000));
 	}
 
 	@Test
@@ -257,12 +264,19 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 		}
 
 		@Bean
+		public PollableChannel publisherChannel() {
+			return new QueueChannel();
+		}
+
+		@Bean
 		@ServiceActivator(inputChannel = "serviceChannel")
 		public MessageHandler service() {
 			final List<Message<?>> collector = this.collector();
 			return new MessageHandler() {
 
 				@Override
+				@Publisher(channel = "publisherChannel")
+				@Payload("#args[0]")
 				public void handleMessage(Message<?> message) throws MessagingException {
 					collector.add(message);
 				}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4051

Previously we can process `@Publisher` annotations only with the `<int:annotation-config>` or with an explicit `@EnablePublisher("")`
- Fix `PublisherRegistrar` to relax from the fact if we have `@EnablePublisher` or not and register `PublisherAnnotationBeanPostProcessor` without `defaultChannelName`
