### PR TITLE
Refactoring for some DSL methods

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/AbstractRouterSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/AbstractRouterSpec.java
@@ -16,10 +16,6 @@
 
 package org.springframework.integration.dsl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.router.AbstractMessageRouter;
 import org.springframework.messaging.MessageChannel;
@@ -36,14 +32,12 @@ import org.springframework.util.Assert;
  * @since 5.0
  */
 public class AbstractRouterSpec<S extends AbstractRouterSpec<S, R>, R extends AbstractMessageRouter>
-		extends MessageHandlerSpec<S, R> implements ComponentsRegistration {
-
-	protected final List<Object> componentsToRegister = new ArrayList<>();
+		extends ConsumerEndpointSpec<S, R> {
 
 	private boolean defaultToParentFlow;
 
 	AbstractRouterSpec(R router) {
-		this.target = router;
+		super(router);
 	}
 
 	/**
@@ -52,7 +46,7 @@ public class AbstractRouterSpec<S extends AbstractRouterSpec<S, R>, R extends Ab
 	 * @see AbstractMessageRouter#setIgnoreSendFailures(boolean)
 	 */
 	public S ignoreSendFailures(boolean ignoreSendFailures) {
-		this.target.setIgnoreSendFailures(ignoreSendFailures);
+		this.handler.setIgnoreSendFailures(ignoreSendFailures);
 		return _this();
 	}
 
@@ -62,7 +56,7 @@ public class AbstractRouterSpec<S extends AbstractRouterSpec<S, R>, R extends Ab
 	 * @see AbstractMessageRouter#setApplySequence(boolean)
 	 */
 	public S applySequence(boolean applySequence) {
-		this.target.setApplySequence(applySequence);
+		this.handler.setApplySequence(applySequence);
 		return _this();
 	}
 
@@ -74,7 +68,7 @@ public class AbstractRouterSpec<S extends AbstractRouterSpec<S, R>, R extends Ab
 	 * @see AbstractMessageRouter#setDefaultOutputChannelName(String)
 	 */
 	public S defaultOutputChannel(String channelName) {
-		this.target.setDefaultOutputChannelName(channelName);
+		this.handler.setDefaultOutputChannelName(channelName);
 		return _this();
 	}
 
@@ -86,7 +80,7 @@ public class AbstractRouterSpec<S extends AbstractRouterSpec<S, R>, R extends Ab
 	 * @see AbstractMessageRouter#setDefaultOutputChannel(MessageChannel)
 	 */
 	public S defaultOutputChannel(MessageChannel channel) {
-		this.target.setDefaultOutputChannel(channel);
+		this.handler.setDefaultOutputChannel(channel);
 		return _this();
 	}
 
@@ -121,11 +115,6 @@ public class AbstractRouterSpec<S extends AbstractRouterSpec<S, R>, R extends Ab
 
 	boolean isDefaultToParentFlow() {
 		return this.defaultToParentFlow;
-	}
-
-	@Override
-	public Collection<Object> getComponentsToRegister() {
-		return this.componentsToRegister;
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
@@ -150,7 +150,7 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 	 */
 	public S transactional(boolean handleMessageAdvice) {
 		TransactionInterceptor transactionInterceptor = new TransactionInterceptorBuilder(handleMessageAdvice).build();
-		this.componentToRegister.add(transactionInterceptor);
+		this.componentsToRegister.add(transactionInterceptor);
 		return transactional(transactionInterceptor);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/EndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/EndpointSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public abstract class EndpointSpec<S extends EndpointSpec<S, F, H>, F extends Be
 		extends IntegrationComponentSpec<S, Tuple2<F, H>>
 		implements ComponentsRegistration {
 
-	protected final Collection<Object> componentToRegister = new ArrayList<Object>();
+	protected final Collection<Object> componentsToRegister = new ArrayList<>();
 
 	protected H handler;
 
@@ -89,7 +89,7 @@ public abstract class EndpointSpec<S extends EndpointSpec<S, F, H>, F extends Be
 	public S poller(PollerSpec pollerMetadataSpec) {
 		Collection<Object> componentsToRegister = pollerMetadataSpec.getComponentsToRegister();
 		if (componentsToRegister != null) {
-			this.componentToRegister.addAll(componentsToRegister);
+			this.componentsToRegister.addAll(componentsToRegister);
 		}
 		return poller(pollerMetadataSpec.get());
 	}
@@ -117,9 +117,9 @@ public abstract class EndpointSpec<S extends EndpointSpec<S, F, H>, F extends Be
 
 	@Override
 	public Collection<Object> getComponentsToRegister() {
-		return this.componentToRegister.isEmpty()
+		return this.componentsToRegister.isEmpty()
 				? null
-				: this.componentToRegister;
+				: this.componentsToRegister;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.springframework.expression.Expression;
+import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.transformer.ContentEnricher;
@@ -32,17 +33,17 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 
+import reactor.util.function.Tuple2;
+
 /**
- * The {@link MessageHandlerSpec} implementation for the {@link ContentEnricher}.
+ * A {@link ConsumerEndpointSpec} extension for the {@link ContentEnricher}.
  *
  * @author Artem Bilan
  * @author Tim Ysewyn
  *
  * @since 5.0
  */
-public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnricher> {
-
-	private final ContentEnricher enricher = new ContentEnricher();
+public class EnricherSpec extends ConsumerEndpointSpec<EnricherSpec, ContentEnricher> {
 
 	private final Map<String, Expression> propertyExpressions = new HashMap<String, Expression>();
 
@@ -50,7 +51,7 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 			new HashMap<String, HeaderValueMessageProcessor<?>>();
 
 	EnricherSpec() {
-		super();
+		super(new ContentEnricher());
 	}
 
 	/**
@@ -59,7 +60,7 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 	 * @see ContentEnricher#setRequestChannel(MessageChannel)
 	 */
 	public EnricherSpec requestChannel(MessageChannel requestChannel) {
-		this.enricher.setRequestChannel(requestChannel);
+		this.handler.setRequestChannel(requestChannel);
 		return _this();
 	}
 
@@ -69,7 +70,7 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 	 * @see ContentEnricher#setRequestChannelName(String)
 	 */
 	public EnricherSpec requestChannel(String requestChannel) {
-		this.enricher.setRequestChannelName(requestChannel);
+		this.handler.setRequestChannelName(requestChannel);
 		return _this();
 	}
 
@@ -79,7 +80,7 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 	 * @see ContentEnricher#setReplyChannel(MessageChannel)
 	 */
 	public EnricherSpec replyChannel(MessageChannel replyChannel) {
-		this.enricher.setReplyChannel(replyChannel);
+		this.handler.setReplyChannel(replyChannel);
 		return _this();
 	}
 
@@ -89,7 +90,7 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 	 * @see ContentEnricher#setReplyChannelName(String)
 	 */
 	public EnricherSpec replyChannel(String replyChannel) {
-		this.enricher.setReplyChannelName(replyChannel);
+		this.handler.setReplyChannelName(replyChannel);
 		return _this();
 	}
 
@@ -99,7 +100,7 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 	 * @see ContentEnricher#setRequestTimeout(Long)
 	 */
 	public EnricherSpec requestTimeout(Long requestTimeout) {
-		this.enricher.setRequestTimeout(requestTimeout);
+		this.handler.setRequestTimeout(requestTimeout);
 		return _this();
 	}
 
@@ -109,7 +110,7 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 	 * @see ContentEnricher#setReplyTimeout(Long)
 	 */
 	public EnricherSpec replyTimeout(Long replyTimeout) {
-		this.enricher.setReplyTimeout(replyTimeout);
+		this.handler.setReplyTimeout(replyTimeout);
 		return _this();
 	}
 
@@ -119,7 +120,7 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 	 * @see ContentEnricher#setRequestPayloadExpression(Expression)
 	 */
 	public EnricherSpec requestPayloadExpression(String requestPayloadExpression) {
-		this.enricher.setRequestPayloadExpression(PARSER.parseExpression(requestPayloadExpression));
+		this.handler.setRequestPayloadExpression(PARSER.parseExpression(requestPayloadExpression));
 		return _this();
 	}
 
@@ -131,7 +132,7 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 	 * @see FunctionExpression
 	 */
 	public <P> EnricherSpec requestPayload(Function<Message<P>, ?> requestPayloadFunction) {
-		this.enricher.setRequestPayloadExpression(new FunctionExpression<>(requestPayloadFunction));
+		this.handler.setRequestPayloadExpression(new FunctionExpression<>(requestPayloadFunction));
 		return _this();
 	}
 
@@ -141,7 +142,7 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 	 * @see ContentEnricher#setShouldClonePayload(boolean)
 	 */
 	public EnricherSpec shouldClonePayload(boolean shouldClonePayload) {
-		this.enricher.setShouldClonePayload(shouldClonePayload);
+		this.handler.setShouldClonePayload(shouldClonePayload);
 		return _this();
 	}
 
@@ -279,15 +280,16 @@ public class EnricherSpec extends MessageHandlerSpec<EnricherSpec, ContentEnrich
 		return _this();
 	}
 
+
 	@Override
-	protected ContentEnricher doGet() {
+	protected Tuple2<ConsumerEndpointFactoryBean, ContentEnricher> doGet() {
 		if (!this.propertyExpressions.isEmpty()) {
-			this.enricher.setPropertyExpressions(this.propertyExpressions);
+			this.handler.setPropertyExpressions(this.propertyExpressions);
 		}
 		if (!this.headerExpressions.isEmpty()) {
-			this.enricher.setHeaderExpressions(this.headerExpressions);
+			this.handler.setHeaderExpressions(this.headerExpressions);
 		}
-		return this.enricher;
+		return super.doGet();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/FilterEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/FilterEndpointSpec.java
@@ -91,7 +91,7 @@ public final class FilterEndpointSpec extends ConsumerEndpointSpec<FilterEndpoin
 		DirectChannel channel = new DirectChannel();
 		IntegrationFlowBuilder flowBuilder = IntegrationFlows.from(channel);
 		discardFlow.configure(flowBuilder);
-		this.componentToRegister.add(flowBuilder.get());
+		this.componentsToRegister.add(flowBuilder.get());
 		return discardChannel(channel);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
@@ -62,7 +62,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 			return recipient(channelName, PARSER.parseExpression(expression));
 		}
 		else {
-			this.target.addRecipient(channelName);
+			this.handler.addRecipient(channelName);
 			return _this();
 		}
 	}
@@ -75,7 +75,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	 */
 	public RecipientListRouterSpec recipient(String channelName, Expression expression) {
 		ExpressionEvaluatingSelector selector = new ExpressionEvaluatingSelector(expression);
-		this.target.addRecipient(channelName, selector);
+		this.handler.addRecipient(channelName, selector);
 		this.componentsToRegister.add(selector);
 		return _this();
 	}
@@ -108,7 +108,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 							? new MethodInvokingSelector(new LambdaMessageProcessor(selector, null))
 							: new MethodInvokingSelector(selector);
 		}
-		this.target.addRecipient(channelName, messageSelector);
+		this.handler.addRecipient(channelName, messageSelector);
 		return _this();
 	}
 
@@ -145,11 +145,11 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	public RecipientListRouterSpec recipient(MessageChannel channel, Expression expression) {
 		if (expression != null) {
 			ExpressionEvaluatingSelector selector = new ExpressionEvaluatingSelector(expression);
-			this.target.addRecipient(channel, selector);
+			this.handler.addRecipient(channel, selector);
 			this.componentsToRegister.add(selector);
 		}
 		else {
-			this.target.addRecipient(channel);
+			this.handler.addRecipient(channel);
 		}
 		return _this();
 	}
@@ -182,7 +182,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 							? new MethodInvokingSelector(new LambdaMessageProcessor(selector, null))
 							: new MethodInvokingSelector(selector);
 		}
-		this.target.addRecipient(channel, messageSelector);
+		this.handler.addRecipient(channel, messageSelector);
 		return _this();
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/transformers/TransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/transformers/TransformerTests.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.transformers;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.MessageRejectedException;
+import org.springframework.integration.annotation.Transformer;
+import org.springframework.integration.channel.FixedSubscriberChannel;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.codec.Codec;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlows;
+import org.springframework.integration.dsl.Transformers;
+import org.springframework.integration.handler.advice.IdempotentReceiverInterceptor;
+import org.springframework.integration.selector.MetadataStoreSelector;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 5.0
+ */
+@RunWith(SpringRunner.class)
+@DirtiesContext
+public class TransformerTests {
+
+	@Autowired
+	@Qualifier("enricherInput")
+	private FixedSubscriberChannel enricherInput;
+
+	@Autowired
+	@Qualifier("enricherInput2")
+	private FixedSubscriberChannel enricherInput2;
+
+	@Autowired
+	@Qualifier("enricherInput3")
+	private FixedSubscriberChannel enricherInput3;
+
+
+	@Test
+	public void testContentEnricher() {
+		QueueChannel replyChannel = new QueueChannel();
+		Message<?> message = MessageBuilder.withPayload(new TestPojo("Bar"))
+				.setHeader(MessageHeaders.REPLY_CHANNEL, replyChannel)
+				.build();
+		this.enricherInput.send(message);
+		Message<?> receive = replyChannel.receive(5000);
+		assertNotNull(receive);
+		assertEquals("Bar Bar", receive.getHeaders().get("foo"));
+		Object payload = receive.getPayload();
+		assertThat(payload, instanceOf(TestPojo.class));
+		TestPojo result = (TestPojo) payload;
+		assertEquals("Bar Bar", result.getName());
+		assertNotNull(result.getDate());
+		assertThat(new Date(), Matchers.greaterThanOrEqualTo(result.getDate()));
+	}
+
+	@Test
+	public void testContentEnricher2() {
+		QueueChannel replyChannel = new QueueChannel();
+		Message<?> message = MessageBuilder.withPayload(new TestPojo("Bar"))
+				.setHeader(MessageHeaders.REPLY_CHANNEL, replyChannel)
+				.build();
+		this.enricherInput2.send(message);
+		Message<?> receive = replyChannel.receive(5000);
+		assertNotNull(receive);
+		assertNull(receive.getHeaders().get("foo"));
+		Object payload = receive.getPayload();
+		assertThat(payload, instanceOf(TestPojo.class));
+		TestPojo result = (TestPojo) payload;
+		assertEquals("Bar Bar", result.getName());
+		assertNotNull(result.getDate());
+		assertThat(new Date(), Matchers.greaterThanOrEqualTo(result.getDate()));
+	}
+
+	@Test
+	public void testContentEnricher3() {
+		QueueChannel replyChannel = new QueueChannel();
+		Message<?> message = MessageBuilder.withPayload(new TestPojo("Bar"))
+				.setHeader(MessageHeaders.REPLY_CHANNEL, replyChannel)
+				.build();
+		this.enricherInput3.send(message);
+		Message<?> receive = replyChannel.receive(5000);
+		assertNotNull(receive);
+		assertEquals("Bar Bar", receive.getHeaders().get("foo"));
+		Object payload = receive.getPayload();
+		assertThat(payload, instanceOf(TestPojo.class));
+		TestPojo result = (TestPojo) payload;
+		assertEquals("Bar", result.getName());
+		assertNull(result.getDate());
+	}
+
+	@Autowired
+	@Qualifier("encodingFlow.input")
+	private MessageChannel encodingFlowInput;
+
+	@Autowired
+	@Qualifier("decodingFlow.input")
+	private MessageChannel decodingFlowInput;
+
+	@Autowired
+	@Qualifier("codecReplyChannel")
+	private PollableChannel codecReplyChannel;
+
+	@Test
+	public void testCodec() throws Exception {
+		this.encodingFlowInput.send(new GenericMessage<>("bar"));
+		Message<?> receive = this.codecReplyChannel.receive(10000);
+		assertNotNull(receive);
+		assertThat(receive.getPayload(), instanceOf(byte[].class));
+		byte[] transformed = (byte[]) receive.getPayload();
+		assertArrayEquals("foo".getBytes(), transformed);
+
+		this.decodingFlowInput.send(new GenericMessage<>(transformed));
+		receive = this.codecReplyChannel.receive(10000);
+		assertNotNull(receive);
+		assertEquals(42, receive.getPayload());
+	}
+
+
+	@Autowired
+	@Qualifier("pojoTransformFlow.input")
+	private MessageChannel pojoTransformFlowInput;
+
+	@Autowired
+	private PollableChannel idempotentDiscardChannel;
+
+	@Test
+	public void transformWithHeader() {
+		QueueChannel replyChannel = new QueueChannel();
+		Message<?> message = MessageBuilder.withPayload("Foo")
+				.setReplyChannel(replyChannel)
+				.build();
+		this.pojoTransformFlowInput.send(message);
+		Message<?> receive = replyChannel.receive(10000);
+		assertNotNull(receive);
+		assertEquals("FooBar", receive.getPayload());
+
+		try {
+			this.pojoTransformFlowInput.send(message);
+			fail("MessageRejectedException expected");
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(MessageRejectedException.class));
+			assertThat(e.getMessage(), containsString("IdempotentReceiver"));
+			assertThat(e.getMessage(), containsString("rejected duplicate Message"));
+		}
+
+		assertNotNull(this.idempotentDiscardChannel.receive(10000));
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class ContextConfiguration {
+
+		@Bean
+		public IntegrationFlow enricherFlow() {
+			return IntegrationFlows.from("enricherInput", true)
+					.enrich(e -> e.requestChannel("enrichChannel")
+							.requestPayloadExpression("payload")
+							.shouldClonePayload(false)
+							.propertyExpression("name", "payload['name']")
+							.propertyFunction("date", m -> new Date())
+							.headerExpression("foo", "payload['name']")
+					)
+					.get();
+		}
+
+		@Bean
+		public IntegrationFlow enricherFlow2() {
+			return IntegrationFlows.from("enricherInput2", true)
+					.enrich(e -> e.requestChannel("enrichChannel")
+							.requestPayloadExpression("payload")
+							.shouldClonePayload(false)
+							.propertyExpression("name", "payload['name']")
+							.propertyExpression("date", "new java.util.Date()")
+					)
+					.get();
+		}
+
+		@Bean
+		public IntegrationFlow enricherFlow3() {
+			return IntegrationFlows.from("enricherInput3", true)
+					.enrich(e -> e.requestChannel("enrichChannel")
+							.requestPayload(Message::getPayload)
+							.shouldClonePayload(false)
+							.<Map<String, String>>headerFunction("foo", m -> m.getPayload().get("name")))
+					.get();
+		}
+
+		@Bean
+		public IntegrationFlow enrichFlow() {
+			return IntegrationFlows.from("enrichChannel")
+					.<TestPojo, Map<?, ?>>transform(p -> Collections.singletonMap("name", p.getName() + " Bar"))
+					.get();
+		}
+
+		@Bean
+		public PollableChannel receivedChannel() {
+			return new QueueChannel();
+		}
+
+		@Bean
+		public PollableChannel codecReplyChannel() {
+			return new QueueChannel();
+		}
+
+		@Bean
+		public IntegrationFlow encodingFlow() {
+			return f -> f
+					.transform(Transformers.encoding(new MyCodec()))
+					.channel("codecReplyChannel");
+		}
+
+		@Bean
+		public IntegrationFlow decodingFlow() {
+			return f -> f
+					.transform(Transformers.decoding(new MyCodec(), m -> Integer.class))
+					.channel("codecReplyChannel");
+		}
+
+		@Bean
+		public IntegrationFlow pojoTransformFlow() {
+			return f -> f
+					.enrichHeaders(h -> h.header("Foo", "Bar"),
+							e -> e.advice(idempotentReceiverInterceptor()))
+					.transform(new PojoTransformer());
+		}
+
+		@Bean
+		public PollableChannel idempotentDiscardChannel() {
+			return new QueueChannel();
+		}
+
+		@Bean
+		public IdempotentReceiverInterceptor idempotentReceiverInterceptor() {
+			IdempotentReceiverInterceptor idempotentReceiverInterceptor =
+					new IdempotentReceiverInterceptor(new MetadataStoreSelector(m -> m.getPayload().toString()));
+			idempotentReceiverInterceptor.setDiscardChannel(idempotentDiscardChannel());
+			idempotentReceiverInterceptor.setThrowExceptionOnRejection(true);
+			return idempotentReceiverInterceptor;
+		}
+
+
+	}
+
+	private static final class TestPojo {
+
+		private String name;
+
+		private Date date;
+
+		private TestPojo(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		@SuppressWarnings("unused")
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Date getDate() {
+			return date;
+		}
+
+		@SuppressWarnings("unused")
+		public void setDate(Date date) {
+			this.date = date;
+		}
+
+	}
+
+	public static class MyCodec implements Codec {
+
+		@Override
+		public void encode(Object object, OutputStream outputStream) throws IOException {
+		}
+
+		@Override
+		public byte[] encode(Object object) throws IOException {
+			return "foo".getBytes();
+		}
+
+		@Override
+		public <T> T decode(InputStream inputStream, Class<T> type) throws IOException {
+			return null;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T decode(byte[] bytes, Class<T> type) throws IOException {
+			return (T) (type.equals(String.class) ? new String(bytes) :
+					type.equals(Integer.class) ? Integer.valueOf(42) : Integer.valueOf(43));
+		}
+
+	}
+
+	public static class PojoTransformer {
+
+		@Transformer
+		public String transform(String payload, @Header("Foo") String header) {
+			return payload + header;
+		}
+
+	}
+
+}


### PR DESCRIPTION
To avoid some extra methods and let to operate with more cleaner API, merge some specs to single entity

* Make `EnricherSpec` and `AbstractRouterSpec` as `extends ConsumerEndpointSpec`
* Remove extra methods in the `IntegrationFlowDefinition`
* Provide refactoring and fixed to `enrich()` and `route()` functions according the `ConsumerEndpointSpec` merge
* Port `TransformerTests` from SI-Java-DSL project