### PR TITLE
Rename ReactiveChannel

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/FluxSubscribableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/FluxSubscribableChannel.java
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.dsl.channel;
+package org.springframework.integration.channel;
 
-import org.springframework.integration.channel.ReactiveChannel;
 import org.springframework.messaging.Message;
 
-import reactor.core.publisher.FluxProcessor;
+import reactor.core.publisher.Flux;
 
 /**
  * @author Artem Bilan
@@ -27,14 +26,8 @@ import reactor.core.publisher.FluxProcessor;
  *
  * @since 5.0
  */
-public class ReactiveChannelSpec extends MessageChannelSpec<ReactiveChannelSpec, ReactiveChannel> {
+public interface FluxSubscribableChannel {
 
-	ReactiveChannelSpec() {
-		this.channel = new ReactiveChannel();
-	}
-
-	ReactiveChannelSpec(FluxProcessor<Message<?>, Message<?>> processor) {
-		this.channel = new ReactiveChannel(processor);
-	}
+	void subscribeTo(Flux<Message<?>> publisher);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/Channels.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/Channels.java
@@ -21,11 +21,11 @@ import java.util.concurrent.Executor;
 
 import org.springframework.integration.dsl.channel.DirectChannelSpec;
 import org.springframework.integration.dsl.channel.ExecutorChannelSpec;
+import org.springframework.integration.dsl.channel.FluxMessageChannelSpec;
 import org.springframework.integration.dsl.channel.MessageChannels;
 import org.springframework.integration.dsl.channel.PriorityChannelSpec;
 import org.springframework.integration.dsl.channel.PublishSubscribeChannelSpec;
 import org.springframework.integration.dsl.channel.QueueChannelSpec;
-import org.springframework.integration.dsl.channel.ReactiveChannelSpec;
 import org.springframework.integration.dsl.channel.RendezvousChannelSpec;
 import org.springframework.integration.store.ChannelMessageStore;
 import org.springframework.integration.store.PriorityCapableChannelMessageStore;
@@ -132,19 +132,19 @@ public class Channels {
 	}
 
 
-	public ReactiveChannelSpec reactive() {
+	public FluxMessageChannelSpec reactive() {
 		return MessageChannels.reactive();
 	}
 
-	public ReactiveChannelSpec reactive(String id) {
+	public FluxMessageChannelSpec reactive(String id) {
 		return MessageChannels.reactive(id);
 	}
 
-	public ReactiveChannelSpec reactive(FluxProcessor<Message<?>, Message<?>> processor) {
+	public FluxMessageChannelSpec reactive(FluxProcessor<Message<?>, Message<?>> processor) {
 		return MessageChannels.reactive(processor);
 	}
 
-	public ReactiveChannelSpec reactive(String id, FluxProcessor<Message<?>, Message<?>> processor) {
+	public FluxMessageChannelSpec reactive(String id, FluxProcessor<Message<?>, Message<?>> processor) {
 		return MessageChannels.reactive(id, processor);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -38,8 +38,8 @@ import org.springframework.integration.aggregator.BarrierMessageHandler;
 import org.springframework.integration.channel.ChannelInterceptorAware;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.FixedSubscriberChannel;
+import org.springframework.integration.channel.FluxMessageChannel;
 import org.springframework.integration.channel.MessageChannelReactiveUtils;
-import org.springframework.integration.channel.ReactiveChannel;
 import org.springframework.integration.channel.interceptor.WireTap;
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.config.SourcePollingChannelAdapterFactoryBean;
@@ -2550,7 +2550,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 				publisher = MessageChannelReactiveUtils.toPublisher(channelForPublisher);
 			}
 			else {
-				MessageChannel reactiveChannel = new ReactiveChannel();
+				MessageChannel reactiveChannel = new FluxMessageChannel();
 				publisher = (Publisher<Message<T>>) reactiveChannel;
 				channel(reactiveChannel);
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
 import org.reactivestreams.Publisher;
 
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.channel.ReactiveChannel;
+import org.springframework.integration.channel.FluxMessageChannel;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.dsl.channel.MessageChannelSpec;
 import org.springframework.integration.dsl.support.FixedSubscriberChannelPrototype;
@@ -35,10 +35,13 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 
+import reactor.core.publisher.Flux;
+
 /**
  * The central factory for fluent {@link IntegrationFlowBuilder} API.
  *
  * @author Artem Bilan
+ * @author Gary Russell
  *
  * @since 5.0
  *
@@ -299,15 +302,15 @@ public final class IntegrationFlows {
 	}
 
 	/**
-	 * Populate a {@link ReactiveChannel} to the {@link IntegrationFlowBuilder} chain
+	 * Populate a {@link FluxMessageChannel} to the {@link IntegrationFlowBuilder} chain
 	 * and subscribe it to the provided {@link Publisher}.
 	 * @param publisher the {@link Publisher} to subscribe to.
 	 * @return new {@link IntegrationFlowBuilder}.
 	 */
-	public static IntegrationFlowBuilder from(Publisher<Message<?>> publisher) {
-		ReactiveChannel reactiveChannel = new ReactiveChannel();
+	public static IntegrationFlowBuilder from(Flux<Message<?>> publisher) {
+		FluxMessageChannel reactiveChannel = new FluxMessageChannel();
 		reactiveChannel.subscribeTo(publisher);
-		return from((MessageChannel) reactiveChannel);
+		return from(reactiveChannel);
 	}
 
 	private static IntegrationFlowBuilder from(MessagingGatewaySupport inboundGateway,

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/FluxMessageChannelSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/FluxMessageChannelSpec.java
@@ -14,19 +14,27 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.channel;
+package org.springframework.integration.dsl.channel;
 
-import org.reactivestreams.Publisher;
-
+import org.springframework.integration.channel.FluxMessageChannel;
 import org.springframework.messaging.Message;
+
+import reactor.core.publisher.FluxProcessor;
 
 /**
  * @author Artem Bilan
+ * @author Gary Russell
  *
  * @since 5.0
  */
-public interface ReactiveSubscribableChannel {
+public class FluxMessageChannelSpec extends MessageChannelSpec<FluxMessageChannelSpec, FluxMessageChannel> {
 
-	void subscribeTo(Publisher<Message<?>> publisher);
+	FluxMessageChannelSpec() {
+		this.channel = new FluxMessageChannel();
+	}
+
+	FluxMessageChannelSpec(FluxProcessor<Message<?>, Message<?>> processor) {
+		this.channel = new FluxMessageChannel(processor);
+	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/MessageChannels.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/MessageChannels.java
@@ -126,19 +126,19 @@ public final class MessageChannels {
 		return MessageChannels.<S>publishSubscribe(executor).id(id);
 	}
 
-	public static ReactiveChannelSpec reactive() {
-		return new ReactiveChannelSpec();
+	public static FluxMessageChannelSpec reactive() {
+		return new FluxMessageChannelSpec();
 	}
 
-	public static ReactiveChannelSpec reactive(String id) {
+	public static FluxMessageChannelSpec reactive(String id) {
 		return reactive().id(id);
 	}
 
-	public static ReactiveChannelSpec reactive(FluxProcessor<Message<?>, Message<?>> processor) {
-		return new ReactiveChannelSpec(processor);
+	public static FluxMessageChannelSpec reactive(FluxProcessor<Message<?>, Message<?>> processor) {
+		return new FluxMessageChannelSpec(processor);
 	}
 
-	public static ReactiveChannelSpec reactive(String id, FluxProcessor<Message<?>, Message<?>> processor) {
+	public static FluxMessageChannelSpec reactive(String id, FluxProcessor<Message<?>, Message<?>> processor) {
 		return reactive(processor).id(id);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.reactivestreams.Publisher;
 
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
-import org.springframework.integration.channel.ReactiveSubscribableChannel;
+import org.springframework.integration.channel.FluxSubscribableChannel;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.routingslip.RoutingSlipRouteStrategy;
@@ -190,7 +190,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 		}
 
 		if (this.async && (reply instanceof ListenableFuture<?> || reply instanceof Publisher<?>)) {
-			if (reply instanceof ListenableFuture<?> || !(getOutputChannel() instanceof ReactiveSubscribableChannel)) {
+			if (reply instanceof ListenableFuture<?> || !(getOutputChannel() instanceof FluxSubscribableChannel)) {
 				ListenableFuture<?> future;
 				if (reply instanceof ListenableFuture<?>) {
 					future = (ListenableFuture<?>) reply;
@@ -235,7 +235,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 				});
 			}
 			else {
-				((ReactiveSubscribableChannel) getOutputChannel())
+				((FluxSubscribableChannel) getOutputChannel())
 						.subscribeTo(Flux.from((Publisher<?>) reply)
 								.map(result -> createOutputMessage(result, requestHeaders)));
 			}

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/FluxMessageChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/FluxMessageChannelTests.java
@@ -36,9 +36,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.channel.FluxMessageChannel;
 import org.springframework.integration.channel.MessageChannelReactiveUtils;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.integration.channel.ReactiveChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -57,10 +57,10 @@ import reactor.core.publisher.Flux;
  */
 @RunWith(SpringRunner.class)
 @DirtiesContext
-public class ReactiveChannelTests {
+public class FluxMessageChannelTests {
 
 	@Autowired
-	private MessageChannel reactiveChannel;
+	private MessageChannel fluxMessageChannel;
 
 	@Autowired
 	private MessageChannel queueChannel;
@@ -69,11 +69,11 @@ public class ReactiveChannelTests {
 	private PollableChannel errorChannel;
 
 	@Test
-	public void testReactiveMessageChannel() throws InterruptedException {
+	public void testFluxMessageChannel() throws InterruptedException {
 		QueueChannel replyChannel = new QueueChannel();
 
 		for (int i = 0; i < 10; i++) {
-			this.reactiveChannel.send(MessageBuilder.withPayload(i).setReplyChannel(replyChannel).build());
+			this.fluxMessageChannel.send(MessageBuilder.withPayload(i).setReplyChannel(replyChannel).build());
 		}
 
 		for (int i = 0; i < 9; i++) {
@@ -116,11 +116,11 @@ public class ReactiveChannelTests {
 		}
 
 		@Bean
-		public MessageChannel reactiveChannel() {
-			return new ReactiveChannel();
+		public MessageChannel fluxMessageChannel() {
+			return new FluxMessageChannel();
 		}
 
-		@ServiceActivator(inputChannel = "reactiveChannel")
+		@ServiceActivator(inputChannel = "fluxMessageChannel")
 		public String handle(int payload) {
 			if (payload == 5) {
 				throw new IllegalStateException("intentional");

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveConsumerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveConsumerTests.java
@@ -47,7 +47,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.integration.channel.ReactiveChannel;
+import org.springframework.integration.channel.FluxMessageChannel;
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.endpoint.ReactiveConsumer;
 import org.springframework.integration.handler.MethodInvokingMessageHandler;
@@ -67,7 +67,7 @@ public class ReactiveConsumerTests {
 
 	@Test
 	public void testReactiveConsumerReactiveChannel() throws InterruptedException {
-		ReactiveChannel testChannel = new ReactiveChannel(EmitterProcessor.create(false));
+		FluxMessageChannel testChannel = new FluxMessageChannel(EmitterProcessor.create(false));
 
 		List<Message<?>> result = new LinkedList<>();
 		CountDownLatch stopLatch = new CountDownLatch(2);
@@ -224,7 +224,7 @@ public class ReactiveConsumerTests {
 
 	@Test
 	public void testReactiveConsumerViaConsumerEndpointFactoryBean() throws Exception {
-		ReactiveChannel testChannel = new ReactiveChannel();
+		FluxMessageChannel testChannel = new FluxMessageChannel();
 
 		List<Message<?>> result = new LinkedList<>();
 		CountDownLatch stopLatch = new CountDownLatch(3);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/ReactiveHttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/ReactiveHttpRequestExecutingMessageHandlerTests.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.integration.channel.ReactiveChannel;
+import org.springframework.integration.channel.FluxMessageChannel;
 import org.springframework.integration.http.HttpHeaders;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
@@ -63,7 +63,7 @@ public class ReactiveHttpRequestExecutingMessageHandlerTests {
 		ReactiveHttpRequestExecutingMessageHandler reactiveHandler =
 				new ReactiveHttpRequestExecutingMessageHandler(destinationUri, webClient);
 
-		ReactiveChannel ackChannel = new ReactiveChannel();
+		FluxMessageChannel ackChannel = new FluxMessageChannel();
 		reactiveHandler.setOutputChannel(ackChannel);
 		reactiveHandler.handleMessage(MessageBuilder.withPayload("hello, world").build());
 


### PR DESCRIPTION
- as discussed last week

TODO:
- should we take the channel outside of the `AbstractMessageChannel` hierarchy?
  - avoid blocking interceptors
  - we would lose channel metrics though
- rename `ReactiveConsumer` ?