### PR TITLE
INT-4254: LockRegLInit: Fix unconditional unlock

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
@@ -242,8 +242,8 @@ public class LockRegistryLeaderInitiator implements SmartLifecycle, DisposableBe
 		synchronized (this.lifecycleMonitor) {
 			if (!this.running) {
 				this.leaderSelector = new LeaderSelector(buildLeaderPath());
-				this.future = this.executorService.submit(this.leaderSelector);
 				this.running = true;
+				this.future = this.executorService.submit(this.leaderSelector);
 				logger.debug("Started LeaderInitiator");
 			}
 		}
@@ -346,8 +346,8 @@ public class LockRegistryLeaderInitiator implements SmartLifecycle, DisposableBe
 				}
 			}
 			finally {
-				this.lock.unlock();
 				if (this.locked) {
+					this.lock.unlock();
 					// We are stopping, therefore not leading any more
 					handleRevoked();
 				}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4254

The `LockRegistryLeaderInitiator#LeaderSelector` unconditional calls
`unlock()` in the `finally` block when the `Lock` might not be locked.

Another problem that `running = true` is set after submitting `LeaderSelector` task.
That might bring the problem that `LeaderSelector` won't be selected because of
`this.running` race condition

* Move `this.running = true` before submitting `LeaderSelector` task
* Move `unlock()` into the `if (this.locked)` condition

**Cherry-pick to 4.3.x**