### PR TITLE
INT-4272: Read Only Header Improvements

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/IntegrationMessageHeaderAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/IntegrationMessageHeaderAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,6 +155,31 @@ public class IntegrationMessageHeaderAccessor extends MessageHeaderAccessor {
 	@Override
 	protected boolean isReadOnly(String headerName) {
 		return super.isReadOnly(headerName) || this.readOnlyHeaders.contains(headerName);
+	}
+
+	public boolean containsReadOnly(MessageHeaders headers) {
+		if (!ObjectUtils.isEmpty(this.readOnlyHeaders)) {
+			for (String readOnly : this.readOnlyHeaders) {
+				if (headers.containsKey(readOnly)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public Map<String, Object> toMap() {
+		if (ObjectUtils.isEmpty(this.readOnlyHeaders)) {
+			return super.toMap();
+		}
+		else {
+			Map<String, Object> headers = super.toMap();
+			for (String header : this.readOnlyHeaders) {
+				headers.remove(header);
+			}
+			return headers;
+		}
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultMessageBuilderFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultMessageBuilderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.integration.support;
+
+import java.util.Arrays;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
@@ -37,7 +39,24 @@ public class DefaultMessageBuilderFactory implements MessageBuilderFactory {
 	 * @since 4.3.2
 	 */
 	public void setReadOnlyHeaders(String... readOnlyHeaders) {
-		this.readOnlyHeaders = readOnlyHeaders;
+		this.readOnlyHeaders = Arrays.copyOf(readOnlyHeaders, readOnlyHeaders.length);
+	}
+
+	/**
+	 * Add headers to the configured list of read only headers.
+	 * @param readOnlyHeaders the additional headers.
+	 * @since 4.3.10
+	 */
+	public void addReadOnlyHeaders(String... readOnlyHeaders) {
+		String[] headers = this.readOnlyHeaders;
+		if (headers == null || headers.length == 0) {
+			headers = Arrays.copyOf(readOnlyHeaders, readOnlyHeaders.length);
+		}
+		else {
+			headers = Arrays.copyOf(headers, headers.length + readOnlyHeaders.length);
+			System.arraycopy(readOnlyHeaders, 0, headers, this.readOnlyHeaders.length, readOnlyHeaders.length);
+		}
+		this.readOnlyHeaders = headers;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MessageBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -293,7 +293,8 @@ public final class MessageBuilder<T> extends AbstractIntegrationMessageBuilder<T
 	@Override
 	@SuppressWarnings("unchecked")
 	public Message<T> build() {
-		if (!this.modified && !this.headerAccessor.isModified() && this.originalMessage != null) {
+		if (!this.modified && !this.headerAccessor.isModified() && this.originalMessage != null
+				&& !this.headerAccessor.containsReadOnly(this.originalMessage.getHeaders())) {
 			return this.originalMessage;
 		}
 		if (this.payload instanceof Throwable) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/MessageBuilderTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/MessageBuilderTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import org.springframework.messaging.Message;
+
+/**
+ * @author Gary Russell
+ * @since 4.3.10
+ *
+ */
+public class MessageBuilderTests {
+
+	@Test
+	public void testReadOnlyHeaders() {
+		DefaultMessageBuilderFactory factory = new DefaultMessageBuilderFactory();
+		Message<?> message = factory.withPayload("bar").setHeader("foo", "baz").setHeader("qux", "fiz").build();
+		assertThat(message.getHeaders().get("foo"), equalTo("baz"));
+		assertThat(message.getHeaders().get("qux"), equalTo("fiz"));
+		factory.setReadOnlyHeaders("foo");
+		message = factory.fromMessage(message).build();
+		assertNull(message.getHeaders().get("foo"));
+		assertThat(message.getHeaders().get("qux"), equalTo("fiz"));
+		factory.addReadOnlyHeaders("qux");
+		message = factory.fromMessage(message).build();
+		assertNull(message.getHeaders().get("foo"));
+		assertNull(message.getHeaders().get("qux"));
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4272

- Honor read only header configuration when building from an unchanged message
- Support adding read only headers to the message builder factory


__cherry-pick to 4.3.x__