### PR TITLE
Rename `recipientMessageSelector()` to recipient()

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
@@ -77,7 +77,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @param selector the selector.
 	 * @return the router spec.
 	 */
-	public RecipientListRouterSpec recipientMessageSelector(String channelName, MessageSelector selector) {
+	public RecipientListRouterSpec recipient(String channelName, MessageSelector selector) {
 		return recipient(channelName, (GenericSelector<Message<?>>) selector);
 	}
 
@@ -131,7 +131,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @param selector the selector.
 	 * @return the router spec.
 	 */
-	public RecipientListRouterSpec recipientMessageSelector(MessageChannel channel, MessageSelector selector) {
+	public RecipientListRouterSpec recipient(MessageChannel channel, MessageSelector selector) {
 		return recipient(channel, (GenericSelector<Message<?>>) selector);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
@@ -566,7 +566,7 @@ public class RouterTests {
 					.<String, String>transform(p -> p.replaceFirst("Payload", ""))
 					.routeToRecipients(r -> r
 							.recipient("foo-channel", "'foo' == payload")
-							.recipientMessageSelector("bar-channel", m ->
+							.recipient("bar-channel", m ->
 									m.getHeaders().containsKey("recipient")
 											&& (boolean) m.getHeaders().get("recipient"))
 							.recipientFlow("'foo' == payload or 'bar' == payload or 'baz' == payload",


### PR DESCRIPTION
The compiler `Java(TM) SE Runtime Environment (build 1.8.0_111-b14)` on Windows 7 x64 says:
```
RecipientListRouterSpec.java:80: warning: [overloads] recipient(String,MessageSelector) in RecipientListRouterSpec is potentially ambiguous with <P>recipient
(String,GenericSelector<P>) in RecipientListRouterSpec
        public RecipientListRouterSpec recipient(String channelName, MessageSelector selector) {
                                       ^
  where P is a type-variable:
    P extends Object declared in method <P>recipient(String,GenericSelector<P>)
RecipientListRouterSpec.java:134: warning: [overloads] recipient(MessageChannel,MessageSelector) in RecipientListRouterSpec is potentially ambiguous with <P>
recipient(MessageChannel,GenericSelector<P>) in RecipientListRouterSpec
        public RecipientListRouterSpec recipient(MessageChannel channel, MessageSelector selector) {
                                       ^
  where P is a type-variable:
    P extends Object declared in method <P>recipient(MessageChannel,GenericSelector<P>)
2 warnings
```

That is interesting what's going on other OS and Java versions