### PR TITLE
INT-4183: Add SSL Handshake Timeout for TCP

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/IpAdapterParserUtils.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/IpAdapterParserUtils.java
@@ -124,6 +124,10 @@ public abstract class IpAdapterParserUtils {
 
 	public static final String MAPPER = "mapper";
 
+	public static final String READ_DELAY = "read-delay";
+
+	public static final String SSL_HANDSHAKE_TIMEOUT = "ssl-handshake-timeout";
+
 	private IpAdapterParserUtils() {
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
@@ -112,6 +112,8 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 
 	private volatile TcpSSLContextSupport sslContextSupport;
 
+	private volatile Integer sslHandshakeTimeout;
+
 	private volatile TcpSocketSupport socketSupport = new DefaultTcpSocketSupport();
 
 	private volatile TcpNioConnectionSupport nioConnectionSupport;
@@ -165,6 +167,9 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 				connectionFactory.setUsingDirectBuffers(this.usingDirectBuffers);
 				connectionFactory.setTcpNioConnectionSupport(this.obtainNioConnectionSupport());
 				this.connectionFactory = connectionFactory;
+			}
+			if (this.sslHandshakeTimeout != null) {
+				this.connectionFactory.setSslHandshakeTimeout(this.sslHandshakeTimeout);
 			}
 		}
 		else {
@@ -495,6 +500,15 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 	@Override
 	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
 		this.applicationEventPublisher = applicationEventPublisher;
+	}
+
+	/**
+	 * Set the SSL handshake timeout (only used with SSL and NIO).
+	 * @param sslHandshakeTimeout the timeout.
+	 * @since 4.3.6
+	 */
+	public void setSslHandshakeTimeout(Integer sslHandshakeTimeout) {
+		this.sslHandshakeTimeout = sslHandshakeTimeout;
 	}
 
 	private boolean isClient() {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryParser.java
@@ -92,7 +92,10 @@ public class TcpConnectionFactoryParser extends AbstractBeanDefinitionParser {
 				IpAdapterParserUtils.SOCKET_SUPPORT);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.MAPPER);
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "read-delay");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.SSL_HANDSHAKE_TIMEOUT);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.READ_DELAY);
 
 		return builder.getBeanDefinition();
 	}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -127,6 +127,8 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 
 	private volatile long readDelay = DEFAULT_READ_DELAY;
 
+	private volatile Integer sslHandshakeTimeout;
+
 	public AbstractConnectionFactory(int port) {
 		this.port = port;
 	}
@@ -454,6 +456,25 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 	public void setNioHarvestInterval(int nioHarvestInterval) {
 		Assert.isTrue(nioHarvestInterval > 0, "NIO Harvest interval must be > 0");
 		this.nioHarvestInterval = nioHarvestInterval;
+	}
+
+	/**
+	 * Set the handshake timeout used when waiting for SSL handshake data; only applies
+	 * to SSL connections, when using NIO.
+	 * @param sslHandshakeTimeout the timeout.
+	 * @since 4.6.3
+	 */
+	public void setSslHandshakeTimeout(int sslHandshakeTimeout) {
+		this.sslHandshakeTimeout = sslHandshakeTimeout;
+	}
+
+	/**
+	 * @return the handshake timeout.
+	 * @see #setSslHandshakeTimeout(int)
+	 * @since 4.6.3
+	 */
+	protected Integer getSslHandshakeTimeout() {
+		return this.sslHandshakeTimeout;
 	}
 
 	protected BlockingQueue<PendingIO> getDelayedReads() {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
@@ -88,6 +88,9 @@ public class TcpNioClientConnectionFactory extends
 				socketChannel, false, this.isLookupHost(), this.getApplicationEventPublisher(), this.getComponentName());
 		connection.setUsingDirectBuffers(this.usingDirectBuffers);
 		connection.setTaskExecutor(this.getTaskExecutor());
+		if (getSslHandshakeTimeout() != null && connection instanceof TcpNioSSLConnection) {
+			((TcpNioSSLConnection) connection).setHandshakeTimeout(getSslHandshakeTimeout());
+		}
 		TcpConnectionSupport wrappedConnection = wrapConnection(connection);
 		initializeConnection(wrappedConnection, socketChannel.socket());
 		socketChannel.configureBlocking(false);

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
@@ -220,6 +220,9 @@ public class TcpNioServerConnectionFactory extends AbstractServerConnectionFacto
 				}
 				connection.setTaskExecutor(getTaskExecutor());
 				connection.setLastRead(now);
+				if (getSslHandshakeTimeout() != null && connection instanceof TcpNioSSLConnection) {
+					((TcpNioSSLConnection) connection).setHandshakeTimeout(getSslHandshakeTimeout());
+				}
 				this.channelMap.put(channel, connection);
 				channel.register(selector, SelectionKey.OP_READ, connection);
 				connection.publishConnectionOpenEvent();

--- a/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-5.0.xsd
+++ b/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-5.0.xsd
@@ -693,6 +693,20 @@
 					</xsd:appinfo>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="ssl-handshake-timeout" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						The timeout (in seconds) to use while performing handshakes on SSL sockets;
+						only applies when 'using-nio' is 'true'. Default: 30.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.integration.ip.tcp.connection.TcpSSLContextSupport" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="socket-support" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
@@ -71,6 +71,7 @@
 		apply-sequence="true"
 		using-nio="true"
 		ssl-context-support="sslContextSupport"
+		ssl-handshake-timeout="43"
 		/>
 
 	<bean id="sslContextSupport" class="org.springframework.integration.ip.tcp.connection.DefaultTcpSSLContextSupport">
@@ -86,6 +87,17 @@
 		lookup-host="false"
 		apply-sequence="true"
 		ssl-context-support="sslContextSupport"
+		socket-support="socketSupport"
+		socket-factory-support="socketFactorySupport" />
+
+	<ip:tcp-connection-factory id="secureServerNio"
+		type="server"
+		port="#{tcpIpUtils.findAvailableServerSocket(5250)}"
+		lookup-host="false"
+		apply-sequence="true"
+		using-nio="true"
+		ssl-context-support="sslContextSupport"
+		ssl-handshake-timeout="34"
 		socket-support="socketSupport"
 		socket-factory-support="socketFactorySupport" />
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -257,6 +257,9 @@ public class ParserUnitTests {
 	TcpNetServerConnectionFactory secureServer;
 
 	@Autowired
+	TcpNioServerConnectionFactory secureServerNio;
+
+	@Autowired
 	TcpSocketFactorySupport socketFactorySupport;
 
 	@Autowired
@@ -343,6 +346,7 @@ public class ParserUnitTests {
 		Object connectionSupport = TestUtils.getPropertyValue(cfS1Nio, "tcpNioConnectionSupport");
 		assertTrue(connectionSupport instanceof DefaultTcpNioSSLConnectionSupport);
 		assertNotNull(TestUtils.getPropertyValue(connectionSupport, "sslContext"));
+		assertEquals(43, TestUtils.getPropertyValue(this.cfS1Nio, "sslHandshakeTimeout"));
 	}
 
 	@Test
@@ -656,6 +660,7 @@ public class ParserUnitTests {
 		DirectFieldAccessor dfa = new DirectFieldAccessor(secureServer);
 		assertSame(socketFactorySupport, dfa.getPropertyValue("tcpSocketFactorySupport"));
 		assertSame(socketSupport, dfa.getPropertyValue("tcpSocketSupport"));
+		assertEquals(34, TestUtils.getPropertyValue(this.secureServerNio, "sslHandshakeTimeout"));
 	}
 
 	public static class FooAdvice extends AbstractRequestHandlerAdvice {

--- a/src/reference/asciidoc/ip.adoc
+++ b/src/reference/asciidoc/ip.adoc
@@ -893,6 +893,9 @@ The `DefaulTcpSSLContextSupport` class also has an optional 'protocol' property,
 
 The keystore file names (first two constructor arguments) use the Spring `Resource` abstraction; by default the files will be located on the classpath, but this can be overridden by using the `file:` prefix, to find the files on the filesystem instead.
 
+Starting with _version 4.3.6_, when using NIO, you can specify an `ssl-handshake-timeout` (seconds) on the connection factory.
+This timeout (default 30) is used during SSL handshake when waiting for data; if the timeout is exceeded, the process is aborted and the socket closed.
+
 ==== Advanced Techniques
 
 In many cases, the configuration described above is all that is needed to enable secure communication over TCP/IP.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4183

Previously, this was hard-coded to 30 seconds.

(I don't think this warrants a "what's new" entry.

__cherry-pick to 4.3.x__