### PR TITLE
Support for sub flows in defining content enricher

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
@@ -142,14 +142,14 @@ public class EnricherSpec extends ConsumerEndpointSpec<EnricherSpec, ContentEnri
 	 * @param subFlow the subFlowDefinition
 	 * @return the enricher spec
 	 */
-	public EnricherSpec subFlow(IntegrationFlow subFlow) {
+	public EnricherSpec requestSubFlow(IntegrationFlow subFlow) {
 		Assert.notNull(subFlow, "'subFlow' must not be null");
 
 		DirectChannel requestChannel = new DirectChannel();
 		IntegrationFlowBuilder flowBuilder = IntegrationFlows.from(requestChannel);
 		subFlow.configure(flowBuilder);
 
-		this.componentsToRegister.add(flowBuilder);
+		this.componentsToRegister.add(flowBuilder.get());
 
 		return requestChannel(requestChannel);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
@@ -41,6 +41,7 @@ import reactor.util.function.Tuple2;
  *
  * @author Artem Bilan
  * @author Tim Ysewyn
+ * @author Ian Bondoc
  *
  * @since 5.0
  */
@@ -150,7 +151,7 @@ public class EnricherSpec extends ConsumerEndpointSpec<EnricherSpec, ContentEnri
 
 		this.componentsToRegister.add(flowBuilder);
 
-		return _this().requestChannel(requestChannel);
+		return requestChannel(requestChannel);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import org.springframework.expression.Expression;
+import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.expression.ValueExpression;
@@ -134,6 +135,22 @@ public class EnricherSpec extends ConsumerEndpointSpec<EnricherSpec, ContentEnri
 	public <P> EnricherSpec requestPayload(Function<Message<P>, ?> requestPayloadFunction) {
 		this.handler.setRequestPayloadExpression(new FunctionExpression<>(requestPayloadFunction));
 		return _this();
+	}
+
+	/**
+	 * @param subFlow the subFlowDefinition
+	 * @return the enricher spec
+	 */
+	public EnricherSpec subFlow(IntegrationFlow subFlow) {
+		Assert.notNull(subFlow, "'subFlow' must not be null");
+
+		DirectChannel requestChannel = new DirectChannel();
+		IntegrationFlowBuilder flowBuilder = IntegrationFlows.from(requestChannel);
+		subFlow.configure(flowBuilder);
+
+		this.componentsToRegister.add(flowBuilder);
+
+		return _this().requestChannel(requestChannel);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -108,7 +108,6 @@ import reactor.util.function.Tuple2;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Gabriele Del Prete
- * @author Ian Bondoc
  *
  * @since 5.0
  *
@@ -1173,23 +1172,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @see EnricherSpec
 	 */
 	public B enrich(Consumer<EnricherSpec> enricherConfigurer) {
-		EnricherSpec enricherSpec = new EnricherSpec();
-		enricherConfigurer.accept(enricherSpec);
-		Collection<Object> componentsToRegister = enricherSpec.getComponentsToRegister();
-		if (!CollectionUtils.isEmpty(componentsToRegister)) {
-			for (Object component : componentsToRegister) {
-				// Currently EnricherSpec only has IntegrationFlowBuilder as a sub component
-				if (component instanceof IntegrationFlowDefinition) {
-					IntegrationFlowDefinition<?> flowBuilder = (IntegrationFlowDefinition<?>) component;
-					addComponent(flowBuilder.get());
-				}
-			}
-		}
-
-		if (componentsToRegister != null) {
-			componentsToRegister.clear();
-		}
-		return register(enricherSpec, null);
+		return register(new EnricherSpec(), enricherConfigurer);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -108,6 +108,7 @@ import reactor.util.function.Tuple2;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Gabriele Del Prete
+ * @author Ian Bondoc
  *
  * @since 5.0
  *
@@ -1180,12 +1181,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 				// Currently EnricherSpec only has IntegrationFlowBuilder as a sub component
 				if (component instanceof IntegrationFlowDefinition) {
 					IntegrationFlowDefinition<?> flowBuilder = (IntegrationFlowDefinition<?>) component;
-					if (flowBuilder.isOutputChannelRequired()) {
-						addComponent(flowBuilder.get());
-					}
-					else {
-						throw new BeanCreationException("Enricher subFlow must require an output channel");
-					}
+					addComponent(flowBuilder.get());
 				}
 			}
 		}


### PR DESCRIPTION
The current enricher allows for specifying a payload, request and response channel where one can request additional data for enriching content or header. This change would allow one to specify an inline call to a handler instead of a request/response channel to grab the additional data.