### PR TITLE
INT-4145: Fix Mocking Issue

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AsyncAmqpGatewayTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AsyncAmqpGatewayTests.java
@@ -95,7 +95,7 @@ public class AsyncAmqpGatewayTests {
 		container.setQueueNames("asyncRQ1");
 		container.afterPropertiesSet();
 		container.start();
-		AsyncRabbitTemplate asyncTemplate = spy(new AsyncRabbitTemplate(template, container));
+		AsyncRabbitTemplate asyncTemplate = new AsyncRabbitTemplate(template, container);
 		asyncTemplate.setEnableConfirms(true);
 		asyncTemplate.setMandatory(true);
 		asyncTemplate.start();
@@ -208,7 +208,7 @@ public class AsyncAmqpGatewayTests {
 
 		// Simulate a nack - it's hard to get Rabbit to generate one
 		// We must have consumed all the real acks by now, though, to prevent partial stubbing errors
-
+		asyncTemplate = mock(AsyncRabbitTemplate.class);
 		RabbitMessageFuture future = asyncTemplate.new RabbitMessageFuture(null, null);
 		willReturn(future).given(asyncTemplate).sendAndReceive(anyString(), anyString(),
 				any(org.springframework.amqp.core.Message.class));
@@ -217,6 +217,7 @@ public class AsyncAmqpGatewayTests {
 		SettableListenableFuture<Boolean> confirmFuture = new SettableListenableFuture<Boolean>();
 		confirmFuture.set(false);
 		dfa.setPropertyValue("confirm", confirmFuture);
+		new DirectFieldAccessor(gateway).setPropertyValue("template", asyncTemplate);
 
 		message = MessageBuilder.withPayload("buz").setErrorChannel(errorChannel).build();
 		gateway.handleMessage(message);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4145

Strange stubbing failure on spied template.

Perhaps some JIT interaction since the method is used normally before stubbing.

Change the spy to a mock for the last part of the test.

**cherry-pick to 4.3.x**
