### PR TITLE
INT-4054: Eliminate usage of `slf4j`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,9 +308,15 @@ project('spring-integration-core') {
 			exclude group: 'org.springframework', module: 'spring-core'
 		}
 //		compile ("org.springframework.cloud:spring-cloud-cluster-core:$springCloudClusterVersion", optional)
-		compile ("io.projectreactor:reactor-stream:$reactorVersion", optional)
+		compile ("io.projectreactor:reactor-stream:$reactorVersion") {
+			optional it
+			exclude group: 'org.slf4j', module: 'slf4j-api'
+		}
 		compile("com.fasterxml.jackson.core:jackson-databind:$jackson2Version", optional)
-		compile("com.jayway.jsonpath:json-path:$jsonpathVersion", optional)
+		compile("com.jayway.jsonpath:json-path:$jsonpathVersion") {
+			optional it
+			exclude group: 'org.slf4j', module: 'slf4j-api'
+		}
 		compile("io.fastjson:boon:$boonVersion", optional)
 		compile("com.esotericsoftware:kryo-shaded:$kryoShadedVersion", optional)
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/leader/DefaultCandidate.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/leader/DefaultCandidate.java
@@ -16,16 +16,20 @@
 
 package org.springframework.integration.leader;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Simple {@link Candidate} for leadership.
  * This implementation simply logs when it is elected and when its leadership is revoked.
+ *
+ * @author Janne Valkealahti
+ * @author Artem Bilan
+ * @since 4.2
  */
 public class DefaultCandidate extends AbstractCandidate {
 
-	private final Logger logger = LoggerFactory.getLogger(this.getClass());
+	private final Log logger = LogFactory.getLog(getClass());
 
 	private volatile Context leaderContext;
 
@@ -48,13 +52,17 @@ public class DefaultCandidate extends AbstractCandidate {
 
 	@Override
 	public void onGranted(Context ctx) {
-		this.logger.info("{} has been granted leadership; context: {}", this, ctx);
+		if (this.logger.isInfoEnabled()) {
+			this.logger.info(this + " has been granted leadership; context: " + ctx);
+		}
 		this.leaderContext = ctx;
 	}
 
 	@Override
 	public void onRevoked(Context ctx) {
-		this.logger.info("{} leadership has been revoked", this, ctx);
+		if (this.logger.isInfoEnabled()) {
+			this.logger.info(this + " leadership has been revoked: " + ctx);
+		}
 	}
 
 	/**


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4054
Fixes GH-1833 (https://github.com/spring-projects/spring-integration/issues/1833)

The `DefaultCandidate` pulled requirement for the `slf4j` dependency via its `Logger` and `LoggerFactory` usage.
- Change `slf4j` to the standard Commons Logging
- Exclude `slf4j` transitive dependencies from `optional` direct dependencies like `reactor` and `json-path`
- Since they are `optional` it is safe to exclude their transitives to force our source code to be free from unexpected dependencies.
  Anyway they don't appear in the target application as a SI transitives and end-user is forced to pull them manually to switch on the desired features.
  If there is need in the `slf4j` for target application, it must be pulled manually as well.

**Cherry-pick to 4.2.x**
