### PR TITLE
INT-4198: TCP: Add Hook to Customize SSLEngine

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/IpAdapterParserUtils.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/IpAdapterParserUtils.java
@@ -118,6 +118,8 @@ public abstract class IpAdapterParserUtils {
 
 	public static final String SOCKET_SUPPORT = "socket-support";
 
+	public static final String NIO_CONNECTION_SUPPORT = "nio-connection-support";
+
 	public static final String SOCKET_FACTORY_SUPPORT = "socket-factory-support";
 
 	public static final String BACKLOG = "backlog";

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
@@ -247,16 +247,8 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 			return new DefaultTcpNioConnectionSupport();
 		}
 		else {
-			DefaultTcpNioSSLConnectionSupport connectionSupport = new DefaultTcpNioSSLConnectionSupport(this.sslContextSupport);
-			try {
-				connectionSupport.afterPropertiesSet();
-			}
-			catch (Exception e) {
-				throw new IllegalStateException("Failed to set up TcpConnectionSupport", e);
-			}
-			return connectionSupport;
+			return new DefaultTcpNioSSLConnectionSupport(this.sslContextSupport);
 		}
-
 	}
 
 	/**

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryParser.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryParser.java
@@ -91,6 +91,8 @@ public class TcpConnectionFactoryParser extends AbstractBeanDefinitionParser {
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.SOCKET_SUPPORT);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
+				IpAdapterParserUtils.NIO_CONNECTION_SUPPORT);
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.MAPPER);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
 				IpAdapterParserUtils.SSL_HANDSHAKE_TIMEOUT);

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/DefaultTcpNioSSLConnectionSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/DefaultTcpNioSSLConnectionSupport.java
@@ -16,12 +16,13 @@
 
 package org.springframework.integration.ip.tcp.connection;
 
+import java.io.IOException;
 import java.nio.channels.SocketChannel;
+import java.security.GeneralSecurityException;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.util.Assert;
 
@@ -32,7 +33,7 @@ import org.springframework.util.Assert;
  * @since 2.2
  *
  */
-public class DefaultTcpNioSSLConnectionSupport implements TcpNioConnectionSupport, InitializingBean {
+public class DefaultTcpNioSSLConnectionSupport implements TcpNioConnectionSupport {
 
 	private volatile SSLContext sslContext;
 
@@ -41,6 +42,13 @@ public class DefaultTcpNioSSLConnectionSupport implements TcpNioConnectionSuppor
 	public DefaultTcpNioSSLConnectionSupport(TcpSSLContextSupport sslContextSupport) {
 		Assert.notNull(sslContextSupport, "TcpSSLContextSupport must not be null");
 		this.sslContextSupport = sslContextSupport;
+		try {
+			this.sslContext = this.sslContextSupport.getSSLContext();
+		}
+		catch (GeneralSecurityException | IOException e) {
+			throw new IllegalArgumentException("Invalid TcpSSLContextSupport - it failed to provide an SSLContext", e);
+		}
+		Assert.notNull(this.sslContext, "SSLContext retrieved from context support must not be null");
 	}
 
 	/**
@@ -57,10 +65,12 @@ public class DefaultTcpNioSSLConnectionSupport implements TcpNioConnectionSuppor
 		return tcpNioSSLConnection;
 	}
 
-	@Override
+	/**
+	 * @deprecated - no longer needed
+	 * @throws Exception an Exception
+	 */
+	@Deprecated
 	public void afterPropertiesSet() throws Exception {
-		this.sslContext = this.sslContextSupport.getSSLContext();
-		Assert.notNull(this.sslContext, "SSLContext must not be null");
 	}
 
 	/**

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/DefaultTcpNioSSLConnectionSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/DefaultTcpNioSSLConnectionSupport.java
@@ -46,18 +46,30 @@ public class DefaultTcpNioSSLConnectionSupport implements TcpNioConnectionSuppor
 	/**
 	 * Creates a {@link TcpNioSSLConnection}.
 	 */
+	@Override
 	public TcpNioConnection createNewConnection(SocketChannel socketChannel, boolean server, boolean lookupHost,
 			ApplicationEventPublisher applicationEventPublisher, String connectionFactoryName) throws Exception {
 		SSLEngine sslEngine = this.sslContext.createSSLEngine();
+		postProcessSSLEngine(sslEngine);
 		TcpNioSSLConnection tcpNioSSLConnection = new TcpNioSSLConnection(socketChannel, server, lookupHost,
 				applicationEventPublisher, connectionFactoryName, sslEngine);
 		tcpNioSSLConnection.init();
 		return tcpNioSSLConnection;
 	}
 
+	@Override
 	public void afterPropertiesSet() throws Exception {
 		this.sslContext = this.sslContextSupport.getSSLContext();
 		Assert.notNull(this.sslContext, "SSLContext must not be null");
+	}
+
+	/**
+	 * Subclasses can post-process the ssl engine (set properties).
+	 * @param sslEngine the engine.
+	 * @since 4.3.7
+	 */
+	protected void postProcessSSLEngine(SSLEngine sslEngine) {
+		// NOSONAR (empty)
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionSupport.java
@@ -47,4 +47,5 @@ public interface TcpNioConnectionSupport {
 			boolean server, boolean lookupHost,
 			ApplicationEventPublisher applicationEventPublisher,
 			String connectionFactoryName) throws Exception;
+
 }

--- a/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-5.0.xsd
+++ b/spring-integration-ip/src/main/resources/org/springframework/integration/ip/config/spring-integration-ip-5.0.xsd
@@ -737,6 +737,23 @@
 					</xsd:appinfo>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="nio-connection-support" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						A reference to a TcpNioConnectionSupport strategy implementation.
+						When 'using-nio' is true, this is used to create connections.
+						Two default implementations are provided 'DefaultTcpNioConnectionSupport'
+						and 'DefaultTcpNioSSLConnectionSupport' depending on whether SSL is in
+						use of not.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type
+								type="org.springframework.integration.ip.tcp.connection.TcpNioConnectionSupport" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="mapper" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests-context.xml
@@ -72,6 +72,7 @@
 		using-nio="true"
 		ssl-context-support="sslContextSupport"
 		ssl-handshake-timeout="43"
+		nio-connection-support="nioConnectionSupport"
 		/>
 
 	<bean id="sslContextSupport" class="org.springframework.integration.ip.tcp.connection.DefaultTcpSSLContextSupport">
@@ -80,6 +81,9 @@
 		<constructor-arg value="secret"/>
 		<constructor-arg value="secret"/>
 	</bean>
+
+	<bean id="nioConnectionSupport"
+		class="org.springframework.integration.ip.tcp.connection.DefaultTcpNioSSLConnectionSupport" />
 
 	<ip:tcp-connection-factory id="secureServer"
 		type="server"

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -347,6 +347,8 @@ public class ParserUnitTests {
 		assertTrue(connectionSupport instanceof DefaultTcpNioSSLConnectionSupport);
 		assertNotNull(TestUtils.getPropertyValue(connectionSupport, "sslContext"));
 		assertEquals(43, TestUtils.getPropertyValue(this.cfS1Nio, "sslHandshakeTimeout"));
+		assertSame(this.ctx.getBean(DefaultTcpNioSSLConnectionSupport.class),
+				TestUtils.getPropertyValue(this.cfS1Nio, "tcpNioConnectionSupport"));
 	}
 
 	@Test

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/SocketSupportTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/SocketSupportTests.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketException;
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,7 +45,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ServerSocketFactory;
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLServerSocket;
 
 import org.junit.Test;
@@ -315,7 +316,7 @@ Certificate fingerprints:
 			testNetClientAndServerSSLDifferentContexts(true);
 			fail("expected Exception");
 		}
-		catch (SSLHandshakeException e) {
+		catch (SSLException | SocketException e) {
 			// NOSONAR
 		}
 	}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
@@ -382,7 +382,7 @@ public class TcpNioConnectionReadTests {
 		assertTrue(errorMessageLetch.await(10, TimeUnit.SECONDS));
 
 		assertThat(errorMessageRef.get().getMessage(),
-				containsString("Connection is closed"));
+				anyOf(containsString("Connection is closed"), containsString("Stream closed after 2 of 3")));
 
 		assertTrue(semaphore.tryAcquire(10000, TimeUnit.MILLISECONDS));
 		assertTrue(removed.size() > 0);
@@ -473,7 +473,6 @@ public class TcpNioConnectionReadTests {
 
 	private void testClosureMidMessageGuts(AbstractByteArraySerializer serializer, String shortMessage)
 			throws Exception {
-		final List<Message<?>> responses = new ArrayList<Message<?>>();
 		final Semaphore semaphore = new Semaphore(0);
 		final List<TcpConnection> added = new ArrayList<TcpConnection>();
 		final List<TcpConnection> removed = new ArrayList<TcpConnection>();
@@ -500,6 +499,7 @@ public class TcpNioConnectionReadTests {
 				removed.add(connection);
 				semaphore.release();
 			}
+
 		});
 		Socket socket = SocketFactory.getDefault().createSocket("localhost", scf.getPort());
 		socket.getOutputStream().write(shortMessage.getBytes());

--- a/src/reference/asciidoc/ip.adoc
+++ b/src/reference/asciidoc/ip.adoc
@@ -886,17 +886,20 @@ After establishing the key stores, the next step is to indicate their locations 
     type="client"
     host="localhost"
     port="1234"
-    ssl-context-support="sslContextSupport"
+    ssl-context-support="sslContextSupport" />
 ----
 
-The `DefaulTcpSSLContextSupport` class also has an optional 'protocol' property, which can be 'SSL' or 'TLS' (default).
+The `DefaulTcpSSLContextSupport` class also has an optional `protocol` property, which can be `SSL` or `TLS` (default).
 
 The keystore file names (first two constructor arguments) use the Spring `Resource` abstraction; by default the files will be located on the classpath, but this can be overridden by using the `file:` prefix, to find the files on the filesystem instead.
 
 Starting with _version 4.3.6_, when using NIO, you can specify an `ssl-handshake-timeout` (seconds) on the connection factory.
 This timeout (default 30) is used during SSL handshake when waiting for data; if the timeout is exceeded, the process is aborted and the socket closed.
 
-==== Advanced Techniques
+[[advanced-techniques]]
+=== Advanced Techniques
+
+==== Strategy Interfaces
 
 In many cases, the configuration described above is all that is needed to enable secure communication over TCP/IP.
 However, a number of strategy interfaces are provided to allow customization and modification of socket factories and sockets.
@@ -904,18 +907,19 @@ However, a number of strategy interfaces are provided to allow customization and
 * `TcpSSLContextSupport`
 * `TcpSocketFactorySupport`
 * `TcpSocketSupport`
+* `TcpNioConnectionSupport`
 
 [source,java]
 ----
 public interface TcpSSLContextSupport {
 
-	SSLContext getSSLContext() throws Exception;
+    SSLContext getSSLContext() throws Exception;
 
 }
 ----
 
 Implementations of this interface are responsible for creating an SSLContext.
-The sole implementation provided by the framework is the `DefaultTcpSSLContextSupport` described above.
+The implementation provided by the framework is the `DefaultTcpSSLContextSupport` described above.
 If you require different behavior, implement this interface and provide the connection factory with a reference to a bean of your class' implementation.
 
 [source,java]
@@ -931,8 +935,8 @@ public interface TcpSocketFactorySupport {
 ----
 
 Implementations of this interface are responsible for obtaining references to `ServerSocketFactory` and `SocketFactory`.
-Two implementations are provided; the first is `DefaultTcpNetSocketFactorySupport` for non-SSL sockets (when no 'ssl-context-support' attribute is defined); this simply uses the JDK's default factories.
-The second implementation is `DefaultTcpNetSSLSocketFactorySupport`; this is used, by default, when an 'ssl-context-support' attribute is defined; it uses the `SSLContext` created by that bean to create the socket factories.
+Two implementations are provided; the first is `DefaultTcpNetSocketFactorySupport` for non-SSL sockets (when no `ssl-context-support` attribute is defined); this simply uses the JDK's default factories.
+The second implementation is `DefaultTcpNetSSLSocketFactorySupport`; this is used, by default, when an `ssl-context-support` attribute is defined; it uses the `SSLContext` created by that bean to create the socket factories.
 
 NOTE: This interface only applies if `using-nio` is "false"; socket factories are not used by NIO.
 
@@ -944,7 +948,7 @@ public interface TcpSocketSupport {
 
     void postProcessSocket(Socket socket);
 
-
+}
 ----
 
 Implementations of this interface can modify sockets after they are created, and after all configured attributes have been applied, but before the sockets are used.
@@ -953,6 +957,68 @@ For example, you could use an implementation of this interface to modify the sup
 The sole implementation provided by the framework is the `DefaultTcpSocketSupport` which does not modify the sockets in any way
 
 To supply your own implementation of `TcpSocketFactorySupport` or `TcpSocketSupport`, provide the connection factory with references to beans of your custom type using the `socket-factory-support` and `socket-support` attributes, respectively.
+
+[source, java]
+----
+public interface TcpNioConnectionSupport {
+
+    TcpNioConnection createNewConnection(SocketChannel socketChannel,
+            boolean server, boolean lookupHost,
+            ApplicationEventPublisher applicationEventPublisher,
+            String connectionFactoryName) throws Exception;
+
+}
+----
+
+This interface is invoked to create `TcpNioConnection` objects (or subclasses).
+Two implementations are provided `DefaultTcpNioSSLConnectionSupport` and `DefaultTcpNioConnectionSupport` which are used depending on whether SSL is in use or not.
+A common use case would be to subclass `DefaultTcpNioSSLConnectionSupport` and override `postProcessSSLEngine`; see the example below.
+
+==== Example: Enabling SSL Client Authentication
+
+To enable client certificate authentication when using SSL, the technique depends on whether NIO is in use or not.
+When NIO is not being used, provide a custom `TcpSocketSupport` implementation to post-process the server socket:
+
+[source, java]
+----
+serverFactory.setTcpSocketSupport(new DefaultTcpSocketSupport() {
+
+    @Override
+    public void postProcessServerSocket(ServerSocket serverSocket) {
+        ((SSLServerSocket) serverSocket).setNeedClientAuth(true);
+    }
+
+});
+----
+
+(When using XML configuration, provide a reference to your bean using the `socket-support` attribute).
+
+When using NIO, provide a custom `TcpNioSslConnectionSupport` implementation to post-process the `SSLEngine`.
+
+[source, java]
+----
+@Bean
+public DefaultTcpNioSSLConnectionSupport tcpNioConnectionSupport() {
+    return new DefaultTcpNioSSLConnectionSupport(serverSslContextSupport) {
+
+            @Override
+            protected void postProcessSSLEngine(SSLEngine sslEngine) {
+                sslEngine.setNeedClientAuth(true);
+            }
+
+    }
+}
+
+@Bean
+public TcpNioServerConnectionFactory server() {
+    ...
+    serverFactory.setTcpNioConnectionSupport(tcpNioConnectionSupport());
+    ...
+}
+----
+
+(When using XML configuration, since _version 4.3.7_, provide a reference to your bean using the `nio-connection-support` attribute).
+
 
 [[ip-endpoint-reference]]
 === IP Configuration Attributes
@@ -1116,6 +1182,11 @@ Defaults to true.
 | Y
 |
 | See <<ssl-tls>>
+| nio-connection-support
+| Y
+| Y
+|
+| See <<advanced-techniques>>
 | read-delay
 | Y
 | Y


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4198

Enable setting properties like `needClientAuth` on the `SSLEngine` - when not using
NIO, this can be set on the server socket with a socket support implementation.

Add `nio-connection-support` to namespace.

Improved "Advanced Techniques" documentation, using this use case as an example.

Fail fast with NIO when SSL handshaking fails.

__cherry-pick to 4.3.x__