### PR TITLE
Remove Jackson imports from JacksonJsonUtils

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/converter/ConfigurableCompositeMessageConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/converter/ConfigurableCompositeMessageConverter.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.springframework.integration.support.json.JacksonJsonUtils;
+import org.springframework.integration.support.json.JacksonPresent;
 import org.springframework.messaging.converter.ByteArrayMessageConverter;
 import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.GenericMessageConverter;
@@ -77,7 +77,7 @@ public class ConfigurableCompositeMessageConverter extends CompositeMessageConve
 	private static Collection<MessageConverter> initDefaults() {
 		List<MessageConverter> converters = new LinkedList<>();
 
-		if (JacksonJsonUtils.isJackson2Present()) {
+		if (JacksonPresent.isJackson2Present()) {
 			converters.add(new MappingJackson2MessageConverter());
 		}
 		converters.add(new ByteArrayMessageConverter());

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonUtils.java
@@ -22,12 +22,6 @@ import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.ClassUtils;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-
 /**
  * Utility methods for Jackson.
  *
@@ -62,19 +56,20 @@ public final class JacksonJsonUtils {
 	}
 
 	/**
-	 * Return an {@link ObjectMapper} if available,
+	 * Return an {@link com.fasterxml.jackson.databind.ObjectMapper} if available,
 	 * supplied with Message specific serializers and deserializers.
 	 * Also configured to store typo info in the {@code @class} property.
 	 * @return the mapper.
 	 * @throws IllegalStateException if an implementation is not available.
 	 * @since 4.3.10
 	 */
-	public static ObjectMapper messagingAwareMapper() {
+	public static com.fasterxml.jackson.databind.ObjectMapper messagingAwareMapper() {
 		if (jackson2Present) {
-			ObjectMapper mapper = new ObjectMapper();
-			mapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
-			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-			mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+			com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+			mapper.configure(com.fasterxml.jackson.databind.MapperFeature.DEFAULT_VIEW_INCLUSION, false);
+			mapper.configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			mapper.enableDefaultTyping(com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping.NON_FINAL,
+					com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY);
 
 			GenericMessageJacksonDeserializer genericMessageDeserializer = new GenericMessageJacksonDeserializer();
 			genericMessageDeserializer.setMapper(mapper);
@@ -88,7 +83,7 @@ public final class JacksonJsonUtils {
 			MutableMessageJacksonDeserializer mutableMessageDeserializer = new MutableMessageJacksonDeserializer();
 			mutableMessageDeserializer.setMapper(mapper);
 
-			mapper.registerModule(new SimpleModule()
+			mapper.registerModule(new com.fasterxml.jackson.databind.module.SimpleModule()
 					.addSerializer(new MessageHeadersJacksonSerializer())
 					.addDeserializer(GenericMessage.class, genericMessageDeserializer)
 					.addDeserializer(ErrorMessage.class, errorMessageDeserializer)

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonUtils.java
@@ -20,7 +20,6 @@ import org.springframework.integration.message.AdviceMessage;
 import org.springframework.integration.support.MutableMessage;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.util.ClassUtils;
 
 /**
  * Utility methods for Jackson.
@@ -37,22 +36,22 @@ public final class JacksonJsonUtils {
 		super();
 	}
 
-	private static final ClassLoader classLoader = JacksonJsonUtils.class.getClassLoader();
-
-	private static final boolean jackson2Present =
-			ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", classLoader) &&
-					ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", classLoader);
-
-	private static final boolean jacksonPresent =
-			ClassUtils.isPresent("org.codehaus.jackson.map.ObjectMapper", classLoader) &&
-					ClassUtils.isPresent("org.codehaus.jackson.JsonGenerator", classLoader);
-
+	/**
+	 * @return true if Jackson 2 is present in the classpath
+	 * @deprecated since 4.3.10 in favor of {@link JacksonPresent}
+	 */
+	@Deprecated
 	public static boolean isJackson2Present() {
-		return jackson2Present;
+		return JacksonPresent.isJackson2Present();
 	}
 
+	/**
+	 * @return true if Jackson 2 is present in the classpath
+	 * @deprecated since 4.3.10 in favor of {@link JacksonPresent}
+	 */
+
 	public static boolean isJacksonPresent() {
-		return jacksonPresent;
+		return JacksonPresent.isJacksonPresent();
 	}
 
 	/**
@@ -64,7 +63,7 @@ public final class JacksonJsonUtils {
 	 * @since 4.3.10
 	 */
 	public static com.fasterxml.jackson.databind.ObjectMapper messagingAwareMapper() {
-		if (jackson2Present) {
+		if (JacksonPresent.isJackson2Present()) {
 			com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
 			mapper.configure(com.fasterxml.jackson.databind.MapperFeature.DEFAULT_VIEW_INCLUSION, false);
 			mapper.configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonPresent.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonPresent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.integration.support.json;
+
+import org.springframework.util.ClassUtils;
+
+/**
+ * The utility to check if Jackson JSON processor is present in the classpath.
+ *
+ * @author Artem Bilan
+ *
+ * @since 4.3.10
+ */
+public final class JacksonPresent {
+
+	private static final ClassLoader classLoader = JacksonJsonUtils.class.getClassLoader();
+
+	private static final boolean jackson2Present =
+			ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", classLoader) &&
+					ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", classLoader);
+
+	private static final boolean jacksonPresent =
+			ClassUtils.isPresent("org.codehaus.jackson.map.ObjectMapper", classLoader) &&
+					ClassUtils.isPresent("org.codehaus.jackson.JsonGenerator", classLoader);
+
+	public static boolean isJackson2Present() {
+		return jackson2Present;
+	}
+
+	public static boolean isJacksonPresent() {
+		return jacksonPresent;
+	}
+
+
+	private JacksonPresent() {
+		super();
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapperProvider.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public final class JsonObjectMapperProvider {
 	 * @throws IllegalStateException if an implementation is not available.
 	 */
 	public static JsonObjectMapper<?, ?> newInstance() {
-		if (JacksonJsonUtils.isJackson2Present()) {
+		if (JacksonPresent.isJackson2Present()) {
 			return new Jackson2JsonObjectMapper();
 		}
 		else if (boonPresent) {
@@ -66,7 +66,7 @@ public final class JsonObjectMapperProvider {
 	 * @since 4.2.7
 	 */
 	public static boolean jsonAvailable() {
-		return JacksonJsonUtils.isJackson2Present() || boonPresent;
+		return JacksonPresent.isJackson2Present() || boonPresent;
 	}
 
 }

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -60,7 +59,7 @@ import org.springframework.integration.http.multipart.MultipartHttpInputMessage;
 import org.springframework.integration.http.support.DefaultHttpHeaderMapper;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
-import org.springframework.integration.support.json.JacksonJsonUtils;
+import org.springframework.integration.support.json.JacksonPresent;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
@@ -194,7 +193,7 @@ public abstract class HttpRequestHandlingEndpointSupport extends MessagingGatewa
 				logger.debug("'Jaxb2RootElementHttpMessageConverter' was added to the 'defaultMessageConverters'.");
 			}
 		}
-		if (JacksonJsonUtils.isJackson2Present()) {
+		if (JacksonPresent.isJackson2Present()) {
 			this.defaultMessageConverters.add(new MappingJackson2HttpMessageConverter());
 			if (logger.isDebugEnabled()) {
 				logger.debug("'MappingJackson2HttpMessageConverter' was added to the 'defaultMessageConverters'.");

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.channel.FixedSubscriberChannel;
 import org.springframework.integration.endpoint.MessageProducerSupport;
-import org.springframework.integration.support.json.JacksonJsonUtils;
+import org.springframework.integration.support.json.JacksonPresent;
 import org.springframework.integration.websocket.IntegrationWebSocketContainer;
 import org.springframework.integration.websocket.ServerWebSocketContainer;
 import org.springframework.integration.websocket.WebSocketListener;
@@ -75,7 +75,7 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 	{
 		this.defaultConverters.add(new StringMessageConverter());
 		this.defaultConverters.add(new ByteArrayMessageConverter());
-		if (JacksonJsonUtils.isJackson2Present()) {
+		if (JacksonPresent.isJackson2Present()) {
 			DefaultContentTypeResolver resolver = new DefaultContentTypeResolver();
 			resolver.setDefaultMimeType(MimeTypeUtils.APPLICATION_JSON);
 			MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/outbound/WebSocketOutboundMessageHandler.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/outbound/WebSocketOutboundMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.ListIterator;
 
 import org.springframework.integration.handler.AbstractMessageHandler;
-import org.springframework.integration.support.json.JacksonJsonUtils;
+import org.springframework.integration.support.json.JacksonPresent;
 import org.springframework.integration.websocket.ClientWebSocketContainer;
 import org.springframework.integration.websocket.IntegrationWebSocketContainer;
 import org.springframework.integration.websocket.support.PassThruSubProtocolHandler;
@@ -52,7 +52,7 @@ public class WebSocketOutboundMessageHandler extends AbstractMessageHandler {
 	{
 		this.defaultConverters.add(new StringMessageConverter());
 		this.defaultConverters.add(new ByteArrayMessageConverter());
-		if (JacksonJsonUtils.isJackson2Present()) {
+		if (JacksonPresent.isJackson2Present()) {
 			DefaultContentTypeResolver resolver = new DefaultContentTypeResolver();
 			resolver.setDefaultMimeType(MimeTypeUtils.APPLICATION_JSON);
 			MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();


### PR DESCRIPTION
Since the classes load their imports explicitly we can't use them for
classes which provides utilities to check classpath

* Move imports to fully qualified names in the target utility method

**Cherry-pick to 4.3.x**