### PR TITLE
INT-2655: (un)marshal only via WebServiceTemplate

### DIFF
--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
@@ -66,7 +66,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 
 	private final Map<String, Expression> uriVariableExpressions = new HashMap<String, Expression>();
 
-	private volatile  StandardEvaluationContext evaluationContext;
+	private volatile StandardEvaluationContext evaluationContext;
 
 	private volatile WebServiceMessageCallback requestCallback;
 
@@ -140,6 +140,10 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 	}
 
 	public void setWebServiceTemplate(WebServiceTemplate webServiceTemplate) {
+		doSetWebServiceTemplate(webServiceTemplate);
+	}
+
+	protected final void doSetWebServiceTemplate(WebServiceTemplate webServiceTemplate) {
 		Assert.notNull(webServiceTemplate, "'webServiceTemplate' must not be null");
 		this.webServiceTemplate = webServiceTemplate;
 		this.webServiceTemplateExplicitlySet = true;

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 
 	public SimpleWebServiceOutboundGateway(DestinationProvider destinationProvider,
 			SourceExtractor<?> sourceExtractor) {
-		this(destinationProvider, sourceExtractor, (WebServiceMessageFactory) null);
+		this(destinationProvider, sourceExtractor, null);
 	}
 
 	public SimpleWebServiceOutboundGateway(DestinationProvider destinationProvider, SourceExtractor<?> sourceExtractor,
@@ -70,7 +70,7 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 	}
 
 	public SimpleWebServiceOutboundGateway(String uri, SourceExtractor<?> sourceExtractor) {
-		this(uri, sourceExtractor, (WebServiceMessageFactory) null);
+		this(uri, sourceExtractor, null);
 	}
 
 	public SimpleWebServiceOutboundGateway(String uri, SourceExtractor<?> sourceExtractor,

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
@@ -160,7 +160,7 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 					return this.result.toString();
 				}
 				else if (this.result instanceof DOMResult) {
-					return  ((DOMResult) this.result).getNode();
+					return ((DOMResult) this.result).getNode();
 				}
 				else {
 					return this.result;

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -212,6 +212,7 @@ public class WebServiceOutboundGatewayParserTests {
 		WebServiceMessageSender messageSender = (WebServiceMessageSender) context.getBean("messageSender");
 		assertEquals(messageSender, ((WebServiceMessageSender[]) accessor.getPropertyValue("messageSenders"))[0]);
 	}
+
 	@Test
 	public void simpleGatewayWithCustomMessageSenderList() {
 		AbstractEndpoint endpoint = this.context.getBean("gatewayWithCustomMessageSenderList", AbstractEndpoint.class);
@@ -283,7 +284,7 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithAllInOneMarshaller");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = TestUtils.getPropertyValue(endpoint,"handler");
+		Object gateway = TestUtils.getPropertyValue(endpoint, "handler");
 		Marshaller marshaller = context.getBean("marshallerAndUnmarshaller", Marshaller.class);
 		assertSame(marshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller", Marshaller.class));
 		assertSame(marshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.unmarshaller", Unmarshaller.class));
@@ -296,7 +297,7 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithSeparateMarshallerAndUnmarshaller");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = TestUtils.getPropertyValue(endpoint,"handler");
+		Object gateway = TestUtils.getPropertyValue(endpoint, "handler");
 		Marshaller marshaller = context.getBean("marshaller", Marshaller.class);
 		Unmarshaller unmarshaller = context.getBean("unmarshaller", Unmarshaller.class);
 		assertSame(marshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller", Marshaller.class));
@@ -310,7 +311,7 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithCustomRequestCallback");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = TestUtils.getPropertyValue(endpoint,"handler");
+		Object gateway = TestUtils.getPropertyValue(endpoint, "handler");
 		assertEquals(MarshallingWebServiceOutboundGateway.class, gateway.getClass());
 		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
 		WebServiceMessageCallback callback = (WebServiceMessageCallback) context.getBean("requestCallback");
@@ -324,7 +325,7 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithAllInOneMarshallerAndMessageFactory");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = TestUtils.getPropertyValue(endpoint,"handler");
+		Object gateway = TestUtils.getPropertyValue(endpoint, "handler");
 		Marshaller marshaller = context.getBean("marshallerAndUnmarshaller", Marshaller.class);
 		assertSame(marshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller", Marshaller.class));
 		assertSame(marshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.unmarshaller", Unmarshaller.class));
@@ -341,7 +342,7 @@ public class WebServiceOutboundGatewayParserTests {
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithSeparateMarshallerAndUnmarshallerAndMessageFactory");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
 
-		Object gateway = TestUtils.getPropertyValue(endpoint,"handler");
+		Object gateway = TestUtils.getPropertyValue(endpoint, "handler");
 
 		Marshaller marshaller = context.getBean("marshaller", Marshaller.class);
 		Unmarshaller unmarshaller = context.getBean("unmarshaller", Unmarshaller.class);

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -283,10 +283,10 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithAllInOneMarshaller");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		MarshallingWebServiceOutboundGateway gateway = (MarshallingWebServiceOutboundGateway) new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		Marshaller marshaller = (Marshaller) context.getBean("marshallerAndUnmarshaller");
-		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "marshaller", Marshaller.class));
-		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "unmarshaller", Unmarshaller.class));
+		Object gateway = TestUtils.getPropertyValue(endpoint,"handler");
+		Marshaller marshaller = context.getBean("marshallerAndUnmarshaller", Marshaller.class);
+		assertSame(marshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller", Marshaller.class));
+		assertSame(marshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.unmarshaller", Unmarshaller.class));
 		context.close();
 	}
 
@@ -296,11 +296,11 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithSeparateMarshallerAndUnmarshaller");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		MarshallingWebServiceOutboundGateway gateway = (MarshallingWebServiceOutboundGateway) new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		Marshaller marshaller = (Marshaller) context.getBean("marshaller");
-		Unmarshaller unmarshaller = (Unmarshaller) context.getBean("unmarshaller");
-		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "marshaller", Marshaller.class));
-		assertEquals(unmarshaller, TestUtils.getPropertyValue(gateway, "unmarshaller", Unmarshaller.class));
+		Object gateway = TestUtils.getPropertyValue(endpoint,"handler");
+		Marshaller marshaller = context.getBean("marshaller", Marshaller.class);
+		Unmarshaller unmarshaller = context.getBean("unmarshaller", Unmarshaller.class);
+		assertSame(marshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller", Marshaller.class));
+		assertSame(unmarshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.unmarshaller", Unmarshaller.class));
 		context.close();
 	}
 
@@ -310,7 +310,7 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithCustomRequestCallback");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		Object gateway = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
+		Object gateway = TestUtils.getPropertyValue(endpoint,"handler");
 		assertEquals(MarshallingWebServiceOutboundGateway.class, gateway.getClass());
 		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
 		WebServiceMessageCallback callback = (WebServiceMessageCallback) context.getBean("requestCallback");
@@ -324,10 +324,10 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithAllInOneMarshallerAndMessageFactory");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		MarshallingWebServiceOutboundGateway gateway = (MarshallingWebServiceOutboundGateway) new DirectFieldAccessor(endpoint).getPropertyValue("handler");
-		Marshaller marshaller = (Marshaller) context.getBean("marshallerAndUnmarshaller");
-		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "marshaller", Marshaller.class));
-		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "unmarshaller", Unmarshaller.class));
+		Object gateway = TestUtils.getPropertyValue(endpoint,"handler");
+		Marshaller marshaller = context.getBean("marshallerAndUnmarshaller", Marshaller.class);
+		assertSame(marshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller", Marshaller.class));
+		assertSame(marshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.unmarshaller", Unmarshaller.class));
 
 		WebServiceMessageFactory messageFactory = (WebServiceMessageFactory) context.getBean("messageFactory");
 		assertEquals(messageFactory, TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageFactory"));
@@ -340,13 +340,16 @@ public class WebServiceOutboundGatewayParserTests {
 				"marshallingWebServiceOutboundGatewayParserTests.xml", this.getClass());
 		AbstractEndpoint endpoint = (AbstractEndpoint) context.getBean("gatewayWithSeparateMarshallerAndUnmarshallerAndMessageFactory");
 		assertEquals(EventDrivenConsumer.class, endpoint.getClass());
-		MarshallingWebServiceOutboundGateway gateway = (MarshallingWebServiceOutboundGateway) new DirectFieldAccessor(endpoint).getPropertyValue("handler");
 
-		Marshaller marshaller = (Marshaller) context.getBean("marshaller");
-		Unmarshaller unmarshaller = (Unmarshaller) context.getBean("unmarshaller");
-		assertEquals(marshaller, TestUtils.getPropertyValue(gateway, "marshaller", Marshaller.class));
-		assertEquals(unmarshaller, TestUtils.getPropertyValue(gateway, "unmarshaller", Unmarshaller.class));
-		WebServiceMessageFactory messageFactory = (WebServiceMessageFactory) context.getBean("messageFactory");
+		Object gateway = TestUtils.getPropertyValue(endpoint,"handler");
+
+		Marshaller marshaller = context.getBean("marshaller", Marshaller.class);
+		Unmarshaller unmarshaller = context.getBean("unmarshaller", Unmarshaller.class);
+
+		assertSame(marshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller", Marshaller.class));
+		assertSame(unmarshaller, TestUtils.getPropertyValue(gateway, "webServiceTemplate.unmarshaller", Unmarshaller.class));
+
+		WebServiceMessageFactory messageFactory = context.getBean("messageFactory", WebServiceMessageFactory.class);
 		assertEquals(messageFactory, TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageFactory"));
 		context.close();
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-2655

There might be some use-cases when end-user expect more control over sending/receiving messages via `WebServiceTemplate`.
It would be better to delegate (un)marshalling logic to the `WebServiceTemplate.marshalSendAndReceive()` directly.