### PR TITLE
INT-4120: Poller Advice Chain Regression

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 
 import org.aopalliance.aop.Advice;
 
-import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.AopUtils;
@@ -133,17 +132,13 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 	@Override
 	protected void applyReceiveOnlyAdviceChain(Collection<Advice> chain) {
 		if (AopUtils.isAopProxy(this.source)) {
-			Advisor[] advisors = ((Advised) this.source).getAdvisors();
-			for (Advisor advisor : advisors)  {
-				Advice advice = advisor.getAdvice();
-				if (advice != null && this.appliedAdvices.contains(advice)) {
-					((Advised) this.source).removeAdvice(advice);
-				}
+			for (Advice advice : this.appliedAdvices) {
+				((Advised) this.source).removeAdvice(advice);
 			}
 			for (Advice advice : chain) {
-				NameMatchMethodPointcutAdvisor sourceAdvice = new NameMatchMethodPointcutAdvisor(advice);
-				sourceAdvice.addMethodName("receive");
-				((Advised) this.source).addAdvice(advice);
+				NameMatchMethodPointcutAdvisor sourceAdvisor = new NameMatchMethodPointcutAdvisor(advice);
+				sourceAdvisor.addMethodName("receive");
+				((Advised) this.source).addAdvisor(sourceAdvisor);
 			}
 		}
 		else {
@@ -159,10 +154,10 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 
 	@Override
 	protected void doStart() {
+		super.doStart();
 		if (this.source instanceof Lifecycle) {
 			((Lifecycle) this.source).start();
 		}
-		super.doStart();
 	}
 
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollerAdviceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollerAdviceTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.endpoint;
 
 import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -34,6 +35,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.aopalliance.aop.Advice;
 import org.aopalliance.intercept.MethodInterceptor;
@@ -41,6 +44,9 @@ import org.aopalliance.intercept.MethodInvocation;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.aop.Advisor;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -188,17 +194,17 @@ public class PollerAdviceTests {
 	public void testMixedAdvice() throws Exception {
 		SourcePollingChannelAdapter adapter = new SourcePollingChannelAdapter();
 		final List<String> callOrder = new ArrayList<String>();
-		final CountDownLatch latch = new CountDownLatch(4); // advice + advice + source + advice
-		adapter.setSource(new MessageSource<Object>() {
-
+		final AtomicReference<CountDownLatch> latch = new AtomicReference<>(new CountDownLatch(4));
+		MessageSource<Object> source = new MessageSource<Object>() {
 			@Override
 			public Message<Object> receive() {
 				callOrder.add("c");
-				latch.countDown();
+				latch.get().countDown();
 				return null;
 			}
-		});
-		adapter.setTrigger(new Trigger() {
+		};
+		adapter.setSource(source);
+		class OnceTrigger implements Trigger {
 
 			private boolean done;
 
@@ -208,7 +214,9 @@ public class PollerAdviceTests {
 				done = true;
 				return date;
 			}
-		});
+
+		}
+		adapter.setTrigger(new OnceTrigger());
 		configure(adapter);
 		List<Advice> adviceChain = new ArrayList<Advice>();
 
@@ -217,26 +225,28 @@ public class PollerAdviceTests {
 			@Override
 			public Object invoke(MethodInvocation invocation) throws Throwable {
 				callOrder.add("a");
-				latch.countDown();
+				latch.get().countDown();
 				return invocation.proceed();
 			}
 
 		}
 		adviceChain.add(new TestGeneralAdvice());
 
+		final AtomicInteger count = new AtomicInteger();
 		class TestSourceAdvice extends AbstractMessageSourceAdvice {
 
 			@Override
 			public boolean beforeReceive(MessageSource<?> target) {
+				count.incrementAndGet();
 				callOrder.add("b");
-				latch.countDown();
+				latch.get().countDown();
 				return true;
 			}
 
 			@Override
 			public Message<?> afterReceive(Message<?> result, MessageSource<?> target) {
 				callOrder.add("d");
-				latch.countDown();
+				latch.get().countDown();
 				return result;
 			}
 
@@ -246,9 +256,43 @@ public class PollerAdviceTests {
 		adapter.setAdviceChain(adviceChain);
 		adapter.afterPropertiesSet();
 		adapter.start();
-		assertTrue(latch.await(10, TimeUnit.SECONDS));
+		assertTrue(latch.get().await(10, TimeUnit.SECONDS));
 		assertThat(callOrder, contains("a", "b", "c", "d")); // advice + advice + source + advice
 		adapter.stop();
+		adapter.setTrigger(new OnceTrigger());
+		latch.set(new CountDownLatch(4));
+		adapter.start();
+		assertTrue(latch.get().await(10, TimeUnit.SECONDS));
+		adapter.stop();
+		assertEquals(2, count.get());
+
+		// Now test when the source is already a proxy.
+
+		MethodInterceptor dummy = new MethodInterceptor() {
+			@Override
+			public Object invoke(MethodInvocation invocation) throws Throwable {
+				return invocation.proceed();
+			}
+		};
+		ProxyFactory pf = new ProxyFactory(source);
+		pf.addAdvice(dummy);
+		adapter.setSource((MessageSource<?>) pf.getProxy());
+		adapter.setTrigger(new OnceTrigger());
+		latch.set(new CountDownLatch(4));
+		count.set(0);
+		callOrder.clear();
+		adapter.start();
+		assertTrue(latch.get().await(10, TimeUnit.SECONDS));
+		assertThat(callOrder, contains("a", "b", "c", "d")); // advice + advice + source + advice
+		adapter.stop();
+		adapter.setTrigger(new OnceTrigger());
+		latch.set(new CountDownLatch(4));
+		adapter.start();
+		assertTrue(latch.get().await(10, TimeUnit.SECONDS));
+		adapter.stop();
+		assertEquals(2, count.get());
+		Advisor[] advisors = ((Advised) adapter.getMessageSource()).getAdvisors();
+		assertEquals(2, advisors.length); // make sure we didn't remove the original one
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4120

INT-3899 moved creating the pollingTask to start() to allow modification
of the advice chain between starts.

Since a new pollingTask is created on each start, this was fine for general advices.

However, for `AbstractMessageSourceAdvice`s, which only advise the `receive()` operation,
the advices are re-applied on every start.

When starting, first remove any advices we added on the previous start.

This handles the case when the source is a naked object, or already a proxy when supplied
to the SPCA.

Remove uneeded cast
