### PR TITLE
INT-4096: Allow to configure `readOnly` headers

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/IntegrationMessageHeaderAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/IntegrationMessageHeaderAccessor.java
@@ -17,12 +17,17 @@
 package org.springframework.integration;
 
 import java.io.Closeable;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  *
@@ -53,8 +58,25 @@ public class IntegrationMessageHeaderAccessor extends MessageHeaderAccessor {
 
 	public static final String CLOSEABLE_RESOURCE = "closableResource";
 
+	private Set<String> readOnlyHeaders = new HashSet<String>();
+
 	public IntegrationMessageHeaderAccessor(Message<?> message) {
 		super(message);
+	}
+
+	/**
+	 * Specify a list of headers which should be considered as a read only
+	 * and prohibited from the population to the message.
+	 * @param readOnlyHeaders the list of headers for {@code readOnly} mode.
+	 * Defaults to {@link MessageHeaders#ID} and {@link MessageHeaders#TIMESTAMP}.
+	 * @since 4.3.2
+	 * @see #isReadOnly(String)
+	 */
+	public void setReadOnlyHeaders(String... readOnlyHeaders) {
+		Assert.noNullElements(readOnlyHeaders, "'readOnlyHeaders' must not be contain null items.");
+		if (!ObjectUtils.isEmpty(readOnlyHeaders)) {
+			this.readOnlyHeaders = new HashSet<String>(Arrays.asList(readOnlyHeaders));
+		}
 	}
 
 	public Long getExpirationDate() {
@@ -128,6 +150,11 @@ public class IntegrationMessageHeaderAccessor extends MessageHeaderAccessor {
 						+ "' header value must be an Boolean.");
 			}
 		}
+	}
+
+	@Override
+	protected boolean isReadOnly(String headerName) {
+		return super.isReadOnly(headerName) || this.readOnlyHeaders.contains(headerName);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
@@ -427,7 +427,9 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar, Bean
 		}
 		if (!alreadyRegistered) {
 			BeanDefinitionBuilder mbfBuilder = BeanDefinitionBuilder
-					.genericBeanDefinition(DefaultMessageBuilderFactory.class);
+					.genericBeanDefinition(DefaultMessageBuilderFactory.class)
+					.addPropertyValue("readOnlyHeaders",
+							IntegrationProperties.getExpressionFor(IntegrationProperties.READ_ONLY_HEADERS));
 			registry.registerBeanDefinition(
 					IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME,
 					mbfBuilder.getBeanDefinition());

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationProperties.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationProperties.java
@@ -72,9 +72,15 @@ public final class IntegrationProperties {
 	public static final String REQUIRE_COMPONENT_ANNOTATION = INTEGRATION_PROPERTIES_PREFIX + "messagingAnnotations.require.componentAnnotation";
 
 	/**
-	 * Specifies the value of {@link org.springframework.integration.config.annotation.MessagingAnnotationPostProcessor#requireComponentAnnotation}.
+	 * Specifies the value of {@link org.springframework.integration.gateway.GatewayProxyFactoryBean#convertReceiveMessage}.
 	 */
 	public static final String GATEWAY_CONVERT_RECEIVE_MESSAGE = INTEGRATION_PROPERTIES_PREFIX + "messagingGateway.convertReceiveMessage";
+
+	/**
+	 * Specifies the value of {@link org.springframework.integration.support.DefaultMessageBuilderFactory#readOnlyHeaders}.
+	 */
+	public static final String READ_ONLY_HEADERS = INTEGRATION_PROPERTIES_PREFIX + "readOnly.headers";
+
 
 	private static Properties defaults;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultMessageBuilderFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultMessageBuilderFactory.java
@@ -17,22 +17,39 @@
 package org.springframework.integration.support;
 
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 4.0
  *
  */
 public class DefaultMessageBuilderFactory implements MessageBuilderFactory {
 
+	private String[] readOnlyHeaders;
+
+	/**
+	 * Specify a list of headers which should be considered as a read only
+	 * and prohibited from the population to the message.
+	 * @param readOnlyHeaders the list of headers for {@code readOnly} mode.
+	 * Defaults to {@link MessageHeaders#ID} and {@link MessageHeaders#TIMESTAMP}.
+	 * @since 4.3.2
+	 */
+	public void setReadOnlyHeaders(String... readOnlyHeaders) {
+		this.readOnlyHeaders = readOnlyHeaders;
+	}
+
 	@Override
 	public <T> MessageBuilder<T> fromMessage(Message<T> message) {
-		return MessageBuilder.fromMessage(message);
+		return MessageBuilder.fromMessage(message)
+				.readOnlyHeaders(this.readOnlyHeaders);
 	}
 
 	@Override
 	public <T> MessageBuilder<T> withPayload(T payload) {
-		return MessageBuilder.withPayload(payload);
+		return MessageBuilder.withPayload(payload)
+				.readOnlyHeaders(this.readOnlyHeaders);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MessageBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MessageBuilder.java
@@ -274,6 +274,13 @@ public final class MessageBuilder<T> extends AbstractIntegrationMessageBuilder<T
 		return this;
 	}
 
+	public MessageBuilder<T> readOnlyHeaders(String... readOnlyHeaders) {
+		this.headerAccessor.setReadOnlyHeaders(readOnlyHeaders);
+		return this;
+	}
+
+
+
 	@Override
 	@SuppressWarnings("unchecked")
 	public Message<T> build() {

--- a/spring-integration-core/src/main/resources/META-INF/spring.integration.default.properties
+++ b/spring-integration-core/src/main/resources/META-INF/spring.integration.default.properties
@@ -5,3 +5,5 @@ spring.integration.taskScheduler.poolSize=10
 spring.integration.messagingTemplate.throwExceptionOnLateReply=false
 spring.integration.messagingAnnotations.require.componentAnnotation=false
 spring.integration.messagingGateway.convertReceiveMessage=false
+# Defaults to MessageHeaders.ID and MessageHeaders.TIMESTAMP
+spring.integration.readOnly.headers=

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests-context.xml
@@ -11,7 +11,7 @@
 
 	<object-to-json-transformer id="emptyContentTypeTransformer" input-channel="customObjectMapperInput" content-type=""/>
 
-	<object-to-json-transformer id="overridenContentTypeTransformer" input-channel="customObjectMapperInput" content-type="text/xml"/>
+	<object-to-json-transformer id="overriddenContentTypeTransformer" input-channel="customObjectMapperInput" content-type="text/xml"/>
 
 	<object-to-json-transformer id="customJsonObjectMapperTransformer" input-channel="customJsonObjectMapperInput"
 								object-mapper="customJsonObjectMapper"/>

--- a/spring-integration-core/src/test/resources/META-INF/spring.integration.properties
+++ b/spring-integration-core/src/test/resources/META-INF/spring.integration.properties
@@ -3,3 +3,4 @@
 #spring.integration.channels.maxBroadcastSubscribers=1
 spring.integration.taskScheduler.poolSize=20
 spring.integration.messagingTemplate.throwExceptionOnLateReply=true
+spring.integration.readOnly.headers=contentType

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileInboundTransactionTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileInboundTransactionTests-context.xml
@@ -12,7 +12,8 @@
 	<context:property-placeholder/>
 
 	<int-file:inbound-channel-adapter id="pseudoTx"
-		channel="input" auto-startup="false" directory="${java.io.tmpdir}/si-test1"
+		channel="input" auto-startup="false"
+						directory="#{T (org.springframework.integration.file.FileInboundTransactionTests).tmpDir.root}/si-test1"
 						use-watch-service="true">
 		<int:poller fixed-rate="500">
 			<int:transactional synchronization-factory="syncFactoryA"/>
@@ -32,7 +33,7 @@
 	<int:channel id="txInput" />
 
 	<int-file:inbound-channel-adapter id="realTx" channel="txInput" auto-startup="false"
-							 directory="${java.io.tmpdir}/si-test2">
+							 directory="#{T (org.springframework.integration.file.FileInboundTransactionTests).tmpDir.root}/si-test2">
 		<int:poller fixed-rate="500">
 			<int:transactional transaction-manager="txManager" synchronization-factory="syncFactoryB"/>
 		</int:poller>

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileInboundTransactionTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileInboundTransactionTests.java
@@ -33,7 +33,6 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/OutboundGatewayFunctionTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/OutboundGatewayFunctionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ public class OutboundGatewayFunctionTests extends LogAdjustingTestSupport {
 		assertTrue(latch1.await(10, TimeUnit.SECONDS));
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(connectionFactory);
-		template.setReceiveTimeout(5000);
+		template.setReceiveTimeout(10000);
 		javax.jms.Message request = template.receive(requestQueue1);
 		assertNotNull(request);
 		final javax.jms.Message jmsReply = request;
@@ -166,7 +166,7 @@ public class OutboundGatewayFunctionTests extends LogAdjustingTestSupport {
 		assertTrue(latch1.await(10, TimeUnit.SECONDS));
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(getConnectionFactory());
-		template.setReceiveTimeout(5000);
+		template.setReceiveTimeout(10000);
 		javax.jms.Message request = template.receive(requestQueue2);
 		assertNotNull(request);
 		final javax.jms.Message jmsReply = request;
@@ -220,7 +220,7 @@ public class OutboundGatewayFunctionTests extends LogAdjustingTestSupport {
 		assertTrue(latch1.await(10, TimeUnit.SECONDS));
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(getConnectionFactory());
-		template.setReceiveTimeout(5000);
+		template.setReceiveTimeout(10000);
 		javax.jms.Message request = template.receive(requestQueue3);
 		assertNotNull(request);
 		final javax.jms.Message jmsReply = request;
@@ -272,7 +272,7 @@ public class OutboundGatewayFunctionTests extends LogAdjustingTestSupport {
 		assertTrue(latch1.await(10, TimeUnit.SECONDS));
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(getConnectionFactory());
-		template.setReceiveTimeout(5000);
+		template.setReceiveTimeout(10000);
 		javax.jms.Message request = template.receive(requestQueue4);
 		assertNotNull(request);
 		final javax.jms.Message jmsReply = request;
@@ -326,7 +326,7 @@ public class OutboundGatewayFunctionTests extends LogAdjustingTestSupport {
 		assertTrue(latch1.await(10, TimeUnit.SECONDS));
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(getConnectionFactory());
-		template.setReceiveTimeout(5000);
+		template.setReceiveTimeout(10000);
 		javax.jms.Message request = template.receive(requestQueue5);
 		assertNotNull(request);
 		final javax.jms.Message jmsReply = request;
@@ -378,7 +378,7 @@ public class OutboundGatewayFunctionTests extends LogAdjustingTestSupport {
 		assertTrue(latch1.await(10, TimeUnit.SECONDS));
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(getConnectionFactory());
-		template.setReceiveTimeout(5000);
+		template.setReceiveTimeout(10000);
 		javax.jms.Message request = template.receive(requestQueue6);
 		assertNotNull(request);
 		final javax.jms.Message jmsReply = request;


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4096
- Introduce `spring.integration.readOnly.headers` Integration property
- Introduce `IntegrationMessageHeaderAccessor.setReadOnlyHeaders()` and use it from the overridden `IntegrationMessageHeaderAccessor.isReadOnly()`
- Add `DefaultMessageBuilderFactory.setReadOnlyHeaders()` and delegate the value to the new `MessageBuilder.readOnlyHeaders()`
- Modify `spring.integration.properties` for the `contentType` as a `readOnly` header for testing
- Ensure that provided logic works via an appropriate modification to the `ObjectToJsonTransformerParserTests`
