### PR TITLE
#2110 Refactor MessageGroupMetadata to be compatible with Jackson serialization

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
@@ -16,14 +16,14 @@
 
 package org.springframework.integration.store;
 
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
-
-import org.springframework.messaging.Message;
-import org.springframework.util.Assert;
 
 /**
  * Value Object holding metadata about a MessageGroup in the MessageGroupStore.
@@ -37,11 +37,9 @@ public class MessageGroupMetadata implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final Object groupId;
+	private List<UUID> messageIds = new LinkedList<UUID>();
 
-	private final List<UUID> messageIds = new LinkedList<UUID>();
-
-	private final long timestamp;
+	private long timestamp;
 
 	private volatile boolean complete;
 
@@ -49,9 +47,12 @@ public class MessageGroupMetadata implements Serializable {
 
 	private volatile int lastReleasedMessageSequenceNumber;
 
+	private MessageGroupMetadata() {
+		//For Jackson
+	}
+
 	public MessageGroupMetadata(MessageGroup messageGroup) {
 		Assert.notNull(messageGroup, "'messageGroup' must not be null");
-		this.groupId = messageGroup.getGroupId();
 		for (Message<?> message : messageGroup.getMessages()) {
 			this.messageIds.add(message.getHeaders().getId());
 		}
@@ -73,10 +74,6 @@ public class MessageGroupMetadata implements Serializable {
 		this.lastModified = lastModified;
 	}
 
-	public Object getGroupId() {
-		return this.groupId;
-	}
-
 	public Iterator<UUID> messageIdIterator() {
 		return this.messageIds.iterator();
 	}
@@ -90,6 +87,10 @@ public class MessageGroupMetadata implements Serializable {
 			return this.messageIds.get(0);
 		}
 		return null;
+	}
+
+	public List<UUID> getMessageIds() {
+		return messageIds;
 	}
 
 	void complete() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
@@ -90,7 +90,7 @@ public class MessageGroupMetadata implements Serializable {
 	}
 
 	public List<UUID> getMessageIds() {
-		return messageIds;
+		return this.messageIds;
 	}
 
 	void complete() {

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageGroupMetadataJacksonTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageGroupMetadataJacksonTest.java
@@ -22,10 +22,10 @@ public class MessageGroupMetadataJacksonTest {
 
 		SimpleMessageGroup messageGroup = mock(SimpleMessageGroup.class);
 		when(messageGroup.isComplete()).thenReturn(true);
-		when(messageGroup.getLastModified()).thenReturn(11111l);
+		when(messageGroup.getLastModified()).thenReturn(11111L);
 		when(messageGroup.getLastReleasedMessageSequenceNumber()).thenReturn(11);
 		when(messageGroup.getGroupId()).thenReturn(true);
-		when(messageGroup.getTimestamp()).thenReturn(111111l);
+		when(messageGroup.getTimestamp()).thenReturn(111111L);
 		when(messageGroup.getSequenceSize()).thenReturn(11);
 		when(messageGroup.getMessages())
 				.thenReturn(Arrays.asList(new GenericMessage<>(String.class), new GenericMessage<>(String.class)));

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageGroupMetadataJacksonTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageGroupMetadataJacksonTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2009-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.integration.store;
 
 import org.junit.Test;
@@ -6,7 +22,9 @@ import org.springframework.messaging.support.GenericMessage;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/MessageGroupMetadataJacksonTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/MessageGroupMetadataJacksonTest.java
@@ -1,0 +1,51 @@
+package org.springframework.integration.store;
+
+import org.junit.Test;
+import org.springframework.integration.support.json.Jackson2JsonObjectMapper;
+import org.springframework.messaging.support.GenericMessage;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Laszlo Szabo
+ */
+public class MessageGroupMetadataJacksonTest {
+
+	private Jackson2JsonObjectMapper om = new Jackson2JsonObjectMapper();
+
+	@Test
+	public void testSerializerStartJobCommand() throws Exception {
+
+		SimpleMessageGroup messageGroup = mock(SimpleMessageGroup.class);
+		when(messageGroup.isComplete()).thenReturn(true);
+		when(messageGroup.getLastModified()).thenReturn(11111l);
+		when(messageGroup.getLastReleasedMessageSequenceNumber()).thenReturn(11);
+		when(messageGroup.getGroupId()).thenReturn(true);
+		when(messageGroup.getTimestamp()).thenReturn(111111l);
+		when(messageGroup.getSequenceSize()).thenReturn(11);
+		when(messageGroup.getMessages())
+				.thenReturn(Arrays.asList(new GenericMessage<>(String.class), new GenericMessage<>(String.class)));
+
+		MessageGroupMetadata reference = new MessageGroupMetadata(messageGroup);
+
+		//Serialize
+		String serialize = om.toJson(reference);
+		assertFalse(serialize.isEmpty());
+
+		//Deserialize
+		MessageGroupMetadata deserialize = om.fromJson(serialize, MessageGroupMetadata.class);
+
+		//check values after deserialization
+		assertEquals(reference.getLastReleasedMessageSequenceNumber(), deserialize.getLastReleasedMessageSequenceNumber());
+		assertEquals(reference.getLastModified(), deserialize.getLastModified());
+		assertEquals(reference.getTimestamp(), deserialize.getTimestamp());
+		assertNotNull(deserialize.firstId());
+		assertEquals(reference.firstId(), deserialize.firstId());
+		assertEquals(reference.getMessageIds().size(), deserialize.getMessageIds().size());
+	}
+
+}


### PR DESCRIPTION
Connected to https://github.com/spring-projects/spring-integration/issues/2110