### PR TITLE
INT-3502: filters for `@IntegrationComponentScan`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/IntegrationComponentScan.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/IntegrationComponentScan.java
@@ -23,6 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.integration.config.IntegrationComponentScanRegistrar;
@@ -53,7 +54,7 @@ public @interface IntegrationComponentScan {
 	 * @return the array of 'basePackages'.
 	 */
 	@AliasFor("basePackages")
-	String[] value() default {};
+	String[] value() default { };
 
 	/**
 	 * Base packages to scan for annotated components.
@@ -62,7 +63,7 @@ public @interface IntegrationComponentScan {
 	 * @return the array of 'basePackages'.
 	 */
 	@AliasFor("value")
-	String[] basePackages() default {};
+	String[] basePackages() default { };
 
 	/**
 	 * Type-safe alternative to {@link #basePackages()} for specifying the packages
@@ -71,6 +72,33 @@ public @interface IntegrationComponentScan {
 	 * that serves no purpose other than being referenced by this attribute.
 	 * @return the array of 'basePackageClasses'.
 	 */
-	Class<?>[] basePackageClasses() default {};
+	Class<?>[] basePackageClasses() default { };
+
+
+	/**
+	 * Indicates whether automatic detection of classes annotated with
+	 * {@code @MessagingGateway} should be enabled.
+	 * @since 5.0
+	 */
+	boolean useDefaultFilters() default true;
+
+	/**
+	 * Specifies which types are eligible for component scanning.
+	 * <p>Further narrows the set of candidate components from everything in {@link #basePackages}
+	 * to everything in the base packages that matches the given filter or filters.
+	 * <p>Note that these filters will be applied in addition to the default filters, if specified.
+	 * Any type under the specified base packages which matches a given filter will be included,
+	 * even if it does not match the default filters (i.e. is not annotated with {@code @Component}).
+	 * @since 5.0
+	 * @see #excludeFilters()
+	 */
+	Filter[] includeFilters() default { };
+
+	/**
+	 * Specifies which types are not eligible for component scanning.
+	 * @since 5.0
+	 * @see #includeFilters()
+	 */
+	Filter[] excludeFilters() default { };
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationComponentScanRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationComponentScanRegistrar.java
@@ -16,22 +16,40 @@
 
 package org.springframework.integration.config;
 
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.Aware;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.EnvironmentAware;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.core.type.filter.AspectJTypeFilter;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.core.type.filter.RegexPatternTypeFilter;
 import org.springframework.core.type.filter.TypeFilter;
 import org.springframework.integration.annotation.MessagingGateway;
+import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
@@ -43,19 +61,27 @@ import org.springframework.util.StringUtils;
  * @since 4.0
  */
 public class IntegrationComponentScanRegistrar implements ImportBeanDefinitionRegistrar,
-		ResourceLoaderAware {
+		ResourceLoaderAware, EnvironmentAware {
 
 	private final Map<TypeFilter, ImportBeanDefinitionRegistrar> componentRegistrars = new HashMap<TypeFilter, ImportBeanDefinitionRegistrar>();
 
 	private ResourceLoader resourceLoader;
 
+	private Environment environment;
+
 	public IntegrationComponentScanRegistrar() {
-		this.componentRegistrars.put(new AnnotationTypeFilter(MessagingGateway.class, true), new MessagingGatewayRegistrar());
+		this.componentRegistrars.put(new AnnotationTypeFilter(MessagingGateway.class, true),
+				new MessagingGatewayRegistrar());
 	}
 
 	@Override
 	public void setResourceLoader(ResourceLoader resourceLoader) {
 		this.resourceLoader = resourceLoader;
+	}
+
+	@Override
+	public void setEnvironment(Environment environment) {
+		this.environment = environment;
 	}
 
 	@Override
@@ -91,9 +117,23 @@ public class IntegrationComponentScanRegistrar implements ImportBeanDefinitionRe
 			}
 		};
 
-		for (TypeFilter typeFilter : this.componentRegistrars.keySet()) {
-			scanner.addIncludeFilter(typeFilter);
+		if ((boolean) componentScan.get("useDefaultFilters")) {
+			for (TypeFilter typeFilter : this.componentRegistrars.keySet()) {
+				scanner.addIncludeFilter(typeFilter);
+			}
 		}
+
+		for (AnnotationAttributes filter : (AnnotationAttributes[]) componentScan.get("includeFilters")) {
+			for (TypeFilter typeFilter : typeFiltersFor(filter, registry)) {
+				scanner.addIncludeFilter(typeFilter);
+			}
+		}
+		for (AnnotationAttributes filter : (AnnotationAttributes[]) componentScan.get("excludeFilters")) {
+			for (TypeFilter typeFilter : typeFiltersFor(filter, registry)) {
+				scanner.addExcludeFilter(typeFilter);
+			}
+		}
+
 
 		scanner.setResourceLoader(this.resourceLoader);
 
@@ -101,11 +141,75 @@ public class IntegrationComponentScanRegistrar implements ImportBeanDefinitionRe
 			Set<BeanDefinition> candidateComponents = scanner.findCandidateComponents(basePackage);
 			for (BeanDefinition candidateComponent : candidateComponents) {
 				if (candidateComponent instanceof AnnotatedBeanDefinition) {
-					for (ImportBeanDefinitionRegistrar importBeanDefinitionRegistrar : this.componentRegistrars.values()) {
-						importBeanDefinitionRegistrar.registerBeanDefinitions(((AnnotatedBeanDefinition) candidateComponent).getMetadata(),
+					for (ImportBeanDefinitionRegistrar registrar : this.componentRegistrars.values()) {
+						registrar.registerBeanDefinitions(((AnnotatedBeanDefinition) candidateComponent).getMetadata(),
 								registry);
 					}
 				}
+			}
+		}
+	}
+
+	private List<TypeFilter> typeFiltersFor(AnnotationAttributes filter, BeanDefinitionRegistry registry) {
+		List<TypeFilter> typeFilters = new ArrayList<>();
+		FilterType filterType = filter.getEnum("type");
+
+		for (Class<?> filterClass : filter.getClassArray("classes")) {
+			switch (filterType) {
+				case ANNOTATION:
+					Assert.isAssignable(Annotation.class, filterClass,
+							"An error occurred while processing a @IntegrationComponentScan ANNOTATION type filter: ");
+					@SuppressWarnings("unchecked")
+					Class<Annotation> annotationType = (Class<Annotation>) filterClass;
+					typeFilters.add(new AnnotationTypeFilter(annotationType));
+					break;
+				case ASSIGNABLE_TYPE:
+					typeFilters.add(new AssignableTypeFilter(filterClass));
+					break;
+				case CUSTOM:
+					Assert.isAssignable(TypeFilter.class, filterClass,
+							"An error occurred while processing a @IntegrationComponentScan CUSTOM type filter: ");
+					TypeFilter typeFilter = BeanUtils.instantiateClass(filterClass, TypeFilter.class);
+					invokeAwareMethods(filter, this.environment, this.resourceLoader, registry);
+					typeFilters.add(typeFilter);
+					break;
+				default:
+					throw new IllegalArgumentException("Filter type not supported with Class value: " + filterType);
+			}
+		}
+
+		for (String expression : filter.getStringArray("pattern")) {
+			switch (filterType) {
+				case ASPECTJ:
+					typeFilters.add(new AspectJTypeFilter(expression, this.resourceLoader.getClassLoader()));
+					break;
+				case REGEX:
+					typeFilters.add(new RegexPatternTypeFilter(Pattern.compile(expression)));
+					break;
+				default:
+					throw new IllegalArgumentException("Filter type not supported with String pattern: " + filterType);
+			}
+		}
+
+		return typeFilters;
+	}
+
+	private static void invokeAwareMethods(Object parserStrategyBean, Environment environment,
+			ResourceLoader resourceLoader, BeanDefinitionRegistry registry) {
+		if (parserStrategyBean instanceof Aware) {
+			if (parserStrategyBean instanceof BeanClassLoaderAware) {
+				ClassLoader classLoader = (registry instanceof ConfigurableBeanFactory ?
+						((ConfigurableBeanFactory) registry).getBeanClassLoader() : resourceLoader.getClassLoader());
+				((BeanClassLoaderAware) parserStrategyBean).setBeanClassLoader(classLoader);
+			}
+			if (parserStrategyBean instanceof BeanFactoryAware && registry instanceof BeanFactory) {
+				((BeanFactoryAware) parserStrategyBean).setBeanFactory((BeanFactory) registry);
+			}
+			if (parserStrategyBean instanceof EnvironmentAware) {
+				((EnvironmentAware) parserStrategyBean).setEnvironment(environment);
+			}
+			if (parserStrategyBean instanceof ResourceLoaderAware) {
+				((ResourceLoaderAware) parserStrategyBean).setResourceLoader(resourceLoader);
 			}
 		}
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3502

For some use-cases it is really useful to filter `@MessagingGateway` components as any other `@ComponentScan` capable.
- Add `useDefaultFilters()`, `includeFilters()` and `excludeFilters()` to the `@IntegrationComponentScan`
- Modify `GatewayInterfaceTests` to reflect changes and be sure that logic is applied properly
