### PR TITLE
INT-4120: Poller Advice Chain Regression

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
@@ -16,13 +16,11 @@
 
 package org.springframework.integration.endpoint;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 
 import org.aopalliance.aop.Advice;
 
-import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.AopUtils;
@@ -134,17 +132,11 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 	@Override
 	protected void applyReceiveOnlyAdviceChain(Collection<Advice> chain) {
 		if (AopUtils.isAopProxy(this.source)) {
-			Advisor[] advisors = ((Advised) this.source).getAdvisors();
-			Arrays.stream(advisors).forEach(advisor -> {
-				Advice advice = advisor.getAdvice();
-				if (advice != null && this.appliedAdvices.contains(advice)) {
-					((Advised) this.source).removeAdvice(advice);
-				}
-			});
+			this.appliedAdvices.stream().forEach(((Advised) this.source)::removeAdvice);
 			for (Advice advice : chain) {
-				NameMatchMethodPointcutAdvisor sourceAdvice = new NameMatchMethodPointcutAdvisor(advice);
-				sourceAdvice.addMethodName("receive");
-				((Advised) this.source).addAdvice(advice);
+				NameMatchMethodPointcutAdvisor sourceAdvisor = new NameMatchMethodPointcutAdvisor(advice);
+				sourceAdvisor.addMethodName("receive");
+				((Advised) this.source).addAdvisor(sourceAdvisor);
 			}
 		}
 		else {
@@ -160,10 +152,10 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 
 	@Override
 	protected void doStart() {
+		super.doStart();
 		if (this.source instanceof Lifecycle) {
 			((Lifecycle) this.source).start();
 		}
-		super.doStart();
 	}
 
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
@@ -16,10 +16,13 @@
 
 package org.springframework.integration.endpoint;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 
 import org.aopalliance.aop.Advice;
 
+import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.AopUtils;
@@ -50,6 +53,10 @@ import org.springframework.util.Assert;
 public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 		implements TrackableComponent {
 
+	private final MessagingTemplate messagingTemplate = new MessagingTemplate();
+
+	private final Collection<Advice> appliedAdvices = new HashSet<>();
+
 	private volatile MessageSource<?> source;
 
 	private volatile MessageChannel outputChannel;
@@ -57,8 +64,6 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 	private volatile String outputChannelName;
 
 	private volatile boolean shouldTrack;
-
-	private final MessagingTemplate messagingTemplate = new MessagingTemplate();
 
 	/**
 	 * Specify the source to be polled for Messages.
@@ -129,6 +134,13 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 	@Override
 	protected void applyReceiveOnlyAdviceChain(Collection<Advice> chain) {
 		if (AopUtils.isAopProxy(this.source)) {
+			Advisor[] advisors = ((Advised) this.source).getAdvisors();
+			Arrays.stream(advisors).forEach(advisor -> {
+				Advice advice = advisor.getAdvice();
+				if (advice != null && this.appliedAdvices.contains(advice)) {
+					((Advised) this.source).removeAdvice(advice);
+				}
+			});
 			for (Advice advice : chain) {
 				NameMatchMethodPointcutAdvisor sourceAdvice = new NameMatchMethodPointcutAdvisor(advice);
 				sourceAdvice.addMethodName("receive");
@@ -142,6 +154,8 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 			}
 			this.source = (MessageSource<?>) proxyFactory.getProxy(getBeanClassLoader());
 		}
+		this.appliedAdvices.clear();
+		this.appliedAdvices.addAll(chain);
 	}
 
 	@Override

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollerAdviceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollerAdviceTests.java
@@ -63,6 +63,7 @@ import org.springframework.integration.config.ExpressionControlBusFactoryBean;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.scheduling.PollSkipAdvice;
 import org.springframework.integration.scheduling.SimplePollSkipStrategy;
+import org.springframework.integration.test.util.OnlyOnceTrigger;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.util.CompoundTrigger;
 import org.springframework.integration.util.DynamicPeriodicTrigger;
@@ -200,19 +201,8 @@ public class PollerAdviceTests {
 			return null;
 		};
 		adapter.setSource(source);
-		class OnceTrigger implements Trigger {
-
-			private boolean done;
-
-			@Override
-			public Date nextExecutionTime(TriggerContext triggerContext) {
-				Date date = done ? null : new Date(System.currentTimeMillis() + 10);
-				done = true;
-				return date;
-			}
-
-		}
-		adapter.setTrigger(new OnceTrigger());
+		OnlyOnceTrigger trigger = new OnlyOnceTrigger();
+		adapter.setTrigger(trigger);
 		configure(adapter);
 		List<Advice> adviceChain = new ArrayList<Advice>();
 
@@ -249,7 +239,7 @@ public class PollerAdviceTests {
 		assertTrue(latch.get().await(10, TimeUnit.SECONDS));
 		assertThat(callOrder, contains("a", "b", "c", "d")); // advice + advice + source + advice
 		adapter.stop();
-		adapter.setTrigger(new OnceTrigger());
+		trigger.reset();
 		latch.set(new CountDownLatch(4));
 		adapter.start();
 		assertTrue(latch.get().await(10, TimeUnit.SECONDS));
@@ -262,7 +252,7 @@ public class PollerAdviceTests {
 		ProxyFactory pf = new ProxyFactory(source);
 		pf.addAdvice(dummy);
 		adapter.setSource((MessageSource<?>) pf.getProxy());
-		adapter.setTrigger(new OnceTrigger());
+		trigger.reset();
 		latch.set(new CountDownLatch(4));
 		count.set(0);
 		callOrder.clear();
@@ -270,7 +260,7 @@ public class PollerAdviceTests {
 		assertTrue(latch.get().await(10, TimeUnit.SECONDS));
 		assertThat(callOrder, contains("a", "b", "c", "d")); // advice + advice + source + advice
 		adapter.stop();
-		adapter.setTrigger(new OnceTrigger());
+		trigger.reset();
 		latch.set(new CountDownLatch(4));
 		adapter.start();
 		assertTrue(latch.get().await(10, TimeUnit.SECONDS));


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4120

INT-3899 moved creating the pollingTask to start() to allow modification
of the advice chain between starts.

Since a new pollingTask is created on each start, this was fine for general advices.

However, for `AbstractMessageSourceAdvice`s, which only advise the `receive()` operation,
the advices are re-applied on every start.

When starting, first remove any advices we added on the previous start.

This handles the case when the source is a naked object, or already a proxy when supplied
to the SPCA.

**I will push a backport PR (minus Java8) after review/merge**
