### PR TITLE
Fix `FluxMessageChannel` for multi sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 	}
 	dependencies {
 		classpath 'io.spring.gradle:dependency-management-plugin:1.0.2.RELEASE'
-		classpath 'io.spring.gradle:spring-io-plugin:0.0.6.RELEASE'
+		classpath 'io.spring.gradle:spring-io-plugin:0.0.7.RELEASE'
 		classpath 'io.spring.gradle:docbook-reference-plugin:0.3.1'
 		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.0'
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/ReactiveStreamsSubscribableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/ReactiveStreamsSubscribableChannel.java
@@ -16,9 +16,9 @@
 
 package org.springframework.integration.channel;
 
-import org.springframework.messaging.Message;
+import org.reactivestreams.Publisher;
 
-import reactor.core.publisher.Flux;
+import org.springframework.messaging.Message;
 
 /**
  * @author Artem Bilan
@@ -26,8 +26,8 @@ import reactor.core.publisher.Flux;
  *
  * @since 5.0
  */
-public interface FluxSubscribableChannel {
+public interface ReactiveStreamsSubscribableChannel {
 
-	void subscribeTo(Flux<Message<?>> publisher);
+	void subscribeTo(Publisher<Message<?>> publisher);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
@@ -39,7 +39,7 @@ import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.endpoint.PollingConsumer;
-import org.springframework.integration.endpoint.ReactiveConsumer;
+import org.springframework.integration.endpoint.ReactiveStreamsConsumer;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.advice.HandleMessageAdvice;
 import org.springframework.integration.scheduling.PollerMetadata;
@@ -286,7 +286,7 @@ public class ConsumerEndpointFactoryBean
 				this.endpoint = pollingConsumer;
 			}
 			else {
-				this.endpoint = new ReactiveConsumer(channel, this.handler);
+				this.endpoint = new ReactiveStreamsConsumer(channel, this.handler);
 			}
 			this.endpoint.setBeanName(this.beanName);
 			this.endpoint.setBeanFactory(this.beanFactory);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -55,7 +55,7 @@ import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.endpoint.AbstractPollingEndpoint;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.endpoint.PollingConsumer;
-import org.springframework.integration.endpoint.ReactiveConsumer;
+import org.springframework.integration.endpoint.ReactiveStreamsConsumer;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.handler.AbstractMessageProducingHandler;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
@@ -321,7 +321,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 			Assert.state(ObjectUtils.isEmpty(pollers), "A '@Poller' should not be specified for Annotation-based " +
 					"endpoint, since '" + inputChannel + "' is a SubscribableChannel (not pollable).");
 			if (inputChannel instanceof Publisher) {
-				endpoint = new ReactiveConsumer(inputChannel, handler);
+				endpoint = new ReactiveStreamsConsumer(inputChannel, handler);
 			}
 			else {
 				endpoint = new EventDrivenConsumer((SubscribableChannel) inputChannel, handler);

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/Channels.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/Channels.java
@@ -31,8 +31,6 @@ import org.springframework.integration.store.ChannelMessageStore;
 import org.springframework.integration.store.PriorityCapableChannelMessageStore;
 import org.springframework.messaging.Message;
 
-import reactor.core.publisher.FluxProcessor;
-
 /**
  * @author Artem Bilan
  * @author Gary Russell
@@ -138,14 +136,6 @@ public class Channels {
 
 	public FluxMessageChannelSpec flux(String id) {
 		return MessageChannels.flux(id);
-	}
-
-	public FluxMessageChannelSpec flux(FluxProcessor<Message<?>, Message<?>> processor) {
-		return MessageChannels.flux(processor);
-	}
-
-	public FluxMessageChannelSpec flux(String id, FluxProcessor<Message<?>, Message<?>> processor) {
-		return MessageChannels.flux(id, processor);
 	}
 
 	Channels() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
@@ -35,8 +35,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 
-import reactor.core.publisher.Flux;
-
 /**
  * The central factory for fluent {@link IntegrationFlowBuilder} API.
  *
@@ -307,10 +305,10 @@ public final class IntegrationFlows {
 	 * @param publisher the {@link Publisher} to subscribe to.
 	 * @return new {@link IntegrationFlowBuilder}.
 	 */
-	public static IntegrationFlowBuilder from(Flux<Message<?>> publisher) {
+	public static IntegrationFlowBuilder from(Publisher<Message<?>> publisher) {
 		FluxMessageChannel reactiveChannel = new FluxMessageChannel();
 		reactiveChannel.subscribeTo(publisher);
-		return from(reactiveChannel);
+		return from((MessageChannel) reactiveChannel);
 	}
 
 	private static IntegrationFlowBuilder from(MessagingGatewaySupport inboundGateway,

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/FluxMessageChannelSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/FluxMessageChannelSpec.java
@@ -17,9 +17,6 @@
 package org.springframework.integration.dsl.channel;
 
 import org.springframework.integration.channel.FluxMessageChannel;
-import org.springframework.messaging.Message;
-
-import reactor.core.publisher.FluxProcessor;
 
 /**
  * @author Artem Bilan
@@ -31,10 +28,6 @@ public class FluxMessageChannelSpec extends MessageChannelSpec<FluxMessageChanne
 
 	FluxMessageChannelSpec() {
 		this.channel = new FluxMessageChannel();
-	}
-
-	FluxMessageChannelSpec(FluxProcessor<Message<?>, Message<?>> processor) {
-		this.channel = new FluxMessageChannel(processor);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/MessageChannels.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/MessageChannels.java
@@ -23,8 +23,6 @@ import org.springframework.integration.store.ChannelMessageStore;
 import org.springframework.integration.store.PriorityCapableChannelMessageStore;
 import org.springframework.messaging.Message;
 
-import reactor.core.publisher.FluxProcessor;
-
 /**
  * @author Artem Bilan
  * @author Gary Russell
@@ -133,15 +131,6 @@ public final class MessageChannels {
 	public static FluxMessageChannelSpec flux(String id) {
 		return flux()
 				.id(id);
-	}
-
-	public static FluxMessageChannelSpec flux(String id, FluxProcessor<Message<?>, Message<?>> processor) {
-		return flux(processor)
-				.id(id);
-	}
-
-	public static FluxMessageChannelSpec flux(FluxProcessor<Message<?>, Message<?>> processor) {
-		return new FluxMessageChannelSpec(processor);
 	}
 
 	private MessageChannels() {

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveStreamsConsumerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveStreamsConsumerTests.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -46,28 +46,26 @@ import org.reactivestreams.Subscription;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.channel.FluxMessageChannel;
+import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
-import org.springframework.integration.endpoint.ReactiveConsumer;
+import org.springframework.integration.endpoint.ReactiveStreamsConsumer;
 import org.springframework.integration.handler.MethodInvokingMessageHandler;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.support.GenericMessage;
 
-import reactor.core.publisher.EmitterProcessor;
-
 /**
  * @author Artem Bilan
  *
  * @since 5.0
  */
-public class ReactiveConsumerTests {
+public class ReactiveStreamsConsumerTests {
 
 	@Test
-	public void testReactiveConsumerReactiveChannel() throws InterruptedException {
-		FluxMessageChannel testChannel = new FluxMessageChannel(EmitterProcessor.create(false));
+	public void testReactiveStreamsConsumerFluxMessageChannel() throws InterruptedException {
+		FluxMessageChannel testChannel = new FluxMessageChannel();
 
 		List<Message<?>> result = new LinkedList<>();
 		CountDownLatch stopLatch = new CountDownLatch(2);
@@ -79,7 +77,7 @@ public class ReactiveConsumerTests {
 
 		MessageHandler testSubscriber = new MethodInvokingMessageHandler(messageHandler, (String) null);
 
-		ReactiveConsumer reactiveConsumer = new ReactiveConsumer(testChannel, testSubscriber);
+		ReactiveStreamsConsumer reactiveConsumer = new ReactiveStreamsConsumer(testChannel, testSubscriber);
 		reactiveConsumer.setBeanFactory(mock(BeanFactory.class));
 		reactiveConsumer.afterPropertiesSet();
 		reactiveConsumer.start();
@@ -103,7 +101,7 @@ public class ReactiveConsumerTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	public void testReactiveConsumerDirectChannel() throws InterruptedException {
+	public void testReactiveStreamsConsumerDirectChannel() throws InterruptedException {
 		DirectChannel testChannel = new DirectChannel();
 
 		Subscriber<Message<?>> testSubscriber = (Subscriber<Message<?>>) Mockito.mock(Subscriber.class);
@@ -117,7 +115,7 @@ public class ReactiveConsumerTests {
 				.given(testSubscriber)
 				.onNext(any(Message.class));
 
-		ReactiveConsumer reactiveConsumer = new ReactiveConsumer(testChannel, testSubscriber);
+		ReactiveStreamsConsumer reactiveConsumer = new ReactiveStreamsConsumer(testChannel, testSubscriber);
 		reactiveConsumer.setBeanFactory(mock(BeanFactory.class));
 		reactiveConsumer.afterPropertiesSet();
 		reactiveConsumer.start();
@@ -163,7 +161,7 @@ public class ReactiveConsumerTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	public void testReactiveConsumerPollableChannel() throws InterruptedException {
+	public void testReactiveStreamsConsumerPollableChannel() throws InterruptedException {
 		QueueChannel testChannel = new QueueChannel();
 
 		Subscriber<Message<?>> testSubscriber = (Subscriber<Message<?>>) Mockito.mock(Subscriber.class);
@@ -177,7 +175,7 @@ public class ReactiveConsumerTests {
 				.given(testSubscriber)
 				.onNext(any(Message.class));
 
-		ReactiveConsumer reactiveConsumer = new ReactiveConsumer(testChannel, testSubscriber);
+		ReactiveStreamsConsumer reactiveConsumer = new ReactiveStreamsConsumer(testChannel, testSubscriber);
 		reactiveConsumer.setBeanFactory(mock(BeanFactory.class));
 		reactiveConsumer.afterPropertiesSet();
 		reactiveConsumer.start();
@@ -223,7 +221,7 @@ public class ReactiveConsumerTests {
 	}
 
 	@Test
-	public void testReactiveConsumerViaConsumerEndpointFactoryBean() throws Exception {
+	public void testReactiveStreamsConsumerViaConsumerEndpointFactoryBean() throws Exception {
 		FluxMessageChannel testChannel = new FluxMessageChannel();
 
 		List<Message<?>> result = new LinkedList<>();

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/reactivestreams/ReactiveStreamsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/reactivestreams/ReactiveStreamsTests.java
@@ -32,7 +32,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.log4j.Level;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.reactivestreams.Publisher;
@@ -49,7 +48,6 @@ import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.channel.MessageChannels;
 import org.springframework.integration.dsl.context.IntegrationFlowContext;
-import org.springframework.integration.test.rule.Log4jLevelAdjuster;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
@@ -68,9 +66,6 @@ import reactor.core.publisher.Flux;
 @RunWith(SpringRunner.class)
 @DirtiesContext
 public class ReactiveStreamsTests {
-
-//	@Rule
-	public Log4jLevelAdjuster adjuster = new Log4jLevelAdjuster(Level.DEBUG, "org.springframework.integration");
 
 	@Autowired
 	@Qualifier("reactiveFlow")


### PR DESCRIPTION
* Rename `ReactiveConsumer` to `ReactiveStreamsConsumer`
* Rename `FluxSubscribableChannel` to `ReactiveStreamsSubscribableChannel`
* Remove the `processor` functionality from the `FluxMessageChannel`
in favor of internal `FluxSink` as it is recommended by the Project Reactor:
> Most of the time, you should try to avoid using a Processor.
They are harder to use correctly and prone to some corner cases.

* Make connectable, upstream publishers for the `FluxMessageChannel` as
bridges to the internal `sink` via `this::send`.
This way we are able to receive data from multi sources.
When the source is completed (e.g. `Mono` in case of WebFlux response),
the downstream flow isn't completed.
* Rework `MessageChannelReactiveUtils#PollableChannelPublisherAdapter`
to be based on the `Flux.create()` and `onRequest()` to poll channel for messages
* Add one more request to the `ReactiveHttpRequestExecutingMessageHandler`
to be sure that we consume different `Mono`s by the `FluxSubscribableChannel`
properly without completion
* Upgrade to the `spring-io-plugin:0.0.7.RELEASE`