### PR TITLE
INT-4099: Fix `closableResource` typo

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/IntegrationMessageHeaderAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/IntegrationMessageHeaderAccessor.java
@@ -51,7 +51,7 @@ public class IntegrationMessageHeaderAccessor extends MessageHeaderAccessor {
 
 	public static final String DUPLICATE_MESSAGE = "duplicateMessage";
 
-	public static final String CLOSEABLE_RESOURCE = "closableResource";
+	public static final String CLOSEABLE_RESOURCE = "closeableResource";
 
 	public IntegrationMessageHeaderAccessor(Message<?> message) {
 		super(message);

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -714,7 +714,7 @@ if (closeable != null) {
 ----
 
 Note: In previous releases the session was in the `file_remoteSession` header, but this is deprecated - use
-`closableResource` instead.
+`closeableResource` instead.
 
 Framework components such as the <<file-splitter,File Splitter>> and <<stream-transformer,Stream Transformer>> will
 automatically close the session after the data is transferred.

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -803,7 +803,7 @@ if (closeable != null) {
 ----
 
 Note: In previous releases the session was in the `file_remoteSession` header, but this is deprecated - use
-`closableResource` instead.
+`closeableResource` instead.
 
 Framework components such as the <<file-splitter,File Splitter>> and <<stream-transformer,Stream Transformer>> will
 automatically close the session after the data is transferred.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4099

The `IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE` value has a typo
- Fix the typo in the `IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE` constant value
- Fix the same type in the (s)ftp.adoc
