### PR TITLE
INT-4078: Don't copy headers in the `Resequencer`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -65,6 +65,10 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 		super.setExpireGroupsUponTimeout(expireGroupsUponTimeout);
 	}
 
+	@Override
+	protected boolean shouldCopyRequestHeaders() {
+		return false;
+	}
 
 	@Override
 	protected void afterRelease(MessageGroup messageGroup, Collection<Message<?>> completedMessages) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4078

Even if it doesn't hurt to `copyHeadersIfAbsent()`, when it just adds a new headers and doesn't override existing like sequence details,
it doesn't sound reasonable for `Resequencer` to modify the message before and after its resequence logic.
- Change `shouldCopyRequestHeaders()` to `false` for `ResequencingMessageHandler`
