### PR TITLE
INT-3825: Messaging annot on Non-public methods

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -272,7 +273,9 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 
 			@Override
 			protected Method[] getMethods(Class<?> type) {
-				return type.getDeclaredMethods();
+				return Stream.of(type.getMethods(), type.getDeclaredMethods())
+						.flatMap(Stream::of)
+						.toArray(Method[]::new);
 			}
 
 		};
@@ -297,7 +300,7 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 			declaredMethodResolver.registerMethodFilter(targetType, annotatedMethodFilter);
 		}
 		context.setVariable("target", this.targetObject);
-		context.addMethodResolver(declaredMethodResolver);
+		context.setMethodResolvers(Collections.singletonList(declaredMethodResolver));
 	}
 
 	private boolean canReturnExpectedType(AnnotatedMethodFilter filter, Class<?> targetType,

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/UniqueMethodFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/UniqueMethodFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,14 @@ package org.springframework.integration.util;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.util.ReflectionUtils;
 import org.springframework.util.ReflectionUtils.MethodFilter;
 
 /**
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  * @since 2.0
  */
 public class UniqueMethodFilter implements MethodFilter {
@@ -33,7 +34,7 @@ public class UniqueMethodFilter implements MethodFilter {
 
 
 	public UniqueMethodFilter(Class<?> targetClass) {
-		ArrayList<Method> allMethods = new ArrayList<Method>(Arrays.asList(targetClass.getMethods()));
+		Method[] allMethods = ReflectionUtils.getAllDeclaredMethods(targetClass);
 		for (Method method : allMethods) {
 			this.uniqueMethods.add(org.springframework.util.ClassUtils.getMostSpecificMethod(method, targetClass));
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -550,6 +550,22 @@ public class MethodInvokingMessageProcessorTests {
 		assertEquals("FOO", targetObject.arguments.get("foo2"));
 	}
 
+	@Test
+	public void testPrivateMethod() throws Exception {
+		class Foo {
+
+			@ServiceActivator
+			private String service(String payload) {
+				return payload.toUpperCase();
+			}
+
+		}
+
+		MessagingMethodInvokerHelper helper = new MessagingMethodInvokerHelper(new Foo(), ServiceActivator.class, false);
+
+		assertEquals("FOO", helper.process(new GenericMessage<>("foo")));
+	}
+
 	private static class ExceptionCauseMatcher extends TypeSafeMatcher<Exception> {
 		private Throwable cause;
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -564,6 +564,7 @@ public class MethodInvokingMessageProcessorTests {
 		MessagingMethodInvokerHelper helper = new MessagingMethodInvokerHelper(new Foo(), ServiceActivator.class, false);
 
 		assertEquals("FOO", helper.process(new GenericMessage<>("foo")));
+		assertEquals("BAR", helper.process(new GenericMessage<>("bar")));
 	}
 
 	private static class ExceptionCauseMatcher extends TypeSafeMatcher<Exception> {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3825

Rework `MessagingMethodInvokerHelper` logic to accept non-public methods with Messaging annotations as candidates for invocation
Adjust SpEL configuration in the `MessagingMethodInvokerHelper` to deal with `declaredMethods()`, not only `public`
