### PR TITLE
INT-4215: Add `ChainFileListFilter`

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.file.filters;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.util.Assert;
+
+/**
+ * The {@link CompositeFileListFilter} extension which chains the result
+ * of the previous filter to the next one.
+ *
+ * @author Artem Bilan
+ *
+ * @since 4.3.7
+ *
+ * @param <F> The type that will be filtered.
+ */
+public class ChainFileListFilter<F> extends CompositeFileListFilter<F> {
+
+	@Override
+	public List<F> filterFiles(F[] files) {
+		Assert.notNull(files, "'files' should not be null");
+		List<F> leftOver = Arrays.asList(files);
+		for (FileListFilter<F> fileFilter : this.fileFilters) {
+			@SuppressWarnings("unchecked")
+			F[] fileArray = (F[]) leftOver.toArray();
+			leftOver = fileFilter.filterFiles(fileArray);
+		}
+		return leftOver;
+	}
+
+}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ import org.springframework.util.Assert;
  */
 public class CompositeFileListFilter<F> implements ReversibleFileListFilter<F>, ResettableFileListFilter<F>, Closeable {
 
-	private final Set<FileListFilter<F>> fileFilters;
+	protected final Set<FileListFilter<F>> fileFilters;
 
 
 	public CompositeFileListFilter() {

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -106,6 +106,11 @@ to, say, network glitches.
 </bean>
 ----
 
+Starting with _version 4.3.7_ a `ChainFileListFilter` (an extension of `CompositeFileListFilter`) has been introduced to allow scenarios when the next filter should accept the result of the previous one.
+One of the sample is combination of `LastModifiedFileListFilter` and `AcceptOnceFileListFilter`, when we are not interested in accepting the file until enough time has elapsed.
+Another scenario is ".done file" approach, when we are not interested in the file until claim check file appears.
+In this case we may meet `.done` file first, so no need to scan for the original file and we can just return it from the filter as a new entry.
+
 Starting with _version 5.0_ an `ExpressionFileListFilter` has been introduced to allow to execute SpEL expression against file as a context evaluation root object.
 For this purpose all the XML components for file handling (local and remote), alongside with an existing `filter` attribute, have been supplied with the `filter-expression` option:
 [source, xml]


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4215
Fixes GH-1998 (https://github.com/spring-projects/spring-integration/issues/1998)

Just make an `CompositeFileListFilter` extension which chains result of the previous filter to the next

**Cherry-pick 4.3.x**