### PR TITLE
INT-4207: Fallback for `replyChannel` resolution

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,7 +146,8 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 		if (getOutputChannel() == null) {
 			Map<?, ?> routingSlipHeader = requestHeaders.get(IntegrationMessageHeaderAccessor.ROUTING_SLIP, Map.class);
 			if (routingSlipHeader != null) {
-				Assert.isTrue(routingSlipHeader.size() == 1, "The RoutingSlip header value must be a SingletonMap");
+				Assert.isTrue(routingSlipHeader.size() == 1,
+						"The RoutingSlip header value must be a SingletonMap");
 				Object key = routingSlipHeader.keySet().iterator().next();
 				Object value = routingSlipHeader.values().iterator().next();
 				Assert.isInstanceOf(List.class, key, "The RoutingSlip key must be List");
@@ -174,6 +175,9 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 
 			if (replyChannel == null) {
 				replyChannel = requestHeaders.getReplyChannel();
+				if (replyChannel == null && reply instanceof Message) {
+					replyChannel = ((Message<?>) reply).getHeaders().getReplyChannel();
+				}
 			}
 		}
 

--- a/src/reference/asciidoc/service-activator.adoc
+++ b/src/reference/asciidoc/service-activator.adoc
@@ -34,12 +34,13 @@ To determine the reply channel, it will first check if an "output-channel" was p
                        ref="somePojo" method="someMethod"/>
 ----
 
-If the method returns a result and no "output-channel" is defined, the framework will then check the Message's `replyChannel` header value.
+If the method returns a result and no "output-channel" is defined, the framework will then check the request Message's `replyChannel` header value.
 If that value is available, it will then check its type.
 If it is a`MessageChannel`, the reply message will be sent to that channel.
 If it is a `String`, then the endpoint will attempt to resolve the channel name to a channel instance.
 If the channel cannot be resolved, then a `DestinationResolutionException` will be thrown.
 It it can be resolved, the Message will be sent there.
+If request Message doesn't have `replyChannel` header and and `reply` object is `Message`, its `replyChannel` header is consulted for target destination.
 This is the technique used for Request Reply messaging in Spring Integration, and it is also an example of the Return Address pattern.
 
 If your method returns a result, and you want to discard it and end the flow, you should configure the `output-channel` to send to a `NullChannel`.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4207

Enhance `AbstractMessageProducingHandler` to fallback for `replyChannel` to the `reply` if it is `Message`.
That lets to avoid extra `bridge` configuration afterwards to make that `reply` as `request` for the same `replyChannel` resolution.

This situation happens in case of error handling when the request message is `ErrorMessage`, typically without original headers to properly consult.
But at the same time `failedMessage` in the `MessagingException` has all required headers.