### PR TITLE
INT-4259: ACorrelationMH: WARN group reschedule

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -519,9 +519,9 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 								processForceRelease(groupId);
 							}
 							catch (MessageDeliveryException e) {
-								if (AbstractCorrelatingMessageHandler.this.logger.isDebugEnabled()) {
-									AbstractCorrelatingMessageHandler.this.logger.debug("The MessageGroup [ "
-											+ groupId + "] is rescheduled by the reason: " + e.getMessage());
+								if (AbstractCorrelatingMessageHandler.this.logger.isWarnEnabled()) {
+									AbstractCorrelatingMessageHandler.this.logger.warn("The MessageGroup ["
+											+ groupId + "] is rescheduled by the reason of:", e);
 								}
 								scheduleGroupToForceComplete(groupId);
 							}
@@ -825,7 +825,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 				}
 				return messageSequenceSize.equals(getSequenceSize())
 						&& !(this.sourceGroup != null ? this.sourceGroup.containsSequence(messageSequenceNumber)
-								: containsSequenceNumber(this.getMessages(), messageSequenceNumber));
+						: containsSequenceNumber(this.getMessages(), messageSequenceNumber));
 			}
 			return true;
 		}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4259

Since DEBUG can switched off for the application, it becomes difficult
to determine the wrong configuration for the discard flow from
the scheduler thread.

* Change logging level to the `WARN` and log the full stack-trace as well
to give more information about the reason of rescheduling group for
`forceComplete`

**Cherry-pick to 4.3.x**