### PR TITLE
ARFOGateway: Directory LiteralExpression->Value...

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -767,35 +767,8 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 	}
 
 	private File evaluateDestinationDirectoryExpression(Message<?> message) {
-
-		final File destinationDirectory;
-
-		final Object destinationDirectoryToUse = this.destinationDirectoryExpression.getValue(
-				this.evaluationContext, message);
-
-		if (destinationDirectoryToUse == null) {
-			throw new IllegalStateException(String.format("The provided " +
-							"destinationDirectoryExpression (%s) must not resolve to null.",
-					this.destinationDirectoryExpression.getExpressionString()));
-		}
-		else if (destinationDirectoryToUse instanceof String) {
-
-			final String destinationDirectoryPath = (String) destinationDirectoryToUse;
-
-			Assert.hasText(destinationDirectoryPath, String.format(
-					"Unable to resolve destination directory name for the provided Expression '%s'.",
-					this.destinationDirectoryExpression.getExpressionString()));
-			destinationDirectory = new File(destinationDirectoryPath);
-		}
-		else if (destinationDirectoryToUse instanceof File) {
-			destinationDirectory = (File) destinationDirectoryToUse;
-		}
-		else {
-			throw new IllegalStateException(String.format("The provided " +
-					"destinationDirectoryExpression (%s) must be of type " +
-					"java.io.File or be a String.", this.destinationDirectoryExpression.getExpressionString()));
-		}
-
+		final File destinationDirectory = ExpressionUtils.expressionToFile(this.destinationDirectoryExpression,
+				this.evaluationContext, message, "Destination Directory");
 		validateDestinationDirectory(destinationDirectory, this.autoCreateDirectory);
 		return destinationDirectory;
 	}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileOutboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileOutboundChannelAdapterIntegrationTests.java
@@ -135,7 +135,8 @@ public class FileOutboundChannelAdapterIntegrationTests {
 			this.inputChannelSaveToSubDirEmptyStringExpression.send(message);
 		}
 		catch (MessageHandlingException e) {
-			Assert.assertEquals("Unable to resolve destination directory name for the provided Expression ''   ''.", e.getCause().getMessage());
+			Assert.assertEquals("Unable to resolve Destination Directory for the provided Expression ''   ''.",
+					e.getCause().getMessage());
 			return;
 		}
 
@@ -192,8 +193,8 @@ public class FileOutboundChannelAdapterIntegrationTests {
 			this.inputChannelSaveToSubDirWithFile.send(messageWithFileHeader);
 		}
 		catch (MessageHandlingException e) {
-			Assert.assertEquals("The provided destinationDirectoryExpression " +
-					"(headers['subDirectory']) must not resolve to null.",
+			Assert.assertEquals("The provided Destination Directory expression " +
+					"(headers['subDirectory']) must not evaluate to null.",
 					e.getCause().getMessage());
 
 			return;
@@ -214,9 +215,9 @@ public class FileOutboundChannelAdapterIntegrationTests {
 			this.inputChannelSaveToSubDirWithFile.send(messageWithFileHeader);
 		}
 		catch (MessageHandlingException e) {
-			Assert.assertEquals("The provided destinationDirectoryExpression" +
-					" (headers['subDirectory']) must be of type " +
-					"java.io.File or be a String.",
+			Assert.assertEquals("The provided Destination Directory expression" +
+					" (headers['subDirectory']) must evaluate to type " +
+					"java.io.File or String, not java.lang.Integer.",
 					e.getCause().getMessage());
 
 			return;


### PR DESCRIPTION
Using a `LiteralExpression` in the `AbstractRemoteFileOutboundGateway` (when the
user provides a `File` for the directory) causes us to create a new `File` object
each time, instead of using the user-supplied `File`.

Use a `ValueExpression` instead.

Move the `FileWritingMessageHandler` logic to `ExpressionUtils` and use it from both places.

Also add a String setter variant for convenient Java Configuration.