### PR TITLE
INT-4113: Add `@Poller.errorChannel()` attribute

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Poller.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Poller.java
@@ -88,6 +88,7 @@ public @interface Poller {
 	/**
 	 * @return The the bean name of default error channel
 	 * for the underlying {@code MessagePublishingErrorHandler}.
+	 * @since 4.3.3
 	 */
 	String errorChannel() default "";
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Poller.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Poller.java
@@ -85,4 +85,10 @@ public @interface Poller {
 	 */
 	String cron() default "";
 
+	/**
+	 * @return The the bean name of default error channel
+	 * for the underlying {@code MessagePublishingErrorHandler}.
+	 */
+	String errorChannel() default "";
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/MessagePublishingErrorHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/MessagePublishingErrorHandler.java
@@ -39,6 +39,7 @@ import org.springframework.util.ErrorHandler;
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class MessagePublishingErrorHandler implements ErrorHandler, BeanFactoryAware {
 
@@ -47,6 +48,8 @@ public class MessagePublishingErrorHandler implements ErrorHandler, BeanFactoryA
 	private volatile DestinationResolver<MessageChannel> channelResolver;
 
 	private volatile MessageChannel defaultErrorChannel;
+
+	private volatile String defaultErrorChannelName;
 
 	private volatile long sendTimeout = 1000;
 
@@ -70,7 +73,22 @@ public class MessagePublishingErrorHandler implements ErrorHandler, BeanFactoryA
 	 * @since 4.3
 	 */
 	public MessageChannel getDefaultErrorChannel() {
+		String defaultErrorChannelName = this.defaultErrorChannelName;
+		if (defaultErrorChannelName != null) {
+			if (this.channelResolver != null) {
+				this.defaultErrorChannel = this.channelResolver.resolveDestination(defaultErrorChannelName);
+				this.defaultErrorChannelName = null;
+			}
+		}
 		return this.defaultErrorChannel;
+	}
+
+	/**
+	 * Specify the bean name of default error channel for this error handler.
+	 * @since 5.0
+	 */
+	public void setDefaultErrorChannelName(String defaultErrorChannelName) {
+		this.defaultErrorChannelName = defaultErrorChannelName;
 	}
 
 	public void setSendTimeout(long sendTimeout) {
@@ -87,7 +105,7 @@ public class MessagePublishingErrorHandler implements ErrorHandler, BeanFactoryA
 
 	@Override
 	public final void handleError(Throwable t) {
-		MessageChannel errorChannel = this.resolveErrorChannel(t);
+		MessageChannel errorChannel = resolveErrorChannel(t);
 		boolean sent = false;
 		if (errorChannel != null) {
 			try {
@@ -123,7 +141,7 @@ public class MessagePublishingErrorHandler implements ErrorHandler, BeanFactoryA
 	private MessageChannel resolveErrorChannel(Throwable t) {
 		Message<?> failedMessage = (t instanceof MessagingException) ?
 				((MessagingException) t).getFailedMessage() : null;
-		if (this.defaultErrorChannel == null && this.channelResolver != null) {
+		if (getDefaultErrorChannel() == null && this.channelResolver != null) {
 			this.defaultErrorChannel = this.channelResolver.resolveDestination(
 					IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME);
 		}
@@ -137,7 +155,7 @@ public class MessagePublishingErrorHandler implements ErrorHandler, BeanFactoryA
 		}
 		Assert.isInstanceOf(String.class, errorChannelHeader,
 				"Unsupported error channel header type. Expected MessageChannel or String, but actual type is [" +
-				errorChannelHeader.getClass() + "]");
+						errorChannelHeader.getClass() + "]");
 		return this.channelResolver.resolveDestination((String) errorChannelHeader);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/MessagePublishingErrorHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/MessagePublishingErrorHandler.java
@@ -85,7 +85,8 @@ public class MessagePublishingErrorHandler implements ErrorHandler, BeanFactoryA
 
 	/**
 	 * Specify the bean name of default error channel for this error handler.
-	 * @since 5.0
+	 * @param defaultErrorChannelName the bean name of the error channel
+	 * @since 4.3.3
 	 */
 	public void setDefaultErrorChannelName(String defaultErrorChannelName) {
 		this.defaultErrorChannelName = defaultErrorChannelName;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -49,6 +49,7 @@ import org.springframework.core.task.TaskExecutor;
 import org.springframework.integration.annotation.IdempotentReceiver;
 import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.config.IntegrationConfigUtils;
 import org.springframework.integration.context.Orderable;
 import org.springframework.integration.endpoint.AbstractEndpoint;
@@ -100,7 +101,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 	protected final Log logger = LogFactory.getLog(this.getClass());
 
-	protected final List<String> messageHandlerAttributes = new ArrayList<String>();
+	protected final List<String> messageHandlerAttributes = new ArrayList<>();
 
 	protected final ConfigurableListableBeanFactory beanFactory;
 
@@ -236,8 +237,8 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 		boolean createEndpoint = StringUtils.hasText(inputChannel);
 		if (!createEndpoint && beanAnnotationAware()) {
 			boolean isBean = AnnotatedElementUtils.isAnnotated(method, Bean.class.getName());
-			Assert.isTrue(!isBean, "A channel name in '" + getInputChannelAttribute() + "' is required when " + this.annotationType +
-					" is used on '@Bean' methods.");
+			Assert.isTrue(!isBean, "A channel name in '" + getInputChannelAttribute() + "' is required when " +
+					this.annotationType + " is used on '@Bean' methods.");
 		}
 		return createEndpoint;
 	}
@@ -343,7 +344,8 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 		PollerMetadata pollerMetadata = null;
 		Poller[] pollers = MessagingAnnotationUtils.resolveAttribute(annotations, "poller", Poller[].class);
 		if (!ObjectUtils.isEmpty(pollers)) {
-			Assert.state(pollers.length == 1, "The 'poller' for an Annotation-based endpoint can have only one '@Poller'.");
+			Assert.state(pollers.length == 1,
+					"The 'poller' for an Annotation-based endpoint can have only one '@Poller'.");
 			Poller poller = pollers[0];
 
 			String ref = poller.value();
@@ -353,6 +355,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 			String fixedRateValue = this.beanFactory.resolveEmbeddedValue(poller.fixedRate());
 			String maxMessagesPerPollValue = this.beanFactory.resolveEmbeddedValue(poller.maxMessagesPerPoll());
 			String cron = this.beanFactory.resolveEmbeddedValue(poller.cron());
+			String errorChannel = this.beanFactory.resolveEmbeddedValue(poller.errorChannel());
 
 			if (StringUtils.hasText(ref)) {
 				Assert.state(!StringUtils.hasText(triggerRef) && !StringUtils.hasText(executorRef) &&
@@ -370,9 +373,11 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 					// SPCAs default to 1 message per poll
 					pollerMetadata.setMaxMessagesPerPoll(1);
 				}
+
 				if (StringUtils.hasText(executorRef)) {
 					pollerMetadata.setTaskExecutor(this.beanFactory.getBean(executorRef, TaskExecutor.class));
 				}
+
 				Trigger trigger = null;
 				if (StringUtils.hasText(triggerRef)) {
 					Assert.state(!StringUtils.hasText(cron) && !StringUtils.hasText(fixedDelayValue)
@@ -396,6 +401,13 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 				}
 				//'Trigger' can be null. 'PollingConsumer' does fallback to the 'new PeriodicTrigger(10)'.
 				pollerMetadata.setTrigger(trigger);
+
+				if (StringUtils.hasText(errorChannel)) {
+					MessagePublishingErrorHandler errorHandler = new MessagePublishingErrorHandler();
+					errorHandler.setDefaultErrorChannelName(errorChannel);
+					errorHandler.setBeanFactory(this.beanFactory);
+					pollerMetadata.setErrorHandler(errorHandler);
+				}
 			}
 		}
 		else {
@@ -425,8 +437,10 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 		return name + IntegrationConfigUtils.HANDLER_ALIAS_SUFFIX;
 	}
 
-	protected void setOutputChannelIfPresent(List<Annotation> annotations, AbstractReplyProducingMessageHandler handler) {
-		String outputChannelName = MessagingAnnotationUtils.resolveAttribute(annotations, "outputChannel", String.class);
+	protected void setOutputChannelIfPresent(List<Annotation> annotations,
+			AbstractReplyProducingMessageHandler handler) {
+		String outputChannelName = MessagingAnnotationUtils.resolveAttribute(annotations, "outputChannel",
+				String.class);
 		if (StringUtils.hasText(outputChannelName)) {
 			handler.setOutputChannelName(outputChannelName);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -101,7 +101,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 	protected final Log logger = LogFactory.getLog(this.getClass());
 
-	protected final List<String> messageHandlerAttributes = new ArrayList<>();
+	protected final List<String> messageHandlerAttributes = new ArrayList<String>();
 
 	protected final ConfigurableListableBeanFactory beanFactory;
 

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -424,7 +424,7 @@ public class AnnotationService {
 }
 ----
 
-Starting with _version 4.3.3_, the `@Poller` is supplied with the `errorChannel` attribute for easier configuration of the underlying `MessagePublishingErrorHandler`.
+Starting with _version 4.3.3_, the `@Poller` annotation now has the `errorChannel` attribute for easier configuration of the underlying `MessagePublishingErrorHandler`.
 This attribute play the same role as `error-channel` in the `<poller>` xml component.
 See <<endpoint-namespace>> for more information.
 

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -374,7 +374,7 @@ public class AnnotationService {
 
 This annotation provides only simple `PollerMetadata` options.
 The `@Poller`'s attributes `maxMessagesPerPoll`, `fixedDelay`, `fixedRate` and `cron` can be configured with _property-placeholders_.
-If it is necessary to provide more polling options (e.g. transaction, advice-chain, error-handler), the `PollerMetadata` should be configured as a generic bean with its bean name used for `@Poller`'s `value` attribute.
+If it is necessary to provide more polling options (e.g. transaction, advice-chain, error-handler etc.), the `PollerMetadata` should be configured as a generic bean with its bean name used for `@Poller`'s `value` attribute.
 In this case, no other attributes are allowed (they would be specified on the `PollerMetadata` bean).
 Note, if `inputChannel` is `PollableChannel` and no `@Poller` is configured, the default `PollerMetadata` will be used, if it is present in the application context.
 To declare the default poller using `@Configuration`, use:
@@ -423,6 +423,10 @@ public class AnnotationService {
     }
 }
 ----
+
+Starting with _version 4.0_, the `@Poller` is supplied with the `errorChannel` attribute for easier configuration of the underlying `MessagePublishingErrorHandler`.
+This attribute play the same role as `error-channel` in the `<poller>` xml component.
+See <<endpoint-namespace>> for more information.
 
 *@InboundChannelAdapter*
 

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -424,7 +424,7 @@ public class AnnotationService {
 }
 ----
 
-Starting with _version 4.0_, the `@Poller` is supplied with the `errorChannel` attribute for easier configuration of the underlying `MessagePublishingErrorHandler`.
+Starting with _version 4.3.3_, the `@Poller` is supplied with the `errorChannel` attribute for easier configuration of the underlying `MessagePublishingErrorHandler`.
 This attribute play the same role as `error-channel` in the `<poller>` xml component.
 See <<endpoint-namespace>> for more information.
 

--- a/src/reference/asciidoc/endpoint.adoc
+++ b/src/reference/asciidoc/endpoint.adoc
@@ -152,14 +152,14 @@ For example, an _Aggregator_ waits for a number of Messages to arrive and is oft
 When using the namespace configuration, you do not strictly need to know all of the details, but it still might be worth knowing that several of these components share a common base class, the `AbstractReplyProducingMessageHandler`, and it provides a `setOutputChannel(..)` method.
 
 [[endpoint-namespace]]
-==== Namespace Support
+==== Endpoint Namespace Support
 
 Throughout the reference manual, you will see specific configuration examples for endpoint elements, such as router, transformer, service-activator, and so on.
 Most of these will support an _input-channel_ attribute and many will support an _output-channel_ attribute.
 After being parsed, these endpoint elements produce an instance of either the `PollingConsumer` or the `EventDrivenConsumer` depending on the type of the _input-channel_ that is referenced: `PollableChannel` or `SubscribableChannel` respectively.
 When the channel is pollable, then the polling behavior is determined based on the endpoint element's _poller_ sub-element and its attributes.
 
-_Configuration_Below you find a _poller_ with all available configuration options:
+In the configuration below you find a _poller_ with all available configuration options:
 
 [source,xml]
 ----

--- a/src/reference/asciidoc/mail.adoc
+++ b/src/reference/asciidoc/mail.adoc
@@ -188,7 +188,7 @@ Alternatively, provide the host, username, and password:
 ----
 
 NOTE: Keep in mind, as with any outbound Channel Adapter, if the referenced channel is a `PollableChannel`,
-a `<poller>` sub-element should be provided (see ).
+a `<poller>` sub-element should be provided (see <<endpoint-namespace>>).
 
 When using the namespace support, a _header-enricher_ Message Transformer is also available.
 This simplifies the application of the headers mentioned above to any Message prior to sending to the Mail Outbound Channel Adapter.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -15,6 +15,9 @@ development process.
 
 ==== Core Changes
 
+The `@Poller` is supplied now with the `errorChannel` attribute for easier configuration of the underlying `MessagePublishingErrorHandler`.
+See <<annotations>> for more information.
+
 ==== JMS Changes
 
 Previously, Spring Integration JMS XML configuration used a default bean name `connectionFactory` for the JMS Connection Factory, allowing the property to be omitted from component definitions.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -15,7 +15,7 @@ development process.
 
 ==== Core Changes
 
-The `@Poller` is supplied now with the `errorChannel` attribute for easier configuration of the underlying `MessagePublishingErrorHandler`.
+The `@Poller` annotation now has the `errorChannel` attribute for easier configuration of the underlying `MessagePublishingErrorHandler`.
 See <<annotations>> for more information.
 
 ==== JMS Changes


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4113
- To simplify `MessagePublishingErrorHandler` and avoid extra `PollerMetadata` beans, added the `errorChannel()` attribute to the `@Poller` annotation
- The `MessagePublishingErrorHandler` now supports the late-binding via new `defaultErrorChannelName`
- Docs about new `errorChannel()` attribute
- Some other docs polishing
