### PR TITLE
INT-4124: ByteBuffer.array() with Direct Buffers

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -441,7 +441,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 		if (logger.isTraceEnabled()) {
 			logger.trace(this.getConnectionId() + " Sending " + rawBuffer.limit() + " to pipe");
 		}
-		this.channelInputStream.write(rawBuffer.array(), rawBuffer.limit());
+		this.channelInputStream.write(rawBuffer);
 		rawBuffer.clear();
 	}
 
@@ -723,10 +723,11 @@ public class TcpNioConnection extends TcpConnectionSupport {
 		 * @param bytesToWrite
 		 * @throws IOException
 		 */
-		public void write(byte[] array, int bytesToWrite) throws IOException {
+		public void write(ByteBuffer byteBuffer) throws IOException {
+			int bytesToWrite = byteBuffer.limit() - byteBuffer.position();
 			if (bytesToWrite > 0) {
 				byte[] buffer = new byte[bytesToWrite];
-				System.arraycopy(array, 0, buffer, 0, bytesToWrite);
+				byteBuffer.get(buffer);
 				this.available.addAndGet(bytesToWrite);
 				if (TcpNioConnection.this.writingLatch != null) {
 					TcpNioConnection.this.writingLatch.countDown();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionTests.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.net.Socket;
+import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -100,7 +101,7 @@ public class TcpNetConnectionTests {
 		TcpNioConnection connection = new TcpNioConnection(socketChannel, true, false, nullPublisher, null);
 		ChannelInputStream inputStream =
 				TestUtils.getPropertyValue(connection, "channelInputStream", ChannelInputStream.class);
-		inputStream.write(new byte[] {(byte) 0x80}, 1);
+		inputStream.write(ByteBuffer.wrap(new byte[] { (byte) 0x80 }));
 		assertEquals(0x80, inputStream.read());
 	}
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
@@ -54,7 +54,9 @@ public class TcpNioConnectionReadTests {
 
 	private AbstractServerConnectionFactory getConnectionFactory(
 			AbstractByteArraySerializer serializer, TcpListener listener, TcpSender sender) throws Exception {
-		AbstractServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
+		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
+		scf.setUsingDirectBuffers(true);
+		scf.setApplicationEventPublisher(e -> { });
 		scf.setSerializer(serializer);
 		scf.setDeserializer(serializer);
 		scf.registerListener(listener);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -386,7 +386,7 @@ public class TcpNioConnectionTests {
 		TcpNioConnection connection = new TcpNioConnection(socketChannel, false, false, null, null);
 		TcpNioConnection.ChannelInputStream stream = (ChannelInputStream) new DirectFieldAccessor(connection)
 				.getPropertyValue("channelInputStream");
-		stream.write("foo".getBytes(), 3);
+		stream.write(ByteBuffer.wrap("foo".getBytes()));
 		byte[] out = new byte[2];
 		int n = stream.read(out);
 		assertEquals(2, n);
@@ -405,8 +405,8 @@ public class TcpNioConnectionTests {
 		TcpNioConnection connection = new TcpNioConnection(socketChannel, false, false, null, null);
 		TcpNioConnection.ChannelInputStream stream = (ChannelInputStream) new DirectFieldAccessor(connection)
 				.getPropertyValue("channelInputStream");
-		stream.write("foo".getBytes(), 3);
-		stream.write("bar".getBytes(), 3);
+		stream.write(ByteBuffer.wrap("foo".getBytes()));
+		stream.write(ByteBuffer.wrap("bar".getBytes()));
 		byte[] out = new byte[6];
 		int n = stream.read(out);
 		assertEquals(6, n);
@@ -421,7 +421,7 @@ public class TcpNioConnectionTests {
 		TcpNioConnection connection = new TcpNioConnection(socketChannel, false, false, null, null);
 		TcpNioConnection.ChannelInputStream stream = (ChannelInputStream) new DirectFieldAccessor(connection)
 				.getPropertyValue("channelInputStream");
-		stream.write("foo".getBytes(), 3);
+		stream.write(ByteBuffer.wrap("foo".getBytes()));
 		byte[] out = new byte[5];
 		int n = stream.read(out, 1, 4);
 		assertEquals(3, n);
@@ -436,7 +436,7 @@ public class TcpNioConnectionTests {
 		TcpNioConnection connection = new TcpNioConnection(socketChannel, false, false, null, null);
 		TcpNioConnection.ChannelInputStream stream = (ChannelInputStream) new DirectFieldAccessor(connection)
 				.getPropertyValue("channelInputStream");
-		stream.write("foo".getBytes(), 3);
+		stream.write(ByteBuffer.wrap("foo".getBytes()));
 		byte[] out = new byte[5];
 		try {
 			stream.read(out, 1, 5);
@@ -480,7 +480,7 @@ public class TcpNioConnectionTests {
 		});
 		Thread.sleep(1000);
 		assertEquals(0x00, out[0]);
-		stream.write("foo".getBytes(), 3);
+		stream.write(ByteBuffer.wrap("foo".getBytes()));
 		assertTrue(latch.await(10, TimeUnit.SECONDS));
 		assertEquals("foo\u0000", new String(out));
 	}
@@ -760,7 +760,7 @@ public class TcpNioConnectionTests {
 				readerFinishedLatch.countDown();
 				return null;
 			}
-		}).when(cis).write(any(byte[].class), Matchers.anyInt());
+		}).when(cis).write(any(ByteBuffer.class));
 
 		doReturn(true).when(logger).isTraceEnabled();
 		doAnswer(new Answer<Void>() {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/util/SocketTestUtils.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/util/SocketTestUtils.java
@@ -234,7 +234,7 @@ public class SocketTestUtils {
 				testCompleteLatch.await(10, TimeUnit.SECONDS);
 			}
 			catch (Exception e1) {
-				e1.printStackTrace();
+				logger.debug("write failed", e1);
 			}
 			finally {
 				if (socket != null) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4124

`ByteBuffer.array()` returns null when Direct.

Change `ChannelInputStream` to use the `ByteBuffer` directly instead of
the underlying `byte[]`.

**change event publisher lambda to mock when cherry-picking**
