### PR TITLE
INT-4167: Fix `ZkLockRegistryTests` race condition

### DIFF
--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
@@ -18,6 +18,7 @@ package org.springframework.integration.zookeeper.lock;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -304,7 +305,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		Lock lock2 = registry.obtain("bar");
 
 		assertFalse("Should not have been able to lock with zookeeper server stopped!",
-					lock2.tryLock(1, TimeUnit.SECONDS));
+				lock2.tryLock(1, TimeUnit.SECONDS));
 
 		testingServer.restart();
 
@@ -329,7 +330,13 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
 		for (int i = 0; i < 10; i++) {
 			Lock lock = registry.obtain("foo");
-			assertTrue(lock.tryLock());
+
+			int n = 0;
+			while (!lock.tryLock() && n++ < 100) {
+				Thread.sleep(100);
+			}
+			assertThat(n, lessThan(100));
+
 			lock.unlock();
 		}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4167

Since the current `ZkLock.tryLock()` is based on the fact of waiting for **at most 1 second**, that still has some timing issue for test-case, when the network delay may affect our expectation.

* Add `Thread.sleep()` with `while()` to the `ZkLockRegistryTests.testTryLock()` test to spin until successful `tryLock()`

**Cherry-pick to 4.3.x & 4.2.x**

Note: to avoid cherry-pick conflict for `4.2.x` just fully copy/paste the modified test