### PR TITLE
INT-4260: MessagePublishingErrorHandler Orig. Msg. [Backport]

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractExecutorChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractExecutorChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.Executor;
 
 import org.springframework.integration.dispatcher.AbstractDispatcher;
+import org.springframework.integration.support.OriginalMessageContainingMessagingException;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
@@ -43,6 +44,7 @@ import org.springframework.util.CollectionUtils;
  * is handed to the {@link Executor#execute(Runnable)}.
  *
  * @author Artem Bilan
+ * @author Gary Russell
  * @see ExecutorChannel
  * @see PublishSubscribeChannel
  * @since 4.2
@@ -154,7 +156,7 @@ public abstract class AbstractExecutorChannel extends AbstractSubscribableChanne
 					triggerAfterMessageHandled(message, ex, interceptorStack);
 				}
 				if (ex instanceof MessagingException) {
-					throw (MessagingException) ex;
+					throw new OriginalMessageContainingMessagingException(message, (MessagingException) ex);
 				}
 				String description = "Failed to handle " + message + " to " + this + " in " + messageHandler;
 				throw new MessageDeliveryException(message, description, ex);

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
@@ -29,6 +29,7 @@ import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.integration.channel.MessagePublishingErrorHandler;
+import org.springframework.integration.support.OriginalMessageContainingMessagingException;
 import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.transaction.ExpressionEvaluatingTransactionSynchronizationProcessor;
 import org.springframework.integration.transaction.IntegrationResourceHolder;
@@ -269,7 +270,17 @@ public abstract class AbstractPollingEndpoint extends AbstractEndpoint implement
 			if (holder != null) {
 				holder.setMessage(message);
 			}
-			this.handleMessage(message);
+			try {
+				this.handleMessage(message);
+			}
+			catch (Exception e) {
+				if (e instanceof MessagingException) {
+					throw new OriginalMessageContainingMessagingException(message, (MessagingException) e);
+				}
+				else {
+					throw new MessagingException(message, e);
+				}
+			}
 			result = true;
 		}
 		return result;

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -480,8 +480,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 		if (error != null) {
 			MessageChannel errorChannel = getErrorChannel();
 			if (errorChannel != null) {
-				Message<?> errorMessage = this.errorMessageStrategy.buildErrorMessage(error,
-						getErrorMessageAttributes(requestMessage));
+				ErrorMessage errorMessage = buildErrorMessage(requestMessage, error);
 				Message<?> errorFlowReply = null;
 				try {
 					errorFlowReply = this.messagingTemplate.sendAndReceive(errorChannel, errorMessage);
@@ -516,6 +515,20 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 			}
 		}
 		return reply;
+	}
+
+	/**
+	 * Build an error message for the message and throwable using the configured
+	 * {@link ErrorMessageStrategy}.
+	 * @param requestMessage the requestMessage.
+	 * @param throwable the throwable.
+	 * @return the error message.
+	 * @since 4.3.10
+	 */
+	protected ErrorMessage buildErrorMessage(Message<?> requestMessage, Throwable throwable) {
+		ErrorMessage errorMessage = this.errorMessageStrategy.buildErrorMessage(throwable,
+				getErrorMessageAttributes(requestMessage));
+		return errorMessage;
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/message/EnhancedErrorMessage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/message/EnhancedErrorMessage.java
@@ -42,17 +42,17 @@ public class EnhancedErrorMessage extends ErrorMessage {
 
 	private final Message<?> originalMessage;
 
-	public EnhancedErrorMessage(Message<?> originalMessage, Throwable payload) {
+	public EnhancedErrorMessage(Throwable payload, Message<?> originalMessage) {
 		super(payload);
 		this.originalMessage = originalMessage;
 	}
 
-	public EnhancedErrorMessage(Message<?> originalMessage, Throwable payload, MessageHeaders headers) {
+	public EnhancedErrorMessage(Throwable payload, MessageHeaders headers, Message<?> originalMessage) {
 		super(payload, headers);
 		this.originalMessage = originalMessage;
 	}
 
-	public EnhancedErrorMessage(Message<?> originalMessage, Throwable payload, Map<String, Object> headers) {
+	public EnhancedErrorMessage(Throwable payload, Map<String, Object> headers, Message<?> originalMessage) {
 		super(payload, headers);
 		this.originalMessage = originalMessage;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultErrorMessageStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultErrorMessageStrategy.java
@@ -40,7 +40,7 @@ public class DefaultErrorMessageStrategy implements ErrorMessageStrategy {
 	public ErrorMessage buildErrorMessage(Throwable throwable, AttributeAccessor attributes) {
 		Object inputMessage = attributes.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
 		return inputMessage instanceof Message
-				? new org.springframework.integration.message.EnhancedErrorMessage((Message<?>) inputMessage, throwable)
+				? new org.springframework.integration.message.EnhancedErrorMessage(throwable, (Message<?>) inputMessage)
 				: new ErrorMessage(throwable);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/OriginalMessageContainingMessagingException.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/OriginalMessageContainingMessagingException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+
+/**
+ * A {@link MessagingException} used to convey the cause and original message to
+ * a {@link org.springframework.integration.channel.MessagePublishingErrorHandler}.
+ *
+ * @author Gary Russell
+ * @since 5.0
+ *
+ */
+public class OriginalMessageContainingMessagingException extends MessagingException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Message<?> originalMessage;
+
+	public OriginalMessageContainingMessagingException(Message<?> originalMessage, MessagingException cause) {
+		super((String) null, cause);
+		this.originalMessage = originalMessage;
+	}
+
+	public Message<?> getOriginalMessage() {
+		return this.originalMessage;
+	}
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.channel.registry;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
@@ -50,6 +51,7 @@ import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.support.OriginalMessageContainingMessagingException;
 import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.support.channel.HeaderChannelRegistry;
 import org.springframework.integration.test.util.TestUtils;
@@ -179,6 +181,8 @@ public class HeaderChannelRegistryTests {
 		Message<?> reply = template.sendAndReceive(new GenericMessage<String>("bar"));
 		assertNotNull(reply);
 		assertTrue(reply instanceof ErrorMessage);
+		assertNotNull(((ErrorMessage) reply).getOriginalMessage());
+		assertThat(reply.getPayload(), not(instanceOf(OriginalMessageContainingMessagingException.class)));
 	}
 
 	@Test

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
@@ -330,7 +330,8 @@ public class ChannelPublishingJmsMessageListener
 			if (errorChannel == null) {
 				throw e;
 			}
-			errorChannel.send(new ErrorMessage(new MessagingException("Inbound conversion failed for: " + jmsMessage, e)));
+			errorChannel.send(this.gatewayDelegate.buildErrorMessage(null,
+					new MessagingException("Inbound conversion failed for: " + jmsMessage, e)));
 			errors = true;
 		}
 		if (!errors) {
@@ -507,6 +508,14 @@ public class ChannelPublishingJmsMessageListener
 		@Override
 		protected Message<?> sendAndReceiveMessage(Object request) {
 			return super.sendAndReceiveMessage(request);
+		}
+
+		/*
+		 * Make visible.
+		 */
+		@Override
+		public ErrorMessage buildErrorMessage(Message<?> requestMessage, Throwable throwable) {
+			return super.buildErrorMessage(requestMessage, throwable);
 		}
 
 		@Override


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4260

MPEH: Populate the `ErrorMessage.originalMessage`, if available and not the same as the `failedMessage`.

Polishing - Subclass Access to buildErrorMessage

So that subclasses can also generate error message for conditions such
as message conversion errors.

Polishing

__Remove lambda - update EnhancedErrorMessage arg order to match 5.0 ErrorMessage__