### PR TITLE
INT-4288: Additional header blacklisting options for AbstractMessageProducingHandler

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.handler;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -56,7 +57,7 @@ import reactor.core.publisher.Mono;
  * @author David Liu
  * @author Artem Bilan
  * @author Gary Russell
- *
+ * @author Marius Bogoevici
  * since 4.1
  */
 public abstract class AbstractMessageProducingHandler extends AbstractMessageHandler
@@ -119,12 +120,41 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	 * @since 4.3.10
 	 */
 	public void setNotPropagatedHeaders(String... headers) {
+		updateNotPropagatedHeaders(headers, false);
+	}
+
+	private void updateNotPropagatedHeaders(String[] headers, boolean merge) {
 		if (!ObjectUtils.isEmpty(headers)) {
 			Assert.noNullElements(headers, "null elements are not allowed in 'headers'");
-			this.notPropagatedHeaders.clear();
+			if (!merge) {
+				this.notPropagatedHeaders.clear();
+			}
 			this.notPropagatedHeaders.addAll(Arrays.asList(headers));
 		}
 		this.selectiveHeaderPropagation = this.notPropagatedHeaders.size() > 0;
+	}
+
+	/**
+	 * @see #setNotPropagatedHeaders(String...)
+	 * @return an immutable {@link java.util.Collection} of headers that will
+	 *         not be copied from the inbound message if
+	 *         {@link #shouldCopyRequestHeaders()} is true.
+	 * @since 4.3.10
+	 */
+	public Collection<String> getNotPropagatedHeaders() {
+		return Collections.unmodifiableSet(this.notPropagatedHeaders);
+	}
+
+	/**
+	 * Add headers that will NOT be copied from the inbound message if
+	 * {@link #shouldCopyRequestHeaders()} is true, instead of overwriting
+	 * the existing set.
+	 * @see #setNotPropagatedHeaders(String...)
+	 * @param headers the headers to not propagate from the inbound message.
+	 * @since 4.3.10
+	 */
+	public void addNotPropagatedHeaders(String... headers) {
+		updateNotPropagatedHeaders(headers, true);
 	}
 
 	@Override


### PR DESCRIPTION
- Add `addNotPropagatedHeaders` so that new
  headers can be added without overriding existing ones.
- Add `getNotPropagatedHeaders` so that existing
  excluded headers can be consulted.