### PR TITLE
INT-4214: Migrate to `InvocableHandlerMethod`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     - mongodb-3.0-precise
     packages:
     - mongodb-org-server
+    - oracle-java8-installer
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingCorrelationStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingCorrelationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.Lifecycle;
 import org.springframework.integration.handler.MethodInvokingMessageProcessor;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
@@ -33,12 +34,12 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Gary Russell
  */
-public class MethodInvokingCorrelationStrategy implements CorrelationStrategy, BeanFactoryAware {
+public class MethodInvokingCorrelationStrategy implements CorrelationStrategy, BeanFactoryAware, Lifecycle {
 
 	private final MethodInvokingMessageProcessor<?> processor;
 
 	public MethodInvokingCorrelationStrategy(Object object, String methodName) {
-		this.processor = new MethodInvokingMessageProcessor<Object>(object, methodName, true);
+		this.processor = new MethodInvokingMessageProcessor<Object>(object, methodName);
 	}
 
 	public MethodInvokingCorrelationStrategy(Object object, Method method) {
@@ -58,6 +59,21 @@ public class MethodInvokingCorrelationStrategy implements CorrelationStrategy, B
 	@Override
 	public Object getCorrelationKey(Message<?> message) {
 		return this.processor.processMessage(message);
+	}
+
+	@Override
+	public void start() {
+		this.processor.start();
+	}
+
+	@Override
+	public void stop() {
+		this.processor.stop();
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.processor.isRunning();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.Lifecycle;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.integration.annotation.Aggregator;
 import org.springframework.integration.store.MessageGroup;
@@ -33,9 +34,12 @@ import org.springframework.messaging.Message;
  * @author Mark Fisher
  * @author Dave Syer
  * @author Gary Russell
+ * @author Artme Bilan
+ *
  * @since 2.0
  */
-public class MethodInvokingMessageGroupProcessor extends AbstractAggregatingMessageGroupProcessor {
+public class MethodInvokingMessageGroupProcessor extends AbstractAggregatingMessageGroupProcessor
+		implements Lifecycle {
 
 	private final MethodInvokingMessageListProcessor<Object> processor;
 
@@ -84,6 +88,21 @@ public class MethodInvokingMessageGroupProcessor extends AbstractAggregatingMess
 	protected final Object aggregatePayloads(MessageGroup group, Map<String, Object> headers) {
 		final Collection<Message<?>> messagesUpForProcessing = group.getMessages();
 		return this.processor.process(messagesUpForProcessing, headers);
+	}
+
+	@Override
+	public void start() {
+		this.processor.start();
+	}
+
+	@Override
+	public void stop() {
+		this.processor.stop();
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.processor.isRunning();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageListProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageListProcessor.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.Lifecycle;
 import org.springframework.integration.util.AbstractExpressionEvaluator;
 import org.springframework.integration.util.MessagingMethodInvokerHelper;
 import org.springframework.messaging.Message;
@@ -33,7 +34,8 @@ import org.springframework.messaging.Message;
  * @author Artem Bilan
  * @since 2.0
  */
-public class MethodInvokingMessageListProcessor<T> extends AbstractExpressionEvaluator {
+public class MethodInvokingMessageListProcessor<T> extends AbstractExpressionEvaluator
+		implements Lifecycle {
 
 	private final MessagingMethodInvokerHelper<T> delegate;
 
@@ -78,6 +80,21 @@ public class MethodInvokingMessageListProcessor<T> extends AbstractExpressionEva
 		catch (Exception e) {
 			throw new IllegalStateException("Failed to process message list", e);
 		}
+	}
+
+	@Override
+	public void start() {
+		this.delegate.start();
+	}
+
+	@Override
+	public void stop() {
+		this.delegate.stop();
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.delegate.isRunning();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageListProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageListProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,17 @@ public class MethodInvokingMessageListProcessor<T> extends AbstractExpressionEva
 	public void setBeanFactory(BeanFactory beanFactory) {
 		super.setBeanFactory(beanFactory);
 		this.delegate.setBeanFactory(beanFactory);
+	}
+
+	/**
+	 * A {@code boolean} flag to use SpEL Expression evaluation or
+	 * {@link org.springframework.messaging.handler.invocation.InvocableHandlerMethod}
+	 * for target method invocation.
+	 * @param useSpelInvoker to use SpEL Expression evaluation or not.
+	 * @since 5.0
+	 */
+	public void setUseSpelInvoker(boolean useSpelInvoker) {
+		this.delegate.setUseSpelInvoker(useSpelInvoker);
 	}
 
 	public String toString() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingReleaseStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingReleaseStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.Lifecycle;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.integration.store.MessageGroup;
 
@@ -28,8 +29,9 @@ import org.springframework.integration.store.MessageGroup;
  *
  * @author Marius Bogoevici
  * @author Dave Syer
+ * @author Artme Bilan
  */
-public class MethodInvokingReleaseStrategy implements ReleaseStrategy, BeanFactoryAware {
+public class MethodInvokingReleaseStrategy implements ReleaseStrategy, BeanFactoryAware, Lifecycle {
 
 	private final MethodInvokingMessageListProcessor<Boolean> adapter;
 
@@ -55,6 +57,21 @@ public class MethodInvokingReleaseStrategy implements ReleaseStrategy, BeanFacto
 	@Override
 	public boolean canRelease(MessageGroup messages) {
 		return this.adapter.process(messages.getMessages(), null);
+	}
+
+	@Override
+	public void start() {
+		this.adapter.start();
+	}
+
+	@Override
+	public void stop() {
+		this.adapter.stop();
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.adapter.isRunning();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.List;
 import org.aopalliance.aop.Advice;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.reactivestreams.Subscriber;
 
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.framework.ProxyFactory;
@@ -44,7 +43,6 @@ import org.springframework.integration.endpoint.ReactiveConsumer;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.advice.HandleMessageAdvice;
 import org.springframework.integration.scheduling.PollerMetadata;
-import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.PollableChannel;
@@ -288,12 +286,7 @@ public class ConsumerEndpointFactoryBean
 				this.endpoint = pollingConsumer;
 			}
 			else {
-				if (this.handler instanceof Subscriber) {
-					this.endpoint = new ReactiveConsumer(channel, (Subscriber<Message<?>>) this.handler);
-				}
-				else {
-					this.endpoint = new ReactiveConsumer(channel, this.handler::handleMessage);
-				}
+				this.endpoint = new ReactiveConsumer(channel, this.handler);
 			}
 			this.endpoint.setBeanName(this.beanName);
 			this.endpoint.setBeanFactory(this.beanFactory);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -27,7 +27,6 @@ import org.aopalliance.aop.Advice;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
 
 import org.springframework.aop.TargetSource;
 import org.springframework.aop.framework.Advised;
@@ -65,7 +64,6 @@ import org.springframework.integration.router.AbstractMessageRouter;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.util.MessagingAnnotationUtils;
-import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.PollableChannel;
@@ -80,8 +78,6 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
-
-import reactor.core.publisher.DirectProcessor;
 
 /**
  * Base class for Method-level annotation post-processors.
@@ -321,17 +317,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 			Assert.state(ObjectUtils.isEmpty(pollers), "A '@Poller' should not be specified for Annotation-based " +
 					"endpoint, since '" + inputChannel + "' is a SubscribableChannel (not pollable).");
 			if (inputChannel instanceof Publisher) {
-				Subscriber<Message<?>> subscriber;
-				if (handler instanceof Subscriber) {
-					subscriber = (Subscriber<Message<?>>) handler;
-				}
-				else {
-					//TODO errorConsumer, completeConsumer
-					DirectProcessor<Message<?>> directProcessor = DirectProcessor.create();
-					directProcessor.doOnNext(handler::handleMessage);
-					subscriber = directProcessor;
-				}
-				endpoint = new ReactiveConsumer(inputChannel, subscriber);
+				endpoint = new ReactiveConsumer(inputChannel, handler);
 			}
 			else {
 				endpoint = new EventDrivenConsumer((SubscribableChannel) inputChannel, handler);

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/EventDrivenConsumer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/EventDrivenConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.integration.endpoint;
 
 import org.springframework.context.Lifecycle;
-import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.router.MessageRouter;
 import org.springframework.integration.support.context.NamedComponent;
@@ -95,7 +94,7 @@ public class EventDrivenConsumer extends AbstractEndpoint implements Integration
 			String channelName = ((NamedComponent) this.inputChannel).getComponentName();
 			String componentType = ((NamedComponent) this.handler).getComponentType();
 			componentType = StringUtils.hasText(componentType) ? componentType : "";
-			String componentName = ((IntegrationObjectSupport) this).getComponentName();
+			String componentName = getComponentName();
 			componentName = (StringUtils.hasText(componentName) && componentName.contains("#")) ? "" : ":" + componentName;
 			StringBuffer buffer = new StringBuffer();
 			buffer.append("{" + componentType + componentName + "} as a subscriber to the '" + channelName + "' channel");

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,6 +70,17 @@ public class MethodInvokingMessageProcessor<T> extends AbstractMessageProcessor<
 	public void setBeanFactory(BeanFactory beanFactory) {
 		super.setBeanFactory(beanFactory);
 		this.delegate.setBeanFactory(beanFactory);
+	}
+
+	/**
+	 * A {@code boolean} flag to use SpEL Expression evaluation or
+	 * {@link org.springframework.messaging.handler.invocation.InvocableHandlerMethod}
+	 * for target method invocation.
+	 * @param useSpelInvoker to use SpEL Expression evaluation or not.
+	 * @since 5.0
+	 */
+	public void setUseSpelInvoker(boolean useSpelInvoker) {
+		this.delegate.setUseSpelInvoker(useSpelInvoker);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/CollectionArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/CollectionArgumentResolver.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.handler.support;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.integration.util.AbstractExpressionEvaluator;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.util.Assert;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 5.0
+ */
+public class CollectionArgumentResolver extends AbstractExpressionEvaluator
+		implements HandlerMethodArgumentResolver {
+
+	private final boolean canProcessMessageList;
+
+	public CollectionArgumentResolver(boolean canProcessMessageList) {
+		this.canProcessMessageList = canProcessMessageList;
+	}
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		Class<?> parameterType = parameter.getParameterType();
+		return Collection.class.isAssignableFrom(parameterType) || parameterType.isArray();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception {
+		Object value = message.getPayload();
+
+		if (this.canProcessMessageList) {
+			Assert.state(value instanceof Collection,
+					"This Argument Resolver support only messages with payload as Collection<Message<?>>");
+			Collection<Message<?>> messages = (Collection<Message<?>>) value;
+
+			parameter.increaseNestingLevel();
+			if (Message.class.isAssignableFrom(parameter.getNestedParameterType())) {
+				value = messages;
+			}
+			else {
+				value = messages.stream()
+						.map(Message::getPayload)
+						.collect(Collectors.toList());
+			}
+			parameter.decreaseNestingLevel();
+		}
+		return getEvaluationContext()
+				.getTypeConverter()
+				.convertValue(value,
+						TypeDescriptor.forObject(value),
+						TypeDescriptor.valueOf(parameter.getParameterType()));
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/CollectionArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/CollectionArgumentResolver.java
@@ -62,7 +62,7 @@ public class CollectionArgumentResolver extends AbstractExpressionEvaluator
 			}
 			else {
 				value = messages.stream()
-						.map(Message::getPayload)
+						.map(m -> m.getPayload())
 						.collect(Collectors.toList());
 			}
 			parameter.decreaseNestingLevel();

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/CollectionArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/CollectionArgumentResolver.java
@@ -35,7 +35,7 @@ import org.springframework.util.Assert;
  * If {@link #canProcessMessageList} is set to {@code true}, only messages
  * with a payload of {@code Collection<Message<?>>) are supported.
  * Depending on the {@link MethodParameter#getNestedParameterType()} the whole
- * {@code Collection<Message<?>>) or just payloads of those messages can be use as an actual argument.
+ * {@code Collection<Message<?>>} or just payloads of those messages can be use as an actual argument.
  * <p>
  * If the value isn't compatible with {@link MethodParameter},
  * the {@link org.springframework.core.convert.ConversionService} is used

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/CollectionArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/CollectionArgumentResolver.java
@@ -29,6 +29,18 @@ import org.springframework.messaging.handler.invocation.HandlerMethodArgumentRes
 import org.springframework.util.Assert;
 
 /**
+ * A {@link HandlerMethodArgumentResolver} implementation for {@link Collection},
+ * {@link Iterator} or {@code array} {@link MethodParameter}.
+ * <p>
+ * If {@link #canProcessMessageList} is set to {@code true}, only messages
+ * with a payload of {@code Collection<Message<?>>) are supported.
+ * Depending on the {@link MethodParameter#getNestedParameterType()} the whole
+ * {@code Collection<Message<?>>) or just payloads of those messages can be use as an actual argument.
+ * <p>
+ * If the value isn't compatible with {@link MethodParameter},
+ * the {@link org.springframework.core.convert.ConversionService} is used
+ * to convert the value to the target type.
+ *
  * @author Artem Bilan
  *
  * @since 5.0
@@ -57,7 +69,7 @@ public class CollectionArgumentResolver extends AbstractExpressionEvaluator
 
 		if (this.canProcessMessageList) {
 			Assert.state(value instanceof Collection,
-					"This Argument Resolver support only messages with payload as Collection<Message<?>>");
+					"This Argument Resolver only supports messages with a payload of Collection<Message<?>>");
 			Collection<Message<?>> messages = (Collection<Message<?>>) value;
 
 			parameter.increaseNestingLevel();
@@ -71,6 +83,7 @@ public class CollectionArgumentResolver extends AbstractExpressionEvaluator
 			}
 			parameter.decreaseNestingLevel();
 		}
+
 		if (Iterator.class.isAssignableFrom(parameter.getParameterType())) {
 			if (value instanceof Iterable) {
 				return ((Iterable) value).iterator();

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MapArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MapArgumentResolver.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.handler.support;
+
+import java.util.Map;
+import java.util.Properties;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.integration.util.BeanFactoryTypeConverter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 5.0
+ */
+public class MapArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private static final TypeDescriptor PROPERTIES_TYPE = TypeDescriptor.valueOf(Properties.class);
+
+	private final BeanFactoryTypeConverter typeConverter = new BeanFactoryTypeConverter();
+
+	public void setConversionService(ConversionService conversionService) {
+		if (conversionService != null) {
+			this.typeConverter.setConversionService(conversionService);
+		}
+	}
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return !parameter.hasParameterAnnotation(Payload.class)
+				&& Map.class.isAssignableFrom(parameter.getParameterType());
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception {
+		Object payload = message.getPayload();
+		if (Properties.class.isAssignableFrom(parameter.getParameterType())) {
+			Map<String, Object> map = message.getHeaders();
+			if (!parameter.hasParameterAnnotation(Headers.class)) {
+				if (payload instanceof Map) {
+					map = (Map<String, Object>) payload;
+				}
+				else if (payload instanceof String && ((String) payload).contains("=")) {
+					return this.typeConverter.convertValue(payload, TypeDescriptor.valueOf(String.class),
+							PROPERTIES_TYPE);
+				}
+			}
+			Properties properties = new Properties();
+			properties.putAll(map);
+			return properties;
+		}
+		else {
+			if (!parameter.hasParameterAnnotation(Headers.class) && payload instanceof Map) {
+				return payload;
+			}
+			else {
+				return message.getHeaders();
+			}
+		}
+
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MapArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MapArgumentResolver.java
@@ -29,6 +29,17 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 
 /**
+ * A {@link HandlerMethodArgumentResolver} implementation to resolve argument
+ * for the {@link MethodParameter} as a {@link Map} or {@link Properties}.
+ * <p>
+ * The {@link Message#getHeaders()} is used when {@link MethodParameter} is marked
+ * with the {@link Headers} annotation or {@link Message#getPayload()} isn't {@link Map}
+ * or {@link Properties} compatible.
+ * <p>
+ * If {@link MethodParameter} is of {@link Properties} type and {@link Message#getPayload()}
+ * is a {@link String} containing {@code =} symbol, the {@link MapArgumentResolver} uses
+ * {@link ConversionService} trying to convert that {@link String} to the {@link Properties} object.
+ *
  * @author Artem Bilan
  *
  * @since 5.0

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MapArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MapArgumentResolver.java
@@ -22,7 +22,7 @@ import java.util.Properties;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
-import org.springframework.integration.util.BeanFactoryTypeConverter;
+import org.springframework.integration.util.AbstractExpressionEvaluator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -44,17 +44,10 @@ import org.springframework.messaging.handler.invocation.HandlerMethodArgumentRes
  *
  * @since 5.0
  */
-public class MapArgumentResolver implements HandlerMethodArgumentResolver {
+public class MapArgumentResolver extends AbstractExpressionEvaluator
+		implements HandlerMethodArgumentResolver {
 
 	private static final TypeDescriptor PROPERTIES_TYPE = TypeDescriptor.valueOf(Properties.class);
-
-	private final BeanFactoryTypeConverter typeConverter = new BeanFactoryTypeConverter();
-
-	public void setConversionService(ConversionService conversionService) {
-		if (conversionService != null) {
-			this.typeConverter.setConversionService(conversionService);
-		}
-	}
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
@@ -73,8 +66,9 @@ public class MapArgumentResolver implements HandlerMethodArgumentResolver {
 					map = (Map<String, Object>) payload;
 				}
 				else if (payload instanceof String && ((String) payload).contains("=")) {
-					return this.typeConverter.convertValue(payload, TypeDescriptor.valueOf(String.class),
-							PROPERTIES_TYPE);
+					return getEvaluationContext()
+							.getTypeConverter()
+							.convertValue(payload, TypeDescriptor.valueOf(String.class), PROPERTIES_TYPE);
 				}
 			}
 			Properties properties = new Properties();

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadExpressionArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadExpressionArgumentResolver.java
@@ -53,10 +53,10 @@ public class PayloadExpressionArgumentResolver extends AbstractExpressionEvaluat
 		Expression expression = this.expressionCache.get(parameter);
 		if (expression == null) {
 			Payload ann = parameter.getParameterAnnotation(Payload.class);
-			expression = EXPRESSION_PARSER.parseExpression("payload." + ann.expression());
+			expression = EXPRESSION_PARSER.parseExpression(ann.expression());
 			this.expressionCache.put(parameter, expression);
 		}
-		return evaluateExpression(expression, message, parameter.getParameterType());
+		return evaluateExpression(expression, message.getPayload(), parameter.getParameterType());
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadExpressionArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadExpressionArgumentResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.handler.support;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.expression.Expression;
+import org.springframework.integration.util.AbstractExpressionEvaluator;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.util.StringUtils;
+
+/**
+ * The {@link HandlerMethodArgumentResolver} for evaluating {@link Payload#expression()}
+ * as a SpEL expression against {@code message} and converting result to expected parameter type.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.0
+ *
+ * @see org.springframework.messaging.handler.annotation.support.PayloadArgumentResolver
+ */
+public class PayloadExpressionArgumentResolver extends AbstractExpressionEvaluator
+		implements HandlerMethodArgumentResolver {
+
+	private final Map<MethodParameter, Expression> expressionCache = new HashMap<>();
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		Payload ann = parameter.getParameterAnnotation(Payload.class);
+		return ann != null && StringUtils.hasText(ann.expression());
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception {
+		Expression expression = this.expressionCache.get(parameter);
+		if (expression == null) {
+			Payload ann = parameter.getParameterAnnotation(Payload.class);
+			expression = EXPRESSION_PARSER.parseExpression("payload." + ann.expression());
+			this.expressionCache.put(parameter, expression);
+		}
+		return evaluateExpression(expression, message, parameter.getParameterType());
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadsArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadsArgumentResolver.java
@@ -79,7 +79,7 @@ public class PayloadsArgumentResolver extends AbstractExpressionEvaluator
 		}
 		else {
 			List<?> payloads = messages.stream()
-					.<Object>map(Message::getPayload)
+					.map(Message::getPayload)
 					.collect(Collectors.toList());
 
 			return getEvaluationContext()

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadsArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadsArgumentResolver.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.handler.support;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.expression.Expression;
+import org.springframework.integration.annotation.Payloads;
+import org.springframework.integration.util.AbstractExpressionEvaluator;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * The {@link HandlerMethodArgumentResolver} for resolving a {@link Collection}
+ * of {@code payloads} or expression against each {@code payload}.
+ * <p>
+ * IMPORTANT: The {@link Message} for argument resolution must contain a {@code payload}
+ * as {@link Collection} of {@link Message}s.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.0
+ */
+public class PayloadsArgumentResolver extends AbstractExpressionEvaluator
+		implements HandlerMethodArgumentResolver {
+
+	private final Map<MethodParameter, Expression> expressionCache = new HashMap<>();
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(Payloads.class);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception {
+		Object payload = message.getPayload();
+		Assert.state(payload instanceof Collection,
+				"This Argument Resolver support only messages with payload as Collection<Message<?>>");
+		Collection<Message<?>> messages = (Collection<Message<?>>) payload;
+
+		if (!this.expressionCache.containsKey(parameter)) {
+			Payloads payloads = parameter.getParameterAnnotation(Payloads.class);
+			String expression = payloads.value();
+			if (StringUtils.hasText(expression)) {
+				this.expressionCache.put(parameter, EXPRESSION_PARSER.parseExpression("![payload." + expression + "]"));
+			}
+			else {
+				this.expressionCache.put(parameter, null);
+			}
+
+		}
+
+		Expression expression = this.expressionCache.get(parameter);
+		if (expression != null) {
+			return evaluateExpression(expression, messages, parameter.getParameterType());
+		}
+		else {
+			List<?> payloads = messages.stream()
+					.map(Message::getPayload)
+					.collect(Collectors.toList());
+
+			return getEvaluationContext()
+					.getTypeConverter()
+					.convertValue(payloads,
+							TypeDescriptor.forObject(payloads),
+							TypeDescriptor.valueOf(parameter.getParameterType()));
+		}
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadsArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadsArgumentResolver.java
@@ -79,7 +79,7 @@ public class PayloadsArgumentResolver extends AbstractExpressionEvaluator
 		}
 		else {
 			List<?> payloads = messages.stream()
-					.map(Message::getPayload)
+					.<Object>map(Message::getPayload)
 					.collect(Collectors.toList());
 
 			return getEvaluationContext()

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides classes for message handlers support.
+ */
+package org.springframework.integration.handler.support;

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.Map;
 
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -58,11 +57,6 @@ public class MutableMessage<T> implements Message<T>, Serializable {
 		this.payload = payload;
 
 		this.headers = new MutableMessageHeaders(headers);
-
-		if (headers != null) {
-			this.headers.put(MessageHeaders.ID, headers.get(MessageHeaders.ID));
-			this.headers.put(MessageHeaders.TIMESTAMP, headers.get(MessageHeaders.TIMESTAMP));
-		}
 	}
 
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageHeaders.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.support;
 
 import java.util.Map;
+import java.util.UUID;
 
 import org.springframework.messaging.MessageHeaders;
 
@@ -27,6 +28,8 @@ import org.springframework.messaging.MessageHeaders;
  *
  * @author Stuart Williams
  * @author David Turanski
+ * @author Artem Bilan
+ *
  * @since 4.2
  */
 public class MutableMessageHeaders extends MessageHeaders {
@@ -34,7 +37,13 @@ public class MutableMessageHeaders extends MessageHeaders {
 	private static final long serialVersionUID = 3084692953798643018L;
 
 	public MutableMessageHeaders(Map<String, Object> headers) {
-		super(headers);
+		super(headers,
+				(headers != null ?
+						(UUID) headers.get(MessageHeaders.ID)
+						: null),
+				(headers != null ?
+						(Long) headers.get(MessageHeaders.TIMESTAMP)
+						: null));
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
@@ -63,7 +63,6 @@ import org.springframework.integration.handler.support.MapArgumentResolver;
 import org.springframework.integration.handler.support.PayloadExpressionArgumentResolver;
 import org.springframework.integration.handler.support.PayloadsArgumentResolver;
 import org.springframework.integration.support.MutableMessage;
-import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.converter.MessageConversionException;
@@ -367,10 +366,7 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 					collectionArgumentResolver.setBeanFactory(getBeanFactory());
 
 					MapArgumentResolver mapArgumentResolver = new MapArgumentResolver();
-					ConversionService conversionService = IntegrationUtils.getConversionService(getBeanFactory());
-					if (conversionService != null) {
-						mapArgumentResolver.setConversionService(conversionService);
-					}
+					mapArgumentResolver.setBeanFactory(getBeanFactory());
 
 					List<HandlerMethodArgumentResolver> customArgumentResolvers = new LinkedList<>();
 					customArgumentResolvers.add(payloadExpressionArgumentResolver);

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
@@ -63,6 +63,7 @@ import org.springframework.integration.handler.support.MapArgumentResolver;
 import org.springframework.integration.handler.support.PayloadExpressionArgumentResolver;
 import org.springframework.integration.handler.support.PayloadsArgumentResolver;
 import org.springframework.integration.support.MutableMessage;
+import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.converter.MessageConversionException;
@@ -365,12 +366,16 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 							new CollectionArgumentResolver(this.canProcessMessageList);
 					collectionArgumentResolver.setBeanFactory(getBeanFactory());
 
+					MapArgumentResolver mapArgumentResolver = new MapArgumentResolver();
+					ConversionService conversionService = IntegrationUtils.getConversionService(getBeanFactory());
+					if (conversionService != null) {
+						mapArgumentResolver.setConversionService(conversionService);
+					}
+
 					List<HandlerMethodArgumentResolver> customArgumentResolvers = new LinkedList<>();
 					customArgumentResolvers.add(payloadExpressionArgumentResolver);
 					customArgumentResolvers.add(payloadsArgumentResolver);
 					customArgumentResolvers.add(collectionArgumentResolver);
-					MapArgumentResolver mapArgumentResolver = new MapArgumentResolver();
-
 					customArgumentResolvers.add(mapArgumentResolver);
 
 					this.messageHandlerMethodFactory.setCustomArgumentResolvers(customArgumentResolvers);

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatingMessageGroupProcessorHeaderTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatingMessageGroupProcessorHeaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,6 +31,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
@@ -48,6 +50,11 @@ public class AggregatingMessageGroupProcessorHeaderTests {
 
 	private final MethodInvokingMessageGroupProcessor methodInvokingProcessor =
 			new MethodInvokingMessageGroupProcessor(new TestAggregatorBean(), "aggregate");
+
+	{
+		this.methodInvokingProcessor.setBeanFactory(mock(BeanFactory.class));
+		this.methodInvokingProcessor.start();
+	}
 
 	@Test
 	public void singleMessageUsingDefaultProcessor() {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatingMessageGroupProcessorHeaderTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatingMessageGroupProcessorHeaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,9 +28,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
@@ -48,6 +51,13 @@ public class AggregatingMessageGroupProcessorHeaderTests {
 
 	private final MethodInvokingMessageGroupProcessor methodInvokingProcessor =
 			new MethodInvokingMessageGroupProcessor(new TestAggregatorBean(), "aggregate");
+
+	@Before
+	public void setup() {
+		this.defaultProcessor.setBeanFactory(mock(BeanFactory.class));
+		this.methodInvokingProcessor.setBeanFactory(mock(BeanFactory.class));
+	}
+
 
 	@Test
 	public void singleMessageUsingDefaultProcessor() {
@@ -283,6 +293,7 @@ public class AggregatingMessageGroupProcessorHeaderTests {
 			}
 			return sb.toString();
 		}
+
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatingMessageGroupProcessorHeaderTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatingMessageGroupProcessorHeaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,7 +30,6 @@ import java.util.Map;
 import org.junit.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
@@ -50,11 +48,6 @@ public class AggregatingMessageGroupProcessorHeaderTests {
 
 	private final MethodInvokingMessageGroupProcessor methodInvokingProcessor =
 			new MethodInvokingMessageGroupProcessor(new TestAggregatorBean(), "aggregate");
-
-	{
-		this.methodInvokingProcessor.setBeanFactory(mock(BeanFactory.class));
-		this.methodInvokingProcessor.start();
-	}
 
 	@Test
 	public void singleMessageUsingDefaultProcessor() {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelationStrategyAdapterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelationStrategyAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,10 @@
 package org.springframework.integration.aggregator;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
@@ -30,7 +28,6 @@ import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Dave Syer
- * @author Artem Bilan
  *
  */
 public class CorrelationStrategyAdapterTests {
@@ -46,8 +43,6 @@ public class CorrelationStrategyAdapterTests {
 	public void testMethodName() {
 		MethodInvokingCorrelationStrategy adapter =
 				new MethodInvokingCorrelationStrategy(new SimpleMessageCorrelator(), "getKey");
-		adapter.setBeanFactory(mock(BeanFactory.class));
-		adapter.start();
 		assertEquals("b", adapter.getCorrelationKey(message));
 	}
 
@@ -55,8 +50,6 @@ public class CorrelationStrategyAdapterTests {
 	public void testCorrelationStrategyAdapterObjectMethod() {
 		MethodInvokingCorrelationStrategy adapter = new MethodInvokingCorrelationStrategy(new SimpleMessageCorrelator(),
 				ReflectionUtils.findMethod(SimpleMessageCorrelator.class, "getKey", Message.class));
-		adapter.setBeanFactory(mock(BeanFactory.class));
-		adapter.start();
 		assertEquals("b", adapter.getCorrelationKey(message));
 	}
 
@@ -64,8 +57,6 @@ public class CorrelationStrategyAdapterTests {
 	public void testCorrelationStrategyAdapterPojoMethod() {
 		MethodInvokingCorrelationStrategy adapter =
 				new MethodInvokingCorrelationStrategy(new SimplePojoCorrelator(), "getKey");
-		adapter.setBeanFactory(mock(BeanFactory.class));
-		adapter.start();
 		assertEquals("foo", adapter.getCorrelationKey(message));
 	}
 
@@ -73,8 +64,6 @@ public class CorrelationStrategyAdapterTests {
 	public void testHeaderPojoMethod() {
 		MethodInvokingCorrelationStrategy adapter =
 				new MethodInvokingCorrelationStrategy(new SimpleHeaderCorrelator(), "getKey");
-		adapter.setBeanFactory(mock(BeanFactory.class));
-		adapter.start();
 		assertEquals("b", adapter.getCorrelationKey(message));
 	}
 
@@ -82,8 +71,6 @@ public class CorrelationStrategyAdapterTests {
 	public void testHeadersPojoMethod() {
 		MethodInvokingCorrelationStrategy adapter = new MethodInvokingCorrelationStrategy(new MultiHeaderCorrelator(),
 				ReflectionUtils.findMethod(MultiHeaderCorrelator.class, "getKey", String.class, String.class));
-		adapter.setBeanFactory(mock(BeanFactory.class));
-		adapter.start();
 		assertEquals("bd", adapter.getCorrelationKey(message));
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelationStrategyAdapterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelationStrategyAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
 package org.springframework.integration.aggregator;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
@@ -28,6 +30,7 @@ import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Dave Syer
+ * @author Artem Bilan
  *
  */
 public class CorrelationStrategyAdapterTests {
@@ -43,6 +46,8 @@ public class CorrelationStrategyAdapterTests {
 	public void testMethodName() {
 		MethodInvokingCorrelationStrategy adapter =
 				new MethodInvokingCorrelationStrategy(new SimpleMessageCorrelator(), "getKey");
+		adapter.setBeanFactory(mock(BeanFactory.class));
+		adapter.start();
 		assertEquals("b", adapter.getCorrelationKey(message));
 	}
 
@@ -50,6 +55,8 @@ public class CorrelationStrategyAdapterTests {
 	public void testCorrelationStrategyAdapterObjectMethod() {
 		MethodInvokingCorrelationStrategy adapter = new MethodInvokingCorrelationStrategy(new SimpleMessageCorrelator(),
 				ReflectionUtils.findMethod(SimpleMessageCorrelator.class, "getKey", Message.class));
+		adapter.setBeanFactory(mock(BeanFactory.class));
+		adapter.start();
 		assertEquals("b", adapter.getCorrelationKey(message));
 	}
 
@@ -57,6 +64,8 @@ public class CorrelationStrategyAdapterTests {
 	public void testCorrelationStrategyAdapterPojoMethod() {
 		MethodInvokingCorrelationStrategy adapter =
 				new MethodInvokingCorrelationStrategy(new SimplePojoCorrelator(), "getKey");
+		adapter.setBeanFactory(mock(BeanFactory.class));
+		adapter.start();
 		assertEquals("foo", adapter.getCorrelationKey(message));
 	}
 
@@ -64,6 +73,8 @@ public class CorrelationStrategyAdapterTests {
 	public void testHeaderPojoMethod() {
 		MethodInvokingCorrelationStrategy adapter =
 				new MethodInvokingCorrelationStrategy(new SimpleHeaderCorrelator(), "getKey");
+		adapter.setBeanFactory(mock(BeanFactory.class));
+		adapter.start();
 		assertEquals("b", adapter.getCorrelationKey(message));
 	}
 
@@ -71,6 +82,8 @@ public class CorrelationStrategyAdapterTests {
 	public void testHeadersPojoMethod() {
 		MethodInvokingCorrelationStrategy adapter = new MethodInvokingCorrelationStrategy(new MultiHeaderCorrelator(),
 				ReflectionUtils.findMethod(MultiHeaderCorrelator.class, "getKey", String.class, String.class));
+		adapter.setBeanFactory(mock(BeanFactory.class));
+		adapter.start();
 		assertEquals("bd", adapter.getCorrelationKey(message));
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessorTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
@@ -53,6 +55,15 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.messaging.support.GenericMessage;
 
+/**
+ * @author Iwein Fuld
+ * @author Dave Syer
+ * @author Mark Fisher
+ * @author Oleg Zhurakousky
+ * @author Gunnar Hillert
+ * @author Gary Russell
+ * @author Artem Bilan
+ */
 @RunWith(MockitoJUnitRunner.class)
 public class MethodInvokingMessageGroupProcessorTests {
 
@@ -90,10 +101,13 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new AnnotatedAggregatorMethod());
+		MethodInvokingMessageGroupProcessor processor =
+				new MethodInvokingMessageGroupProcessor(new AnnotatedAggregatorMethod());
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.start();
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
-		assertThat((Integer) ((Message<?>) result).getPayload(), is(7));
+		assertThat(((Message<?>) result).getPayload(), is(7));
 	}
 
 	@Test
@@ -101,6 +115,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		@SuppressWarnings("unused")
 		class SimpleAggregator {
+
 			public Integer and(List<Integer> flags) {
 				int result = 0;
 				for (Integer flag : flags) {
@@ -110,10 +125,12 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.start();
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
-		assertThat((Integer) ((Message<?>) result).getPayload(), is(7));
+		assertThat(((Message<?>) result).getPayload(), is(7));
 	}
 
 	@Test
@@ -121,6 +138,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		@SuppressWarnings("unused")
 		class SimpleAggregator {
+
 			public Integer and(List<Message<Integer>> flags) {
 				int result = 0;
 				for (Message<Integer> flag : flags) {
@@ -130,10 +148,12 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.start();
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
-		assertThat((Integer) ((Message<?>) result).getPayload(), is(7));
+		assertThat(((Message<?>) result).getPayload(), is(7));
 	}
 
 	@Test
@@ -141,6 +161,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		@SuppressWarnings("unused")
 		class SimpleAggregator {
+
 			public String and(List<Integer> flags, @Header("foo") List<Integer> header) {
 				List<Integer> result = new ArrayList<Integer>();
 				for (int flag : flags) {
@@ -153,11 +174,13 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.start();
 		messagesUpForProcessing.add(MessageBuilder.withPayload(3).setHeader("foo", Arrays.asList(101, 102)).build());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
-		assertThat((String) ((Message<?>) result).getPayload(), is("[1, 2, 4, 3, 101, 102]"));
+		assertThat(((Message<?>) result).getPayload(), is("[1, 2, 4, 3, 101, 102]"));
 	}
 
 	@Test
@@ -165,6 +188,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		@SuppressWarnings("unused")
 		class SimpleAggregator {
+
 			public String and(@Payloads List<?> rawFlags, @Header("foo") List<Integer> header) {
 				@SuppressWarnings("unchecked")
 				List<Integer> flags = (List<Integer>) rawFlags;
@@ -179,11 +203,13 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.start();
 		messagesUpForProcessing.add(MessageBuilder.withPayload(3).setHeader("foo", Arrays.asList(101, 102)).build());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
-		assertThat((String) ((Message<?>) result).getPayload(), is("[1, 2, 4, 3, 101, 102]"));
+		assertThat(((Message<?>) result).getPayload(), is("[1, 2, 4, 3, 101, 102]"));
 	}
 
 	@Test
@@ -191,6 +217,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		@SuppressWarnings("unused")
 		class SimpleAggregator {
+
 			@Aggregator
 			public String and(@Payloads List<Integer> flags) {
 				List<Integer> result = new ArrayList<Integer>();
@@ -199,15 +226,18 @@ public class MethodInvokingMessageGroupProcessorTests {
 				}
 				return result.toString();
 			}
+
 			public String or(List<Integer> flags) {
 				throw new UnsupportedOperationException("Not expected");
 			}
 		}
 
-		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.start();
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
-		assertThat((String) ((Message<?>) result).getPayload(), is("[1, 2, 4]"));
+		assertThat(((Message<?>) result).getPayload(), is("[1, 2, 4]"));
 	}
 
 	@Test
@@ -215,6 +245,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		@SuppressWarnings("unused")
 		class SimpleAggregator {
+
 			public Integer and(Collection<Integer> flags) {
 				int result = 0;
 				for (Integer flag : flags) {
@@ -224,10 +255,12 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.start();
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
-		assertThat((Integer) ((Message<?>) result).getPayload(), is(7));
+		assertThat(((Message<?>) result).getPayload(), is(7));
 	}
 
 	@Test
@@ -235,6 +268,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		@SuppressWarnings("unused")
 		class SimpleAggregator {
+
 			public Integer and(int[] flags) {
 				int result = 0;
 				for (int flag : flags) {
@@ -244,10 +278,13 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.start();
+
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
-		assertThat((Integer) ((Message<?>) result).getPayload(), is(7));
+		assertThat(((Message<?>) result).getPayload(), is(7));
 	}
 
 
@@ -256,6 +293,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		@SuppressWarnings("unused")
 		class SimpleAggregator {
+
 			public Integer and(Iterator<Integer> flags) {
 				int result = 0;
 				while (flags.hasNext()) {
@@ -266,17 +304,24 @@ public class MethodInvokingMessageGroupProcessorTests {
 		}
 
 		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
+		processor.setBeanFactory(mock(BeanFactory.class));
+
 		GenericConversionService conversionService = new DefaultConversionService();
 		conversionService.addConverter(new Converter<ArrayList<?>, Iterator<?>>() {
+
 			@Override
 			public Iterator<?> convert(ArrayList<?> source) {
 				return source.iterator();
 			}
+
 		});
 		processor.setConversionService(conversionService);
+
+		processor.start();
+
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
-		assertThat((Integer) ((Message<?>) result).getPayload(), is(7));
+		assertThat(((Message<?>) result).getPayload(), is(7));
 	}
 
 	@Test
@@ -284,6 +329,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		@SuppressWarnings("unused")
 		class UnannotatedAggregator {
+
 			public Integer and(List<Integer> flags) {
 				int result = 0;
 				for (Integer flag : flags) {
@@ -302,10 +348,13 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new UnannotatedAggregator());
+		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new UnannotatedAggregator());
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.start();
+
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
-		assertThat((Integer) ((Message<?>) result).getPayload(), is(7));
+		assertThat(((Message<?>) result).getPayload(), is(7));
 	}
 
 	@Test
@@ -313,6 +362,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		@SuppressWarnings("unused")
 		class UnannotatedAggregator {
+
 			public Iterator<?> and(Iterator<Message<?>> flags) {
 
 				return flags;
@@ -328,7 +378,11 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new UnannotatedAggregator());
+		MethodInvokingMessageGroupProcessor processor =
+				new MethodInvokingMessageGroupProcessor(new UnannotatedAggregator());
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.start();
+
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
 		assertTrue(((Message<?>) result).getPayload() instanceof Iterator<?>);
@@ -355,7 +409,11 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new AnnotatedParametersAggregator());
+		MethodInvokingMessageGroupProcessor processor =
+				new MethodInvokingMessageGroupProcessor(new AnnotatedParametersAggregator());
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.start();
+
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
 		Object payload = ((Message<?>) result).getPayload();
@@ -382,6 +440,8 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		SingleAnnotationTestBean bean = new SingleAnnotationTestBean();
 		MethodInvokingMessageGroupProcessor aggregator = new MethodInvokingMessageGroupProcessor(bean);
+		aggregator.setBeanFactory(mock(BeanFactory.class));
+		aggregator.start();
 		SimpleMessageGroup group = new SimpleMessageGroup("FOO");
 		group.add(new GenericMessage<String>("foo"));
 		group.add(new GenericMessage<String>("bar"));
@@ -392,14 +452,19 @@ public class MethodInvokingMessageGroupProcessorTests {
 	public void testHeaderParameters() throws Exception {
 
 		class SingleAnnotationTestBean {
+
 			@Aggregator
 			public String method1(List<String> input, @Header("foo") String foo) {
 				return input.get(0) + foo;
 			}
+
 		}
 
 		SingleAnnotationTestBean bean = new SingleAnnotationTestBean();
 		MethodInvokingMessageGroupProcessor aggregator = new MethodInvokingMessageGroupProcessor(bean);
+		aggregator.setBeanFactory(mock(BeanFactory.class));
+		aggregator.start();
+
 		SimpleMessageGroup group = new SimpleMessageGroup("FOO");
 		group.add(MessageBuilder.withPayload("foo").setHeader("foo", "bar").build());
 		group.add(MessageBuilder.withPayload("bar").setHeader("foo", "bar").build());
@@ -410,14 +475,19 @@ public class MethodInvokingMessageGroupProcessorTests {
 	public void testHeadersParameters() throws Exception {
 
 		class SingleAnnotationTestBean {
+
 			@Aggregator
 			public String method1(List<String> input, @Headers Map<String, ?> map) {
 				return input.get(0) + map.get("foo");
 			}
+
 		}
 
 		SingleAnnotationTestBean bean = new SingleAnnotationTestBean();
 		MethodInvokingMessageGroupProcessor aggregator = new MethodInvokingMessageGroupProcessor(bean);
+		aggregator.setBeanFactory(mock(BeanFactory.class));
+		aggregator.start();
+
 		SimpleMessageGroup group = new SimpleMessageGroup("FOO");
 		group.add(MessageBuilder.withPayload("foo").setHeader("foo", "bar").build());
 		group.add(MessageBuilder.withPayload("bar").setHeader("foo", "bar").build());
@@ -461,6 +531,9 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		NoAnnotationTestBean bean = new NoAnnotationTestBean();
 		MethodInvokingMessageGroupProcessor aggregator = new MethodInvokingMessageGroupProcessor(bean);
+		aggregator.setBeanFactory(mock(BeanFactory.class));
+		aggregator.start();
+
 		SimpleMessageGroup group = new SimpleMessageGroup("FOO");
 		group.add(new GenericMessage<String>("foo"));
 		group.add(new GenericMessage<String>("bar"));
@@ -507,14 +580,17 @@ public class MethodInvokingMessageGroupProcessorTests {
 		QueueChannel output = new QueueChannel();
 		GreetingService testBean = new GreetingBean();
 		ProxyFactory proxyFactory = new ProxyFactory(testBean);
-		proxyFactory.setProxyTargetClass(false);
+		proxyFactory.setProxyTargetClass(true);
 		testBean = (GreetingService) proxyFactory.getProxy();
 		MethodInvokingMessageGroupProcessor aggregator = new MethodInvokingMessageGroupProcessor(testBean);
+		aggregator.setBeanFactory(mock(BeanFactory.class));
 		AggregatingMessageHandler handler = new AggregatingMessageHandler(aggregator);
 		handler.setReleaseStrategy(new MessageCountReleaseStrategy());
 		handler.setOutputChannel(output);
+
 		EventDrivenConsumer endpoint = new EventDrivenConsumer(input, handler);
 		endpoint.start();
+
 		Message<?> message = MessageBuilder.withPayload("proxy").setCorrelationId("abc").build();
 		input.send(message);
 		assertEquals("hello proxy", output.receive(0).getPayload());
@@ -533,7 +609,9 @@ public class MethodInvokingMessageGroupProcessorTests {
 		handler.setReleaseStrategy(new MessageCountReleaseStrategy());
 		handler.setOutputChannel(output);
 		EventDrivenConsumer endpoint = new EventDrivenConsumer(input, handler);
+		endpoint.setBeanFactory(mock(BeanFactory.class));
 		endpoint.start();
+
 		Message<?> message = MessageBuilder.withPayload("proxy").setCorrelationId("abc").build();
 		input.send(message);
 		assertEquals("hello proxy", output.receive(0).getPayload());
@@ -541,7 +619,9 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 
 	public interface GreetingService {
+
 		String sayHello(List<String> names);
+
 	}
 
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessorTests.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -38,7 +37,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import org.springframework.aop.framework.ProxyFactory;
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
@@ -101,10 +99,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MethodInvokingMessageGroupProcessor processor =
-				new MethodInvokingMessageGroupProcessor(new AnnotatedAggregatorMethod());
-		processor.setBeanFactory(mock(BeanFactory.class));
-		processor.start();
+		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new AnnotatedAggregatorMethod());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
 		assertThat(((Message<?>) result).getPayload(), is(7));
@@ -125,9 +120,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
-		processor.setBeanFactory(mock(BeanFactory.class));
-		processor.start();
+		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
 		assertThat(((Message<?>) result).getPayload(), is(7));
@@ -148,9 +141,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
-		processor.setBeanFactory(mock(BeanFactory.class));
-		processor.start();
+		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
 		assertThat(((Message<?>) result).getPayload(), is(7));
@@ -174,9 +165,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
-		processor.setBeanFactory(mock(BeanFactory.class));
-		processor.start();
+		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
 		messagesUpForProcessing.add(MessageBuilder.withPayload(3).setHeader("foo", Arrays.asList(101, 102)).build());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
@@ -203,9 +192,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
-		processor.setBeanFactory(mock(BeanFactory.class));
-		processor.start();
+		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
 		messagesUpForProcessing.add(MessageBuilder.withPayload(3).setHeader("foo", Arrays.asList(101, 102)).build());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
@@ -232,9 +219,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
-		processor.setBeanFactory(mock(BeanFactory.class));
-		processor.start();
+		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
 		assertThat(((Message<?>) result).getPayload(), is("[1, 2, 4]"));
@@ -255,9 +240,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
-		processor.setBeanFactory(mock(BeanFactory.class));
-		processor.start();
+		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
 		assertThat(((Message<?>) result).getPayload(), is(7));
@@ -278,10 +261,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
-		processor.setBeanFactory(mock(BeanFactory.class));
-		processor.start();
-
+		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
 		assertThat(((Message<?>) result).getPayload(), is(7));
@@ -304,8 +284,6 @@ public class MethodInvokingMessageGroupProcessorTests {
 		}
 
 		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new SimpleAggregator());
-		processor.setBeanFactory(mock(BeanFactory.class));
-
 		GenericConversionService conversionService = new DefaultConversionService();
 		conversionService.addConverter(new Converter<ArrayList<?>, Iterator<?>>() {
 
@@ -316,9 +294,6 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		});
 		processor.setConversionService(conversionService);
-
-		processor.start();
-
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
 		assertThat(((Message<?>) result).getPayload(), is(7));
@@ -348,10 +323,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new UnannotatedAggregator());
-		processor.setBeanFactory(mock(BeanFactory.class));
-		processor.start();
-
+		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new UnannotatedAggregator());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
 		assertThat(((Message<?>) result).getPayload(), is(7));
@@ -378,11 +350,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MethodInvokingMessageGroupProcessor processor =
-				new MethodInvokingMessageGroupProcessor(new UnannotatedAggregator());
-		processor.setBeanFactory(mock(BeanFactory.class));
-		processor.start();
-
+		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new UnannotatedAggregator());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
 		assertTrue(((Message<?>) result).getPayload() instanceof Iterator<?>);
@@ -409,11 +377,7 @@ public class MethodInvokingMessageGroupProcessorTests {
 			}
 		}
 
-		MethodInvokingMessageGroupProcessor processor =
-				new MethodInvokingMessageGroupProcessor(new AnnotatedParametersAggregator());
-		processor.setBeanFactory(mock(BeanFactory.class));
-		processor.start();
-
+		MessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(new AnnotatedParametersAggregator());
 		when(messageGroupMock.getMessages()).thenReturn(messagesUpForProcessing);
 		Object result = processor.processMessageGroup(messageGroupMock);
 		Object payload = ((Message<?>) result).getPayload();
@@ -440,8 +404,6 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		SingleAnnotationTestBean bean = new SingleAnnotationTestBean();
 		MethodInvokingMessageGroupProcessor aggregator = new MethodInvokingMessageGroupProcessor(bean);
-		aggregator.setBeanFactory(mock(BeanFactory.class));
-		aggregator.start();
 		SimpleMessageGroup group = new SimpleMessageGroup("FOO");
 		group.add(new GenericMessage<String>("foo"));
 		group.add(new GenericMessage<String>("bar"));
@@ -462,9 +424,6 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		SingleAnnotationTestBean bean = new SingleAnnotationTestBean();
 		MethodInvokingMessageGroupProcessor aggregator = new MethodInvokingMessageGroupProcessor(bean);
-		aggregator.setBeanFactory(mock(BeanFactory.class));
-		aggregator.start();
-
 		SimpleMessageGroup group = new SimpleMessageGroup("FOO");
 		group.add(MessageBuilder.withPayload("foo").setHeader("foo", "bar").build());
 		group.add(MessageBuilder.withPayload("bar").setHeader("foo", "bar").build());
@@ -485,9 +444,6 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		SingleAnnotationTestBean bean = new SingleAnnotationTestBean();
 		MethodInvokingMessageGroupProcessor aggregator = new MethodInvokingMessageGroupProcessor(bean);
-		aggregator.setBeanFactory(mock(BeanFactory.class));
-		aggregator.start();
-
 		SimpleMessageGroup group = new SimpleMessageGroup("FOO");
 		group.add(MessageBuilder.withPayload("foo").setHeader("foo", "bar").build());
 		group.add(MessageBuilder.withPayload("bar").setHeader("foo", "bar").build());
@@ -531,9 +487,6 @@ public class MethodInvokingMessageGroupProcessorTests {
 
 		NoAnnotationTestBean bean = new NoAnnotationTestBean();
 		MethodInvokingMessageGroupProcessor aggregator = new MethodInvokingMessageGroupProcessor(bean);
-		aggregator.setBeanFactory(mock(BeanFactory.class));
-		aggregator.start();
-
 		SimpleMessageGroup group = new SimpleMessageGroup("FOO");
 		group.add(new GenericMessage<String>("foo"));
 		group.add(new GenericMessage<String>("bar"));
@@ -583,7 +536,6 @@ public class MethodInvokingMessageGroupProcessorTests {
 		proxyFactory.setProxyTargetClass(true);
 		testBean = (GreetingService) proxyFactory.getProxy();
 		MethodInvokingMessageGroupProcessor aggregator = new MethodInvokingMessageGroupProcessor(testBean);
-		aggregator.setBeanFactory(mock(BeanFactory.class));
 		AggregatingMessageHandler handler = new AggregatingMessageHandler(aggregator);
 		handler.setReleaseStrategy(new MessageCountReleaseStrategy());
 		handler.setOutputChannel(output);
@@ -609,7 +561,6 @@ public class MethodInvokingMessageGroupProcessorTests {
 		handler.setReleaseStrategy(new MessageCountReleaseStrategy());
 		handler.setOutputChannel(output);
 		EventDrivenConsumer endpoint = new EventDrivenConsumer(input, handler);
-		endpoint.setBeanFactory(mock(BeanFactory.class));
 		endpoint.start();
 
 		Message<?> message = MessageBuilder.withPayload("proxy").setCorrelationId("abc").build();

--- a/spring-integration-core/src/test/java/org/springframework/integration/bus/ApplicationContextMessageBusTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/bus/ApplicationContextMessageBusTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ import org.springframework.scheduling.support.PeriodicTrigger;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public class ApplicationContextMessageBusTests {
 
@@ -74,7 +75,7 @@ public class ApplicationContextMessageBusTests {
 		endpoint.setBeanFactory(mock(BeanFactory.class));
 		context.registerEndpoint("testEndpoint", endpoint);
 		context.refresh();
-		Message<?> result = targetChannel.receive(3000);
+		Message<?> result = targetChannel.receive(10000);
 		assertEquals("test", result.getPayload());
 		context.stop();
 	}
@@ -88,19 +89,19 @@ public class ApplicationContextMessageBusTests {
 		QueueChannel targetChannel = new QueueChannel();
 		context.registerChannel("targetChannel", targetChannel);
 		context.refresh();
-		Message<?> result = targetChannel.receive(100);
+		Message<?> result = targetChannel.receive(10);
 		assertNull(result);
 		context.stop();
 	}
 
 	@Test
-	public void autodetectionWithApplicationContext() {
+	public void autoDetectionWithApplicationContext() {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("messageBusTests.xml", this.getClass());
 		context.start();
 		PollableChannel sourceChannel = (PollableChannel) context.getBean("sourceChannel");
 		sourceChannel.send(new GenericMessage<String>("test"));
 		PollableChannel targetChannel = (PollableChannel) context.getBean("targetChannel");
-		Message<?> result = targetChannel.receive(3000);
+		Message<?> result = targetChannel.receive(10000);
 		assertEquals("test", result.getPayload());
 		context.close();
 	}
@@ -136,7 +137,7 @@ public class ApplicationContextMessageBusTests {
 		context.registerEndpoint("testEndpoint2", endpoint2);
 		context.refresh();
 		inputChannel.send(new GenericMessage<String>("testing"));
-		Message<?> message1 = outputChannel1.receive(3000);
+		Message<?> message1 = outputChannel1.receive(10000);
 		Message<?> message2 = outputChannel2.receive(0);
 		context.stop();
 		assertTrue("exactly one message should be null", message1 == null ^ message2 == null);

--- a/spring-integration-core/src/test/java/org/springframework/integration/bus/messageBusTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/bus/messageBusTests.xml
@@ -33,4 +33,6 @@
 	<bean id="handler" class="org.springframework.integration.message.TestHandlers"
 		factory-method="echoHandler" />
 
+	<bean id="integrationConversionService" class="org.springframework.core.convert.support.DefaultConversionService"/>
+
 </beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveConsumerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveConsumerTests.java
@@ -75,7 +75,7 @@ public class ReactiveConsumerTests {
 			stopLatch.countDown();
 		};
 
-		MethodInvokingMessageHandler testSubscriber = new MethodInvokingMessageHandler(messageHandler, (String) null);
+		MessageHandler testSubscriber = new MethodInvokingMessageHandler(messageHandler, (String) null);
 
 		ReactiveConsumer reactiveConsumer = new ReactiveConsumer(testChannel, testSubscriber);
 		reactiveConsumer.setBeanFactory(mock(BeanFactory.class));

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/SubscriberOrderTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/SubscriberOrderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,18 +32,20 @@ import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.dispatcher.RoundRobinLoadBalancingStrategy;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public class SubscriberOrderTests {
 
 	@Test
 	public void directChannelAndFailoverDispatcherWithSingleCallPerMethod() {
-		GenericApplicationContext context = new GenericApplicationContext();
+		GenericApplicationContext context = TestUtils.createTestApplicationContext();
 		context.registerBeanDefinition("postProcessor", new RootBeanDefinition(MessagingAnnotationPostProcessor.class));
 		RootBeanDefinition channelDefinition = new RootBeanDefinition(DirectChannel.class);
 		context.registerBeanDefinition("input", channelDefinition);
@@ -70,7 +72,7 @@ public class SubscriberOrderTests {
 
 	@Test
 	public void directChannelAndFailoverDispatcherWithMultipleCallsPerMethod() {
-		GenericApplicationContext context = new GenericApplicationContext();
+		GenericApplicationContext context = TestUtils.createTestApplicationContext();
 		context.registerBeanDefinition("postProcessor", new RootBeanDefinition(MessagingAnnotationPostProcessor.class));
 		BeanDefinitionBuilder channelBuilder = BeanDefinitionBuilder.rootBeanDefinition(DirectChannel.class);
 		channelBuilder.addConstructorArgValue(null);
@@ -112,7 +114,7 @@ public class SubscriberOrderTests {
 
 	@Test
 	public void directChannelAndRoundRobinDispatcher() {
-		GenericApplicationContext context = new GenericApplicationContext();
+		GenericApplicationContext context = TestUtils.createTestApplicationContext();
 		context.registerBeanDefinition("postProcessor", new RootBeanDefinition(MessagingAnnotationPostProcessor.class));
 		RootBeanDefinition channelDefinition = new RootBeanDefinition(DirectChannel.class);
 		channelDefinition.getConstructorArgumentValues().addGenericArgumentValue(new RoundRobinLoadBalancingStrategy());

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/MessageProducerSupportTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/MessageProducerSupportTests.java
@@ -83,6 +83,7 @@ public class MessageProducerSupportTests {
 	@Test
 	public void validateSuccessfulErrorFlowDoesNotThrowErrors() {
 		TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
+		testApplicationContext.refresh();
 		DirectChannel outChannel = new DirectChannel();
 		outChannel.subscribe(message -> {
 			throw new RuntimeException("problems");

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/MessageProducerSupportTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/MessageProducerSupportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.handler.ServiceActivatingHandler;
@@ -43,6 +41,7 @@ import org.springframework.messaging.support.GenericMessage;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Kris Jacyna
+ * @author Artem Bilan
  * @since 2.0.1
  */
 public class MessageProducerSupportTests {
@@ -83,6 +82,7 @@ public class MessageProducerSupportTests {
 
 	@Test
 	public void validateSuccessfulErrorFlowDoesNotThrowErrors() {
+		TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
 		DirectChannel outChannel = new DirectChannel();
 		outChannel.subscribe(message -> {
 			throw new RuntimeException("problems");
@@ -90,13 +90,13 @@ public class MessageProducerSupportTests {
 		PublishSubscribeChannel errorChannel = new PublishSubscribeChannel();
 		SuccessfulErrorService errorService = new SuccessfulErrorService();
 		ServiceActivatingHandler handler  = new ServiceActivatingHandler(errorService);
-		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setBeanFactory(testApplicationContext);
 		handler.afterPropertiesSet();
 		errorChannel.subscribe(handler);
 		MessageProducerSupport mps = new MessageProducerSupport() { };
 		mps.setOutputChannel(outChannel);
 		mps.setErrorChannel(errorChannel);
-		mps.setBeanFactory(TestUtils.createTestApplicationContext());
+		mps.setBeanFactory(testApplicationContext);
 		mps.afterPropertiesSet();
 		mps.start();
 		Message<?> message = new GenericMessage<String>("hello");
@@ -106,6 +106,7 @@ public class MessageProducerSupportTests {
 		assertEquals(MessageDeliveryException.class, errorMessage.getPayload().getClass());
 		MessageDeliveryException exception = (MessageDeliveryException) errorMessage.getPayload();
 		assertEquals(message, exception.getFailedMessage());
+		testApplicationContext.close();
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorEndpointTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ public class ServiceActivatorEndpointTests {
 
 	@Test
 	public void returnAddressHeaderWithChannelName() {
+		TestUtils.TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
 		QueueChannel channel = new QueueChannel(1);
 		channel.setBeanName("testChannel");
 		TestChannelResolver channelResolver = new TestChannelResolver();
@@ -98,10 +99,12 @@ public class ServiceActivatorEndpointTests {
 		Message<?> reply = channel.receive(0);
 		assertNotNull(reply);
 		assertEquals("FOO", reply.getPayload());
+		testApplicationContext.close();
 	}
 
 	@Test
 	public void dynamicReplyChannel() throws Exception {
+		TestUtils.TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
 		final QueueChannel replyChannel1 = new QueueChannel();
 		final QueueChannel replyChannel2 = new QueueChannel();
 		replyChannel2.setBeanName("replyChannel2");
@@ -116,7 +119,7 @@ public class ServiceActivatorEndpointTests {
 		TestChannelResolver channelResolver = new TestChannelResolver();
 		channelResolver.addChannel("replyChannel2", replyChannel2);
 		endpoint.setChannelResolver(channelResolver);
-		endpoint.setBeanFactory(mock(BeanFactory.class));
+		endpoint.setBeanFactory(testApplicationContext);
 		endpoint.afterPropertiesSet();
 		Message<String> testMessage1 = MessageBuilder.withPayload("bar")
 				.setReplyChannel(replyChannel1).build();
@@ -134,6 +137,7 @@ public class ServiceActivatorEndpointTests {
 		reply2 = replyChannel2.receive(0);
 		assertNotNull(reply2);
 		assertEquals("foobar", reply2.getPayload());
+		testApplicationContext.close();
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorEndpointTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorEndpointTests.java
@@ -85,13 +85,14 @@ public class ServiceActivatorEndpointTests {
 	@Test
 	public void returnAddressHeaderWithChannelName() {
 		TestUtils.TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
+		testApplicationContext.refresh();
 		QueueChannel channel = new QueueChannel(1);
 		channel.setBeanName("testChannel");
 		TestChannelResolver channelResolver = new TestChannelResolver();
 		channelResolver.addChannel("testChannel", channel);
 		ServiceActivatingHandler endpoint = this.createEndpoint();
 		endpoint.setChannelResolver(channelResolver);
-		endpoint.setBeanFactory(mock(BeanFactory.class));
+		endpoint.setBeanFactory(testApplicationContext);
 		endpoint.afterPropertiesSet();
 		Message<?> message = MessageBuilder.withPayload("foo")
 				.setReplyChannelName("testChannel").build();
@@ -105,6 +106,7 @@ public class ServiceActivatorEndpointTests {
 	@Test
 	public void dynamicReplyChannel() throws Exception {
 		TestUtils.TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
+		testApplicationContext.refresh();
 		final QueueChannel replyChannel1 = new QueueChannel();
 		final QueueChannel replyChannel2 = new QueueChannel();
 		replyChannel2.setBeanName("replyChannel2");

--- a/spring-integration-core/src/test/java/org/springframework/integration/filter/FilterAnnotationMethodResolutionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/filter/FilterAnnotationMethodResolutionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,8 @@ import org.springframework.messaging.MessageHandler;
 
 /**
  * @author Mark Fisher
+ * @author Artme Bilan
+ *
  * @since 2.0
  */
 public class FilterAnnotationMethodResolutionTests {
@@ -39,6 +41,7 @@ public class FilterAnnotationMethodResolutionTests {
 	@Test
 	public void resolveAnnotatedMethod() throws Exception {
 		TestUtils.TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
+		testApplicationContext.refresh();
 		FilterFactoryBean factoryBean = new FilterFactoryBean();
 		factoryBean.setBeanFactory(testApplicationContext);
 		AnnotatedTestFilter filter = new AnnotatedTestFilter();
@@ -80,6 +83,7 @@ public class FilterAnnotationMethodResolutionTests {
 			this.invokedCorrectMethod = true;
 			return true;
 		}
+
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/filter/FilterAnnotationMethodResolutionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/filter/FilterAnnotationMethodResolutionTests.java
@@ -22,13 +22,13 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.messaging.Message;
 import org.springframework.integration.annotation.Filter;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.FilterFactoryBean;
-import org.springframework.messaging.MessageHandler;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
 
 /**
  * @author Mark Fisher
@@ -38,8 +38,9 @@ public class FilterAnnotationMethodResolutionTests {
 
 	@Test
 	public void resolveAnnotatedMethod() throws Exception {
+		TestUtils.TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
 		FilterFactoryBean factoryBean = new FilterFactoryBean();
-		factoryBean.setBeanFactory(new DefaultListableBeanFactory());
+		factoryBean.setBeanFactory(testApplicationContext);
 		AnnotatedTestFilter filter = new AnnotatedTestFilter();
 		factoryBean.setTargetObject(filter);
 		MessageHandler handler = factoryBean.getObject();
@@ -49,6 +50,7 @@ public class FilterAnnotationMethodResolutionTests {
 		assertNotNull(result);
 		assertTrue(filter.invokedCorrectMethod);
 		assertFalse(filter.invokedIncorrectMethod);
+		testApplicationContext.close();
 	}
 
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/MessagingGatewayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/MessagingGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/MessagingGatewayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/MessagingGatewayTests.java
@@ -249,6 +249,7 @@ public class MessagingGatewayTests {
 	@Test
 	public void validateErrorChannelWithSuccessfulReply() {
 		TestUtils.TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
+		testApplicationContext.refresh();
 		DirectChannel reqChannel = new DirectChannel();
 		reqChannel.subscribe(message -> {
 			throw new RuntimeException("ooops");

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/MessagingGatewayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/MessagingGatewayTests.java
@@ -248,13 +248,14 @@ public class MessagingGatewayTests {
 	// should not fail but it does now
 	@Test
 	public void validateErrorChannelWithSuccessfulReply() {
+		TestUtils.TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
 		DirectChannel reqChannel = new DirectChannel();
 		reqChannel.subscribe(message -> {
 			throw new RuntimeException("ooops");
 		});
 		PublishSubscribeChannel errorChannel = new PublishSubscribeChannel();
 		ServiceActivatingHandler handler  = new ServiceActivatingHandler(new MyOneWayErrorService());
-		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setBeanFactory(testApplicationContext);
 		handler.afterPropertiesSet();
 		errorChannel.subscribe(handler);
 
@@ -268,6 +269,7 @@ public class MessagingGatewayTests {
 		this.messagingGateway.start();
 
 		this.messagingGateway.send("hello");
+		testApplicationContext.close();
 	}
 
 	public static class MyErrorService {

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.expression.spel.SpelCompilerMode;
 import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.gateway.GatewayProxyFactoryBean;
@@ -594,6 +595,19 @@ public class MethodInvokingMessageProcessorTests {
 			processor.processMessage(message);
 		}
 		stopWatch.stop();
+
+
+		System.setProperty("spring.expression.compiler.mode", SpelCompilerMode.IMMEDIATE.name());
+		processor = new MethodInvokingMessageProcessor(service, method);
+		processor.setUseSpelInvoker(true);
+
+		stopWatch.start("Compiled SpEL");
+		for (int i = 0; i < 10000; i++) {
+			processor.processMessage(message);
+		}
+		stopWatch.stop();
+
+		System.clearProperty("spring.expression.compiler.mode");
 
 		logger.warn(stopWatch.prettyPrint());
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterFactoryBeanTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterFactoryBeanTests.java
@@ -40,6 +40,7 @@ public class RouterFactoryBeanTests {
 	@Test
 	public void testOutputChannelName() throws Exception {
 		TestUtils.TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
+		testApplicationContext.refresh();
 		RouterFactoryBean fb = new RouterFactoryBean();
 		fb.setTargetObject(this);
 		fb.setTargetMethodName("foo");

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterFactoryBeanTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +18,18 @@ package org.springframework.integration.router.config;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.RouterFactoryBean;
-import org.springframework.messaging.MessageChannel;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 4.2.5
  *
  */
@@ -41,19 +39,20 @@ public class RouterFactoryBeanTests {
 
 	@Test
 	public void testOutputChannelName() throws Exception {
+		TestUtils.TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
 		RouterFactoryBean fb = new RouterFactoryBean();
 		fb.setTargetObject(this);
 		fb.setTargetMethodName("foo");
 		fb.setDefaultOutputChannelName("bar");
-		BeanFactory beanFactory = mock(BeanFactory.class);
 		QueueChannel bar = new QueueChannel();
-		doReturn(bar).when(beanFactory).getBean("bar", MessageChannel.class);
-		fb.setBeanFactory(beanFactory);
+		testApplicationContext.registerBean("bar", bar);
+		fb.setBeanFactory(testApplicationContext);
 		MessageHandler handler = fb.getObject();
 		this.routeAttempted = false;
 		handler.handleMessage(new GenericMessage<>("foo"));
 		assertNotNull(bar.receive(10000));
 		assertTrue(this.routeAttempted);
+		testApplicationContext.close();
 	}
 
 	public String foo() {

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/util/TestUtils.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/util/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.format.support.DefaultFormattingConversionService;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessagingException;
@@ -90,6 +91,7 @@ public abstract class TestUtils {
 		ThreadPoolTaskScheduler scheduler = createTaskScheduler(10);
 		scheduler.setErrorHandler(errorHandler);
 		registerBean("taskScheduler", scheduler, context);
+		registerBean("integrationConversionService", new DefaultFormattingConversionService(), context);
 		return context;
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4186

* Rework `MessagingMethodInvokerHelper` to delegate to the `InvocableHandlerMethod` with its `HandlerMethodArgumentResolver` infrastructure instead of SpEL
* Introduce several `HandlerMethodArgumentResolver` to address some SI use-cases like `@Payloads`, `@Payload(expression = "")` and `Collection` as argument
* Initialize `DefaultMessageHandlerMethodFactory` in the `MessagingMethodInvokerHelper.start()`.
With that I observed several `Lifecycle` problem when we don't have proper delegate from the top.
* Fix `AbstractCorrelatingMessageHandler` and similar to delegate `Lifecycle` properly
* Fix `ReactiveConsumer` to delegate `Lifecycle` to the `MessageHandler`
* Fix `MutableMessage` do not `generateId()` and set `timestamp` headers if we already have them in the provided headers
* With all that `Lifecycle` many tests must be fixed to call `start()`