### PR TITLE
INT-4143: Backport fixes for Gemfire tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -361,10 +361,6 @@ project('spring-integration-ftp') {
 
 project('spring-integration-gemfire') {
 	description = 'Spring Integration GemFire Support'
-	tasks.withType(Test).matching {it.name ==~ /(springIo.+)|(test)|(testAll)/}.all {
-		forkEvery = 1
-		systemProperties['gemfire.disableShutdownHook'] = 'true'
-	}
 	dependencies {
 		compile project(":spring-integration-core")
 		compile ("org.springframework.data:spring-data-gemfire:$springGemfireVersion") {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PayloadSerializingTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PayloadSerializingTransformerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,14 +35,17 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.transformer.MessageTransformationException;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
 public class PayloadSerializingTransformerParserTests {
 
 	@Autowired
@@ -70,7 +73,7 @@ public class PayloadSerializingTransformerParserTests {
 	@Test
 	public void queueChannelWithStringMessage() throws Exception {
 		queueInput.send(new GenericMessage<String>("foo"));
-		Message<?> result = output.receive(3000);
+		Message<?> result = output.receive(10000);
 		assertNotNull(result);
 		assertTrue(result.getPayload() instanceof byte[]);
 		assertEquals("foo", deserialize((byte[]) result.getPayload()));
@@ -90,7 +93,7 @@ public class PayloadSerializingTransformerParserTests {
 	@Test
 	public void queueChannelWithObjectMessage() throws Exception {
 		queueInput.send(new GenericMessage<TestBean>(new TestBean()));
-		Message<?> result = output.receive(3000);
+		Message<?> result = output.receive(10000);
 		assertTrue(result.getPayload() instanceof byte[]);
 		Object deserialized = deserialize((byte[]) result.getPayload());
 		assertEquals(TestBean.class, deserialized.getClass());
@@ -105,7 +108,7 @@ public class PayloadSerializingTransformerParserTests {
 	@Test
 	public void customSerializer() throws Exception {
 		customSerializerInput.send(new GenericMessage<String>("test"));
-		Message<?> result = output.receive(3000);
+		Message<?> result = output.receive(10000);
 		assertNotNull(result);
 		assertEquals(byte[].class, result.getPayload().getClass());
 		assertEquals("TEST", new String((byte[]) result.getPayload(), "UTF-8"));
@@ -134,6 +137,7 @@ public class PayloadSerializingTransformerParserTests {
 			outputStream.flush();
 			outputStream.close();
 		}
+
 	}
 
 }

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStoreTests.java
@@ -52,6 +52,7 @@ public class GemfireMetadataStoreTests {
 
 	@AfterClass
 	public static void cleanUp() {
+		getRegion().close();
 		if (cache != null) {
 			cache.close();
 			Assert.isTrue(cache.isClosed(), "Cache did not close after close() call");

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/outbound/CacheWritingMessageHandlerTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/outbound/CacheWritingMessageHandlerTests.java
@@ -52,11 +52,13 @@ public class CacheWritingMessageHandlerTests {
 	public void mapPayloadWritesToCache() throws Exception {
 		CacheFactoryBean cacheFactoryBean = new CacheFactoryBean();
 		Cache cache = cacheFactoryBean.getObject();
-		RegionFactoryBean<String, String> regionFactoryBean = new RegionFactoryBean<String, String>() {};
+
+		RegionFactoryBean<String, String> regionFactoryBean = new RegionFactoryBean<String, String>() { };
 		regionFactoryBean.setName("test.mapPayloadWritesToCache");
 		regionFactoryBean.setCache(cache);
 		regionFactoryBean.afterPropertiesSet();
 		Region<String, String> region = regionFactoryBean.getObject();
+
 		assertEquals(0, region.size());
 
 		CacheWritingMessageHandler handler = new CacheWritingMessageHandler(region);
@@ -69,7 +71,9 @@ public class CacheWritingMessageHandlerTests {
 		handler.handleMessage(message);
 		assertEquals(1, region.size());
 		assertEquals("bar", region.get("foo"));
-		cache.close();
+
+		regionFactoryBean.destroy();
+		cacheFactoryBean.destroy();
 	}
 
 	@Test
@@ -77,12 +81,15 @@ public class CacheWritingMessageHandlerTests {
 	public void ExpressionsWriteToCache() throws Exception {
 		CacheFactoryBean cacheFactoryBean = new CacheFactoryBean();
 		Cache cache = cacheFactoryBean.getObject();
-		RegionFactoryBean<String, Object> regionFactoryBean = new RegionFactoryBean<String, Object>() {};
+
+		RegionFactoryBean<String, Object> regionFactoryBean = new RegionFactoryBean<String, Object>() { };
 		regionFactoryBean.setName("test.expressionsWriteToCache");
 		regionFactoryBean.setCache(cache);
 		regionFactoryBean.afterPropertiesSet();
 		Region<String, Object> region = regionFactoryBean.getObject();
+
 		assertEquals(0, region.size());
+
 		CacheWritingMessageHandler handler = new CacheWritingMessageHandler(region);
 
 		Map<String, String> expressions = new HashMap<String, String>();
@@ -106,7 +113,9 @@ public class CacheWritingMessageHandlerTests {
 		handler.handleMessage(new GenericMessage<String>("test"));
 		assertEquals(3, region.size());
 		assertEquals(10L, region.get("baz"));
-		cache.close();
+
+		regionFactoryBean.destroy();
+		cacheFactoryBean.destroy();
 	}
 
 }

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/DelayerHandlerRescheduleIntegrationTests-context.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/DelayerHandlerRescheduleIntegrationTests-context.xml
@@ -6,7 +6,8 @@
 	http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<beans:bean id="messageStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
-		<beans:constructor-arg value="#{T (org.springframework.integration.gemfire.store.DelayerHandlerRescheduleIntegrationTests).cache}"/>
+		<beans:constructor-arg
+				value="#{T (org.springframework.integration.gemfire.store.DelayerHandlerRescheduleIntegrationTests).region}"/>
 	</beans:bean>
 
 	<channel id="output">

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/DelayerHandlerRescheduleIntegrationTests.java
@@ -39,9 +39,10 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.util.Assert;
 
 import com.gemstone.gemfire.cache.Cache;
+import com.gemstone.gemfire.cache.Region;
+import com.gemstone.gemfire.cache.Scope;
 
 
 /**
@@ -53,22 +54,28 @@ public class DelayerHandlerRescheduleIntegrationTests {
 
 	public static final String DELAYER_ID = "delayerWithGemfireMS";
 
-	public static Cache cache;
+	public static Region<Object, Object> region;
+
+	private static CacheFactoryBean cacheFactoryBean;
 
 	@ClassRule
 	public static LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@BeforeClass
 	public static void startUp() throws Exception {
-		CacheFactoryBean cacheFactoryBean = new CacheFactoryBean();
-		cache = cacheFactoryBean.getObject();
+		cacheFactoryBean = new CacheFactoryBean();
+		cacheFactoryBean.afterPropertiesSet();
+		Cache cache = cacheFactoryBean.getObject();
+		region = cache.createRegionFactory().setScope(Scope.LOCAL).create("sig-tests");
 	}
 
 	@AfterClass
-	public static void cleanUp() {
-		if (cache != null) {
-			cache.close();
-			Assert.isTrue(cache.isClosed(), "Cache did not close after close() call");
+	public static void cleanUp() throws Exception {
+		if (region != null) {
+			region.close();
+		}
+		if (cacheFactoryBean != null) {
+			cacheFactoryBean.destroy();
 		}
 	}
 

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireGroupStoreTests.java
@@ -29,10 +29,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -43,11 +43,9 @@ import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.util.Assert;
 
 import com.gemstone.gemfire.cache.Cache;
 import com.gemstone.gemfire.cache.Region;
@@ -63,16 +61,13 @@ import junit.framework.AssertionFailedError;
  */
 public class GemfireGroupStoreTests {
 
-	private Cache cache;
+	public static CacheFactoryBean cacheFactoryBean;
 
-	private Region<Object, Object> region;
-
-	@Rule
-	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
+	private static Region<Object, Object> region;
 
 	@Test
 	public void testNonExistingEmptyMessageGroup() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		assertNotNull(messageGroup);
@@ -82,7 +77,7 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testMessageGroupWithAddedMessage() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("Hello");
@@ -90,7 +85,7 @@ public class GemfireGroupStoreTests {
 		assertEquals(1, messageGroup.size());
 
 		// make sure the store is properly rebuild from Gemfire
-		store = new GemfireMessageStore(this.region);
+		store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 
 		messageGroup = store.getMessageGroup(1);
@@ -99,7 +94,7 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testRemoveMessageFromTheGroup() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("2");
@@ -124,7 +119,7 @@ public class GemfireGroupStoreTests {
 		assertEquals(2, messageGroup.size());
 
 		// make sure the store is properly rebuild from Gemfire
-		store = new GemfireMessageStore(this.region);
+		store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 
 		messageGroup = store.getMessageGroup(1);
@@ -134,7 +129,7 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testRemoveMessageGroup() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> message = new GenericMessage<String>("Hello");
@@ -148,7 +143,7 @@ public class GemfireGroupStoreTests {
 		assertEquals(0, messageGroupA.size());
 
 		// make sure the store is properly rebuild from Gemfire
-		store = new GemfireMessageStore(this.region);
+		store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 
 		messageGroup = store.getMessageGroup(1);
@@ -159,7 +154,7 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testRemoveNonExistingMessageFromTheGroup() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		store.addMessageToGroup(messageGroup.getGroupId(), new GenericMessage<String>("1"));
@@ -168,14 +163,14 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testRemoveNonExistingMessageFromNonExistingTheGroup() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		store.removeMessageFromGroup(1, new GenericMessage<String>("2"));
 	}
 
 	@Test
 	public void testCompleteMessageGroup() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> messageToMark = new GenericMessage<String>("1");
@@ -187,7 +182,7 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testLastReleasedSequenceNumber() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 		MessageGroup messageGroup = store.getMessageGroup(1);
 		Message<?> messageToMark = new GenericMessage<String>("1");
@@ -199,10 +194,10 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testMultipleInstancesOfGroupStore() throws Exception {
-		GemfireMessageStore store1 = new GemfireMessageStore(this.region);
+		GemfireMessageStore store1 = new GemfireMessageStore(region);
 		store1.afterPropertiesSet();
 
-		GemfireMessageStore store2 = new GemfireMessageStore(this.region);
+		GemfireMessageStore store2 = new GemfireMessageStore(region);
 		store2.afterPropertiesSet();
 
 		Message<?> message = new GenericMessage<String>("1");
@@ -211,7 +206,7 @@ public class GemfireGroupStoreTests {
 
 		assertEquals(2, messageGroup.getMessages().size());
 
-		GemfireMessageStore store3 = new GemfireMessageStore(this.region);
+		GemfireMessageStore store3 = new GemfireMessageStore(region);
 		store3.afterPropertiesSet();
 
 		messageGroup = store3.removeMessageFromGroup(1, message);
@@ -221,7 +216,7 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testWithMessageHistory() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 
 		store.getMessageGroup(1);
@@ -248,9 +243,9 @@ public class GemfireGroupStoreTests {
 
 	@Test
 	public void testIteratorOfMessageGroups() throws Exception {
-		GemfireMessageStore store1 = new GemfireMessageStore(this.region);
+		GemfireMessageStore store1 = new GemfireMessageStore(region);
 		store1.afterPropertiesSet();
-		GemfireMessageStore store2 = new GemfireMessageStore(this.region);
+		GemfireMessageStore store2 = new GemfireMessageStore(region);
 		store2.afterPropertiesSet();
 
 		store1.addMessageToGroup(1, new GenericMessage<String>("1"));
@@ -281,9 +276,9 @@ public class GemfireGroupStoreTests {
 	@Ignore
 	public void testConcurrentModifications() throws Exception {
 
-		final GemfireMessageStore store1 = new GemfireMessageStore(this.region);
+		final GemfireMessageStore store1 = new GemfireMessageStore(region);
 		store1.afterPropertiesSet();
-		final GemfireMessageStore store2 = new GemfireMessageStore(this.region);
+		final GemfireMessageStore store2 = new GemfireMessageStore(region);
 		store2.afterPropertiesSet();
 
 		final Message<?> message = new GenericMessage<String>("1");
@@ -373,17 +368,27 @@ public class GemfireGroupStoreTests {
 	}
 
 	@Before
-	public void init() throws Exception {
-		CacheFactoryBean cacheFactoryBean = new CacheFactoryBean();
-		this.cache = cacheFactoryBean.getObject();
-		this.region = cache.createRegionFactory().setScope(Scope.LOCAL).create("sig-tests");
+	public void prepare() {
+		if (region != null) {
+			region.clear();
+		}
 	}
 
-	@After
-	public void cleanup() {
-		if (this.cache != null) {
-			this.cache.close();
-			Assert.isTrue(this.cache.isClosed(), "Cache did not close after close() call");
+	@BeforeClass
+	public static void init() throws Exception {
+		cacheFactoryBean = new CacheFactoryBean();
+		cacheFactoryBean.afterPropertiesSet();
+		Cache cache = cacheFactoryBean.getObject();
+		region = cache.createRegionFactory().setScope(Scope.LOCAL).create("sig-tests");
+	}
+
+	@AfterClass
+	public static void cleanup() throws Exception {
+		if (region != null) {
+			region.close();
+		}
+		if (cacheFactoryBean != null) {
+			cacheFactoryBean.destroy();
 		}
 	}
 

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/GemfireMessageStoreTests.java
@@ -24,8 +24,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.springframework.data.gemfire.CacheFactoryBean;
@@ -37,7 +38,6 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.util.Assert;
 
 import com.gemstone.gemfire.cache.Cache;
 import com.gemstone.gemfire.cache.Region;
@@ -47,17 +47,18 @@ import com.gemstone.gemfire.cache.Scope;
  * @author Mark Fisher
  * @author David Turanski
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.1
  */
 public class GemfireMessageStoreTests {
 
-	private Cache cache;
+	private static CacheFactoryBean cacheFactoryBean;
 
-	private Region<Object, Object> region;
+	private static Region<Object, Object> region;
 
 	@Test
 	public void addAndGetMessage() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 
 		Message<?> message = MessageBuilder.withPayload("test").build();
@@ -70,17 +71,19 @@ public class GemfireMessageStoreTests {
 	public void testRegionConstructor() throws Exception {
 		RegionFactoryBean<Object, Object> region = new RegionFactoryBean<Object, Object>() {};
 		region.setName("someRegion");
-		region.setCache(this.cache);
+		region.setCache(cacheFactoryBean.getObject());
 		region.afterPropertiesSet();
 
 		GemfireMessageStore store = new GemfireMessageStore(region.getObject());
 		store.afterPropertiesSet();
 		assertSame(region.getObject(), TestUtils.getPropertyValue(store, "messageStoreRegion"));
+
+		region.destroy();
 	}
 
 	@Test
 	public void testWithMessageHistory() throws Exception {
-		GemfireMessageStore store = new GemfireMessageStore(this.region);
+		GemfireMessageStore store = new GemfireMessageStore(region);
 		store.afterPropertiesSet();
 
 		Message<?> message = new GenericMessage<String>("Hello");
@@ -103,7 +106,7 @@ public class GemfireMessageStoreTests {
 
 	@Test
 	public void testAddAndRemoveMessagesFromMessageGroup() throws Exception {
-		GemfireMessageStore messageStore = new GemfireMessageStore(this.region);
+		GemfireMessageStore messageStore = new GemfireMessageStore(region);
 		messageStore.afterPropertiesSet();
 
 		String groupId = "X";
@@ -121,17 +124,26 @@ public class GemfireMessageStoreTests {
 	}
 
 	@Before
-	public void init() throws Exception {
-		CacheFactoryBean cacheFactoryBean = new CacheFactoryBean();
-		this.cache = cacheFactoryBean.getObject();
-		this.region = cache.createRegionFactory().setScope(Scope.LOCAL).create("sig-tests");
+	public void prepare() {
+		if (region != null) {
+			region.clear();
+		}
 	}
 
-	@After
-	public void cleanup() {
-		if (this.cache != null) {
-			this.cache.close();
-			Assert.isTrue(this.cache.isClosed(), "Cache did not close after close() call");
+	@BeforeClass
+	public static void init() throws Exception {
+		cacheFactoryBean = new CacheFactoryBean();
+		Cache cache = cacheFactoryBean.getObject();
+		region = cache.createRegionFactory().setScope(Scope.LOCAL).create("sig-tests");
+	}
+
+	@AfterClass
+	public static void cleanup() throws Exception {
+		if (region != null) {
+			region.close();
+		}
+		if (cacheFactoryBean != null) {
+			cacheFactoryBean.destroy();
 		}
 	}
 

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-aggregator-config-a.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-aggregator-config-a.xml
@@ -4,17 +4,16 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
-	
+
 	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="gemfireStore"/>
-	
+
 	<int:channel id="outputChannel">
 		<int:queue/>
 	</int:channel>
-	
+
 	<bean id="gemfireStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
-		<constructor-arg ref="cache"/>
+		<constructor-arg
+				value="#{T (org.springframework.integration.gemfire.store.GemfireGroupStoreTests).cacheFactoryBean.object}"/>
 	</bean>
-	
-	<bean id="cache" class="org.springframework.data.gemfire.CacheFactoryBean"/>
 
 </beans>

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-aggregator-config.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-aggregator-config.xml
@@ -4,17 +4,16 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
-	
+
 	<int:aggregator input-channel="inputChannel" output-channel="outputChannel" message-store="gemfireStore"/>
-	
+
 	<int:channel id="outputChannel">
 		<int:queue/>
 	</int:channel>
-	
+
 	<bean id="gemfireStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
-		<constructor-arg ref="myCache"/>
+		<constructor-arg
+				value="#{T (org.springframework.integration.gemfire.store.GemfireGroupStoreTests).cacheFactoryBean.object}"/>
 	</bean>
-	
-	<bean id="myCache" class="org.springframework.data.gemfire.CacheFactoryBean"/>
 
 </beans>

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-queue-config.xml
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/store/gemfire-queue-config.xml
@@ -4,24 +4,23 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
-	
-	
+
+
 	<int:channel id="gemfireQueue">
 		<int:queue message-store="gemfireStore"/>
 	</int:channel>
-	
+
 	<int:bridge input-channel="gemfireQueue" output-channel="outputQueue">
 		<int:poller fixed-rate="1000" max-messages-per-poll="200"/>
 	</int:bridge>
-	
+
 	<int:channel id="outputQueue">
 		<int:queue/>
 	</int:channel>
-	
+
 	<bean id="gemfireStore" class="org.springframework.integration.gemfire.store.GemfireMessageStore">
-		<constructor-arg ref="gemfireCache"/>
+		<constructor-arg
+				value="#{T (org.springframework.integration.gemfire.store.GemfireGroupStoreTests).cacheFactoryBean.object}"/>
 	</bean>
-	
-	<bean id="gemfireCache" class="org.springframework.data.gemfire.CacheFactoryBean"/>
 
 </beans>

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
@@ -355,11 +355,13 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 	@Test
 	public void testTryLock() throws Exception {
 		ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
-		for (int i = 0; i < 10; i++) {
-			Lock lock = registry.obtain("foo");
-			assertTrue(lock.tryLock());
-			lock.unlock();
-		}
+		Lock lock = registry.obtain("foo");
+
+		assertTrue(lock.tryLock());
+		lock.unlock();
+
+		assertTrue(lock.tryLock());
+		lock.unlock();
 
 		registry.destroy();
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4143

Gemfire: some fixes and optimization for tests

See https://build.spring.io/browse/INT-AT42SIO-199/

In some places we start `Cache` but doesn't close/destroy it in the end.
That sometimes causes conflicts with the already started GemFire from other tests or wrong state around `BeanFactoryLocator`
- Ensure `Cache` destroy in the end of each test
- In addition destroy `Region` as well to avoid unexpected race conditions, too
- Plus optimize some tests to start `Cache` and `Region` only once per test class, not for each test method

From here I can say that it even would be better to start `Cache`, and therefore whole GemFire, only once per entire Gemfire module test suite.
But that is fully different story.

Remove `forkEvery` from Gemfire module

Allow get a performance improvement for the build.

The `gradlew clean :spring-integration-gemfire:testAll` with existing state is like:

```
Total time: 3 mins 41.375 secs
```

With this fix and without `forkEvery`:

```
Total time: 1 mins 42.699 secs
```

So, 2 min saved time!

Plus fix timeouts in the `PayloadSerializingTransformerParserTests`

Conflicts:
    spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/inbound/CacheListeningMessageProducerTests.java
    spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/outbound/CacheWritingMessageHandlerTests.java
- Change `ZkLockRegistryTests.testTryLock()` to a couple attempts, since there is still some network backpressure involved
  https://build.spring.io/browse/INT-AT42SIO-311/
