### PR TITLE
INT-4117: File Outbound Set File Permissions

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -558,6 +558,12 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 					if (timestamp instanceof Number) {
 						resultFile.setLastModified(((Number) timestamp).longValue());
 					}
+					else if (timestamp == null) {
+						if (this.logger.isWarnEnabled()) {
+							this.logger.warn("Could not set lastModified, header " + FileHeaders.SET_MODIFIED
+									+ " must be a Number, not null");
+						}
+					}
 					else {
 						if (this.logger.isWarnEnabled()) {
 							this.logger.warn("Could not set lastModified, header " + FileHeaders.SET_MODIFIED

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerBeanDefinitionBuilder.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerBeanDefinitionBuilder.java
@@ -75,6 +75,7 @@ abstract class FileWritingMessageHandlerBeanDefinitionBuilder {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "flush-interval");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "flush-when-idle");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "flush-predicate");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "chmod");
 		String remoteFileNameGenerator = element.getAttribute("filename-generator");
 		String remoteFileNameGeneratorExpression = element.getAttribute("filename-generator-expression");
 		boolean hasRemoteFileNameGenerator = StringUtils.hasText(remoteFileNameGenerator);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerFactoryBean.java
@@ -73,6 +73,8 @@ public class FileWritingMessageHandlerFactoryBean
 
 	private volatile MessageFlushPredicate flushPredicate;
 
+	private String chmod;
+
 	public void setFileExistsMode(String fileExistsModeAsString) {
 		this.fileExistsMode = FileExistsMode.getForString(fileExistsModeAsString);
 	}
@@ -137,6 +139,10 @@ public class FileWritingMessageHandlerFactoryBean
 		this.flushPredicate = flushPredicate;
 	}
 
+	public void setChmod(String chmod) {
+		this.chmod = chmod;
+	}
+
 	@Override
 	protected FileWritingMessageHandler createHandler() {
 
@@ -194,6 +200,9 @@ public class FileWritingMessageHandlerFactoryBean
 		}
 		if (this.flushPredicate != null) {
 			handler.setFlushPredicate(this.flushPredicate);
+		}
+		if (this.chmod != null) {
+			handler.setChmodOctal(this.chmod);
 		}
 
 		return handler;

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileWritingMessageHandlerSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileWritingMessageHandlerSpec.java
@@ -245,6 +245,19 @@ public class FileWritingMessageHandlerSpec
 		return this;
 	}
 
+	/**
+	 * Set the file permissions after uploading, e.g. 0600 for
+	 * owner read/write. Only applies to file systems that support posix
+	 * file permissions.
+	 * @param chmod the permissions.
+	 * @throws IllegalArgumentException if the value is higher than 0777.
+	 * @see FileWritingMessageHandler#setChmod(int)
+	 */
+	public FileWritingMessageHandlerSpec chmod(int chmod) {
+		this.target.setChmod(chmod);
+		return this;
+	}
+
 	@Override
 	public Collection<Object> getComponentsToRegister() {
 		if (this.defaultFileNameGenerator != null) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileWritingMessageHandlerSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileWritingMessageHandlerSpec.java
@@ -251,6 +251,7 @@ public class FileWritingMessageHandlerSpec
 	 * file permissions.
 	 * @param chmod the permissions.
 	 * @throws IllegalArgumentException if the value is higher than 0777.
+	 * @return the spec.
 	 * @see FileWritingMessageHandler#setChmod(int)
 	 */
 	public FileWritingMessageHandlerSpec chmod(int chmod) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileUtils.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.file.support;
+
+import java.nio.file.FileSystems;
+
+/**
+ * Utilities for operations on Files.
+ *
+ * @author Gary Russell
+ * @since 5.0
+ *
+ */
+public final class FileUtils {
+
+	public static final boolean IS_POSIX = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+
+	private FileUtils() {
+		super();
+	}
+
+}

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
@@ -597,6 +597,7 @@ Only files matching this regular expression will be picked up by this adapter.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attributeGroup ref="chmod" />
 		<xsd:attributeGroup ref="integration:smartLifeCycleAttributeGroup"/>
     </xsd:complexType>
 
@@ -1024,6 +1025,17 @@ Only files matching this regular expression will be picked up by this adapter.
 			<xsd:simpleType>
 				<xsd:union memberTypes="mode xsd:string"/>
 			</xsd:simpleType>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="chmod">
+		<xsd:attribute name="chmod" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Change the mode of the file (or remote file) after writing. Integer value
+					expressed in Octal, e.g. '644'.
+				</xsd:documentation>
+			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:attributeGroup>
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests-context.xml
@@ -17,6 +17,7 @@
 								   channel="testChannel"
 								   directory="${java.io.tmpdir}"
 								   temporary-file-suffix=".foo"
+								   chmod="777"
 								   filename-generator-expression="'foo.txt'"/>
 
 	<file:outbound-channel-adapter id="adapterWithCustomNameGenerator"

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests.java
@@ -43,6 +43,7 @@ import org.springframework.integration.file.DefaultFileNameGenerator;
 import org.springframework.integration.file.FileWritingMessageHandler;
 import org.springframework.integration.file.FileWritingMessageHandler.MessageFlushPredicate;
 import org.springframework.integration.file.support.FileExistsMode;
+import org.springframework.integration.file.support.FileUtils;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
@@ -142,7 +143,9 @@ public class FileOutboundChannelAdapterParserTests {
 		assertEquals("'foo.txt'", expression.getExpressionString());
 		assertEquals(Boolean.FALSE, handlerAccessor.getPropertyValue("deleteSourceFiles"));
 		assertEquals(Boolean.TRUE, handlerAccessor.getPropertyValue("flushWhenIdle"));
-		assertThat(TestUtils.getPropertyValue(handler, "permissions", Set.class).size(), equalTo(9));
+		if (FileUtils.IS_POSIX) {
+			assertThat(TestUtils.getPropertyValue(handler, "permissions", Set.class).size(), equalTo(9));
+		}
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.file.config;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
@@ -26,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -140,6 +142,7 @@ public class FileOutboundChannelAdapterParserTests {
 		assertEquals("'foo.txt'", expression.getExpressionString());
 		assertEquals(Boolean.FALSE, handlerAccessor.getPropertyValue("deleteSourceFiles"));
 		assertEquals(Boolean.TRUE, handlerAccessor.getPropertyValue("flushWhenIdle"));
+		assertThat(TestUtils.getPropertyValue(handler, "permissions", Set.class).size(), equalTo(9));
 	}
 
 	@Test

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-5.0.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-5.0.xsd
@@ -66,7 +66,7 @@
 						</xsd:annotation>
 					</xsd:attribute>
 					<xsd:attributeGroup ref="int-file:remoteOutboundAttributeGroup" />
-					<xsd:attributeGroup ref="chmod" />
+					<xsd:attributeGroup ref="int-file:chmod" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -496,7 +496,7 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
-					<xsd:attributeGroup ref="chmod" />
+					<xsd:attributeGroup ref="int-file:chmod" />
 					<xsd:attributeGroup ref="int-file:remoteOutboundAttributeGroup" />
 				</xsd:extension>
 			</xsd:complexContent>
@@ -640,17 +640,6 @@
 		</xsd:attribute>
 		<xsd:attributeGroup ref="integration:smartLifeCycleAttributeGroup"/>
 	</xsd:complexType>
-
-	<xsd:attributeGroup name="chmod">
-		<xsd:attribute name="chmod" type="xsd:string">
-			<xsd:annotation>
-				<xsd:documentation>
-					Change the mode of the remote file after transferring. Integer value
-					expressed in Octal, e.g. '644'.
-				</xsd:documentation>
-			</xsd:annotation>
-		</xsd:attribute>
-	</xsd:attributeGroup>
 
 	<xsd:attributeGroup name="tempSuffixGroup">
 		<xsd:attribute name="temporary-file-suffix" type="xsd:string">

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -706,6 +706,12 @@ copy was required).
 For other payloads, if the `FileHeaders.SET_MODIFIED` header (`file_setModified`) is present, it will be used to set
 the destination file's `lastModified` timestamp, as long as the header is a `Number`.
 
+[[file-permissions]]
+==== File Permissions
+
+Starting with _version 5.0_, when writing files to a file system that supports Posix permissions, you can specify those permissions on the outbound channel adapter or gateway.
+The property is an integer and is usually supplied in the familiar octal format; e.g. `0640` meaning the owner has read/write permissions, the group has read only permission and others have no access.
+
 [[file-outbound-channel-adapter]]
 ==== File Outbound Channel Adapter
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -111,7 +111,11 @@ See <<file-tailing>> for more information.
 The flush predicates for the `FileWritingMessageHandler` now have an additional parameter.
 See <<file-flushing>> for more information.
 
-The file outbound channel adapter (`FileWritingMessageHandler`) now supports the `REPLACE_IF_MODIFIED` `FileExistsMode`.
+The file outbound channel adapter and gateway (`FileWritingMessageHandler`) now support the `REPLACE_IF_MODIFIED` `FileExistsMode`.
+See <<file-writing-destination-exists>> for more information.
+
+They also now support setting file permissions on the newly written file.
+See <<file-permissions>> for more information.
 
 ==== (S)FTP Changes
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4117

Add an option to set file permissions on the `FileWritingMessageHandler` when the file system supports it.