### PR TITLE
INT-4187 Add an option to skip StdErr process if it is not needed

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
@@ -35,6 +35,7 @@ import org.springframework.util.StringUtils;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Ali Shahbour
  * @since 3.0
  *
  */
@@ -42,6 +43,8 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 		implements BeanNameAware, SmartLifecycle, ApplicationEventPublisherAware {
 
 	private volatile String nativeOptions;
+
+	private volatile boolean enableStatusReader = true;
 
 	private volatile File file;
 
@@ -75,6 +78,10 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 		if (StringUtils.hasText(nativeOptions)) {
 			this.nativeOptions = nativeOptions;
 		}
+	}
+
+	public void setEnableStatusReader(boolean enableStatusReader) {
+		this.enableStatusReader = enableStatusReader;
 	}
 
 	public void setFile(File file) {
@@ -180,6 +187,7 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 		FileTailingMessageProducerSupport adapter;
 		if (this.delay == null && this.end == null && this.reopen == null) {
 			adapter = new OSDelegatingFileTailingMessageProducer();
+			((OSDelegatingFileTailingMessageProducer) adapter).setEnableStatusReader(this.enableStatusReader);
 			if (this.nativeOptions != null) {
 				((OSDelegatingFileTailingMessageProducer) adapter).setOptions(this.nativeOptions);
 			}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
@@ -84,6 +84,7 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 	 * If false, thread for capturing stderr will not be started
 	 * and stderr output will be ignored
 	 * @param enableStatusReader true or false
+	 * @since 4.3.6
 	 */
 	public void setEnableStatusReader(boolean enableStatusReader) {
 		this.enableStatusReader = enableStatusReader;

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
@@ -80,6 +80,11 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 		}
 	}
 
+	/**
+	 * If false, thread for capturing stderr will not be started
+	 * and stderr output will be ignored
+	 * @param enableStatusReader true or false
+	 */
 	public void setEnableStatusReader(boolean enableStatusReader) {
 		this.enableStatusReader = enableStatusReader;
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParser.java
@@ -28,6 +28,7 @@ import org.springframework.util.StringUtils;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Ali Shahbour
  * @since 3.0
  *
  */
@@ -41,6 +42,7 @@ public class FileTailInboundChannelAdapterParser extends AbstractChannelAdapterP
 			builder.addPropertyReference("outputChannel", channelName);
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "native-options");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "enable-status-reader");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "file");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "task-executor");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "task-scheduler");

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/tail/OSDelegatingFileTailingMessageProducer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/tail/OSDelegatingFileTailingMessageProducer.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @author Gavin Gray
+ * @author Ali Shahbour
  * @since 3.0
  *
  */
@@ -46,6 +47,8 @@ public class OSDelegatingFileTailingMessageProducer extends FileTailingMessagePr
 
 	private volatile String command = "ADAPTER_NOT_INITIALIZED";
 
+	private volatile boolean enableStatusReader = true;
+
 	private volatile BufferedReader reader;
 
 	private volatile TaskScheduler scheduler;
@@ -57,6 +60,10 @@ public class OSDelegatingFileTailingMessageProducer extends FileTailingMessagePr
 		else {
 			this.options = options;
 		}
+	}
+
+	public void setEnableStatusReader(boolean enableStatusReader) {
+		this.enableStatusReader = enableStatusReader;
 	}
 
 	public String getCommand() {
@@ -114,7 +121,8 @@ public class OSDelegatingFileTailingMessageProducer extends FileTailingMessagePr
 			BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
 			this.process = process;
 			this.startProcessMonitor();
-			this.startStatusReader();
+			if(enableStatusReader)
+				this.startStatusReader();
 			this.reader = reader;
 			this.getTaskExecutor().execute(this);
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/tail/OSDelegatingFileTailingMessageProducer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/tail/OSDelegatingFileTailingMessageProducer.java
@@ -62,6 +62,11 @@ public class OSDelegatingFileTailingMessageProducer extends FileTailingMessagePr
 		}
 	}
 
+	/**
+	 * If false, thread for capturing stderr will not be started
+	 * and stderr output will be ignored
+	 * @param enableStatusReader true or false
+	 */
 	public void setEnableStatusReader(boolean enableStatusReader) {
 		this.enableStatusReader = enableStatusReader;
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/tail/OSDelegatingFileTailingMessageProducer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/tail/OSDelegatingFileTailingMessageProducer.java
@@ -121,8 +121,9 @@ public class OSDelegatingFileTailingMessageProducer extends FileTailingMessagePr
 			BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
 			this.process = process;
 			this.startProcessMonitor();
-			if(enableStatusReader)
+			if (this.enableStatusReader) {
 				this.startStatusReader();
+			}
 			this.reader = reader;
 			this.getTaskExecutor().execute(this);
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/tail/OSDelegatingFileTailingMessageProducer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/tail/OSDelegatingFileTailingMessageProducer.java
@@ -66,6 +66,7 @@ public class OSDelegatingFileTailingMessageProducer extends FileTailingMessagePr
 	 * If false, thread for capturing stderr will not be started
 	 * and stderr output will be ignored
 	 * @param enableStatusReader true or false
+     * @since 4.3.6
 	 */
 	public void setEnableStatusReader(boolean enableStatusReader) {
 		this.enableStatusReader = enableStatusReader;

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
@@ -234,6 +234,14 @@ Only files matching this regular expression will be picked up by this adapter.
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:attribute>
+            <xsd:attribute name="enable-status-reader" type="xsd:boolean">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        Configure the adapter to either start a thread for capturing stderr or not
+                        Default: True
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
             <xsd:attribute name="file" type="xsd:string">
                 <xsd:annotation>
                     <xsd:documentation>

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests-context.xml
@@ -28,6 +28,7 @@
 		native-options="-F -n 6"
 		task-executor="exec"
 		task-scheduler="sched"
+		enable-status-reader="false"
 		file-delay="456"
 		file="/tmp/foo"
 		auto-startup="true"

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests.java
@@ -38,6 +38,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.annotation.DirtiesContext;
 
 /**
  * @author Gary Russell
@@ -47,6 +48,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
 public class FileTailInboundChannelAdapterParserTests {
 
 	@Autowired @Qualifier("default")
@@ -78,6 +80,7 @@ public class FileTailInboundChannelAdapterParserTests {
 		assertEquals("tail -F -n 0 " + fileName, TestUtils.getPropertyValue(defaultAdapter, "command"));
 		assertSame(exec, TestUtils.getPropertyValue(defaultAdapter, "taskExecutor"));
 		assertTrue(TestUtils.getPropertyValue(defaultAdapter, "autoStartup", Boolean.class));
+		assertTrue(TestUtils.getPropertyValue(defaultAdapter, "enableStatusReader", Boolean.class));
 		assertEquals(123, TestUtils.getPropertyValue(defaultAdapter, "phase"));
 		assertSame(this.tailErrorChannel, TestUtils.getPropertyValue(defaultAdapter, "errorChannel"));
 		this.defaultAdapter.stop();
@@ -95,7 +98,7 @@ public class FileTailInboundChannelAdapterParserTests {
 		assertSame(exec, TestUtils.getPropertyValue(nativeAdapter, "taskExecutor"));
 		assertSame(sched, TestUtils.getPropertyValue(nativeAdapter, "taskScheduler"));
 		assertTrue(TestUtils.getPropertyValue(nativeAdapter, "autoStartup", Boolean.class));
-		assertTrue(TestUtils.getPropertyValue(nativeAdapter, "enableStatusReader" ,Boolean.class));
+		assertFalse(TestUtils.getPropertyValue(nativeAdapter, "enableStatusReader", Boolean.class));
 		assertEquals(123, TestUtils.getPropertyValue(nativeAdapter, "phase"));
 		assertEquals(456L, TestUtils.getPropertyValue(nativeAdapter, "tailAttemptsDelay"));
 	}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests.java
@@ -44,6 +44,7 @@ import org.springframework.test.annotation.DirtiesContext;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Gavin Gray
+ * @author Ali Shahbour
  * @since 3.0
  */
 @ContextConfiguration

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests.java
@@ -95,6 +95,7 @@ public class FileTailInboundChannelAdapterParserTests {
 		assertSame(exec, TestUtils.getPropertyValue(nativeAdapter, "taskExecutor"));
 		assertSame(sched, TestUtils.getPropertyValue(nativeAdapter, "taskScheduler"));
 		assertTrue(TestUtils.getPropertyValue(nativeAdapter, "autoStartup", Boolean.class));
+		assertTrue(TestUtils.getPropertyValue(nativeAdapter, "enableStatusReader" ,Boolean.class));
 		assertEquals(123, TestUtils.getPropertyValue(nativeAdapter, "phase"));
 		assertEquals(456L, TestUtils.getPropertyValue(nativeAdapter, "tailAttemptsDelay"));
 	}

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -455,8 +455,8 @@ If the tail command fails (on some platforms, a missing file causes the `tail` t
 	file="/tmp/foo"/>
 ----
 
-This creates a native adapter with default '-F -n 0' options (follow the file name from the current end) and discard any messages logged to stderr.
-
+By default native adapter capture from standard output and send them as messages and from standard error to raise events.
+You can discard the standard error events by setting enable-status-reader to false.
 
 [source,xml]
 ----

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -448,6 +448,18 @@ If the tail command fails (on some platforms, a missing file causes the `tail` t
 
 [source,xml]
 ----
+<int-file:tail-inbound-channel-adapter id="native"
+	channel="input"
+	enable-status-reader="false"
+	task-executor="exec"
+	file="/tmp/foo"/>
+----
+
+This creates a native adapter with default '-F -n 0' options (follow the file name from the current end) and discard any messages logged to stderr.
+
+
+[source,xml]
+----
 <int-file:tail-inbound-channel-adapter id="apache"
 	channel="input"
 	task-executor="exec"


### PR DESCRIPTION
based on INT-4187 and my question in [stack overflow ](http://stackoverflow.com/questions/41075112/file-tail-inbound-channel-adapter-stderr-and-stdout) . I did name the new field enableStatusReader per function name .

This is my first contribution so if i did any thing wrong please tell me