### PR TITLE
INT-4180: RecipientListRouterSpec Fix

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
@@ -20,6 +20,7 @@ import org.springframework.expression.Expression;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.core.GenericSelector;
 import org.springframework.integration.core.MessageSelector;
+import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.filter.ExpressionEvaluatingSelector;
 import org.springframework.integration.filter.MethodInvokingSelector;
 import org.springframework.integration.handler.LambdaMessageProcessor;
@@ -32,6 +33,7 @@ import org.springframework.util.StringUtils;
  * An {@link AbstractRouterSpec} for a {@link RecipientListRouter}.
  *
  * @author Artem Bilan
+ * @author Gary Russell
  *
  * @since 5.0
  */
@@ -122,7 +124,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @return the router spec.
 	 */
 	public RecipientListRouterSpec recipient(MessageChannel channel) {
-		return recipient(channel, (String) null);
+		return recipient(channel, new ValueExpression<Boolean>(Boolean.TRUE));
 	}
 
 	/**
@@ -132,7 +134,8 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 * @return the router spec.
 	 */
 	public RecipientListRouterSpec recipient(MessageChannel channel, String expression) {
-		return recipient(channel, StringUtils.hasText(expression) ? PARSER.parseExpression(expression) : null);
+		Assert.hasText(expression, "'expression' cannot be null or empty");
+		return recipient(channel, PARSER.parseExpression(expression));
 	}
 
 	/**

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
@@ -61,6 +61,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Artem Bilan
+ * @author Gary Russell
  *
  * @since 5.0
  */
@@ -441,6 +442,10 @@ public class RouterTests {
 	@Qualifier("recipientListOrderResult")
 	private PollableChannel recipientListOrderResult;
 
+	@Autowired
+	@Qualifier("alwaysRecipient")
+	private QueueChannel alwaysRecipient;
+
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testRecipientListRouterOrder() {
@@ -455,6 +460,8 @@ public class RouterTests {
 		assertNotNull(receive);
 		result = (AtomicReference<String>) receive.getPayload();
 		assertEquals("Hello World", result.get());
+
+		assertEquals(1, this.alwaysRecipient.getQueueSize());
 	}
 
 	@Autowired
@@ -582,7 +589,6 @@ public class RouterTests {
 					.get();
 		}
 
-
 		@Bean
 		public RoutingTestBean routingTestBean() {
 			return new RoutingTestBean();
@@ -646,6 +652,7 @@ public class RouterTests {
 		public IntegrationFlow recipientListOrderFlow() {
 			return f -> f
 					.routeToRecipients(r -> r
+							.recipient(alwaysRecipient())
 							.recipient("recipient2.input")
 							.recipient("recipient1.input"));
 		}
@@ -672,6 +679,11 @@ public class RouterTests {
 
 		@Bean
 		public PollableChannel recipientListOrderResult() {
+			return new QueueChannel();
+		}
+
+		@Bean
+		public QueueChannel alwaysRecipient() {
 			return new QueueChannel();
 		}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4180

Use true `ValueExpression` for recipient() without selector.

Assert selector epresion string is not null or empty.

Add test.