### PR TITLE
AMQP: Use ErrorMessageStrategy

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -30,7 +30,6 @@ import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
 import org.springframework.integration.context.OrderlyShutdownCapable;
 import org.springframework.integration.endpoint.MessageProducerSupport;
-import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.util.Assert;
 
 import com.rabbitmq.client.Channel;
@@ -137,7 +136,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 			}
 			catch (RuntimeException e) {
 				if (getErrorChannel() != null) {
-					getMessagingTemplate().send(getErrorChannel(), new ErrorMessage(
+					getMessagingTemplate().send(getErrorChannel(), buildErrorMessage(null,
 							new ListenerExecutionFailedException("Message conversion failed", e, message)));
 				}
 				else {

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
@@ -34,7 +34,6 @@ import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
 import org.springframework.integration.gateway.MessagingGatewaySupport;
-import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -177,7 +176,7 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 			}
 			catch (RuntimeException e) {
 				if (getErrorChannel() != null) {
-					AmqpInboundGateway.this.messagingTemplate.send(getErrorChannel(), new ErrorMessage(
+					AmqpInboundGateway.this.messagingTemplate.send(getErrorChannel(), buildErrorMessage(null,
 							new ListenerExecutionFailedException("Message conversion failed", e, message)));
 				}
 				else {


### PR DESCRIPTION
Fix a couple of places where `ErrorMessage` was created directly instead
of delegating to the configured `ErrorMessageStrategy`.