### PR TITLE
INT-4220: Leaders: warn event publishing errors

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/leader/Context.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/leader/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,17 +20,21 @@ package org.springframework.integration.leader;
  * Interface that defines the context for candidate leadership.
  * Instances of this object are passed to {@link Candidate candidates}
  * upon granting and revoking of leadership.
+ * <p>
+ * The {@link Context} is {@link FunctionalInterface}
+ * with no-op implementation for the {@link #yield()}.
  *
  * @author Patrick Peralta
  * @author Janne Valkealahti
+ * @author Artem Bilan
  *
  */
+@FunctionalInterface
 public interface Context {
 
 	/**
 	 * Checks if the {@link Candidate} this context was
 	 * passed to is the leader.
-	 *
 	 * @return true if the {@link Candidate} this context was
 	 *         passed to is the leader
 	 */
@@ -41,5 +45,8 @@ public interface Context {
 	 * to relinquish leadership. This method has no effect
 	 * if the candidate is not currently the leader.
 	 */
-	void yield();
+	default void yield() {
+		// no-op
+	}
+
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/leader/JdbcLockRegistryLeaderInitiatorTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/leader/JdbcLockRegistryLeaderInitiatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,8 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.Level;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.integration.jdbc.lock.DefaultLockRepository;
@@ -37,7 +35,6 @@ import org.springframework.integration.leader.Context;
 import org.springframework.integration.leader.DefaultCandidate;
 import org.springframework.integration.leader.event.LeaderEventPublisher;
 import org.springframework.integration.support.leader.LockRegistryLeaderInitiator;
-import org.springframework.integration.test.rule.Log4jLevelAdjuster;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
@@ -47,9 +44,6 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
  * @since 4.3.1
  */
 public class JdbcLockRegistryLeaderInitiatorTests {
-
-	@Rule
-	public Log4jLevelAdjuster logAdjuster = new Log4jLevelAdjuster(Level.DEBUG, "org.springframework.integration");
 
 	public static EmbeddedDatabase dataSource;
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4220

Currently when an error is thrown from the event publishing the role granting is broken and we just go to the role revoking.

* Since it's just an event publishing it shouldn't effect the original leader election.
* `try...catch` event publishing in the `LeaderInitiator` and `logger.warn` an `Exception`
* Make `leader/Context` as `@FunctionalInterface` for simple Lambda use-case like `NULL_CONTEXT` - `() -> false`
* Remove all the internal `NullContext` implementations in favor of above mention Lambda
* In the `LockRegistryLeaderInitiator` use `CustomizableThreadFactory` instead of custom `ThreadFactory` for prefixing
* Add `zookeeper/leader/LeaderInitiator#getContext()` for external usage and consistency with other similar components
* Fix `CuratorContext.toString()` typo