### PR TITLE
INT-4238: Detect Subscription Failures and QOS

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
@@ -249,7 +249,7 @@ public class MqttPahoMessageDrivenChannelAdapter extends AbstractMqttMessageDriv
 			if (this.applicationEventPublisher != null) {
 				this.applicationEventPublisher.publishEvent(new MqttConnectionFailedEvent(this, e));
 			}
-			logger.error("Error connecting or subscribing to " + Arrays.asList(topics), e);
+			logger.error("Error connecting or subscribing to " + Arrays.toString(topics), e);
 			this.client.disconnectForcibly(this.completionTimeout);
 			throw e;
 		}
@@ -258,7 +258,7 @@ public class MqttPahoMessageDrivenChannelAdapter extends AbstractMqttMessageDriv
 		}
 		if (this.client.isConnected()) {
 			this.connected = true;
-			String message = "Connected and subscribed to " + Arrays.asList(topics);
+			String message = "Connected and subscribed to " + Arrays.toString(topics);
 			if (logger.isDebugEnabled()) {
 				logger.debug(message);
 			}

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
@@ -501,10 +501,11 @@ public class MqttAdapterTests {
 		assertNotNull(method.get());
 		Log logger = spy(TestUtils.getPropertyValue(adapter, "logger", Log.class));
 		new DirectFieldAccessor(adapter).setPropertyValue("logger", logger);
-		given(logger.isInfoEnabled()).willReturn(true);
+		given(logger.isWarnEnabled()).willReturn(true);
 		method.get().invoke(adapter);
 		verify(logger, atLeastOnce())
-				.info("Granted QOS different to Requested QOS; topics: [baz, fix] requested: [1, 1] granted: [2, 0]");
+				.warn("Granted QOS different to Requested QOS; topics: [baz, fix] requested: [1, 1] granted: [2, 0]");
+		verify(client).setTimeToWait(30_000L);
 	}
 
 	private MqttPahoMessageDrivenChannelAdapter buildAdapter(final IMqttClient client, Boolean cleanSession,


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4238

Revert to using the sync client in the message-driven adapter so we can detect
subscription failures (the sync client throws an exception).

The only reason to use the async client was to timeout disconnects; this can
be achieved with the sync client and `disconnectForcibly`.

Also, the subscribe method updates the qos argument with the granted QOS values.

Detect and log if any QOS does not match the request.

__cherry-pick to 4.3.x, 4.2.x (change 4.2.x to use Java 8 for tests?)__