### PR TITLE
INT-4178: Retry `CannotSerializeTransactionException` in `JdbcLockRegistry`

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
@@ -26,6 +26,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.CannotSerializeTransactionException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.integration.support.locks.DefaultLockRegistry;
 import org.springframework.integration.support.locks.ExpirableLockRegistry;
@@ -120,6 +121,9 @@ public class JdbcLockRegistry implements ExpirableLockRegistry {
 					}
 					break;
 				}
+				catch (CannotSerializeTransactionException e) {
+					// try again
+				}
 				catch (TransactionTimedOutException e) {
 					// try again
 				}
@@ -153,6 +157,9 @@ public class JdbcLockRegistry implements ExpirableLockRegistry {
 						}
 					}
 					break;
+				}
+				catch (CannotSerializeTransactionException e) {
+					// try again
 				}
 				catch (TransactionTimedOutException e) {
 					// try again
@@ -197,6 +204,9 @@ public class JdbcLockRegistry implements ExpirableLockRegistry {
 						this.delegate.unlock();
 					}
 					return acquired;
+				}
+				catch (CannotSerializeTransactionException e) {
+					// try again
 				}
 				catch (TransactionTimedOutException e) {
 					// try again


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4178

The `JdbcLockRegistry` does not retry `CannotSerializeTransactionException` thrown by `DefaultLockRepository.acquire` which in turn causes `LockRegistryLeaderInitiator`s thread to get stuck.

* catch `CannotSerializeTransactionException` on `DefaultLockRepository.acquire` and ignore it to ensure a retry

I'm not sure how to test this properly since it's environment specific (PostgreSQL) but I'll be happy to update the PR if you have an idea how to test it.