### PR TITLE
INT-4060: FTP Gateway: Add `NLST` and `workDir`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ subprojects { subproject ->
 			testCompile project(":spring-integration-test-support")
 		}
 
-		testRuntime "org.slf4j:slf4j-log4j12:$slf4jVersion"
+		testCompile "org.slf4j:slf4j-log4j12:$slf4jVersion"
 	}
 
 	// enable all compiler warnings; individual projects may customize further

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/MessageSessionCallback.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/MessageSessionCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.messaging.Message;
  * @author Artem Bilan
  * @since 4.2
  */
+@FunctionalInterface
 public interface MessageSessionCallback<F, T> {
 
 	/**

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/OperationsCallback.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/OperationsCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,33 +16,29 @@
 
 package org.springframework.integration.file.remote;
 
-import java.io.IOException;
-
-import org.springframework.integration.file.remote.session.Session;
-
 /**
- * Callback invoked by {@code RemoteFileOperations.execute()} - allows multiple operations
- * on a session.
- *
+ * Callback for using the same session for multiple
+ * RemoteFileTemplate operations.
+
  * @param <F> the type the operations accepts.
  * @param <T> the type the callback returns.
  *
- * @author Gary Russell
- * @since 3.0
+ * @author Artem Bilan
  *
+ * @since 5.0
  */
 @FunctionalInterface
-public interface SessionCallback<F, T> {
+public interface OperationsCallback<F, T> {
 
 	/**
-	 * Called within the context of a session.
-	 * Perform some operation(s) on the session. The caller will take
-	 * care of closing the session after this method exits.
+	 * Execute any number of operations using a dedicated remote
+	 * session as long as those operations are performed
+	 * on the template argument and on the calling thread.
+	 * The session will be closed when the callback exits.
 	 *
-	 * @param session The session.
-	 * @return The result of type T.
-	 * @throws IOException Any IOException.
+	 * @param operations the RemoteFileOperations.
+	 * @return the result of operations.
 	 */
-	T doInSession(Session<F> session) throws IOException;
+	T doInOperations(RemoteFileOperations<F> operations);
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileOperations.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileOperations.java
@@ -137,6 +137,16 @@ public interface RemoteFileOperations<F> {
 	<T> T execute(SessionCallback<F, T> callback);
 
 	/**
+	 * Invoke the callback and run all operations on the template argument in a dedicated
+	 * thread-bound session and reliably close the it afterwards.
+	 * @param action the call back.
+	 * @param <T> the return type.
+	 * @return the result from the {@link OperationsCallback#doInOperations(RemoteFileOperations)}
+	 * @since 5.0
+	 */
+	<T> T invoke(OperationsCallback<F, T> action);
+
+	/**
 	 * Execute the callback's doWithClient method after obtaining a session's
 	 * client, providing access to low level methods.
 	 * Reliably closes the session when the method exits.

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -43,6 +43,7 @@ import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.AbstractFileInfo;
 import org.springframework.integration.file.remote.MessageSessionCallback;
 import org.springframework.integration.file.remote.RemoteFileTemplate;
+import org.springframework.integration.file.remote.RemoteFileUtils;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.support.FileExistsMode;
@@ -721,6 +722,12 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	 */
 	protected boolean mv(Message<?> message, Session<F> session, String remoteFilePath, String remoteFileNewPath)
 			throws IOException {
+		int lastSeparator = remoteFileNewPath.lastIndexOf(this.remoteFileTemplate.getRemoteFileSeparator());
+		if (lastSeparator > 0) {
+			String remoteFileDirectory = remoteFileNewPath.substring(0, lastSeparator + 1);
+			RemoteFileUtils.makeDirectories(remoteFileDirectory, session,
+					this.remoteFileTemplate.getRemoteFileSeparator(), this.logger);
+		}
 		session.rename(remoteFilePath, remoteFileNewPath);
 		return true;
 	}

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
@@ -891,6 +891,7 @@ Only files matching this regular expression will be picked up by this adapter.
 	<xsd:simpleType name="remoteGatewayCommand">
 		<xsd:restriction base="xsd:token">
 			<xsd:enumeration value="ls"/>
+			<xsd:enumeration value="nlst"/>
 			<xsd:enumeration value="get"/>
 			<xsd:enumeration value="rm"/>
 			<xsd:enumeration value="mget"/>

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParser.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.file.config.AbstractRemoteFileOutboundGatewayParser;
 import org.springframework.integration.file.remote.RemoteFileOperations;
 import org.springframework.integration.ftp.filters.FtpRegexPatternFileListFilter;
@@ -30,6 +31,7 @@ import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.1
  *
  */
@@ -66,6 +68,9 @@ public class FtpOutboundGatewayParser extends AbstractRemoteFileOutboundGatewayP
 				.getValue();
 		templateDefinition.getPropertyValues()
 				.add("existsMode", FtpRemoteFileTemplate.ExistsMode.NLST);
+
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "working-dir-expression",
+				"workingDirExpressionString");
 	}
 
 }

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/FtpOutboundGatewaySpec.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/FtpOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,28 @@
 
 package org.springframework.integration.ftp.dsl;
 
+import java.util.function.Function;
+
 import org.apache.commons.net.ftp.FTPFile;
 
+import org.springframework.expression.Expression;
+import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.file.dsl.RemoteFileOutboundGatewaySpec;
-import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
 import org.springframework.integration.ftp.filters.FtpRegexPatternFileListFilter;
 import org.springframework.integration.ftp.filters.FtpSimplePatternFileListFilter;
+import org.springframework.integration.ftp.gateway.FtpOutboundGateway;
+import org.springframework.messaging.Message;
 
 /**
  * A {@link RemoteFileOutboundGatewaySpec} for FTP.
  *
  * @author Artem Bilan
+ *
  * @since 5.0
  */
 public class FtpOutboundGatewaySpec extends RemoteFileOutboundGatewaySpec<FTPFile, FtpOutboundGatewaySpec> {
 
-	FtpOutboundGatewaySpec(AbstractRemoteFileOutboundGateway<FTPFile> outboundGateway) {
+	FtpOutboundGatewaySpec(FtpOutboundGateway outboundGateway) {
 		super(outboundGateway);
 	}
 
@@ -50,5 +56,37 @@ public class FtpOutboundGatewaySpec extends RemoteFileOutboundGatewaySpec<FTPFil
 	public FtpOutboundGatewaySpec regexFileNameFilter(String regex) {
 		return filter(new FtpRegexPatternFileListFilter(regex));
 	}
+
+	/**
+	 * Specify a SpEL {@link Expression} to evaluate FTP client working directory
+	 * against request message.
+	 * @param workingDirExpression the SpEL expression to evaluate working directory
+	 */
+	public FtpOutboundGatewaySpec workingDirExpression(String workingDirExpression) {
+		((FtpOutboundGateway) this.target).setWorkingDirExpressionString(workingDirExpression);
+		return this;
+	}
+
+	/**
+	 * Specify a SpEL {@link Expression} to evaluate FTP client working directory
+	 * against request message.
+	 * @param workingDirExpression the SpEL expression to evaluate working directory
+	 */
+	public FtpOutboundGatewaySpec workingDirExpression(Expression workingDirExpression) {
+		((FtpOutboundGateway) this.target).setWorkingDirExpression(workingDirExpression);
+		return this;
+	}
+
+	/**
+	 * Specify a {@link Function} to evaluate FTP client working directory
+	 * against request message.
+	 * @param workingDirFunction the function to evaluate working directory
+	 */
+	public FtpOutboundGatewaySpec workingDirFunction(Function<Message<?>, String> workingDirFunction) {
+		((FtpOutboundGateway) this.target).setWorkingDirExpression(new FunctionExpression<>(workingDirFunction));
+		return this;
+	}
+
+
 
 }

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,42 @@
 
 package org.springframework.integration.ftp.gateway;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Callable;
 
+import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.file.remote.AbstractFileInfo;
 import org.springframework.integration.file.remote.MessageSessionCallback;
 import org.springframework.integration.file.remote.RemoteFileTemplate;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
+import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.ftp.session.FtpFileInfo;
 import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
+import org.springframework.messaging.Message;
 
 /**
  * Outbound Gateway for performing remote file operations via FTP/FTPS.
  *
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.1
  */
 public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFile> {
+
+	private Expression workingDirExpression;
+
+	private StandardEvaluationContext evaluationContext;
 
 	/**
 	 * Construct an instance using the provided session factory and callback for
@@ -111,6 +125,26 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 		this(remoteFileTemplate, command, null);
 	}
 
+	/**
+	 * Specify an {@link Expression} to evaluate FTP client working directory
+	 * against request message.
+	 * @param workingDirExpression the expression to evaluate working directory
+	 * @since 5.0
+	 */
+	public void setWorkingDirExpression(Expression workingDirExpression) {
+		this.workingDirExpression = workingDirExpression;
+	}
+
+	/**
+	 * Specify a SpEL {@link Expression} to evaluate FTP client working directory
+	 * against request message.
+	 * @param workingDirExpression the SpEL expression to evaluate working directory
+	 * @since 5.0
+	 */
+	public void setWorkingDirExpressionString(String workingDirExpression) {
+		setWorkingDirExpression(EXPRESSION_PARSER.parseExpression(workingDirExpression));
+	}
+
 	@Override
 	public String getComponentType() {
 		return "ftp:outbound-gateway";
@@ -151,9 +185,75 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 	}
 
 	@Override
+	protected void doInit() {
+		super.doInit();
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+	}
+
+	@Override
 	protected FTPFile enhanceNameWithSubDirectory(FTPFile file, String directory) {
 		file.setName(directory + file.getName());
 		return file;
+	}
+
+	@Override
+	protected List<?> ls(Message<?> message, Session<FTPFile> session, String dir) throws IOException {
+		return doInWorkingDirectory(message, session,
+				() -> super.ls(message, session, dir));
+	}
+
+	@Override
+	protected List<String> nlst(Message<?> message, Session<FTPFile> session, String dir) throws IOException {
+		return doInWorkingDirectory(message, session,
+				() -> super.nlst(message, session, dir));
+	}
+
+	@Override
+	protected File get(Message<?> message, Session<FTPFile> session, String remoteDir, String remoteFilePath,
+			String remoteFilename, FTPFile fileInfoParam) throws IOException {
+		return doInWorkingDirectory(message, session,
+				() -> super.get(message, session, remoteDir, remoteFilePath, remoteFilename, fileInfoParam));
+	}
+
+	@Override
+	protected List<File> mGet(Message<?> message, Session<FTPFile> session, String remoteDirectory,
+			String remoteFilename) throws IOException {
+		return doInWorkingDirectory(message, session,
+				() -> super.mGet(message, session, remoteDirectory, remoteFilename));
+	}
+
+	@Override
+	protected boolean rm(Message<?> message, Session<FTPFile> session, String remoteFilePath) throws IOException {
+		return doInWorkingDirectory(message, session,
+				() -> super.rm(message, session, remoteFilePath));
+	}
+
+	private <V> V doInWorkingDirectory(Message<?> message, Session<FTPFile> session, Callable<V> task)
+			throws IOException {
+		Expression workingDirExpression = this.workingDirExpression;
+		FTPClient ftpClient = (FTPClient) session.getClientInstance();
+		String currentWorkingDirectory = null;
+		try {
+			if (workingDirExpression != null) {
+				currentWorkingDirectory = ftpClient.printWorkingDirectory();
+				String workingDir = workingDirExpression.getValue(this.evaluationContext, message, String.class);
+				ftpClient.changeWorkingDirectory(workingDir);
+			}
+			return task.call();
+		}
+		catch (Exception e) {
+			if (e instanceof IOException) {
+				throw (IOException) e;
+			}
+			else {
+				throw new IOException("Uncategorised IO exception", e);
+			}
+		}
+		finally {
+			if (workingDirExpression != null) {
+				ftpClient.changeWorkingDirectory(currentWorkingDirectory);
+			}
+		}
 	}
 
 }

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
@@ -228,6 +228,13 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 				() -> super.rm(message, session, remoteFilePath));
 	}
 
+	@Override
+	protected boolean mv(Message<?> message, Session<FTPFile> session, String remoteFilePath, String remoteFileNewPath)
+			throws IOException {
+		return doInWorkingDirectory(message, session,
+				() -> super.mv(message, session, remoteFilePath, remoteFileNewPath));
+	}
+
 	private <V> V doInWorkingDirectory(Message<?> message, Session<FTPFile> session, Callable<V> task)
 			throws IOException {
 		Expression workingDirExpression = this.workingDirExpression;
@@ -244,6 +251,10 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 		catch (Exception e) {
 			if (e instanceof IOException) {
 				throw (IOException) e;
+
+			}
+			else if (e instanceof RuntimeException) {
+				throw (RuntimeException) e;
 			}
 			else {
 				throw new IOException("Uncategorised IO exception", e);

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-5.0.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-5.0.xsd
@@ -220,6 +220,13 @@
 							<xsd:union memberTypes="int-file:remoteGatewayCommand xsd:string"/>
 						</xsd:simpleType>
 					</xsd:attribute>
+					<xsd:attribute name="working-dir-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								The SpEL expression to evaluate FTP client working directory against request message.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="session-callback" type="xsd:string">
 						<xsd:annotation>
 							<xsd:appinfo>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -178,6 +178,12 @@
 
 	<int-ftp:outbound-gateway session-factory="ftpSessionFactory"
 							  request-channel="inboundLs"
+							  command="ls"
+							  command-options="-1"
+							  reply-channel="output"/>
+
+	<int-ftp:outbound-gateway session-factory="ftpSessionFactory"
+							  request-channel="inboundNlst"
 							  command="nlst"
 							  working-dir-expression="'ftpSource'"
 							  reply-channel="output"/>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests-context.xml
@@ -178,8 +178,8 @@
 
 	<int-ftp:outbound-gateway session-factory="ftpSessionFactory"
 							  request-channel="inboundLs"
-							  command="ls"
-							  command-options="-1"
+							  command="nlst"
+							  working-dir-expression="'ftpSource'"
 							  reply-channel="output"/>
 
 	<int-ftp:inbound-channel-adapter id="ftpInbound"

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -608,18 +608,14 @@ public class FtpServerOutboundTests extends FtpTestSupport {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	public void testLsForNullDir() throws IOException {
-		Session<FTPFile> session = ftpSessionFactory.getSession();
-		((FTPClient) session.getClientInstance()).changeWorkingDirectory("ftpSource");
-		session.close();
-
-		this.inboundLs.send(new GenericMessage<String>("foo"));
+	public void testNlstAndWorkingDirExpression() throws IOException {
+		this.inboundLs.send(new GenericMessage<>("foo"));
 		Message<?> receive = this.output.receive(10000);
 		assertNotNull(receive);
 		assertThat(receive.getPayload(), instanceOf(List.class));
 		List<String> files = (List<String>) receive.getPayload();
-		assertEquals(2, files.size());
-		assertThat(files, containsInAnyOrder(" ftpSource1.txt", "ftpSource2.txt"));
+		assertEquals(3, files.size());
+		assertThat(files, containsInAnyOrder("subFtpSource", " ftpSource1.txt", "ftpSource2.txt"));
 
 		FTPFile[] ftpFiles = ftpSessionFactory.getSession().list(null);
 		for (FTPFile ftpFile : ftpFiles) {

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/gateway/SftpOutboundGateway.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/gateway/SftpOutboundGateway.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.springframework.integration.file.remote.AbstractFileInfo;
 import org.springframework.integration.file.remote.ClientCallbackWithoutResult;
 import org.springframework.integration.file.remote.MessageSessionCallback;
+import org.springframework.integration.file.remote.RemoteFileOperations;
 import org.springframework.integration.file.remote.RemoteFileTemplate;
 import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway;
 import org.springframework.integration.file.remote.session.SessionFactory;
@@ -147,8 +148,8 @@ public class SftpOutboundGateway extends AbstractRemoteFileOutboundGateway<LsEnt
 	}
 
 	@Override
-	protected void doChmod(RemoteFileTemplate<LsEntry> remoteFileTemplate, final String path, final int chmod) {
-		remoteFileTemplate.executeWithClient((ClientCallbackWithoutResult<ChannelSftp>) client -> {
+	protected void doChmod(RemoteFileOperations<LsEntry> remoteFileOperations, final String path, final int chmod) {
+		remoteFileOperations.executeWithClient((ClientCallbackWithoutResult<ChannelSftp>) client -> {
 				try {
 					client.chmod(chmod, path);
 				}

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -768,6 +768,7 @@ The _FTP Outbound Gateway_ provides a limited set of commands to interact with a
 Commands supported are:
 
 * ls (list files)
+* nlsr (list file names)
 * get (retrieve file)
 * mget (retrieve file(s))
 * rm (remove file(s))
@@ -803,6 +804,23 @@ therefore the `expression` attribute can be omitted.
 From Java perspective there are two new constructor without `expression` argument for convenience.
 The `null` for `LS` command is treated as an Client working directory according to the FTP protocol.
 The working directory can be set via the `FTPClient.changeWorkingDirectory()` function when you extend the `DefaultFtpSessionFactory` and implement `postProcessClientAfterConnect()` callback.
+
+*nlst*
+
+(Since _version 5.0_)
+
+Lists remote file names and supports the following options:
+
+* -f - do not sort the list
+
+The message payload resulting from an _nlst_ operation is a list of file names.
+
+The remote directory that the _nlst_ command acted on is provided in the `file_remoteDirectory` header.
+
+Unlike the `-1` option for the _ls_ command (see above), the _nlst_ command perform real `NLST` command on target FTP server.
+This command is useful when server doesn't support `LS` by security restrictions or some other reason.
+At the same time the result of the _nlst_ is just names, therefore framework can't determine which entity is directory to perform filtering or recursive listing, for example.
+The target application is responsible in the proper logic on the result of this _nlst_ command.
 
 *get*
 
@@ -986,17 +1004,18 @@ Here is an example of a gateway configured for an ls command...
     reply-channel="toSplitter"/>
 ----
 
-The payload of the message sent to the toSplitter channel is a list of String objects containing the filename of each
-file.
+The payload of the message sent to the `toSplitter` channel is a list of String objects containing the filename of each file.
 If the `command-options` was omitted, it would be a list of `FileInfo` objects.
-Options are provided space-delimited, e.g.
-`command-options="-1 -dirs -links"`.
+Options are provided space-delimited, e.g. `command-options="-1 -dirs -links"`.
 
 Starting with _version 4.2_, the `GET`, `MGET`, `PUT` and `MPUT` commands support a `FileExistsMode` property (`mode`
 when using the namespace support). This affects the behavior when the local file exists (`GET` and `MGET`) or the remote
 file exists (`PUT` and `MPUT`). Supported modes are `REPLACE`, `APPEND`, `FAIL` and `IGNORE`.
 For backwards compatibility, the default mode for `PUT` and `MPUT` operations is `REPLACE` and for `GET` and `MGET`
 operations, the default is `FAIL`.
+
+Starting with _version 5.0_, the `setWorkingDirExpression()` (`working-dir-expression`) option is added to the `FtpOutboundGateway` (`<int-ftp:outbound-gateway>`) to change the client working directory at runtime against request message.
+The previous working directory is restored after gateway operation.
 
 ==== Configuring with Java Configuration
 
@@ -1178,6 +1197,12 @@ See `FtpSession.exists()` for more information.
 Since we know that the `FileExistsMode.FAIL` case is always only looking for a file (and not a directory), we safely use `NLST` mode for the `FtpMessageHandler` and `FtpOutboundGateway` components.
 
 For any other cases the `FtpRemoteFileTemplate` can be extended for implementing a custom logic in the overridden `exist()` method.
+
+Starting with _version 5.0_, the new `RemoteFileOperations.invoke(OperationsCallback<F, T> action)` method has been added.
+This method allows to perform several `RemoteFileOperations` calls in the scope of the same, thread-bounded, `Session`.
+This is useful when you need to perform several high-level API of the `RemoteFileTemplate` as one unit of work.
+For example `AbstractRemoteFileOutboundGateway` does that with the _mput_ command implementation, where we perform _put_ for each file in the provided directory and recursively for its sub-directories.
+See their JavaDocs for more information.
 
 [[ftp-session-callback]]
 === MessageSessionCallback

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -791,6 +791,7 @@ The _SFTP Outbound Gateway_ provides a limited set of commands to interact with 
 Commands supported are:
 
 * ls (list files)
+* nlst (list file names)
 * get (retrieve file)
 * mget (retrieve file(s))
 * rm (remove file(s))
@@ -820,6 +821,20 @@ When using the recursive option (`-R`), the `fileName` includes any subdirectory
 If the `-dirs` option is included, each recursive directory is also returned as an element in the list.
 In this case, it is recommended that the `-1` is not used because you would not be able to determine files Vs.
 directories, which is achievable using the `FileInfo` objects.
+
+*nlst*
+
+(Since _version 5.0_)
+
+Lists remote file names and supports the following options:
+
+* -f - do not sort the list
+
+The message payload resulting from an _nlst_ operation is a list of file names.
+
+The remote directory that the _nlst_ command acted on is provided in the `file_remoteDirectory` header.
+
+The SFTP protocol doesn't provide _list names_ functionality, s this command is fully equivalent of the _ls_ command with `-1` option and added here for convenience.
 
 *get*
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -136,6 +136,10 @@ The FTP and SFTP outbound channel adapters, as well as `PUT` command of the outb
 The inbound channel adapters now can build file tree locally and use a new `RecursiveDirectoryScanner` by default for local directory.
 Also these adapters can now be switched to the `WatchService` instead.
 
+The `NLST` command has been added to the `AbstractRemoteFileOutboundGateway` to perform only list files names remote command.
+
+The `FtpOutboundGateway` can now be supplied with `workingDirExpression` to change the FTP client working directory for the current request message.
+
 See <<ftp>> and <<sftp>> for more information.
 
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -140,6 +140,8 @@ The `NLST` command has been added to the `AbstractRemoteFileOutboundGateway` to 
 
 The `FtpOutboundGateway` can now be supplied with `workingDirExpression` to change the FTP client working directory for the current request message.
 
+The `RemoteFileTemplate` is supplied now with the `invoke(OperationsCallback<F, T> action)` to perform several `RemoteFileOperations` calls in the scope of the same, thread-bounded, `Session`.
+
 See <<ftp>> and <<sftp>> for more information.
 
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4060

* Add `NLST` command to the `AbstractRemoteFileOutboundGateway` to perform
`listNames` on the target session.
Useful in case of server doesn't allow to perform `LS` or the names set is
sufficient for application requirements
* Add `workingDirExpression` to the `FtpOutboundGateway` to allow to perform
`FtpClient.changeWorkingDirectory()` based on the current request message
* Change `slf4j-log4j12` to the `testCompile` -
the FTP tests fail in the IDE with `ClassNotFoundException`