### PR TITLE
INT-4089 Add Source support for WS header mapping

### DIFF
--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/DefaultSoapHeaderMapperTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/DefaultSoapHeaderMapperTests.java
@@ -100,20 +100,20 @@ public class DefaultSoapHeaderMapperTests {
 	@Test
 	public void testRealSoapHeader() throws Exception {
 		String soap =
-				"<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">"
-						+ "<soapenv:Header>"
-						+ "<auth>"
+			"<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">"
+				+ "<soapenv:Header>"
+					+ "<auth>"
 						+ "<username>user</username>"
 						+ "<password>pass</password>"
-						+ "</auth>"
-						+ "<bar>BAR</bar>"
-						+ "<baz>BAZ</baz>"
-						+ "<qux>qux</qux>"
-						+ "</soapenv:Header>"
-						+ "<soapenv:Body>"
-						+ "<foo>foo</foo>"
-						+ "</soapenv:Body>"
-						+ "</soapenv:Envelope>";
+					+ "</auth>"
+					+ "<bar>BAR</bar>"
+					+ "<baz>BAZ</baz>"
+					+ "<qux>qux</qux>"
+				+ "</soapenv:Header>"
+				+ "<soapenv:Body>"
+					+ "<foo>foo</foo>"
+				+ "</soapenv:Body>"
+			+ "</soapenv:Envelope>";
 		SOAPMessage message = MessageFactory.newInstance()
 				.createMessage(new MimeHeaders(), new ByteArrayInputStream(soap.getBytes("UTF-8")));
 		SoapMessage soapMessage = new SaajSoapMessage(message);
@@ -186,7 +186,7 @@ public class DefaultSoapHeaderMapperTests {
 				"<auth xmlns='http://test.auth.org'>"
 						+ "<username>user</username>"
 						+ "<password>pass</password>"
-						+ "</auth>";
+				+ "</auth>";
 		Source source = new StringSource(docString);
 		headers.put("auth", source);
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -130,4 +130,6 @@ See <<stomp>> for more information.
 
 The `WebServiceOutboundGateway` s can now be supplied with an externally configured `WebServiceTemplate` instances.
 
+The `DefaultSoapHeaderMapper` can now map `javax.xml.transform.Source` user-defined headers to SOAP header element.
+
 See <<ws>> for more information.

--- a/src/reference/asciidoc/ws.adoc
+++ b/src/reference/asciidoc/ws.adoc
@@ -240,3 +240,34 @@ assertEquals("username", nodeList.item(0).getNodeName());
 assertEquals("user", nodeList.item(0).getFirstChild().getNodeValue());
 ...
 ----
+
+Starting with _version 5.0_, the `DefaultSoapHeaderMapper` supports `javax.xml.transform.Source` for user-defined headers and populates them as child nodes of the `<soapenv:Header>`:
+[source, java]
+----
+Map<String, Object> headers = new HashMap<>();
+
+String authXml =
+     "<auth xmlns='http://test.auth.org'>"
+           + "<username>user</username>"
+           + "<password>pass</password>"
+           + "</auth>";
+headers.put("auth", new StringSource(authXml));
+...
+DefaultSoapHeaderMapper mapper = new DefaultSoapHeaderMapper();
+mapper.setRequestHeaderNames("auth");
+----
+And in the end we have SOAP envelope as:
+[source, xml]
+----
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+    <soapenv:Header>
+        <auth xmlns="http://test.auth.org">
+            <username>user</username>
+            <password>pass</password>
+        </auth>
+    </soapenv:Header>
+    <soapenv:Body>
+        ...
+    </soapenv:Body>
+</soapenv:Envelope>
+----


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4089

Right now `DefaultSoapHeaderMapper` can map only `String` user-defined headers and only to the `SAOP:Header` attributes.

* Add functionality to map `Source` user-defined headers as sub-elements of the `SAOP:Header`