### PR TITLE
Make DefaultLockRepository constructor public

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
@@ -76,7 +76,7 @@ public class DefaultLockRepository implements LockRepository, InitializingBean {
 
 
 	@Autowired
-	DefaultLockRepository(DataSource dataSource) {
+	public DefaultLockRepository(DataSource dataSource) {
 		this.template = new JdbcTemplate(dataSource);
 	}
 


### PR DESCRIPTION
Otherwise you can't create an instance of it in @Configuration.
