### PR TITLE
INT-4257: Introduce ErrorMessagePublishingRecoveryCallback

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,12 +173,22 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 		catch (RuntimeException e) {
 			MessageChannel errorChannel = getErrorChannel();
 			if (errorChannel != null) {
-				this.messagingTemplate.send(errorChannel, new ErrorMessage(e));
+				this.messagingTemplate.send(errorChannel, buildErrorMessage(e));
 			}
-			else  {
+			else {
 				throw e;
 			}
 		}
+	}
+
+	/**
+	 * Build an {@link ErrorMessage} for the exception.
+	 * @param exception the exception.
+	 * @return the error message.
+	 * @since 4.3.9
+	 */
+	protected ErrorMessage buildErrorMessage(RuntimeException exception) {
+		return new ErrorMessage(exception);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -44,6 +44,12 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublishingRecovery
 		setErrorMessageStrategy(new DefaultRecovererErrorMessageStrategy());
 	}
 
+	public ErrorMessageSendingRecoverer(MessageChannel channel, ErrorMessageStrategy errorMessageStrategy) {
+		setRecoveryChannel(channel);
+		setErrorMessageStrategy(errorMessageStrategy);
+	}
+
+
 	public static class DefaultRecovererErrorMessageStrategy implements ErrorMessageStrategy {
 
 		@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -50,14 +50,14 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublishingRecovery
 			Throwable lastThrowable = context.getLastThrowable();
 			if (lastThrowable == null) {
 				lastThrowable = new RetryExceptionNotAvailableException(
-						(Message<?>) context.getAttribute("message"),
+						(Message<?>) context.getAttribute(MESSAGE_CONTEXT_KEY),
 						"No retry exception available; " +
 								"this can occur, for example, if the RetryPolicy allowed zero attempts " +
 								"to execute the handler; " +
 								"RetryContext: " + context.toString());
 			}
 			else if (!(lastThrowable instanceof MessagingException)) {
-				lastThrowable = new MessagingException((Message<?>) context.getAttribute("message"),
+				lastThrowable = new MessagingException((Message<?>) context.getAttribute(MESSAGE_CONTEXT_KEY),
 						lastThrowable.getMessage(), lastThrowable);
 			}
 			return new ErrorMessage(lastThrowable);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -27,32 +27,52 @@ import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.RetryContext;
 
 /**
- * RecoveryCallback that sends the final throwable as an ErrorMessage after
+ * A {@link RecoveryCallback} that sends the final throwable as an
+ * {@link org.springframework.messaging.support.ErrorMessage} after
  * retry exhaustion.
  *
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.2
  *
  */
 public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implements RecoveryCallback<Object> {
 
+	/**
+	 * Construct instance with the default {@code errorChannel}
+	 * to publish recovery error message.
+	 * @since 4.3.10
+	 */
 	public ErrorMessageSendingRecoverer() {
 		this(null);
 	}
 
+	/**
+	 * Construct instance based on the provided message channel.
+	 * The {@link DefaultErrorMessageStrategy} is used for building error message to publish.
+	 * @param channel the message channel to publish error messages on recovery action.
+	 */
 	public ErrorMessageSendingRecoverer(MessageChannel channel) {
-		setRecoveryChannel(channel);
+		this(channel, new DefaultErrorMessageStrategy());
 	}
 
+	/**
+	 * Construct instance based on the provided message channel and {@link ErrorMessageStrategy}.
+	 * @param channel the message channel to publish error messages on recovery action.
+	 * @param errorMessageStrategy the {@link ErrorMessageStrategy}
+	 * to build error message for publishing.
+	 * @since 4.3.10
+	 */
 	public ErrorMessageSendingRecoverer(MessageChannel channel, ErrorMessageStrategy errorMessageStrategy) {
-		setRecoveryChannel(channel);
+		setChannel(channel);
 		setErrorMessageStrategy(errorMessageStrategy);
 	}
 
 	@Override
 	public Object recover(RetryContext context) throws Exception {
-		return recover(context.getLastThrowable(), context);
+		publish(context.getLastThrowable(), context);
+		return null;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
@@ -97,7 +97,7 @@ public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice
 
 	@Override
 	public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
-		context.setAttribute(ErrorMessagePublishingRecoveryCallback.MESSAGE_CONTEXT_KEY, messageHolder.get());
+		context.setAttribute(ErrorMessagePublishingRecoveryCallback.FAILED_MESSAGE_CONTEXT_KEY, messageHolder.get());
 		return true;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.handler.advice;
 
-import org.springframework.integration.support.ErrorMessagePublishingRecoveryCallback;
+import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.retry.RecoveryCallback;
@@ -97,7 +97,7 @@ public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice
 
 	@Override
 	public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
-		context.setAttribute(ErrorMessagePublishingRecoveryCallback.FAILED_MESSAGE_CONTEXT_KEY, messageHolder.get());
+		context.setAttribute(ErrorMessageUtils.FAILED_MESSAGE_CONTEXT_KEY, messageHolder.get());
 		return true;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.handler.advice;
 
+import org.springframework.integration.support.ErrorMessagePublishingRecoveryCallback;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.retry.RecoveryCallback;
@@ -96,16 +97,18 @@ public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice
 
 	@Override
 	public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
-		context.setAttribute("message", messageHolder.get());
+		context.setAttribute(ErrorMessagePublishingRecoveryCallback.MESSAGE_CONTEXT_KEY, messageHolder.get());
 		return true;
 	}
 
 	@Override
-	public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
+	public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
+			Throwable throwable) {
 	}
 
 	@Override
-	public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
+	public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
+			Throwable throwable) {
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/message/EnhancedErrorMessage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/message/EnhancedErrorMessage.java
@@ -26,7 +26,7 @@ import org.springframework.messaging.support.ErrorMessage;
  * An error message that is enhanced with a message that is available at the
  * stack frame where the error message is generated. Typically this will be a
  * message that begins a subflow, whereas if the {@link Throwable} payload is
- * a {@link org.springframework.messaging.MessagingException}, it's failedMessage
+ * a {@link org.springframework.messaging.MessagingException}, its failedMessage
  * property will contain the message at the point where the exception occurred.
  *
  * @author Gary Russell
@@ -37,25 +37,25 @@ public class EnhancedErrorMessage extends ErrorMessage {
 
 	private static final long serialVersionUID = 5857673472822628678L;
 
-	private final Message<?> inputMessage;
+	private final Message<?> originalMessage;
 
-	public EnhancedErrorMessage(Message<?> inputMessage, Throwable payload) {
+	public EnhancedErrorMessage(Message<?> originalMessage, Throwable payload) {
 		super(payload);
-		this.inputMessage = inputMessage;
+		this.originalMessage = originalMessage;
 	}
 
-	public EnhancedErrorMessage(Message<?> inputMessage, Throwable payload, MessageHeaders headers) {
+	public EnhancedErrorMessage(Message<?> originalMessage, Throwable payload, MessageHeaders headers) {
 		super(payload, headers);
-		this.inputMessage = inputMessage;
+		this.originalMessage = originalMessage;
 	}
 
-	public EnhancedErrorMessage(Message<?> inputMessage, Throwable payload, Map<String, Object> headers) {
+	public EnhancedErrorMessage(Message<?> originalMessage, Throwable payload, Map<String, Object> headers) {
 		super(payload, headers);
-		this.inputMessage = inputMessage;
+		this.originalMessage = originalMessage;
 	}
 
-	public Message<?> getInputMessage() {
-		return this.inputMessage;
+	public Message<?> getOriginalMessage() {
+		return this.originalMessage;
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/message/EnhancedErrorMessage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/message/EnhancedErrorMessage.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.message;
+
+import java.util.Map;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.ErrorMessage;
+
+/**
+ * An error message that is enhanced with a message that is available at the
+ * stack frame where the error message is generated. Typically this will be a
+ * message that begins a subflow, whereas if the {@link Throwable} payload is
+ * a {@link org.springframework.messaging.MessagingException}, it's failedMessage
+ * property will contain the message at the point where the exception occurred.
+ *
+ * @author Gary Russell
+ * @since 4.3.9
+ *
+ */
+public class EnhancedErrorMessage extends ErrorMessage {
+
+	private static final long serialVersionUID = 5857673472822628678L;
+
+	private final Message<?> inputMessage;
+
+	public EnhancedErrorMessage(Message<?> inputMessage, Throwable payload) {
+		super(payload);
+		this.inputMessage = inputMessage;
+	}
+
+	public EnhancedErrorMessage(Message<?> inputMessage, Throwable payload, MessageHeaders headers) {
+		super(payload, headers);
+		this.inputMessage = inputMessage;
+	}
+
+	public EnhancedErrorMessage(Message<?> inputMessage, Throwable payload, Map<String, Object> headers) {
+		super(payload, headers);
+		this.inputMessage = inputMessage;
+	}
+
+	public Message<?> getInputMessage() {
+		return this.inputMessage;
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/message/EnhancedErrorMessage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/message/EnhancedErrorMessage.java
@@ -30,9 +30,12 @@ import org.springframework.messaging.support.ErrorMessage;
  * property will contain the message at the point where the exception occurred.
  *
  * @author Gary Russell
- * @since 4.3.9
  *
+ * @since 4.3.10
+ *
+ * @deprecated since 4.3.10 in favor of direct {@link ErrorMessage} usage since 5.0.
  */
+@Deprecated
 public class EnhancedErrorMessage extends ErrorMessage {
 
 	private static final long serialVersionUID = 5857673472822628678L;

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultErrorMessageStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultErrorMessageStrategy.java
@@ -17,13 +17,12 @@
 package org.springframework.integration.support;
 
 import org.springframework.core.AttributeAccessor;
-import org.springframework.integration.message.EnhancedErrorMessage;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.ErrorMessage;
 
 /**
  * A simple {@link ErrorMessageStrategy} implementations which produces
- * {@link EnhancedErrorMessage} if the {@link AttributeAccessor} has
+ * a error message with original message if the {@link AttributeAccessor} has
  * {@link ErrorMessageUtils#INPUT_MESSAGE_CONTEXT_KEY} attribute.
  * Otherwise plain {@link ErrorMessage} with the {@code throwable} as {@code payload}.
  *
@@ -37,10 +36,11 @@ import org.springframework.messaging.support.ErrorMessage;
 public class DefaultErrorMessageStrategy implements ErrorMessageStrategy {
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public ErrorMessage buildErrorMessage(Throwable throwable, AttributeAccessor context) {
 		Object inputMessage = context.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
 		return inputMessage instanceof Message
-				? new EnhancedErrorMessage((Message<?>) inputMessage, throwable)
+				? new org.springframework.integration.message.EnhancedErrorMessage((Message<?>) inputMessage, throwable)
 				: new ErrorMessage(throwable);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultErrorMessageStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultErrorMessageStrategy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support;
+
+import org.springframework.core.AttributeAccessor;
+import org.springframework.integration.message.EnhancedErrorMessage;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.ErrorMessage;
+
+/**
+ * A simple {@link ErrorMessageStrategy} implementations which produces
+ * {@link EnhancedErrorMessage} if the {@link AttributeAccessor} has
+ * {@link ErrorMessageUtils#INPUT_MESSAGE_CONTEXT_KEY} attribute.
+ * Otherwise plain {@link ErrorMessage} with the {@code throwable} as {@code payload}.
+ *
+ * @author Gary Russell
+ * @author Artem Bilan
+ *
+ * @since 4.3.10
+ *
+ * @see ErrorMessageUtils
+ */
+public class DefaultErrorMessageStrategy implements ErrorMessageStrategy {
+
+	@Override
+	public ErrorMessage buildErrorMessage(Throwable throwable, AttributeAccessor context) {
+		Object inputMessage = context.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
+		return inputMessage instanceof Message
+				? new EnhancedErrorMessage((Message<?>) inputMessage, throwable)
+				: new ErrorMessage(throwable);
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessagePublisher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessagePublisher.java
@@ -24,7 +24,6 @@ import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.core.AttributeAccessor;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessagingTemplate;
-import org.springframework.integration.message.EnhancedErrorMessage;
 import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -202,24 +201,6 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 
 			this.messagingTemplate.setDefaultChannel(this.channel);
 		}
-	}
-
-	/**
-	 * A simple {@link ErrorMessageStrategy} implementations which produces
-	 * {@link EnhancedErrorMessage} if the {@link AttributeAccessor} has
-	 * {@link ErrorMessageUtils#INPUT_MESSAGE_CONTEXT_KEY} attribute.
-	 * Otherwise plain {@link ErrorMessage} with the {@code throwable} as {@code payload}.
-	 */
-	public static class DefaultErrorMessageStrategy implements ErrorMessageStrategy {
-
-		@Override
-		public ErrorMessage buildErrorMessage(Throwable throwable, AttributeAccessor context) {
-			Object inputMessage = context.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
-			return inputMessage instanceof Message
-					? new EnhancedErrorMessage((Message<?>) inputMessage, throwable)
-					: new ErrorMessage(throwable);
-		}
-
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessagePublishingRecoveryCallback.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessagePublishingRecoveryCallback.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.core.MessagingTemplate;
+import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.core.DestinationResolver;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.retry.RecoveryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link RecoveryCallback} that sends the {@link ErrorMessage}
+ * after retry exhaustion.
+ * <p>
+ * A {@link ErrorMessageStrategy} can be used to provide customization for the
+ * target {@link ErrorMessage} based on the {@link RetryContext}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 4.3.9
+ */
+public class ErrorMessagePublishingRecoveryCallback implements RecoveryCallback<Void>, BeanFactoryAware {
+
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	protected final MessagingTemplate messagingTemplate = new MessagingTemplate();
+
+	private DestinationResolver<MessageChannel> channelResolver;
+
+	private MessageChannel recoveryChannel;
+
+	private String recoveryChannelName;
+
+	private ErrorMessageStrategy errorMessageStrategy = new ErrorMessageStrategy() {
+
+		@Override
+		public ErrorMessage buildErrorMessage(RetryContext context) {
+			return new ErrorMessage(context.getLastThrowable());
+		}
+
+	};
+
+	public final void setErrorMessageStrategy(ErrorMessageStrategy errorMessageStrategy) {
+		Assert.notNull(errorMessageStrategy, "'errorMessageStrategy' must not be null");
+		this.errorMessageStrategy = errorMessageStrategy;
+	}
+
+	public final void setRecoveryChannel(MessageChannel recoveryChannel) {
+		this.recoveryChannel = recoveryChannel;
+	}
+
+	public void setRecoveryChannelName(String recoveryChannelName) {
+		this.recoveryChannelName = recoveryChannelName;
+	}
+
+	public void setSendTimeout(long sendTimeout) {
+		this.messagingTemplate.setSendTimeout(sendTimeout);
+	}
+
+	public void setChannelResolver(DestinationResolver<MessageChannel> channelResolver) {
+		this.channelResolver = channelResolver;
+	}
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) {
+		Assert.notNull(beanFactory, "beanFactory must not be null");
+		if (this.channelResolver == null) {
+			this.channelResolver = new BeanFactoryChannelResolver(beanFactory);
+		}
+	}
+
+	@Override
+	public Void recover(RetryContext context) throws Exception {
+		populateRecoveryChannel();
+		ErrorMessage errorMessage = this.errorMessageStrategy.buildErrorMessage(context);
+		if (this.logger.isDebugEnabled() && errorMessage.getPayload() instanceof MessagingException) {
+			MessagingException exception = (MessagingException) errorMessage.getPayload();
+			this.logger.debug("Sending ErrorMessage: failedMessage: " + exception.getFailedMessage(), exception);
+		}
+		this.messagingTemplate.send(errorMessage);
+		return null;
+	}
+
+	private void populateRecoveryChannel() {
+		if (this.messagingTemplate.getDefaultDestination() == null) {
+			if (this.recoveryChannel == null) {
+				String recoveryChannelName = this.recoveryChannelName;
+				if (recoveryChannelName == null) {
+					recoveryChannelName = IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME;
+				}
+				if (this.channelResolver != null) {
+					this.recoveryChannel = this.channelResolver.resolveDestination(recoveryChannelName);
+				}
+			}
+
+			this.messagingTemplate.setDefaultChannel(this.recoveryChannel);
+		}
+	}
+
+	/**
+	 * A strategy to be used on the recovery function to produce
+	 * a {@link ErrorMessage} based on the {@link RetryContext}.
+	 */
+	public interface ErrorMessageStrategy {
+
+		ErrorMessage buildErrorMessage(RetryContext context);
+
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessagePublishingRecoveryCallback.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessagePublishingRecoveryCallback.java
@@ -53,7 +53,12 @@ public class ErrorMessagePublishingRecoveryCallback implements RecoveryCallback<
 	/**
 	 * The retry context key for the message object.
 	 */
-	public static final String MESSAGE_CONTEXT_KEY = "message";
+	public static final String FAILED_MESSAGE_CONTEXT_KEY = "message";
+
+	/**
+	 * The retry context key for the message object.
+	 */
+	public static final String INPUT_MESSAGE_CONTEXT_KEY = "inputMessage";
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
@@ -121,21 +126,45 @@ public class ErrorMessagePublishingRecoveryCallback implements RecoveryCallback<
 	 * @throws Exception if the recovery fails.
 	 */
 	public void recover(MessagingException exception) throws Exception {
-		recover(exception.getFailedMessage(), exception);
+		recover(null, exception.getFailedMessage(), exception);
 	}
 
 	/**
 	 * Publish an error message for the supplied message and throwable. If the throwable
 	 * is already a {@link MessagingException} containing the message in its
 	 * {@code failedMessage} property, use {@link #recover(MessagingException)} instead.
-	 * @param message the message.
+	 * @param failedMessage the message.
 	 * @param throwable the throwable.
 	 * @throws Exception if the recovery fails.
 	 */
-	public void recover(Message<?> message, Throwable throwable) throws Exception {
+	public void recover(Message<?> failedMessage, Throwable throwable) throws Exception {
+		recover(null, failedMessage, throwable);
+	}
+
+	/**
+	 * Publish an error message for the supplied exception.
+	 * @param inputMessage the message that started the subflow.
+	 * @param exception the exception.
+	 * @throws Exception if the recovery fails.
+	 */
+	public void recover(Message<?> inputMessage, MessagingException exception) throws Exception {
+		recover(inputMessage, exception.getFailedMessage(), exception);
+	}
+
+	/**
+	 * Publish an error message for the supplied message and throwable. If the throwable
+	 * is already a {@link MessagingException} containing the message in its
+	 * {@code failedMessage} property, use {@link #recover(MessagingException)} instead.
+	 * @param inputMessage the message that started the subflow.
+	 * @param failedMessage the message.
+	 * @param throwable the throwable.
+	 * @throws Exception if the recovery fails.
+	 */
+	public void recover(Message<?> inputMessage, Message<?> failedMessage, Throwable throwable) throws Exception {
 		RetryContextSupport context = new RetryContextSupport(null);
 		context.registerThrowable(throwable);
-		context.setAttribute(MESSAGE_CONTEXT_KEY, message);
+		context.setAttribute(INPUT_MESSAGE_CONTEXT_KEY, inputMessage);
+		context.setAttribute(FAILED_MESSAGE_CONTEXT_KEY, failedMessage);
 		recover(context);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessagePublishingRecoveryCallback.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessagePublishingRecoveryCallback.java
@@ -43,7 +43,7 @@ import org.springframework.util.Assert;
  *
  * @since 4.3.9
  */
-public class ErrorMessagePublishingRecoveryCallback implements RecoveryCallback<Void>, BeanFactoryAware {
+public class ErrorMessagePublishingRecoveryCallback implements RecoveryCallback<Object>, BeanFactoryAware {
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
@@ -94,7 +94,7 @@ public class ErrorMessagePublishingRecoveryCallback implements RecoveryCallback<
 	}
 
 	@Override
-	public Void recover(RetryContext context) throws Exception {
+	public Object recover(RetryContext context) throws Exception {
 		populateRecoveryChannel();
 		ErrorMessage errorMessage = this.errorMessageStrategy.buildErrorMessage(context);
 		if (this.logger.isDebugEnabled() && errorMessage.getPayload() instanceof MessagingException) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessageStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessageStrategy.java
@@ -18,11 +18,17 @@ package org.springframework.integration.support;
 
 import org.springframework.core.AttributeAccessor;
 import org.springframework.messaging.support.ErrorMessage;
-import org.springframework.retry.RetryContext;
 
 /**
- * A strategy to be used on the recovery function to produce
- * a {@link ErrorMessage} based on the {@link RetryContext}.
+ * A strategy to build an {@link ErrorMessage} based on the provided
+ * {@link Throwable} and {@link AttributeAccessor} as a context.
+ * <p>
+ * The {@code Throwable payload} is typically {@link org.springframework.messaging.MessagingException}
+ * which {@code failedMessage} property can be used to determine a cause of the error.
+ * <p>
+ * This strategy can be used for the
+ * {@link org.springframework.integration.handler.advice.ErrorMessageSendingRecoverer}
+ * for {@link org.springframework.retry.RetryContext} access.
  *
  * @author Artem Bilan
  * @author Gary Russell

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessageStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessageStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support;
+
+import org.springframework.core.AttributeAccessor;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.retry.RetryContext;
+
+/**
+ * A strategy to be used on the recovery function to produce
+ * a {@link ErrorMessage} based on the {@link RetryContext}.
+ *
+ * @author Artem Bilan
+ * @author Gary Russell
+ *
+ * @since 4.3.10
+ */
+public interface ErrorMessageStrategy {
+
+	/**
+	 * Build the error message.
+	 * @param payload the payload.
+	 * @param attributes the attributes.
+	 * @return the ErrorMessage.
+	 */
+	ErrorMessage buildErrorMessage(Throwable payload, AttributeAccessor attributes);
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessageUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessageUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support;
+
+import org.springframework.core.AttributeAccessor;
+import org.springframework.core.AttributeAccessorSupport;
+import org.springframework.messaging.Message;
+
+/**
+ * @author Gary Russell
+ * @since 4.3.10
+ *
+ */
+public final class ErrorMessageUtils {
+
+	/**
+	 * The retry context key for the message object.
+	 */
+	public static final String FAILED_MESSAGE_CONTEXT_KEY = "message";
+	/**
+	 * The retry context key for the message object.
+	 */
+	public static final String INPUT_MESSAGE_CONTEXT_KEY = "inputMessage";
+
+	private ErrorMessageUtils() {
+		super();
+	}
+
+	/**
+	 * Return a {@link AttributeAccessor} for the provided arguments.
+	 * @param inputMessage the input message.
+	 * @param failedMessage the failed message.
+	 * @return the context.
+	 */
+	public static AttributeAccessor getAttributeAccessor(Message<?> inputMessage, Message<?> failedMessage) {
+		AttributeAccessorSupport attributes = new ErrorMessageAttributes();
+		if (inputMessage != null) {
+			attributes.setAttribute(INPUT_MESSAGE_CONTEXT_KEY, inputMessage);
+		}
+		if (failedMessage != null) {
+			attributes.setAttribute(FAILED_MESSAGE_CONTEXT_KEY, failedMessage);
+		}
+		return attributes;
+	}
+
+	@SuppressWarnings("serial")
+	private static class ErrorMessageAttributes extends AttributeAccessorSupport {
+
+		ErrorMessageAttributes() {
+			super();
+		}
+
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessageUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/ErrorMessageUtils.java
@@ -21,18 +21,21 @@ import org.springframework.core.AttributeAccessorSupport;
 import org.springframework.messaging.Message;
 
 /**
+ * Utilities for building error messages.
+ *
  * @author Gary Russell
+ *
  * @since 4.3.10
  *
  */
 public final class ErrorMessageUtils {
 
 	/**
-	 * The retry context key for the message object.
+	 * The context key for the message object.
 	 */
 	public static final String FAILED_MESSAGE_CONTEXT_KEY = "message";
 	/**
-	 * The retry context key for the message object.
+	 * The context key for the message object.
 	 */
 	public static final String INPUT_MESSAGE_CONTEXT_KEY = "inputMessage";
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/RetryAdviceParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/RetryAdviceParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ public class RetryAdviceParserTests {
 
 		assertNull(TestUtils.getPropertyValue(a1, "recoveryCallback"));
 		assertNotNull(TestUtils.getPropertyValue(a7, "recoveryCallback"));
-		assertSame(this.foo, TestUtils.getPropertyValue(a7, "recoveryCallback.messagingTemplate.defaultDestination"));
+		assertSame(this.foo, TestUtils.getPropertyValue(a7, "recoveryCallback.recoveryChannel"));
 		assertEquals(4567L, TestUtils.getPropertyValue(a7, "recoveryCallback.messagingTemplate.sendTimeout"));
 
 		assertSame(this.a1, TestUtils.getPropertyValue(this.handler1, "adviceChain", List.class).get(0));

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/RetryAdviceParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/RetryAdviceParserTests.java
@@ -37,6 +37,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 4.0
  *
  */
@@ -99,7 +101,7 @@ public class RetryAdviceParserTests {
 
 		assertNull(TestUtils.getPropertyValue(a1, "recoveryCallback"));
 		assertNotNull(TestUtils.getPropertyValue(a7, "recoveryCallback"));
-		assertSame(this.foo, TestUtils.getPropertyValue(a7, "recoveryCallback.recoveryChannel"));
+		assertSame(this.foo, TestUtils.getPropertyValue(a7, "recoveryCallback.channel"));
 		assertEquals(4567L, TestUtils.getPropertyValue(a7, "recoveryCallback.messagingTemplate.sendTimeout"));
 
 		assertSame(this.a1, TestUtils.getPropertyValue(this.handler1, "adviceChain", List.class).get(0));

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -1042,7 +1042,7 @@ public class AdvisedMessageHandlerTests {
 	public void enhancedRecoverer() throws Exception {
 		QueueChannel channel = new QueueChannel();
 		ErrorMessageSendingRecoverer recoverer = new ErrorMessageSendingRecoverer(channel);
-		recoverer.recover(new GenericMessage<>("foo"), new GenericMessage<>("bar"), new RuntimeException("baz"));
+		recoverer.publish(new GenericMessage<>("foo"), new GenericMessage<>("bar"), new RuntimeException("baz"));
 		Message<?> error = channel.receive(0);
 		assertThat(error, instanceOf(EnhancedErrorMessage.class));
 		assertThat(error.getPayload(), instanceOf(MessagingException.class));

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -64,7 +64,6 @@ import org.springframework.integration.filter.MessageFilter;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.advice.ExpressionEvaluatingRequestHandlerAdvice.MessageHandlingExpressionEvaluatingAdviceException;
 import org.springframework.integration.message.AdviceMessage;
-import org.springframework.integration.message.EnhancedErrorMessage;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.util.ErrorHandlingTaskExecutor;
 import org.springframework.messaging.Message;
@@ -1039,18 +1038,20 @@ public class AdvisedMessageHandlerTests {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void enhancedRecoverer() throws Exception {
 		QueueChannel channel = new QueueChannel();
 		ErrorMessageSendingRecoverer recoverer = new ErrorMessageSendingRecoverer(channel);
 		recoverer.publish(new GenericMessage<>("foo"), new GenericMessage<>("bar"), new RuntimeException("baz"));
 		Message<?> error = channel.receive(0);
-		assertThat(error, instanceOf(EnhancedErrorMessage.class));
+		assertThat(error, instanceOf(org.springframework.integration.message.EnhancedErrorMessage.class));
 		assertThat(error.getPayload(), instanceOf(MessagingException.class));
 		MessagingException payload = (MessagingException) error.getPayload();
 		assertThat(payload.getCause(), instanceOf(RuntimeException.class));
 		assertThat(payload.getCause().getMessage(), equalTo("baz"));
 		assertThat(payload.getFailedMessage().getPayload(), equalTo("bar"));
-		assertThat(((EnhancedErrorMessage) error).getInputMessage().getPayload(), equalTo("foo"));
+		assertThat(((org.springframework.integration.message.EnhancedErrorMessage) error).getOriginalMessage()
+				.getPayload(), equalTo("foo"));
 	}
 
 	private interface Bar {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4257

To make a target `ErrorMessage` customizable introduce
`ErrorMessagePublishingRecoveryCallback` and
`ErrorMessageStrategy` to inject

**Cherry-pick to 4.3.x**