### PR TITLE
INT-4228: Fix Hidden Channel Bean Defition Error

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -292,9 +292,14 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 				inputChannel = this.channelResolver.resolveDestination(inputChannelName);
 			}
 			catch (DestinationResolutionException e) {
-				inputChannel = new DirectChannel();
-				this.beanFactory.registerSingleton(inputChannelName, inputChannel);
-				inputChannel = (MessageChannel) this.beanFactory.initializeBean(inputChannel, inputChannelName);
+				if (e.getCause() instanceof NoSuchBeanDefinitionException) {
+					inputChannel = new DirectChannel();
+					this.beanFactory.registerSingleton(inputChannelName, inputChannel);
+					inputChannel = (MessageChannel) this.beanFactory.initializeBean(inputChannel, inputChannelName);
+				}
+				else {
+					throw e;
+				}
 			}
 			Assert.notNull(inputChannel, "failed to resolve inputChannel '" + inputChannelName + "'");
 
@@ -303,7 +308,6 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 		return endpoint;
 	}
 
-	@SuppressWarnings("unchecked")
 	protected AbstractEndpoint doCreateEndpoint(MessageHandler handler, MessageChannel inputChannel,
 			List<Annotation> annotations) {
 		AbstractEndpoint endpoint;

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/channel/BeanFactoryChannelResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/channel/BeanFactoryChannelResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.core.DestinationResolutionException;
@@ -88,6 +89,10 @@ public class BeanFactoryChannelResolver implements DestinationResolver<MessageCh
 			return this.beanFactory.getBean(name, MessageChannel.class);
 		}
 		catch (BeansException e) {
+			if (!(e instanceof NoSuchBeanDefinitionException)) {
+				throw new DestinationResolutionException("A bean definition with name '"
+						+ name + "' exists, but failed to be created", e);
+			}
 			if (!this.initialized) {
 				synchronized (this) {
 					if (!this.initialized) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessorChannelCreationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessorChannelCreationTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.config.annotation;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.core.DestinationResolutionException;
+
+/**
+ * @author Gary Russell
+ * @since 4.3.8
+ *
+ */
+public class MessagingAnnotationPostProcessorChannelCreationTests {
+
+	@Test
+	public void testAutoCreateChannel() {
+		ConfigurableListableBeanFactory beanFactory = mock(ConfigurableListableBeanFactory.class);
+		given(beanFactory.getBean("channel", MessageChannel.class)).willThrow(NoSuchBeanDefinitionException.class);
+		willAnswer(invocation -> invocation.getArgument(0))
+			.given(beanFactory).initializeBean(any(DirectChannel.class), eq("channel"));
+		willAnswer(invocation -> invocation.getArgument(0))
+			.given(beanFactory).initializeBean(any(MessageHandler.class), eq("foo.foo.serviceActivator.handler"));
+		MessagingAnnotationPostProcessor mapp = new MessagingAnnotationPostProcessor();
+		mapp.setBeanFactory(beanFactory);
+		mapp.afterPropertiesSet();
+		mapp.postProcessAfterInitialization(new Foo(), "foo");
+		verify(beanFactory).registerSingleton(eq("channel"), any(DirectChannel.class));
+	}
+
+	@Test
+	public void testDontCreateChannelWhenChannelHasBadDefinition() {
+		ConfigurableListableBeanFactory beanFactory = mock(ConfigurableListableBeanFactory.class);
+		given(beanFactory.getBean("channel", MessageChannel.class)).willThrow(BeanCreationException.class);
+		willAnswer(invocation -> invocation.getArgument(0))
+			.given(beanFactory).initializeBean(any(DirectChannel.class), eq("channel"));
+		willAnswer(invocation -> invocation.getArgument(0))
+			.given(beanFactory).initializeBean(any(MessageHandler.class), eq("foo.foo.serviceActivator.handler"));
+		MessagingAnnotationPostProcessor mapp = new MessagingAnnotationPostProcessor();
+		mapp.setBeanFactory(beanFactory);
+		mapp.afterPropertiesSet();
+		try {
+			mapp.postProcessAfterInitialization(new Foo(), "foo");
+			fail("Expected a DestinationResolutionException");
+		}
+		catch (DestinationResolutionException e) {
+			assertThat(e.getMessage(),
+					containsString("A bean definition with name 'channel' exists, but failed to be created"));
+		}
+	}
+
+	public static class Foo {
+
+		@ServiceActivator(inputChannel = "channel")
+		public void foo(String in) {
+			// empty
+		}
+	}
+
+}


### PR DESCRIPTION
JIRA:

Previously, if a bean definition for a channel exists, but has configuration issues,
the `AbstractMethodAnnotationPostProcessor` still went ahead and created a `DirectChannel`.
Only with TRACE logging was the root cause apparent.

This was because all `BeanException` s cause that behavior.

Now, only `NoSuchBeanDefinitionException` will cause auto-creation of channels.

Tested with mocks and a real Boot app, which now correctly reports

```
15:28:41.582 [main] DEBUG o.s.b.d.LoggingFailureAnalysisReporter - Application failed to start due to an exception
org.springframework.beans.factory.NoSuchBeanDefinitionException: No bean named 'rabbitConnectionFactory' available
```

__cherry-pick to 4.3.x__