### PR TITLE
Java DSL polishing around `HeaderEnricherSpec`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BarrierSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BarrierSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.util.Assert;
 
 import reactor.util.function.Tuple2;
-import reactor.util.function.Tuples;
 
 /**
  * A {@link MessageHandlerSpec} for the {@link BarrierMessageHandler}.
@@ -96,15 +95,13 @@ public class BarrierSpec extends ConsumerEndpointSpec<BarrierSpec, BarrierMessag
 
 	@Override
 	public Tuple2<ConsumerEndpointFactoryBean, BarrierMessageHandler> doGet() {
-		BarrierMessageHandler barrierMessageHandler =
-				new BarrierMessageHandler(this.timeout, this.outputProcessor, this.correlationStrategy);
-		barrierMessageHandler.setAdviceChain(this.adviceChain);
-		barrierMessageHandler.setRequiresReply(this.requiresReply);
-		barrierMessageHandler.setSendTimeout(this.sendTimeout);
-		barrierMessageHandler.setAsync(this.async);
-		barrierMessageHandler.setOrder(this.order);
-		this.endpointFactoryBean.setHandler(barrierMessageHandler);
-		return Tuples.of(this.endpointFactoryBean, barrierMessageHandler);
+		this.handler = new BarrierMessageHandler(this.timeout, this.outputProcessor, this.correlationStrategy);
+		this.handler.setAdviceChain(this.adviceChain);
+		this.handler.setRequiresReply(this.requiresReply);
+		this.handler.setSendTimeout(this.sendTimeout);
+		this.handler.setAsync(this.async);
+		this.handler.setOrder(this.order);
+		return super.doGet();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
@@ -34,6 +34,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
 
+import reactor.util.function.Tuple2;
+
 /**
  * A {@link EndpointSpec} for consumer endpoints.
  *
@@ -52,9 +54,6 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 
 	protected ConsumerEndpointSpec(H messageHandler) {
 		super(messageHandler);
-		if (messageHandler != null) {
-			this.endpointFactoryBean.setHandler(messageHandler);
-		}
 		this.endpointFactoryBean.setAdviceChain(this.adviceChain);
 		if (messageHandler instanceof AbstractReplyProducingMessageHandler) {
 			((AbstractReplyProducingMessageHandler) messageHandler).setAdviceChain(this.adviceChain);
@@ -225,6 +224,12 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 			logger.warn("'async' can be applied only for AbstractMessageProducingHandler");
 		}
 		return _this();
+	}
+
+	@Override
+	protected Tuple2<ConsumerEndpointFactoryBean, H> doGet() {
+		this.endpointFactoryBean.setHandler(this.handler);
+		return super.doGet();
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/correlation/CorrelationHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/correlation/CorrelationHandlerTests.java
@@ -177,7 +177,7 @@ public class CorrelationHandlerTests {
 			return f -> f.enrichHeaders(s -> s.header("FOO", "BAR"))
 					.split("testSplitterData", "buildList", c -> c.applySequence(false))
 					.channel(MessageChannels.executor(taskExecutor()))
-					.split(Message.class, m -> m.getPayload(), c -> c.applySequence(false))
+					.split(Message.class, Message::getPayload, c -> c.applySequence(false))
 					.channel(MessageChannels.executor(taskExecutor()))
 					.split(s -> s
 							.applySequence(false)

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/transformers/TransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/transformers/TransformerTests.java
@@ -268,8 +268,9 @@ public class TransformerTests {
 		@Bean
 		public IntegrationFlow pojoTransformFlow() {
 			return f -> f
-					.enrichHeaders(h -> h.header("Foo", "Bar"),
-							e -> e.advice(idempotentReceiverInterceptor()))
+					.enrichHeaders(h -> h
+							.header("Foo", "Bar")
+							.advice(idempotentReceiverInterceptor()))
 					.transform(new PojoTransformer());
 		}
 


### PR DESCRIPTION
* Make `HeaderEnricherSpec extends ConsumerEndpointSpec` to avoid extra
EIP-method with two `Consumer`s, when only one for
the `HeaderEnricherSpec` can address all the options - header enricher,
as well as target endpoint
* Move `this.endpointFactoryBean.setHandler(this.handler)` into
the `ConsumerEndpointSpec#doGet()` instead of ctor to avoid
duplicate code from the target implementations (e.g. `BarrierSpec`)