### PR TITLE
INT-4135: Ignore case check for HTTP Content-Type

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -462,7 +462,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 						if (logger.isDebugEnabled()) {
 							logger.debug(MessageFormat.format("setting headerName=[{0}], value={1}", name, value));
 						}
-						if (CONTENT_TYPE.equals(name)) {
+						if (CONTENT_TYPE.equalsIgnoreCase(name)) {
 							name = MessageHeaders.CONTENT_TYPE;
 						}
 						this.setMessageHeader(target, name, value);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageInboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageInboundTests.java
@@ -583,6 +583,15 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 		assertEquals(MediaType.valueOf("text/plain"), httpHeaders.getContentType());
 	}
 
+	@Test
+	public void testContentTypeInboundHeader() throws Exception {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.inboundMapper();
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(HttpHeaders.CONTENT_TYPE.toLowerCase(), "text/plain");
+		Map<String, ?> result = mapper.toHeaders(headers);
+		assertEquals(MediaType.valueOf("text/plain"), result.get(MessageHeaders.CONTENT_TYPE));
+	}
+
 
 	public static class TestClass {
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4135

The incoming `Content-Type` HTTP header can be in any arbitrary case.

Fix `DefaultHttpHeaderMapper` `Content-Type` header re-mapping to the `MessageHeaders.CONTENT_TYPE` via `equalsIgnoreCase()` comparison

**Cherry-pick to 4.3.x**
