### PR TITLE
INT-4053: Avoid Reactor dependency requirement

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/splitter/FileSplitter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/splitter/FileSplitter.java
@@ -43,9 +43,8 @@ import org.springframework.integration.support.json.JsonObjectMapper;
 import org.springframework.integration.support.json.JsonObjectMapperProvider;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-
-import reactor.core.support.Assert;
 
 /**
  * The {@link AbstractMessageSplitter} implementation to split the {@link File}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4053

The recent changes to the `FileSplitter` introduced (by IDE autocompletion mistake) hidden dependency of Reactor using its `Assert` class instead of Spring's one

**Cherry-pick to 4.2.x**
