### PR TITLE
INT-4115: (S)FtpPersistentFileFilter by default

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileInboundChannelAdapterParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileInboundChannelAdapterParser.java
@@ -51,8 +51,7 @@ public abstract class AbstractRemoteFileInboundChannelAdapterParser extends Abst
 
 		// configure the InboundFileSynchronizer properties
 		BeanDefinition expressionDef = IntegrationNamespaceUtils.createExpressionDefinitionFromValueOrExpression(
-				"remote-directory", "remote-directory-expression", parserContext,
-				element, false);
+				"remote-directory", "remote-directory-expression", parserContext, element, false);
 		if (expressionDef != null) {
 			synchronizerBuilder.addPropertyValue("remoteDirectoryExpression", expressionDef);
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileInboundChannelAdapterParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileInboundChannelAdapterParser.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.ExpressionFactoryBean;
 import org.springframework.integration.config.xml.AbstractPollingInboundChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
+import org.springframework.integration.file.filters.AbstractPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.synchronizer.InboundFileSynchronizer;
 import org.springframework.util.StringUtils;
@@ -36,6 +37,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 public abstract class AbstractRemoteFileInboundChannelAdapterParser extends AbstractPollingInboundChannelAdapterParser {
@@ -49,7 +51,8 @@ public abstract class AbstractRemoteFileInboundChannelAdapterParser extends Abst
 
 		// configure the InboundFileSynchronizer properties
 		BeanDefinition expressionDef = IntegrationNamespaceUtils.createExpressionDefinitionFromValueOrExpression(
-				"remote-directory", "remote-directory-expression", parserContext, element, false);
+				"remote-directory", "remote-directory-expression", parserContext,
+				element, false);
 		if (expressionDef != null) {
 			synchronizerBuilder.addPropertyValue("remoteDirectoryExpression", expressionDef);
 		}
@@ -59,8 +62,10 @@ public abstract class AbstractRemoteFileInboundChannelAdapterParser extends Abst
 		String remoteFileSeparator = element.getAttribute("remote-file-separator");
 		synchronizerBuilder.addPropertyValue("remoteFileSeparator", remoteFileSeparator);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(synchronizerBuilder, element, "temporary-file-suffix");
+
 		FileParserUtils.configureFilter(synchronizerBuilder, element, parserContext,
-				getSimplePatternFileListFilterClass(), getRegexPatternFileListFilterClass());
+				getSimplePatternFileListFilterClass(), getRegexPatternFileListFilterClass(),
+				getPersistentAcceptOnceFileListFilterClass());
 
 		// build the MessageSource
 		BeanDefinitionBuilder messageSourceBuilder =
@@ -93,5 +98,7 @@ public abstract class AbstractRemoteFileInboundChannelAdapterParser extends Abst
 	protected abstract Class<? extends FileListFilter<?>> getSimplePatternFileListFilterClass();
 
 	protected abstract Class<? extends FileListFilter<?>> getRegexPatternFileListFilterClass();
+
+	protected abstract Class<? extends AbstractPersistentAcceptOnceFileListFilter<?>> getPersistentAcceptOnceFileListFilterClass();
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileStreamingInboundChannelAdapterParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileStreamingInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractPollingInboundChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.core.MessageSource;
+import org.springframework.integration.file.filters.AbstractPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.RemoteFileOperations;
 import org.springframework.util.StringUtils;
@@ -33,6 +34,8 @@ import org.springframework.util.StringUtils;
  * Abstract base class for parsing remote file streaming inbound channel adapters.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 4.3
  */
 public abstract class AbstractRemoteFileStreamingInboundChannelAdapterParser
@@ -56,7 +59,7 @@ public abstract class AbstractRemoteFileStreamingInboundChannelAdapterParser
 		String remoteFileSeparator = element.getAttribute("remote-file-separator");
 		messageSourceBuilder.addPropertyValue("remoteFileSeparator", remoteFileSeparator);
 		FileParserUtils.configureFilter(messageSourceBuilder, element, parserContext,
-				getSimplePatternFileListFilterClass(), getRegexPatternFileListFilterClass());
+				getSimplePatternFileListFilterClass(), getRegexPatternFileListFilterClass(), getPersistentAcceptOnceFileListFilterClass());
 
 		String comparator = element.getAttribute("comparator");
 		if (StringUtils.hasText(comparator)) {
@@ -73,5 +76,7 @@ public abstract class AbstractRemoteFileStreamingInboundChannelAdapterParser
 	protected abstract Class<? extends FileListFilter<?>> getSimplePatternFileListFilterClass();
 
 	protected abstract Class<? extends FileListFilter<?>> getRegexPatternFileListFilterClass();
+
+	protected abstract Class<? extends AbstractPersistentAcceptOnceFileListFilter<?>> getPersistentAcceptOnceFileListFilterClass();
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileParserUtils.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileParserUtils.java
@@ -20,12 +20,16 @@ import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.file.DefaultFileNameGenerator;
+import org.springframework.integration.file.filters.AbstractPersistentAcceptOnceFileListFilter;
+import org.springframework.integration.file.filters.CompositeFileListFilter;
 import org.springframework.integration.file.filters.ExpressionFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.RemoteFileOperations;
+import org.springframework.integration.metadata.SimpleMetadataStore;
 import org.springframework.util.StringUtils;
 
 /**
@@ -34,6 +38,7 @@ import org.springframework.util.StringUtils;
  * @author David Turanski
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 3.0
  *
  */
@@ -93,7 +98,8 @@ public final class FileParserUtils {
 	}
 
 	static void configureFilter(BeanDefinitionBuilder synchronizerBuilder, Element element, ParserContext parserContext,
-			Class<? extends FileListFilter<?>> patternClass, Class<? extends FileListFilter<?>> regexClass) {
+			Class<? extends FileListFilter<?>> patternClass, Class<? extends FileListFilter<?>> regexClass,
+			Class<? extends AbstractPersistentAcceptOnceFileListFilter<?>> persistentAcceptOnceFileListFilterClass) {
 		String filter = element.getAttribute("filter");
 		String filterExpression = element.getAttribute("filter-expression");
 		String fileNamePattern = element.getAttribute("filename-pattern");
@@ -118,7 +124,7 @@ public final class FileParserUtils {
 			}
 			if (count != 1) {
 				parserContext.getReaderContext().error("at most one of 'filename-pattern', " +
-						"'filename-regex', 'filter' or 'filter-expression' is allowed on remote file inbound adapter",
+								"'filename-regex', 'filter' or 'filter-expression' is allowed on remote file inbound adapter",
 						element);
 			}
 			if (hasFilter) {
@@ -132,16 +138,44 @@ public final class FileParserUtils {
 				synchronizerBuilder.addPropertyValue("filter", expressionFilterBeanDefinition);
 			}
 			else if (hasFileNamePattern) {
-				BeanDefinitionBuilder filterBuilder = BeanDefinitionBuilder.genericBeanDefinition(patternClass);
-				filterBuilder.addConstructorArgValue(fileNamePattern);
-				synchronizerBuilder.addPropertyValue("filter", filterBuilder.getBeanDefinition());
+				BeanDefinition patterFilter =
+						BeanDefinitionBuilder.genericBeanDefinition(patternClass)
+								.addConstructorArgValue(fileNamePattern)
+								.getBeanDefinition();
+
+				composeFilters(synchronizerBuilder, persistentAcceptOnceFileListFilterClass, patterFilter);
 			}
-			else if (hasFileNameRegex) {
-				BeanDefinitionBuilder filterBuilder = BeanDefinitionBuilder.genericBeanDefinition(regexClass);
-				filterBuilder.addConstructorArgValue(fileNameRegex);
-				synchronizerBuilder.addPropertyValue("filter", filterBuilder.getBeanDefinition());
+			else {
+				BeanDefinition regexFilter = BeanDefinitionBuilder.genericBeanDefinition(regexClass)
+						.addConstructorArgValue(fileNameRegex)
+						.getBeanDefinition();
+
+				composeFilters(synchronizerBuilder, persistentAcceptOnceFileListFilterClass, regexFilter);
 			}
 		}
+	}
+
+	private static void composeFilters(BeanDefinitionBuilder synchronizerBuilder,
+			Class<? extends AbstractPersistentAcceptOnceFileListFilter<?>> persistentAcceptOnceFileListFilterClass,
+			BeanDefinition filter) {
+		BeanDefinition persistentFilter =
+				BeanDefinitionBuilder.genericBeanDefinition(persistentAcceptOnceFileListFilterClass)
+						.addConstructorArgValue(
+								BeanDefinitionBuilder
+										.genericBeanDefinition(SimpleMetadataStore.class)
+										.getBeanDefinition())
+						.addConstructorArgValue("remoteFileMessageSource")
+						.getBeanDefinition();
+
+		ManagedList<BeanDefinition> filters = new ManagedList<>();
+		filters.add(filter);
+		filters.add(persistentFilter);
+
+		BeanDefinition compositeFilterDefinition =
+				BeanDefinitionBuilder.genericBeanDefinition(CompositeFileListFilter.class)
+						.addConstructorArgValue(filters)
+						.getBeanDefinition();
+		synchronizerBuilder.addPropertyValue("filter", compositeFilterDefinition);
 	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileParserUtils.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileParserUtils.java
@@ -124,7 +124,7 @@ public final class FileParserUtils {
 			}
 			if (count != 1) {
 				parserContext.getReaderContext().error("at most one of 'filename-pattern', " +
-								"'filename-regex', 'filter' or 'filter-expression' is allowed on remote file inbound adapter",
+						"'filename-regex', 'filter' or 'filter-expression' is allowed on remote file inbound adapter",
 						element);
 			}
 			if (hasFilter) {
@@ -138,12 +138,12 @@ public final class FileParserUtils {
 				synchronizerBuilder.addPropertyValue("filter", expressionFilterBeanDefinition);
 			}
 			else if (hasFileNamePattern) {
-				BeanDefinition patterFilter =
+				BeanDefinition patternFilter =
 						BeanDefinitionBuilder.genericBeanDefinition(patternClass)
 								.addConstructorArgValue(fileNamePattern)
 								.getBeanDefinition();
 
-				composeFilters(synchronizerBuilder, persistentAcceptOnceFileListFilterClass, patterFilter);
+				composeFilters(synchronizerBuilder, persistentAcceptOnceFileListFilterClass, patternFilter);
 			}
 			else {
 				BeanDefinition regexFilter = BeanDefinitionBuilder.genericBeanDefinition(regexClass)

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileInboundChannelAdapterSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileInboundChannelAdapterSpec.java
@@ -27,7 +27,6 @@ import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessageSourceSpec;
 import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.file.FileReadingMessageSource;
-import org.springframework.integration.file.filters.CompositeFileListFilter;
 import org.springframework.integration.file.filters.ExpressionFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.synchronizer.AbstractInboundFileSynchronizer;
@@ -50,8 +49,6 @@ public abstract class RemoteFileInboundChannelAdapterSpec<F, S extends RemoteFil
 		implements ComponentsRegistration {
 
 	protected final AbstractInboundFileSynchronizer<F> synchronizer;
-
-	private CompositeFileListFilter<F> filter;
 
 	private ExpressionFileListFilter<F> expressionFileListFilter;
 
@@ -172,19 +169,7 @@ public abstract class RemoteFileInboundChannelAdapterSpec<F, S extends RemoteFil
 	 * @return the spec.
 	 */
 	public S filter(FileListFilter<F> filter) {
-		if (this.filter == null) {
-			if (filter instanceof CompositeFileListFilter) {
-				this.filter = (CompositeFileListFilter<F>) filter;
-			}
-			else {
-				this.filter = new CompositeFileListFilter<>();
-				this.filter.addFilter(filter);
-			}
-			this.synchronizer.setFilter(this.filter);
-		}
-		else {
-			this.filter.addFilter(filter);
-		}
+		this.synchronizer.setFilter(filter);
 		return _this();
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileStreamingInboundChannelAdapterSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileStreamingInboundChannelAdapterSpec.java
@@ -25,7 +25,6 @@ import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessageSourceSpec;
 import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.file.FileReadingMessageSource;
-import org.springframework.integration.file.filters.CompositeFileListFilter;
 import org.springframework.integration.file.filters.ExpressionFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.AbstractRemoteFileStreamingMessageSource;
@@ -48,8 +47,6 @@ public abstract class RemoteFileStreamingInboundChannelAdapterSpec<F,
 		MS extends AbstractRemoteFileStreamingMessageSource<F>>
 		extends MessageSourceSpec<S, MS>
 		implements ComponentsRegistration {
-
-	private CompositeFileListFilter<F> filter;
 
 	private ExpressionFileListFilter<F> expressionFileListFilter;
 
@@ -101,19 +98,7 @@ public abstract class RemoteFileStreamingInboundChannelAdapterSpec<F,
 	 * @return the spec.
 	 */
 	public S filter(FileListFilter<F> filter) {
-		if (this.filter == null) {
-			if (filter instanceof CompositeFileListFilter) {
-				this.filter = (CompositeFileListFilter<F>) filter;
-			}
-			else {
-				this.filter = new CompositeFileListFilter<F>();
-				this.filter.addFilter(filter);
-			}
-			this.target.setFilter(this.filter);
-		}
-		else {
-			this.filter.addFilter(filter);
-		}
+		this.target.setFilter(filter);
 		return _this();
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
@@ -46,6 +46,8 @@ import org.springframework.util.Assert;
  * referencing a remote file.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 4.3
  *
  */
@@ -111,6 +113,10 @@ public abstract class AbstractRemoteFileStreamingMessageSource<F>
 	 * @param filter the file list filter.
 	 */
 	public void setFilter(FileListFilter<F> filter) {
+		doSetFilter(filter);
+	}
+
+	public void doSetFilter(FileListFilter<F> filter) {
 		this.filter = filter;
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
@@ -116,7 +116,7 @@ public abstract class AbstractRemoteFileStreamingMessageSource<F>
 		doSetFilter(filter);
 	}
 
-	public void doSetFilter(FileListFilter<F> filter) {
+	protected final void doSetFilter(FileListFilter<F> filter) {
 		this.filter = filter;
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -152,11 +152,14 @@ public abstract class AbstractInboundFileSynchronizer<F>
 
 	/**
 	 * Specify an expression that evaluates to the full path to the remote directory.
-	 *
 	 * @param remoteDirectoryExpression The remote directory expression.
 	 * @since 4.2
 	 */
 	public void setRemoteDirectoryExpression(Expression remoteDirectoryExpression) {
+		doSetRemoteDirectoryExpression(remoteDirectoryExpression);
+	}
+
+	protected final void doSetRemoteDirectoryExpression(Expression remoteDirectoryExpression) {
 		Assert.notNull(remoteDirectoryExpression, "'remoteDirectoryExpression' must not be null");
 		this.remoteDirectoryExpression = remoteDirectoryExpression;
 	}
@@ -166,6 +169,10 @@ public abstract class AbstractInboundFileSynchronizer<F>
 	 * @param filter the file list filter.
 	 */
 	public void setFilter(FileListFilter<F> filter) {
+		doSetFilter(filter);
+	}
+
+	public void doSetFilter(FileListFilter<F> filter) {
 		this.filter = filter;
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -172,7 +172,7 @@ public abstract class AbstractInboundFileSynchronizer<F>
 		doSetFilter(filter);
 	}
 
-	public void doSetFilter(FileListFilter<F> filter) {
+	protected final void doSetFilter(FileListFilter<F> filter) {
 		this.filter = filter;
 	}
 

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParser.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@
 package org.springframework.integration.ftp.config;
 
 import org.springframework.integration.file.config.AbstractRemoteFileInboundChannelAdapterParser;
+import org.springframework.integration.file.filters.AbstractPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.synchronizer.InboundFileSynchronizer;
+import org.springframework.integration.ftp.filters.FtpPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.ftp.filters.FtpRegexPatternFileListFilter;
 import org.springframework.integration.ftp.filters.FtpSimplePatternFileListFilter;
 import org.springframework.integration.ftp.inbound.FtpInboundFileSynchronizer;
@@ -29,6 +31,8 @@ import org.springframework.integration.ftp.inbound.FtpInboundFileSynchronizingMe
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class FtpInboundChannelAdapterParser extends AbstractRemoteFileInboundChannelAdapterParser {
@@ -51,6 +55,11 @@ public class FtpInboundChannelAdapterParser extends AbstractRemoteFileInboundCha
 	@Override
 	protected Class<? extends FileListFilter<?>> getRegexPatternFileListFilterClass() {
 		return FtpRegexPatternFileListFilter.class;
+	}
+
+	@Override
+	protected Class<? extends AbstractPersistentAcceptOnceFileListFilter<?>> getPersistentAcceptOnceFileListFilterClass() {
+		return FtpPersistentAcceptOnceFileListFilter.class;
 	}
 
 }

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/config/FtpStreamingInboundChannelAdapterParser.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/config/FtpStreamingInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ package org.springframework.integration.ftp.config;
 
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.file.config.AbstractRemoteFileStreamingInboundChannelAdapterParser;
+import org.springframework.integration.file.filters.AbstractPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.RemoteFileOperations;
+import org.springframework.integration.ftp.filters.FtpPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.ftp.filters.FtpRegexPatternFileListFilter;
 import org.springframework.integration.ftp.filters.FtpSimplePatternFileListFilter;
 import org.springframework.integration.ftp.inbound.FtpStreamingMessageSource;
@@ -27,6 +29,8 @@ import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 4.3
  *
  */
@@ -50,6 +54,11 @@ public class FtpStreamingInboundChannelAdapterParser extends AbstractRemoteFileS
 	@Override
 	protected Class<? extends FileListFilter<?>> getRegexPatternFileListFilterClass() {
 		return FtpRegexPatternFileListFilter.class;
+	}
+
+	@Override
+	protected Class<? extends AbstractPersistentAcceptOnceFileListFilter<?>> getPersistentAcceptOnceFileListFilterClass() {
+		return FtpPersistentAcceptOnceFileListFilter.class;
 	}
 
 }

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpInboundFileSynchronizer.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpInboundFileSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.remote.synchronizer.AbstractInboundFileSynchronizer;
+import org.springframework.integration.ftp.filters.FtpPersistentAcceptOnceFileListFilter;
+import org.springframework.integration.metadata.SimpleMetadataStore;
 
 /**
  * An implementation of {@link AbstractInboundFileSynchronizer} for FTP.
@@ -41,7 +43,8 @@ public class FtpInboundFileSynchronizer extends AbstractInboundFileSynchronizer<
 	 */
 	public FtpInboundFileSynchronizer(SessionFactory<FTPFile> sessionFactory) {
 		super(sessionFactory);
-		setRemoteDirectoryExpression(new LiteralExpression(null));
+		doSetRemoteDirectoryExpression(new LiteralExpression(null));
+		doSetFilter(new FtpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "ftpMessageSource"));
 	}
 
 	@Override

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpInboundFileSynchronizer.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpInboundFileSynchronizer.java
@@ -38,7 +38,6 @@ public class FtpInboundFileSynchronizer extends AbstractInboundFileSynchronizer<
 
 	/**
 	 * Create a synchronizer with the {@link SessionFactory} used to acquire {@link Session} instances.
-	 *
 	 * @param sessionFactory The session factory.
 	 */
 	public FtpInboundFileSynchronizer(SessionFactory<FTPFile> sessionFactory) {

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSource.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,12 +26,16 @@ import org.apache.commons.net.ftp.FTPFile;
 import org.springframework.integration.file.remote.AbstractFileInfo;
 import org.springframework.integration.file.remote.AbstractRemoteFileStreamingMessageSource;
 import org.springframework.integration.file.remote.RemoteFileTemplate;
+import org.springframework.integration.ftp.filters.FtpPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.ftp.session.FtpFileInfo;
+import org.springframework.integration.metadata.SimpleMetadataStore;
 
 /**
  * Message source for streaming FTP remote file contents.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 4.3
  *
  */
@@ -42,7 +46,7 @@ public class FtpStreamingMessageSource extends AbstractRemoteFileStreamingMessag
 	 * @param template the template.
 	 */
 	public FtpStreamingMessageSource(RemoteFileTemplate<FTPFile> template) {
-		super(template, null);
+		this(template, null);
 	}
 
 	/**
@@ -55,6 +59,7 @@ public class FtpStreamingMessageSource extends AbstractRemoteFileStreamingMessag
 	public FtpStreamingMessageSource(RemoteFileTemplate<FTPFile> template,
 			Comparator<AbstractFileInfo<FTPFile>> comparator) {
 		super(template, comparator);
+		doSetFilter(new FtpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "ftpMessageSource"));
 	}
 
 	@Override

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSource.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSource.java
@@ -59,7 +59,7 @@ public class FtpStreamingMessageSource extends AbstractRemoteFileStreamingMessag
 	public FtpStreamingMessageSource(RemoteFileTemplate<FTPFile> template,
 			Comparator<AbstractFileInfo<FTPFile>> comparator) {
 		super(template, comparator);
-		doSetFilter(new FtpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "ftpMessageSource"));
+		doSetFilter(new FtpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "ftpStreamingMessageSource"));
 	}
 
 	@Override

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpParserInboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpParserInboundTests-context.xml
@@ -3,12 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:ftp="http://www.springframework.org/schema/integration/ftp"
 	   xmlns:int="http://www.springframework.org/schema/integration"
-	   xmlns:context="http://www.springframework.org/schema/context"
-	   xmlns:ftps="http://www.springframework.org/schema/integration/ftps"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	    http://www.springframework.org/schema/integration/ftps http://www.springframework.org/schema/integration/ftp/spring-integration-ftps.xsd
         http://www.springframework.org/schema/integration  http://www.springframework.org/schema/integration/spring-integration.xsd
-       http://www.springframework.org/schema/integration/ftp http://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+       http://www.springframework.org/schema/integration/ftp http://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd">
 
 	<bean id="ftpSessionFactory" class="org.springframework.integration.ftp.session.DefaultFtpSessionFactory">
 		<property name="host" value="localhost"/>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
@@ -38,6 +38,7 @@ import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.file.FileHeaders;
+import org.springframework.integration.file.filters.AcceptAllFileListFilter;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.ftp.FtpTestSupport;
 import org.springframework.integration.ftp.session.FtpFileInfo;
@@ -125,6 +126,7 @@ public class FtpStreamingMessageSourceTests extends FtpTestSupport {
 		@InboundChannelAdapter(channel = "stream")
 		public MessageSource<InputStream> ftpMessageSource() {
 			FtpStreamingMessageSource messageSource = new FtpStreamingMessageSource(template(), null);
+			messageSource.setFilter(new AcceptAllFileListFilter<>());
 			messageSource.setRemoteDirectory("ftpSource/");
 			return messageSource;
 		}

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/config/SftpInboundChannelAdapterParser.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/config/SftpInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@
 package org.springframework.integration.sftp.config;
 
 import org.springframework.integration.file.config.AbstractRemoteFileInboundChannelAdapterParser;
+import org.springframework.integration.file.filters.AbstractPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.synchronizer.InboundFileSynchronizer;
+import org.springframework.integration.sftp.filters.SftpPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.sftp.filters.SftpRegexPatternFileListFilter;
 import org.springframework.integration.sftp.filters.SftpSimplePatternFileListFilter;
 import org.springframework.integration.sftp.inbound.SftpInboundFileSynchronizer;
@@ -29,6 +31,8 @@ import org.springframework.integration.sftp.inbound.SftpInboundFileSynchronizing
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class SftpInboundChannelAdapterParser extends AbstractRemoteFileInboundChannelAdapterParser {
@@ -51,6 +55,11 @@ public class SftpInboundChannelAdapterParser extends AbstractRemoteFileInboundCh
 	@Override
 	protected Class<? extends FileListFilter<?>> getRegexPatternFileListFilterClass() {
 		return SftpRegexPatternFileListFilter.class;
+	}
+
+	@Override
+	protected Class<? extends AbstractPersistentAcceptOnceFileListFilter<?>> getPersistentAcceptOnceFileListFilterClass() {
+		return SftpPersistentAcceptOnceFileListFilter.class;
 	}
 
 }

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/config/SftpStreamingInboundChannelAdapterParser.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/config/SftpStreamingInboundChannelAdapterParser.java
@@ -18,8 +18,10 @@ package org.springframework.integration.sftp.config;
 
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.file.config.AbstractRemoteFileStreamingInboundChannelAdapterParser;
+import org.springframework.integration.file.filters.AbstractPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.RemoteFileOperations;
+import org.springframework.integration.sftp.filters.SftpPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.sftp.filters.SftpRegexPatternFileListFilter;
 import org.springframework.integration.sftp.filters.SftpSimplePatternFileListFilter;
 import org.springframework.integration.sftp.inbound.SftpStreamingMessageSource;
@@ -27,6 +29,8 @@ import org.springframework.integration.sftp.session.SftpRemoteFileTemplate;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 4.3
  *
  */
@@ -50,6 +54,11 @@ public class SftpStreamingInboundChannelAdapterParser extends AbstractRemoteFile
 	@Override
 	protected Class<? extends FileListFilter<?>> getRegexPatternFileListFilterClass() {
 		return SftpRegexPatternFileListFilter.class;
+	}
+
+	@Override
+	protected Class<? extends AbstractPersistentAcceptOnceFileListFilter<?>> getPersistentAcceptOnceFileListFilterClass() {
+		return SftpPersistentAcceptOnceFileListFilter.class;
 	}
 
 }

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpInboundFileSynchronizer.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpInboundFileSynchronizer.java
@@ -29,15 +29,20 @@ import com.jcraft.jsch.ChannelSftp.LsEntry;
  * @author Josh Long
  * @author Oleg Zhurakousky
  * @author Mark Fisher
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class SftpInboundFileSynchronizer extends AbstractInboundFileSynchronizer<LsEntry> {
 
+	/**
+	 * Create a synchronizer with the {@code SessionFactory} used to acquire {@code Session} instances.
+	 * @param sessionFactory The session factory.
+	 */
 	public SftpInboundFileSynchronizer(SessionFactory<LsEntry> sessionFactory) {
 		super(sessionFactory);
 		doSetFilter(new SftpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "sftpMessageSource"));
 	}
-
 
 	@Override
 	protected boolean isFile(LsEntry file) {

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpInboundFileSynchronizer.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpInboundFileSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springframework.integration.sftp.inbound;
 
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.remote.synchronizer.AbstractInboundFileSynchronizer;
+import org.springframework.integration.metadata.SimpleMetadataStore;
+import org.springframework.integration.sftp.filters.SftpPersistentAcceptOnceFileListFilter;
 
 import com.jcraft.jsch.ChannelSftp.LsEntry;
 
@@ -33,6 +35,7 @@ public class SftpInboundFileSynchronizer extends AbstractInboundFileSynchronizer
 
 	public SftpInboundFileSynchronizer(SessionFactory<LsEntry> sessionFactory) {
 		super(sessionFactory);
+		doSetFilter(new SftpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "sftpMessageSource"));
 	}
 
 

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSource.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import java.util.List;
 import org.springframework.integration.file.remote.AbstractFileInfo;
 import org.springframework.integration.file.remote.AbstractRemoteFileStreamingMessageSource;
 import org.springframework.integration.file.remote.RemoteFileTemplate;
+import org.springframework.integration.metadata.SimpleMetadataStore;
+import org.springframework.integration.sftp.filters.SftpPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.sftp.session.SftpFileInfo;
 
 import com.jcraft.jsch.ChannelSftp.LsEntry;
@@ -32,6 +34,8 @@ import com.jcraft.jsch.ChannelSftp.LsEntry;
  * Message source for streaming SFTP remote file contents.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 4.3
  *
  */
@@ -42,7 +46,7 @@ public class SftpStreamingMessageSource extends AbstractRemoteFileStreamingMessa
 	 * @param template the template.
 	 */
 	public SftpStreamingMessageSource(RemoteFileTemplate<LsEntry> template) {
-		super(template, null);
+		this(template, null);
 	}
 
 	/**
@@ -55,6 +59,7 @@ public class SftpStreamingMessageSource extends AbstractRemoteFileStreamingMessa
 	public SftpStreamingMessageSource(RemoteFileTemplate<LsEntry> template,
 			Comparator<AbstractFileInfo<LsEntry>> comparator) {
 		super(template, comparator);
+		doSetFilter(new SftpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "sftpMessageSource"));
 	}
 
 	@Override

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSource.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSource.java
@@ -59,7 +59,7 @@ public class SftpStreamingMessageSource extends AbstractRemoteFileStreamingMessa
 	public SftpStreamingMessageSource(RemoteFileTemplate<LsEntry> template,
 			Comparator<AbstractFileInfo<LsEntry>> comparator) {
 		super(template, comparator);
-		doSetFilter(new SftpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "sftpMessageSource"));
+		doSetFilter(new SftpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "sftpStreamingMessageSource"));
 	}
 
 	@Override

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
@@ -37,6 +37,7 @@ import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.file.FileHeaders;
+import org.springframework.integration.file.filters.AcceptAllFileListFilter;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.integration.sftp.SftpTestSupport;
@@ -126,6 +127,7 @@ public class SftpStreamingMessageSourceTests extends SftpTestSupport {
 		@InboundChannelAdapter(channel = "stream")
 		public MessageSource<InputStream> sftpMessageSource() {
 			SftpStreamingMessageSource messageSource = new SftpStreamingMessageSource(template(), null);
+			messageSource.setFilter(new AcceptAllFileListFilter<>());
 			messageSource.setRemoteDirectory("sftpSource/");
 			return messageSource;
 		}

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -256,7 +256,7 @@ Unlike outbound gateways and adapters where the root object of the SpEL Evaluati
 So, the root object of the SpEL Evaluation Context is the original name of the remote file (String).
 
 The inbound channel adapter first retrieves the file to a local directory and then emits each file according to the poller configuration.
-Starting with _version 5.0_ you can now limit the number of files fetched from the FTP server when new file retrievals are needed.
+Starting with _version 5.0_, you can now limit the number of files fetched from the FTP server when new file retrievals are needed.
 This can be beneficial when the target files are very large and/or when running in a clustered system with a persistent file list filter discussed below.
 Use `max-fetch-size` for this purpose; a negative value (default) means no limit and all matching files will be retrieved.
 
@@ -284,6 +284,8 @@ Since _version 4.0_, this filter requires a `ConcurrentMetadataStore`.
 When used with a shared data store (such as `Redis` with the `RedisMetadataStore`) this allows filter keys to be shared across multiple application or server instances.
 
 Starting with _version 5.0_, the `FtpPersistentAcceptOnceFileListFilter` with in-memory `SimpleMetadataStore` is applied by default for the `FtpInboundFileSynchronizer`.
+This filter is also applied together with the `regex` or `pattern` option in the XML configuration as well as via `FtpInboundChannelAdapterSpec` in Java DSL.
+Any other use-cases can be reached via `CompositeFileListFilter` (or `ChainFileListFilter`).
 
 The above discussion refers to filtering the files before retrieving them.
 Once the files have been retrieved, an additional filter is applied to the files on the file system.
@@ -293,7 +295,7 @@ Unless your application removes files after processing, the adapter will re-proc
 Also, if you configure the `filter` to use a `FtpPersistentAcceptOnceFileListFilter`, and the remote file timestamp changes (causing it to be re-fetched), the default local filter will not allow this new file to be processed.
 
 Use the `local-filter` attribute to configure the behavior of the local file system filter.
-Starting with _verion 4.3.8_, a `FileSystemPersistentAcceptOnceFileListFilter` is configured by default.
+Starting with _version 4.3.8_, a `FileSystemPersistentAcceptOnceFileListFilter` is configured by default.
 This filter stores the accepted file names and modified timestamp in an instance of the `MetadataStore` strategy (<<metadata-store>>), and will detect changes to the local file modified time.
 The default `MetadataStore` is a `SimpleMetadataStore` which stores state in memory.
 
@@ -530,9 +532,10 @@ See <<file-splitter>> and <<stream-transformer>> for more information about thes
 
 Only one of `filename-pattern`, `filename-regex`, `filter` or `filter-expression` is allowed.
 
-IMPORTANT: Starting with _version 5.0_, by default, the `FtpStreamingMessageSource` adapter prevents duplicates for remote files via `FtpPersistentFileListFilter` based on the in-memory `SimpleMetadataStore`.
-If you wish to use a filename pattern (or regex) as well, use a `CompositeFileListFilter`.
+IMPORTANT: Starting with _version 5.0_, by default, the `FtpStreamingMessageSource` adapter prevents duplicates for remote files via `FtpPersistentAcceptOnceFileListFilter` based on the in-memory `SimpleMetadataStore`.
+This filter is also applied by default together with the filename pattern (or regex) as well.
 If there is a requirement to allow duplicates, the `AcceptAllFileListFilter` can be used.
+Any other use-cases can be reached via `CompositeFileListFilter` (or `ChainFileListFilter`).
 The java configuration below shows one technique to remove the remote file after processing, avoiding duplicates.
 
 Use the `max-fetch-size` attribute to limit the number of files fetched on each poll when a fetch is necessary; set to 1 and use a persistent filter when running in a clustered environment.

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -283,6 +283,8 @@ This filter matches on the filename and the remote modified time.
 Since _version 4.0_, this filter requires a `ConcurrentMetadataStore`.
 When used with a shared data store (such as `Redis` with the `RedisMetadataStore`) this allows filter keys to be shared across multiple application or server instances.
 
+Starting with _version 5.0_, the `FtpPersistentAcceptOnceFileListFilter` with in-memory `SimpleMetadataStore` is applied by default for the `FtpInboundFileSynchronizer`.
+
 The above discussion refers to filtering the files before retrieving them.
 Once the files have been retrieved, an additional filter is applied to the files on the file system.
 By default, this is an `AcceptOnceFileListFilter` which, as discussed, retains state in memory and does not consider the file's modified time.

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -530,12 +530,10 @@ See <<file-splitter>> and <<stream-transformer>> for more information about thes
 
 Only one of `filename-pattern`, `filename-regex`, `filter` or `filter-expression` is allowed.
 
-IMPORTANT: Unlike the non-streaming inbound channel adapter, this adapter does not prevent duplicates by default.
-If you do not delete the remote file (e.g. using an outbound gateway with an rm command) and you wish to prevent the
-file being processed again, you can configure an `FtpPersistentFileListFilter` in the `filter` attribute.
-If you don't actually want to persist the state, an in-memory `SimpleMetadataStore` can be used with the filter.
+IMPORTANT: Starting with _version 5.0_, by default, the `FtpStreamingMessageSource` adapter prevents duplicates for remote files via `FtpPersistentFileListFilter` based on the in-memory `SimpleMetadataStore`.
 If you wish to use a filename pattern (or regex) as well, use a `CompositeFileListFilter`.
-The java configuration below shows one technique to remove the remote file after processing.
+If there is a requirement to allow duplicates, the `AcceptAllFileListFilter` can be used.
+The java configuration below shows one technique to remove the remote file after processing, avoiding duplicates.
 
 Use the `max-fetch-size` attribute to limit the number of files fetched on each poll when a fetch is necessary; set to 1 and use a persistent filter when running in a clustered environment.
 
@@ -562,10 +560,9 @@ public class FtpJavaApplication {
     @Bean
     @InboundChannelAdapter(channel = "stream")
     public MessageSource<InputStream> ftpMessageSource() {
-        FtpStreamingMessageSource messageSource = new FtpStreamingMessageSource(template(), null);
+        FtpStreamingMessageSource messageSource = new FtpStreamingMessageSource(template());
         messageSource.setRemoteDirectory("ftpSource/");
-        messageSource.setFilter(new FtpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(),
-                           "streaming"));
+        messageSource.setFilter(new AcceptAllFileListFilter<>());
         messageSource.setMaxFetchSize(1);
         return messageSource;
     }

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -346,6 +346,8 @@ Since _version 4.0_, this filter requires a `ConcurrentMetadataStore`.
 When used with a shared data store (such as `Redis` with the `RedisMetadataStore`) this allows filter keys to be shared across multiple application or server instances.
 
 Starting with _version 5.0_, the `SftpPersistentAcceptOnceFileListFilter` with in-memory `SimpleMetadataStore` is applied by default for the `SftpInboundFileSynchronizer`.
+This filter is also applied together with the `regex` or `pattern` option in the XML configuration as well as via `FtpInboundChannelAdapterSpec` in Java DSL.
+Any other use-cases can be reached via `CompositeFileListFilter` (or `ChainFileListFilter`).
 
 The above discussion refers to filtering the files before retrieving them.
 Once the files have been retrieved, an additional filter is applied to the files on the file system.
@@ -355,7 +357,7 @@ Unless your application removes files after processing, the adapter will re-proc
 Also, if you configure the `filter` to use a `FtpPersistentAcceptOnceFileListFilter`, and the remote file timestamp changes (causing it to be re-fetched), the default local filter will not allow this new file to be processed.
 
 Use the `local-filter` attribute to configure the behavior of the local file system filter.
-Starting with _verion 4.3.8_, a `FileSystemPersistentAcceptOnceFileListFilter` is configured by default.
+Starting with _version 4.3.8_, a `FileSystemPersistentAcceptOnceFileListFilter` is configured by default.
 This filter stores the accepted file names and modified timestamp in an instance of the `MetadataStore` strategy (<<metadata-store>>), and will detect changes to the local file modified time.
 The default `MetadataStore` is a `SimpleMetadataStore` which stores state in memory.
 
@@ -569,9 +571,10 @@ See <<file-splitter>> and <<stream-transformer>> for more information about thes
 
 Only one of `filename-pattern`, `filename-regex`, `filter` or `filter-expression` is allowed.
 
-IMPORTANT: Starting with _version 5.0_, by default, the `SftpStreamingMessageSource` adapter prevents duplicates for remote files via `SftpPersistentFileListFilter` based on the in-memory `SimpleMetadataStore`.
-If you wish to use a filename pattern (or regex) as well, use a `CompositeFileListFilter`.
+IMPORTANT: Starting with _version 5.0_, by default, the `SftpStreamingMessageSource` adapter prevents duplicates for remote files via `SftpPersistentAcceptOnceFileListFilter` based on the in-memory `SimpleMetadataStore`.
+This filter is also applied by default together with the filename pattern (or regex) as well.
 If there is a requirement to allow duplicates, the `AcceptAllFileListFilter` can be used.
+Any other use-cases can be reached via `CompositeFileListFilter` (or `ChainFileListFilter`).
 The java configuration below shows one technique to remove the remote file after processing, avoiding duplicates.
 
 Use the `max-fetch-size` attribute to limit the number of files fetched on each poll when a fetch is necessary; set to 1 and use a persistent filter when running in a clustered environment.

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -569,12 +569,10 @@ See <<file-splitter>> and <<stream-transformer>> for more information about thes
 
 Only one of `filename-pattern`, `filename-regex`, `filter` or `filter-expression` is allowed.
 
-IMPORTANT: Unlike the non-streaming inbound channel adapter, this adapter does not prevent duplicates by default.
-If you do not delete the remote file (e.g. using an outbound gateway with an rm command) and you wish to prevent the
-file being processed again, you can configure an `SftpPersistentFileListFilter` in the `filter` attribute.
-If you don't actually want to persist the state, an in-memory `SimpleMetadataStore` can be used with the filter.
+IMPORTANT: Starting with _version 5.0_, by default, the `SftpStreamingMessageSource` adapter prevents duplicates for remote files via `SftpPersistentFileListFilter` based on the in-memory `SimpleMetadataStore`.
 If you wish to use a filename pattern (or regex) as well, use a `CompositeFileListFilter`.
-The java configuration below shows one technique to remove the remote file after processing.
+If there is a requirement to allow duplicates, the `AcceptAllFileListFilter` can be used.
+The java configuration below shows one technique to remove the remote file after processing, avoiding duplicates.
 
 Use the `max-fetch-size` attribute to limit the number of files fetched on each poll when a fetch is necessary; set to 1 and use a persistent filter when running in a clustered environment.
 
@@ -601,10 +599,9 @@ public class SftpJavaApplication {
     @Bean
     @InboundChannelAdapter(channel = "stream")
     public MessageSource<InputStream> ftpMessageSource() {
-        SftpStreamingMessageSource messageSource = new SftpStreamingMessageSource(template(), null);
+        SftpStreamingMessageSource messageSource = new SftpStreamingMessageSource(template());
         messageSource.setRemoteDirectory("sftpSource/");
-        messageSource.setFilter(new SftpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(),
-                           "streaming"));
+        messageSource.setFilter(new AcceptAllFileListFilter<>());
         messageSource.setMaxFetchSize(1);
         return messageSource;
     }

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -345,6 +345,8 @@ This filter matches on the filename and the remote modified time.
 Since _version 4.0_, this filter requires a `ConcurrentMetadataStore`.
 When used with a shared data store (such as `Redis` with the `RedisMetadataStore`) this allows filter keys to be shared across multiple application or server instances.
 
+Starting with _version 5.0_, the `SftpPersistentAcceptOnceFileListFilter` with in-memory `SimpleMetadataStore` is applied by default for the `SftpInboundFileSynchronizer`.
+
 The above discussion refers to filtering the files before retrieving them.
 Once the files have been retrieved, an additional filter is applied to the files on the file system.
 By default, this is an`AcceptOnceFileListFilter` which, as discussed, retains state in memory and does not consider the file's modified time.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -90,20 +90,17 @@ The file outbound channel adapter (`FileWritingMessageHandler`) now supports the
 
 The inbound channel adapters now have a property `max-fetch-size` which is used to limit the number of files fetched during a poll when there are no files currently in the local directory.
 They also are configured with a `FileSystemPersistentAcceptOnceFileListFilter` in the `local-filter` by default.
-See <<ftp-inbound>> and <<sftp-inbound>> for more information.
 
 The regex and pattern filters can now be configured to always pass directories.
 This can be useful when using recursion in the outbound gateways.
 
 All the Inbound Channel Adapters (streaming and synchronization-based) now use an appropriate `AbstractPersistentAcceptOnceFileListFilter` implementation by default to prevent remote files duplicate downloads.
 
-See <<ftp>> and <<sftp>> for more information.
-
 The FTP and SFTP outbound gateways now support the `REPLACE_IF_MODIFIED` `FileExistsMode` when fetching remote files.
-See <<ftp-outbound-gateway>> and <<sftp-outbound-gateway>> for more information.
 
 The (S)FTP streaming inbound channel adapters now add remote file information in a message header.
-See <<ftp-streaming>> and <<sftp-streaming>> for more information.
+
+See <<ftp>> and <<sftp>> for more information.
 
 The FTP and SFTP outbound channel adapters, as well as `PUT` command of the outbound gateways, now support `InputStream` as `payload`, too.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -94,7 +94,10 @@ See <<ftp-inbound>> and <<sftp-inbound>> for more information.
 
 The regex and pattern filters can now be configured to always pass directories.
 This can be useful when using recursion in the outbound gateways.
-See <<ftp-outbound-gateway>> and <<sftp-outbound-gateway>> for more information.
+
+All the Inbound Channel Adapters (streaming and synchronization-based) now use an appropriate `AbstractPersistentAcceptOnceFileListFilter` implementation by default to prevent remote files duplicate downloads.
+
+See <<ftp>> and <<sftp>> for more information.
 
 The FTP and SFTP outbound gateways now support the `REPLACE_IF_MODIFIED` `FileExistsMode` when fetching remote files.
 See <<ftp-outbound-gateway>> and <<sftp-outbound-gateway>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4115

Apply `(S)FtpPersistentAcceptOnceFileListFilter` for the `(S)FtpInboundFileSynchronizer` by default to avoid cases to sync the same remote files to the local directory again.
Especially when `localFileName` strategy is applied and we end up with new local files, but with the same remote content