### PR TITLE
INT-4013: `<ref bean>` for `channel-interceptor`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GlobalChannelInterceptorParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GlobalChannelInterceptorParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.BeanDefinitionParserDelegate;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.channel.interceptor.GlobalChannelInterceptorWrapper;
 import org.springframework.util.xml.DomUtils;
@@ -59,19 +60,24 @@ public class GlobalChannelInterceptorParser extends AbstractBeanDefinitionParser
 
 	@Override
 	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
-		BeanDefinitionBuilder globalChannelInterceptorBuilder = BeanDefinitionBuilder.genericBeanDefinition(GlobalChannelInterceptorWrapper.class);
+		BeanDefinitionBuilder globalChannelInterceptorBuilder =
+				BeanDefinitionBuilder.genericBeanDefinition(GlobalChannelInterceptorWrapper.class);
 		Object childBeanDefinition = getBeanDefinitionBuilderConstructorValue(element, parserContext);
 		globalChannelInterceptorBuilder.addConstructorArgValue(childBeanDefinition);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(globalChannelInterceptorBuilder, element, "order");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(globalChannelInterceptorBuilder, element, CHANNEL_NAME_PATTERN_ATTRIBUTE, "patterns");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(globalChannelInterceptorBuilder, element,
+				CHANNEL_NAME_PATTERN_ATTRIBUTE, "patterns");
 		return globalChannelInterceptorBuilder.getBeanDefinition();
 	}
 
 	protected Object getBeanDefinitionBuilderConstructorValue(Element element, ParserContext parserContext) {
-		BeanComponentDefinition interceptorBeanDefinition = IntegrationNamespaceUtils.parseInnerHandlerDefinition(element, parserContext);
+		BeanComponentDefinition interceptorBeanDefinition =
+				IntegrationNamespaceUtils.parseInnerHandlerDefinition(element, parserContext);
 		if (interceptorBeanDefinition != null) {
 			return interceptorBeanDefinition;
 		}
+
+		BeanDefinitionParserDelegate delegate = parserContext.getDelegate();
 		String beanName = null;
 		if (element.hasAttribute(REF_ATTRIBUTE)) {
 			beanName = element.getAttribute(REF_ATTRIBUTE);
@@ -86,8 +92,11 @@ public class GlobalChannelInterceptorParser extends AbstractBeanDefinitionParser
 				if ("wire-tap".equals(child.getLocalName())) {
 					beanName = new WireTapParser().parse(child, parserContext);
 				}
+				else if (delegate.nodeNameEquals(child, BeanDefinitionParserDelegate.REF_ELEMENT)) {
+					return delegate.parsePropertySubElement(child, null);
+				}
 				else {
-					BeanDefinition beanDef = parserContext.getDelegate().parseCustomElement(child);
+					BeanDefinition beanDef = delegate.parseCustomElement(child);
 					beanName = BeanDefinitionReaderUtils.generateBeanName(beanDef, parserContext.getRegistry());
 				}
 			}

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalChannelInterceptorTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalChannelInterceptorTests-context.xml
@@ -57,10 +57,12 @@
 	<int:channel-interceptor pattern="input*, foo" order="-3">
 		<bean class="org.springframework.integration.channel.interceptor.GlobalChannelInterceptorTests$SampleInterceptor" p:testIdentifier="two"/>
 	</int:channel-interceptor>
+
 	<int:channel-interceptor pattern="input*" order="-4">
-		<bean class="org.springframework.integration.channel.interceptor.GlobalChannelInterceptorTests$SampleInterceptor" p:testIdentifier="three"/>
+		<ref bean="sampleInterceptor" />
 	</int:channel-interceptor>
 
+	<bean id="sampleInterceptor" class="org.springframework.integration.channel.interceptor.GlobalChannelInterceptorTests$SampleInterceptor" p:testIdentifier="three"/>
 
 	<bean id="channelInterceptor" class="org.springframework.integration.channel.interceptor.GlobalChannelInterceptorTests$SampleInterceptor" p:testIdentifier="seven"/>
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4013

Previously we couldn't define a config as :

``` xml
<int:channel-interceptor pattern="input*">
      <ref bean="sampleInterceptor" />
</int:channel-interceptor>
```
- Fix `GlobalChannelInterceptorParser` to distinguish `BeanDefinitionParserDelegate.REF_ELEMENT` child elements
  and extract an appropriate `BeanReference`
- Modify `GlobalChannelInterceptorTests-context.xml` to prove the fix and meet JIRA requirements
