### PR TITLE
INT-4102: autoStartup = false for JMS container

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsMessageDrivenEndpoint.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsMessageDrivenEndpoint.java
@@ -31,6 +31,7 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class JmsMessageDrivenEndpoint extends AbstractEndpoint implements DisposableBean, OrderlyShutdownCapable {
 
@@ -72,6 +73,7 @@ public class JmsMessageDrivenEndpoint extends AbstractEndpoint implements Dispos
 		listenerContainer.setMessageListener(listener);
 		this.listener = listener;
 		this.listenerContainer = listenerContainer;
+		this.listenerContainer.setAutoStartup(false);
 		setPhase(Integer.MAX_VALUE / 2);
 		this.externalContainer = externalContainer;
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsInboundGatewayParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsInboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.jms.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -322,6 +323,10 @@ public class JmsInboundGatewayParserTests {
 				"inboundGatewayWithContainerReference.xml", this.getClass());
 		JmsMessageDrivenEndpoint gateway =
 				context.getBean("gatewayWithContainerReference", JmsMessageDrivenEndpoint.class);
+		AbstractMessageListenerContainer messageListenerContainer = context.getBean("messageListenerContainer",
+				AbstractMessageListenerContainer.class);
+		assertFalse(gateway.isRunning());
+		assertFalse(messageListenerContainer.isRunning());
 		SmartLifecycleRoleController roleController = context.getBean(SmartLifecycleRoleController.class);
 		@SuppressWarnings("unchecked")
 		MultiValueMap<String, SmartLifecycle> lifecycles =
@@ -331,7 +336,9 @@ public class JmsInboundGatewayParserTests {
 		gateway.start();
 		AbstractMessageListenerContainer container = (AbstractMessageListenerContainer)
 				new DirectFieldAccessor(gateway).getPropertyValue("listenerContainer");
-		assertEquals(context.getBean("messageListenerContainer"), container);
+		assertEquals(messageListenerContainer, container);
+		assertTrue(gateway.isRunning());
+		assertTrue(messageListenerContainer.isRunning());
 		gateway.stop();
 		context.close();
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/inboundGatewayWithContainerReference.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/inboundGatewayWithContainerReference.xml
@@ -31,7 +31,6 @@
 	<bean id="messageListenerContainer" class="org.springframework.jms.listener.DefaultMessageListenerContainer">
 		<property name="connectionFactory" ref="testConnectionFactory"/>
 		<property name="destinationName" value="testDestination"/>
-		<property name="autoStartup" value="false"/>
 	</bean>
 
 </beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4102

There is inconsistency when we mark `JmsMessageDrivenEndpoint` for `autoStartup = false`,
but external container can still be started by the application context, because of it own default `autoStartup = true`.
- Mark `container` `autoStartup = false` in the `JmsMessageDrivenEndpoint` ctor to align lifecycles.

**Cherry-pick to 4.3.x**
