### PR TITLE
INT-4210: DSL: Make a final `.log()` Terminal

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/WireTapSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/WireTapSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.dsl.channel;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -104,10 +103,10 @@ public class WireTapSpec extends IntegrationComponentSpec<WireTapSpec, WireTap> 
 	@Override
 	public Collection<Object> getComponentsToRegister() {
 		if (this.selector != null) {
-			return Arrays.asList(this.selector, this.target);
+			return Collections.singleton(this.selector);
 		}
 		else {
-			return Collections.singletonList(this.target);
+			return null;
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/flowservices/FlowServiceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/flowservices/FlowServiceTests.java
@@ -167,7 +167,8 @@ public class FlowServiceTests {
 					.enrichHeaders(Collections.singletonMap("foo", "FOO"))
 					.filter(this)
 					.handle(this)
-					.channel(MessageChannels.queue("myFlowAdapterOutput"));
+					.channel(MessageChannels.queue("myFlowAdapterOutput"))
+					.log();
 		}
 
 		public String messageSource() {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4210

Previously use-case like:
```
.transform()
.log()
.get();
```
failed with the `Dispatcher has no subscribers` for an implicit channel populated by the `.wireTap()` because actually `LoggingHandler` is placed on the wire-tapped channel

Since logically it looks like end-user tries to have `LoggingHandler` as a terminal of the flow, we add `nullChannel` if `WireTapSpec` is in the end of the flow definition.

If user would like to continue flow (e.g. return reply to the `replyChannel`), he must end more EIP-methods after `.log()` (like before, of course)