### PR TITLE
INT-4261: Do not register resource to TX twice

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
@@ -320,7 +320,7 @@ public abstract class AbstractPollingEndpoint extends AbstractEndpoint implement
 					integrationSynchronization.setShouldUnbindAtCompletion(false);
 
 					if (!TransactionSynchronizationManager.hasResource(resource)) {
-						TransactionSynchronizationManager.bindResource(key,
+						TransactionSynchronizationManager.bindResource(resource,
 								integrationSynchronization.getResourceHolder());
 					}
 				}

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
@@ -310,18 +310,21 @@ public abstract class AbstractPollingEndpoint extends AbstractEndpoint implement
 		if (this.transactionSynchronizationFactory != null && resource != null &&
 				TransactionSynchronizationManager.isActualTransactionActive()) {
 			TransactionSynchronization synchronization = this.transactionSynchronizationFactory.create(resource);
-			TransactionSynchronizationManager.registerSynchronization(synchronization);
-			if (synchronization instanceof IntegrationResourceHolderSynchronization) {
-				IntegrationResourceHolderSynchronization integrationSynchronization =
-						((IntegrationResourceHolderSynchronization) synchronization);
-				integrationSynchronization.setShouldUnbindAtCompletion(false);
-				IntegrationResourceHolder resourceHolder = integrationSynchronization.getResourceHolder();
-				if (key != null) {
-					resourceHolder.addAttribute(key, resource);
+			if (synchronization != null) {
+				TransactionSynchronizationManager.registerSynchronization(synchronization);
+				if (synchronization instanceof IntegrationResourceHolderSynchronization) {
+					IntegrationResourceHolderSynchronization integrationSynchronization =
+							((IntegrationResourceHolderSynchronization) synchronization);
+					integrationSynchronization.setShouldUnbindAtCompletion(false);
+					IntegrationResourceHolder resourceHolder = integrationSynchronization.getResourceHolder();
+					if (key != null) {
+						resourceHolder.addAttribute(key, resource);
+					}
+					return resourceHolder;
 				}
-				return resourceHolder;
 			}
 		}
+
 		return null;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
@@ -309,19 +309,30 @@ public abstract class AbstractPollingEndpoint extends AbstractEndpoint implement
 	private IntegrationResourceHolder bindResourceHolderIfNecessary(String key, Object resource) {
 		if (this.transactionSynchronizationFactory != null && resource != null &&
 				TransactionSynchronizationManager.isActualTransactionActive()) {
+
 			TransactionSynchronization synchronization = this.transactionSynchronizationFactory.create(resource);
 			if (synchronization != null) {
 				TransactionSynchronizationManager.registerSynchronization(synchronization);
+
 				if (synchronization instanceof IntegrationResourceHolderSynchronization) {
 					IntegrationResourceHolderSynchronization integrationSynchronization =
 							((IntegrationResourceHolderSynchronization) synchronization);
 					integrationSynchronization.setShouldUnbindAtCompletion(false);
-					IntegrationResourceHolder resourceHolder = integrationSynchronization.getResourceHolder();
-					if (key != null) {
-						resourceHolder.addAttribute(key, resource);
+
+					if (!TransactionSynchronizationManager.hasResource(resource)) {
+						TransactionSynchronizationManager.bindResource(key,
+								integrationSynchronization.getResourceHolder());
 					}
-					return resourceHolder;
 				}
+			}
+
+			Object resourceHolder = TransactionSynchronizationManager.getResource(resource);
+			if (resourceHolder instanceof IntegrationResourceHolder) {
+				IntegrationResourceHolder integrationResourceHolder = (IntegrationResourceHolder) resourceHolder;
+				if (key != null) {
+					integrationResourceHolder.addAttribute(key, resource);
+				}
+				return integrationResourceHolder;
 			}
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/transaction/DefaultTransactionSynchronizationFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transaction/DefaultTransactionSynchronizationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,10 +26,13 @@ import org.springframework.util.Assert;
  * Default implementation of {@link TransactionSynchronizationFactory} which takes an instance of
  * {@link TransactionSynchronizationProcessor} allowing you to create a {@link TransactionSynchronization}
  * using {{@link #create(Object)} method.
+ * <p>
+ * If resource under the provided {@code key} is already registered, the factory returns {@code null}.
  *
  * @author Gary Russell
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ *
  * @since 2.2
  */
 public class DefaultTransactionSynchronizationFactory implements TransactionSynchronizationFactory {
@@ -46,13 +49,16 @@ public class DefaultTransactionSynchronizationFactory implements TransactionSync
 	@Override
 	public TransactionSynchronization create(Object key) {
 		Assert.notNull(key, "'key' must not be null");
-		DefaultTransactionalResourceSynchronization synchronization = new DefaultTransactionalResourceSynchronization(key);
-		TransactionSynchronizationManager.bindResource(key, synchronization.getResourceHolder());
-		return synchronization;
+		if (!TransactionSynchronizationManager.hasResource(key)) {
+			DefaultTransactionalResourceSynchronization synchronization =
+					new DefaultTransactionalResourceSynchronization(key);
+			TransactionSynchronizationManager.bindResource(key, synchronization.getResourceHolder());
+			return synchronization;
+		}
+
+		return null;
 	}
 
-	/**
-	 */
 	private final class DefaultTransactionalResourceSynchronization extends IntegrationResourceHolderSynchronization {
 
 		DefaultTransactionalResourceSynchronization(Object resourceKey) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/transaction/DefaultTransactionSynchronizationFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transaction/DefaultTransactionSynchronizationFactory.java
@@ -20,14 +20,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
+
 /**
  * Default implementation of {@link TransactionSynchronizationFactory} which takes an instance of
  * {@link TransactionSynchronizationProcessor} allowing you to create a {@link TransactionSynchronization}
  * using {{@link #create(Object)} method.
- * <p>
- * If resource under the provided {@code key} is already registered, the factory returns {@code null}.
  *
  * @author Gary Russell
  * @author Oleg Zhurakousky
@@ -49,14 +47,7 @@ public class DefaultTransactionSynchronizationFactory implements TransactionSync
 	@Override
 	public TransactionSynchronization create(Object key) {
 		Assert.notNull(key, "'key' must not be null");
-		if (!TransactionSynchronizationManager.hasResource(key)) {
-			DefaultTransactionalResourceSynchronization synchronization =
-					new DefaultTransactionalResourceSynchronization(key);
-			TransactionSynchronizationManager.bindResource(key, synchronization.getResourceHolder());
-			return synchronization;
-		}
-
-		return null;
+		return new DefaultTransactionalResourceSynchronization(key);
 	}
 
 	private final class DefaultTransactionalResourceSynchronization extends IntegrationResourceHolderSynchronization {

--- a/spring-integration-core/src/main/java/org/springframework/integration/transaction/PassThroughTransactionSynchronizationFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transaction/PassThroughTransactionSynchronizationFactory.java
@@ -17,23 +17,16 @@
 package org.springframework.integration.transaction;
 
 import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
 
 /**
  * A simple {@link TransactionSynchronizationFactory} implementation which produces
- * an {@link IntegrationResourceHolderSynchronization} and registers
- * an {@link IntegrationResourceHolder} under the provided {@code key} with
- * the current transaction scope.
- * <p>
- * If resource under the provided {@code key} is already registered, the factory returns {@code null}.
+ * an {@link IntegrationResourceHolderSynchronization} with an {@link IntegrationResourceHolder}.
  *
  * @author Andreas Baer
  * @author Artem Bilan
  *
  * @since 5.0
- *
- * @see TransactionSynchronizationManager#bindResource(Object, Object)
  */
 public class PassThroughTransactionSynchronizationFactory implements TransactionSynchronizationFactory {
 
@@ -41,14 +34,7 @@ public class PassThroughTransactionSynchronizationFactory implements Transaction
 	@Override
 	public TransactionSynchronization create(Object key) {
 		Assert.notNull(key, "'key' must not be null");
-		if (!TransactionSynchronizationManager.hasResource(key)) {
-			IntegrationResourceHolderSynchronization synchronization =
-					new IntegrationResourceHolderSynchronization(new IntegrationResourceHolder(), key);
-			TransactionSynchronizationManager.bindResource(key, synchronization.getResourceHolder());
-			return synchronization;
-		}
-
-		return null;
+		return new IntegrationResourceHolderSynchronization(new IntegrationResourceHolder(), key);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/transaction/PassThroughTransactionSynchronizationFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transaction/PassThroughTransactionSynchronizationFactory.java
@@ -25,8 +25,11 @@ import org.springframework.util.Assert;
  * an {@link IntegrationResourceHolderSynchronization} and registers
  * an {@link IntegrationResourceHolder} under the provided {@code key} with
  * the current transaction scope.
+ * <p>
+ * If resource under the provided {@code key} is already registered, the factory returns {@code null}.
  *
  * @author Andreas Baer
+ * @author Artem Bilan
  *
  * @since 5.0
  *
@@ -38,10 +41,14 @@ public class PassThroughTransactionSynchronizationFactory implements Transaction
 	@Override
 	public TransactionSynchronization create(Object key) {
 		Assert.notNull(key, "'key' must not be null");
-		IntegrationResourceHolderSynchronization synchronization =
-				new IntegrationResourceHolderSynchronization(new IntegrationResourceHolder(), key);
-		TransactionSynchronizationManager.bindResource(key, synchronization.getResourceHolder());
-		return synchronization;
+		if (!TransactionSynchronizationManager.hasResource(key)) {
+			IntegrationResourceHolderSynchronization synchronization =
+					new IntegrationResourceHolderSynchronization(new IntegrationResourceHolder(), key);
+			TransactionSynchronizationManager.bindResource(key, synchronization.getResourceHolder());
+			return synchronization;
+		}
+
+		return null;
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/TransactionSynchronizationQueueChannelTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/TransactionSynchronizationQueueChannelTests-context.xml
@@ -10,7 +10,7 @@
 	</int:channel>
 
 	<int:service-activator input-channel="queueChannel" ref="service" method="handle">
-		<int:poller fixed-delay="5000">
+		<int:poller max-messages-per-poll="1" fixed-delay="1" receive-timeout="-1">
 			<int:transactional synchronization-factory="txSyncFactory"/>
 		</int:poller>
 	</int:service-activator>
@@ -33,7 +33,7 @@
 	</int:channel>
 
 	<int:service-activator input-channel="queueChannel2" ref="service" method="handle">
-		<int:poller fixed-delay="5000">
+		<int:poller max-messages-per-poll="1" fixed-delay="1" receive-timeout="-1">
 			<int:transactional synchronization-factory="txSyncFactory2"/>
 		</int:poller>
 	</int:service-activator>

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/TransactionSynchronizationQueueChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/TransactionSynchronizationQueueChannelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,16 +32,20 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.2
  *
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
 public class TransactionSynchronizationQueueChannelTests {
 
 	@Autowired

--- a/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/transactionTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/transactionTests.xml
@@ -24,21 +24,21 @@
 
 	<service-activator input-channel="badInput" ref="testBean"
 		method="bad" output-channel="output">
-		<poller max-messages-per-poll="1" fixed-rate="10000">
+		<poller max-messages-per-poll="1" fixed-delay="1" receive-timeout="-1">
 			<transactional transaction-manager="txManager" />
 		</poller>
 	</service-activator>
 
 	<service-activator input-channel="goodInput" ref="testBean"
 		method="good" output-channel="output">
-		<poller max-messages-per-poll="1" fixed-rate="10000">
+		<poller max-messages-per-poll="1" fixed-delay="1" receive-timeout="-1">
 			<transactional transaction-manager="txManager" />
 		</poller>
 	</service-activator>
 	
 	<service-activator id="advicedSa" input-channel="goodInputWithAdvice" ref="testBean"
 		method="good" output-channel="output">
-		<poller max-messages-per-poll="1" fixed-rate="10000">
+		<poller max-messages-per-poll="1" fixed-delay="1" receive-timeout="-1">
 			<advice-chain>
 				<ref bean="txAdvise"/>
 				<ref bean="adviceA" />

--- a/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/transactionTests.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/transactionTests.xml
@@ -43,6 +43,7 @@
 				<ref bean="txAdvise"/>
 				<ref bean="adviceA" />
 				<beans:bean class="org.springframework.integration.dispatcher.PollingTransactionTests.SampleAdvice"/>
+				<beans:bean class="org.springframework.integration.dispatcher.PollingTransactionTests.SimpleRepeatAdvice"/>
 			</advice-chain>
 		</poller>
 	</service-activator>

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
@@ -195,11 +195,13 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport implements Be
 					TransactionSynchronization synchronization =
 							ImapIdleChannelAdapter.this.transactionSynchronizationFactory
 									.create(ImapIdleChannelAdapter.this);
-					TransactionSynchronizationManager.registerSynchronization(synchronization);
-					if (synchronization instanceof IntegrationResourceHolderSynchronization) {
-						IntegrationResourceHolder holder =
-								((IntegrationResourceHolderSynchronization) synchronization).getResourceHolder();
-						holder.setMessage(message);
+					if (synchronization != null) {
+						TransactionSynchronizationManager.registerSynchronization(synchronization);
+						if (synchronization instanceof IntegrationResourceHolderSynchronization) {
+							IntegrationResourceHolder holder =
+									((IntegrationResourceHolderSynchronization) synchronization).getResourceHolder();
+							holder.setMessage(message);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4261

When we have some `Advice` withing TX Advice which may perform `doPoll()`
several times, we unconditionally call
`transactionSynchronizationFactory.create(resource)`.
With the out-of-the-box implementations
`DefaultTransactionSynchronizationFactory` and
`PassThroughTransactionSynchronizationFactory`
we preform `TransactionSynchronizationManager.bindResource()`.
If resource is already there, an `IllegalStateException` is thrown

* Check that resource isn't bound already to the TX and don't create a new
`TransactionalResourceSynchronization` - just return `null`
* Check in the target users for the `null` before registering synchronization