### PR TITLE
INT-4197: Fix annotation case when non `messages`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
@@ -391,7 +391,7 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 				return;
 			}
 			if (methodName == null
-					&& ObjectUtils.containsElement(new String[] {"start", "stop", "isRunning"}, method1.getName())) {
+					&& ObjectUtils.containsElement(new String[] { "start", "stop", "isRunning" }, method1.getName())) {
 				return;
 			}
 			HandlerMethod handlerMethod1 = null;

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -391,7 +391,7 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 				return;
 			}
 			if (methodName == null
-					&& ObjectUtils.containsElement(new String[] { "start", "stop", "isRunning" }, method1.getName())) {
+					&& ObjectUtils.containsElement(new String[] {"start", "stop", "isRunning"}, method1.getName())) {
 				return;
 			}
 			HandlerMethod handlerMethod1 = null;
@@ -742,8 +742,9 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 					sb.append("message");
 					this.setExclusiveTargetParameterType(parameterTypeDescriptor, methodParameter);
 				}
-				else if ((parameterTypeDescriptor.isAssignableTo(messageListTypeDescriptor)
-						|| parameterTypeDescriptor.isAssignableTo(messageArrayTypeDescriptor))) {
+				else if (this.canProcessMessageList &&
+						(parameterTypeDescriptor.isAssignableTo(messageListTypeDescriptor)
+								|| parameterTypeDescriptor.isAssignableTo(messageArrayTypeDescriptor))) {
 					sb.append("messages");
 					this.setExclusiveTargetParameterType(parameterTypeDescriptor, methodParameter);
 				}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +18,23 @@ package org.springframework.integration.config.annotation;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import org.springframework.messaging.Message;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.Router;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.test.util.TestUtils.TestApplicationContext;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public class RouterAnnotationPostProcessorTests {
 
@@ -41,11 +44,20 @@ public class RouterAnnotationPostProcessorTests {
 
 	private QueueChannel outputChannel = new QueueChannel();
 
+	private DirectChannel routingChannel = new DirectChannel();
+
+	private QueueChannel integerChannel = new QueueChannel();
+
+	private QueueChannel stringChannel = new QueueChannel();
+
 
 	@Before
 	public void init() {
 		context.registerChannel("input", inputChannel);
 		context.registerChannel("output", outputChannel);
+		context.registerChannel("routingChannel", routingChannel);
+		context.registerChannel("integerChannel", integerChannel);
+		context.registerChannel("stringChannel", stringChannel);
 	}
 
 
@@ -63,6 +75,24 @@ public class RouterAnnotationPostProcessorTests {
 		context.stop();
 	}
 
+	@Test
+	public void testRouterWithListParam() {
+		MessagingAnnotationPostProcessor postProcessor = new MessagingAnnotationPostProcessor();
+		postProcessor.setBeanFactory(context.getBeanFactory());
+		postProcessor.afterPropertiesSet();
+		TestRouter testRouter = new TestRouter();
+		postProcessor.postProcessAfterInitialization(testRouter, "test");
+		context.refresh();
+		routingChannel.send(new GenericMessage<String>("foo"));
+		Message<?> replyMessage = stringChannel.receive(0);
+		assertEquals("foo", replyMessage.getPayload());
+
+		routingChannel.send(new GenericMessage<Integer>(2));
+		replyMessage = integerChannel.receive(0);
+		assertEquals(2, replyMessage.getPayload());
+		context.stop();
+	}
+
 
 	@MessageEndpoint
 	public static class TestRouter {
@@ -71,6 +101,20 @@ public class RouterAnnotationPostProcessorTests {
 		public String test(String s) {
 			return null;
 		}
+
+		@Router(inputChannel = "routingChannel")
+		public String route(List<?> payload) {
+			if (payload.size() == 0) {
+				return null;
+			}
+			if (payload.get(0) instanceof Integer) {
+				return "integerChannel";
+			}
+			else {
+				return "stringChannel";
+			}
+		}
+
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessorTests.java
@@ -18,6 +18,7 @@ package org.springframework.integration.config.annotation;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
@@ -83,10 +84,12 @@ public class RouterAnnotationPostProcessorTests {
 		TestRouter testRouter = new TestRouter();
 		postProcessor.postProcessAfterInitialization(testRouter, "test");
 		context.refresh();
-		routingChannel.send(new GenericMessage<String>("foo"));
-		Message<?> replyMessage = stringChannel.receive(0);
-		assertEquals("foo", replyMessage.getPayload());
 
+		routingChannel.send(new GenericMessage<>(Collections.singletonList("foo")));
+		Message<?> replyMessage = stringChannel.receive(0);
+		assertEquals(Collections.singletonList("foo"), replyMessage.getPayload());
+
+		// The SpEL ReflectiveMethodExecutor does a conversion of single value to the List
 		routingChannel.send(new GenericMessage<Integer>(2));
 		replyMessage = integerChannel.receive(0);
 		assertEquals(2, replyMessage.getPayload());

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterParserTests-context.xml
@@ -96,6 +96,6 @@
 	</router>
 
 	<beans:bean id="testChannelResolver"
-		class="org.springframework.integration.router.config.RouterParserTests$TestChannelResover"/>
+		class="org.springframework.integration.router.config.RouterParserTests$TestChannelResolver"/>
 
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -285,7 +285,7 @@ public class RouterParserTests {
 	}
 
 
-	static class TestChannelResover implements DestinationResolver<MessageChannel> {
+	static class TestChannelResolver implements DestinationResolver<MessageChannel> {
 
 		@Override
 		public MessageChannel resolveDestination(String channelName) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4197

Since `Collection<Message<?>>` can be possible only if really deal with messages as a group (`MethodInvokingMessageListProcessor`), the case with the `List<?>` param for Messaging Annotation method should not be treated as candidate for `messages` collection.

* Add `this.canProcessMessageList` condition to avoid `messages` SpEL expression when we are not in the `MethodInvokingMessageListProcessor` environment

**Cherry-pick to 4.3.x**