### PR TITLE
INT-1463 Fix PriorityChannel#getRemainingCapacity

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PriorityChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PriorityChannel.java
@@ -85,6 +85,11 @@ public class PriorityChannel extends QueueChannel {
 	}
 
 	@Override
+	public int getRemainingCapacity() {
+		return this.upperBound.availablePermits();
+	}
+
+	@Override
 	protected boolean doSend(Message<?> message, long timeout) {
 		if (!this.upperBound.tryAcquire(timeout)) {
 			return false;

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelCapacityPlaceholderTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelCapacityPlaceholderTests-context.xml
@@ -13,11 +13,12 @@
 	<context:property-placeholder
 		location="/org/springframework/integration/channel/config/ChannelCapacityPlaceholderTests.properties"/>
 
-	<gateway id="gateway"
-		service-interface="org.springframework.integration.channel.config.ChannelCapacityPlaceholderTests$TestService"/>
-
 	<channel id="channel">
 		<queue capacity="${capacity}"/>
+	</channel>
+
+	<channel id="priorityChannel">
+		<priority-queue capacity="${capacity}"/>
 	</channel>
 
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelCapacityPlaceholderTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelCapacityPlaceholderTests.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.integration.channel.PriorityChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.test.context.ContextConfiguration;
@@ -31,6 +32,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -51,12 +53,16 @@ public class ChannelCapacityPlaceholderTests {
 		assertEquals(98, channel.getRemainingCapacity());
 	}
 
-
-	public interface TestService {
-
-		@org.springframework.integration.annotation.Gateway(requestChannel = "channel")
-		void test();
-
+	@Test
+	public void testCapacityOnPriorityChannel() {
+		PriorityChannel channel = context.getBean("priorityChannel", PriorityChannel.class);
+		assertNotNull(channel);
+		assertEquals(99, channel.getRemainingCapacity());
+		channel.send(MessageBuilder.withPayload("test1").build());
+		channel.send(MessageBuilder.withPayload("test2").build());
+		assertEquals(97, channel.getRemainingCapacity());
+		assertNotNull(channel.receive(0));
+		assertEquals(98, channel.getRemainingCapacity());
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueGatewayIntegrationTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueGatewayIntegrationTests-context.xml
@@ -26,7 +26,7 @@
 	<int-redis:queue-outbound-gateway id="outboundGateway"
 									  request-channel="sendChannel"
 									  queue="#{redisQueue.toString()}"
-									  reply-timeout="1000"
+									  reply-timeout="10000"
 									  requires-reply="true"
 									  reply-channel="outputChannel"/>
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-1463

An existing `QueueChannel#getRemainingCapacity()` is based on the `BlockingQueue#getRemainingCapacity()` which is always `Integer.MAX_VALUE`
and doesn't reflect reality for provided `capacity`
- Fix `PriorityChannel` to return `upperBound.availablePermits()` for `getRemainingCapacity()`
- Add test for `PriorityChannel` on the matter
- Also increase `reply-timeout` for `<int-redis:queue-outbound-gateway>` in `RedisQueueGatewayIntegrationTests-context.xml` from 1 sec to 10 secs
