### PR TITLE
INT-4195: More Aggregator Performance Improvements

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -752,6 +752,8 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 
 	protected static class SequenceAwareMessageGroup extends SimpleMessageGroup {
 
+		private final SimpleMessageGroup sourceGroup;
+
 		public SequenceAwareMessageGroup(MessageGroup messageGroup) {
 			/*
 			 * Since this group is temporary, and never added to, we simply use the
@@ -760,6 +762,12 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 			 */
 			super(messageGroup.getMessages(), null, messageGroup.getGroupId(), messageGroup.getTimestamp(),
 					messageGroup.isComplete(), true);
+			if (messageGroup instanceof SimpleMessageGroup) {
+				this.sourceGroup = (SimpleMessageGroup) messageGroup;
+			}
+			else {
+				this.sourceGroup = null;
+			}
 		}
 
 		/**
@@ -777,17 +785,25 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 			Integer messageSequenceNumber = messageHeaderAccessor.getSequenceNumber();
 			if (messageSequenceNumber != null && messageSequenceNumber > 0) {
 				Integer messageSequenceSize = messageHeaderAccessor.getSequenceSize();
-				return messageSequenceSize.equals(this.getSequenceSize())
-						&& !this.containsSequenceNumber(this.getMessages(), messageSequenceNumber);
+				return messageSequenceSize.equals(getSequenceSize())
+						&& !(this.sourceGroup != null ? this.sourceGroup.containsSequence(messageSequenceNumber)
+								: containsSequenceNumber(this.getMessages(), messageSequenceNumber));
 			}
 			return true;
 		}
 
 		private boolean containsSequenceNumber(Collection<Message<?>> messages, Integer messageSequenceNumber) {
 			for (Message<?> member : messages) {
-				Integer memberSequenceNumber = new IntegrationMessageHeaderAccessor(member).getSequenceNumber();
-				if (messageSequenceNumber.equals(memberSequenceNumber)) {
-					return true;
+				Object sequenceNumber = member.getHeaders().get(
+						IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER);
+				if (sequenceNumber instanceof Integer) {
+					Integer memberSequenceNumber = (Integer) sequenceNumber;
+					if (messageSequenceNumber.equals(memberSequenceNumber)) {
+						return true;
+					}
+				}
+				else {
+					throw new IllegalArgumentException("Expected Integer for sequenceNumber header");
 				}
 			}
 			return false;

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -781,10 +781,14 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 			if (this.size() == 0) {
 				return true;
 			}
-			IntegrationMessageHeaderAccessor messageHeaderAccessor = new IntegrationMessageHeaderAccessor(message);
-			Integer messageSequenceNumber = messageHeaderAccessor.getSequenceNumber();
+			Integer messageSequenceNumber = message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER,
+					Integer.class);
 			if (messageSequenceNumber != null && messageSequenceNumber > 0) {
-				Integer messageSequenceSize = messageHeaderAccessor.getSequenceSize();
+				Integer messageSequenceSize = message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE,
+						Integer.class);
+				if (messageSequenceSize == null) {
+					messageSequenceSize = Integer.valueOf(0);
+				}
 				return messageSequenceSize.equals(getSequenceSize())
 						&& !(this.sourceGroup != null ? this.sourceGroup.containsSequence(messageSequenceNumber)
 								: containsSequenceNumber(this.getMessages(), messageSequenceNumber));
@@ -794,16 +798,9 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 
 		private boolean containsSequenceNumber(Collection<Message<?>> messages, Integer messageSequenceNumber) {
 			for (Message<?> member : messages) {
-				Object sequenceNumber = member.getHeaders().get(
-						IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER);
-				if (sequenceNumber instanceof Integer) {
-					Integer memberSequenceNumber = (Integer) sequenceNumber;
-					if (messageSequenceNumber.equals(memberSequenceNumber)) {
-						return true;
-					}
-				}
-				else {
-					throw new IllegalArgumentException("Expected Integer for sequenceNumber header");
+				if (messageSequenceNumber.equals(member.getHeaders().get(
+						IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, Integer.class))) {
+					return true;
 				}
 			}
 			return false;

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
@@ -18,8 +18,10 @@ package org.springframework.integration.store;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.messaging.Message;
@@ -43,6 +45,8 @@ public class SimpleMessageGroup implements MessageGroup {
 	private final Object groupId;
 
 	private final Collection<Message<?>> messages;
+
+	private final Set<Integer> sequences = new HashSet<>();
 
 	private final long timestamp;
 
@@ -114,6 +118,7 @@ public class SimpleMessageGroup implements MessageGroup {
 
 	@Override
 	public boolean remove(Message<?> message) {
+		this.sequences.remove(message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER));
 		return this.messages.remove(message);
 	}
 
@@ -123,6 +128,10 @@ public class SimpleMessageGroup implements MessageGroup {
 	}
 
 	private boolean addMessage(Message<?> message) {
+		Object sequence = message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER);
+		if (sequence instanceof Integer) {
+			this.sequences.add((Integer) sequence);
+		}
 		return this.messages.add(message);
 	}
 
@@ -175,6 +184,18 @@ public class SimpleMessageGroup implements MessageGroup {
 	@Override
 	public void clear() {
 		this.messages.clear();
+		this.sequences.clear();
+	}
+
+	/**
+	 * Return true if a message with this sequence number header exists in
+	 * the group.
+	 * @param sequence the sequence number.
+	 * @return true if it exists.
+	 * @since 4.3.7
+	 */
+	public boolean containsSequence(Integer sequence) {
+		return this.sequences.contains(sequence);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
@@ -128,10 +128,8 @@ public class SimpleMessageGroup implements MessageGroup {
 	}
 
 	private boolean addMessage(Message<?> message) {
-		Object sequence = message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER);
-		if (sequence instanceof Integer) {
-			this.sequences.add((Integer) sequence);
-		}
+		Integer sequence = message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, Integer.class);
+		this.sequences.add(sequence != null ? sequence : 0);
 		return this.messages.add(message);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatorTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.aggregator;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -127,6 +128,55 @@ public class AggregatorTests {
 		Collection<?> result = resultFuture.get(10, TimeUnit.SECONDS);
 		assertNotNull(result);
 		assertEquals(60000, result.size());
+	}
+
+	@Test
+	public void testAggPerfDefaultPartial() throws InterruptedException, ExecutionException, TimeoutException {
+		AggregatingMessageHandler handler = new AggregatingMessageHandler(new DefaultAggregatingMessageGroupProcessor());
+		handler.setCorrelationStrategy(message -> "foo");
+		handler.setReleasePartialSequences(true);
+		DirectChannel outputChannel = new DirectChannel();
+		handler.setOutputChannel(outputChannel);
+
+		final CompletableFuture<Collection<?>> resultFuture = new CompletableFuture<>();
+		outputChannel.subscribe(message -> {
+			Collection<?> payload = (Collection<?>) message.getPayload();
+			logger.warn("Received " + payload.size());
+			resultFuture.complete(payload);
+		});
+
+		SimpleMessageStore store = new SimpleMessageStore();
+
+		SimpleMessageGroupFactory messageGroupFactory =
+				new SimpleMessageGroupFactory(SimpleMessageGroupFactory.GroupType.BLOCKING_QUEUE);
+
+		store.setMessageGroupFactory(messageGroupFactory);
+
+		handler.setMessageStore(store);
+
+
+		StopWatch stopwatch = new StopWatch();
+		stopwatch.start();
+		for (int i = 0; i < 120000; i++) {
+			if (i % 10000 == 0) {
+				stopwatch.stop();
+				logger.warn("Sent " + i + " in " + stopwatch.getTotalTimeSeconds() +
+						" (10k in " + stopwatch.getLastTaskTimeMillis() + "ms)");
+				stopwatch.start();
+			}
+			handler.handleMessage(MessageBuilder.withPayload("foo")
+					.setSequenceSize(120000)
+					.setSequenceNumber(i + 1)
+					.build());
+		}
+		stopwatch.stop();
+		logger.warn("Sent " + 120000 + " in " + stopwatch.getTotalTimeSeconds() +
+				" (10k in " + stopwatch.getLastTaskTimeMillis() + "ms)");
+
+		Collection<?> result = resultFuture.get(10, TimeUnit.SECONDS);
+		assertNotNull(result);
+		assertEquals(120000, result.size());
+		assertThat(stopwatch.getTotalTimeSeconds(), lessThan(60.0)); // actually < 2.0, was many minutes
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4195

Avoid the N^2 search in `SequenceAwareMessageGroup` when the group is a
`SimpleMessageGroup`.
Avoid the use of the header accessor if the N^2 search is needed (SPR-15045).

__cherry-pick to 4.3.x__