### PR TITLE
INT-4267: Add JSON (De)Serializers for Messaging

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/message/AdviceMessage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/message/AdviceMessage.java
@@ -19,6 +19,7 @@ package org.springframework.integration.message;
 import java.util.Map;
 
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.GenericMessage;
 
 /**
@@ -45,6 +46,20 @@ public class AdviceMessage<T> extends GenericMessage<T> {
 	}
 
 	public AdviceMessage(T payload, Map<String, Object> headers, Message<?> inputMessage) {
+		super(payload, headers);
+		this.inputMessage = inputMessage;
+	}
+
+	/**
+	 * A constructor with the {@link MessageHeaders} instance to use.
+	 * <p><strong>Note:</strong> the given {@code MessageHeaders} instance is used
+	 * directly in the new message, i.e. it is not copied.
+	 * @param payload the message payload (never {@code null})
+	 * @param headers message headers
+	 * @param inputMessage the input message for advice.
+	 * @since 4.3.10
+	 */
+	public AdviceMessage(T payload, MessageHeaders headers, Message<?> inputMessage) {
 		super(payload, headers);
 		this.inputMessage = inputMessage;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.store;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -50,7 +51,7 @@ public class MessageGroupMetadata implements Serializable {
 	private volatile int lastReleasedMessageSequenceNumber;
 
 	private MessageGroupMetadata() {
-		//For Jackson
+		//For Jackson deserialization
 	}
 
 	public MessageGroupMetadata(MessageGroup messageGroup) {
@@ -92,7 +93,7 @@ public class MessageGroupMetadata implements Serializable {
 	}
 
 	public List<UUID> getMessageIds() {
-		return this.messageIds;
+		return Collections.unmodifiableList(this.messageIds);
 	}
 
 	void complete() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
@@ -31,17 +31,17 @@ import org.springframework.util.Assert;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Laszlo Szabo
+ *
  * @since 2.1
  */
 public class MessageGroupMetadata implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final Object groupId;
+	private List<UUID> messageIds = new LinkedList<UUID>();
 
-	private final List<UUID> messageIds = new LinkedList<UUID>();
-
-	private final long timestamp;
+	private long timestamp;
 
 	private volatile boolean complete;
 
@@ -49,9 +49,12 @@ public class MessageGroupMetadata implements Serializable {
 
 	private volatile int lastReleasedMessageSequenceNumber;
 
+	private MessageGroupMetadata() {
+		//For Jackson
+	}
+
 	public MessageGroupMetadata(MessageGroup messageGroup) {
 		Assert.notNull(messageGroup, "'messageGroup' must not be null");
-		this.groupId = messageGroup.getGroupId();
 		for (Message<?> message : messageGroup.getMessages()) {
 			this.messageIds.add(message.getHeaders().getId());
 		}
@@ -73,10 +76,6 @@ public class MessageGroupMetadata implements Serializable {
 		this.lastModified = lastModified;
 	}
 
-	public Object getGroupId() {
-		return this.groupId;
-	}
-
 	public Iterator<UUID> messageIdIterator() {
 		return this.messageIds.iterator();
 	}
@@ -90,6 +89,10 @@ public class MessageGroupMetadata implements Serializable {
 			return this.messageIds.get(0);
 		}
 		return null;
+	}
+
+	public List<UUID> getMessageIds() {
+		return this.messageIds;
 	}
 
 	void complete() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageHolder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageHolder.java
@@ -31,9 +31,13 @@ public class MessageHolder implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final Message<?> message;
+	private Message<?> message;
 
-	private final MessageMetadata messageMetadata;
+	private MessageMetadata messageMetadata;
+
+	private MessageHolder() {
+		//For Jackson
+	}
 
 	public MessageHolder(Message<?> message) {
 		Assert.notNull(message, "'message' must not be null.");

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageHolder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.util.Assert;
  * The {@link MessageStore} specific value object to keep the {@link Message} and its metadata.
  *
  * @author Artem Bilan
+ *
  * @since 5.0
  */
 public class MessageHolder implements Serializable {
@@ -36,7 +37,7 @@ public class MessageHolder implements Serializable {
 	private MessageMetadata messageMetadata;
 
 	private MessageHolder() {
-		//For Jackson
+		//For Jackson deserialization
 	}
 
 	public MessageHolder(Message<?> message) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageMetadata.java
@@ -29,9 +29,13 @@ public class MessageMetadata implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final UUID messageId;
+	private UUID messageId;
 
 	private long timestamp;
+
+	private MessageMetadata() {
+		//For Jackson
+	}
 
 	public MessageMetadata(UUID messageId) {
 		this.messageId = messageId;

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.UUID;
  * Value Object holding metadata about a Message in the MessageStore.
  *
  * @author Artem Bilan
+ *
  * @since 5.0
  */
 public class MessageMetadata implements Serializable {
@@ -31,10 +32,10 @@ public class MessageMetadata implements Serializable {
 
 	private UUID messageId;
 
-	private long timestamp;
+	private volatile long timestamp;
 
 	private MessageMetadata() {
-		//For Jackson
+		//For Jackson deserialization
 	}
 
 	public MessageMetadata(UUID messageId) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/AdviceMessageJacksonDeserializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/AdviceMessageJacksonDeserializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support.json;
+
+import java.io.IOException;
+
+import org.springframework.integration.message.AdviceMessage;
+import org.springframework.integration.support.MutableMessageHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.util.ClassUtils;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * The {@link MessageJacksonDeserializer} implementation for the {@link AdviceMessage}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.0
+ */
+public class AdviceMessageJacksonDeserializer extends MessageJacksonDeserializer<AdviceMessage<?>> {
+
+	private static final long serialVersionUID = 1L;
+
+	@SuppressWarnings("unchecked")
+	public AdviceMessageJacksonDeserializer() {
+		super((Class<AdviceMessage<?>>) ClassUtils.getUserClass(AdviceMessage.class));
+	}
+
+	@Override
+	protected AdviceMessage<?> buildMessage(MutableMessageHeaders headers, Object payload, JsonNode root,
+			DeserializationContext ctxt) throws IOException {
+		Message<?> inputMessage = getMapper().readValue(root.get("inputMessage").traverse(), Message.class);
+		return new AdviceMessage<Object>(payload, (MessageHeaders) headers, inputMessage);
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/AdviceMessageJacksonDeserializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/AdviceMessageJacksonDeserializer.java
@@ -22,7 +22,6 @@ import org.springframework.integration.message.AdviceMessage;
 import org.springframework.integration.support.MutableMessageHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
-import org.springframework.util.ClassUtils;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -32,7 +31,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  *
  * @author Artem Bilan
  *
- * @since 5.0
+ * @since 4.3.10
  */
 public class AdviceMessageJacksonDeserializer extends MessageJacksonDeserializer<AdviceMessage<?>> {
 
@@ -40,7 +39,7 @@ public class AdviceMessageJacksonDeserializer extends MessageJacksonDeserializer
 
 	@SuppressWarnings("unchecked")
 	public AdviceMessageJacksonDeserializer() {
-		super((Class<AdviceMessage<?>>) ClassUtils.getUserClass(AdviceMessage.class));
+		super((Class<AdviceMessage<?>>) (Class<?>) AdviceMessage.class);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/ErrorMessageJacksonDeserializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/ErrorMessageJacksonDeserializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support.json;
+
+import java.io.IOException;
+
+import org.springframework.integration.support.MutableMessageHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.ErrorMessage;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+/**
+ * The {@link MessageJacksonDeserializer} implementation for the {@link ErrorMessage}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.0
+ */
+public class ErrorMessageJacksonDeserializer extends MessageJacksonDeserializer<ErrorMessage> {
+
+	private static final long serialVersionUID = 1L;
+
+	public ErrorMessageJacksonDeserializer() {
+		super(ErrorMessage.class);
+		setPayloadType(TypeFactory.defaultInstance().constructType(Throwable.class));
+	}
+
+	@Override
+	protected ErrorMessage buildMessage(MutableMessageHeaders headers, Object payload, JsonNode root,
+			DeserializationContext ctxt) throws IOException {
+		Message<?> originalMessage = getMapper().readValue(root.get("originalMessage").traverse(), Message.class);
+		return new ErrorMessage((Throwable) payload, headers, originalMessage);
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/ErrorMessageJacksonDeserializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/ErrorMessageJacksonDeserializer.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
  *
  * @author Artem Bilan
  *
- * @since 5.0
+ * @since 4.3.10
  */
 public class ErrorMessageJacksonDeserializer extends MessageJacksonDeserializer<ErrorMessage> {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/GenericMessageJacksonDeserializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/GenericMessageJacksonDeserializer.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 
 import org.springframework.integration.support.MutableMessageHeaders;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.util.ClassUtils;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -30,7 +29,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  *
  * @author Artem Bilan
  *
- * @since 5.0
+ * @since 4.3.10
  */
 public class GenericMessageJacksonDeserializer extends MessageJacksonDeserializer<GenericMessage<?>> {
 
@@ -38,7 +37,7 @@ public class GenericMessageJacksonDeserializer extends MessageJacksonDeserialize
 
 	@SuppressWarnings("unchecked")
 	public GenericMessageJacksonDeserializer() {
-		super((Class<GenericMessage<?>>) ClassUtils.getUserClass(GenericMessage.class));
+		super((Class<GenericMessage<?>>) (Class<?>) GenericMessage.class);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/GenericMessageJacksonDeserializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/GenericMessageJacksonDeserializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support.json;
+
+import java.io.IOException;
+
+import org.springframework.integration.support.MutableMessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.util.ClassUtils;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * The {@link MessageJacksonDeserializer} implementation for the {@link GenericMessage}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.0
+ */
+public class GenericMessageJacksonDeserializer extends MessageJacksonDeserializer<GenericMessage<?>> {
+
+	private static final long serialVersionUID = 1L;
+
+	@SuppressWarnings("unchecked")
+	public GenericMessageJacksonDeserializer() {
+		super((Class<GenericMessage<?>>) ClassUtils.getUserClass(GenericMessage.class));
+	}
+
+	@Override
+	protected GenericMessage<?> buildMessage(MutableMessageHeaders headers, Object payload, JsonNode root,
+			DeserializationContext ctxt) throws IOException {
+		return new GenericMessage<Object>(payload, headers);
+	}
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapperProvider.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapperProvider.java
@@ -17,17 +17,7 @@
 package org.springframework.integration.support.json;
 
 
-import org.springframework.integration.message.AdviceMessage;
-import org.springframework.integration.support.MutableMessage;
-import org.springframework.messaging.support.ErrorMessage;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.ClassUtils;
-
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 
 /**
  * Simple factory to provide {@linkplain JsonObjectMapper}
@@ -77,46 +67,6 @@ public final class JsonObjectMapperProvider {
 	 */
 	public static boolean jsonAvailable() {
 		return JacksonJsonUtils.isJackson2Present() || boonPresent;
-	}
-
-	/**
-	 * Return an {@link ObjectMapper} if available,
-	 * supplied with Message specific serializers and deserializers.
-	 * Also configured to store typo info in the {@code @class} property.
-	 * @return the mapper.
-	 * @throws IllegalStateException if an implementation is not available.
-	 */
-	public static ObjectMapper jacksonMessageAwareMapper() {
-		if (JacksonJsonUtils.isJackson2Present()) {
-			ObjectMapper mapper = new ObjectMapper();
-			mapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
-			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-			mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
-
-			GenericMessageJacksonDeserializer genericMessageDeserializer = new GenericMessageJacksonDeserializer();
-			genericMessageDeserializer.setMapper(mapper);
-
-			ErrorMessageJacksonDeserializer errorMessageDeserializer = new ErrorMessageJacksonDeserializer();
-			errorMessageDeserializer.setMapper(mapper);
-
-			AdviceMessageJacksonDeserializer adviceMessageDeserializer = new AdviceMessageJacksonDeserializer();
-			adviceMessageDeserializer.setMapper(mapper);
-
-			MutableMessageJacksonDeserializer mutableMessageDeserializer = new MutableMessageJacksonDeserializer();
-			mutableMessageDeserializer.setMapper(mapper);
-
-			mapper.registerModule(new SimpleModule()
-					.addSerializer(new MessageHeadersJacksonSerializer())
-					.addDeserializer(GenericMessage.class, genericMessageDeserializer)
-					.addDeserializer(ErrorMessage.class, errorMessageDeserializer)
-					.addDeserializer(AdviceMessage.class, adviceMessageDeserializer)
-					.addDeserializer(MutableMessage.class, mutableMessageDeserializer)
-			);
-			return mapper;
-		}
-		else {
-			throw new IllegalStateException("No jackson-databind.jar is present in the classpath.");
-		}
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapperProvider.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapperProvider.java
@@ -17,7 +17,17 @@
 package org.springframework.integration.support.json;
 
 
+import org.springframework.integration.message.AdviceMessage;
+import org.springframework.integration.support.MutableMessage;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.ClassUtils;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 /**
  * Simple factory to provide {@linkplain JsonObjectMapper}
@@ -67,6 +77,46 @@ public final class JsonObjectMapperProvider {
 	 */
 	public static boolean jsonAvailable() {
 		return JacksonJsonUtils.isJackson2Present() || boonPresent;
+	}
+
+	/**
+	 * Return an {@link ObjectMapper} if available,
+	 * supplied with Message specific serializers and deserializers.
+	 * Also configured to store typo info in the {@code @class} property.
+	 * @return the mapper.
+	 * @throws IllegalStateException if an implementation is not available.
+	 */
+	public static ObjectMapper jacksonMessageAwareMapper() {
+		if (JacksonJsonUtils.isJackson2Present()) {
+			ObjectMapper mapper = new ObjectMapper();
+			mapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
+			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+
+			GenericMessageJacksonDeserializer genericMessageDeserializer = new GenericMessageJacksonDeserializer();
+			genericMessageDeserializer.setMapper(mapper);
+
+			ErrorMessageJacksonDeserializer errorMessageDeserializer = new ErrorMessageJacksonDeserializer();
+			errorMessageDeserializer.setMapper(mapper);
+
+			AdviceMessageJacksonDeserializer adviceMessageDeserializer = new AdviceMessageJacksonDeserializer();
+			adviceMessageDeserializer.setMapper(mapper);
+
+			MutableMessageJacksonDeserializer mutableMessageDeserializer = new MutableMessageJacksonDeserializer();
+			mutableMessageDeserializer.setMapper(mapper);
+
+			mapper.registerModule(new SimpleModule()
+					.addSerializer(new MessageHeadersJacksonSerializer())
+					.addDeserializer(GenericMessage.class, genericMessageDeserializer)
+					.addDeserializer(ErrorMessage.class, errorMessageDeserializer)
+					.addDeserializer(AdviceMessage.class, adviceMessageDeserializer)
+					.addDeserializer(MutableMessage.class, mutableMessageDeserializer)
+			);
+			return mapper;
+		}
+		else {
+			throw new IllegalStateException("No jackson-databind.jar is present in the classpath.");
+		}
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/MessageHeadersJacksonSerializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/MessageHeadersJacksonSerializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support.json;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.springframework.messaging.MessageHeaders;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * A Jackson {@link StdSerializer} implementation to serialize {@link MessageHeaders}
+ * as a {@link HashMap}.
+ * <p>
+ * This technique is much reliable during deserialization, especially when the
+ * {@code typeId} property is used to store the type.
+ *
+ * @author Artem Bilan
+ *
+ * @since 4.3.10
+ */
+public class MessageHeadersJacksonSerializer extends StdSerializer<MessageHeaders> {
+
+	private static final long serialVersionUID = 1L;
+
+	public MessageHeadersJacksonSerializer() {
+		super(MessageHeaders.class);
+	}
+
+	@Override
+	public void serializeWithType(MessageHeaders value, JsonGenerator gen, SerializerProvider serializers,
+			TypeSerializer typeSer) throws IOException {
+		serialize(value, gen, serializers);
+	}
+
+	@Override
+	public void serialize(MessageHeaders value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+		gen.writeObject(new HashMap<String, Object>(value));
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/MessageJacksonDeserializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/MessageJacksonDeserializer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support.json;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.integration.support.MutableMessageHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdNodeBasedDeserializer;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+/**
+ * A Jackson {@link StdNodeBasedDeserializer} extension for {@link Message} implementations.
+ *
+ * @author Artem Bilan
+ *
+ * @since 4.3.10
+ */
+public abstract class MessageJacksonDeserializer<T extends Message<?>> extends StdNodeBasedDeserializer<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private JavaType payloadType = TypeFactory.defaultInstance().constructType(Object.class);
+
+	private ObjectMapper mapper = new ObjectMapper();
+
+	protected MessageJacksonDeserializer(Class<T> targetType) {
+		super(targetType);
+		this.mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+	}
+
+	public void setMapper(ObjectMapper mapper) {
+		Assert.notNull(mapper, "'mapper' must not be null");
+		this.mapper = mapper;
+	}
+
+	protected final void setPayloadType(JavaType payloadType) {
+		Assert.notNull(payloadType, "'payloadType' must not be null");
+		this.payloadType = payloadType;
+	}
+
+	protected ObjectMapper getMapper() {
+		return this.mapper;
+	}
+
+	@Override
+	public T convert(JsonNode root, DeserializationContext ctxt) throws IOException {
+		Map<String, Object> headers = this.mapper.readValue(root.get("headers").traverse(),
+				TypeFactory.defaultInstance().constructMapType(HashMap.class, String.class, Object.class));
+		Object payload = this.mapper.readValue(root.get("payload").traverse(), this.payloadType);
+		return buildMessage(new MutableMessageHeaders(headers), payload, root, ctxt);
+	}
+
+	protected abstract T buildMessage(MutableMessageHeaders headers, Object payload, JsonNode root,
+			DeserializationContext ctxt) throws IOException;
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/MutableMessageJacksonDeserializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/MutableMessageJacksonDeserializer.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 
 import org.springframework.integration.support.MutableMessage;
 import org.springframework.integration.support.MutableMessageHeaders;
-import org.springframework.util.ClassUtils;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -30,7 +29,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  *
  * @author Artem Bilan
  *
- * @since 5.0
+ * @since 4.3.10
  */
 public class MutableMessageJacksonDeserializer extends MessageJacksonDeserializer<MutableMessage<?>> {
 
@@ -38,7 +37,7 @@ public class MutableMessageJacksonDeserializer extends MessageJacksonDeserialize
 
 	@SuppressWarnings("unchecked")
 	public MutableMessageJacksonDeserializer() {
-		super((Class<MutableMessage<?>>) ClassUtils.getUserClass(MutableMessage.class));
+		super((Class<MutableMessage<?>>) (Class<?>) MutableMessage.class);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/MutableMessageJacksonDeserializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/MutableMessageJacksonDeserializer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support.json;
+
+import java.io.IOException;
+
+import org.springframework.integration.support.MutableMessage;
+import org.springframework.integration.support.MutableMessageHeaders;
+import org.springframework.util.ClassUtils;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * The {@link MessageJacksonDeserializer} implementation for the {@link MutableMessage}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.0
+ */
+public class MutableMessageJacksonDeserializer extends MessageJacksonDeserializer<MutableMessage<?>> {
+
+	private static final long serialVersionUID = 1L;
+
+	@SuppressWarnings("unchecked")
+	public MutableMessageJacksonDeserializer() {
+		super((Class<MutableMessage<?>>) ClassUtils.getUserClass(MutableMessage.class));
+	}
+
+	@Override
+	protected MutableMessage<?> buildMessage(MutableMessageHeaders headers, Object payload, JsonNode root,
+			DeserializationContext ctxt) throws IOException {
+		return new MutableMessage<Object>(payload, headers);
+	}
+
+}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
@@ -53,7 +53,7 @@ import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.MutableMessage;
-import org.springframework.integration.support.json.JsonObjectMapperProvider;
+import org.springframework.integration.support.json.JacksonJsonUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ErrorMessage;
@@ -429,7 +429,7 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 		RedisConnectionFactory jcf = getConnectionFactoryForTest();
 		RedisMessageStore store = new RedisMessageStore(jcf);
 
-		ObjectMapper mapper = JsonObjectMapperProvider.jacksonMessageAwareMapper();
+		ObjectMapper mapper = JacksonJsonUtils.messagingAwareMapper();
 
 		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(mapper);
 		store.setValueSerializer(serializer);

--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -319,7 +319,7 @@ Handling these events using an `<int-event:inbound-channel-adapter/>` can be use
 
 As described in EIP, a http://www.eaipatterns.com/MessageStore.html[Message Store] allows you to persist Messages.
 This can be very useful when dealing with components that have a capability to buffer messages (_Aggregator, Resequencer_, etc.) if reliability is a concern.
-In Spring Integration, the MessageStore strategy also provides the foundation for thehttp://www.eaipatterns.com/StoreInLibrary.html[ClaimCheck] pattern, which is described in EIP as well.
+In Spring Integration, the MessageStore strategy also provides the foundation for the http://www.eaipatterns.com/StoreInLibrary.html[ClaimCheck] pattern, which is described in EIP as well.
 
 Spring Integration's Redis module provides the `RedisMessageStore`.
 
@@ -338,6 +338,21 @@ As you can see it is a simple bean configuration, and it expects a `RedisConnect
 
 By default the `RedisMessageStore` will use Java serialization to serialize the Message.
 However if you want to use a different serialization technique (e.g., JSON), you can provide your own serializer via the `valueSerializer` property of the `RedisMessageStore`.
+
+Starting with _version 4.3.10_, the Framework provides Jackson Serializer and Deserializer implementations for `Message`s and `MessageHeaders` - `MessageHeadersJacksonSerializer` and `MessageJacksonDeserializer` hierarchy, respectively.
+They has to be configured via `SimpleModule` options for the `ObjectMapper`.
+In addition the `enableDefaultTyping` should be configured on the `ObjectMapper` to add type information for each serialized complex object.
+That type information is unequivocally used during deserialization.
+To avoid such a boilerplate codding, the Framework suggest utility as of `JacksonJsonUtils.messagingAwareMapper()`, which is already supplied with all mentioned above properties and serializers.
+To manage JSON serialization in the `RedisMessageStore`, it must be then configured like:
+
+[source,java]
+----
+RedisMessageStore store = new RedisMessageStore(jedisConnectionFactory);
+ObjectMapper mapper = JacksonJsonUtils.messagingAwareMapper();
+RedisSerializer<Object> serializer = new GenericJackson2JsonRedisSerializer(mapper);
+store.setValueSerializer(serializer);
+----
 
 [[redis-cms]]
 ==== Redis Channel Message Stores


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4267
Fixes: spring-projects/spring-integration#2110

The documentation clearly point that we can simply use JSON (de)serialization
with the `RedisMessageStore`, but actually it isn't so easy

* Fix `MessageGroupMetadata`, `MessageHolder`, `MessageMetadata` for Jackson
deserialization compatibility
* Add `MessageHeaders`-based ctor to the `AdviceMessage`
* Add `MessageHeadersJacksonSerializer` to serialize `MessageHeaders`
to the `HashMap` for easier deserialization afterwards
* Add deserializer implementations for all `Message` types
* Add convenient `JsonObjectMapperProvider#jacksonMessageAwareMapper()`
factory method to build `ObjectMapper` supplied with mentioned above
(de)serializers

**Cherry-pick to 4.3.10 without `MessageHolder` and `MessageMetadata`**