### PR TITLE
INT-4218: MessagingMethodInvokerHelp improvements

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
@@ -440,17 +440,18 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 				}
 			}
 			else if (e instanceof IllegalStateException) {
-				if (e.getCause() instanceof IllegalArgumentException
-						&& (!"argument type mismatch".equals(e.getCause().getMessage())
+				if (!(e.getCause() instanceof IllegalArgumentException) ||
+						!e.getStackTrace()[0].getClassName().equals(InvocableHandlerMethod.class.getName()) ||
+						(!"argument type mismatch".equals(e.getCause().getMessage()) &&
 						// JVM generates GeneratedMethodAccessor### after several calls with less error checking
-						&& !e.getCause().getMessage().startsWith("java.lang.ClassCastException@"))) {
+						!e.getCause().getMessage().startsWith("java.lang.ClassCastException@"))) {
 					throw e;
 				}
 			}
 
 			Expression expression = handlerMethod.expression;
 
-			if (++handlerMethod.failedAttempts == FAILED_ATTEMPTS_THRESHOLD) {
+			if (++handlerMethod.failedAttempts >= FAILED_ATTEMPTS_THRESHOLD) {
 				handlerMethod.spelOnly = true;
 				if (logger.isInfoEnabled()) {
 					logger.info("Failed to invoke [ " + handlerMethod.invocableHandlerMethod +

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorAnnotationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.handler;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -38,6 +39,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessageHeaders;
@@ -52,6 +54,7 @@ import org.springframework.messaging.support.GenericMessage;
  * @author Iwein Fuld
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class MethodInvokingMessageProcessorAnnotationTests {
@@ -102,7 +105,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 		Method method = TestService.class.getMethod("requiredHeader", Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
 		Message<String> messageWithHeader = MessageBuilder.withPayload("foo")
-				.setHeader("num", new Integer(123)).build();
+				.setHeader("num", 123).build();
 		GenericMessage<String> messageWithoutHeader = new GenericMessage<String>("foo");
 
 		processor.processMessage(messageWithHeader);
@@ -113,7 +116,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageWithRequiredHeaderProvided() throws Exception {
 		Method method = TestService.class.getMethod("requiredHeader", Integer.class);
 		Message<String> message = MessageBuilder.withPayload("foo")
-				.setHeader("num", new Integer(123)).build();
+				.setHeader("num", 123).build();
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
 		Object result = processor.processMessage(message);
 		assertEquals(123, result);
@@ -133,7 +136,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 		Method method = TestService.class.getMethod("optionalAndRequiredHeader", String.class, Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
 		Message<String> message = MessageBuilder.withPayload("foo")
-				.setHeader("num", new Integer(123)).build();
+				.setHeader("num", 123).build();
 		Object result = processor.processMessage(message);
 		assertEquals("null123", result);
 	}
@@ -143,7 +146,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 		Method method = TestService.class.getMethod("optionalAndRequiredHeader", String.class, Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
 		Message<String> message = MessageBuilder.withPayload("foo")
-				.setHeader("num", new Integer(123))
+				.setHeader("num", 123)
 				.setHeader("prop", "bar")
 				.build();
 		Object result = processor.processMessage(message);
@@ -156,10 +159,15 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
 		Message<String> message = MessageBuilder.withPayload("test")
 				.setHeader("prop1", "foo").setHeader("prop2", "bar").build();
-		Object result = processor.processMessage(message);
-		Properties props = (Properties) result;
-		assertEquals("foo", props.getProperty("prop1"));
-		assertEquals("bar", props.getProperty("prop2"));
+		assertFalse(TestUtils.getPropertyValue(processor, "delegate.handlerMethod.spelOnly", Boolean.class));
+		for (int i = 0; i < 100; i++) {
+			Object result = processor.processMessage(message);
+			Properties props = (Properties) result;
+			assertEquals("foo", props.getProperty("prop1"));
+			assertEquals("bar", props.getProperty("prop2"));
+		}
+
+		assertTrue(TestUtils.getPropertyValue(processor, "delegate.handlerMethod.spelOnly", Boolean.class));
 	}
 
 	@Test
@@ -210,8 +218,8 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 		Method method = TestService.class.getMethod("mapHeaders", Map.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
 		Message<String> message = MessageBuilder.withPayload("test")
-				.setHeader("attrib1", new Integer(123))
-				.setHeader("attrib2", new Integer(456)).build();
+				.setHeader("attrib1", 123)
+				.setHeader("attrib2", 456).build();
 		Map<String, Object> result = (Map<String, Object>) processor.processMessage(message);
 		assertEquals(123, result.get("attrib1"));
 		assertEquals(456, result.get("attrib2"));
@@ -225,8 +233,8 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 		payload.put("attrib1", 88);
 		payload.put("attrib2", 99);
 		Message<Map<String, Integer>> message = MessageBuilder.withPayload(payload)
-				.setHeader("attrib1", new Integer(123))
-				.setHeader("attrib2", new Integer(456)).build();
+				.setHeader("attrib1", 123)
+				.setHeader("attrib2", 456).build();
 		Map<String, Integer> result = (Map<String, Integer>) processor.processMessage(message);
 		assertEquals(2, result.size());
 		assertEquals(new Integer(88), result.get("attrib1"));
@@ -337,11 +345,19 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	}
 
 
+	private Message<?> getMessage() {
+		MessageBuilder<Employee> builder = MessageBuilder.withPayload(employee);
+		builder.setHeader("day", "monday");
+		builder.setHeader("month", "September");
+		return builder.build();
+	}
+
 	@SuppressWarnings("unused")
 	private static class MultipleMappingAnnotationTestBean {
 
 		public void test(@Payload("payload") @Header("foo") String s) {
 		}
+
 	}
 
 
@@ -379,7 +395,8 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 			return lastName + ", " + firstName;
 		}
 
-		public String optionalAndRequiredHeader(@Header(required = false) String prop, @Header(value = "num", required = true) Integer num) {
+		public String optionalAndRequiredHeader(@Header(required = false) String prop,
+				@Header(value = "num", required = true) Integer num) {
 			return prop + num;
 		}
 
@@ -444,13 +461,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 			ids.add(id);
 			return "foo";
 		}
-	}
 
-	private Message<?> getMessage() {
-		MessageBuilder<Employee> builder = MessageBuilder.withPayload(employee);
-		builder.setHeader("day", "monday");
-		builder.setHeader("month", "September");
-		return builder.build();
 	}
 
 
@@ -472,6 +483,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 		public String getLname() {
 			return lname;
 		}
+
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorAnnotationTests.java
@@ -160,12 +160,18 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 		Message<String> message = MessageBuilder.withPayload("test")
 				.setHeader("prop1", "foo").setHeader("prop2", "bar").build();
 		assertFalse(TestUtils.getPropertyValue(processor, "delegate.handlerMethod.spelOnly", Boolean.class));
-		for (int i = 0; i < 100; i++) {
+		for (int i = 0; i < 99; i++) {
 			Object result = processor.processMessage(message);
 			Properties props = (Properties) result;
 			assertEquals("foo", props.getProperty("prop1"));
 			assertEquals("bar", props.getProperty("prop2"));
+			assertFalse(TestUtils.getPropertyValue(processor, "delegate.handlerMethod.spelOnly", Boolean.class));
 		}
+
+		Object result = processor.processMessage(message);
+		Properties props = (Properties) result;
+		assertEquals("foo", props.getProperty("prop1"));
+		assertEquals("bar", props.getProperty("prop2"));
 
 		assertTrue(TestUtils.getPropertyValue(processor, "delegate.handlerMethod.spelOnly", Boolean.class));
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -736,7 +736,7 @@ public class MethodInvokingMessageProcessorTests {
 	private DirectFieldAccessor compileImmediate(MethodInvokingMessageProcessor processor) {
 		// Update the parser configuration compiler mode
 		SpelParserConfiguration config = TestUtils.getPropertyValue(processor,
-				"delegate.handlerMethod.EXPRESSION_PARSER.configuration", SpelParserConfiguration.class);
+				"delegate.EXPRESSION_PARSER.configuration", SpelParserConfiguration.class);
 		DirectFieldAccessor accessor = new DirectFieldAccessor(config);
 		accessor.setPropertyValue("compilerMode", SpelCompilerMode.IMMEDIATE);
 		return accessor;

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -716,8 +716,8 @@ public class TcpNioConnectionTests {
 			@Override
 			public boolean onMessage(Message<?> message) {
 				if (!(message instanceof ErrorMessage)) {
-					assemblerLatch.countDown();
 					assembler.set(Thread.currentThread());
+					assemblerLatch.countDown();
 				}
 				return false;
 			}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4218

* Add `InvocableHandlerMethod` invocation threshold logic to give up eventually in favor of permanent expression evaluation
* Add `ParametersWrapper.toString()` for better logging messages
* Log `InvocableHandlerMethod` invocation failure message in favor of SpEL only once when `failedAttempts` is exceeded already
* Switch to `spelOnly` mode after that
* Refactor `MessagingMethodInvokerHelper.processInternal()` to separate SpEL or Ivocable logic via their own invocation methods
* Move `MessagingMethodInvokerHelper.HandlerMethod` static fields to the `MessagingMethodInvokerHelper` level since it doesn't matter from this class perspective but can be reused in other places from top level of the `MessagingMethodInvokerHelper` class
* Catch `IllegalArgumentException` with the `java.lang.ClassCastException@...` message.
See http://stackoverflow.com/questions/16042591/reflections-illegalargumentexception-causes for more info