### PR TITLE
INT-4284: Exception to overwrite id or timestamp

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
@@ -242,7 +242,7 @@ class GatewayMethodInboundMessageMapper implements InboundMessageMapper<Object[]
 						"payload or Message. Found more than one on method [" + methodParameter.getMethod() + "]");
 	}
 
-	private String determineHeaderName(Annotation headerAnnotation, MethodParameter methodParameter) {
+	static String determineHeaderName(Annotation headerAnnotation, MethodParameter methodParameter) {
 		String valueAttribute = (String) AnnotationUtils.getValue(headerAnnotation);
 		String headerName = StringUtils.hasText(valueAttribute) ? valueAttribute : methodParameter.getParameterName();
 		Assert.notNull(headerName, "Cannot determine header name. Possible reasons: -debug is " +
@@ -250,11 +250,10 @@ class GatewayMethodInboundMessageMapper implements InboundMessageMapper<Object[]
 		return headerName;
 	}
 
-	private static List<MethodParameter> getMethodParameterList(Method method) {
+	static List<MethodParameter> getMethodParameterList(Method method) {
 		List<MethodParameter> parameterList = new LinkedList<>();
 		ParameterNameDiscoverer parameterNameDiscoverer = new LocalVariableTableParameterNameDiscoverer();
-		int parameterCount = method.getParameterTypes().length;
-		for (int i = 0; i < parameterCount; i++) {
+		for (int i = 0; i < method.getParameterCount(); i++) {
 			MethodParameter methodParameter = new SynthesizingMethodParameter(method, i);
 			methodParameter.initParameterNameDiscovery(parameterNameDiscoverer);
 			parameterList.add(methodParameter);
@@ -307,8 +306,7 @@ class GatewayMethodInboundMessageMapper implements InboundMessageMapper<Object[]
 						foundPayloadAnnotation = true;
 					}
 					else if (annotation.annotationType().equals(Header.class)) {
-						String headerName =
-								GatewayMethodInboundMessageMapper.this.determineHeaderName(annotation, methodParameter);
+						String headerName = determineHeaderName(annotation, methodParameter);
 						if ((Boolean) AnnotationUtils.getValue(annotation, "required") && argumentValue == null) {
 							throw new IllegalArgumentException("Received null argument value for required header: '"
 									+ headerName + "'");

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MessageBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MessageBuilder.java
@@ -152,7 +152,12 @@ public final class MessageBuilder<T> extends AbstractIntegrationMessageBuilder<T
 	 */
 	@Override
 	public MessageBuilder<T> removeHeader(String headerName) {
-		this.headerAccessor.removeHeader(headerName);
+		if (!this.headerAccessor.isReadOnly(headerName)) {
+			this.headerAccessor.removeHeader(headerName);
+		}
+		else if (logger.isInfoEnabled()) {
+			logger.info("The header [" + headerName + "] is ignored for removal because it is is readOnly.");
+		}
 		return this;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/HeaderEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/HeaderEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,15 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.handler.MessageProcessor;
+import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.transformer.support.HeaderValueMessageProcessor;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
 
 /**
@@ -112,7 +115,7 @@ public class HeaderEnricher extends IntegrationObjectSupport implements Transfor
 
 				boolean headerDoesNotExist = headerMap.get(key) == null;
 
-				/**
+				/*
 				 * Only evaluate value expression if necessary
 				 */
 				if (headerDoesNotExist || shouldOverwrite) {
@@ -155,23 +158,36 @@ public class HeaderEnricher extends IntegrationObjectSupport implements Transfor
 	@Override
 	public void onInit() throws Exception {
 		boolean shouldOverwrite = this.defaultOverwrite;
-		for (HeaderValueMessageProcessor<?> processor : this.headersToAdd.values()) {
-			if (processor instanceof BeanFactoryAware && this.getBeanFactory() != null) {
-				((BeanFactoryAware) processor).setBeanFactory(this.getBeanFactory());
+		boolean checkReadOnlyHeaders = getMessageBuilderFactory() instanceof DefaultMessageBuilderFactory;
+
+		for (Entry<String, ? extends HeaderValueMessageProcessor<?>> entry : this.headersToAdd.entrySet()) {
+			if (checkReadOnlyHeaders &&
+					(MessageHeaders.ID.equals(entry.getKey()) || MessageHeaders.TIMESTAMP.equals(entry.getKey()))) {
+				throw new BeanInitializationException(
+						"HeaderEnricher cannot override 'id' and 'timestamp' read-only headers.\n" +
+								"Wrong 'headersToAdd' [" + this.headersToAdd
+								+ "] configuration for " + getComponentName());
+			}
+
+			HeaderValueMessageProcessor<?> processor = entry.getValue();
+			if (processor instanceof BeanFactoryAware && getBeanFactory() != null) {
+				((BeanFactoryAware) processor).setBeanFactory(getBeanFactory());
 			}
 			Boolean processorOverwrite = processor.isOverwrite();
 			if (processorOverwrite != null) {
 				shouldOverwrite |= processorOverwrite;
 			}
 		}
+
 		if (this.messageProcessor != null
 				&& this.messageProcessor instanceof BeanFactoryAware
-				&& this.getBeanFactory() != null) {
-			((BeanFactoryAware) this.messageProcessor).setBeanFactory(this.getBeanFactory());
+				&& getBeanFactory() != null) {
+			((BeanFactoryAware) this.messageProcessor).setBeanFactory(getBeanFactory());
 		}
-		if (!shouldOverwrite && !this.shouldSkipNulls) {
-			logger.warn(this.getComponentName()
-					+ " is configured to not overwrite existing headers. 'shouldSkipNulls = false' will have no effect");
+
+		if (!shouldOverwrite && !this.shouldSkipNulls && logger.isWarnEnabled()) {
+			logger.warn(getComponentName() +
+					" is configured to not overwrite existing headers. 'shouldSkipNulls = false' will have no effect");
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingHeaderEnricherTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingHeaderEnricherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,30 @@
 
 package org.springframework.integration.handler;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
 
-import org.springframework.messaging.Message;
-import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.transformer.HeaderEnricher;
+import org.springframework.integration.transformer.support.StaticHeaderValueMessageProcessor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Payload;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class MethodInvokingHeaderEnricherTests {
@@ -89,6 +99,21 @@ public class MethodInvokingHeaderEnricherTests {
 		assertEquals("ABC", result.getHeaders().get("bar"));
 	}
 
+	@Test
+	public void overwriteId() {
+		HeaderEnricher enricher =
+				new HeaderEnricher(Collections.singletonMap(MessageHeaders.ID,
+				new StaticHeaderValueMessageProcessor<>("foo")));
+
+		try {
+			enricher.afterPropertiesSet();
+			fail("BeanInitializationException expected");
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(BeanInitializationException.class));
+			assertThat(e.getMessage(), containsString("HeaderEnricher cannot override 'id' and 'timestamp' read-only headers."));
+		}
+	}
 
 	public static class TestBean {
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/ContentEnricherTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/ContentEnricherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.transformer;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -27,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,6 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -47,9 +50,11 @@ import org.springframework.integration.endpoint.PollingConsumer;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.ReplyRequiredException;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.transformer.support.StaticHeaderValueMessageProcessor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.support.PeriodicTrigger;
 
@@ -87,7 +92,7 @@ public class ContentEnricherTests {
 	public void replyChannelReplyTimingOut() throws Exception {
 
 		final long requestTimeout = 500L;
-		final long replyTimeout = 700L;
+		final long replyTimeout = 100L;
 
 		final DirectChannel replyChannel = new DirectChannel();
 		final QueueChannel requestChannel = new QueueChannel(1);
@@ -519,6 +524,40 @@ public class ContentEnricherTests {
 		Message<?> reply = replyChannel.receive(10000);
 		Target result = (Target) reply.getPayload();
 		assertEquals("failed target", result.getName());
+	}
+
+	@Test
+	public void testOverwriteTimestamp() {
+		ContentEnricher contentEnricher = new ContentEnricher();
+		contentEnricher.setHeaderExpressions(
+				Collections.singletonMap(MessageHeaders.TIMESTAMP, new StaticHeaderValueMessageProcessor<>("foo")));
+
+		contentEnricher.setBeanFactory(mock(BeanFactory.class));
+		try {
+			contentEnricher.afterPropertiesSet();
+			fail("BeanInitializationException expected");
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(BeanInitializationException.class));
+			assertThat(e.getMessage(), containsString("ContentEnricher cannot override 'id' and 'timestamp' read-only headers."));
+		}
+	}
+
+	@Test
+	public void testOverwriteIdNullResult() {
+		ContentEnricher contentEnricher = new ContentEnricher();
+		contentEnricher.setNullResultHeaderExpressions(
+				Collections.singletonMap(MessageHeaders.ID, new StaticHeaderValueMessageProcessor<>("foo")));
+
+		contentEnricher.setBeanFactory(mock(BeanFactory.class));
+		try {
+			contentEnricher.afterPropertiesSet();
+			fail("BeanInitializationException expected");
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(BeanInitializationException.class));
+			assertThat(e.getMessage(), containsString("ContentEnricher cannot override 'id' and 'timestamp' read-only headers."));
+		}
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/HeaderFilterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/HeaderFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,35 @@
 
 package org.springframework.integration.transformer;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static org.springframework.integration.test.matcher.HeaderMatcher.hasHeaderKey;
 
+import java.util.Date;
 import java.util.UUID;
 
 import org.junit.Test;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class HeaderFilterTests {
@@ -74,6 +85,62 @@ public class HeaderFilterTests {
 		assertEquals("testErrorChannel", result.getHeaders().getErrorChannel());
 		assertEquals(replyChannel, result.getHeaders().getReplyChannel());
 		assertEquals(correlationId, new IntegrationMessageHeaderAccessor(result).getCorrelationId());
+	}
+
+	@Test
+	public void testIdHeaderRemoval() {
+		HeaderFilter filter = new HeaderFilter("foo", MessageHeaders.ID);
+		try {
+			filter.afterPropertiesSet();
+			fail("BeanInitializationException expected");
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(BeanInitializationException.class));
+			assertThat(e.getMessage(), containsString("HeaderFilter cannot remove 'id' and 'timestamp' read-only headers."));
+		}
+	}
+
+	@Test
+	public void testTimestampHeaderRemoval() {
+		HeaderFilter filter = new HeaderFilter(MessageHeaders.TIMESTAMP);
+		try {
+			filter.afterPropertiesSet();
+			fail("BeanInitializationException expected");
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(BeanInitializationException.class));
+			assertThat(e.getMessage(), containsString("HeaderFilter cannot remove 'id' and 'timestamp' read-only headers."));
+		}
+	}
+
+	@Test
+	public void testIdPatternRemoval() {
+		HeaderFilter filter = new HeaderFilter("*", MessageHeaders.ID);
+		filter.setPatternMatch(true);
+		try {
+			filter.afterPropertiesSet();
+			fail("BeanInitializationException expected");
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(BeanInitializationException.class));
+			assertThat(e.getMessage(), containsString("HeaderFilter cannot remove 'id' and 'timestamp' read-only headers."));
+		}
+	}
+
+	@Test
+	public void testPatternRemoval() {
+		HeaderFilter filter = new HeaderFilter("time*");
+		filter.setPatternMatch(true);
+
+		filter.afterPropertiesSet();
+		Message<String> message = MessageBuilder.withPayload("test")
+				.setHeader("time", new Date())
+				.build();
+
+		Message<?> result = filter.transform(message);
+
+		assertThat(result, hasHeaderKey(MessageHeaders.TIMESTAMP));
+		assertThat(result, not(hasHeaderKey("time")));
 	}
 
 }

--- a/src/reference/asciidoc/message.adoc
+++ b/src/reference/asciidoc/message.adoc
@@ -374,8 +374,15 @@ In addition to the default strategy, two additional `IdGenerators` are provided;
 ===== Read-only Headers
 
 The `MessageHeaders.ID` and `MessageHeaders.TIMESTAMP` are read-only headers and the cannot be overridden.
-With the `spring.integration.readOnly.headers` global property (see <<global-properties>>) you can specify any header names which become read-only.
+
+Since _version 4.3.2_, the `MessageBuilder` provides the `readOnlyHeaders(String... readOnlyHeaders)` API to customize a list of headers which should not be copied from an upstream `Message`.
+Just the `MessageHeaders.ID` and `MessageHeaders.TIMESTAMP` are read only by default.
+The global `spring.integration.readOnly.headers` property (see <<global-properties>>) is provided to customize `DefaultMessageBuilderFactory` for Framework components.
+This can be useful when you would like do not populate some out-of-the-box headers, like `contentType` by the `ObjectToJsonTransformer` (see <<json-transformers>>).
+
 When you try to build a new message using `MessageBuilder`, this kind of headers are ignored and particular `INFO` message is emitted to logs.
+
+Starting with _version 5.0_, <<gateway,Messaging Gateway>>, <<header-enricher,Header Enricher>>, <<payload-enricher,Content Enricher>> and <<header-filter, Header Filter>> don't allow to configure `MessageHeaders.ID` and `MessageHeaders.TIMESTAMP` header names when `DefaultMessageBuilderFactory` is used and they throw `BeanInitializationException`.
 
 [[message-implementations]]
 ==== Message Implementations
@@ -468,8 +475,3 @@ assertEquals(2, lessImportantMessage.getHeaders().getPriority());
 
 The `priority` header is only considered when using a `PriorityChannel` (as described in the next chapter).
 It is defined as _java.lang.Integer_.
-
-Since _version 4.3.2_, the `MessageBuilder` provides the `readOnlyHeaders(String... readOnlyHeaders)` API to customize a list of headers which should not be copied from an upstream `Message`.
-Just the `MessageHeaders.ID` and `MessageHeaders.TIMESTAMP` are read only by default.
-The global `spring.integration.readOnly.headers` property (see <<global-properties>>) is provided to customize `DefaultMessageBuilderFactory` for Framework components.
-This can be useful when you would like do not populate some out-of-the-box headers, like `contentType` by the `ObjectToJsonTransformer` (see <<json-transformers>>).


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4284

To inform end-user that he/she can't override `id` and `timestamp` headers
throw a `BeanInitializationException` from the `gateway`, `header-enricher`,
`enricher` and `header-filter`  configuration when `id` and `timestamp` are
explicitly provided