### PR TITLE
Get rid of Java 7 restriction in `FileWritingMH`

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -493,19 +493,13 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 
 	private File handleFileMessage(final File sourceFile, File tempFile, final File resultFile) throws IOException {
 		if (!FileExistsMode.APPEND.equals(this.fileExistsMode) && this.deleteSourceFiles) {
-			try {
-				rename(sourceFile, resultFile);
-				return resultFile;
-			}
-			catch (IOException e) {
-				if (this.logger.isInfoEnabled()) {
-					this.logger.info("Failed to move file '" + sourceFile + "'. Using copy and delete fallback.", e);
-				}
-			}
+			rename(sourceFile, resultFile);
+			return resultFile;
 		}
-
-		BufferedInputStream bis = new BufferedInputStream(new FileInputStream(sourceFile));
-		return handleInputStreamMessage(bis, sourceFile, tempFile, resultFile);
+		else {
+			BufferedInputStream bis = new BufferedInputStream(new FileInputStream(sourceFile));
+			return handleInputStreamMessage(bis, sourceFile, tempFile, resultFile);
+		}
 	}
 
 	private File handleInputStreamMessage(final InputStream sourceFileInputStream, File originalFile, File tempFile,


### PR DESCRIPTION
Since SI-5.0 is based on Java 8 no reason to have condition for the `java.nio.Files` class in the `FileWritingMessageHandler`
Also add package protected ctors to the inner private classes in the `FileWritingMessageHandler` to avoid generated synthetic classes in case of default ctor
