### PR TITLE
INT-4201: Fix Gateway Param Annotation Aliases

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ParameterNameDiscoverer;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.SynthesizingMethodParameter;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -247,7 +248,7 @@ class GatewayMethodInboundMessageMapper implements InboundMessageMapper<Object[]
 		ParameterNameDiscoverer parameterNameDiscoverer = new LocalVariableTableParameterNameDiscoverer();
 		int parameterCount = method.getParameterTypes().length;
 		for (int i = 0; i < parameterCount; i++) {
-			MethodParameter methodParameter = new MethodParameter(method, i);
+			MethodParameter methodParameter = new SynthesizingMethodParameter(method, i);
 			methodParameter.initParameterNameDiscovery(parameterNameDiscoverer);
 			parameterList.add(methodParameter);
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithHeaderAnnotations-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithHeaderAnnotations-context.xml
@@ -11,6 +11,7 @@
 			 default-request-channel="requestChannel"
 			 service-interface="org.springframework.integration.gateway.GatewayWithHeaderAnnotations$TestService" />
 
-	<service-activator input-channel="requestChannel" expression="payload + headers.priority + headers.$custom"/>
+	<service-activator input-channel="requestChannel"
+		expression="payload + headers.priority + headers.$custom + headers.baz"/>
 
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithHeaderAnnotations.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithHeaderAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  * @since 2.0
  */
 @ContextConfiguration
@@ -43,15 +44,15 @@ public class GatewayWithHeaderAnnotations {
 	@Test // INT-1205
 	public void priorityAsArgument() {
 		TestService gateway = (TestService) applicationContext.getBean("gateway");
-		String result = gateway.test("foo", 99, "bar");
-		assertEquals("foo99bar", result);
+		String result = gateway.test("foo", 99, "bar", "qux");
+		assertEquals("foo99barqux", result);
 	}
 
 
 	public interface TestService {
 		// wrt INT-1205, priority no longer has a $ prefix, so here we are testing the $custom header as well
 		String test(String str, @Header(IntegrationMessageHeaderAccessor.PRIORITY) int priority,
-				@Header("$custom") String custom);
+				@Header("$custom") String custom, @Header(name = "baz") String baz);
 
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4201

name<->value alias was not processed correctly so using
`@Header(name = "baz") String baz` did not work.

Use `SynthesizingMethodParameter`.

__cherry-pick to 4.3.x__