### PR TITLE
INT-4242: Don't send body for HEAD and TRACE, too

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
@@ -72,6 +72,9 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public abstract class AbstractHttpRequestExecutingMessageHandler extends AbstractReplyProducingMessageHandler {
 
+	private static final List<HttpMethod> noBodyHttpMethods =
+			Arrays.asList(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.TRACE);
+
 	private final Map<String, Expression> uriVariableExpressions = new HashMap<>();
 
 	private volatile StandardEvaluationContext evaluationContext;
@@ -426,7 +429,7 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	}
 
 	private boolean shouldIncludeRequestBody(HttpMethod httpMethod) {
-		return !HttpMethod.GET.equals(httpMethod);
+		return !(CollectionUtils.containsInstance(noBodyHttpMethods, httpMethod));
 	}
 
 	private MediaType resolveContentType(String content, Charset charset) {

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -331,7 +331,6 @@ public class HttpRequestExecutingMessageHandlerTests {
 	 * This test and the one below might look identical, but they are not. This test
 	 * injected "5" into the list as String resulting in the Content-TYpe being
 	 * application/x-www-form-urlencoded
-	 * @throws Exception
 	 */
 	@Test
 	public void stringKeyNullCollectionValueMixedFormDataString() throws Exception {
@@ -379,7 +378,6 @@ public class HttpRequestExecutingMessageHandlerTests {
 	/**
 	 * This test and the one above might look identical, but they are not. This test
 	 * injected 5 into the list as int resulting in Content-type being multipart/form-data
-	 * @throws Exception
 	 */
 	@Test
 	public void stringKeyNullCollectionValueMixedFormDataObject() throws Exception {
@@ -604,7 +602,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		assertEquals(MediaType.TEXT_XML, request.getHeaders().getContentType());
 	}
 
-	@Test // no asertions just a warn message in a log
+	@Test // no assertions just a warn message in a log
 	public void testWarnMessageForNonPostPutAndExtractPayload() throws Exception {
 		// should see a warn message
 
@@ -638,7 +636,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 	}
 
 	@Test
-	public void contentTypeIsNotSetForGetRequest() throws Exception {
+	public void contentTypeIsNotSetForGetAndHeadRequest() throws Exception {
 		// GET
 		HttpRequestExecutingMessageHandler handler =
 				new HttpRequestExecutingMessageHandler("http://www.springsource.org/spring-integration");
@@ -668,7 +666,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		}
 		catch (Exception e) {
 			assertEquals("intentional", e.getCause().getMessage());
-			assertEquals(MediaType.TEXT_XML, template.lastRequestEntity.get().getHeaders().getContentType());
+			assertNull(template.lastRequestEntity.get().getHeaders().getContentType());
 		}
 
 
@@ -695,7 +693,7 @@ public class HttpRequestExecutingMessageHandlerTests {
 		}
 		catch (Exception e) {
 			assertEquals("intentional", e.getCause().getMessage());
-			assertEquals(MediaType.TEXT_XML, template.lastRequestEntity.get().getHeaders().getContentType());
+			assertNull(template.lastRequestEntity.get().getHeaders().getContentType());
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4242
Fixes spring-projects/spring-integration#2085

According to the RFC7231 (https://tools.ietf.org/html/rfc7231), the `HEAD` is fully similar to `GET` and its body does not have sense.
The `TRACE` method can't have body at all.
The `OPTIONS` may have body, but that is already custom target server logic to parse it properly

* Modify `AbstractHttpRequestExecutingMessageHandler` do not include `payload` as a request body for `GET`, `HEAD` and `TRACE`

Also see https://github.com/spring-projects/spring-integration/wiki/Spring-Integration-4.3-to-5.0-Migration-Guide