### PR TITLE
Fix Compiled SpEL Test

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
@@ -979,7 +979,7 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 		}
 	}
 
-	private static class ParametersWrapper {
+	public static class ParametersWrapper {
 
 		private final Object payload;
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -576,17 +576,17 @@ public class MethodInvokingMessageProcessorTests {
 	@Test
 	public void testPerformanceSpelVersusInvocable() throws Exception {
 		AnnotatedTestService service = new AnnotatedTestService();
-		Method method = service.getClass().getMethod("messageAndHeader", Message.class, Integer.class);
+		Method method = service.getClass().getMethod("integerMethod", Integer.class);
 
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
 		processor.setUseSpelInvoker(true);
 
-		Message<String> message = MessageBuilder.withPayload("foo").setHeader("number", 42).build();
+		Message<Integer> message = MessageBuilder.withPayload(42).build();
 
 		StopWatch stopWatch = new StopWatch("SpEL vs Invocable Performance");
 
 		stopWatch.start("SpEL");
-		int count = 10_000;
+		int count = 20_000;
 		for (int i = 0; i < count; i++) {
 			processor.processMessage(message);
 		}
@@ -613,8 +613,6 @@ public class MethodInvokingMessageProcessorTests {
 			processor.processMessage(message);
 		}
 		stopWatch.stop();
-
-		System.clearProperty("spring.expression.compiler.mode");
 
 		logger.warn(stopWatch.prettyPrint());
 	}
@@ -727,8 +725,7 @@ public class MethodInvokingMessageProcessorTests {
 
 	}
 
-	@SuppressWarnings("unused")
-	private static class AnnotatedTestService {
+	public static class AnnotatedTestService {
 
 		AnnotatedTestService() {
 			super();


### PR DESCRIPTION
Several problems:

- Setting the system property is not enough since the `static` parser already has its configuration
- Changing the ParametersWrapper to `private` made property accessing not compilable (the method and class must be public).
- The expression...

```
 #target.messageAndHeader(message, headers['number'] != null ? headers['number'] : T(org.springframework.util.Assert).isTrue(false, 'required header not available: number'))
```

...is not compilable anyway because else part of the ternery is not compilable because the `TypeReference.exitTypeDescriptor` is `null` (assert call).

(My mistake - I originally thought it was the `NullLiteral`.

So, in effect, the compiledSpEL test is invalid.

This commit addresses the first two bullets.
