### PR TITLE
INT-3941: Align JMS Config with Spring Boot

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelParser.java
@@ -52,11 +52,8 @@ public class JmsChannelParser extends AbstractChannelParser {
 		if (StringUtils.hasText(messageDriven)) {
 			builder.addConstructorArgValue(messageDriven);
 		}
-		String connectionFactory = element.getAttribute("connection-factory");
-		if (!StringUtils.hasText(connectionFactory)) {
-			connectionFactory = "connectionFactory";
-		}
-		builder.addPropertyReference("connectionFactory", connectionFactory);
+		builder.addPropertyReference(JmsParserUtils.CONNECTION_FACTORY_PROPERTY,
+				JmsParserUtils.determineConnectionFactoryBeanName(element, parserContext));
 		if ("channel".equals(element.getLocalName())) {
 			this.parseDestination(element, parserContext, builder, "queue");
 		}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsInboundChannelAdapterParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsInboundChannelAdapterParser.java
@@ -51,19 +51,19 @@ public class JmsInboundChannelAdapterParser extends AbstractPollingInboundChanne
 		if (StringUtils.hasText(componentName)) {
 			builder.addPropertyValue("componentName", componentName);
 		}
-		String jmsTemplate = element.getAttribute(JmsAdapterParserUtils.JMS_TEMPLATE_ATTRIBUTE);
-		String destination = element.getAttribute(JmsAdapterParserUtils.DESTINATION_ATTRIBUTE);
-		String destinationName = element.getAttribute(JmsAdapterParserUtils.DESTINATION_NAME_ATTRIBUTE);
-		String headerMapper = element.getAttribute(JmsAdapterParserUtils.HEADER_MAPPER_ATTRIBUTE);
+		String jmsTemplate = element.getAttribute(JmsParserUtils.JMS_TEMPLATE_ATTRIBUTE);
+		String destination = element.getAttribute(JmsParserUtils.DESTINATION_ATTRIBUTE);
+		String destinationName = element.getAttribute(JmsParserUtils.DESTINATION_NAME_ATTRIBUTE);
+		String headerMapper = element.getAttribute(JmsParserUtils.HEADER_MAPPER_ATTRIBUTE);
 		boolean hasJmsTemplate = StringUtils.hasText(jmsTemplate);
 		boolean hasDestinationRef = StringUtils.hasText(destination);
 		boolean hasDestinationName = StringUtils.hasText(destinationName);
 		if (hasJmsTemplate) {
-			JmsAdapterParserUtils.verifyNoJmsTemplateAttributes(element, parserContext);
+			JmsParserUtils.verifyNoJmsTemplateAttributes(element, parserContext);
 			builder.addConstructorArgReference(jmsTemplate);
 		}
 		else {
-			builder.addConstructorArgValue(JmsAdapterParserUtils.parseJmsTemplateBeanDefinition(element, parserContext));
+			builder.addConstructorArgValue(JmsParserUtils.parseJmsTemplateBeanDefinition(element, parserContext));
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "acknowledge", "sessionAcknowledgeMode");
 		if (hasDestinationRef || hasDestinationName) {
@@ -72,20 +72,20 @@ public class JmsInboundChannelAdapterParser extends AbstractPollingInboundChanne
 					parserContext.getReaderContext().error("The 'destination-name' " +
 							"and 'destination' attributes are mutually exclusive.", parserContext.extractSource(element));
 				}
-				builder.addPropertyReference(JmsAdapterParserUtils.DESTINATION_PROPERTY, destination);
+				builder.addPropertyReference(JmsParserUtils.DESTINATION_PROPERTY, destination);
 			}
 			else if (hasDestinationName) {
-				builder.addPropertyValue(JmsAdapterParserUtils.DESTINATION_NAME_PROPERTY, destinationName);
+				builder.addPropertyValue(JmsParserUtils.DESTINATION_NAME_PROPERTY, destinationName);
 			}
 		}
 		else if (!hasJmsTemplate) {
-			parserContext.getReaderContext().error("either a '" + JmsAdapterParserUtils.JMS_TEMPLATE_ATTRIBUTE +
-					"' or one of '" + JmsAdapterParserUtils.DESTINATION_ATTRIBUTE + "' or '"
-					+ JmsAdapterParserUtils.DESTINATION_NAME_ATTRIBUTE +
+			parserContext.getReaderContext().error("either a '" + JmsParserUtils.JMS_TEMPLATE_ATTRIBUTE +
+					"' or one of '" + JmsParserUtils.DESTINATION_ATTRIBUTE + "' or '"
+					+ JmsParserUtils.DESTINATION_NAME_ATTRIBUTE +
 					"' attributes must be provided for a polling JMS adapter", parserContext.extractSource(element));
 		}
 		if (StringUtils.hasText(headerMapper)) {
-			builder.addPropertyReference(JmsAdapterParserUtils.HEADER_MAPPER_PROPERTY, headerMapper);
+			builder.addPropertyReference(JmsParserUtils.HEADER_MAPPER_PROPERTY, headerMapper);
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "selector", "messageSelector");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "extract-payload");

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsMessageDrivenEndpointParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsMessageDrivenEndpointParser.java
@@ -59,9 +59,9 @@ public class JmsMessageDrivenEndpointParser extends AbstractSingleBeanDefinition
 
 
 	private static String[] containerAttributes = new String[] {
-		JmsAdapterParserUtils.CONNECTION_FACTORY_PROPERTY,
-		JmsAdapterParserUtils.DESTINATION_ATTRIBUTE,
-		JmsAdapterParserUtils.DESTINATION_NAME_ATTRIBUTE,
+		JmsParserUtils.CONNECTION_FACTORY_PROPERTY,
+		JmsParserUtils.DESTINATION_ATTRIBUTE,
+		JmsParserUtils.DESTINATION_NAME_ATTRIBUTE,
 		"destination-resolver", "transaction-manager",
 		"concurrent-consumers", "max-concurrent-consumers",
 		"acknowledge",
@@ -168,8 +168,8 @@ public class JmsMessageDrivenEndpointParser extends AbstractSingleBeanDefinition
 					"Exactly one of '" + destinationAttribute +
 					"' or '" + destinationNameAttribute + "' is required.", element);
 		}
-		builder.addPropertyReference(JmsAdapterParserUtils.CONNECTION_FACTORY_PROPERTY,
-				JmsAdapterParserUtils.determineConnectionFactoryBeanName(element, parserContext));
+		builder.addPropertyReference(JmsParserUtils.CONNECTION_FACTORY_PROPERTY,
+				JmsParserUtils.determineConnectionFactoryBeanName(element, parserContext));
 		if (hasDestination) {
 			builder.addPropertyReference("destination", destination);
 		}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundChannelAdapterParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundChannelAdapterParser.java
@@ -38,21 +38,21 @@ public class JmsOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 	@Override
 	protected AbstractBeanDefinition parseConsumer(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(JmsSendingMessageHandler.class);
-		String jmsTemplate = element.getAttribute(JmsAdapterParserUtils.JMS_TEMPLATE_ATTRIBUTE);
-		String destination = element.getAttribute(JmsAdapterParserUtils.DESTINATION_ATTRIBUTE);
-		String destinationName = element.getAttribute(JmsAdapterParserUtils.DESTINATION_NAME_ATTRIBUTE);
-		String destinationExpression = element.getAttribute(JmsAdapterParserUtils.DESTINATION_EXPRESSION_ATTRIBUTE);
-		String headerMapper = element.getAttribute(JmsAdapterParserUtils.HEADER_MAPPER_ATTRIBUTE);
+		String jmsTemplate = element.getAttribute(JmsParserUtils.JMS_TEMPLATE_ATTRIBUTE);
+		String destination = element.getAttribute(JmsParserUtils.DESTINATION_ATTRIBUTE);
+		String destinationName = element.getAttribute(JmsParserUtils.DESTINATION_NAME_ATTRIBUTE);
+		String destinationExpression = element.getAttribute(JmsParserUtils.DESTINATION_EXPRESSION_ATTRIBUTE);
+		String headerMapper = element.getAttribute(JmsParserUtils.HEADER_MAPPER_ATTRIBUTE);
 		boolean hasJmsTemplate = StringUtils.hasText(jmsTemplate);
 		boolean hasDestinationRef = StringUtils.hasText(destination);
 		boolean hasDestinationName = StringUtils.hasText(destinationName);
 		boolean hasDestinationExpression = StringUtils.hasText(destinationExpression);
 		if (hasJmsTemplate) {
-			JmsAdapterParserUtils.verifyNoJmsTemplateAttributes(element, parserContext);
+			JmsParserUtils.verifyNoJmsTemplateAttributes(element, parserContext);
 			builder.addConstructorArgReference(jmsTemplate);
 		}
 		else {
-			builder.addConstructorArgValue(JmsAdapterParserUtils.parseJmsTemplateBeanDefinition(element, parserContext));
+			builder.addConstructorArgValue(JmsParserUtils.parseJmsTemplateBeanDefinition(element, parserContext));
 		}
 
 		if (hasDestinationRef || hasDestinationName || hasDestinationExpression) {
@@ -61,26 +61,26 @@ public class JmsOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 						"'destination-expression' attributes are mutually exclusive.", parserContext.extractSource(element));
 			}
 			if (hasDestinationRef) {
-				builder.addPropertyReference(JmsAdapterParserUtils.DESTINATION_PROPERTY, destination);
+				builder.addPropertyReference(JmsParserUtils.DESTINATION_PROPERTY, destination);
 			}
 			else if (hasDestinationName) {
-				builder.addPropertyValue(JmsAdapterParserUtils.DESTINATION_NAME_PROPERTY, destinationName);
+				builder.addPropertyValue(JmsParserUtils.DESTINATION_NAME_PROPERTY, destinationName);
 			}
 			else if (hasDestinationExpression) {
 				BeanDefinitionBuilder expressionBuilder = BeanDefinitionBuilder.genericBeanDefinition(ExpressionFactoryBean.class);
 				expressionBuilder.addConstructorArgValue(destinationExpression);
-				builder.addPropertyValue(JmsAdapterParserUtils.DESTINATION_EXPRESSION_PROPERTY, expressionBuilder.getBeanDefinition());
+				builder.addPropertyValue(JmsParserUtils.DESTINATION_EXPRESSION_PROPERTY, expressionBuilder.getBeanDefinition());
 			}
 		}
 		else if (!hasJmsTemplate) {
-			parserContext.getReaderContext().error("either a '" + JmsAdapterParserUtils.JMS_TEMPLATE_ATTRIBUTE +
-					"' or one of '" + JmsAdapterParserUtils.DESTINATION_ATTRIBUTE + "', '"
-					+ JmsAdapterParserUtils.DESTINATION_NAME_ATTRIBUTE + "', or '" +
-					JmsAdapterParserUtils.DESTINATION_EXPRESSION_ATTRIBUTE +
+			parserContext.getReaderContext().error("either a '" + JmsParserUtils.JMS_TEMPLATE_ATTRIBUTE +
+					"' or one of '" + JmsParserUtils.DESTINATION_ATTRIBUTE + "', '"
+					+ JmsParserUtils.DESTINATION_NAME_ATTRIBUTE + "', or '" +
+					JmsParserUtils.DESTINATION_EXPRESSION_ATTRIBUTE +
 					"' attributes must be provided", parserContext.extractSource(element));
 		}
 		if (StringUtils.hasText(headerMapper)) {
-			builder.addPropertyReference(JmsAdapterParserUtils.HEADER_MAPPER_PROPERTY, headerMapper);
+			builder.addPropertyReference(JmsParserUtils.HEADER_MAPPER_PROPERTY, headerMapper);
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "extract-payload");
 		return builder.getBeanDefinition();

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundGatewayParser.java
@@ -45,7 +45,8 @@ public class JmsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(JmsOutboundGateway.class);
-		builder.addPropertyReference("connectionFactory", element.getAttribute("connection-factory"));
+		builder.addPropertyReference(JmsParserUtils.CONNECTION_FACTORY_PROPERTY,
+				JmsParserUtils.determineConnectionFactoryBeanName(element, parserContext));
 		parseDestination(element, parserContext, builder, "request-destination", "request-destination-name",
 				"request-destination-expression", "requestDestination", "requestDestinationName",
 				"requestDestinationExpression", true);

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsParserUtils.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsParserUtils.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.jms.config;
 
 import org.w3c.dom.Element;
+
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
@@ -31,7 +32,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Gary Russell
  */
-abstract class JmsAdapterParserUtils {
+abstract class JmsParserUtils {
 
 	static final String JMS_TEMPLATE_ATTRIBUTE = "jms-template";
 
@@ -68,7 +69,7 @@ abstract class JmsAdapterParserUtils {
 	};
 
 	static String determineConnectionFactoryBeanName(Element element, ParserContext parserContext) {
-		String connectionFactoryBeanName = "connectionFactory";
+		String connectionFactoryBeanName = "jmsConnectionFactory";
 		if (element.hasAttribute(CONNECTION_FACTORY_ATTRIBUTE)) {
 			connectionFactoryBeanName = element.getAttribute(CONNECTION_FACTORY_ATTRIBUTE);
 			if (!StringUtils.hasText(connectionFactoryBeanName)) {
@@ -81,8 +82,8 @@ abstract class JmsAdapterParserUtils {
 
 	static BeanDefinition parseJmsTemplateBeanDefinition(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(DynamicJmsTemplate.class);
-		builder.addPropertyReference(JmsAdapterParserUtils.CONNECTION_FACTORY_PROPERTY,
-				JmsAdapterParserUtils.determineConnectionFactoryBeanName(element, parserContext));
+		builder.addPropertyReference(JmsParserUtils.CONNECTION_FACTORY_PROPERTY,
+				determineConnectionFactoryBeanName(element, parserContext));
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "destination-resolver");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "pub-sub-domain");

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-5.0.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-5.0.xsd
@@ -151,7 +151,7 @@
 			<xsd:annotation>
 				<xsd:documentation>
 	Reference to a JMS ConnectionFactory. If none is provided, the default
-	bean name for the reference will be "connectionFactory".
+	bean name for the reference will be "jmsConnectionFactory".
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
@@ -1009,7 +1009,7 @@
 					</xsd:appinfo>
 				</xsd:annotation>
 			</xsd:attribute>
-			<xsd:attribute name="connection-factory" type="xsd:string" default="connectionFactory">
+			<xsd:attribute name="connection-factory" type="xsd:string" default="jmsConnectionFactory">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
 	The name of a ConnectionFactory bean. Default is 'connectionFactory'.

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsInboundChannelAdapterTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsInboundChannelAdapterTests-context.xml
@@ -18,7 +18,7 @@
  	</util:properties>
  	
 	<int-jms:inbound-channel-adapter channel="out" session-transacted="true"
-			connection-factory="connectionFactory" destination-name="incatQ"
+			connection-factory="jmsConnectionFactory" destination-name="incatQ"
 			receive-timeout="500" acknowledge="${jmsAcknowledgeModeTransacted}">
 		<int:poller fixed-delay="500"/>
 	</int-jms:inbound-channel-adapter>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsInboundChannelAdapterTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsInboundChannelAdapterTests.java
@@ -63,7 +63,7 @@ public class JmsInboundChannelAdapterTests extends ActiveMQMultiContextTests {
 	public static class CFConfig {
 
 		@Bean
-		public ConnectionFactory connectionFactory() {
+		public ConnectionFactory jmsConnectionFactory() {
 			return amqFactory;
 		}
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsOutboundChannelAdapterTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsOutboundChannelAdapterTests-context.xml
@@ -8,14 +8,14 @@
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd">
 
 	<int-jms:message-driven-channel-adapter channel="toOut"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		acknowledge="transacted"
 		destination-name="outcatQ1"/>
 
 	<int:publish-subscribe-channel id="toOut" />
 
 	<int-jms:outbound-channel-adapter channel="toOut" order="1"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		destination-name="outcatQ2"
 		session-transacted="true" />
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsOutboundChannelAdapterTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsOutboundChannelAdapterTests.java
@@ -69,7 +69,7 @@ public class JmsOutboundChannelAdapterTests extends ActiveMQMultiContextTests {
 	public static class CFConfig {
 
 		@Bean
-		public ConnectionFactory connectionFactory() {
+		public ConnectionFactory jmsConnectionFactory() {
 			return connectionFactory;
 		}
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsOutboundInsideChainTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsOutboundInsideChainTests-context.xml
@@ -44,7 +44,7 @@
 		<constructor-arg value="test.queue2"/>
 	</bean>
 
-	<bean id="connectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
 		<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>
 	</bean>
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/DefaultConfigurationTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/DefaultConfigurationTests-context.xml
@@ -9,7 +9,7 @@
 
 	<jms:outbound-channel-adapter id="adapter" destination-name="testQueue" auto-startup="false"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="message-driven-test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/Exception-nonSiProducer-siConsumer.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/Exception-nonSiProducer-siConsumer.xml
@@ -71,7 +71,7 @@
 		<constructor-arg value="request.queue.c"/>
 	</bean>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/ExceptionHandlingSiConsumerTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/ExceptionHandlingSiConsumerTests.java
@@ -43,11 +43,12 @@ public class ExceptionHandlingSiConsumerTests {
 	public void nonSiProducer_siConsumer_sync_withReturn() throws Exception {
 		ActiveMqTestUtils.prepare();
 		ConfigurableApplicationContext applicationContext = new ClassPathXmlApplicationContext("Exception-nonSiProducer-siConsumer.xml", ExceptionHandlingSiConsumerTests.class);
-		JmsTemplate jmsTemplate = new JmsTemplate(applicationContext.getBean("connectionFactory", ConnectionFactory.class));
+		JmsTemplate jmsTemplate = new JmsTemplate(applicationContext.getBean("jmsConnectionFactory", ConnectionFactory.class));
 		Destination request = applicationContext.getBean("requestQueueA", Destination.class);
 		final Destination reply = applicationContext.getBean("replyQueueA", Destination.class);
 		jmsTemplate.send(request, new MessageCreator() {
 
+			@Override
 			public Message createMessage(Session session) throws JMSException {
 				TextMessage message = session.createTextMessage();
 				message.setText("echoChannel");
@@ -64,11 +65,12 @@ public class ExceptionHandlingSiConsumerTests {
 	public void nonSiProducer_siConsumer_sync_withReturnNoException() throws Exception {
 		ActiveMqTestUtils.prepare();
 		ConfigurableApplicationContext applicationContext = new ClassPathXmlApplicationContext("Exception-nonSiProducer-siConsumer.xml", ExceptionHandlingSiConsumerTests.class);
-		JmsTemplate jmsTemplate = new JmsTemplate(applicationContext.getBean("connectionFactory", ConnectionFactory.class));
+		JmsTemplate jmsTemplate = new JmsTemplate(applicationContext.getBean("jmsConnectionFactory", ConnectionFactory.class));
 		Destination request = applicationContext.getBean("requestQueueB", Destination.class);
 		final Destination reply = applicationContext.getBean("replyQueueB", Destination.class);
 		jmsTemplate.send(request, new MessageCreator() {
 
+			@Override
 			public Message createMessage(Session session) throws JMSException {
 				TextMessage message = session.createTextMessage();
 				message.setText("echoWithExceptionChannel");

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/ExtractRequestReplyPayloadTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/ExtractRequestReplyPayloadTests-context.xml
@@ -32,7 +32,7 @@
 	<bean id="extractRecRepQueue" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="request.queue.req.rep"/>
 	</bean>
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/GlobalChannelInterceptorTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/GlobalChannelInterceptorTests-context.xml
@@ -25,7 +25,7 @@
 
 	<int-jms:channel id="jmsChannel" cache="${CACHELEVEL}" queue="jmsQueue" container-type="${listenerContainer}"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/InboundOneWayErrorTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/InboundOneWayErrorTests-context.xml
@@ -32,14 +32,14 @@
 	</bean>
 
 	<bean id="container" class="org.springframework.jms.listener.DefaultMessageListenerContainer">
-		<property name="connectionFactory" ref="connectionFactory"/>
+		<property name="connectionFactory" ref="jmsConnectionFactory"/>
 		<property name="destination" ref="queueA"/>
 		<property name="errorHandler" ref="testErrorHandler"/>
 	</bean>
 
 	<bean id="testErrorHandler" class="org.springframework.integration.jms.config.InboundOneWayErrorTests$TestErrorHandler"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/InboundOneWayErrorTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/InboundOneWayErrorTests.java
@@ -31,11 +31,11 @@ import javax.jms.Session;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.PollableChannel;
-import org.springframework.jms.core.JmsTemplate;
-import org.springframework.jms.core.MessageCreator;
 import org.springframework.util.ErrorHandler;
 
 /**
@@ -46,9 +46,10 @@ public class InboundOneWayErrorTests {
 	@Test
 	public void noErrorChannel() throws Exception {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("InboundOneWayErrorTests-context.xml", getClass());
-		JmsTemplate jmsTemplate = new JmsTemplate(context.getBean("connectionFactory", ConnectionFactory.class));
+		JmsTemplate jmsTemplate = new JmsTemplate(context.getBean("jmsConnectionFactory", ConnectionFactory.class));
 		Destination queue = context.getBean("queueA", Destination.class);
 		jmsTemplate.send(queue, new MessageCreator() {
+			@Override
 			public javax.jms.Message createMessage(Session session) throws JMSException {
 				return session.createTextMessage("test-A");
 			}
@@ -66,9 +67,10 @@ public class InboundOneWayErrorTests {
 	@Test
 	public void errorChannel() throws Exception {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("InboundOneWayErrorTests-context.xml", getClass());
-		JmsTemplate jmsTemplate = new JmsTemplate(context.getBean("connectionFactory", ConnectionFactory.class));
+		JmsTemplate jmsTemplate = new JmsTemplate(context.getBean("jmsConnectionFactory", ConnectionFactory.class));
 		Destination queue = context.getBean("queueB", Destination.class);
 		jmsTemplate.send(queue, new MessageCreator() {
+			@Override
 			public javax.jms.Message createMessage(Session session) throws JMSException {
 				return session.createTextMessage("test-B");
 			}
@@ -107,6 +109,7 @@ public class InboundOneWayErrorTests {
 
 		private volatile Throwable lastError;
 
+		@Override
 		public void handleError(Throwable t) {
 			this.lastError = t;
 			this.latch.countDown();

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelHistoryTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelHistoryTests-context.xml
@@ -21,7 +21,7 @@
 		<constructor-arg value="request.queue."/>
 	</bean>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests-context.xml
@@ -63,13 +63,13 @@
 	<bean id="destinationResolver"
 		  class="org.springframework.integration.jms.config.JmsChannelParserTests$TestDestinationResolver"/>
 
-	<bean id="connectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
 		<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>
 	</bean>
 
-	<alias name="connectionFactory" alias="connFact"/>
+	<alias name="jmsConnectionFactory" alias="connFact"/>
 
-	<jms:channel id="withPlaceholders" queue="${queue}" 
+	<jms:channel id="withPlaceholders" queue="${queue}"
 									   concurrency="${concurrency}"/>
 
 	<jms:channel id="withDefaultContainer" queue-name="default.container.queue" />

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsDynamicDestinationTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsDynamicDestinationTests-context.xml
@@ -27,7 +27,7 @@
 		<int:queue capacity="1"/>
 	</int:channel>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>
@@ -37,7 +37,7 @@
 		<property name="cacheProducers" value="false"/>
 	</bean>
 
-	<jms:listener-container>
+	<jms:listener-container connection-factory="jmsConnectionFactory">
 		<jms:listener destination="queue.test.dynamic.gateway.1" ref="responder" method="one"/>
 		<jms:listener destination="queue.test.dynamic.gateway.2" ref="responder" method="two"/>
 	</jms:listener-container>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsPriorityTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsPriorityTests-context.xml
@@ -21,7 +21,7 @@
 		<int:queue capacity="2"/>
 	</int:channel>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>
@@ -31,7 +31,7 @@
 		<property name="cacheProducers" value="false"/>
 	</bean>
 
-	<jms:listener-container>
+	<jms:listener-container connection-factory="jmsConnectionFactory">
 		<jms:listener destination="queue.test.priority.gateway" ref="priorityReader"/>
 	</jms:listener-container>
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsWithMarshallingMessageConverterTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsWithMarshallingMessageConverterTests-context.xml
@@ -47,7 +47,7 @@
 		<constructor-arg value="reply.queue"/>
 	</bean>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/MessageHistoryTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/MessageHistoryTests-context.xml
@@ -32,7 +32,7 @@
     
     <int:poller id="poller" default="true" fixed-delay="10"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/MessageHistoryTests-gateways.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/MessageHistoryTests-gateways.xml
@@ -32,7 +32,7 @@
 		<int:interval-trigger interval="10"/>
 	</int:poller>
 	
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/MessageHistoryTests-withHeaderMapper.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/MessageHistoryTests-withHeaderMapper.xml
@@ -28,7 +28,7 @@
 	
 	<bean id="headerMapper" class="org.springframework.integration.jms.config.JmsMessageHistoryTests$SampleHeaderMapper"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/gatewayMaintainsReplyChannel.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/gatewayMaintainsReplyChannel.xml
@@ -23,7 +23,7 @@
 	<int:chain input-channel="requests">
 		<int-jms:outbound-gateway request-destination="requestQueueA"
 	                              reply-destination="replyQueueB"
-	                              connection-factory="connectionFactory"
+	                              connection-factory="jmsConnectionFactory"
 	                              receive-timeout="100000"
 	                              reply-timeout="200000"/>
 	</int:chain>
@@ -32,7 +32,7 @@
 		<int-jms:outbound-gateway id="gateway"
 		                          request-destination="requestQueueA"
 	                              reply-destination="replyQueueB"
-	                              connection-factory="connectionFactory"
+	                              connection-factory="jmsConnectionFactory"
 	                              receive-timeout="100000"
 	                              reply-timeout="200000"/>
 	</int:chain>
@@ -41,7 +41,7 @@
 		<int-jms:outbound-gateway id="gateway"
 	                              request-destination="requestQueueA"
 	                              reply-destination="replyQueueB"
-	                              connection-factory="connectionFactory"
+	                              connection-factory="jmsConnectionFactory"
 	                              receive-timeout="100000"
 	                              reply-timeout="200000"/>
 		<int:transformer expression="payload"/>
@@ -52,7 +52,7 @@
 		<int-jms:outbound-gateway id="badChainGateway"
 		                          request-destination="requestQueueA"
 	                              reply-destination="replyQueueB"
-	                              connection-factory="connectionFactory"
+	                              connection-factory="jmsConnectionFactory"
 	                              receive-timeout="100000"
 	                              reply-channel="badOutputChannel"
 	                              reply-timeout="200000"/>
@@ -69,7 +69,7 @@
 	</bean>
 
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/inboundGatewayDefault.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/inboundGatewayDefault.xml
@@ -18,7 +18,7 @@
 					 	 request-destination-name="testDestinationName"
 					 	 request-channel="requestChannel"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/inboundGatewayWithDurableSubscription.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/inboundGatewayWithDurableSubscription.xml
@@ -24,7 +24,7 @@
 						 subscription-shared="true"
 						 client-id="testClientId" />
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/inboundGatewayWithMessageSelector.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/inboundGatewayWithMessageSelector.xml
@@ -19,7 +19,7 @@
 					 	 request-channel="requestChannel"
 					 	 selector="TestProperty = 'foo'"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/inboundGatewayWithReplyQos.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/inboundGatewayWithReplyQos.xml
@@ -22,7 +22,7 @@
 					 	 reply-delivery-persistent="false"
 					 	 explicit-qos-enabled-for-replies="true"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewayWithDefaultConnectionFactory.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewayWithDefaultConnectionFactory.xml
@@ -18,7 +18,7 @@
 					 	 request-destination-name="testDestinationName"
 					 	 request-channel="requestChannel"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="message-driven-test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewayWithPubSubDomain.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewayWithPubSubDomain.xml
@@ -20,7 +20,7 @@
 			request-channel="output"
 			auto-startup="false"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewayWithReplyChannel.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewayWithReplyChannel.xml
@@ -29,7 +29,7 @@
 	<bean id="testReplyDestination" class="org.apache.activemq.command.ActiveMQQueue">
 		<constructor-arg value="testReplyDestination"/>
 	</bean>
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewaysWithExtractPayloadAttributes.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsGatewaysWithExtractPayloadAttributes.xml
@@ -44,7 +44,7 @@
 	                     extract-request-payload="false"
 	                     auto-startup="false"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test-message"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithDestinationAndDefaultConnectionFactory.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithDestinationAndDefaultConnectionFactory.xml
@@ -18,7 +18,7 @@
 
 	<bean id="testDestination" class="org.springframework.integration.jms.StubDestination"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="polling-test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithDestinationNameAndDefaultConnectionFactory.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithDestinationNameAndDefaultConnectionFactory.xml
@@ -16,7 +16,7 @@
 		<integration:queue capacity="1"/>
 	</integration:channel>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="polling-test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithDurableSubscription.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithDurableSubscription.xml
@@ -24,7 +24,7 @@
 			client-id="testClientId"
 			channel="output"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithHeaderMapper.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithHeaderMapper.xml
@@ -19,11 +19,11 @@
 	<bean id="mapper" class="org.springframework.integration.jms.config.TestJmsHeaderMapper"/>
 
 	<bean id="jmsTemplate" class="org.springframework.jms.core.JmsTemplate">
-		<property name="connectionFactory" ref="connectionFactory"/>
+		<property name="connectionFactory" ref="jmsConnectionFactory"/>
 		<property name="defaultDestinationName" value="test"/>
 	</bean>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="polling-test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithJmsTemplate.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithJmsTemplate.xml
@@ -25,11 +25,11 @@
 	</integration:channel>
 
 	<bean id="jmsTemplate" class="org.springframework.jms.core.JmsTemplate">
-		<property name="connectionFactory" ref="connectionFactory"/>
+		<property name="connectionFactory" ref="jmsConnectionFactory"/>
 		<property name="defaultDestinationName" value="test"/>
 	</bean>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="polling-test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithMessageConverter.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithMessageConverter.xml
@@ -22,7 +22,7 @@
 		<integration:queue capacity="1"/>
 	</integration:channel>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithMessageSelector.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithMessageSelector.xml
@@ -34,7 +34,7 @@
 
 	<bean id="testDestination" class="org.springframework.integration.jms.StubDestination"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithPubSubDomain.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithPubSubDomain.xml
@@ -22,7 +22,7 @@
 			channel="output"/>
 	 <!-- adding a sub name should not make it durable INT-3680 -->
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithReceiveTimeout.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsInboundWithReceiveTimeout.xml
@@ -16,7 +16,7 @@
 		<integration:queue capacity="1"/>
 	</integration:channel>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayReplyDestOptions-fail.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayReplyDestOptions-fail.xml
@@ -18,7 +18,7 @@
 	                      reply-destination="replyQueue"
 	                      reply-destination-expression="'foo'"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test-message"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayReplyDestOptions.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayReplyDestOptions.xml
@@ -32,7 +32,7 @@
 	                      request-channel="requestChannel"
 	                      reply-destination-expression="@replyQueue"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test-message"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithConverter.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithConverter.xml
@@ -21,7 +21,7 @@
 		<si:poller fixed-delay="1000"/>
 	</jms:outbound-gateway>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test-message"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithDeliveryPersistent.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithDeliveryPersistent.xml
@@ -49,7 +49,7 @@
 
 	<task:executor id="exec" />
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="message-driven-test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithOrder.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithOrder.xml
@@ -17,7 +17,7 @@
 	                      request-channel="requestChannel"
 	                      order="99" requires-reply="true"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test-message"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithPubSubSettings.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundGatewayWithPubSubSettings.xml
@@ -24,7 +24,7 @@
 	                      reply-pub-sub-domain="true"
 	                      request-channel="requestChannel"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="test-message"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundWithDefaultConnectionFactory.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundWithDefaultConnectionFactory.xml
@@ -15,7 +15,7 @@
 	<jms:outbound-channel-adapter id="adapter"
 			channel="input" destination="testDestination"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="target-test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundWithHeaderMapper.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundWithHeaderMapper.xml
@@ -19,7 +19,7 @@
 
 	<bean id="mapper" class="org.springframework.integration.jms.config.TestJmsHeaderMapper"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="target-test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundWithMessageConverter.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundWithMessageConverter.xml
@@ -19,7 +19,7 @@
 
 	<bean id="converter" class="org.springframework.integration.jms.config.TestMessageConverter"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="target-test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundWithOrder.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundWithOrder.xml
@@ -15,7 +15,7 @@
 	<jms:outbound-channel-adapter id="adapter"
 			channel="input" destination="testDestination" order="123"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="target-test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundWithQos.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundWithQos.xml
@@ -19,7 +19,7 @@
 	<jms:outbound-channel-adapter id="defaultAdapter"
 			channel="input" destination="testDestination"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
 		<constructor-arg>
 			<bean class="org.springframework.integration.jms.StubConnection">
 				<constructor-arg value="target-test"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/GatewaySerializedReplyChannelTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/GatewaySerializedReplyChannelTests-context.xml
@@ -7,7 +7,7 @@
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/integration/jms http://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd">
 
-	<bean id="connectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
 		<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>
 	</bean>
 
@@ -18,12 +18,12 @@
 	</int:channel>
 
 	<int-jms:outbound-gateway request-channel="input" reply-channel="output"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="serialized.reply.channel" />
 
 	<int-jms:inbound-gateway request-channel="foo" reply-channel="baz"
 		request-destination-name="serialized.reply.channel"
-		connection-factory="connectionFactory"/>
+		connection-factory="jmsConnectionFactory"/>
 
 	<int:header-enricher input-channel="foo" output-channel="bar">
 		<int:header-channels-to-string />

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCachedConsumersTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCachedConsumersTests.java
@@ -216,7 +216,7 @@ public class RequestReplyScenariosWithCachedConsumersTests extends ActiveMQMulti
 		try {
 			RequestReplyExchanger gateway =
 					context.getBean("correlationPropagatingConsumerWithOptimizationDelayFirstReply", RequestReplyExchanger.class);
-			final ConnectionFactory connectionFactory = context.getBean("connectionFactory", ConnectionFactory.class);
+			final ConnectionFactory connectionFactory = context.getBean("jmsConnectionFactory", ConnectionFactory.class);
 
 			final Destination requestDestination = context.getBean("siOutQueueE", Destination.class);
 			final Destination replyDestination = context.getBean("siInQueueE", Destination.class);

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/StopStartTests-context.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/StopStartTests-context.xml
@@ -12,7 +12,7 @@
 	<int-jms:outbound-gateway id="out"
 			auto-startup="false"
 			request-channel="test"
-			connection-factory="connectionFactory"
+			connection-factory="jmsConnectionFactory"
 			request-destination-name="testout"
 			correlation-key="JMSCorrelationID"
 			reply-destination-name="testreply">
@@ -20,13 +20,13 @@
 	</int-jms:outbound-gateway>
 
 	<int-jms:inbound-gateway
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-channel="upcase"
 		request-destination-name="testout"/>
 
 	<int:transformer input-channel="upcase" expression="payload.toUpperCase()" />
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/broken-broker.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/broken-broker.xml
@@ -12,14 +12,14 @@
 	<int:gateway id="brkenBrokerGateway" default-request-channel="outGatewayInChannel"/>
 
 	<int-jms:outbound-gateway id="jog" request-channel="outGatewayInChannel"
-	    connection-factory="connectionFactory"
+	    connection-factory="jmsConnectionFactory"
 		request-destination-name="brokenBrokerRequestQueue"
 		correlation-key="JMSCorrelationID"
 		receive-timeout="1000"/>
 
 	<int-jms:inbound-gateway request-channel="jmsInChannel"
 						     request-destination-name="brokenBrokerRequestQueue"
-							 connection-factory="connectionFactory"
+							 connection-factory="jmsConnectionFactory"
 							 concurrent-consumers="10"
 							 reply-timeout="10000"/>
 
@@ -29,7 +29,7 @@
 
 	<int:service-activator input-channel="jmsInChannel" expression="payload"/>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="tcp://localhost:61623"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/explicit-correlation-key.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/explicit-correlation-key.xml
@@ -9,7 +9,7 @@
 	<int:gateway id="explicitCorrelationKeyGateway" default-request-channel="explicitCorrelationIn"/>
 
 	<int-jms:outbound-gateway request-channel="explicitCorrelationIn"
-	    connection-factory="connectionFactory"
+	    connection-factory="jmsConnectionFactory"
 		request-destination="explicitCorrelationJmsOut"
 		correlation-key="bar"/>
 
@@ -20,7 +20,7 @@
 	<int-jms:inbound-gateway request-channel="requestIn"
 	    request-destination="explicitCorrelationJmsOut"
 	    correlation-key="bar"
-		connection-factory="connectionFactory"/>
+		connection-factory="jmsConnectionFactory"/>
 
 	<int:transformer input-channel="requestIn" expression="payload"/>
 
@@ -29,7 +29,7 @@
 	<int:gateway id="explicitCorrelationKeyGatewayB" default-request-channel="explicitCorrelationInB"/>
 
 	<int-jms:outbound-gateway request-channel="explicitCorrelationInB"
-	    connection-factory="connectionFactory"
+	    connection-factory="jmsConnectionFactory"
 		request-destination="explicitCorrelationJmsOutB"
 		correlation-key="JMSCorrelationID"/>
 
@@ -40,7 +40,7 @@
 	<int-jms:inbound-gateway request-channel="requestInB"
 							 request-destination="explicitCorrelationJmsOutB"
 							 correlation-key="JMSCorrelationID"
-							 connection-factory="connectionFactory"/>
+							 connection-factory="jmsConnectionFactory"/>
 
 	<int:transformer input-channel="requestInB" expression="payload"/>
 
@@ -49,7 +49,7 @@
 	<int:gateway id="existingCorrelationKeyGatewayB" default-request-channel="existingCorrelationInB"/>
 
 	<int-jms:outbound-gateway request-channel="existingCorrelationInB"
-	    connection-factory="connectionFactory"
+	    connection-factory="jmsConnectionFactory"
 		request-destination="existingCorrelationJmsOutB"
 		correlation-key="JMSCorrelationID*"/>
 
@@ -60,7 +60,7 @@
 	<int-jms:inbound-gateway request-channel="requestExistingCorrelationInB"
 							 request-destination="existingCorrelationJmsOutB"
 							 correlation-key="JMSCorrelationID"
-							 connection-factory="connectionFactory"/>
+							 connection-factory="jmsConnectionFactory"/>
 
 	<int:chain input-channel="requestExistingCorrelationInB" >
 		<int:header-enricher>
@@ -74,7 +74,7 @@
 	<int:gateway id="explicitCorrelationKeyGatewayC" default-request-channel="explicitCorrelationInC"/>
 
 	<int-jms:outbound-gateway id="outGateway" request-channel="explicitCorrelationInC"
-	    connection-factory="connectionFactory"
+	    connection-factory="jmsConnectionFactory"
 		request-destination="explicitCorrelationJmsOutC"
 		reply-destination-name="explicitCorrelationJmsInC"
 		correlation-key="foo"
@@ -87,13 +87,13 @@
 	<int-jms:inbound-gateway id="inGateway" request-channel="requestInC"
 	    request-destination="explicitCorrelationJmsOutC"
 	    correlation-key="foo"
-		connection-factory="connectionFactory"/>
+		connection-factory="jmsConnectionFactory"/>
 
 	<int:transformer input-channel="requestInC">
 		<bean class="org.springframework.integration.jms.request_reply.RequestReplyScenariosWithCorrelationKeyProvidedTests.DelayedService"/>
 	</int:transformer>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/honor-timeout.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/honor-timeout.xml
@@ -10,13 +10,13 @@
 	<int:gateway default-request-channel="in" default-request-timeout="20000" default-reply-timeout="20000"/>
 
 	<int-jms:outbound-gateway request-channel="in"
-	    connection-factory="connectionFactory"
+	    connection-factory="jmsConnectionFactory"
 		request-destination-name="honorTimeoutQueue"
 		receive-timeout="15000"/>
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="honorTimeoutQueue"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="1"
 		reply-timeout="15000"/>
 
@@ -28,7 +28,7 @@
 		<int:transformer expression="payload"/>
 	</int:chain>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/mult-producer-and-consumers-temp-reply.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/mult-producer-and-consumers-temp-reply.xml
@@ -17,13 +17,13 @@
 
 	<int-jms:outbound-gateway request-channel="outGatewayInChannel"
 		receive-timeout="20000"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="multiOutGatewayTempQueue"
 		correlation-key="JMSCorrelationID"/>
 
 	<int-jms:inbound-gateway request-channel="jmsInChannel"
 						     request-destination-name="multiOutGatewayTempQueue"
-							 connection-factory="connectionFactory"
+							 connection-factory="jmsConnectionFactory"
 							 concurrent-consumers="10"
 							 reply-timeout="20000"/>
 
@@ -35,7 +35,7 @@
 		<bean class="org.springframework.integration.jms.request_reply.RequestReplyScenariosWithTempReplyQueuesTests.MyRandomlySlowService"/>
 	</int:service-activator>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-01.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-01.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline01" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		receive-timeout="10000"
 		request-destination-name="pipeline01-queue-01">
 		<int-jms:reply-listener />
@@ -18,7 +18,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="pipeline01-queue-01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -31,7 +31,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		receive-timeout="10000"
 		request-destination-name="pipeline01-queue-02">
 		<int-jms:reply-listener />
@@ -39,13 +39,13 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="pipeline01-queue-02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-02.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-02.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline02" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="pipeline02-queue-01"
 		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
@@ -19,7 +19,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="pipeline02-queue-01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -32,7 +32,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		receive-timeout="10000"
 		request-destination-name="pipeline02-queue-02">
 		<int-jms:reply-listener />
@@ -40,13 +40,13 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="pipeline02-queue-02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-03.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-03.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline03" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline03"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="pipeline03-queue-01"
 		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
@@ -19,7 +19,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="pipeline03-queue-01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -32,7 +32,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="pipeline03-queue-02"
 		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
@@ -41,13 +41,13 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="pipeline03-queue-02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-04.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-04.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline04" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline04"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		receive-timeout="10000"
 		request-destination-name="pipeline04-queue-01">
 		<int-jms:reply-listener />
@@ -18,7 +18,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="pipeline04-queue-01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -31,7 +31,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="pipeline04-queue-02"
 		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
@@ -40,13 +40,13 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="pipeline04-queue-02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-05.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-05.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline05" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline05"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="pipeline05-queue-01"
 		receive-timeout="10000"
 		correlation-key="foo">
@@ -19,7 +19,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="pipeline05-queue-01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="foo"/>
@@ -33,7 +33,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		receive-timeout="10000"
 		request-destination-name="pipeline05-queue-02">
 		<int-jms:reply-listener />
@@ -41,13 +41,13 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="pipeline05-queue-02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-06.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-06.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline06" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline06"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		receive-timeout="10000"
 		request-destination-name="pipeline06-queue-01">
 		<int-jms:reply-listener />
@@ -18,7 +18,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="pipeline06-queue-01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -31,7 +31,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="pipeline06-queue-02"
 		receive-timeout="10000"
 		correlation-key="foo">
@@ -40,14 +40,14 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="pipeline06-queue-02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="foo"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-07.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-07.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline07" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline07"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="pipeline07-queue-01"
 		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
@@ -19,7 +19,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="pipeline07-queue-01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -32,7 +32,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="pipeline07-queue-02"
 		receive-timeout="10000"
 		correlation-key="foo">
@@ -41,14 +41,14 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="pipeline07-queue-02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="foo"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-08.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-08.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline08" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline08"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="pipeline08-queue-01"
 		receive-timeout="10000"
 		correlation-key="foo">
@@ -19,7 +19,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="pipeline08-queue-01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="foo"/>
@@ -33,7 +33,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="pipeline08-queue-02"
 		receive-timeout="10000"
 		correlation-key="JMSCorrelationID">
@@ -42,13 +42,13 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="pipeline08-queue-02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-09.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-09.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline09" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline09"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="pipeline09-queue-01"
 		receive-timeout="10000"
 		correlation-key="foo">
@@ -19,7 +19,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="pipeline09-queue-01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="foo"/>
@@ -33,7 +33,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="pipeline09-queue-02"
 		receive-timeout="10000"
 		correlation-key="bar">
@@ -42,14 +42,14 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="pipeline09-queue-02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="bar"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-01.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-01.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline01" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline01-01"
 		receive-timeout="10000"
 		request-destination-name="siOutQueue01-01">
@@ -19,7 +19,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="siOutQueue01-01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -32,20 +32,20 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination-name="anotherGatewayQueue01-01">
 		<int-jms:reply-listener />
 	</int-jms:outbound-gateway>
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="anotherGatewayQueue01-01"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline02" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline02-01"
 		correlation-key="corr02"
 		receive-timeout="10000"
@@ -21,7 +21,7 @@
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="siOutQueue02"
 		correlation-key="corr02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -34,7 +34,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline02-02"
 		correlation-key="corr02"
 		receive-timeout="10000"
@@ -45,14 +45,14 @@
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="anotherGatewayQueue02"
 		correlation-key="corr02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload" output-channel="toThird" />
 
 	<int-jms:outbound-gateway request-channel="toThird"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline02-03"
 		receive-timeout="10000"
 		request-destination-name="thirdGatewayQueue02">
@@ -61,13 +61,13 @@
 
 	<int-jms:inbound-gateway request-channel="thirdIn"
 		request-destination-name="thirdGatewayQueue02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:bridge input-channel="thirdIn" />
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02a.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-02a.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline02" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline02"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline02a-01"
 		correlation-key="corr02a"
 		receive-timeout="10000"
@@ -21,7 +21,7 @@
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="siOutQueue02a"
 		correlation-key="corr02a"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -34,7 +34,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline02a-01"
 		correlation-key="corr02a"
 		receive-timeout="10000"
@@ -45,14 +45,14 @@
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="anotherGatewayQueue02a"
 		correlation-key="corr02a"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload" output-channel="toThird" />
 
 	<int-jms:outbound-gateway request-channel="toThird"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline02a-01"
 		correlation-key="corr02a"
 		receive-timeout="10000"
@@ -63,13 +63,13 @@
 	<int-jms:inbound-gateway request-channel="thirdIn"
 		request-destination-name="thirdGatewayQueue02a"
 		correlation-key="corr02a"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:bridge input-channel="thirdIn" />
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline03" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline03"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline03-01"
 		correlation-key="JMSCorrelationID"
 		receive-timeout="10000"
@@ -20,7 +20,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="siOutQueue03"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -33,7 +33,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline03-02"
 		correlation-key="corr03"
 		receive-timeout="10000"
@@ -44,14 +44,14 @@
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="anotherGatewayQueue03"
 		correlation-key="corr03"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload" output-channel="toThird" />
 
 	<int-jms:outbound-gateway request-channel="toThird"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline03-03"
 		correlation-key="corr03"
 		receive-timeout="10000"
@@ -62,13 +62,13 @@
 	<int-jms:inbound-gateway request-channel="thirdIn"
 		request-destination-name="thirdGatewayQueue03"
 		correlation-key="corr03"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:bridge input-channel="thirdIn" />
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03a.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-03a.xml
@@ -11,7 +11,7 @@
 
 	<int-jms:outbound-gateway request-channel="pipeline03"
 		reply-channel="reply1"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline03a-01"
 		correlation-key="JMSCorrelationID"
 		receive-timeout="30000"
@@ -28,7 +28,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="siOutQueue03a"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -43,7 +43,7 @@
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
 		reply-channel="reply2"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline03a-01"
 		correlation-key="corr03a"
 		receive-timeout="30000"
@@ -59,7 +59,7 @@
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="anotherGatewayQueue03a"
 		correlation-key="corr03a"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -71,7 +71,7 @@
 	<int-jms:outbound-gateway request-channel="toThird"
 		reply-channel="add10kOnTheWayBack"
 		correlation-key="corr03a"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline03a-01"
 		receive-timeout="30000"
 		request-destination-name="thirdGatewayQueue03a">
@@ -86,7 +86,7 @@
 	<int-jms:inbound-gateway request-channel="thirdIn"
 		request-destination-name="thirdGatewayQueue03a"
 		correlation-key="corr03a"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -95,7 +95,7 @@
 		<int:service-activator ref="capture" />
 	</int:chain>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-04.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-04.xml
@@ -11,7 +11,7 @@
 
 	<int-jms:outbound-gateway request-channel="pipeline04"
 		reply-channel="reply1"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline04-01"
 		correlation-key="foo"
 		receive-timeout="30000"
@@ -28,7 +28,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="siOutQueue04"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		correlation-key="foo"
 		reply-timeout="10000"/>
@@ -44,7 +44,7 @@
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
 		reply-channel="reply2"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline04-02"
 		receive-timeout="30000"
 		request-destination-name="anotherGatewayQueue04">
@@ -58,7 +58,7 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="anotherGatewayQueue04"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
@@ -67,7 +67,7 @@
 		<int:service-activator ref="capture" />
 	</int:chain>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-05.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-05.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline05" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline05"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline05-01"
 		correlation-key="foo"
 		receive-timeout="10000"
@@ -20,7 +20,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="siOutQueue05"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		correlation-key="foo"
 		reply-timeout="10000"/>
@@ -34,7 +34,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline05-02"
 		request-destination-name="anotherGatewayQueue05"
 		receive-timeout="10000"
@@ -44,13 +44,13 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="anotherGatewayQueue05"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-06.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-06.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline06" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline06"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline06-01"
 		correlation-key="JMSCorrelationID"
 		receive-timeout="10000"
@@ -20,7 +20,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="siOutQueue06"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		correlation-key="JMSCorrelationID"
 		reply-timeout="10000"/>
@@ -34,7 +34,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline06-02"
 		request-destination-name="anotherGatewayQueue06"
 		receive-timeout="10000"
@@ -44,14 +44,14 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="anotherGatewayQueue06"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="foo"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-07.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/pipeline-named-queue-07.xml
@@ -10,7 +10,7 @@
 	<int:gateway default-request-channel="pipeline07" default-request-timeout="10000" default-reply-timeout="10000"/>
 
 	<int-jms:outbound-gateway request-channel="pipeline07"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline07-01"
 		correlation-key="foo"
 		receive-timeout="10000"
@@ -20,7 +20,7 @@
 
 	<int-jms:inbound-gateway request-channel="jmsIn"
 		request-destination-name="siOutQueue07"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		correlation-key="foo"
 		reply-timeout="10000"/>
@@ -34,7 +34,7 @@
 	</int:chain>
 
 	<int-jms:outbound-gateway request-channel="anotherGatewayChannel"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		reply-destination-name="pipeline07-02"
 		request-destination-name="anotherGatewayQueue07"
 		receive-timeout="10000"
@@ -44,14 +44,14 @@
 
 	<int-jms:inbound-gateway request-channel="anotherIn"
 		request-destination-name="anotherGatewayQueue07"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		concurrent-consumers="10"
 		reply-timeout="10000"
 		correlation-key="bar"/>
 
 	<int:transformer input-channel="anotherIn" expression="payload"/>
 
-	<bean id="connectionFactory"
+	<bean id="jmsConnectionFactory"
 		class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-cached-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-cached-consumers.xml
@@ -9,7 +9,7 @@
 	<int:gateway id="standardMessageIdCopyingConsumerWithOptimization" default-request-channel="jmsInOptimizedA"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInOptimizedA"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination="siOutQueueOptimizedA"
 		reply-destination="siInQueueOptimizedA"
 		receive-timeout="10000"
@@ -31,7 +31,7 @@
 	<int:gateway id="standardMessageIdCopyingConsumerWithoutOptimization" default-request-channel="jmsInNonOptimizedB"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedB"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination="siOutQueueNonOptimizedB"
 		receive-timeout="10000"
 		reply-destination="siInQueueNonOptimizedB">
@@ -51,7 +51,7 @@
 	<int:gateway id="correlationPropagatingConsumerWithOptimization" default-request-channel="jmsInOptimizedC"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInOptimizedC"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination="siOutQueueOptimizedC"
 		reply-destination="siInQueueOptimizedC"
 		correlation-key="JMSCorrelationID">
@@ -71,7 +71,7 @@
 	<int:gateway id="correlationPropagatingConsumerWithoutOptimization" default-request-channel="jmsInNonOptimizedD"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedD"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination="siOutQueueNonOptimizedD"
 		reply-destination="siInQueueNonOptimizedD">
 		<int-jms:reply-listener />
@@ -90,7 +90,7 @@
 	<int:gateway id="correlationPropagatingConsumerWithOptimizationDelayFirstReply" default-request-channel="jmsInE"/>
 
 	<int-jms:outbound-gateway id="fastGateway" request-channel="jmsInE"
-	    connection-factory="connectionFactory"
+	    connection-factory="jmsConnectionFactory"
 		request-destination="siOutQueueE"
 		reply-destination="siInQueueE"
 		receive-timeout="500"
@@ -106,7 +106,7 @@
 		<constructor-arg value="siInQueueE"/>
 	</bean>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false" />

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-no-cached-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-no-cached-consumers.xml
@@ -9,7 +9,7 @@
 	<int:gateway id="optimized" default-request-channel="jmsInOptimized"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInOptimized"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination="siOutQueueA"
 		reply-destination="siInQueueA"
 		receive-timeout="10000"
@@ -30,7 +30,7 @@
 	<int:gateway id="nonoptimized" default-request-channel="jmsInNonOptimized"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInNonOptimized"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		receive-timeout="10000"
 		request-destination="siOutQueueB"
 		reply-destination="siInQueueB">
@@ -50,7 +50,7 @@
 	<int:gateway id="optimizedMessageId" default-request-channel="jmsInOptimizedC"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInOptimizedC"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination="siOutQueueC"
 		receive-timeout="10000"
 		reply-destination="siInQueueC"
@@ -71,7 +71,7 @@
 	<int:gateway id="nonoptimizedMessageId" default-request-channel="jmsInNonOptimizedD"/>
 
 	<int-jms:outbound-gateway request-channel="jmsInNonOptimizedD"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		request-destination="siOutQueueD"
 		receive-timeout="10000"
 		reply-destination="siInQueueD">
@@ -86,7 +86,7 @@
 		<constructor-arg value="siInQueueD.not.cached"/>
 	</bean>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-temp-reply-consumers.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/producer-temp-reply-consumers.xml
@@ -9,7 +9,7 @@
 	<int:gateway default-request-channel="jmsIn"/>
 
 	<int-jms:outbound-gateway request-channel="jmsIn"
-		connection-factory="connectionFactory"
+		connection-factory="jmsConnectionFactory"
 		receive-timeout="10000"
 		request-destination="siOutQueue">
 		<int-jms:reply-listener />
@@ -19,7 +19,7 @@
 		<constructor-arg value="siOutQueueA"/>
 	</bean>
 
-	<bean id="connectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+	<bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
 		<property name="targetConnectionFactory">
 			<bean class="org.apache.activemq.ActiveMQConnectionFactory">
 				<property name="brokerURL" value="vm://localhost?broker.persistent=false"/>

--- a/src/reference/asciidoc/jms.adoc
+++ b/src/reference/asciidoc/jms.adoc
@@ -37,7 +37,7 @@ That means that it invokes `receive()` when triggered.
 This should only be used in situations where polling is done relatively infrequently and timeliness is not important.
 For all other situations (a vast majority of JMS-based use-cases), the _message-driven-channel-adapter_ described below is a better option.
 
-NOTE: All of the JMS adapters that require a reference to the `ConnectionFactory` will automatically look for a bean named "connectionFactory" by default.
+NOTE: All of the JMS adapters that require a reference to the `ConnectionFactory` will automatically look for a bean named `jmsConnectionFactory` by default.
 That is why you don't see a "connection-factory" attribute in many of the examples.
 However, if your JMS `ConnectionFactory` has a different bean name, then you will need to provide that attribute.
 
@@ -135,7 +135,7 @@ If no 'error-channel' is defined, the exception is thrown back to the container,
 === Outbound Channel Adapter
 
 The `JmsSendingMessageHandler` implements the `MessageHandler` interface and is capable of converting Spring Integration `Messages` to JMS messages and then sending to a JMS destination.
-It requires either a 'jmsTemplate' reference or both 'connectionFactory' and 'destination' references (again, the 'destinationName' may be provided in place of the 'destination').
+It requires either a `jmsTemplate` reference or both `jmsConnectionFactory` and `destination` references (again, the `destinationName` may be provided in place of the `destination`).
 As with the inbound Channel Adapter, the easiest way to configure this adapter is with the namespace support.
 The following configuration will produce an adapter that receives Spring Integration Messages from the "exampleChannel" and then converts those into JMS Messages and sends them to the JMS Destination reference whose bean name is "outQueue".
 [source,xml]
@@ -450,7 +450,7 @@ If either of these conditions are not met, `async` is ignored.
 </int-jms:outbound-gateway>
 ----
 
-<1> Reference to a `javax.jms.ConnectionFactory`; default `connectionFactory`.
+<1> Reference to a `javax.jms.ConnectionFactory`; default `jmsConnectionFactory`.
 
 
 <2> The name of a property that will contain correlation data to correlate responses with replies.
@@ -663,7 +663,7 @@ For either type of JMS-backed channel, the name of the destination may be provid
 ----
 
 In the examples above, the Destination names would be resolved by Spring's default `DynamicDestinationResolver` implementation, but any implementation of the `DestinationResolver` interface could be provided.
-Also, the JMS `ConnectionFactory` is a required property of the channel, but by default the expected bean name would be "connectionFactory".
+Also, the JMS `ConnectionFactory` is a required property of the channel, but by default the expected bean name would be `jmsConnectionFactory`.
 The example below provides both a custom instance for resolution of the JMS Destination names and a different name for the ConnectionFactory.
 [source,xml]
 ----

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -17,10 +17,7 @@ development process.
 
 ==== JMS Changes
 
-Previously, Spring Integration used a default bean name `connectionFactory` for the JMS Connection Factory, allowing the property to be omitted from component definitions.
-
-Spring Boot auto-configures a bean name `jmsConnectionFactory`.
-
-Since it is common to use Spring Integration XML configuration with Spring Boot, it was decided that it would be useful to align the two so that an SI app can use the auto configured bean.
+Previously, Spring Integration JMS XML configuration used a default bean name `connectionFactory` for the JMS Connection Factory, allowing the property to be omitted from component definitions.
+Now it has been renamed to the `jmsConnectionFactory` value, which is used by Spring Boot to auto-configure JMS Connection Factory bean.
 
 If your application is relying on the previous behavior, rename your `connectionFactory` bean to `jmsConnectionFactory`, or specifically configure your components to use your bean using its current name.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -14,3 +14,13 @@ development process.
 === General Changes
 
 ==== Core Changes
+
+==== JMS Changes
+
+Previously, Spring Integration used a default bean name `connectionFactory` for the JMS Connection Factory, allowing the property to be omitted from component definitions.
+
+Spring Boot auto-configures a bean name `jmsConnectionFactory`.
+
+Since it is common to use Spring Integration XML configuration with Spring Boot, it was decided that it would be useful to align the two so that an SI app can use the auto configured bean.
+
+If your application is relying on the previous behavior, rename your `connectionFactory` bean to `jmsConnectionFactory`, or specifically configure your components to use your bean using its current name.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -18,6 +18,6 @@ development process.
 ==== JMS Changes
 
 Previously, Spring Integration JMS XML configuration used a default bean name `connectionFactory` for the JMS Connection Factory, allowing the property to be omitted from component definitions.
-Now it has been renamed to the `jmsConnectionFactory` value, which is used by Spring Boot to auto-configure JMS Connection Factory bean.
+It has now been renamed to `jmsConnectionFactory`, which is the bean name used by Spring Boot to auto-configure the JMS Connection Factory bean.
 
 If your application is relying on the previous behavior, rename your `connectionFactory` bean to `jmsConnectionFactory`, or specifically configure your components to use your bean using its current name.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3941

Previously, like the SF `<jms:/>` namespace, Spring Integration used a default bean
name `connectionFactory` for the JMS Connection Factory.

Spring Boot auto-configures a bean name `jmsConnectionFactory`.

Since it is still common to use Spring Integration XML configuration with Spring Boot,
it is useful to align the two so that an SI app can use the auto configured bean.
