### PR TITLE
INT-4064: Simplify `IdempotentReInt` Java Config

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -279,43 +279,6 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 		return adviceChain;
 	}
 
-	protected final void setAdviceChainIfPresent(String beanName, List<Annotation> annotations, MessageHandler handler) {
-		String[] adviceChainNames = MessagingAnnotationUtils.resolveAttribute(annotations, ADVICE_CHAIN_ATTRIBUTE,
-				String[].class);
-		/*
-		 * Note: we don't merge advice chain contents; if the directAnnotation has a non-empty
-		 * attribute, it wins. You cannot "remove" an advice chain from a meta-annotation
-		 * by setting an empty array on the custom annotation.
-		 */
-		if (adviceChainNames != null && adviceChainNames.length > 0) {
-			if (!(handler instanceof AbstractReplyProducingMessageHandler)) {
-				throw new IllegalArgumentException("Cannot apply advice chain to " + handler.getClass().getName());
-			}
-			List<Advice> adviceChain = new ArrayList<Advice>();
-			for (String adviceChainName : adviceChainNames) {
-				Object adviceChainBean = this.beanFactory.getBean(adviceChainName);
-				if (adviceChainBean instanceof Advice) {
-					adviceChain.add((Advice) adviceChainBean);
-				}
-				else if (adviceChainBean instanceof Advice[]) {
-					Collections.addAll(adviceChain, (Advice[]) adviceChainBean);
-				}
-				else if (adviceChainBean instanceof Collection) {
-					@SuppressWarnings("unchecked")
-					Collection<Advice> adviceChainEntries = (Collection<Advice>) adviceChainBean;
-					for (Advice advice : adviceChainEntries) {
-						adviceChain.add(advice);
-					}
-				}
-				else {
-					throw new IllegalArgumentException("Invalid advice chain type:" +
-						adviceChainName.getClass().getName() + " for bean '" + beanName + "'");
-				}
-			}
-			((AbstractReplyProducingMessageHandler) handler).setAdviceChain(adviceChain);
-		}
-	}
-
 	protected AbstractEndpoint createEndpoint(MessageHandler handler, Method method, List<Annotation> annotations) {
 		AbstractEndpoint endpoint = null;
 		String inputChannelName = MessagingAnnotationUtils.resolveAttribute(annotations, getInputChannelAttribute(),

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -32,6 +32,7 @@ import org.springframework.aop.framework.Advised;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.DefaultBeanFactoryPointcutAdvisor;
 import org.springframework.aop.support.NameMatchMethodPointcut;
+import org.springframework.aop.support.NameMatchMethodPointcutAdvisor;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionValidationException;
@@ -55,6 +56,7 @@ import org.springframework.integration.endpoint.PollingConsumer;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.handler.AbstractMessageProducingHandler;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.handler.advice.HandleMessageAdvice;
 import org.springframework.integration.router.AbstractMessageRouter;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
@@ -70,6 +72,7 @@ import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.PeriodicTrigger;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
@@ -134,8 +137,15 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 				return null;
 			}
 		}
+
+		List<Advice> adviceChain = extractAdviceChain(beanName, annotations);
+
 		MessageHandler handler = createHandler(bean, method, annotations);
-		setAdviceChainIfPresent(beanName, annotations, handler);
+
+		if (!CollectionUtils.isEmpty(adviceChain) && handler instanceof AbstractReplyProducingMessageHandler) {
+			((AbstractReplyProducingMessageHandler) handler).setAdviceChain(adviceChain);
+		}
+
 		if (handler instanceof Orderable) {
 			Order orderAnnotation = AnnotationUtils.findAnnotation(method, Order.class);
 			if (orderAnnotation != null) {
@@ -189,6 +199,23 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 			}
 		}
 
+		if (!CollectionUtils.isEmpty(adviceChain)) {
+			for (Advice advice : adviceChain) {
+				if (advice instanceof HandleMessageAdvice) {
+					NameMatchMethodPointcutAdvisor handlerAdvice = new NameMatchMethodPointcutAdvisor(advice);
+					handlerAdvice.addMethodName("handleMessage");
+					if (handler instanceof Advised) {
+						((Advised) handler).addAdvisor(handlerAdvice);
+					}
+					else {
+						ProxyFactory proxyFactory = new ProxyFactory(handler);
+						proxyFactory.addAdvisor(handlerAdvice);
+						handler = (MessageHandler) proxyFactory.getProxy(this.beanFactory.getBeanClassLoader());
+					}
+				}
+			}
+		}
+
 		AbstractEndpoint endpoint = createEndpoint(handler, method, annotations);
 		if (endpoint != null) {
 			return endpoint;
@@ -215,6 +242,41 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 	protected boolean beanAnnotationAware() {
 		return true;
+	}
+
+	private List<Advice> extractAdviceChain(String beanName, List<Annotation> annotations) {
+		List<Advice> adviceChain = null;
+		String[] adviceChainNames = MessagingAnnotationUtils.resolveAttribute(annotations, ADVICE_CHAIN_ATTRIBUTE,
+				String[].class);
+		/*
+		 * Note: we don't merge advice chain contents; if the directAnnotation has a non-empty
+		 * attribute, it wins. You cannot "remove" an advice chain from a meta-annotation
+		 * by setting an empty array on the custom annotation.
+		 */
+		if (adviceChainNames != null && adviceChainNames.length > 0) {
+			adviceChain = new ArrayList<Advice>();
+			for (String adviceChainName : adviceChainNames) {
+				Object adviceChainBean = this.beanFactory.getBean(adviceChainName);
+				if (adviceChainBean instanceof Advice) {
+					adviceChain.add((Advice) adviceChainBean);
+				}
+				else if (adviceChainBean instanceof Advice[]) {
+					Collections.addAll(adviceChain, (Advice[]) adviceChainBean);
+				}
+				else if (adviceChainBean instanceof Collection) {
+					@SuppressWarnings("unchecked")
+					Collection<Advice> adviceChainEntries = (Collection<Advice>) adviceChainBean;
+					for (Advice advice : adviceChainEntries) {
+						adviceChain.add(advice);
+					}
+				}
+				else {
+					throw new IllegalArgumentException("Invalid advice chain type:" +
+							adviceChainName.getClass().getName() + " for bean '" + beanName + "'");
+				}
+			}
+		}
+		return adviceChain;
 	}
 
 	protected final void setAdviceChainIfPresent(String beanName, List<Annotation> annotations, MessageHandler handler) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
@@ -22,6 +22,7 @@ import org.aopalliance.aop.Advice;
 
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.integration.handler.advice.HandleMessageAdvice;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -81,10 +82,16 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 		super.onInit();
 		if (!CollectionUtils.isEmpty(this.adviceChain)) {
 			ProxyFactory proxyFactory = new ProxyFactory(new AdvisedRequestHandler());
+			boolean advised = false;
 			for (Advice advice : this.adviceChain) {
-				proxyFactory.addAdvice(advice);
+				if (!(advice instanceof HandleMessageAdvice)) {
+					proxyFactory.addAdvice(advice);
+					advised = true;
+				}
 			}
-			this.advisedRequestHandler = (RequestHandler) proxyFactory.getProxy(this.beanClassLoader);
+			if (advised) {
+				this.advisedRequestHandler = (RequestHandler) proxyFactory.getProxy(this.beanClassLoader);
+			}
 		}
 		doInit();
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractHandleMessageAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractHandleMessageAdvice.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.handler.advice;
+
+import java.lang.reflect.Method;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+
+/**
+ * The base {@link HandleMessageAdvice} for advices which can be applied only
+ * for the {@link MessageHandler#handleMessage(Message)}.
+ *
+ * @author Artem Bilan
+ * @since 4.3.1
+ */
+public abstract class AbstractHandleMessageAdvice implements HandleMessageAdvice {
+
+	protected final Log logger = LogFactory.getLog(this.getClass());
+
+	@Override
+	public final Object invoke(MethodInvocation invocation) throws Throwable {
+		Method method = invocation.getMethod();
+		Object invocationThis = invocation.getThis();
+		Object[] arguments = invocation.getArguments();
+		boolean isMessageHandler = invocationThis != null && invocationThis instanceof MessageHandler;
+		boolean isMessageMethod = method.getName().equals("handleMessage")
+				&& (arguments.length == 1 && arguments[0] instanceof Message);
+		if (!isMessageHandler || !isMessageMethod) {
+			if (this.logger.isWarnEnabled()) {
+				String clazzName = invocationThis == null
+						? method.getDeclaringClass().getName()
+						: invocationThis.getClass().getName();
+				this.logger.warn("This advice " + getClass().getName() +
+						" can only be used for MessageHandlers; an attempt to advise method '"
+						+ method.getName() + "' in '" + clazzName + "' is ignored.");
+			}
+			return invocation.proceed();
+		}
+
+		Message<?> message = (Message<?>) arguments[0];
+		return doInvoke(invocation, message);
+	}
+
+	protected abstract Object doInvoke(MethodInvocation invocation, Message<?> message) throws Throwable;
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/HandleMessageAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/HandleMessageAdvice.java
@@ -16,51 +16,15 @@
 
 package org.springframework.integration.handler.advice;
 
-import java.lang.reflect.Method;
-
 import org.aopalliance.intercept.MethodInterceptor;
-import org.aopalliance.intercept.MethodInvocation;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandler;
 
 /**
- * The base {@link MethodInterceptor} for advices which can be applied only
- * for the {@link MessageHandler#handleMessage(Message)}.
+ * The marker {@link MethodInterceptor} interface extension
+ * to distinguish advices for some reason.
  *
  * @author Artem Bilan
  * @since 4.3.1
  */
-public abstract class HandleMessageAdvice implements MethodInterceptor {
-
-	protected final Log logger = LogFactory.getLog(this.getClass());
-
-	@Override
-	public final Object invoke(MethodInvocation invocation) throws Throwable {
-		Method method = invocation.getMethod();
-		Object invocationThis = invocation.getThis();
-		Object[] arguments = invocation.getArguments();
-		boolean isMessageHandler = invocationThis != null && invocationThis instanceof MessageHandler;
-		boolean isMessageMethod = method.getName().equals("handleMessage")
-				&& (arguments.length == 1 && arguments[0] instanceof Message);
-		if (!isMessageHandler || !isMessageMethod) {
-			if (this.logger.isWarnEnabled()) {
-				String clazzName = invocationThis == null
-						? method.getDeclaringClass().getName()
-						: invocationThis.getClass().getName();
-				this.logger.warn("This advice " + getClass().getName() +
-						" can only be used for MessageHandlers; an attempt to advise method '"
-						+ method.getName() + "' in '" + clazzName + "' is ignored.");
-			}
-			return invocation.proceed();
-		}
-
-		Message<?> message = (Message<?>) arguments[0];
-		return doInvoke(invocation, message);
-	}
-
-	protected abstract Object doInvoke(MethodInvocation invocation, Message<?> message) throws Throwable;
+public interface HandleMessageAdvice extends MethodInterceptor {
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/HandleMessageAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/HandleMessageAdvice.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.handler.advice;
+
+import java.lang.reflect.Method;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+
+/**
+ * The base {@link MethodInterceptor} for advices which can be applied only
+ * for the {@link MessageHandler#handleMessage(Message)}.
+ *
+ * @author Artem Bilan
+ * @since 4.3.1
+ */
+public abstract class HandleMessageAdvice implements MethodInterceptor {
+
+	protected final Log logger = LogFactory.getLog(this.getClass());
+
+	@Override
+	public final Object invoke(MethodInvocation invocation) throws Throwable {
+		Method method = invocation.getMethod();
+		Object invocationThis = invocation.getThis();
+		Object[] arguments = invocation.getArguments();
+		boolean isMessageHandler = invocationThis != null && invocationThis instanceof MessageHandler;
+		boolean isMessageMethod = method.getName().equals("handleMessage")
+				&& (arguments.length == 1 && arguments[0] instanceof Message);
+		if (!isMessageHandler || !isMessageMethod) {
+			if (this.logger.isWarnEnabled()) {
+				String clazzName = invocationThis == null
+						? method.getDeclaringClass().getName()
+						: invocationThis.getClass().getName();
+				this.logger.warn("This advice " + getClass().getName() +
+						" can only be used for MessageHandlers; an attempt to advise method '"
+						+ method.getName() + "' in '" + clazzName + "' is ignored.");
+			}
+			return invocation.proceed();
+		}
+
+		Message<?> message = (Message<?>) arguments[0];
+		return doInvoke(invocation, message);
+	}
+
+	protected abstract Object doInvoke(MethodInvocation invocation, Message<?> message) throws Throwable;
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/IdempotentReceiverInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/IdempotentReceiverInterceptor.java
@@ -55,7 +55,7 @@ import org.springframework.util.Assert;
  * @see org.springframework.integration.selector.MetadataStoreSelector
  * @see org.springframework.integration.config.IdempotentReceiverAutoProxyCreatorInitializer
  */
-public class IdempotentReceiverInterceptor extends HandleMessageAdvice implements BeanFactoryAware {
+public class IdempotentReceiverInterceptor extends AbstractHandleMessageAdvice implements BeanFactoryAware {
 
 	private final MessagingTemplate messagingTemplate = new MessagingTemplate();
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/IdempotentReceiverIntegrationTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/IdempotentReceiverIntegrationTests.java
@@ -232,8 +232,7 @@ public class IdempotentReceiverIntegrationTests {
 
 		@Bean
 		@org.springframework.integration.annotation.Transformer(inputChannel = "input",
-				outputChannel = "output", adviceChain = "fooAdvice")
-		@IdempotentReceiver("idempotentReceiverInterceptor")
+				outputChannel = "output", adviceChain = {"fooAdvice", "idempotentReceiverInterceptor"})
 		public Transformer transformer() {
 			return new Transformer() {
 

--- a/src/reference/asciidoc/handler-advice.adoc
+++ b/src/reference/asciidoc/handler-advice.adoc
@@ -452,6 +452,28 @@ For more information, see the http://docs.spring.io/spring-framework/docs/curren
 
 While the abstract class mentioned above is provided as a convenience, you can add any `Advice` to the chain, including a transaction advice.
 
+[[handle-message-advice]]
+=== Handle Message Advice
+
+Starting with _version 4.3.1_ a new `HandleMessageAdvice` with the `AbstractHandleMessageAdvice` base implementation have been introduced.
+Its purpose to develop `Advice` s which should be applied exactly to the `MessageHandler.handlerMessage()` method, but not to the `AbstractReplyProducingMessageHandler.RequestHandler.handleRequestMessage()`.
+The premise of such an abstraction has been dictated with the fact that we still configure and get applied `Advice` s for the `MessageHandler.handlerMessage()` as is with the `<request-handler-advice-chain>`, when the target `MessageHandler` isn't `AbstractReplyProducingMessageHandler`.
+But otherwise they are just ignored because advices are applied for the `AbstractReplyProducingMessageHandler.RequestHandler.handleRequestMessage()` method.
+
+Now `HandleMessageAdvice` implementations (such an <<idempotent-receiver, Idempotent Receiver>>) are dissociated from the `adviceChain` and properly applied for `MessageHandler.handlerMessage()` independently of the `MessageHandler` implementation.
+But you should bare in mind that advices order is not complied and with the configuration like:
+
+[source,xml]
+----
+<int:request-handler-advice-chain>
+    <tx:advice ... />
+    <bean ref="myHandleMessageAdvice" />
+</request-handler-advice-chain>
+----
+
+The `<tx:advice>` is applied for the `AbstractReplyProducingMessageHandler.RequestHandler.handleRequestMessage()`, but `myHandleMessageAdvice` is popped and applied for the `MessageHandler.handlerMessage()` and, therefore, invoked before the `<tx:advice>`.
+To retain the order you should follow with standard http://docs.spring.io/spring/docs/current/spring-framework-reference/html/aop-api.html[Spring AOP] configuration approach and use endpoint `id` together with the `.handler` suffix to obtain target `MessageHandler` bean.
+
 [[advising-filters]]
 ==== Advising Filters
 
@@ -620,3 +642,6 @@ public MessageHandler myService() {
     ....
 }
 ----
+
+NOTE: The `IdempotentReceiverInterceptor` is designed only for the `MessageHandler.handleMessage(Message<?>)` method and starting with _version 4.3.1_ it implements `HandleMessageAdvice`, with the `AbstractHandleMessageAdvice` as a base class, for better dissociation.
+See <<handle-message-advice>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4064

We configure `IdempotentReceiver` via `<int:idempotent-receiver>` component or `@IdempotentReceiver` annotation.
In case of regular Java config, e.g. direct `ConsumerEndpointFactoryBean` usage or Java DSL,
it isn't possible to configure `idempotentReceiverInterceptor` enough easy
- Introduce `if...else` logic into `ConsumerEndpointFactoryBean` to proxy `MessageHandler`,
  if `adviceChain` contains an newly-introduced `HandleMessageAdvice`.
  And do that independently if `MessageHandler` is `AbstractReplyProducingMessageHandler`
- Make `idempotentReceiverInterceptor extends HandleMessageAdvice`
- Skip `HandleMessageAdvice` in the `AbstractReplyProducingMessageHandler`
- Add advice applying logic into the `AbstractMethodAnnotationPostProcessor` as well
