### PR TITLE
INT-4252 IntegrationFlow: allow custom bean names

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterDMLCSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterDMLCSpec.java
@@ -24,18 +24,20 @@ import org.springframework.amqp.rabbit.listener.DirectMessageListenerContainer;
  * Spec for an inbound channel adapter with a {@link DirectMessageListenerContainer}.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
-public class AmqpInboundChannelAdapterDMLCSpec extends AmqpInboundChannelAdapterSpec<AmqpInboundChannelAdapterDMLCSpec,
-		DirectMessageListenerContainer> {
+public class AmqpInboundChannelAdapterDMLCSpec
+		extends AmqpInboundChannelAdapterSpec<AmqpInboundChannelAdapterDMLCSpec, DirectMessageListenerContainer> {
 
 	AmqpInboundChannelAdapterDMLCSpec(DirectMessageListenerContainer listenerContainer) {
-		super(listenerContainer);
+		super(new DirectMessageListenerContainerSpec(listenerContainer));
 	}
 
 	AmqpInboundChannelAdapterDMLCSpec configureContainer(Consumer<DirectMessageListenerContainerSpec> configurer) {
-		configurer.accept(new DirectMessageListenerContainerSpec(this.listenerContainer));
+		configurer.accept((DirectMessageListenerContainerSpec) this.listenerContainerSpec);
 		return this;
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterSMLCSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterSMLCSpec.java
@@ -24,18 +24,20 @@ import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
  * Spec for an inbound channel adapter with a {@link SimpleMessageListenerContainer}.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
-public class AmqpInboundChannelAdapterSMLCSpec extends AmqpInboundChannelAdapterSpec<AmqpInboundChannelAdapterSMLCSpec,
-		SimpleMessageListenerContainer> {
+public class AmqpInboundChannelAdapterSMLCSpec
+		extends AmqpInboundChannelAdapterSpec<AmqpInboundChannelAdapterSMLCSpec, SimpleMessageListenerContainer> {
 
 	AmqpInboundChannelAdapterSMLCSpec(SimpleMessageListenerContainer listenerContainer) {
-		super(listenerContainer);
+		super(new SimpleMessageListenerContainerSpec(listenerContainer));
 	}
 
 	AmqpInboundChannelAdapterSMLCSpec configureContainer(Consumer<SimpleMessageListenerContainerSpec> configurer) {
-		configurer.accept(new SimpleMessageListenerContainerSpec(this.listenerContainer));
+		configurer.accept((SimpleMessageListenerContainerSpec) this.listenerContainerSpec);
 		return this;
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterSpec.java
@@ -18,7 +18,6 @@ package org.springframework.integration.amqp.dsl;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.Executor;
 
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter;
@@ -32,6 +31,7 @@ import org.springframework.integration.dsl.MessageProducerSpec;
  * @param <C> the container type.
  *
  * @author Artem Bilan
+ *
  * @since 5.0
  */
 public abstract class AmqpInboundChannelAdapterSpec
@@ -39,26 +39,16 @@ public abstract class AmqpInboundChannelAdapterSpec
 		extends AmqpBaseInboundChannelAdapterSpec<S>
 		implements ComponentsRegistration {
 
-	protected final C listenerContainer;
+	protected final AbstractMessageListenerContainerSpec<?, C> listenerContainerSpec;
 
-	AmqpInboundChannelAdapterSpec(C listenerContainer) {
-		super(new AmqpInboundChannelAdapter(listenerContainer));
-		this.listenerContainer = listenerContainer;
-	}
-
-	/**
-	 * @param containerId the bean name for internal listener container instance.
-	 * @return the spec.
-	 * @see SimpleMessageListenerContainer#setBeanName(String)
-	 */
-	public AmqpInboundChannelAdapterSpec containerId(String containerId) {
-		this.containerId = containerId;
-		return this;
+	AmqpInboundChannelAdapterSpec(AbstractMessageListenerContainerSpec<?, C> listenerContainerSpec) {
+		super(new AmqpInboundChannelAdapter(listenerContainerSpec.get()));
+		this.listenerContainerSpec = listenerContainerSpec;
 	}
 
 	@Override
 	public Map<Object, String> getComponentsToRegister() {
-		return Collections.singletonMap(this.listenerContainer, this.containerId);
+		return Collections.singletonMap(this.listenerContainerSpec.get(), this.listenerContainerSpec.getId());
 	}
 
 }

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterSpec.java
@@ -16,8 +16,9 @@
 
 package org.springframework.integration.amqp.dsl;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.Executor;
 
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter;
@@ -45,9 +46,19 @@ public abstract class AmqpInboundChannelAdapterSpec
 		this.listenerContainer = listenerContainer;
 	}
 
+	/**
+	 * @param containerId the bean name for internal listener container instance.
+	 * @return the spec.
+	 * @see SimpleMessageListenerContainer#setBeanName(String)
+	 */
+	public AmqpInboundChannelAdapterSpec containerId(String containerId) {
+		this.containerId = containerId;
+		return this;
+	}
+
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		return Collections.<Object>singleton(this.listenerContainer);
+	public Map<Object, String> getComponentsToRegister() {
+		return Collections.singletonMap(this.listenerContainer, this.containerId);
 	}
 
 }

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundGatewayDMLCSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundGatewayDMLCSpec.java
@@ -25,6 +25,8 @@ import org.springframework.amqp.rabbit.listener.DirectMessageListenerContainer;
  * Spec for a gateway with a {@link DirectMessageListenerContainer}.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
@@ -32,15 +34,15 @@ public class AmqpInboundGatewayDMLCSpec
 		extends AmqpInboundGatewaySpec<AmqpInboundGatewayDMLCSpec, DirectMessageListenerContainer> {
 
 	AmqpInboundGatewayDMLCSpec(DirectMessageListenerContainer listenerContainer, AmqpTemplate amqpTemplate) {
-		super(listenerContainer, amqpTemplate);
+		super(new DirectMessageListenerContainerSpec(listenerContainer), amqpTemplate);
 	}
 
 	AmqpInboundGatewayDMLCSpec(DirectMessageListenerContainer listenerContainer) {
-		super(listenerContainer);
+		super(new DirectMessageListenerContainerSpec(listenerContainer));
 	}
 
 	public AmqpInboundGatewayDMLCSpec configureContainer(Consumer<DirectMessageListenerContainerSpec> configurer) {
-		configurer.accept(new DirectMessageListenerContainerSpec(this.listenerContainer));
+		configurer.accept((DirectMessageListenerContainerSpec) this.listenerContainerSpec);
 		return this;
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundGatewaySMLCSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundGatewaySMLCSpec.java
@@ -25,6 +25,8 @@ import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
  * Spec for a gateway with a {@link SimpleMessageListenerContainer}.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
@@ -32,15 +34,15 @@ public class AmqpInboundGatewaySMLCSpec
 		extends AmqpInboundGatewaySpec<AmqpInboundGatewaySMLCSpec, SimpleMessageListenerContainer> {
 
 	AmqpInboundGatewaySMLCSpec(SimpleMessageListenerContainer listenerContainer, AmqpTemplate amqpTemplate) {
-		super(listenerContainer, amqpTemplate);
+		super(new SimpleMessageListenerContainerSpec(listenerContainer), amqpTemplate);
 	}
 
 	AmqpInboundGatewaySMLCSpec(SimpleMessageListenerContainer listenerContainer) {
-		super(listenerContainer);
+		super(new SimpleMessageListenerContainerSpec(listenerContainer));
 	}
 
 	public AmqpInboundGatewaySMLCSpec configureContainer(Consumer<SimpleMessageListenerContainerSpec> configurer) {
-		configurer.accept(new SimpleMessageListenerContainerSpec(this.listenerContainer));
+		configurer.accept((SimpleMessageListenerContainerSpec) this.listenerContainerSpec);
 		return this;
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundGatewaySpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 
 package org.springframework.integration.amqp.dsl;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.Executor;
 
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
@@ -54,9 +55,19 @@ public abstract class AmqpInboundGatewaySpec
 		this.listenerContainer = listenerContainer;
 	}
 
+	/**
+	 * @param containerId the bean name for internal listener container instance.
+	 * @return the spec.
+	 * @see SimpleMessageListenerContainer#setBeanName(String)
+	 */
+	public AmqpInboundGatewaySpec containerId(String containerId) {
+		this.containerId = containerId;
+		return this;
+	}
+
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		return Collections.<Object>singleton(this.listenerContainer);
+	public Map<Object, String> getComponentsToRegister() {
+		return Collections.singletonMap(this.listenerContainer, this.containerId);
 	}
 
 }

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundGatewaySpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundGatewaySpec.java
@@ -18,11 +18,9 @@ package org.springframework.integration.amqp.dsl;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.Executor;
 
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
-import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.integration.amqp.inbound.AmqpInboundGateway;
 import org.springframework.integration.dsl.ComponentsRegistration;
 
@@ -30,44 +28,41 @@ import org.springframework.integration.dsl.ComponentsRegistration;
  * An {@link AmqpBaseInboundGatewaySpec} implementation for a {@link AmqpInboundGateway}.
  * Allows to provide {@link AbstractMessageListenerContainer} options.
  *
+ * @param <S> the spec type.
+ * @param <C> the container type.
+ *
  * @author Artem Bilan
+ *
  * @since 5.0
  */
 public abstract class AmqpInboundGatewaySpec
 				<S extends AmqpInboundGatewaySpec<S, C>, C extends AbstractMessageListenerContainer>
-		extends AmqpBaseInboundGatewaySpec<S> implements ComponentsRegistration {
+		extends AmqpBaseInboundGatewaySpec<S>
+		implements ComponentsRegistration {
 
-	protected final C listenerContainer;
+	protected final AbstractMessageListenerContainerSpec<?, C> listenerContainerSpec;
 
-	AmqpInboundGatewaySpec(C listenerContainer) {
-		super(new AmqpInboundGateway(listenerContainer));
-		this.listenerContainer = listenerContainer;
+	AmqpInboundGatewaySpec(AbstractMessageListenerContainerSpec<?, C> listenerContainerSpec) {
+		super(new AmqpInboundGateway(listenerContainerSpec.get()));
+		this.listenerContainerSpec = listenerContainerSpec;
 	}
 
 	/**
 	 * Instantiate {@link AmqpInboundGateway} based on the provided {@link AbstractMessageListenerContainer}
 	 * and {@link AmqpTemplate}.
-	 * @param listenerContainer the {@link SimpleMessageListenerContainer} to use.
+	 * @param listenerContainerSpec the {@link AbstractMessageListenerContainerSpec} to use.
 	 * @param amqpTemplate the {@link AmqpTemplate} to use.
 	 */
-	AmqpInboundGatewaySpec(C listenerContainer, AmqpTemplate amqpTemplate) {
-		super(new AmqpInboundGateway(listenerContainer, amqpTemplate));
-		this.listenerContainer = listenerContainer;
-	}
-
-	/**
-	 * @param containerId the bean name for internal listener container instance.
-	 * @return the spec.
-	 * @see SimpleMessageListenerContainer#setBeanName(String)
-	 */
-	public AmqpInboundGatewaySpec containerId(String containerId) {
-		this.containerId = containerId;
-		return this;
+	AmqpInboundGatewaySpec(
+			AbstractMessageListenerContainerSpec<?, C> listenerContainerSpec,
+			AmqpTemplate amqpTemplate) {
+		super(new AmqpInboundGateway(listenerContainerSpec.get(), amqpTemplate));
+		this.listenerContainerSpec = listenerContainerSpec;
 	}
 
 	@Override
 	public Map<Object, String> getComponentsToRegister() {
-		return Collections.singletonMap(this.listenerContainer, this.containerId);
+		return Collections.singletonMap(this.listenerContainerSpec.get(), this.listenerContainerSpec.getId());
 	}
 
 }

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/dsl/AmqpTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/dsl/AmqpTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -89,6 +90,11 @@ public class AmqpTests {
 	@Autowired(required = false)
 	@Qualifier("amqpInboundGatewayContainer")
 	private SimpleMessageListenerContainer amqpInboundGatewayContainer;
+
+	@AfterClass
+	public static void tearDown() {
+		brokerRunning.removeTestQueues();
+	}
 
 	@Test
 	public void testAmqpInboundGatewayFlow() throws Exception {

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/AbstractRouterSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/AbstractRouterSpec.java
@@ -96,7 +96,7 @@ public class AbstractRouterSpec<S extends AbstractRouterSpec<S, R>, R extends Ab
 		IntegrationFlowBuilder flowBuilder = IntegrationFlows.from(channel);
 		subFlow.configure(flowBuilder);
 
-		this.componentsToRegister.add(flowBuilder);
+		this.componentsToRegister.put(flowBuilder, null);
 
 		return defaultOutputChannel(channel);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/ComponentsRegistration.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/ComponentsRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.dsl;
 
-import java.util.Collection;
+import java.util.Map;
 
 /**
  * The marker interface for the {@link IntegrationComponentSpec} implementation,
@@ -33,6 +33,6 @@ import java.util.Collection;
 @FunctionalInterface
 public interface ComponentsRegistration {
 
-	Collection<Object> getComponentsToRegister();
+	Map<Object, String> getComponentsToRegister();
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
@@ -149,7 +149,7 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 	 */
 	public S transactional(boolean handleMessageAdvice) {
 		TransactionInterceptor transactionInterceptor = new TransactionInterceptorBuilder(handleMessageAdvice).build();
-		this.componentsToRegister.add(transactionInterceptor);
+		this.componentsToRegister.put(transactionInterceptor, null);
 		return transactional(transactionInterceptor);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/EndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/EndpointSpec.java
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.dsl;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.springframework.beans.factory.BeanNameAware;
@@ -46,7 +46,7 @@ public abstract class EndpointSpec<S extends EndpointSpec<S, F, H>, F extends Be
 		extends IntegrationComponentSpec<S, Tuple2<F, H>>
 		implements ComponentsRegistration {
 
-	protected final Collection<Object> componentsToRegister = new ArrayList<>();
+	protected final Map<Object, String> componentsToRegister = new LinkedHashMap<>();
 
 	protected H handler;
 
@@ -87,9 +87,9 @@ public abstract class EndpointSpec<S extends EndpointSpec<S, F, H>, F extends Be
 	 * @see PollerSpec
 	 */
 	public S poller(PollerSpec pollerMetadataSpec) {
-		Collection<Object> componentsToRegister = pollerMetadataSpec.getComponentsToRegister();
+		Map<Object, String> componentsToRegister = pollerMetadataSpec.getComponentsToRegister();
 		if (componentsToRegister != null) {
-			this.componentsToRegister.addAll(componentsToRegister);
+			this.componentsToRegister.putAll(componentsToRegister);
 		}
 		return poller(pollerMetadataSpec.get());
 	}
@@ -116,7 +116,7 @@ public abstract class EndpointSpec<S extends EndpointSpec<S, F, H>, F extends Be
 	public abstract S autoStartup(boolean autoStartup);
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
+	public Map<Object, String> getComponentsToRegister() {
 		return this.componentsToRegister.isEmpty()
 				? null
 				: this.componentsToRegister;

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/EnricherSpec.java
@@ -150,7 +150,7 @@ public class EnricherSpec extends ConsumerEndpointSpec<EnricherSpec, ContentEnri
 		IntegrationFlowBuilder flowBuilder = IntegrationFlows.from(requestChannel);
 		subFlow.configure(flowBuilder);
 
-		this.componentsToRegister.add(flowBuilder.get());
+		this.componentsToRegister.put(flowBuilder.get(), null);
 
 		return requestChannel(requestChannel);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/FilterEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/FilterEndpointSpec.java
@@ -91,7 +91,7 @@ public final class FilterEndpointSpec extends ConsumerEndpointSpec<FilterEndpoin
 		DirectChannel channel = new DirectChannel();
 		IntegrationFlowBuilder flowBuilder = IntegrationFlows.from(channel);
 		discardFlow.configure(flowBuilder);
-		this.componentsToRegister.add(flowBuilder.get());
+		this.componentsToRegister.put(flowBuilder.get(), null);
 		return discardChannel(channel);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/HeaderEnricherSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/HeaderEnricherSpec.java
@@ -437,7 +437,7 @@ public class HeaderEnricherSpec extends ConsumerEndpointSpec<HeaderEnricherSpec,
 		headerEnricher.setShouldSkipNulls(this.shouldSkipNulls);
 		headerEnricher.setMessageProcessor(this.messageProcessor);
 
-		this.componentsToRegister.add(headerEnricher);
+		this.componentsToRegister.put(headerEnricher, null);
 
 		this.handler = new MessageTransformingHandler(headerEnricher);
 		return super.doGet();

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public abstract class IntegrationFlowAdapter implements IntegrationFlow, SmartLi
 		IntegrationFlowDefinition<?> targetFlow = buildFlow();
 		Assert.state(targetFlow != null, "the 'buildFlow()' must not return null");
 		flow.integrationComponents.clear();
-		flow.integrationComponents.addAll(targetFlow.integrationComponents);
+		flow.integrationComponents.putAll(targetFlow.integrationComponents);
 		this.targetIntegrationFlow = flow.get();
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/PollerSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/PollerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package org.springframework.integration.dsl;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 import org.aopalliance.aop.Advice;
@@ -49,7 +49,7 @@ public final class PollerSpec extends IntegrationComponentSpec<PollerSpec, Polle
 
 	private final List<Advice> adviceChain = new LinkedList<>();
 
-	private final Collection<Object> componentsToRegister = new ArrayList<>();
+	private final Map<Object, String> componentsToRegister = new LinkedHashMap<>();
 
 	PollerSpec(Trigger trigger) {
 		this.target = new PollerMetadata();
@@ -92,7 +92,7 @@ public final class PollerSpec extends IntegrationComponentSpec<PollerSpec, Polle
 	public PollerSpec errorChannel(MessageChannel errorChannel) {
 		MessagePublishingErrorHandler errorHandler = new MessagePublishingErrorHandler();
 		errorHandler.setDefaultErrorChannel(errorChannel);
-		this.componentsToRegister.add(errorHandler);
+		this.componentsToRegister.put(errorHandler, null);
 		return errorHandler(errorHandler);
 	}
 
@@ -106,7 +106,7 @@ public final class PollerSpec extends IntegrationComponentSpec<PollerSpec, Polle
 	public PollerSpec errorChannel(String errorChannelName) {
 		MessagePublishingErrorHandler errorHandler = new MessagePublishingErrorHandler();
 		errorHandler.setDefaultErrorChannelName(errorChannelName);
-		this.componentsToRegister.add(errorHandler);
+		this.componentsToRegister.put(errorHandler, null);
 		return errorHandler(errorHandler);
 	}
 
@@ -163,7 +163,7 @@ public final class PollerSpec extends IntegrationComponentSpec<PollerSpec, Polle
 	 */
 	public PollerSpec transactional() {
 		TransactionInterceptor transactionInterceptor = new TransactionInterceptorBuilder().build();
-		this.componentsToRegister.add(transactionInterceptor);
+		this.componentsToRegister.put(transactionInterceptor, null);
 		return transactional(transactionInterceptor);
 	}
 
@@ -193,7 +193,7 @@ public final class PollerSpec extends IntegrationComponentSpec<PollerSpec, Polle
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
+	public Map<Object, String> getComponentsToRegister() {
 		return this.componentsToRegister;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/PublishSubscribeSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/PublishSubscribeSpec.java
@@ -16,9 +16,8 @@
 
 package org.springframework.integration.dsl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 import org.springframework.integration.dsl.channel.PublishSubscribeChannelSpec;
@@ -30,7 +29,7 @@ import org.springframework.integration.dsl.channel.PublishSubscribeChannelSpec;
  */
 public class PublishSubscribeSpec extends PublishSubscribeChannelSpec<PublishSubscribeSpec> {
 
-	private final List<Object> subscriberFlows = new ArrayList<>();
+	private final Map<Object, String> subscriberFlows = new LinkedHashMap<>();
 
 	PublishSubscribeSpec() {
 		super();
@@ -50,15 +49,15 @@ public class PublishSubscribeSpec extends PublishSubscribeChannelSpec<PublishSub
 				IntegrationFlows.from(this.channel)
 						.bridge();
 		flow.configure(flowBuilder);
-		this.subscriberFlows.add(flowBuilder.get());
+		this.subscriberFlows.put(flowBuilder.get(), null);
 		return _this();
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		List<Object> objects = new ArrayList<Object>();
-		objects.addAll(super.getComponentsToRegister());
-		objects.addAll(this.subscriberFlows);
+	public Map<Object, String> getComponentsToRegister() {
+		Map<Object, String> objects = new LinkedHashMap<>();
+		objects.putAll(super.getComponentsToRegister());
+		objects.putAll(this.subscriberFlows);
 		return objects;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/PublisherIntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/PublisherIntegrationFlow.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.dsl;
 
-import java.util.Set;
+import java.util.Map;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -35,7 +35,7 @@ class PublisherIntegrationFlow<T> extends StandardIntegrationFlow implements Pub
 
 	private final Publisher<Message<T>> delegate;
 
-	PublisherIntegrationFlow(Set<Object> integrationComponents, Publisher<Message<T>> publisher) {
+	PublisherIntegrationFlow(Map<Object, String> integrationComponents, Publisher<Message<T>> publisher) {
 		super(integrationComponents);
 		this.delegate = publisher;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/RecipientListRouterSpec.java
@@ -76,7 +76,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 	public RecipientListRouterSpec recipient(String channelName, Expression expression) {
 		ExpressionEvaluatingSelector selector = new ExpressionEvaluatingSelector(expression);
 		this.handler.addRecipient(channelName, selector);
-		this.componentsToRegister.add(selector);
+		this.componentsToRegister.put(selector, null);
 		return _this();
 	}
 
@@ -146,7 +146,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 		if (expression != null) {
 			ExpressionEvaluatingSelector selector = new ExpressionEvaluatingSelector(expression);
 			this.handler.addRecipient(channel, selector);
-			this.componentsToRegister.add(selector);
+			this.componentsToRegister.put(selector, null);
 		}
 		else {
 			this.handler.addRecipient(channel);
@@ -247,7 +247,7 @@ public class RecipientListRouterSpec extends AbstractRouterSpec<RecipientListRou
 		DirectChannel channel = new DirectChannel();
 		IntegrationFlowBuilder flowBuilder = IntegrationFlows.from(channel);
 		subFlow.configure(flowBuilder);
-		this.componentsToRegister.add(flowBuilder.get());
+		this.componentsToRegister.put(flowBuilder.get(), null);
 		return channel;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/RouterSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/RouterSpec.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.dsl;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -161,19 +160,19 @@ public final class RouterSpec<K, R extends AbstractMappingMessageRouter>
 		IntegrationFlowBuilder flowBuilder = IntegrationFlows.from(channel);
 		subFlow.configure(flowBuilder);
 
-		this.componentsToRegister.add(flowBuilder);
+		this.componentsToRegister.put(flowBuilder, null);
 
 		this.mappingProvider.addMapping(key, channel);
 		return _this();
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
+	public Map<Object, String> getComponentsToRegister() {
 		// The 'mappingProvider' must be added to the 'componentsToRegister' in the end to
 		// let all other components to be registered before the 'RouterMappingProvider.onInit()' logic.
 		if (!this.mappingProviderRegistered) {
 			if (!this.mappingProvider.mapping.isEmpty()) {
-				this.componentsToRegister.add(this.mappingProvider);
+				this.componentsToRegister.put(this.mappingProvider, null);
 			}
 			this.mappingProviderRegistered = true;
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
@@ -16,10 +16,12 @@
 
 package org.springframework.integration.dsl;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.context.SmartLifecycle;
@@ -63,7 +65,7 @@ import org.springframework.context.SmartLifecycle;
  */
 public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle {
 
-	private final List<Object> integrationComponents;
+	private final Map<Object, String> integrationComponents;
 
 	private final List<SmartLifecycle> lifecycles = new LinkedList<>();
 
@@ -71,8 +73,8 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 
 	private boolean running;
 
-	StandardIntegrationFlow(Set<Object> integrationComponents) {
-		this.integrationComponents = new LinkedList<>(integrationComponents);
+	StandardIntegrationFlow(Map<Object, String> integrationComponents) {
+		this.integrationComponents = new LinkedHashMap<>(integrationComponents);
 	}
 
 	//TODO Figure out some custom DestinationResolver when we don't register singletons - remove NOSONAR above when done
@@ -84,13 +86,13 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 		return this.registerComponents;
 	}
 
-	public void setIntegrationComponents(List<Object> integrationComponents) {
+	public void setIntegrationComponents(Map<Object, String> integrationComponents) {
 		this.integrationComponents.clear();
-		this.integrationComponents.addAll(integrationComponents);
+		this.integrationComponents.putAll(integrationComponents);
 	}
 
-	public List<Object> getIntegrationComponents() {
-		return this.integrationComponents;
+	public Map<Object, String> getIntegrationComponents() {
+		return Collections.unmodifiableMap(this.integrationComponents);
 	}
 
 	@Override
@@ -101,7 +103,8 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 	@Override
 	public void start() {
 		if (!this.running) {
-			ListIterator<Object> iterator = this.integrationComponents.listIterator(this.integrationComponents.size());
+			List<Object> components = new LinkedList<>(this.integrationComponents.keySet());
+			ListIterator<Object> iterator = components.listIterator(this.integrationComponents.size());
 			this.lifecycles.clear();
 			while (iterator.hasPrevious()) {
 				Object component = iterator.previous();

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/MessageChannelSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/MessageChannelSpec.java
@@ -18,9 +18,10 @@ package org.springframework.integration.dsl.channel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.channel.interceptor.WireTap;
@@ -44,7 +45,7 @@ public abstract class MessageChannelSpec<S extends MessageChannelSpec<S, C>, C e
 		extends IntegrationComponentSpec<S, C>
 		implements ComponentsRegistration {
 
-	private final List<Object> componentsToRegister = new ArrayList<>();
+	private final Map<Object, String> componentsToRegister = new LinkedHashMap<>();
 
 	private final List<Class<?>> datatypes = new ArrayList<>();
 
@@ -108,7 +109,7 @@ public abstract class MessageChannelSpec<S extends MessageChannelSpec<S, C>, C e
 	 */
 	public S wireTap(WireTapSpec wireTapSpec) {
 		WireTap interceptor = wireTapSpec.get();
-		this.componentsToRegister.add(interceptor);
+		this.componentsToRegister.put(interceptor, null);
 		return interceptor(interceptor);
 	}
 
@@ -118,7 +119,7 @@ public abstract class MessageChannelSpec<S extends MessageChannelSpec<S, C>, C e
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
+	public Map<Object, String> getComponentsToRegister() {
 		return this.componentsToRegister;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/WireTapSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/channel/WireTapSpec.java
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.dsl.channel;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.springframework.expression.Expression;
 import org.springframework.integration.channel.interceptor.WireTap;
@@ -101,9 +101,9 @@ public class WireTapSpec extends IntegrationComponentSpec<WireTapSpec, WireTap> 
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
+	public Map<Object, String> getComponentsToRegister() {
 		if (this.selector != null) {
-			return Collections.singleton(this.selector);
+			return Collections.singletonMap(this.selector, null);
 		}
 		else {
 			return null;

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowRegistration.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.messaging.MessageChannel;
  * and provide an API for some useful {@link IntegrationFlow} options and its lifecycle.
  *
  * @author Artem Bilan
+ *
  * @since 5.0
  *
  * @see IntegrationFlowContext
@@ -80,7 +81,7 @@ public class IntegrationFlowRegistration {
 		if (this.inputChannel == null) {
 			if (this.integrationFlow instanceof StandardIntegrationFlow) {
 				StandardIntegrationFlow integrationFlow = (StandardIntegrationFlow) this.integrationFlow;
-				Object next = integrationFlow.getIntegrationComponents().iterator().next();
+				Object next = integrationFlow.getIntegrationComponents().keySet().iterator().next();
 				if (next instanceof MessageChannel) {
 					this.inputChannel = (MessageChannel) next;
 				}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileInboundChannelAdapterSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileInboundChannelAdapterSpec.java
@@ -17,9 +17,9 @@
 package org.springframework.integration.file.dsl;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.springframework.beans.factory.BeanCreationException;
@@ -260,9 +260,9 @@ public class FileInboundChannelAdapterSpec
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
+	public Map<Object, String> getComponentsToRegister() {
 		if (this.expressionFileListFilter != null) {
-			return Collections.singleton(this.expressionFileListFilter);
+			return Collections.singletonMap(this.expressionFileListFilter, null);
 		}
 		else {
 			return null;

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileTransferringMessageHandlerSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileTransferringMessageHandlerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 package org.springframework.integration.file.dsl;
 
 import java.nio.charset.Charset;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.springframework.expression.common.LiteralExpression;
@@ -228,9 +228,9 @@ public abstract class FileTransferringMessageHandlerSpec<F, S extends FileTransf
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
+	public Map<Object, String> getComponentsToRegister() {
 		if (this.defaultFileNameGenerator != null) {
-			return Collections.singletonList(this.defaultFileNameGenerator);
+			return Collections.singletonMap(this.defaultFileNameGenerator, null);
 		}
 		return null;
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileWritingMessageHandlerSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileWritingMessageHandlerSpec.java
@@ -17,8 +17,8 @@
 package org.springframework.integration.file.dsl;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.springframework.expression.Expression;
@@ -246,9 +246,9 @@ public class FileWritingMessageHandlerSpec
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
+	public Map<Object, String> getComponentsToRegister() {
 		if (this.defaultFileNameGenerator != null) {
-			return Collections.singletonList(this.defaultFileNameGenerator);
+			return Collections.singletonMap(this.defaultFileNameGenerator, null);
 		}
 		return null;
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileInboundChannelAdapterSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileInboundChannelAdapterSpec.java
@@ -17,9 +17,8 @@
 package org.springframework.integration.file.dsl;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.springframework.expression.Expression;
@@ -234,12 +233,12 @@ public abstract class RemoteFileInboundChannelAdapterSpec<F, S extends RemoteFil
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		List<Object> componentsToRegister = new ArrayList<>();
-		componentsToRegister.add(this.synchronizer);
+	public Map<Object, String> getComponentsToRegister() {
+		Map<Object, String> componentsToRegister = new LinkedHashMap<>();
+		componentsToRegister.put(this.synchronizer, null);
 
 		if (this.expressionFileListFilter != null) {
-			componentsToRegister.add(this.expressionFileListFilter);
+			componentsToRegister.put(this.expressionFileListFilter, null);
 		}
 
 		return componentsToRegister;

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileOutboundGatewaySpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileOutboundGatewaySpec.java
@@ -17,9 +17,8 @@
 package org.springframework.integration.file.dsl;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.springframework.expression.Expression;
@@ -340,13 +339,13 @@ public abstract class RemoteFileOutboundGatewaySpec<F, S extends RemoteFileOutbo
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		List<Object> componentsToRegister = new ArrayList<>();
+	public Map<Object, String> getComponentsToRegister() {
+		Map<Object, String> componentsToRegister = new LinkedHashMap<>();
 		if (this.expressionFileListFilter != null) {
-			componentsToRegister.add(this.expressionFileListFilter);
+			componentsToRegister.put(this.expressionFileListFilter, null);
 		}
 		if (this.mputExpressionFileListFilter != null) {
-			componentsToRegister.add(this.expressionFileListFilter);
+			componentsToRegister.put(this.mputExpressionFileListFilter, null);
 		}
 
 		return componentsToRegister;

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileStreamingInboundChannelAdapterSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileStreamingInboundChannelAdapterSpec.java
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.file.dsl;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.springframework.expression.Expression;
@@ -127,9 +127,9 @@ public abstract class RemoteFileStreamingInboundChannelAdapterSpec<F,
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
+	public Map<Object, String> getComponentsToRegister() {
 		if (this.expressionFileListFilter != null) {
-			return Collections.singleton(this.expressionFileListFilter);
+			return Collections.singletonMap(this.expressionFileListFilter, null);
 		}
 		else {
 			return null;

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/BaseHttpInboundEndpointSpec.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/BaseHttpInboundEndpointSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.integration.http.dsl;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -306,10 +305,10 @@ public abstract class BaseHttpInboundEndpointSpec<S extends BaseHttpInboundEndpo
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
+	public Map<Object, String> getComponentsToRegister() {
 		HeaderMapper<HttpHeaders> headerMapperToRegister =
 				(this.explicitHeaderMapper != null ? this.explicitHeaderMapper : this.headerMapper);
-		return Collections.singletonList(headerMapperToRegister);
+		return Collections.singletonMap(headerMapperToRegister, null);
 	}
 
 	/**

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/BaseHttpMessageHandlerSpec.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/BaseHttpMessageHandlerSpec.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.http.dsl;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -310,10 +309,11 @@ public abstract class BaseHttpMessageHandlerSpec<S extends BaseHttpMessageHandle
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
+	public Map<Object, String> getComponentsToRegister() {
 		this.target.setUriVariableExpressions(this.uriVariableExpressions);
-		return Collections.singletonList(this.headerMapper);
+		return Collections.singletonMap(this.headerMapper, null);
 	}
 
 	protected abstract boolean isClientSet();
+
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpInboundChannelAdapterSpec.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpInboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.ip.dsl;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessageProducerSpec;
@@ -29,6 +29,8 @@ import org.springframework.scheduling.TaskScheduler;
  * A {@link MessageProducerSpec} for {@link TcpReceivingChannelAdapter}s.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
@@ -89,9 +91,10 @@ public class TcpInboundChannelAdapterSpec
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		return this.connectionFactory == null ? Collections.emptyList()
-				: Collections.singletonList(this.connectionFactory);
+	public Map<Object, String> getComponentsToRegister() {
+		return this.connectionFactory != null
+				? Collections.singletonMap(this.connectionFactory, this.connectionFactory.getComponentName())
+				: null;
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpInboundGatewaySpec.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpInboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.ip.dsl;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessagingGatewaySpec;
@@ -29,6 +29,8 @@ import org.springframework.scheduling.TaskScheduler;
  * A {@link MessagingGatewaySpec} for {@link TcpInboundGateway}s.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
@@ -88,9 +90,10 @@ public class TcpInboundGatewaySpec extends MessagingGatewaySpec<TcpInboundGatewa
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		return this.connectionFactory == null ? Collections.emptyList()
-				: Collections.singletonList(this.connectionFactory);
+	public Map<Object, String> getComponentsToRegister() {
+		return this.connectionFactory != null
+				? Collections.singletonMap(this.connectionFactory, this.connectionFactory.getComponentName())
+				: null;
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpOutboundChannelAdapterSpec.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpOutboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.ip.dsl;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessageHandlerSpec;
@@ -29,6 +29,8 @@ import org.springframework.scheduling.TaskScheduler;
  * A {@link MessageHandlerSpec} for {@link TcpSendingMessageHandler}s.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
@@ -89,9 +91,10 @@ public class TcpOutboundChannelAdapterSpec
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		return this.connectionFactory == null ? Collections.emptyList()
-				: Collections.singletonList(this.connectionFactory);
+	public Map<Object, String> getComponentsToRegister() {
+		return this.connectionFactory != null
+				? Collections.singletonMap(this.connectionFactory, this.connectionFactory.getComponentName())
+				: null;
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpOutboundGatewaySpec.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.ip.dsl;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.springframework.integration.dsl.ComponentsRegistration;
@@ -31,6 +31,8 @@ import org.springframework.messaging.Message;
  * A {@link MessageHandlerSpec} for {@link TcpOutboundGateway}s.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
@@ -88,9 +90,10 @@ public class TcpOutboundGatewaySpec extends MessageHandlerSpec<TcpOutboundGatewa
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		return this.connectionFactory == null ? Collections.emptyList()
-				: Collections.singletonList(this.connectionFactory);
+	public Map<Object, String> getComponentsToRegister() {
+		return this.connectionFactory != null
+				? Collections.singletonMap(this.connectionFactory, this.connectionFactory.getComponentName())
+				: null;
 	}
 
 }

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/DynamicJmsTemplate.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/DynamicJmsTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import org.springframework.util.Assert;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
+ *
  * @since 2.0.2
  */
 public class DynamicJmsTemplate extends JmsTemplate {
@@ -32,13 +34,13 @@ public class DynamicJmsTemplate extends JmsTemplate {
 			return super.getPriority();
 		}
 		Assert.isTrue(priority >= 0 && priority <= 9, "JMS priority must be in the range of 0-9");
-		return priority.intValue();
+		return priority;
 	}
 
 	@Override
 	public long getReceiveTimeout() {
 		Long receiveTimeout = DynamicJmsTemplateProperties.getReceiveTimeout();
-		return (receiveTimeout != null) ? receiveTimeout.longValue() : super.getReceiveTimeout();
+		return (receiveTimeout != null) ? receiveTimeout : super.getReceiveTimeout();
 	}
 
 }

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,10 +211,15 @@ public final class Jms {
 	 * @param connectionFactory the JMS ConnectionFactory to build on
 	 * @return the {@link JmsMessageDrivenChannelAdapterSpec} instance
 	 */
-	public static JmsMessageDrivenChannelAdapterSpec
-			.JmsMessageDrivenChannelAdapterListenerContainerSpec<JmsDefaultListenerContainerSpec, DefaultMessageListenerContainer>
+	public static JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<JmsDefaultListenerContainerSpec, DefaultMessageListenerContainer>
 	messageDrivenChannelAdapter(ConnectionFactory connectionFactory) {
-		return messageDrivenChannelAdapter(connectionFactory, DefaultMessageListenerContainer.class);
+		try {
+			return new JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<>(
+					new JmsDefaultListenerContainerSpec().connectionFactory(connectionFactory));
+		}
+		catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
 	}
 
 	/**

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsDestinationAccessorSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsDestinationAccessorSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,10 @@ import org.springframework.jms.support.destination.JmsDestinationAccessor;
  * @param <A> the target {@link JmsDestinationAccessor} implementation type.
  *
  * @author Artem Bilan
+ *
  * @since 5.0
  */
-public abstract class
-		JmsDestinationAccessorSpec<S extends JmsDestinationAccessorSpec<S, A>, A extends JmsDestinationAccessor>
+public abstract class JmsDestinationAccessorSpec<S extends JmsDestinationAccessorSpec<S, A>, A extends JmsDestinationAccessor>
 		extends IntegrationComponentSpec<S, A> {
 
 	protected JmsDestinationAccessorSpec(A accessor) {
@@ -42,6 +42,11 @@ public abstract class
 	S connectionFactory(ConnectionFactory connectionFactory) {
 		this.target.setConnectionFactory(connectionFactory);
 		return _this();
+	}
+
+	@Override
+	public S id(String id) {
+		return super.id(id);
 	}
 
 	/**

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsInboundChannelAdapterSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsInboundChannelAdapterSpec.java
@@ -16,11 +16,14 @@
 
 package org.springframework.integration.jms.dsl;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
 
+import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessageSourceSpec;
 import org.springframework.integration.jms.JmsDestinationPollingSource;
 import org.springframework.integration.jms.JmsHeaderMapper;
@@ -33,6 +36,7 @@ import org.springframework.util.Assert;
  * @param <S> the target {@link JmsInboundChannelAdapterSpec} implementation type.
  *
  * @author Artem Bilan
+ *
  * @since 5.0
  */
 public class JmsInboundChannelAdapterSpec<S extends JmsInboundChannelAdapterSpec<S>>
@@ -92,8 +96,9 @@ public class JmsInboundChannelAdapterSpec<S extends JmsInboundChannelAdapterSpec
 	/**
 	 * A {@link JmsTemplate}-based {@link JmsInboundChannelAdapterSpec} extension.
 	 */
-	public static class JmsInboundChannelSpecTemplateAware extends
-			JmsInboundChannelAdapterSpec<JmsInboundChannelSpecTemplateAware> {
+	public static class JmsInboundChannelSpecTemplateAware
+			extends JmsInboundChannelAdapterSpec<JmsInboundChannelSpecTemplateAware>
+			implements ComponentsRegistration {
 
 		JmsInboundChannelSpecTemplateAware(ConnectionFactory connectionFactory) {
 			super(connectionFactory);
@@ -109,6 +114,11 @@ public class JmsInboundChannelAdapterSpec<S extends JmsInboundChannelAdapterSpec
 			Assert.notNull(configurer, "'configurer' must not be null");
 			configurer.accept(this.jmsTemplateSpec);
 			return _this();
+		}
+
+		@Override
+		public Map<Object, String> getComponentsToRegister() {
+			return Collections.singletonMap(this.jmsTemplateSpec.get(), this.jmsTemplateSpec.getId());
 		}
 
 	}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsMessageDrivenChannelAdapterSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsMessageDrivenChannelAdapterSpec.java
@@ -16,10 +16,13 @@
 
 package org.springframework.integration.jms.dsl;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import javax.jms.Destination;
 
+import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessageProducerSpec;
 import org.springframework.integration.jms.ChannelPublishingJmsMessageListener;
 import org.springframework.integration.jms.JmsHeaderMapper;
@@ -34,6 +37,7 @@ import org.springframework.util.Assert;
  * @param <S> the target {@link JmsMessageDrivenChannelAdapterSpec} implementation type.
  *
  * @author Artem Bilan
+ *
  * @since 5.0
  */
 public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChannelAdapterSpec<S>>
@@ -81,7 +85,8 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 	 */
 	public static class
 			JmsMessageDrivenChannelAdapterListenerContainerSpec<S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>
-			extends JmsMessageDrivenChannelAdapterSpec<JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C>> {
+			extends JmsMessageDrivenChannelAdapterSpec<JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C>>
+			implements ComponentsRegistration {
 
 		private final JmsListenerContainerSpec<S, C> spec;
 
@@ -89,6 +94,7 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 			super(spec.get());
 			this.spec = spec;
 			this.spec.get().setAutoStartup(false);
+
 		}
 
 		/**
@@ -123,6 +129,11 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 			Assert.notNull(configurer, "'configurer' must not be null");
 			configurer.accept(this.spec);
 			return _this();
+		}
+
+		@Override
+		public Map<Object, String> getComponentsToRegister() {
+			return Collections.singletonMap(this.spec.get(), this.spec.getId());
 		}
 
 	}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsOutboundChannelAdapterSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsOutboundChannelAdapterSpec.java
@@ -16,12 +16,15 @@
 
 package org.springframework.integration.jms.dsl;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
 
+import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessageHandlerSpec;
 import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.jms.JmsHeaderMapper;
@@ -127,8 +130,9 @@ public class JmsOutboundChannelAdapterSpec<S extends JmsOutboundChannelAdapterSp
 	/**
 	 * A {@link JmsTemplate}-based {@link JmsOutboundChannelAdapterSpec} extension.
 	 */
-	public static class JmsOutboundChannelSpecTemplateAware extends
-			JmsOutboundChannelAdapterSpec<JmsOutboundChannelSpecTemplateAware> {
+	public static class JmsOutboundChannelSpecTemplateAware
+			extends JmsOutboundChannelAdapterSpec<JmsOutboundChannelSpecTemplateAware>
+			implements ComponentsRegistration {
 
 		JmsOutboundChannelSpecTemplateAware(ConnectionFactory connectionFactory) {
 			super(connectionFactory);
@@ -138,6 +142,11 @@ public class JmsOutboundChannelAdapterSpec<S extends JmsOutboundChannelAdapterSp
 			Assert.notNull(configurer, "'configurer' must not be null");
 			configurer.accept(this.jmsTemplateSpec);
 			return _this();
+		}
+
+		@Override
+		public Map<Object, String> getComponentsToRegister() {
+			return Collections.singletonMap(this.jmsTemplateSpec.get(), this.jmsTemplateSpec.getId());
 		}
 
 	}

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/dsl/JpaBaseOutboundEndpointSpec.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/dsl/JpaBaseOutboundEndpointSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package org.springframework.integration.jpa.dsl;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessageHandlerSpec;
@@ -159,8 +159,8 @@ public abstract class JpaBaseOutboundEndpointSpec<S extends JpaBaseOutboundEndpo
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		return Collections.singletonList(this.jpaExecutor);
+	public Map<Object, String> getComponentsToRegister() {
+		return Collections.singletonMap(this.jpaExecutor, null);
 	}
 
 }

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/dsl/JpaInboundChannelAdapterSpec.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/dsl/JpaInboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.jpa.dsl;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.springframework.expression.Expression;
 import org.springframework.integration.dsl.ComponentsRegistration;
@@ -183,8 +183,8 @@ public class JpaInboundChannelAdapterSpec
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		return Collections.singletonList(this.jpaExecutor);
+	public Map<Object, String> getComponentsToRegister() {
+		return Collections.singletonMap(this.jpaExecutor, null);
 	}
 
 }

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/dsl/ImapIdleChannelAdapterSpec.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/dsl/ImapIdleChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package org.springframework.integration.mail.dsl;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
@@ -64,7 +64,7 @@ public class ImapIdleChannelAdapterSpec
 
 	private final ImapMailReceiver receiver;
 
-	private final Collection<Object> componentsToRegister = new ArrayList<Object>();
+	private final Map<Object, String> componentsToRegister = new LinkedHashMap<>();
 
 	private final List<Advice> adviceChain = new LinkedList<>();
 
@@ -80,7 +80,7 @@ public class ImapIdleChannelAdapterSpec
 		super(new ImapIdleChannelAdapter(receiver));
 		this.target.setAdviceChain(this.adviceChain);
 		this.receiver = receiver;
-		this.componentsToRegister.add(receiver);
+		this.componentsToRegister.put(receiver, receiver.getComponentName());
 		this.externalReceiver = externalReceiver;
 	}
 
@@ -326,7 +326,7 @@ public class ImapIdleChannelAdapterSpec
 	 */
 	public ImapIdleChannelAdapterSpec transactional() {
 		TransactionInterceptor transactionInterceptor = new TransactionInterceptorBuilder(false).build();
-		this.componentsToRegister.add(transactionInterceptor);
+		this.componentsToRegister.put(transactionInterceptor, null);
 		return transactional(transactionInterceptor);
 	}
 
@@ -352,7 +352,7 @@ public class ImapIdleChannelAdapterSpec
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
+	public Map<Object, String> getComponentsToRegister() {
 		return this.componentsToRegister;
 	}
 

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/dsl/MailInboundChannelAdapterSpec.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/dsl/MailInboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.mail.dsl;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -50,7 +50,7 @@ import org.springframework.util.Assert;
  * @since 5.0
  */
 public abstract class
-		MailInboundChannelAdapterSpec<S extends MailInboundChannelAdapterSpec<S, R>, R extends AbstractMailReceiver>
+MailInboundChannelAdapterSpec<S extends MailInboundChannelAdapterSpec<S, R>, R extends AbstractMailReceiver>
 		extends MessageSourceSpec<S, MailReceivingMessageSource>
 		implements ComponentsRegistration {
 
@@ -253,8 +253,8 @@ public abstract class
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		return Collections.<Object>singletonList(this.receiver);
+	public Map<Object, String> getComponentsToRegister() {
+		return Collections.singletonMap(this.receiver, this.receiver.getComponentName());
 	}
 
 	@Override

--- a/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/dsl/ScriptMessageSourceSpec.java
+++ b/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/dsl/ScriptMessageSourceSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.scripting.dsl;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
@@ -126,8 +125,8 @@ public class ScriptMessageSourceSpec extends MessageSourceSpec<ScriptMessageSour
 	}
 
 	@Override
-	public Collection<Object> getComponentsToRegister() {
-		return Collections.singletonList(this.delegate.get());
+	public Map<Object, String> getComponentsToRegister() {
+		return Collections.singletonMap(this.delegate.get(), this.delegate.getId());
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4252

To allow to provide arbitrary bean names for the intermediate components
in the `IntegrationFlow` change `ComponentsRegistration` to return
a `Map<Object, String>` instead of raw `Collection<Object>`

* Use the value from that map in the `IntegrationFlowBeanPostProcessor` as a
fallback option before walking into bean name generation
* Provide `containerId` option for the AMQP DSL components