### PR TITLE
INT-4127: Fix `ZkLock.tryLock()` timing issue

### DIFF
--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
@@ -271,7 +271,7 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry, DisposableB
 		@Override
 		public boolean tryLock() {
 			try {
-				return tryLock(0, TimeUnit.MICROSECONDS);
+				return tryLock(1, TimeUnit.SECONDS);
 			}
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
@@ -352,4 +352,16 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		registry.destroy();
 	}
 
+	@Test
+	public void testTryLock() throws Exception {
+		ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
+		for (int i = 0; i < 10; i++) {
+			Lock lock = registry.obtain("foo");
+			assertTrue(lock.tryLock());
+			lock.unlock();
+		}
+
+		registry.destroy();
+	}
+
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4127
Fixes GH-1913 (https://github.com/spring-projects/spring-integration/issues/1913)

The current `tryLock()` implementation with the `0` timeout to wait for underlying `InterProcessMutex` answer makes this function almost fully impossible
- Fix `ZkLock.tryLock()` to delegate with the `tryLock(1, TimeUnit.SECONDS)` to give some time window chance for network communication.
  It isn't ideal for the `tryLock()` contract, but at least it is better then don't let the feature to work at all.

**Cherry-pick to 4.3.x & 4.2.x**
