### PR TITLE
INT-4255: JSON Embedded Headers Message Mapper

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/BytesMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/BytesMessageMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mapping;
+
+/**
+ * An {@link OutboundMessageMapper} and {@link InboundMessageMapper} that
+ * maps to/from {@code byte[]}.
+ *
+ * @author Gary Russell
+ * @since 5.0
+ *
+ */
+public interface BytesMessageMapper extends InboundMessageMapper<byte[]>, OutboundMessageMapper<byte[]> {
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/EmbeddedJsonHeadersMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/EmbeddedJsonHeadersMessageMapper.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support.json;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import org.springframework.integration.mapping.BytesMessageMapper;
+import org.springframework.integration.support.MutableMessage;
+import org.springframework.integration.support.MutableMessageHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * For outbound messages, uses a message-aware Jackson object mapper to render the message
+ * as JSON. For messages with {@code byte[]} payloads, if rendered as JSON, Jackson
+ * performs Base64 conversion on the bytes. If the {@link #setRawBytes(boolean) rawBytes}
+ * property is true (default), the result has the form
+ * &lt;headersLen&gt;&lt;headers&gt;&lt;payloadLen&gt;&lt;payload&gt;; with the headers
+ * rendered in JSON and the payload unchanged.
+ * <p>
+ * By default, all headers are included; you can provide regular expressions to specify a
+ * subset of headers.
+ * <p>
+ * For inbound messages, in addition to pure JSON and the above format, the Spring Cloud
+ * Stream {@code EmbeddedHeadersMessageConverter} format is also supported:
+ * {@code 0xff, n(1), [ [lenHdr(1), hdr, lenValue(4), value] ... ]}. The 0xff indicates
+ * this format; n is the number of headers (max 255); for each header, the name length (1
+ * byte) is followed by the name, followed by the value length (int) followed by the value
+ * (json).
+ * <p>
+ * If neither special format is detected, or an error occurs during conversion, the
+ * payload of the message is the original {@code byte[]}.
+ * <p>
+ * <b>IMPORTANT</b>
+ * <p>
+ * The default object mapper uses default typing. From the Jacskson Javadocs:
+ * <p>
+ * NOTE: use of Default Typing can be a potential security risk if incoming content comes
+ * from untrusted sources, and it is recommended that this is either not done, or, if
+ * enabled, use {@link ObjectMapper#setDefaultTyping} passing a custom
+ * {@link com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder} implementation that
+ * white-lists legal types to use.
+ * <p>
+ * A constructor is provided allowing the provision of such a configured object mapper.
+ *
+ * @author Gary Russell
+ * @since 5.0
+ *
+ */
+public class EmbeddedJsonHeadersMessageMapper implements BytesMessageMapper {
+
+	private final ObjectMapper objectMapper;
+
+	private final List<Pattern> headerPatterns;
+
+	private final boolean allHeaders;
+
+	private boolean rawBytes = true;
+
+	/**
+	 * Construct an instance that embeds all headers, using the default
+	 * JSON Object mapper.
+	 */
+	public EmbeddedJsonHeadersMessageMapper() {
+		this(Collections.singleton(Pattern.compile(".*")));
+	}
+
+	/**
+	 * Construct an instance that embeds headers matching the supplied patterns, using
+	 * the default JSON object mapper.
+	 * @param headerPatterns the patterns.
+	 */
+	public EmbeddedJsonHeadersMessageMapper(Collection<Pattern> headerPatterns) {
+		this(JacksonJsonUtils.messagingAwareMapper(), headerPatterns);
+	}
+
+	/**
+	 * Construct an instance that embeds headers matching the supplied patterns using the
+	 * supplied JSON object mapper.
+	 * @param objectMapper the object mapper.
+	 * @param headerPatterns the patterns.
+	 */
+	public EmbeddedJsonHeadersMessageMapper(ObjectMapper objectMapper, Collection<Pattern> headerPatterns) {
+		this.objectMapper = objectMapper;
+		this.headerPatterns = new ArrayList<>(headerPatterns);
+		this.allHeaders = this.headerPatterns.size() == 1 && this.headerPatterns.get(0).pattern().equals(".*");
+	}
+
+	/**
+	 * Set to false to encode byte[] payloads as base64 in JSON. When true,
+	 * byte[] payloads are rendered as discussed in the class description.
+	 * @param rawBytes false to encode as base64.
+	 */
+	public void setRawBytes(boolean rawBytes) {
+		this.rawBytes = rawBytes;
+	}
+
+	public Collection<Pattern> getHeaderPatterns() {
+		return Collections.unmodifiableCollection(this.headerPatterns);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public byte[] fromMessage(Message<?> message) throws Exception {
+		Message<?> messageToEncode = this.allHeaders ? message : pruneHeaders(message);
+		if (this.rawBytes && message.getPayload() instanceof byte[]) {
+			return fromBytesPayload((Message<byte[]>) messageToEncode);
+		}
+		else {
+			return this.objectMapper.writeValueAsBytes(messageToEncode);
+		}
+	}
+
+	private Message<?> pruneHeaders(Message<?> message) {
+		Map<String, Object> headersToEmbed = new HashMap<>();
+		message.getHeaders().forEach((k, v) -> {
+			if (this.headerPatterns.stream().anyMatch(p -> p.matcher(k).matches())) {
+				headersToEmbed.put(k, v);
+			}
+		});
+		return new MutableMessage<>(message.getPayload(), headersToEmbed);
+	}
+
+	private byte[] fromBytesPayload(Message<byte[]> message) throws UnsupportedEncodingException, Exception {
+		byte[] headers = this.objectMapper.writeValueAsBytes(message.getHeaders());
+		byte[] payload = message.getPayload();
+		ByteBuffer buffer = ByteBuffer.wrap(new byte[8 + headers.length + payload.length]);
+		buffer.putInt(headers.length);
+		buffer.put(headers);
+		buffer.putInt(payload.length);
+		buffer.put(payload);
+		return buffer.array();
+	}
+
+	@Override
+	public Message<?> toMessage(byte[] bytes) throws Exception {
+		Message<?> message = null;
+		try {
+			message = decodeNativeFormat(bytes);
+		}
+		catch (Exception e) {
+			// empty
+		}
+		if (message == null) {
+			try {
+				message = decodeSCStFormat(bytes);
+			}
+			catch (Exception e) {
+				// empty
+			}
+		}
+		if (message == null) {
+			try {
+				message = (Message<?>) this.objectMapper.readValue(bytes, Object.class);
+			}
+			catch (Exception e) {
+				// empty
+			}
+		}
+		if (message != null) {
+			return message;
+		}
+		else {
+			return new GenericMessage<>(bytes);
+		}
+	}
+
+	private Message<?> decodeNativeFormat(byte[] bytes) throws Exception {
+		ByteBuffer buffer = ByteBuffer.wrap(bytes);
+		if (buffer.remaining() > 4) {
+			int headersLen = buffer.getInt();
+			if (headersLen >= 0 && headersLen < buffer.remaining() - 4) {
+				buffer.position(headersLen + 4);
+				int payloadLen = buffer.getInt();
+				if (payloadLen != buffer.remaining()) {
+					buffer.position(0);
+					return null;
+				}
+				else {
+					buffer.position(4);
+					@SuppressWarnings("unchecked")
+					Map<String, Object> headers = this.objectMapper.readValue(bytes, buffer.position(), headersLen,
+							HashMap.class);
+					buffer.position(buffer.position() + headersLen);
+					buffer.getInt();
+					Object payload;
+					byte[] payloadBytes = new byte[payloadLen];
+					buffer.get(payloadBytes);
+					payload = payloadBytes;
+					return new GenericMessage<Object>(payload, new MutableMessageHeaders(headers));
+				}
+			}
+		}
+		buffer.position(0);
+		return null;
+	}
+
+	private Message<?> decodeSCStFormat(byte[] bytes) throws Exception {
+		ByteBuffer buffer = ByteBuffer.wrap(bytes);
+		int headerCount = buffer.get() & 0xff;
+		if (headerCount != 255) {
+			return null;
+		}
+		else {
+			headerCount = buffer.get() & 0xff;
+			Map<String, Object> headers = new HashMap<String, Object>();
+			for (int i = 0; i < headerCount; i++) {
+				int len = buffer.get() & 0xff;
+				String headerName = new String(bytes, buffer.position(), len, "UTF-8");
+				buffer.position(buffer.position() + len);
+				len = buffer.getInt();
+				Object headerContent = this.objectMapper.readValue(bytes, buffer.position(), len, Object.class);
+				headers.put(headerName, headerContent);
+				buffer.position(buffer.position() + len);
+			}
+			byte[] newPayload = new byte[buffer.remaining()];
+			buffer.get(newPayload);
+			fixIdIfPresent(headers);
+			return new GenericMessage<>(newPayload, new MutableMessageHeaders(headers));
+		}
+	}
+
+	private void fixIdIfPresent(Map<String, Object> headers) {
+		if (headers.containsKey(MessageHeaders.ID) && headers.get(MessageHeaders.ID) instanceof String) {
+			headers.put(MessageHeaders.ID, UUID.fromString((String) headers.get(MessageHeaders.ID)));
+		}
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonInboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonInboundMessageMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import org.springframework.util.Assert;
 /**
  * {@link org.springframework.integration.mapping.InboundMessageMapper} implementation that maps incoming JSON messages
  * to a {@link Message} with the specified payload type.
+ * <p>
+ * Consider using the {@link EmbeddedJsonHeadersMessageMapper} instead.
  *
  * @author Jeremy Grelle
  * @author Oleg Zhurakousky
@@ -60,6 +62,7 @@ public class JsonInboundMessageMapper extends AbstractJsonInboundMessageMapper<J
 		return headerTypes;
 	}
 
+	@Override
 	public Message<?> toMessage(String jsonMessage) throws Exception {
 		return this.messageParser.doInParser(this, jsonMessage);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonOutboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonOutboundMessageMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,16 @@ import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
 /**
- * {@link OutboundMessageMapper} implementation the converts a {@link Message} to a JSON string representation.
+ * {@link OutboundMessageMapper} implementation the converts a {@link Message} to a JSON
+ * string representation.
+ * <p>
+ * Consider using the {@link EmbeddedJsonHeadersMessageMapper} instead; it provides more
+ * flexibility for determining which headers are included.
  *
  * @author Jeremy Grelle
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 2.0
  */
 public class JsonOutboundMessageMapper implements OutboundMessageMapper<String> {
@@ -47,6 +52,7 @@ public class JsonOutboundMessageMapper implements OutboundMessageMapper<String> 
 		this.shouldExtractPayload = shouldExtractPayload;
 	}
 
+	@Override
 	public String fromMessage(Message<?> message) throws Exception {
 		return this.jsonObjectMapper.toJson(this.shouldExtractPayload ? message.getPayload() : message);
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/json/EmbeddedJsonHeadersMessageMapperTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/json/EmbeddedJsonHeadersMessageMapperTests.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertThat;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
-import java.util.regex.Pattern;
 
 import org.junit.Test;
 
@@ -47,7 +46,7 @@ public class EmbeddedJsonHeadersMessageMapperTests {
 
 	@Test
 	public void testEmbedSome() throws Exception {
-		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper(Pattern.compile("id"));
+		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper("id");
 		GenericMessage<String> message = new GenericMessage<>("foo");
 		Message<?> decoded = mapper.toMessage(mapper.fromMessage(message));
 		assertThat(decoded.getPayload(), equalTo(message.getPayload()));
@@ -76,7 +75,7 @@ public class EmbeddedJsonHeadersMessageMapperTests {
 
 	@Test
 	public void testBytesEmbedSome() throws Exception {
-		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper(Pattern.compile("id"));
+		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper("I*");
 		GenericMessage<byte[]> message = new GenericMessage<>("foo".getBytes(), Collections.singletonMap("bar", "baz"));
 		byte[] bytes = mapper.fromMessage(message);
 		ByteBuffer bb = ByteBuffer.wrap(bytes);

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/json/EmbeddedJsonHeadersMessageMapperTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/json/EmbeddedJsonHeadersMessageMapperTests.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support.json;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
+
+/**
+ * @author Gary Russell
+ * @since 5.0
+ *
+ */
+public class EmbeddedJsonHeadersMessageMapperTests {
+
+	private final Jackson2JsonObjectMapper objectMapper = new Jackson2JsonObjectMapper();
+
+	@Test
+	public void testEmbedAll() throws Exception {
+		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper();
+		GenericMessage<String> message = new GenericMessage<>("foo");
+		assertThat(mapper.toMessage(mapper.fromMessage(message)), equalTo(message));
+
+	}
+
+	@Test
+	public void testEmbedSome() throws Exception {
+		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper(
+				Collections.singleton(Pattern.compile("id")));
+		GenericMessage<String> message = new GenericMessage<>("foo");
+		Message<?> decoded = mapper.toMessage(mapper.fromMessage(message));
+		assertThat(decoded.getPayload(), equalTo(message.getPayload()));
+		assertThat(decoded.getHeaders().getId(), equalTo(message.getHeaders().getId()));
+	}
+
+	@Test
+	public void testBytesEmbedAll() throws Exception {
+		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper();
+		GenericMessage<byte[]> message = new GenericMessage<>("foo".getBytes());
+		Thread.sleep(2);
+		byte[] bytes = mapper.fromMessage(message);
+		ByteBuffer bb = ByteBuffer.wrap(bytes);
+		int headerLen = bb.getInt();
+		byte[] headerBytes = new byte[headerLen];
+		bb.get(headerBytes);
+		String headers = new String(headerBytes);
+		assertThat(headers, containsString(message.getHeaders().getId().toString()));
+		assertThat(headers, containsString(String.valueOf(message.getHeaders().getTimestamp())));
+		assertThat(bb.getInt(), equalTo(3));
+		assertThat(bb.remaining(), equalTo(3));
+		assertThat((char) bb.get(), equalTo('f'));
+		assertThat((char) bb.get(), equalTo('o'));
+		assertThat((char) bb.get(), equalTo('o'));
+	}
+
+	@Test
+	public void testBytesEmbedSome() throws Exception {
+		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper(
+				Collections.singleton(Pattern.compile("id")));
+		GenericMessage<byte[]> message = new GenericMessage<>("foo".getBytes(), Collections.singletonMap("bar", "baz"));
+		byte[] bytes = mapper.fromMessage(message);
+		ByteBuffer bb = ByteBuffer.wrap(bytes);
+		int headerLen = bb.getInt();
+		byte[] headerBytes = new byte[headerLen];
+		bb.get(headerBytes);
+		String headers = new String(headerBytes);
+		assertThat(headers, containsString(message.getHeaders().getId().toString()));
+		assertThat(headers, not(containsString("bar")));
+		assertThat(bb.getInt(), equalTo(3));
+		assertThat(bb.remaining(), equalTo(3));
+		assertThat((char) bb.get(), equalTo('f'));
+		assertThat((char) bb.get(), equalTo('o'));
+		assertThat((char) bb.get(), equalTo('o'));
+	}
+
+	@Test
+	public void testBytesEmbedAllJson() throws Exception {
+		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper();
+		mapper.setRawBytes(false);
+		GenericMessage<byte[]> message = new GenericMessage<>("foo".getBytes());
+		byte[] mappedBytes = mapper.fromMessage(message);
+		String mapped = new String(mappedBytes);
+		assertThat(mapped, containsString("[B\",\"Zm9v"));
+		@SuppressWarnings("unchecked")
+		Message<byte[]> decoded = (Message<byte[]>) mapper.toMessage(mappedBytes);
+		assertThat(new String(decoded.getPayload()), equalTo("foo"));
+
+	}
+
+	@Test
+	public void testBytesDecodeAll() throws Exception {
+		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper();
+		GenericMessage<byte[]> message = new GenericMessage<>("foo".getBytes());
+		Message<?> decoded = mapper.toMessage(mapper.fromMessage(message));
+		assertThat(decoded, equalTo(message));
+	}
+
+	@Test
+	public void testDecodeScst() throws Exception {
+		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper();
+		GenericMessage<byte[]> message = new GenericMessage<>("foo".getBytes());
+		Message<?> decoded = mapper.toMessage(scstEmbedHeaders(message, MessageHeaders.ID, MessageHeaders.TIMESTAMP));
+		assertThat(decoded, equalTo(message));
+	}
+
+	private byte[] scstEmbedHeaders(Message<byte[]> original, String... headers) throws Exception {
+		byte[][] headerValues = new byte[headers.length][];
+		int n = 0;
+		int headerCount = 0;
+		int headersLength = 0;
+		for (String header : headers) {
+			Object value = original.getHeaders().get(header) == null ? null : original.getHeaders().get(header);
+			if (value != null) {
+				String json = this.objectMapper.toJson(value);
+				headerValues[n] = json.getBytes("UTF-8");
+				headerCount++;
+				headersLength += header.length() + headerValues[n++].length;
+			}
+			else {
+				headerValues[n++] = null;
+			}
+		}
+		// 0xff, n(1), [ [lenHdr(1), hdr, lenValue(4), value] ... ]
+		byte[] newPayload = new byte[original.getPayload().length + headersLength + headerCount * 5 + 2];
+		ByteBuffer byteBuffer = ByteBuffer.wrap(newPayload);
+		byteBuffer.put((byte) 0xff); // signal new format
+		byteBuffer.put((byte) headerCount);
+		for (int i = 0; i < headers.length; i++) {
+			if (headerValues[i] != null) {
+				byteBuffer.put((byte) headers[i].length());
+				byteBuffer.put(headers[i].getBytes("UTF-8"));
+				byteBuffer.putInt(headerValues[i].length);
+				byteBuffer.put(headerValues[i]);
+			}
+		}
+		byteBuffer.put(original.getPayload());
+		return byteBuffer.array();
+	}
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/json/EmbeddedJsonHeadersMessageMapperTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/json/EmbeddedJsonHeadersMessageMapperTests.java
@@ -28,7 +28,6 @@ import java.util.regex.Pattern;
 import org.junit.Test;
 
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.GenericMessage;
 
 /**
@@ -37,8 +36,6 @@ import org.springframework.messaging.support.GenericMessage;
  *
  */
 public class EmbeddedJsonHeadersMessageMapperTests {
-
-	private final Jackson2JsonObjectMapper objectMapper = new Jackson2JsonObjectMapper();
 
 	@Test
 	public void testEmbedAll() throws Exception {
@@ -50,8 +47,7 @@ public class EmbeddedJsonHeadersMessageMapperTests {
 
 	@Test
 	public void testEmbedSome() throws Exception {
-		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper(
-				Collections.singleton(Pattern.compile("id")));
+		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper(Pattern.compile("id"));
 		GenericMessage<String> message = new GenericMessage<>("foo");
 		Message<?> decoded = mapper.toMessage(mapper.fromMessage(message));
 		assertThat(decoded.getPayload(), equalTo(message.getPayload()));
@@ -80,8 +76,7 @@ public class EmbeddedJsonHeadersMessageMapperTests {
 
 	@Test
 	public void testBytesEmbedSome() throws Exception {
-		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper(
-				Collections.singleton(Pattern.compile("id")));
+		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper(Pattern.compile("id"));
 		GenericMessage<byte[]> message = new GenericMessage<>("foo".getBytes(), Collections.singletonMap("bar", "baz"));
 		byte[] bytes = mapper.fromMessage(message);
 		ByteBuffer bb = ByteBuffer.wrap(bytes);
@@ -118,48 +113,6 @@ public class EmbeddedJsonHeadersMessageMapperTests {
 		GenericMessage<byte[]> message = new GenericMessage<>("foo".getBytes());
 		Message<?> decoded = mapper.toMessage(mapper.fromMessage(message));
 		assertThat(decoded, equalTo(message));
-	}
-
-	@Test
-	public void testDecodeScst() throws Exception {
-		EmbeddedJsonHeadersMessageMapper mapper = new EmbeddedJsonHeadersMessageMapper();
-		GenericMessage<byte[]> message = new GenericMessage<>("foo".getBytes());
-		Message<?> decoded = mapper.toMessage(scstEmbedHeaders(message, MessageHeaders.ID, MessageHeaders.TIMESTAMP));
-		assertThat(decoded, equalTo(message));
-	}
-
-	private byte[] scstEmbedHeaders(Message<byte[]> original, String... headers) throws Exception {
-		byte[][] headerValues = new byte[headers.length][];
-		int n = 0;
-		int headerCount = 0;
-		int headersLength = 0;
-		for (String header : headers) {
-			Object value = original.getHeaders().get(header) == null ? null : original.getHeaders().get(header);
-			if (value != null) {
-				String json = this.objectMapper.toJson(value);
-				headerValues[n] = json.getBytes("UTF-8");
-				headerCount++;
-				headersLength += header.length() + headerValues[n++].length;
-			}
-			else {
-				headerValues[n++] = null;
-			}
-		}
-		// 0xff, n(1), [ [lenHdr(1), hdr, lenValue(4), value] ... ]
-		byte[] newPayload = new byte[original.getPayload().length + headersLength + headerCount * 5 + 2];
-		ByteBuffer byteBuffer = ByteBuffer.wrap(newPayload);
-		byteBuffer.put((byte) 0xff); // signal new format
-		byteBuffer.put((byte) headerCount);
-		for (int i = 0; i < headers.length; i++) {
-			if (headerValues[i] != null) {
-				byteBuffer.put((byte) headers[i].length());
-				byteBuffer.put(headers[i].getBytes("UTF-8"));
-				byteBuffer.putInt(headerValues[i].length);
-				byteBuffer.put(headerValues[i]);
-			}
-		}
-		byteBuffer.put(original.getPayload());
-		return byteBuffer.array();
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
@@ -92,7 +92,9 @@ public class TcpMessageMapper implements
 	/**
 	 * Sets whether outbound String payloads are to be converted
 	 * to byte[]. Default is true.
+	 * Ignored if a {@link BytesMessageMapper} is provided.
 	 * @param stringToBytes The stringToBytes to set.
+	 * @see #setBytesMessageMapper(BytesMessageMapper)
 	 */
 	public void setStringToBytes(boolean stringToBytes) {
 		this.stringToBytes = stringToBytes;
@@ -143,8 +145,11 @@ public class TcpMessageMapper implements
 
 	/**
 	 * Set a {@link BytesMessageMapper} to use when mapping byte[].
+	 * {@link #setStringToBytes(boolean)} is ignored when a {@link BytesMessageMapper}
+	 * is provided.
 	 * @param bytesMessageMapper the mapper.
 	 * @since 5.0
+	 * @see #setStringToBytes(boolean)
 	 */
 	public void setBytesMessageMapper(BytesMessageMapper bytesMessageMapper) {
 		this.bytesMessageMapper = bytesMessageMapper;

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.integration.ip.IpHeaders;
+import org.springframework.integration.mapping.BytesMessageMapper;
 import org.springframework.integration.mapping.InboundMessageMapper;
 import org.springframework.integration.mapping.OutboundMessageMapper;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
@@ -77,6 +78,8 @@ public class TcpMessageMapper implements
 	private volatile boolean addContentTypeHeader;
 
 	private BeanFactory beanFactory;
+
+	private BytesMessageMapper bytesMessageMapper;
 
 	/**
 	 * Set the charset to use when converting outbound String messages to {@code byte[]}.
@@ -138,6 +141,15 @@ public class TcpMessageMapper implements
 		this.beanFactory = beanFactory;
 	}
 
+	/**
+	 * Set a {@link BytesMessageMapper} to use when mapping byte[].
+	 * @param bytesMessageMapper the mapper.
+	 * @since 5.0
+	 */
+	public void setBytesMessageMapper(BytesMessageMapper bytesMessageMapper) {
+		this.bytesMessageMapper = bytesMessageMapper;
+	}
+
 	protected MessageBuilderFactory getMessageBuilderFactory() {
 		if (!this.messageBuilderFactorySet) {
 			if (this.beanFactory != null) {
@@ -148,12 +160,20 @@ public class TcpMessageMapper implements
 		return this.messageBuilderFactory;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public Message<?> toMessage(TcpConnection connection) throws Exception {
 		Message<Object> message = null;
 		Object payload = connection.getPayload();
 		if (payload != null) {
-			AbstractIntegrationMessageBuilder<Object> messageBuilder = getMessageBuilderFactory().withPayload(payload);
+			AbstractIntegrationMessageBuilder<Object> messageBuilder;
+			if (this.bytesMessageMapper != null && payload instanceof byte[]) {
+				messageBuilder = (AbstractIntegrationMessageBuilder<Object>) getMessageBuilderFactory()
+						.fromMessage(this.bytesMessageMapper.toMessage((byte[]) payload));
+			}
+			else {
+				messageBuilder = getMessageBuilderFactory().withPayload(payload);
+			}
 			this.addStandardHeaders(connection, messageBuilder);
 			this.addCustomHeaders(connection, messageBuilder);
 			message = messageBuilder.build();
@@ -208,6 +228,9 @@ public class TcpMessageMapper implements
 
 	@Override
 	public Object fromMessage(Message<?> message) throws Exception {
+		if (this.bytesMessageMapper != null) {
+			return this.bytesMessageMapper.fromMessage(message);
+		}
 		if (this.stringToBytes) {
 			return getPayloadAsBytes(message);
 		}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4255

- Support embedding headers for transports that don't support headers (TCP, Kafka, etc)
- Use the new message-aware Jackson ObjectMapper
- Provide a mechanism to more efficiently support byte[] payloads (avoid Base64 encoding)
- Support decoding "legacy" SCSt embedded headers