### PR TITLE
Upgrade to Reactor-3.0.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ subprojects { subproject ->
 		pahoMqttClientVersion = '1.0.2'
 		postgresVersion = '9.1-901-1.jdbc4'
 		reactorNettyVersion = '0.6.2.RELEASE'
-		reactorVersion = '3.0.6.BUILD-SNAPSHOT'
+		reactorVersion = '3.0.6.RELEASE'
 		romeToolsVersion = '1.7.0'
 		servletApiVersion = '3.1.0'
 		slf4jVersion = "1.7.21"

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ subprojects { subproject ->
 		pahoMqttClientVersion = '1.0.2'
 		postgresVersion = '9.1-901-1.jdbc4'
 		reactorNettyVersion = '0.6.2.RELEASE'
-		reactorVersion = '3.0.5.RELEASE'
+		reactorVersion = '3.0.6.BUILD-SNAPSHOT'
 		romeToolsVersion = '1.7.0'
 		servletApiVersion = '3.1.0'
 		slf4jVersion = "1.7.21"

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/MessageChannelReactiveUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/MessageChannelReactiveUtils.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.channel;
 
+import java.time.Duration;
 import java.util.Iterator;
 
 import org.reactivestreams.Publisher;
@@ -85,7 +86,7 @@ public final class MessageChannelReactiveUtils {
 					<Message<?>>create(emitter -> {
 								MessageHandler messageHandler = emitter::next;
 								this.channel.subscribe(messageHandler);
-								emitter.setCancellation(() -> this.channel.unsubscribe(messageHandler));
+								emitter.onCancel(() -> this.channel.unsubscribe(messageHandler));
 							},
 							FluxSink.OverflowStrategy.IGNORE)
 					.subscribe((Subscriber<? super Message<?>>) subscriber);
@@ -125,7 +126,7 @@ public final class MessageChannelReactiveUtils {
 
 			};
 
-			Mono.<Message<?>>delayMillis(100)
+			Mono.<Message<?>>delay(Duration.ofMillis(100))
 					.repeat()
 					.concatMap(value -> Flux.fromIterable(() -> messageIterator))
 					.subscribe((Subscriber<? super Message<?>>) subscriber);

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveConsumerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveConsumerTests.java
@@ -26,6 +26,7 @@ import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.LinkedList;
@@ -59,6 +60,7 @@ import reactor.core.publisher.EmitterProcessor;
 
 /**
  * @author Artem Bilan
+ *
  * @since 5.0
  */
 public class ReactiveConsumerTests {
@@ -198,6 +200,9 @@ public class ReactiveConsumerTests {
 		testChannel.send(testMessage);
 
 		reactiveConsumer.start();
+
+		verify(testSubscriber, times(2)).onSubscribe(subscriptionArgumentCaptor.capture());
+		subscription = subscriptionArgumentCaptor.getValue();
 
 		subscription.request(2);
 


### PR DESCRIPTION
According to some rework and deprecations in the latest Reactor,
fix Reactor-based components to follow with the latest paradigmas

* Use `Flux` wrapper in the `ReactiveChannel` to track cancellation
instead of deprecated `Operators.SubscriberAdapter`
* Do similar `Flux.from(publisher)` in the `doSubscribeTo()`
to avoid subscribers delegation and, therefore, unnecessary call stack
* Rework `ReactiveConsumer` to wrap to a new `BaseSubscriber`
on each `ReactiveConsumer.start()`.
We need this wrapping to prevent subscriber cancellation from the
upstream `Publisher` on error.
We can't rely here on the `Flux.retry()` because upstream
`DirectProcessor` is marked as terminated on any error