### PR TITLE
AMQP: Add Support for SCSt Error Handling

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -26,10 +26,19 @@ import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFaile
 import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.core.AttributeAccessor;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
+import org.springframework.integration.amqp.support.AmqpMessageHeaderErrorMessageStrategy;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
 import org.springframework.integration.context.OrderlyShutdownCapable;
 import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.integration.support.ErrorMessageStrategy;
+import org.springframework.integration.support.ErrorMessageUtils;
+import org.springframework.retry.RecoveryCallback;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
 
 import com.rabbitmq.client.Channel;
@@ -47,12 +56,17 @@ import com.rabbitmq.client.Channel;
 public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 		OrderlyShutdownCapable {
 
+	private static final ThreadLocal<AttributeAccessor> attributesHolder = new ThreadLocal<AttributeAccessor>();
+
 	private final AbstractMessageListenerContainer messageListenerContainer;
 
 	private volatile MessageConverter messageConverter = new SimpleMessageConverter();
 
 	private volatile AmqpHeaderMapper headerMapper = DefaultAmqpHeaderMapper.inboundMapper();
 
+	private RetryTemplate retryTemplate;
+
+	private RecoveryCallback<? extends Object> recoveryCallback;
 
 	public AmqpInboundChannelAdapter(AbstractMessageListenerContainer listenerContainer) {
 		Assert.notNull(listenerContainer, "listenerContainer must not be null");
@@ -62,6 +76,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 						"configure its own listener implementation.");
 		this.messageListenerContainer = listenerContainer;
 		this.messageListenerContainer.setAutoStartup(false);
+		setErrorMessageStrategy(new AmqpMessageHeaderErrorMessageStrategy());
 	}
 
 
@@ -75,6 +90,31 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 		this.headerMapper = headerMapper;
 	}
 
+	/**
+	 * Set a {@link RetryTemplate} to use for retrying a message delivery within the
+	 * adapter. Unlike adding retry at the container level, this can be used with an
+	 * {@code ErrorMessageSendingRecoverer} {@link RecoveryCallback} to publish to the
+	 * error channel after retries are exhausted. You generally should not configure an
+	 * error channel when using retry here, use a {@link RecoveryCallback} instead.
+	 * @param retryTemplate the template.
+	 * @see #setRecoveryCallback(RecoveryCallback)
+	 * @since 4.3.10.
+	 */
+	public void setRetryTemplate(RetryTemplate retryTemplate) {
+		this.retryTemplate = retryTemplate;
+	}
+
+	/**
+	 * Set a {@link RecoveryCallback} when using retry within the adapter.
+	 * @param recoveryCallback the callback.
+	 * @see #setRetryTemplate(RetryTemplate)
+	 * @since 4.3.10
+	 */
+	public void setRecoveryCallback(RecoveryCallback<? extends Object> recoveryCallback) {
+		this.recoveryCallback = recoveryCallback;
+	}
+
+
 	@Override
 	public String getComponentType() {
 		return "amqp:inbound-channel-adapter";
@@ -82,7 +122,16 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 
 	@Override
 	protected void onInit() {
-		this.messageListenerContainer.setMessageListener(new Listener());
+		if (this.retryTemplate != null) {
+			Assert.state(getErrorChannel() == null, "Cannot have an 'errorChannel' property when a 'RetryTemplate' is "
+					+ "provided; use an 'ErrorMessageSendingRecoverer' in the 'recoveryCallback' property to "
+					+ "send an error message when retries are exhausted");
+		}
+		Listener messageListener = new Listener();
+		if (this.retryTemplate != null) {
+			this.retryTemplate.registerListener(messageListener);
+		}
+		this.messageListenerContainer.setMessageListener(messageListener);
 		this.messageListenerContainer.afterPropertiesSet();
 		super.onInit();
 	}
@@ -115,24 +164,61 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 		return 0;
 	}
 
-	protected class Listener implements ChannelAwareMessageListener {
+	/**
+	 * If there's a retry template, it will set the attributes holder via the listener. If
+	 * there's no retry template, but there's an error channel, we create a new attributes
+	 * holder here. If an attributes holder exists (by either method), we set the
+	 * attributes for use by the {@link ErrorMessageStrategy}.
+	 * @param record the record.
+	 * @param message the message.
+	 * @since 4.3.10
+	 */
+	private void setAttributesIfNecessary(Message amqpMessage, org.springframework.messaging.Message<?> message) {
+		boolean needHolder = getErrorChannel() != null && this.retryTemplate == null;
+		boolean needAttributes = needHolder || this.retryTemplate != null;
+		if (needHolder) {
+			attributesHolder.set(ErrorMessageUtils.getAttributeAccessor(null, null));
+		}
+		if (needAttributes) {
+			AttributeAccessor attributes = attributesHolder.get();
+			if (attributes != null) {
+				attributes.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY, message);
+				attributes.setAttribute(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_DATA, amqpMessage);
+			}
+		}
+	}
 
+	@Override
+	protected AttributeAccessor getErrorMessageAttributes(org.springframework.messaging.Message<?> message) {
+		AttributeAccessor attributes = attributesHolder.get();
+		if (attributes == null) {
+			return super.getErrorMessageAttributes(message);
+		}
+		else {
+			return attributes;
+		}
+	}
+
+	protected class Listener implements ChannelAwareMessageListener, RetryListener {
+
+		@SuppressWarnings("unchecked")
 		@Override
-		public void onMessage(Message message, Channel channel) throws Exception {
+		public void onMessage(final Message message, final Channel channel) throws Exception {
 			try {
-				Object payload = AmqpInboundChannelAdapter.this.messageConverter.fromMessage(message);
-				Map<String, Object> headers = AmqpInboundChannelAdapter.this.headerMapper
-						.toHeadersFromRequest(message.getMessageProperties());
-				if (AmqpInboundChannelAdapter.this.messageListenerContainer.getAcknowledgeMode()
-						== AcknowledgeMode.MANUAL) {
-					headers.put(AmqpHeaders.DELIVERY_TAG, message.getMessageProperties().getDeliveryTag());
-					headers.put(AmqpHeaders.CHANNEL, channel);
+				if (AmqpInboundChannelAdapter.this.retryTemplate == null) {
+					processMessage(message, channel);
 				}
-				sendMessage(
-						getMessageBuilderFactory()
-								.withPayload(payload)
-								.copyHeaders(headers)
-								.build());
+				else {
+					AmqpInboundChannelAdapter.this.retryTemplate.execute(new RetryCallback<Object, RuntimeException>() {
+
+						@Override
+						public Void doWithRetry(RetryContext context) throws RuntimeException {
+							processMessage(message, channel);
+							return null;
+						}
+
+					}, (RecoveryCallback<Object>) AmqpInboundChannelAdapter.this.recoveryCallback);
+				}
 			}
 			catch (RuntimeException e) {
 				if (getErrorChannel() != null) {
@@ -143,6 +229,44 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 					throw e;
 				}
 			}
+			finally {
+				attributesHolder.remove();
+			}
+		}
+
+		private void processMessage(Message message, Channel channel) {
+			Object payload = AmqpInboundChannelAdapter.this.messageConverter.fromMessage(message);
+			Map<String, Object> headers = AmqpInboundChannelAdapter.this.headerMapper
+					.toHeadersFromRequest(message.getMessageProperties());
+			if (AmqpInboundChannelAdapter.this.messageListenerContainer.getAcknowledgeMode()
+					== AcknowledgeMode.MANUAL) {
+				headers.put(AmqpHeaders.DELIVERY_TAG, message.getMessageProperties().getDeliveryTag());
+				headers.put(AmqpHeaders.CHANNEL, channel);
+			}
+			final org.springframework.messaging.Message<Object> messagingMessage = getMessageBuilderFactory()
+					.withPayload(payload)
+					.copyHeaders(headers)
+					.build();
+			setAttributesIfNecessary(message, messagingMessage);
+			sendMessage(messagingMessage);
+		}
+
+		@Override
+		public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
+			attributesHolder.set(context);
+			return true;
+		}
+
+		@Override
+		public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
+				Throwable throwable) {
+			// Empty
+		}
+
+		@Override
+		public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
+				Throwable throwable) {
+			// Empty
 		}
 
 	}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/AmqpMessageHeaderErrorMessageStrategy.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/AmqpMessageHeaderErrorMessageStrategy.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.amqp.support;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.core.AttributeAccessor;
+import org.springframework.integration.support.ErrorMessageStrategy;
+import org.springframework.integration.support.ErrorMessageUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.ErrorMessage;
+
+/**
+ * {@link ErrorMessageStrategy} extension that adds the raw AMQP message as
+ * a header to the {@link org.springframework.integration.message.EnhancedErrorMessage}.
+ *
+ * @author Gary Russell
+ * @since 4.3.10
+ *
+ */
+public class AmqpMessageHeaderErrorMessageStrategy implements ErrorMessageStrategy {
+
+	/**
+	 * Header name/retry context variable for the raw received message.
+	 */
+	public static final String AMQP_RAW_DATA = "amqp_data"; // move to AmqpHeaders.RAW_DATA in 2.0
+
+	@SuppressWarnings("deprecation")
+	@Override
+	public ErrorMessage buildErrorMessage(Throwable throwable, AttributeAccessor context) {
+		Object inputMessage = context.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
+		Map<String, Object> headers = Collections.singletonMap(
+				AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_DATA,
+				context.getAttribute(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_DATA));
+		return inputMessage instanceof Message
+				? new org.springframework.integration.message.EnhancedErrorMessage(throwable, headers,
+						(Message<?>) inputMessage)
+				: new ErrorMessage(throwable, headers);
+	}
+
+}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
@@ -32,6 +32,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.gateway.MessagingGatewaySupport;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
@@ -330,8 +331,9 @@ public class ChannelPublishingJmsMessageListener
 			if (errorChannel == null) {
 				throw e;
 			}
-			errorChannel.send(this.gatewayDelegate.buildErrorMessage(
-					new MessagingException("Inbound conversion failed for: " + jmsMessage, e)));
+			this.gatewayDelegate.getMessagingTemplate().send(errorChannel,
+					this.gatewayDelegate.buildErrorMessage(
+							new MessagingException("Inbound conversion failed for: " + jmsMessage, e)));
 			errors = true;
 		}
 		if (!errors) {
@@ -510,8 +512,12 @@ public class ChannelPublishingJmsMessageListener
 			return super.sendAndReceiveMessage(request);
 		}
 
-		public ErrorMessage buildErrorMessage(Throwable throwable) {
+		protected ErrorMessage buildErrorMessage(Throwable throwable) {
 			return super.buildErrorMessage(null, throwable);
+		}
+
+		protected MessagingTemplate getMessagingTemplate() {
+			return this.messagingTemplate;
 		}
 
 		@Override


### PR DESCRIPTION
See: https://github.com/spring-cloud/spring-cloud-stream/issues/913
    
Add retry within `onMessage` so we have access to the converted message as well
as the original spring-amqp message, which is added to the `ErrorMessage` as a
header.
    
Similar to the work in spring-integration-kafka.

Also backport listener refactoring

INT-4256: AMQP: Conversion Errors to ErrorChannel
