### PR TITLE
INT-4172: canWrite(mediaType) in SerializingHttpMC

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/converter/SerializingHttpMessageConverter.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/converter/SerializingHttpMessageConverter.java
@@ -34,11 +34,14 @@ import org.springframework.util.FileCopyUtils;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class SerializingHttpMessageConverter extends AbstractHttpMessageConverter<Serializable> {
 
-	private static final MediaType APPLICATION_JAVA_SERIALIZED_OBJECT = new MediaType("application", "x-java-serialized-object");
+	private static final MediaType APPLICATION_JAVA_SERIALIZED_OBJECT =
+			new MediaType("application", "x-java-serialized-object");
 
 
 	/** Creates a new instance of the {@code SerializingHttpMessageConverter}. */
@@ -54,7 +57,7 @@ public class SerializingHttpMessageConverter extends AbstractHttpMessageConverte
 
 	@Override
 	public boolean canWrite(Class<?> clazz, MediaType mediaType) {
-		return (Serializable.class.isAssignableFrom(clazz) && APPLICATION_JAVA_SERIALIZED_OBJECT.includes(mediaType));
+		return Serializable.class.isAssignableFrom(clazz) && canWrite(mediaType);
 	}
 
 	@Override


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4172

The `SerializingHttpMessageConverter` which can be customized via `setSupportedMediaTypes()`, but at the same time `canWrite(Class<?> clazz, MediaType mediaType)` consult only default `APPLICATION_JAVA_SERIALIZED_OBJECT`

The target application really may face different media types for the `Serialized` objects not just built-in `application/x-java-serialized-object`

Since we can customize `SerializingHttpMessageConverter` via  `setSupportedMediaTypes()` that will be fully consistent to consult `canWrite(mediaType)`