### PR TITLE
INT-4087: Fix `tryLock(timeout)` contract for ZK

### DIFF
--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
@@ -20,15 +20,22 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.locks.InterProcessMutex;
+import org.apache.zookeeper.CreateMode;
 
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.integration.support.locks.ExpirableLockRegistry;
 import org.springframework.messaging.MessagingException;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.util.Assert;
 
 /**
@@ -36,10 +43,11 @@ import org.springframework.util.Assert;
  * Curator {@link InterProcessMutex}.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 4.2
  *
  */
-public class ZookeeperLockRegistry implements ExpirableLockRegistry {
+public class ZookeeperLockRegistry implements ExpirableLockRegistry, DisposableBean {
 
 	private static final String DEFAULT_ROOT = "/SpringIntegration-LockRegistry";
 
@@ -50,6 +58,8 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry {
 	private final Map<String, ZkLock> locks = new HashMap<String, ZkLock>();
 
 	private final boolean trackingTime;
+
+	private final ThreadPoolTaskExecutor mutexTaskExecutor = new ThreadPoolTaskExecutor();
 
 	/**
 	 * Construct a lock registry using the default {@link KeyToPathStrategy} which
@@ -81,6 +91,9 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry {
 		this.client = client;
 		this.keyToPath = keyToPath;
 		this.trackingTime = !keyToPath.bounded();
+		this.mutexTaskExecutor.setAllowCoreThreadTimeOut(true);
+		this.mutexTaskExecutor.setBeanName("ZookeeperLockRegistryExecutor");
+		this.mutexTaskExecutor.initialize();
 	}
 
 	@Override
@@ -92,7 +105,7 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry {
 			synchronized (this.locks) {
 				lock = this.locks.get(path);
 				if (lock == null) {
-					lock = new ZkLock(this.client, path);
+					lock = new ZkLock(this.client, mutexTaskExecutor, path);
 					this.locks.put(path, lock);
 				}
 				if (this.trackingTime) {
@@ -127,6 +140,11 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry {
 				}
 			}
 		}
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		this.mutexTaskExecutor.shutdown();
 	}
 
 	/**
@@ -179,14 +197,20 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry {
 
 	private static final class ZkLock implements Lock {
 
+		private final CuratorFramework client;
+
 		private final InterProcessMutex mutex;
+
+		private final AsyncTaskExecutor mutexTaskExecutor;
 
 		private final String path;
 
 		private long lastUsed;
 
-		private ZkLock(CuratorFramework client, String path) {
+		private ZkLock(CuratorFramework client, AsyncTaskExecutor mutexTaskExecutor, String path) {
+			this.client = client;
 			this.mutex = new InterProcessMutex(client, path);
+			this.mutexTaskExecutor = mutexTaskExecutor;
 			this.path = path;
 		}
 
@@ -204,7 +228,7 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry {
 				this.mutex.acquire();
 			}
 			catch (Exception e) {
-				throw new RuntimeException("Failed to aquire mutex at " + this.path, e);
+				throw new RuntimeException("Failed to acquire mutex at " + this.path, e);
 			}
 		}
 
@@ -231,11 +255,42 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry {
 
 		@Override
 		public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+			Future<String> future = null;
 			try {
-				return this.mutex.acquire(time, unit);
+				long startTime = System.currentTimeMillis();
+
+				future = this.mutexTaskExecutor.submit(new Callable<String>() {
+
+					@Override
+					public String call() throws Exception {
+						return ZkLock.this.client.create()
+								.creatingParentContainersIfNeeded()
+								.withProtection()
+								.withMode(CreateMode.EPHEMERAL_SEQUENTIAL)
+								.forPath(ZkLock.this.path);
+					}
+
+				});
+
+				long waitTime = unit.toMillis(time);
+
+				String ourPath = future.get(waitTime, TimeUnit.MILLISECONDS);
+
+				if (ourPath == null) {
+					future.cancel(true);
+					return false;
+				}
+				else {
+					waitTime = waitTime - (System.currentTimeMillis() - startTime);
+					return this.mutex.acquire(waitTime, TimeUnit.MILLISECONDS);
+				}
+			}
+			catch (TimeoutException e) {
+				future.cancel(true);
+				return false;
 			}
 			catch (Exception e) {
-				throw new MessagingException("Failed to aquire mutex at " + this.path, e);
+				throw new MessagingException("Failed to acquire mutex at " + this.path, e);
 			}
 		}
 

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/ZookeeperTestSupport.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/ZookeeperTestSupport.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.zookeeper;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -77,7 +76,6 @@ public class ZookeeperTestSupport {
 		CuratorFramework client = CuratorFrameworkFactory.newClient(testingServer.getConnectString(),
 				new BoundedExponentialBackoffRetry(100, 1000, 3));
 		client.start();
-		client.blockUntilConnected(10000, TimeUnit.SECONDS);
 		return client;
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4087
Fixes GH-1863 (https://github.com/spring-projects/spring-integration/issues/1863)

If ZK Client loses the connection to ensemble, it tries to reconnect on the next operation and does that exactly for the `connectionTimeoutMs` and provided `RetryPolicy`.
According to the `Lock.tryLock(long time, TimeUnit unit)` contract we can wait for the lock only during provided `timeout`.
- Introduce `mutexTaskExecutor` and perform `ZK.forPath()` command in the separate `Thread` and wait for the `Future` during provided timeout.
- Perform `mutex.acquire()` only after successful `Future` result and only for the remained timeout.

**Cherry-pick to 4.2.x**
