### PR TITLE
Fix Race condition in the TxSyncQueueChannelTests

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/TransactionSynchronizationQueueChannelTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/TransactionSynchronizationQueueChannelTests-context.xml
@@ -5,6 +5,11 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
+	<bean id="transactionManager" class="org.springframework.integration.transaction.PseudoTransactionManager" />
+
+	<bean id="service"
+		  class="org.springframework.integration.channel.TransactionSynchronizationQueueChannelTests$Service"/>
+
 	<int:channel id="queueChannel">
 		<int:queue />
 	</int:channel>
@@ -15,7 +20,6 @@
 		</int:poller>
 	</int:service-activator>
 
-	<bean id="service" class="org.springframework.integration.channel.TransactionSynchronizationQueueChannelTests$Service"/>
 
 	<int:transaction-synchronization-factory id="txSyncFactory">
 		<int:after-commit channel="good" />
@@ -25,8 +29,6 @@
 	<int:channel id="good">
 		<int:queue />
 	</int:channel>
-
-	<bean id="transactionManager" class="org.springframework.integration.transaction.PseudoTransactionManager" />
 
 	<int:channel id="queueChannel2">
 		<int:queue />
@@ -42,9 +44,5 @@
 		<int:after-commit expression="payload + ' processed ok from ' + #inputChannel.componentName"
 			channel="good" />
 	</int:transaction-synchronization-factory>
-
-	<int:channel id="good">
-		<int:queue />
-	</int:channel>
 
 </beans>


### PR DESCRIPTION
https://build.spring.io/browse/INT-MASTER-653

The test-case uses only 1 second to wait for the message
in the `QueueChannel`.
That isn't enough on slow environment like CI causing failure for
the current test and unexpected value in the queue for the subsequent
tests

* Fix timeouts
* Get rid of `CountDownLatch` - the same is done by the wait on queues
* Purge queue in between tests.
This way we may not have failed subsequent test, thus failure analyze
will be much easier
* Rework `testRollback()` to wait for good result after one retry over
rollback
* Remove duplicate bean definition from XML config

**Cherry-pick to 4.3.x and 4.2.x**