### PR TITLE
INT-4270: Make MessageChannels CGLib-Compatible

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,8 +98,8 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 		admin.declareQueue(this.queue);
 		this.binding = BindingBuilder.bind(this.queue).to(this.exchange);
 		admin.declareBinding(this.binding);
-		if (!this.initialized && this.getAmqpTemplate() instanceof RabbitTemplate) {
-			ConnectionFactory connectionFactory = this.getConnectionFactory();
+		if (!this.initialized && getAmqpTemplate() instanceof RabbitTemplate) {
+			ConnectionFactory connectionFactory = getConnectionFactory();
 			if (connectionFactory != null) {
 				connectionFactory.addConnectionListener(this);
 			}
@@ -108,9 +108,9 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 		return this.queue.getName();
 	}
 
-	private void doDeclares() {
-		if (this.isRunning()) {
-			AmqpAdmin admin = this.getAdmin();
+	protected void doDeclares() {
+		if (isRunning()) {
+			AmqpAdmin admin = getAdmin();
 			if (admin != null) {
 				if (this.queue != null) {
 					admin.declareQueue(this.queue);
@@ -125,7 +125,7 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 	@Override
 	protected AbstractDispatcher createDispatcher() {
 		BroadcastingDispatcher broadcastingDispatcher = new BroadcastingDispatcher(true);
-		broadcastingDispatcher.setBeanFactory(this.getBeanFactory());
+		broadcastingDispatcher.setBeanFactory(getBeanFactory());
 		return broadcastingDispatcher;
 	}
 
@@ -137,15 +137,15 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 	@Override
 	public void destroy() throws Exception {
 		super.destroy();
-		if (this.getConnectionFactory() != null) {
-			this.getConnectionFactory().removeConnectionListener(this);
+		if (getConnectionFactory() != null) {
+			getConnectionFactory().removeConnectionListener(this);
 			this.initialized = false;
 		}
 	}
 
 	@Override
 	public void start() {
-		this.doDeclares(); // connection may have been lost while we were stopped
+		doDeclares(); // connection may have been lost while we were stopped
 		super.start();
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -369,7 +369,7 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 	 * <code>false</code> if the sending thread is interrupted.
 	 */
 	@Override
-	public final boolean send(Message<?> message) {
+	public boolean send(Message<?> message) {
 		return this.send(message, -1);
 	}
 
@@ -388,7 +388,7 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 	 * time or the sending thread is interrupted.
 	 */
 	@Override
-	public final boolean send(Message<?> message, long timeout) {
+	public boolean send(Message<?> message, long timeout) {
 		Assert.notNull(message, "message must not be null");
 		Assert.notNull(message.getPayload(), "message payload must not be null");
 		if (this.shouldTrack) {
@@ -450,7 +450,7 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 		}
 	}
 
-	private Message<?> convertPayloadIfNecessary(Message<?> message) {
+	protected Message<?> convertPayloadIfNecessary(Message<?> message) {
 		// first pass checks if the payload type already matches any of the datatypes
 		for (Class<?> datatype : this.datatypes) {
 			if (datatype.isAssignableFrom(message.getPayload().getClass())) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractPollableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractPollableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public abstract class AbstractPollableChannel extends AbstractMessageChannel
 	 * receiving thread is interrupted.
 	 */
 	@Override
-	public final Message<?> receive() {
+	public Message<?> receive() {
 		return receive(-1);
 	}
 
@@ -86,7 +86,7 @@ public abstract class AbstractPollableChannel extends AbstractMessageChannel
 	 * interrupted.
 	 */
 	@Override
-	public final Message<?> receive(long timeout) {
+	public Message<?> receive(long timeout) {
 		ChannelInterceptorList interceptorList = getInterceptors();
 		Deque<ChannelInterceptor> interceptorStack = null;
 		boolean counted = false;

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractSubscribableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractSubscribableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public abstract class AbstractSubscribableChannel extends AbstractMessageChannel
 		return removed;
 	}
 
-	private void adjustCounterIfNecessary(MessageDispatcher dispatcher, int delta) {
+	protected void adjustCounterIfNecessary(MessageDispatcher dispatcher, int delta) {
 		if (delta != 0) {
 			if (logger.isInfoEnabled()) {
 				logger.info("Channel '" + this.getFullChannelName() + "' has " + dispatcher.getHandlerCount()
@@ -78,7 +78,7 @@ public abstract class AbstractSubscribableChannel extends AbstractMessageChannel
 		}
 	}
 
-	private MessageDispatcher getRequiredDispatcher() {
+	protected MessageDispatcher getRequiredDispatcher() {
 		MessageDispatcher dispatcher = getDispatcher();
 		Assert.state(dispatcher != null, "'dispatcher' must not be null");
 		return dispatcher;

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/FluxMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/FluxMessageChannel.java
@@ -89,7 +89,7 @@ public class FluxMessageChannel extends AbstractMessageChannel
 		}
 	}
 
-	private void doSubscribeTo(Publisher<Message<?>> publisher) {
+	protected void doSubscribeTo(Publisher<Message<?>> publisher) {
 		Flux.from(publisher)
 				.doOnSubscribe(s -> FluxMessageChannel.this.upstreamSubscribed = true)
 				.doOnComplete(() -> {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/AbstractJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/AbstractJmsChannel.java
@@ -38,7 +38,7 @@ public abstract class AbstractJmsChannel extends AbstractMessageChannel {
 	}
 
 
-	JmsTemplate getJmsTemplate() {
+	protected JmsTemplate getJmsTemplate() {
 		return this.jmsTemplate;
 	}
 

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public class SubscribableJmsChannel extends AbstractJmsChannel implements Subscr
 		this.initialized = true;
 	}
 
-	private void configureDispatcher(boolean isPubSub) {
+	protected void configureDispatcher(boolean isPubSub) {
 		if (isPubSub) {
 			BroadcastingDispatcher broadcastingDispatcher = new BroadcastingDispatcher(true);
 			broadcastingDispatcher.setBeanFactory(this.getBeanFactory());


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4270

Remove `final` modifiers from channel methods and make `private` methods `protected`.

Since Spring Boot 2.0 now uses `proxyTargetClass=true` by default (and has done that for
transactional proxies since 1.4), we must relax these restrictions so that CGLib can
proxy channels (which is often done to make subflows run in a transaction).

__cherry-pick to 4.3.x__