### PR TITLE
INT-4284: INFO about overriding readOnly headers

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/IntegrationMessageHeaderAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/IntegrationMessageHeaderAccessor.java
@@ -155,7 +155,7 @@ public class IntegrationMessageHeaderAccessor extends MessageHeaderAccessor {
 	}
 
 	@Override
-	protected boolean isReadOnly(String headerName) {
+	public boolean isReadOnly(String headerName) {
 		return super.isReadOnly(headerName) || this.readOnlyHeaders.contains(headerName);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MessageBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MessageBuilder.java
@@ -20,6 +20,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -42,6 +45,8 @@ import org.springframework.util.ObjectUtils;
  * @author Artem Bilan
  */
 public final class MessageBuilder<T> extends AbstractIntegrationMessageBuilder<T> {
+
+	private static final Log logger = LogFactory.getLog(MessageBuilder.class);
 
 	private final T payload;
 
@@ -176,7 +181,16 @@ public final class MessageBuilder<T> extends AbstractIntegrationMessageBuilder<T
 	 */
 	@Override
 	public MessageBuilder<T> copyHeadersIfAbsent(Map<String, ?> headersToCopy) {
-		this.headerAccessor.copyHeadersIfAbsent(headersToCopy);
+		if (headersToCopy != null) {
+			for (Map.Entry<String, ?> entry : headersToCopy.entrySet()) {
+				if (!this.headerAccessor.isReadOnly(entry.getKey())) {
+					this.headerAccessor.setHeaderIfAbsent(entry.getKey(), entry.getValue());
+				}
+				else if (logger.isInfoEnabled()) {
+					logger.info("The header [" + entry + "] is ignored for population because it is is readOnly.");
+				}
+			}
+		}
 		return this;
 	}
 

--- a/src/reference/asciidoc/message.adoc
+++ b/src/reference/asciidoc/message.adoc
@@ -370,6 +370,13 @@ If the strategy is the same, but parameterized, the strategy in the first contex
 
 In addition to the default strategy, two additional `IdGenerators` are provided; `org.springframework.util.JdkIdGenerator` uses the previous `UUID.randomUUID()` mechanism; `o.s.i.support.IdGenerators.SimpleIncrementingIdGenerator` can be used in cases where a UUID is not really needed and a simple incrementing value is sufficient.
 
+[[read-only-headers]]
+===== Read-only Headers
+
+The `MessageHeaders.ID` and `MessageHeaders.TIMESTAMP` are read-only headers and the cannot be overridden.
+With the `spring.integration.readOnly.headers` global property (see <<global-properties>>) you can specify any header names which become read-only.
+When you try to build a new message using `MessageBuilder`, this kind of headers are ignored and particular `INFO` message is emitted to logs.
+
 [[message-implementations]]
 ==== Message Implementations
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4284

Add `INFO` into the `MessageBuilder#copyHeadersIfAbsent()` when end-user
tries to populate headers which are `readOnly`

We can't throw exception on the matter since can modify `readOnlyHeaders`
and that would force end-user to add `header-filter` logic to the application.

**Cherry-pick 4.3.x**