### PR TITLE
INT-4175: Fix SftpSessionFactory race condition

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -378,7 +378,19 @@ public class DefaultSftpSessionFactory implements SessionFactory<LsEntry>, Share
 				jschSession = new JSchSessionWrapper(initJschSession());
 			}
 			SftpSession sftpSession = new SftpSession(jschSession);
-			sftpSession.connect();
+
+			if (this.isSharedSession) {
+				this.sharedSessionLock.readLock().lock();
+			}
+			try {
+				sftpSession.connect();
+			}
+			finally {
+				if (this.isSharedSession) {
+					this.sharedSessionLock.readLock().unlock();
+				}
+			}
+
 			jschSession.addChannel();
 			return sftpSession;
 		}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4175

When the `isSharedSession` is used for the `DefaultSftpSessionFactory`,
there is some race condition window when we can call the target `this.jschSession.connect()` several times and end up with the session is already connected.

Wrap `sftpSession.connect()` to the `this.sharedSessionLock.readLock().lock()` when `isSharedSession` to protect from that race condition.

Note: there is no test for this change because it is pretty tricky to build barriers between threads for this kind of race conditions.
Especially after introduction `this.sharedSessionLock.readLock().lock()` around guilty code

**Cherry-pick to 4.3.x & 4.2.x**