### PR TITLE
INT-4012: PriorityChannel refinement

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PointToPointChannelParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/PointToPointChannelParser.java
@@ -94,7 +94,6 @@ public class PointToPointChannelParser extends AbstractChannelParser {
 					parserContext.getReaderContext().error("The 'capacity' attribute is not allowed"
 							+ " when providing a 'message-store' to a custom MessageGroupStore.", element);
 				}
-				builder.getRawBeanDefinition().setBeanClass(QueueChannel.class);
 			}
 
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/Channels.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/Channels.java
@@ -86,18 +86,17 @@ public class Channels {
 		return MessageChannels.priority(id);
 	}
 
-	public QueueChannelSpec.MessageStoreSpec priority(String id, PriorityCapableChannelMessageStore messageGroupStore,
+	public PriorityChannelSpec priority(String id, PriorityCapableChannelMessageStore messageGroupStore,
 			Object groupId) {
 		return MessageChannels.priority(id, messageGroupStore, groupId);
 	}
 
-	public QueueChannelSpec.MessageStoreSpec priority(PriorityCapableChannelMessageStore messageGroupStore,
-			Object groupId) {
-		return MessageChannels.priority(messageGroupStore, groupId);
-	}
-
 	public RendezvousChannelSpec rendezvous() {
 		return MessageChannels.rendezvous();
+	}
+
+	public PriorityChannelSpec priority(PriorityCapableChannelMessageStore messageGroupStore, Object groupId) {
+		return MessageChannels.priority(messageGroupStore, groupId);
 	}
 
 	public RendezvousChannelSpec rendezvous(String id) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/MessageChannels.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/MessageChannels.java
@@ -95,18 +95,17 @@ public final class MessageChannels {
 		return priority().id(id);
 	}
 
-	public static QueueChannelSpec.MessageStoreSpec priority(PriorityCapableChannelMessageStore messageGroupStore,
-			Object groupId) {
-		return new QueueChannelSpec.MessageStoreSpec(messageGroupStore, groupId);
+	public static PriorityChannelSpec priority(PriorityCapableChannelMessageStore messageGroupStore, Object groupId) {
+		return priority().messageStore(messageGroupStore, groupId);
 	}
 
-	public static QueueChannelSpec.MessageStoreSpec priority(String id,
+	public static PriorityChannelSpec priority(String id,
 			PriorityCapableChannelMessageStore messageGroupStore, Object groupId) {
-		return queue(messageGroupStore, groupId).id(id);
+		return priority(messageGroupStore, groupId).id(id);
 	}
 
 	public static <S extends PublishSubscribeChannelSpec<S>> PublishSubscribeChannelSpec<S> publishSubscribe() {
-		return new PublishSubscribeChannelSpec<S>();
+		return new PublishSubscribeChannelSpec<>();
 	}
 
 	public static <S extends PublishSubscribeChannelSpec<S>> PublishSubscribeChannelSpec<S> publishSubscribe(
@@ -116,7 +115,7 @@ public final class MessageChannels {
 
 	public static <S extends PublishSubscribeChannelSpec<S>> PublishSubscribeChannelSpec<S> publishSubscribe(
 			Executor executor) {
-		return new PublishSubscribeChannelSpec<S>(executor);
+		return new PublishSubscribeChannelSpec<>(executor);
 	}
 
 	public static <S extends PublishSubscribeChannelSpec<S>> PublishSubscribeChannelSpec<S> publishSubscribe(String id,
@@ -125,6 +124,7 @@ public final class MessageChannels {
 	}
 
 	private MessageChannels() {
+		super();
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChannelWithMessageStoreParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChannelWithMessageStoreParserTests.java
@@ -16,8 +16,10 @@
 
 package org.springframework.integration.config;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 
 import java.util.concurrent.TimeUnit;
 
@@ -26,6 +28,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.integration.channel.PriorityChannel;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.PriorityCapableChannelMessageStore;
 import org.springframework.integration.store.SimpleMessageStore;
@@ -35,14 +38,14 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author Dave Syer
+ * @author Artem Bilan
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
+@DirtiesContext
 public class ChannelWithMessageStoreParserTests {
 
 	private static final String BASE_PACKAGE = "org.springframework.integration";
@@ -58,13 +61,16 @@ public class ChannelWithMessageStoreParserTests {
 	@Autowired
 	private TestHandler handler;
 
-	@Autowired @Qualifier("messageStore")
+	@Autowired
+	@Qualifier("messageStore")
 	private MessageGroupStore messageGroupStore;
 
-	@Autowired @Qualifier("priority")
+	@Autowired
+	@Qualifier("priority")
 	private PollableChannel priorityChannel;
 
-	@Autowired @Qualifier("priorityMessageStore")
+	@Autowired
+	@Qualifier("priorityMessageStore")
 	private MessageGroupStore priorityMessageStore;
 
 	@Test
@@ -87,6 +93,7 @@ public class ChannelWithMessageStoreParserTests {
 	@DirtiesContext
 	public void testPriorityMessageStore() {
 		assertSame(this.priorityMessageStore, TestUtils.getPropertyValue(this.priorityChannel, "queue.messageGroupStore"));
+		assertThat(this.priorityChannel, instanceOf(PriorityChannel.class));
 	}
 
 	private static <T> Message<T> createMessage(T payload, Object correlationId, int sequenceSize, int sequenceNumber,

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
@@ -140,8 +140,7 @@ public class ConfigurableMongoDbMessageGroupStoreTests extends AbstractMongoDbMe
 		context.refresh();
 
 		Object priorityChannel = context.getBean("priorityChannel");
-		assertThat(priorityChannel, Matchers.not(Matchers.instanceOf(PriorityChannel.class)));
-		assertThat(priorityChannel, Matchers.instanceOf(QueueChannel.class));
+		assertThat(priorityChannel, Matchers.instanceOf(PriorityChannel.class));
 
 		QueueChannel channel = (QueueChannel) priorityChannel;
 

--- a/src/reference/asciidoc/channel.adoc
+++ b/src/reference/asciidoc/channel.adoc
@@ -520,7 +520,7 @@ public BasicMessageGroupStore mongoDbChannelMessageStore(MongoDbFactory mongoDbF
 
 @Bean
 public PollableChannel priorityQueue(BasicMessageGroupStore mongoDbChannelMessageStore) {
-    return new QueueChannel(new MessageGroupQueue(mongoDbChannelMessageStore, "priorityQueue"));
+    return new PriorityChannel(new MessageGroupQueue(mongoDbChannelMessageStore, "priorityQueue"));
 }
 ----
 
@@ -540,18 +540,22 @@ public IntegrationFlow priorityFlow(PriorityCapableChannelMessageStore mongoDbCh
 }
 ----
 
-Another option to customize the QueueChannel environment is provided by the `ref` attribute of the `<int:queue>` sub-element.
+Another option to customize the `QueueChannel` environment is provided by the `ref` attribute of the `<int:queue>` sub-element or particular constructor.
 This attribute implies the reference to any `java.util.Queue` implementation.
-An implementation is provided by the https://github.com/reactor/reactor[Project Reactor] and its `reactor.queue.PersistentQueue` implementation for the https://github.com/OpenHFT/Chronicle-Queue[IndexedChronicle]:
+For example Hazelcast distributed https://hazelcast.com/use-cases/imdg/imdg-messaging/[`IQueue`]:
 
 [source,java]
 ----
 @Bean
-public QueueChannel reactorQueue() {
-    return new QueueChannel(new PersistentQueueSpec<Message<?>>()
-                    .codec(new JavaSerializationCodec<Message<?>>())
-                    .basePath(System.getProperty("java.io.tmpdir") + "/reactor-queue")
-                    .get());
+public HazelcastInstance hazelcastInstance() {
+    return Hazelcast.newHazelcastInstance(new Config()
+                                           .setProperty("hazelcast.logging.type", "log4j"));
+}
+
+@Bean
+public PollableChannel distributedQueue() {
+    return new QueueChannel(hazelcastInstance()
+                              .getQueue("springIntegrationQueue"));
 }
 ----
 
@@ -632,7 +636,7 @@ The following example demonstrates all of these:
 ----
 
 Since _version 4.0_, the `priority-channel` child element supports the `message-store` option (`comparator` and `capacity` are not allowed in that case).
-The message store must be a `PriorityCapableChannelMessageStore` and, in this case, the namespace parser will declare a `QueueChannel` instead of a `PriorityChannel`.
+The message store must be a `PriorityCapableChannelMessageStore` and, in this case.
 Implementations of the `PriorityCapableChannelMessageStore` are currently provided for `Redis`, `JDBC` and `MongoDB`.
 See <<channel-configuration-queuechannel>> and <<message-store>> for more information.
 You can find sample configuration in <<jdbc-message-store-channels>>.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4012

Previously to configure a `priority` for the `MessageChannel` we should configure `QueueChannel` for particular `MessageStore`.
Although the target priority logic is really in the `MessageStore` implementation, it isn't so obvious why we can't use `PriorityChannel` instance for `MessageStore` case as well.

* Add `PriorityCapableChannelMessageStore` and `MessageGroupQueue` based ctors to the `PriorityChannel` for consistency.
* Delegate the logic to the super `QueueChannel` as before
* Rework `PointToPointChannelParser` and Java DSL components to reflect a new state of the `PriorityChannel`
* Improve Docs on the matter