### PR TITLE
INT-4074 Late channel resolution for GatewayProxy

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
@@ -142,13 +142,13 @@ public class MessagingGatewayRegistrar implements ImportBeanDefinitionRegistrar,
 
 
 		if (StringUtils.hasText(defaultRequestChannel)) {
-			gatewayProxyBuilder.addPropertyReference("defaultRequestChannel", defaultRequestChannel);
+			gatewayProxyBuilder.addPropertyValue("defaultRequestChannelName", defaultRequestChannel);
 		}
 		if (StringUtils.hasText(defaultReplyChannel)) {
-			gatewayProxyBuilder.addPropertyReference("defaultReplyChannel", defaultReplyChannel);
+			gatewayProxyBuilder.addPropertyValue("defaultReplyChannelName", defaultReplyChannel);
 		}
 		if (StringUtils.hasText(errorChannel)) {
-			gatewayProxyBuilder.addPropertyReference("errorChannel", errorChannel);
+			gatewayProxyBuilder.addPropertyValue("errorChannelName", errorChannel);
 		}
 		if (asyncExecutor == null || AnnotationConstants.NULL.equals(asyncExecutor)) {
 			gatewayProxyBuilder.addPropertyValue("asyncExecutor", null);

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -93,9 +93,15 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 
 	private volatile MessageChannel defaultRequestChannel;
 
+	private volatile String defaultRequestChannelName;
+
 	private volatile MessageChannel defaultReplyChannel;
 
+	private volatile String defaultReplyChannelName;
+
 	private volatile MessageChannel errorChannel;
+
+	private volatile String errorChannelName;
 
 	private volatile Long defaultRequestTimeout;
 
@@ -159,7 +165,6 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 
 	/**
 	 * Set the default request channel.
-	 *
 	 * @param defaultRequestChannel the channel to which request messages will
 	 * be sent if no request channel has been configured with an annotation.
 	 */
@@ -168,10 +173,19 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 	}
 
 	/**
+	 * Set the default request channel bean name.
+	 * @param defaultRequestChannelName the channel name to which request messages will
+	 * be sent if no request channel has been configured with an annotation.
+	 * @since 4.2.9
+	 */
+	public void setDefaultRequestChannelName(String defaultRequestChannelName) {
+		this.defaultRequestChannelName = defaultRequestChannelName;
+	}
+
+	/**
 	 * Set the default reply channel. If no default reply channel is provided,
 	 * and no reply channel is configured with annotations, an anonymous,
 	 * temporary channel will be used for handling replies.
-	 *
 	 * @param defaultReplyChannel the channel from which reply messages will be
 	 * received if no reply channel has been configured with an annotation
 	 */
@@ -180,14 +194,36 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 	}
 
 	/**
+	 * Set the default reply channel bean name. If no default reply channel is provided,
+	 * and no reply channel is configured with annotations, an anonymous,
+	 * temporary channel will be used for handling replies.
+	 * @param defaultReplyChannelName the channel name from which reply messages will be
+	 * received if no reply channel has been configured with an annotation
+	 * @since 4.2.9
+	 */
+	public void setDefaultReplyChannelName(String defaultReplyChannelName) {
+		this.defaultReplyChannelName = defaultReplyChannelName;
+	}
+
+	/**
 	 * Set the error channel. If no error channel is provided, this gateway will
 	 * propagate Exceptions to the caller. To completely suppress Exceptions, provide
 	 * a reference to the "nullChannel" here.
-	 *
 	 * @param errorChannel The error channel.
 	 */
 	public void setErrorChannel(MessageChannel errorChannel) {
 		this.errorChannel = errorChannel;
+	}
+
+	/**
+	 * Set the error channel name. If no error channel is provided, this gateway will
+	 * propagate Exceptions to the caller. To completely suppress Exceptions, provide
+	 * a reference to the "nullChannel" here.
+	 * @param errorChannelName The error channel bean name.
+	 * @since 4.2.9
+	 */
+	public void setErrorChannelName(String errorChannelName) {
+		this.errorChannelName = errorChannelName;
 	}
 
 	/**
@@ -456,13 +492,12 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 
 	private MethodInvocationGateway createGatewayForMethod(Method method) {
 		Gateway gatewayAnnotation = method.getAnnotation(Gateway.class);
-		MessageChannel requestChannel = this.defaultRequestChannel;
 		String requestChannelName = null;
-		MessageChannel replyChannel = this.defaultReplyChannel;
 		String replyChannelName = null;
 		Long requestTimeout = this.defaultRequestTimeout;
 		Long replyTimeout = this.defaultReplyTimeout;
-		String payloadExpression = this.globalMethodMetadata != null ? this.globalMethodMetadata.getPayloadExpression()
+		String payloadExpression = this.globalMethodMetadata != null
+				? this.globalMethodMetadata.getPayloadExpression()
 				: null;
 		Map<String, Expression> headerExpressions = new HashMap<String, Expression>();
 		if (gatewayAnnotation != null) {
@@ -492,7 +527,7 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 					String name = gatewayHeader.name();
 					boolean hasValue = StringUtils.hasText(value);
 
-					if (!(hasValue ^ StringUtils.hasText(expression))) {
+					if (hasValue == StringUtils.hasText(expression)) {
 						throw new BeanDefinitionStoreException("exactly one of 'value' or 'expression' " +
 								"is required on a gateway's header.");
 					}
@@ -533,23 +568,39 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 		}
 		messageMapper.setBeanFactory(this.getBeanFactory());
 		MethodInvocationGateway gateway = new MethodInvocationGateway(messageMapper);
-		gateway.setErrorChannel(this.errorChannel);
+
+		if (this.errorChannel != null) {
+			gateway.setErrorChannel(this.errorChannel);
+		}
+		else if (StringUtils.hasText(this.errorChannelName)) {
+			gateway.setErrorChannelName(this.errorChannelName);
+		}
+
 		if (this.getTaskScheduler() != null) {
 			gateway.setTaskScheduler(this.getTaskScheduler());
 		}
 		gateway.setBeanName(this.getComponentName());
+
 		if (StringUtils.hasText(requestChannelName)) {
 			gateway.setRequestChannelName(requestChannelName);
 		}
-		else {
-			gateway.setRequestChannel(requestChannel);
+		else if (StringUtils.hasText(this.defaultRequestChannelName)) {
+			gateway.setRequestChannelName(this.defaultRequestChannelName);
 		}
+		else {
+			gateway.setRequestChannel(this.defaultRequestChannel);
+		}
+
 		if (StringUtils.hasText(replyChannelName)) {
 			gateway.setReplyChannelName(replyChannelName);
 		}
-		else {
-			gateway.setReplyChannel(replyChannel);
+		else if (StringUtils.hasText(this.defaultReplyChannelName)) {
+			gateway.setReplyChannelName(this.defaultReplyChannelName);
 		}
+		else {
+			gateway.setReplyChannel(this.defaultReplyChannel);
+		}
+
 		if (requestTimeout == null) {
 			gateway.setRequestTimeout(-1);
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChainParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -394,8 +394,8 @@ public class ChainParserTests {
 		//INT-3117
 		GatewayProxyFactoryBean gatewayProxyFactoryBean = this.beanFactory.getBean("&subComponentsIdSupport1$child.gatewayWithinChain.handler",
 				GatewayProxyFactoryBean.class);
-		assertSame(this.strings, TestUtils.getPropertyValue(gatewayProxyFactoryBean, "defaultRequestChannel", MessageChannel.class));
-		assertSame(this.numbers, TestUtils.getPropertyValue(gatewayProxyFactoryBean, "defaultReplyChannel", MessageChannel.class));
+		assertEquals("strings", TestUtils.getPropertyValue(gatewayProxyFactoryBean, "defaultRequestChannelName"));
+		assertEquals("numbers", TestUtils.getPropertyValue(gatewayProxyFactoryBean, "defaultReplyChannelName"));
 		assertEquals(new Long(1000), TestUtils.getPropertyValue(gatewayProxyFactoryBean, "defaultRequestTimeout", Long.class));
 		assertEquals(new Long(100), TestUtils.getPropertyValue(gatewayProxyFactoryBean, "defaultReplyTimeout", Long.class));
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4074

If the `@ServiceActivator` component is processed first the application will start.
However, if another component that relies on the channel creation goes first it'll fail as the bean for the channel does not exist.
- Add `name` setters for all channels in the `GatewayProxyFactoryBean` to allow late channel resolution in the target `MethodInvocationGateway`
- Change `MessagingGatewayRegistrar` to populate channel properties as names not bean references

**Cherry-pick to 4.2.x**
