### PR TITLE
MessagingGateway default errorChannel

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
@@ -73,7 +73,7 @@ public @interface MessagingGateway {
 	 * reference to the {@code nullChannel} here.
 	 * @return the suggested channel name, if any
 	 */
-	String errorChannel() default "";
+	String errorChannel() default "errorChannel";
 
 	/**
 	 * Provides the amount of time dispatcher would wait to send a {@code Message}.


### PR DESCRIPTION
set the default errorChannel to send all error message to the global default errorChannel
