### PR TITLE
Fix race conditions in TcpNioConnectionReadTests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,4 @@ install: true
 env:
   - TERM=dumb SI_FATAL_WHEN_NO_BEANFACTORY=true NO_REFERENCE_TASK=true
 script:
-#    - ./gradlew check --refresh-dependencies --no-daemon
-    - ./gradlew :spring-integration-ip:test --no-daemon --tests=*TcpNioConnectionReadTests -d
+    - ./gradlew check --refresh-dependencies --no-daemon

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,5 @@ install: true
 env:
   - TERM=dumb SI_FATAL_WHEN_NO_BEANFACTORY=true NO_REFERENCE_TASK=true
 script:
-    - ./gradlew check --refresh-dependencies --no-daemon
+#    - ./gradlew check --refresh-dependencies --no-daemon
+    - ./gradlew :spring-integration-ip:test --no-daemon --tests=*TcpNioConnectionReadTests -d


### PR DESCRIPTION
https://build.spring.io/browse/INT-SI43X-60

After introduction the `sendErrorToListener()` function for the `TcpConnectionSupport`, all the tests in the `TcpNioConnectionReadTests` have flaw to be affected by the race condition to release semaphore in the `onMessage()` and don't get a connection as closed yet.

* Fix the tests adding `CountDownLatch` for the `ErrorMessage` and `AtomicReference` to assert an Exception message afterwards.

**Cherry-pick to 4.3.x**