### PR TITLE
INT-2625(4.3.x): Refactoring for JdbcMessageStore

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageStore.java
@@ -204,7 +204,9 @@ public class JdbcMessageStore extends AbstractMessageGroupStore implements Messa
 
 	/**
 	 * Convenient constructor for configuration use.
+	 * @deprecated since 4.3.9 in favor of {@link #JdbcMessageStore(DataSource)}
 	 */
+	@Deprecated
 	public JdbcMessageStore() {
 		this.deserializer = new DeserializingConverter();
 		this.serializer = new SerializingConverter();
@@ -216,8 +218,19 @@ public class JdbcMessageStore extends AbstractMessageGroupStore implements Messa
 	 * @param dataSource a {@link DataSource}
 	 */
 	public JdbcMessageStore(DataSource dataSource) {
-		this();
-		this.jdbcTemplate = new JdbcTemplate(dataSource);
+		this(new JdbcTemplate(dataSource));
+	}
+
+	/**
+	 * Create a {@link MessageStore} with all mandatory properties.
+	 * @param jdbcOperations a {@link JdbcOperations}
+	 * @since 4.3.9
+	 */
+	public JdbcMessageStore(JdbcOperations jdbcOperations) {
+		Assert.notNull(jdbcOperations, "'dataSource' must not be null");
+		this.jdbcTemplate = jdbcOperations;
+		this.deserializer = new DeserializingConverter();
+		this.serializer = new SerializingConverter();
 	}
 
 	/**
@@ -242,21 +255,21 @@ public class JdbcMessageStore extends AbstractMessageGroupStore implements Messa
 	}
 
 	/**
-	 * The JDBC {@link DataSource} to use when interacting with the database. Either this property can be set or the
-	 * {@link #setJdbcTemplate(JdbcOperations) jdbcTemplate}.
-	 *
+	 * The JDBC {@link DataSource} to use when interacting with the database.
 	 * @param dataSource a {@link DataSource}
+	 * @deprecated since 4.3.9 in favor of {@link #JdbcMessageStore(DataSource)}
 	 */
+	@Deprecated
 	public void setDataSource(DataSource dataSource) {
 		this.jdbcTemplate = new JdbcTemplate(dataSource);
 	}
 
 	/**
-	 * The {@link JdbcOperations} to use when interacting with the database. Either this property can be set or the
-	 * {@link #setDataSource(DataSource) dataSource}.
-	 *
+	 * The {@link JdbcOperations} to use when interacting with the database.
 	 * @param jdbcTemplate a {@link JdbcOperations}
+	 * @deprecated since 4.3.9 in favor of {@link #JdbcMessageStore(DataSource)}
 	 */
+	@Deprecated
 	public void setJdbcTemplate(JdbcOperations jdbcTemplate) {
 		this.jdbcTemplate = jdbcTemplate;
 	}
@@ -291,7 +304,13 @@ public class JdbcMessageStore extends AbstractMessageGroupStore implements Messa
 		this.deserializer = new DeserializingConverter((Deserializer) deserializer);
 	}
 
+	/**
+	 * The bean instance initializer.
+	 * @throws Exception the initialization exception
+	 * @deprecated since 4.3.9 in favor of initialization and assertions in constructors.
+	 */
 	@Override
+	@Deprecated
 	public void afterPropertiesSet() throws Exception {
 		Assert.state(this.jdbcTemplate != null, "A DataSource or JdbcTemplate must be provided");
 	}

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcMessageStoreParser.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcMessageStoreParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.jdbc.config;
 
+import org.w3c.dom.Element;
+
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
@@ -23,10 +25,9 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.jdbc.JdbcMessageStore;
 import org.springframework.util.StringUtils;
-import org.w3c.dom.Element;
 
 /**
- * Parser for {@link org.springframework.integration.jdbc.JdbcMessageStore}.
+ * Parser for {@link JdbcMessageStore}.
  *
  * @author Dave Syer
  * @since 2.0
@@ -44,19 +45,19 @@ public class JdbcMessageStoreParser extends AbstractBeanDefinitionParser {
 		String dataSourceRef = element.getAttribute("data-source");
 		String simpleJdbcOperationsRef = element.getAttribute("jdbc-operations");
 		boolean refToDataSourceSet = StringUtils.hasText(dataSourceRef);
-		boolean refToSimpleJdbcOperaitonsSet = StringUtils.hasText(simpleJdbcOperationsRef);
-		if ((refToDataSourceSet && refToSimpleJdbcOperaitonsSet)
-				|| (!refToDataSourceSet && !refToSimpleJdbcOperaitonsSet)) {
+		boolean refToSimpleJdbcOperationsSet = StringUtils.hasText(simpleJdbcOperationsRef);
+		if ((refToDataSourceSet && refToSimpleJdbcOperationsSet)
+				|| (!refToDataSourceSet && !refToSimpleJdbcOperationsSet)) {
 			parserContext.getReaderContext().error(
 					"Exactly one of the attributes data-source or "
 							+ "simple-jdbc-operations should be set for the JDBC message-store", source);
 		}
 
 		if (refToDataSourceSet) {
-			builder.addPropertyReference("dataSource", dataSourceRef);
+			builder.addConstructorArgReference(dataSourceRef);
 		}
 		else {
-			builder.addPropertyReference("jdbcTemplate", simpleJdbcOperationsRef);
+			builder.addConstructorArgReference(simpleJdbcOperationsRef);
 		}
 
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "lob-handler");

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
@@ -6,8 +6,8 @@
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 	http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<beans:bean id="messageStore"
-				class="org.springframework.integration.jdbc.DelayerHandlerRescheduleIntegrationTests$TestJdbcMessageStore">
+	<beans:bean id="messageStore" class="org.springframework.integration.jdbc.JdbcMessageStore">
+		<beans:constructor-arg value="#{T (org.springframework.integration.jdbc.DelayerHandlerRescheduleIntegrationTests).dataSource}"/>
 		<beans:property name="lazyLoadMessageGroups" value="false"/>
 	</beans:bean>
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,16 +170,6 @@ public class DelayerHandlerRescheduleIntegrationTests {
 		//On transaction rollback the delayed Message should remain in the persistent MessageStore
 		assertEquals(1, messageStore.messageGroupSize(delayerMessageGroupId));
 		context.close();
-	}
-
-	@SuppressWarnings("unused")
-	private static class TestJdbcMessageStore extends JdbcMessageStore {
-
-		private TestJdbcMessageStore() {
-			super();
-			this.setDataSource(dataSource);
-		}
-
 	}
 
 	@SuppressWarnings("unused")


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-2625

Since `jdbcOperations` is mandatory property of the `JdbcMessageStore`,
make it as constructor arg to encourage users always specify `DataSource`
or `JdbcOperations`.
With that we don't need `afterPropertiesSet()` any more