### PR TITLE
Gemfire: some fixes and optimization for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -366,10 +366,6 @@ project('spring-integration-ftp') {
 
 project('spring-integration-gemfire') {
 	description = 'Spring Integration GemFire Support'
-	tasks.withType(Test).matching {it.name ==~ /(springIo.+)|(test)|(testAll)/}.all {
-		forkEvery = 1
-		systemProperties['gemfire.disableShutdownHook'] = 'true'
-	}
 	dependencies {
 		compile project(":spring-integration-core")
 		compile ("org.springframework.data:spring-data-gemfire:$springGemfireVersion") {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PayloadSerializingTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PayloadSerializingTransformerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,14 +35,17 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.transformer.MessageTransformationException;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
 public class PayloadSerializingTransformerParserTests {
 
 	@Autowired
@@ -70,7 +73,7 @@ public class PayloadSerializingTransformerParserTests {
 	@Test
 	public void queueChannelWithStringMessage() throws Exception {
 		queueInput.send(new GenericMessage<String>("foo"));
-		Message<?> result = output.receive(3000);
+		Message<?> result = output.receive(10000);
 		assertNotNull(result);
 		assertTrue(result.getPayload() instanceof byte[]);
 		assertEquals("foo", deserialize((byte[]) result.getPayload()));
@@ -90,7 +93,7 @@ public class PayloadSerializingTransformerParserTests {
 	@Test
 	public void queueChannelWithObjectMessage() throws Exception {
 		queueInput.send(new GenericMessage<TestBean>(new TestBean()));
-		Message<?> result = output.receive(3000);
+		Message<?> result = output.receive(10000);
 		assertTrue(result.getPayload() instanceof byte[]);
 		Object deserialized = deserialize((byte[]) result.getPayload());
 		assertEquals(TestBean.class, deserialized.getClass());
@@ -105,7 +108,7 @@ public class PayloadSerializingTransformerParserTests {
 	@Test
 	public void customSerializer() throws Exception {
 		customSerializerInput.send(new GenericMessage<String>("test"));
-		Message<?> result = output.receive(3000);
+		Message<?> result = output.receive(10000);
 		assertNotNull(result);
 		assertEquals(byte[].class, result.getPayload().getClass());
 		assertEquals("TEST", new String((byte[]) result.getPayload(), "UTF-8"));
@@ -134,6 +137,7 @@ public class PayloadSerializingTransformerParserTests {
 			outputStream.flush();
 			outputStream.close();
 		}
+
 	}
 
 }

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStoreTests.java
@@ -53,6 +53,7 @@ public class GemfireMetadataStoreTests {
 
 	@AfterClass
 	public static void cleanUp() {
+		getRegion().close();
 		if (cache != null) {
 			cache.close();
 			Assert.isTrue(cache.isClosed(), "Cache did not close after close() call");

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/outbound/CacheWritingMessageHandlerTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/outbound/CacheWritingMessageHandlerTests.java
@@ -52,11 +52,13 @@ public class CacheWritingMessageHandlerTests {
 	public void mapPayloadWritesToCache() throws Exception {
 		CacheFactoryBean cacheFactoryBean = new CacheFactoryBean();
 		Cache cache = cacheFactoryBean.getObject();
+
 		RegionFactoryBean<String, String> regionFactoryBean = new RegionFactoryBean<String, String>() { };
 		regionFactoryBean.setName("test.mapPayloadWritesToCache");
 		regionFactoryBean.setCache(cache);
 		regionFactoryBean.afterPropertiesSet();
 		Region<String, String> region = regionFactoryBean.getObject();
+
 		assertEquals(0, region.size());
 
 		CacheWritingMessageHandler handler = new CacheWritingMessageHandler(region);
@@ -69,7 +71,9 @@ public class CacheWritingMessageHandlerTests {
 		handler.handleMessage(message);
 		assertEquals(1, region.size());
 		assertEquals("bar", region.get("foo"));
-		cache.close();
+
+		regionFactoryBean.destroy();
+		cacheFactoryBean.destroy();
 	}
 
 	@Test
@@ -77,12 +81,15 @@ public class CacheWritingMessageHandlerTests {
 	public void ExpressionsWriteToCache() throws Exception {
 		CacheFactoryBean cacheFactoryBean = new CacheFactoryBean();
 		Cache cache = cacheFactoryBean.getObject();
+
 		RegionFactoryBean<String, Object> regionFactoryBean = new RegionFactoryBean<String, Object>() { };
 		regionFactoryBean.setName("test.expressionsWriteToCache");
 		regionFactoryBean.setCache(cache);
 		regionFactoryBean.afterPropertiesSet();
 		Region<String, Object> region = regionFactoryBean.getObject();
+
 		assertEquals(0, region.size());
+
 		CacheWritingMessageHandler handler = new CacheWritingMessageHandler(region);
 
 		Map<String, String> expressions = new HashMap<String, String>();
@@ -106,7 +113,9 @@ public class CacheWritingMessageHandlerTests {
 		handler.handleMessage(new GenericMessage<String>("test"));
 		assertEquals(3, region.size());
 		assertEquals(10L, region.get("baz"));
-		cache.close();
+
+		regionFactoryBean.destroy();
+		cacheFactoryBean.destroy();
 	}
 
 }

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/DelayerHandlerRescheduleIntegrationTests-context.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/DelayerHandlerRescheduleIntegrationTests-context.xml
@@ -6,7 +6,8 @@
 	http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<beans:bean id="messageStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
-		<beans:constructor-arg value="#{T (org.springframework.integration.gemfire.store.DelayerHandlerRescheduleIntegrationTests).cache}"/>
+		<beans:constructor-arg
+				value="#{T (org.springframework.integration.gemfire.store.DelayerHandlerRescheduleIntegrationTests).cacheFactoryBean.object}"/>
 	</beans:bean>
 
 	<channel id="output">

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/DelayerHandlerRescheduleIntegrationTests.java
@@ -42,9 +42,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.util.Assert;
-
-import com.gemstone.gemfire.cache.Cache;
 
 
 /**
@@ -56,22 +53,21 @@ public class DelayerHandlerRescheduleIntegrationTests {
 
 	public static final String DELAYER_ID = "delayerWithGemfireMS";
 
-	public static Cache cache;
+	public static CacheFactoryBean cacheFactoryBean;
 
 	@ClassRule
 	public static LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@BeforeClass
 	public static void startUp() throws Exception {
-		CacheFactoryBean cacheFactoryBean = new CacheFactoryBean();
-		cache = cacheFactoryBean.getObject();
+		cacheFactoryBean = new CacheFactoryBean();
+		cacheFactoryBean.afterPropertiesSet();
 	}
 
 	@AfterClass
-	public static void cleanUp() {
-		if (cache != null) {
-			cache.close();
-			Assert.isTrue(cache.isClosed(), "Cache did not close after close() call");
+	public static void cleanUp() throws Exception {
+		if (cacheFactoryBean != null) {
+			cacheFactoryBean.destroy();
 		}
 	}
 

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
@@ -30,10 +30,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -44,11 +44,9 @@ import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.util.Assert;
 
 import com.gemstone.gemfire.cache.Cache;
 import com.gemstone.gemfire.cache.Region;
@@ -64,16 +62,13 @@ import junit.framework.AssertionFailedError;
  */
 public class GemfireGroupStoreTests {
 
-	private Cache cache;
+	public static CacheFactoryBean cacheFactoryBean;
 
-	private Region<Object, Object> region;
-
-	@Rule
-	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
+	private static Region<Object, Object> region;
 
 	@Test
 	public void testNonExistingEmptyMessageGroup() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		assertNotNull(messageGroup);
@@ -83,7 +78,7 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testMessageGroupWithAddedMessage() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("Hello");
@@ -91,7 +86,7 @@ public class GemfireGroupStoreTests {
 		assertEquals(1, messageGroup.size());
 
 		// make sure the store is properly rebuild from Gemfire
-		store = new GemfireMessageStore(this.region);
+		store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 
 		messageGroup = store.getMessageGroup(1);
@@ -100,7 +95,7 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testRemoveMessageFromTheGroup() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("2");
@@ -125,7 +120,7 @@ public class GemfireGroupStoreTests {
 		assertEquals(2, messageGroup.size());
 
 		// make sure the store is properly rebuild from Gemfire
-		store = new GemfireMessageStore(this.region);
+		store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 
 		messageGroup = store.getMessageGroup(1);
@@ -135,7 +130,7 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testRemoveMessageGroup() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("Hello");
@@ -149,7 +144,7 @@ public class GemfireGroupStoreTests {
 		assertEquals(0, messageGroupA.size());
 
 		// make sure the store is properly rebuild from Gemfire
-		store = new GemfireMessageStore(this.region);
+		store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 
 		messageGroup = store.getMessageGroup(1);
@@ -160,7 +155,7 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testRemoveNonExistingMessageFromTheGroup() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		store.addMessagesToGroup(messageGroup.getGroupId(), new GenericMessage<String>("1"));
@@ -169,14 +164,14 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testRemoveNonExistingMessageFromNonExistingTheGroup() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		store.removeMessagesFromGroup(1, new GenericMessage<String>("2"));
 	}
 
 	@Test
 	public void testCompleteMessageGroup() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> messageToMark = new GenericMessage<String>("1");
@@ -188,7 +183,7 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testLastReleasedSequenceNumber() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> messageToMark = new GenericMessage<String>("1");
@@ -200,10 +195,10 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testMultipleInstancesOfGroupStore() throws Exception {
-		GemfireMessageStore store1 = new GemfireMessageStore(this.region);
+		GemfireMessageStore store1 = new GemfireMessageStore(region);
 		store1.afterPropertiesSet();
 
-		GemfireMessageStore store2 = new GemfireMessageStore(this.region);
+		GemfireMessageStore store2 = new GemfireMessageStore(region);
 		store2.afterPropertiesSet();
 
 		Message<?> message = new GenericMessage<String>("1");
@@ -212,7 +207,7 @@ public class GemfireGroupStoreTests {
 
 		assertEquals(2, messageGroup.getMessages().size());
 
-		GemfireMessageStore store3 = new GemfireMessageStore(this.region);
+		GemfireMessageStore store3 = new GemfireMessageStore(region);
 		store3.afterPropertiesSet();
 
 		store3.removeMessagesFromGroup(1, message);
@@ -223,7 +218,7 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testWithMessageHistory() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 
 		store.getMessageGroup(1);
@@ -250,9 +245,9 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testIteratorOfMessageGroups() throws Exception {
-		GemfireMessageStore store1 = new GemfireMessageStore(this.region);
+		GemfireMessageStore store1 = new GemfireMessageStore(region);
 		store1.afterPropertiesSet();
-		GemfireMessageStore store2 = new GemfireMessageStore(this.region);
+		GemfireMessageStore store2 = new GemfireMessageStore(region);
 		store2.afterPropertiesSet();
 
 		store1.addMessagesToGroup(1, new GenericMessage<String>("1"));
@@ -282,9 +277,9 @@ public class GemfireGroupStoreTests {
 	@Ignore
 	public void testConcurrentModifications() throws Exception {
 
-		final GemfireMessageStore store1 = new GemfireMessageStore(this.region);
+		final GemfireMessageStore store1 = new GemfireMessageStore(region);
 		store1.afterPropertiesSet();
-		final GemfireMessageStore store2 = new GemfireMessageStore(this.region);
+		final GemfireMessageStore store2 = new GemfireMessageStore(region);
 		store2.afterPropertiesSet();
 
 		final Message<?> message = new GenericMessage<String>("1");
@@ -375,17 +370,27 @@ public class GemfireGroupStoreTests {
 	}
 
 	@Before
-	public void init() throws Exception {
-		CacheFactoryBean cacheFactoryBean = new CacheFactoryBean();
-		this.cache = cacheFactoryBean.getObject();
-		this.region = cache.createRegionFactory().setScope(Scope.LOCAL).create("sig-tests");
+	public void prepare() {
+		if (region != null) {
+			region.clear();
+		}
 	}
 
-	@After
-	public void cleanup() {
-		if (this.cache != null) {
-			this.cache.close();
-			Assert.isTrue(this.cache.isClosed(), "Cache did not close after close() call");
+	@BeforeClass
+	public static void init() throws Exception {
+		cacheFactoryBean = new CacheFactoryBean();
+		cacheFactoryBean.afterPropertiesSet();
+		Cache cache = cacheFactoryBean.getObject();
+		region = cache.createRegionFactory().setScope(Scope.LOCAL).create("sig-tests");
+	}
+
+	@AfterClass
+	public static void cleanup() throws Exception {
+		if (region != null) {
+			region.close();
+		}
+		if (cacheFactoryBean != null) {
+			cacheFactoryBean.destroy();
 		}
 	}
 

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-aggregator-config-a.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-aggregator-config-a.xml
@@ -4,17 +4,16 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
-	
+
 	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="gemfireStore"/>
-	
+
 	<int:channel id="outputChannel">
 		<int:queue/>
 	</int:channel>
-	
+
 	<bean id="gemfireStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
-		<constructor-arg ref="cache"/>
+		<constructor-arg
+				value="#{T (org.springframework.integration.gemfire.store.GemfireGroupStoreTests).cacheFactoryBean.object}"/>
 	</bean>
-	
-	<bean id="cache" class="org.springframework.data.gemfire.CacheFactoryBean"/>
 
 </beans>

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-aggregator-config.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-aggregator-config.xml
@@ -4,17 +4,16 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
-	
+
 	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="gemfireStore"/>
-	
+
 	<int:channel id="outputChannel">
 		<int:queue/>
 	</int:channel>
-	
+
 	<bean id="gemfireStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
-		<constructor-arg ref="myCache"/>
+		<constructor-arg
+				value="#{T (org.springframework.integration.gemfire.store.GemfireGroupStoreTests).cacheFactoryBean.object}"/>
 	</bean>
-	
-	<bean id="myCache" class="org.springframework.data.gemfire.CacheFactoryBean"/>
 
 </beans>

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-queue-config.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-queue-config.xml
@@ -4,24 +4,23 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
-	
-	
+
+
 	<int:channel id="gemfireQueue">
 		<int:queue message-store="gemfireStore"/>
 	</int:channel>
-	
+
 	<int:bridge input-channel="gemfireQueue" output-channel="outputQueue">
 		<int:poller fixed-rate="1000" max-messages-per-poll="200"/>
 	</int:bridge>
-	
+
 	<int:channel id="outputQueue">
 		<int:queue/>
 	</int:channel>
-	
+
 	<bean id="gemfireStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
-		<constructor-arg ref="gemfireCache"/>
+		<constructor-arg
+				value="#{T (org.springframework.integration.gemfire.store.GemfireGroupStoreTests).cacheFactoryBean.object}"/>
 	</bean>
-	
-	<bean id="gemfireCache" class="org.springframework.data.gemfire.CacheFactoryBean"/>
 
 </beans>


### PR DESCRIPTION
See https://build.spring.io/browse/INT-AT42SIO-199/

In some places we start `Cache` but doesn't close/destroy it in the end.
That sometimes causes conflicts with the already started GemFire from other tests or wrong state around `BeanFactoryLocator`
- Ensure `Cache` destroy in the end of each test
- In addition destroy `Region` as well to avoid unexpected race conditions, too
- Plus optimize some tests to start `Cache` and `Region` only once per test class, not for each test method

From here I can say that it even would be better to start `Cache`, and therefore whole GemFire, only once per entire Gemfire module test suite.
But that is fully different story.
