### PR TITLE
Some fixes and improvements

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentAcceptOnceFileListFilter.java
@@ -94,6 +94,7 @@ public abstract class AbstractPersistentAcceptOnceFileListFilter<F> extends Abst
 	 */
 	@Override
 	public void rollback(F file, List<F> files) {
+		// If file must be removed all subsequent files should be removed as well
 		boolean rollingBack = false;
 		for (F fileToRollback : files) {
 			if (fileToRollback.equals(file)) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
@@ -572,7 +572,7 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 		return directoryPath;
 	}
 
-	private final class StreamHolder {
+	private static final class StreamHolder {
 
 		private final InputStream stream;
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.regex.Pattern;
 
+import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.endpoint.AbstractMessageSource;
 import org.springframework.integration.file.FileReadingMessageSource;
@@ -31,7 +32,6 @@ import org.springframework.integration.file.filters.CompositeFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.filters.RegexPatternFileListFilter;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
 
 /**
@@ -153,8 +153,8 @@ public abstract class AbstractInboundFileSynchronizingMessageSource<F>
 			throw e;
 		}
 		catch (Exception e) {
-			throw new MessagingException(
-					"Failure during initialization of MessageSource for: " + this.getClass(), e);
+			throw new BeanInitializationException("Failure during initialization of MessageSource for: "
+					+ this.getClass(), e);
 		}
 	}
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpParserInboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpParserInboundTests.java
@@ -31,8 +31,8 @@ import org.junit.Test;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.messaging.MessagingException;
 
 /**
  * @author Oleg Zhurakousky
@@ -63,7 +63,7 @@ public class FtpParserInboundTests {
 		catch (BeansException e) {
 			assertThat(e, Matchers.instanceOf(BeanCreationException.class));
 			Throwable cause = e.getCause();
-			assertThat(cause, Matchers.instanceOf(MessagingException.class));
+			assertThat(cause, Matchers.instanceOf(BeanInitializationException.class));
 			cause = cause.getCause();
 			assertThat(cause, Matchers.instanceOf(FileNotFoundException.class));
 			assertEquals("bar", cause.getMessage());

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/channel/SubscribableRedisChannelTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/channel/SubscribableRedisChannelTests.java
@@ -99,7 +99,7 @@ public class SubscribableRedisChannelTests extends RedisAvailableTests {
 		MessageListenerAdapter listener = channelMapping.entrySet().iterator().next().getValue().iterator().next();
 		Object delegate = TestUtils.getPropertyValue(listener, "delegate");
 		try {
-			ReflectionUtils.findMethod(delegate.getClass(), "handleMessage", String.class).invoke(delegate,
+			ReflectionUtils.findMethod(delegate.getClass(), "handleMessage", Object.class).invoke(delegate,
 					"Hello, world!");
 			fail("Exception expected");
 		}

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -49,12 +49,17 @@ import com.jcraft.jsch.UserInfo;
  * @author Gary Russell
  * @author David Liu
  * @author Pat Turner
+ * @author Artem Bilan
  *
  * @since 2.0
  */
 public class DefaultSftpSessionFactory implements SessionFactory<LsEntry>, SharedSessionCapable {
 
 	private static final Log logger = LogFactory.getLog(DefaultSftpSessionFactory.class);
+
+	static {
+		JSch.setLogger(new JschLogger());
+	}
 
 	private final ReadWriteLock sharedSessionLock = new ReentrantReadWriteLock();
 
@@ -343,7 +348,6 @@ public class DefaultSftpSessionFactory implements SessionFactory<LsEntry>, Share
 	public SftpSession getSession() {
 		Assert.hasText(this.host, "host must not be empty");
 		Assert.hasText(this.user, "user must not be empty");
-		Assert.isTrue(this.port >= 0, "port must be a positive number");
 		Assert.isTrue(StringUtils.hasText(this.userInfoWrapper.getPassword()) || this.privateKey != null,
 				"either a password or a private key is required");
 		try {
@@ -384,8 +388,6 @@ public class DefaultSftpSessionFactory implements SessionFactory<LsEntry>, Share
 	}
 
 	private com.jcraft.jsch.Session initJschSession() throws Exception {
-		JSch.setLogger(new JschLogger());
-
 		if (this.port <= 0) {
 			this.port = 22;
 		}

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/JschProxyFactoryBean.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/JschProxyFactoryBean.java
@@ -64,7 +64,7 @@ public class JschProxyFactoryBean extends AbstractFactoryBean<Proxy> {
 		case HTTP:
 			return ProxyHTTP.class;
 		default:
-			throw new UnsupportedOperationException("Invalid type:" + this.type);
+			throw new IllegalArgumentException("Invalid type:" + this.type);
 		}
 	}
 
@@ -84,7 +84,7 @@ public class JschProxyFactoryBean extends AbstractFactoryBean<Proxy> {
 			httpProxy.setUserPasswd(this.user, this.password);
 			return httpProxy;
 		default:
-			throw new UnsupportedOperationException("Invalid type:" + this.type);
+			throw new IllegalArgumentException("Invalid type:" + this.type);
 		}
 	}
 

--- a/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/inbound/StompInboundChannelAdapter.java
+++ b/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/inbound/StompInboundChannelAdapter.java
@@ -206,7 +206,7 @@ public class StompInboundChannelAdapter extends MessageProducerSupport implement
 			}
 		}
 		catch (Exception e) {
-			logger.warn("The exception during unsubscribtion.", e);
+			logger.warn("The exception during unsubscription.", e);
 		}
 		this.subscriptions.clear();
 	}

--- a/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/config/SyslogReceivingChannelAdapterFactoryBean.java
+++ b/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/config/SyslogReceivingChannelAdapterFactoryBean.java
@@ -181,7 +181,7 @@ public class SyslogReceivingChannelAdapterFactoryBean extends AbstractFactoryBea
 			else if (this.applicationEventPublisher != null) {
 				((TcpSyslogReceivingChannelAdapter) adapter).setApplicationEventPublisher(this.applicationEventPublisher);
 			}
-			Assert.isNull(this.udpAdapter, "Cannot specifiy 'udp-attributes' when the protocol is 'tcp'");
+			Assert.isNull(this.udpAdapter, "Cannot specify 'udp-attributes' when the protocol is 'tcp'");
 		}
 		else if (this.protocol == Protocol.udp) {
 			adapter = new UdpSyslogReceivingChannelAdapter();
@@ -189,7 +189,7 @@ public class SyslogReceivingChannelAdapterFactoryBean extends AbstractFactoryBea
 				Assert.isNull(this.port, "Cannot specify both 'port' and 'udpAdapter'");
 				((UdpSyslogReceivingChannelAdapter) adapter).setUdpAdapter(this.udpAdapter);
 			}
-			Assert.isNull(this.connectionFactory, "Cannot specifiy 'connection-factory' unless the protocol is 'tcp'");
+			Assert.isNull(this.connectionFactory, "Cannot specify 'connection-factory' unless the protocol is 'tcp'");
 		}
 		else {
 			throw new IllegalStateException("Unsupported protocol: " + this.protocol.toString());

--- a/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/config/SyslogReceivingChannelAdapterParserTests.java
+++ b/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/config/SyslogReceivingChannelAdapterParserTests.java
@@ -196,7 +196,7 @@ public class SyslogReceivingChannelAdapterParserTests {
 		catch (BeanCreationException e) {
 			e.printStackTrace();
 
-			assertEquals("Cannot specifiy 'udp-attributes' when the protocol is 'tcp'", e.getCause().getMessage());
+			assertEquals("Cannot specify 'udp-attributes' when the protocol is 'tcp'", e.getCause().getMessage());
 		}
 	}
 
@@ -208,7 +208,7 @@ public class SyslogReceivingChannelAdapterParserTests {
 			fail("Expected exception");
 		}
 		catch (BeanCreationException e) {
-			assertEquals("Cannot specifiy 'connection-factory' unless the protocol is 'tcp'",
+			assertEquals("Cannot specify 'connection-factory' unless the protocol is 'tcp'",
 					e.getCause().getMessage());
 		}
 	}

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/selector/RegexTestXPathMessageSelector.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/selector/RegexTestXPathMessageSelector.java
@@ -98,7 +98,7 @@ public class RegexTestXPathMessageSelector extends AbstractXPathMessageSelector 
 	public boolean accept(Message<?> message) {
 		Node nodeToTest = getConverter().convertToNode(message.getPayload());
 		String xPathResult = getXPathExpresion().evaluateAsString(nodeToTest);
-		return StringUtils.hasText(xPathResult) ? xPathResult.matches(this.regex) : false;
+		return StringUtils.hasText(xPathResult) && xPathResult.matches(this.regex);
 	}
 
 }

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/selector/XmlValidatingMessageSelector.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/selector/XmlValidatingMessageSelector.java
@@ -133,9 +133,7 @@ public class XmlValidatingMessageSelector implements MessageSelector {
 						new AggregatedXmlMessageValidationException(
 								Arrays.<Throwable>asList(validationExceptions)));
 			}
-			if (this.logger.isDebugEnabled()) {
-				this.logger.debug("Message was rejected due to XML Validation errors");
-			}
+			this.logger.debug("Message was rejected due to XML Validation errors");
 		}
 		return validationSuccess;
 	}

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/CuratorFrameworkFactoryBean.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/CuratorFrameworkFactoryBean.java
@@ -19,7 +19,6 @@ package org.springframework.integration.zookeeper.config;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.utils.CloseableUtils;
 
@@ -31,7 +30,8 @@ import org.springframework.util.Assert;
  * A spring-friendly way to build a {@link CuratorFramework} and implementing {@link SmartLifecycle}.
  *
  * @author Gary Russell
- *
+ * @author Artem Bilan
+ * @since 4.2
  */
 public class CuratorFrameworkFactoryBean implements FactoryBean<CuratorFramework>, SmartLifecycle {
 
@@ -67,7 +67,7 @@ public class CuratorFrameworkFactoryBean implements FactoryBean<CuratorFramework
 	/**
 	 * Construct an instance using the supplied connection string and retry policy.
 	 * @param connectionString list of servers to connect to
-	 * @param retryPolicy the retry policy
+	 * @param retryPolicy      the retry policy
 	 */
 	public CuratorFrameworkFactoryBean(String connectionString, RetryPolicy retryPolicy) {
 		Assert.notNull(connectionString, "'connectionString' cannot be null");
@@ -122,9 +122,8 @@ public class CuratorFrameworkFactoryBean implements FactoryBean<CuratorFramework
 	public void stop() {
 		synchronized (this.lifecycleLock) {
 			if (this.running) {
-				if (this.client.getState().equals(CuratorFrameworkState.STARTED)) {
-					CloseableUtils.closeQuietly(this.client);
-				}
+				CloseableUtils.closeQuietly(this.client);
+				this.running = false;
 			}
 		}
 	}

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/leader/LeaderInitiator.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/leader/LeaderInitiator.java
@@ -208,7 +208,7 @@ public class LeaderInitiator implements SmartLifecycle {
 		if (!ns.endsWith("/")) {
 			ns = ns + "/";
 		}
-		return String.format(ns + "%s", this.candidate.getRole());
+		return ns + this.candidate.getRole();
 	}
 
 	/**


### PR DESCRIPTION
- Fix several typos in log messages. And some test on the matter as well
- Add comment to `AbstractPersistentAcceptOnceFileListFilter.rollback()` to clarify the reason of `rollingBack` variable
- Make `RemoteFileTemplate.StreamHolder` as `static` to avoid extra internal variable to outer class instance
- Replace `MessagingException` with `AbstractInboundFileSynchronizingMessageSource` in `init()` method of some components. It isn't Messaging yet in that phase
- Fix `SubscribableRedisChannel.MessageListenerDelegate` to handle `Object` not `String`, because with the `serializer` injection there is no guaranty that incoming is always `String`
- Move `JSch.setLogger(new JschLogger());` in the `DefaultSftpSessionFactory` to `static` block. It really should be done only once
- Remove `Assert.isTrue(this.port >= 0)` from the `DefaultSftpSessionFactory`. The subsequant `initJschSession()` convert it to default `22` port
- Change in the `JschProxyFactoryBean` `UnsupportedOperationException` to `IllegalArgumentException`. Wrong enum is wrong argument. That isn't a problem of operation
- Simplify `stop()` in the `CuratorFrameworkFactoryBean` and mark it as a `this.running = false`. Otherwise it wasn't able to be restarted
- Expose `leaderEventPublisher` in the `LeaderInitiatorFactoryBean`  and fix `stop(Runnable callback)` with propagation `callback` to delegate.
