### PR TITLE
INT-4290: JacksonJsonUtils: Add trusted packages

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.1
  */
 public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupStore implements MessageStore {
@@ -92,10 +93,14 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> Message<T> addMessage(Message<T> message) {
+		doAddMessage(message);
+		return (Message<T>) getMessage(message.getHeaders().getId());
+	}
+
+	protected void doAddMessage(Message<?> message) {
 		Assert.notNull(message, "'message' must not be null");
 		UUID messageId = message.getHeaders().getId();
 		doStoreIfAbsent(MESSAGE_KEY_PREFIX + messageId, new MessageHolder(message));
-		return (Message<T>) getMessage(messageId);
 	}
 
 	@Override
@@ -162,7 +167,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 		}
 
 		for (Message<?> message : messages) {
-			addMessage(message);
+			doAddMessage(message);
 			if (metadata != null) {
 				metadata.add(message.getHeaders().getId());
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonUtils.java
@@ -38,7 +38,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
-import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 /**
@@ -71,7 +70,7 @@ public final class JacksonJsonUtils {
 			mapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
 			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-			mapper.setDefaultTyping(createWhitelistedDefaultTyping(trustedPackages));
+			mapper.setDefaultTyping(new WhitelistTypeResolverBuilder(trustedPackages));
 
 			GenericMessageJacksonDeserializer genericMessageDeserializer = new GenericMessageJacksonDeserializer();
 			genericMessageDeserializer.setMapper(mapper);
@@ -99,13 +98,6 @@ public final class JacksonJsonUtils {
 		}
 	}
 
-	private static TypeResolverBuilder<?> createWhitelistedDefaultTyping(String... trustedPackages) {
-		TypeResolverBuilder<?> typeResolverBuilder = new WhitelistTypeResolverBuilder(trustedPackages);
-		typeResolverBuilder = typeResolverBuilder.init(JsonTypeInfo.Id.CLASS, null);
-		typeResolverBuilder = typeResolverBuilder.inclusion(JsonTypeInfo.As.PROPERTY);
-		return typeResolverBuilder;
-	}
-
 	/**
 	 * An implementation of {@link ObjectMapper.DefaultTypeResolverBuilder}
 	 * that wraps a default {@link TypeIdResolver} to the {@link WhitelistTypeIdResolver}.
@@ -117,11 +109,16 @@ public final class JacksonJsonUtils {
 	 */
 	private static final class WhitelistTypeResolverBuilder extends ObjectMapper.DefaultTypeResolverBuilder {
 
+		private static final long serialVersionUID = 1L;
+
 		private final String[] trustedPackages;
 
 		WhitelistTypeResolverBuilder(String... trustedPackages) {
 			super(ObjectMapper.DefaultTyping.NON_FINAL);
 			this.trustedPackages = trustedPackages;
+
+			init(JsonTypeInfo.Id.CLASS, null)
+					.inclusion(JsonTypeInfo.As.PROPERTY);
 		}
 
 		@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonUtils.java
@@ -16,15 +16,29 @@
 
 package org.springframework.integration.support.json;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.springframework.integration.message.AdviceMessage;
 import org.springframework.integration.support.MutableMessage;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 /**
@@ -46,16 +60,18 @@ public final class JacksonJsonUtils {
 	 * Return an {@link com.fasterxml.jackson.databind.ObjectMapper} if available,
 	 * supplied with Message specific serializers and deserializers.
 	 * Also configured to store typo info in the {@code @class} property.
+	 * @param trustedPackages the trusted Java packages for deserialization.
 	 * @return the mapper.
 	 * @throws IllegalStateException if an implementation is not available.
 	 * @since 4.3.10
 	 */
-	public static com.fasterxml.jackson.databind.ObjectMapper messagingAwareMapper() {
+	public static com.fasterxml.jackson.databind.ObjectMapper messagingAwareMapper(String... trustedPackages) {
 		if (JacksonPresent.isJackson2Present()) {
 			ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
 			mapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
 			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-			mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+
+			mapper.setDefaultTyping(createWhitelistedDefaultTyping(trustedPackages));
 
 			GenericMessageJacksonDeserializer genericMessageDeserializer = new GenericMessageJacksonDeserializer();
 			genericMessageDeserializer.setMapper(mapper);
@@ -81,6 +97,148 @@ public final class JacksonJsonUtils {
 		else {
 			throw new IllegalStateException("No jackson-databind.jar is present in the classpath.");
 		}
+	}
+
+	private static TypeResolverBuilder<?> createWhitelistedDefaultTyping(String... trustedPackages) {
+		TypeResolverBuilder<?> typeResolverBuilder = new WhitelistTypeResolverBuilder(trustedPackages);
+		typeResolverBuilder = typeResolverBuilder.init(JsonTypeInfo.Id.CLASS, null);
+		typeResolverBuilder = typeResolverBuilder.inclusion(JsonTypeInfo.As.PROPERTY);
+		return typeResolverBuilder;
+	}
+
+	/**
+	 * An implementation of {@link ObjectMapper.DefaultTypeResolverBuilder}
+	 * that wraps a default {@link TypeIdResolver} to the {@link WhitelistTypeIdResolver}.
+	 *
+	 * @author Rob Winch
+	 * @author Artem Bilan
+	 *
+	 * @since 4.3.11
+	 */
+	private static final class WhitelistTypeResolverBuilder extends ObjectMapper.DefaultTypeResolverBuilder {
+
+		private final String[] trustedPackages;
+
+		WhitelistTypeResolverBuilder(String... trustedPackages) {
+			super(ObjectMapper.DefaultTyping.NON_FINAL);
+			this.trustedPackages = trustedPackages;
+		}
+
+		@Override
+		protected TypeIdResolver idResolver(MapperConfig<?> config, JavaType baseType, Collection<NamedType> subtypes,
+				boolean forSer, boolean forDeser) {
+			TypeIdResolver delegate = super.idResolver(config, baseType, subtypes, forSer, forDeser);
+			return new WhitelistTypeIdResolver(delegate, this.trustedPackages);
+		}
+
+	}
+
+	/**
+	 * A {@link TypeIdResolver} that delegates to an existing implementation
+	 * and throws an IllegalStateException if the class being looked up is not whitelisted,
+	 * does not provide an explicit mixin mappings.
+	 *
+	 * @author Rob Winch
+	 * @author Artem Bilan
+	 *
+	 * @since 4.3.11
+	 */
+	private static final class WhitelistTypeIdResolver implements TypeIdResolver {
+
+		private static final List<String> TRUSTED_PACKAGES =
+				Arrays.asList(
+						"java.util",
+						"java.lang",
+						"org.springframework.messaging.support",
+						"org.springframework.integration.support",
+						"org.springframework.integration.message",
+						"org.springframework.integration.store"
+				);
+
+		private final TypeIdResolver delegate;
+
+		private final Set<String> trustedPackages = new LinkedHashSet<>(TRUSTED_PACKAGES);
+
+		WhitelistTypeIdResolver(TypeIdResolver delegate, String... trustedPackages) {
+			this.delegate = delegate;
+			if (trustedPackages != null) {
+				for (String whiteListClass : trustedPackages) {
+					if ("*".equals(whiteListClass)) {
+						this.trustedPackages.clear();
+						break;
+					}
+					else {
+						this.trustedPackages.add(whiteListClass);
+					}
+				}
+			}
+		}
+
+		@Override
+		public void init(JavaType baseType) {
+			this.delegate.init(baseType);
+		}
+
+		@Override
+		public String idFromValue(Object value) {
+			return this.delegate.idFromValue(value);
+		}
+
+		@Override
+		public String idFromValueAndType(Object value, Class<?> suggestedType) {
+			return this.delegate.idFromValueAndType(value, suggestedType);
+		}
+
+		@Override
+		public String idFromBaseType() {
+			return this.delegate.idFromBaseType();
+		}
+
+		@Override
+		public JavaType typeFromId(DatabindContext context, String id) throws IOException {
+			DeserializationConfig config = (DeserializationConfig) context.getConfig();
+			JavaType result = this.delegate.typeFromId(context, id);
+
+			String packageName = result.getRawClass().getPackage().getName();
+			if (isTrustedPackage(packageName)) {
+				return this.delegate.typeFromId(context, id);
+			}
+
+			boolean isExplicitMixin = config.findMixInClassFor(result.getRawClass()) != null;
+			if (isExplicitMixin) {
+				return result;
+			}
+
+			throw new IllegalArgumentException("The class with " + id + " and name of " +
+					"" + result.getRawClass().getName() + " is not in the trusted packages: " +
+					"" + this.trustedPackages + ". " +
+					"If you believe this class is safe to deserialize, please provide its name or an explicit Mixin. " +
+					"If the serialization is only done by a trusted source, you can also enable default typing.");
+		}
+
+		private boolean isTrustedPackage(String packageName) {
+			if (!this.trustedPackages.isEmpty()) {
+				for (String trustedPackage : this.trustedPackages) {
+					if (packageName.equals(trustedPackage) || packageName.startsWith(trustedPackage + ".")) {
+						return true;
+					}
+				}
+				return false;
+			}
+
+			return true;
+		}
+
+		@Override
+		public String getDescForKnownTypeIds() {
+			return this.delegate.getDescForKnownTypeIds();
+		}
+
+		@Override
+		public JsonTypeInfo.Id getMechanism() {
+			return this.delegate.getMechanism();
+		}
+
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
@@ -459,7 +459,10 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 
 		Message<Foo> fooMessage = new GenericMessage<>(new Foo("foo"));
 		try {
-			store.addMessagesToGroup(1, fooMessage);
+			store.addMessageToGroup(1, fooMessage)
+					.getMessages()
+					.iterator()
+					.next();
 			fail("SerializationException expected");
 		}
 		catch (Exception e) {
@@ -513,15 +516,21 @@ public class RedisMessageGroupStoreTests extends RedisAvailableTests {
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
 			Foo foo1 = (Foo) o;
-			return Objects.equals(this.foo, foo1.foo);
+
+			return this.foo != null ? this.foo.equals(foo1.foo) : foo1.foo == null;
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(this.foo);
+			return Objects.hashCode(this.foo);
 		}
 
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4290

See CVE-2017-4995

To disallow deserialization of unknown classes,
the `JacksonJsonUtils#messagingAwareMapper()` can now be supplied
with the `trustedPackages`.
The default list is:
```
java.util
java.lang
org.springframework.messaging.support
org.springframework.integration.support
org.springframework.integration.message
org.springframework.integration.store
```
Can be configured with `*` (asterisk) with meaning trust all

**Cherry-pick to 4.3.x**