### PR TITLE
INT-4188: Add Idle Event Interval Support

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
@@ -46,6 +46,8 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 
 	private volatile boolean enableStatusReader = true;
 
+	private volatile Long idleEventInterval;
+
 	private volatile File file;
 
 	private volatile TaskExecutor taskExecutor;
@@ -88,6 +90,15 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 	 */
 	public void setEnableStatusReader(boolean enableStatusReader) {
 		this.enableStatusReader = enableStatusReader;
+	}
+
+	/**
+	 * How often to emit {@link FileTailingMessageProducerSupport.FileTailingIdleEvent}s in milliseconds.
+	 * @param idleEventInterval the interval.
+	 * @since 5.0
+	 */
+	public void setIdleEventInterval(long idleEventInterval) {
+		this.idleEventInterval = idleEventInterval;
 	}
 
 	public void setFile(File file) {
@@ -221,6 +232,9 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 		}
 		if (this.fileDelay != null) {
 			adapter.setTailAttemptsDelay(this.fileDelay);
+		}
+		if (this.idleEventInterval != null) {
+			adapter.setIdleEventInterval(this.idleEventInterval);
 		}
 		adapter.setOutputChannel(this.outputChannel);
 		adapter.setErrorChannel(this.errorChannel);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParser.java
@@ -43,6 +43,7 @@ public class FileTailInboundChannelAdapterParser extends AbstractChannelAdapterP
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "native-options");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "enable-status-reader");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "idle-event-interval");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "file");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "task-executor");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "task-scheduler");

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/TailAdapterSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/TailAdapterSpec.java
@@ -67,8 +67,8 @@ public class TailAdapterSpec extends MessageProducerSpec<TailAdapterSpec, FileTa
 
 
 	/**
-	 * This field control the stderr events
-	 * @param enableStatusReader
+	 * This field control the stderr events.
+	 * @param enableStatusReader boolean to enable or disable events from stderr.
 	 * @return the spec
 	 */
 	public TailAdapterSpec enableStatusReader(boolean enableStatusReader) {
@@ -77,8 +77,8 @@ public class TailAdapterSpec extends MessageProducerSpec<TailAdapterSpec, FileTa
 	}
 
 	/**
-	 * Specify the idle interval before start sending idle events
-	 * @param idleEventInterval
+	 * Specify the idle interval before start sending idle events.
+	 * @param idleEventInterval interval in ms for the event idle time.
 	 * @return the spec.
 	 */
 	public TailAdapterSpec idleEventInterval(long idleEventInterval)  {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/TailAdapterSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/TailAdapterSpec.java
@@ -65,6 +65,27 @@ public class TailAdapterSpec extends MessageProducerSpec<TailAdapterSpec, FileTa
 		return _this();
 	}
 
+
+	/**
+	 * This field control the stderr events
+	 * @param enableStatusReader
+	 * @return the spec
+	 */
+	public TailAdapterSpec enableStatusReader(boolean enableStatusReader) {
+		this.factoryBean.setEnableStatusReader(enableStatusReader);
+		return _this();
+	}
+
+	/**
+	 * Specify the idle interval before start sending idle events
+	 * @param idleEventInterval
+	 * @return the spec.
+	 */
+	public TailAdapterSpec idleEventInterval(long idleEventInterval)  {
+		this.factoryBean.setIdleEventInterval(idleEventInterval);
+		return _this();
+	}
+
 	/**
 	 * Configure a task executor. Defaults to a
 	 * {@link org.springframework.core.task.SimpleAsyncTaskExecutor}.

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/tail/FileTailingMessageProducerSupport.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/tail/FileTailingMessageProducerSupport.java
@@ -169,7 +169,7 @@ public abstract class FileTailingMessageProducerSupport extends MessageProducerS
 
 	private void publishIdleEvent(long idleTime) {
 
-		if (this.eventPublisher != null) {
+		if (this.eventPublisher != null && getFile().exists()) {
 			FileTailingIdleEvent event = new FileTailingIdleEvent(this, this.file, idleTime);
 			this.eventPublisher.publishEvent(event);
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/tail/FileTailingMessageProducerSupport.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/tail/FileTailingMessageProducerSupport.java
@@ -28,7 +28,6 @@ import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.event.FileIntegrationEvent;
 import org.springframework.messaging.Message;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 
 /**
@@ -108,11 +107,6 @@ public abstract class FileTailingMessageProducerSupport extends MessageProducerS
 	}
 
 	@Override
-	public void setTaskScheduler(TaskScheduler taskScheduler) {
-		super.setTaskScheduler(taskScheduler);
-	}
-
-	@Override
 	public String getComponentType() {
 		return "file:tail-inbound-channel-adapter";
 	}
@@ -144,11 +138,11 @@ public abstract class FileTailingMessageProducerSupport extends MessageProducerS
 		if (this.idleEventInterval > 0) {
 			this.idleEventScheduledFuture = getTaskScheduler().scheduleWithFixedDelay(() -> {
 				long now = System.currentTimeMillis();
-				long lastAlertAt = FileTailingMessageProducerSupport.this.lastNoMessageAlert.get();
-				long lastReceive = FileTailingMessageProducerSupport.this.lastReceive;
-				if (now > lastReceive + FileTailingMessageProducerSupport.this.idleEventInterval
-						&& now > lastAlertAt + FileTailingMessageProducerSupport.this.idleEventInterval
-						&& FileTailingMessageProducerSupport.this.lastNoMessageAlert.compareAndSet(lastAlertAt, now)) {
+				long lastAlertAt = this.lastNoMessageAlert.get();
+				long lastReceive = this.lastReceive;
+				if (now > lastReceive + this.idleEventInterval
+						&& now > lastAlertAt + this.idleEventInterval
+						&& this.lastNoMessageAlert.compareAndSet(lastAlertAt, now)) {
 					publishIdleEvent(now - lastReceive);
 				}
 			}, this.idleEventInterval);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/tail/FileTailingMessageProducerSupport.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/tail/FileTailingMessageProducerSupport.java
@@ -54,7 +54,7 @@ public abstract class FileTailingMessageProducerSupport extends MessageProducerS
 
 	private long idleEventInterval = 0;
 
-	private volatile long lastReceive = System.currentTimeMillis();
+	private volatile long lastProduce = System.currentTimeMillis();
 
 	private ScheduledFuture<?> idleEventScheduledFuture;
 
@@ -98,6 +98,16 @@ public abstract class FileTailingMessageProducerSupport extends MessageProducerS
 		this.tailAttemptsDelay = tailAttemptsDelay;
 	}
 
+	/**
+	 * How often to emit {@link FileTailingIdleEvent}s in milliseconds.
+	 * @param idleEventInterval the interval.
+	 * @since 5.0
+	 */
+	public void setIdleEventInterval(long idleEventInterval) {
+		Assert.isTrue(idleEventInterval > 0, "'idleEventInterval' must be > 0");
+		this.idleEventInterval = idleEventInterval;
+	}
+
 	protected long getMissingFileDelay() {
 		return this.tailAttemptsDelay;
 	}
@@ -139,7 +149,7 @@ public abstract class FileTailingMessageProducerSupport extends MessageProducerS
 			this.idleEventScheduledFuture = getTaskScheduler().scheduleWithFixedDelay(() -> {
 				long now = System.currentTimeMillis();
 				long lastAlertAt = this.lastNoMessageAlert.get();
-				long lastReceive = this.lastReceive;
+				long lastReceive = this.lastProduce;
 				if (now > lastReceive + this.idleEventInterval
 						&& now > lastAlertAt + this.idleEventInterval
 						&& this.lastNoMessageAlert.compareAndSet(lastAlertAt, now)) {
@@ -157,16 +167,6 @@ public abstract class FileTailingMessageProducerSupport extends MessageProducerS
 		}
 	}
 
-	/**
-	 * How often to emit {@link FileTailingIdleEvent}s in milliseconds.
-	 * @param idleEventInterval the interval.
-	 * @since 5.0
-	 */
-	public void setIdleEventInterval(long idleEventInterval) {
-		Assert.isTrue(idleEventInterval > 0, "'idleEventInterval' must be > 0");
-		this.idleEventInterval = idleEventInterval;
-	}
-
 	private void publishIdleEvent(long idleTime) {
 
 		if (this.eventPublisher != null) {
@@ -180,7 +180,7 @@ public abstract class FileTailingMessageProducerSupport extends MessageProducerS
 
 	private void updateLastReceive() {
 		if (this.idleEventInterval > 0) {
-			this.lastReceive = System.currentTimeMillis();
+			this.lastProduce = System.currentTimeMillis();
 		}
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/tail/OSDelegatingFileTailingMessageProducer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/tail/OSDelegatingFileTailingMessageProducer.java
@@ -23,8 +23,6 @@ import java.util.Date;
 
 import org.springframework.messaging.MessagingException;
 import org.springframework.scheduling.SchedulingAwareRunnable;
-import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.Assert;
 
 /**
@@ -50,8 +48,6 @@ public class OSDelegatingFileTailingMessageProducer extends FileTailingMessagePr
 	private volatile boolean enableStatusReader = true;
 
 	private volatile BufferedReader reader;
-
-	private volatile TaskScheduler scheduler;
 
 	public void setOptions(String options) {
 		if (options == null) {
@@ -138,18 +134,7 @@ public class OSDelegatingFileTailingMessageProducer extends FileTailingMessagePr
 		}
 	}
 
-	private TaskScheduler getRequiredTaskScheduler() {
-		if (this.scheduler == null) {
-			TaskScheduler taskScheduler = super.getTaskScheduler();
-			if (taskScheduler == null) {
-				ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-				scheduler.initialize();
-				taskScheduler = scheduler;
-			}
-			this.scheduler = taskScheduler;
-		}
-		return this.scheduler;
-	}
+
 	/**
 	 * Runs a thread that waits for the Process result.
 	 */
@@ -185,7 +170,7 @@ public class OSDelegatingFileTailingMessageProducer extends FileTailingMessagePr
 				if (logger.isInfoEnabled()) {
 					logger.info("Restarting tail process in " + getMissingFileDelay() + " milliseconds");
 				}
-				getRequiredTaskScheduler()
+				this.getRequiredTaskScheduler()
 						.schedule(this::runExec, new Date(System.currentTimeMillis() + getMissingFileDelay()));
 			}
 		});

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/tail/OSDelegatingFileTailingMessageProducer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/tail/OSDelegatingFileTailingMessageProducer.java
@@ -170,7 +170,7 @@ public class OSDelegatingFileTailingMessageProducer extends FileTailingMessagePr
 				if (logger.isInfoEnabled()) {
 					logger.info("Restarting tail process in " + getMissingFileDelay() + " milliseconds");
 				}
-				this.getRequiredTaskScheduler()
+				getTaskScheduler()
 						.schedule(this::runExec, new Date(System.currentTimeMillis() + getMissingFileDelay()));
 			}
 		});

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
@@ -302,6 +302,13 @@ Only files matching this regular expression will be picked up by this adapter.
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:attribute>
+            <xsd:attribute name="idle-event-interval" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        The delay in milliseconds between idle events when no new lines are being tailed.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
             <xsd:attribute name="end">
                 <xsd:annotation>
                     <xsd:documentation>

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
@@ -272,8 +272,8 @@ Only files matching this regular expression will be picked up by this adapter.
                         A reference to a TaskScheduler; the default is the 'taskScheduler' bean
                         which is automatically configured for all Spring Integration applications.
                         The scheduler is used by the native adapter to reschedule
-                        the 'tail' process after a failure according to the 'file-delay'.
-                        This attribute is not allowed when using the Apache adapter.
+                        the 'tail' process after a failure according to the 'file-delay', and also
+                        it is used to send idle event.
                     </xsd:documentation>
                     <xsd:appinfo>
                         <tool:annotation kind="ref">

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
@@ -273,7 +273,7 @@ Only files matching this regular expression will be picked up by this adapter.
                         which is automatically configured for all Spring Integration applications.
                         The scheduler is used by the native adapter to reschedule
                         the 'tail' process after a failure according to the 'file-delay', and also
-                        it is used to send idle event.
+                        it is used to emit idle event.
                     </xsd:documentation>
                     <xsd:appinfo>
                         <tool:annotation kind="ref">

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests-context.xml
@@ -44,6 +44,7 @@
 		file="/tmp/bar"
 		delay="${foo}"
 		file-delay="10000"
+		idle-event-interval="10000"
 		auto-startup="false"
 		phase="123" />
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests.java
@@ -112,6 +112,7 @@ public class FileTailInboundChannelAdapterParserTests {
 		assertSame(exec, TestUtils.getPropertyValue(apacheDefault, "taskExecutor"));
 		assertEquals(2000L, TestUtils.getPropertyValue(apacheDefault, "pollingDelay"));
 		assertEquals(10000L, TestUtils.getPropertyValue(apacheDefault, "tailAttemptsDelay"));
+		assertEquals(10000L, TestUtils.getPropertyValue(apacheDefault, "idleEventInterval"));
 		assertFalse(TestUtils.getPropertyValue(apacheDefault, "autoStartup", Boolean.class));
 		assertEquals(123, TestUtils.getPropertyValue(apacheDefault, "phase"));
 		assertEquals(Boolean.TRUE, TestUtils.getPropertyValue(apacheDefault, "end"));

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/tail/FileTailingMessageProducerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/tail/FileTailingMessageProducerTests.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
@@ -148,13 +149,15 @@ public class FileTailingMessageProducerTests {
 		});
 		File file = new File(testDir, "foo");
 		file.delete();
-		file.createNewFile();
 		adapter.setFile(file);
 		QueueChannel outputChannel = new QueueChannel();
 		adapter.setOutputChannel(outputChannel);
 		adapter.setIdleEventInterval(100);
 		adapter.afterPropertiesSet();
 		adapter.start();
+		boolean noEvent = countDownLatch.await(500, TimeUnit.MILLISECONDS);
+		assertFalse("event should not emit when no file exit", noEvent);
+		file.createNewFile();
 		boolean eventRaised = countDownLatch.await(1, TimeUnit.SECONDS);
 		assertTrue("idle event did not emit", eventRaised);
 		adapter.stop();

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -411,9 +411,9 @@ Examples of such events are:
 
 This sequence of events might occur, for example, when a file is rotated.
 
-`[message=Idle timeout, file=/tmp/foo] [idle time=5438]`
+NOTE: Starting with version 5.0, a `FileTailingIdleEvent` is emitted when there is no data in the file during `idleEventInterval`.
 
-Idle events can be received if needed by setting `idleEventInterval` to a value greater than zero.
+`[message=Idle timeout, file=/tmp/foo] [idle time=5438]`
 
 NOTE: Not all platforms supporting a `tail` command provide these status messages.
 

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -411,7 +411,7 @@ Examples of such events are:
 
 This sequence of events might occur, for example, when a file is rotated.
 
-NOTE: Starting with version 5.0, a `FileTailingIdleEvent` is emitted when there is no data in the file during `idleEventInterval`.
+Starting with version 5.0, a `FileTailingIdleEvent` is emitted when there is no data in the file during `idleEventInterval`.
 
 `[message=Idle timeout, file=/tmp/foo] [idle time=5438]`
 

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -411,6 +411,10 @@ Examples of such events are:
 
 This sequence of events might occur, for example, when a file is rotated.
 
+`[message=Idle timeout, file=/tmp/foo] [idle time=5438]`
+
+Idle events can be received if needed by setting `idleEventInterval` to a value greater than zero.
+
 NOTE: Not all platforms supporting a `tail` command provide these status messages.
 
 Messages emitted from these endpoints have the following headers:
@@ -457,6 +461,19 @@ If the tail command fails (on some platforms, a missing file causes the `tail` t
 
 By default native adapter capture from standard output and send them as messages and from standard error to raise events.
 Starting with _version 4.3.6_, you can discard the standard error events by setting the `enable-status-reader` to `false`.
+
+[source,xml]
+----
+<int-file:tail-inbound-channel-adapter id="native"
+	channel="input"
+	idle-event-interval="5000"
+	task-executor="exec"
+	file="/tmp/foo"/>
+----
+
+`IdleEventInterval` is set to 5000 then if no lines are written for 5 second `FileTailingIdleEvent` will be triggered every 5 second.
+
+This can be useful if we need to stop the adapter.
 
 [source,xml]
 ----

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -52,6 +52,7 @@ The new `FileHeaders.RELATIVE_PATH` Message header has been introduced to repres
 See <<file-reading>> for more information.
 
 The tail adapter now support `IdelEventInterval` to emit events when idle.
+See <<file-tailing>> for more information.
 
 ==== (S)FTP Changes
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -51,6 +51,8 @@ See <<feed>> for more information.
 The new `FileHeaders.RELATIVE_PATH` Message header has been introduced to represent relative path in the `FileReadingMessageSource`.
 See <<file-reading>> for more information.
 
+The tail adapter now support `IdelEventInterval` to emit events when idle.
+
 ==== (S)FTP Changes
 
 The inbound channel adapters now have a property `max-fetch-size` which is used to limit the number of files fetched during a poll when there are no files currently in the local directory.


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/INT-4188

    * add `<idle-event-interval>` XSD element
    * add `FileTailingIdleEvent`
    * move `TaskScheduler` and `getRequiredTaskScheduler` to FileTailingMessageProducerSupport
    * add `setIdleEventInterval`

I only exposed one attribute and it is used for both scheduling the check and checking the idle time , as a result it may take up to 2X the idle time to be fired .