### PR TITLE
INT-4296: Fix APPEND_NO_FLUSH Timing Problem

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -620,13 +620,12 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 		if (append) {
 			final File fileToWriteTo = this.determineFileToWrite(resultFile, tempFile);
 
-			final FileState state = getFileState(fileToWriteTo, false);
-
 			WhileLockedProcessor whileLockedProcessor = new WhileLockedProcessor(this.lockRegistry,
 					fileToWriteTo.getAbsolutePath()) {
 
 				@Override
 				protected void whileLocked() throws IOException {
+					FileState state = getFileState(fileToWriteTo, false);
 					BufferedOutputStream bos = null;
 					try {
 						bos = state != null ? state.stream : createOutputStream(fileToWriteTo, true);
@@ -704,8 +703,6 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 			throws IOException {
 		final File fileToWriteTo = this.determineFileToWrite(resultFile, tempFile);
 
-		final FileState state = getFileState(fileToWriteTo, false);
-
 		final boolean append = FileExistsMode.APPEND.equals(this.fileExistsMode);
 
 		WhileLockedProcessor whileLockedProcessor = new WhileLockedProcessor(this.lockRegistry,
@@ -713,6 +710,7 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 
 			@Override
 			protected void whileLocked() throws IOException {
+				FileState state = getFileState(fileToWriteTo, false);
 				BufferedOutputStream bos = null;
 				try {
 					bos = state != null ? state.stream : createOutputStream(fileToWriteTo, append);
@@ -748,8 +746,6 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 			throws IOException {
 		final File fileToWriteTo = this.determineFileToWrite(resultFile, tempFile);
 
-		final FileState state = getFileState(fileToWriteTo, true);
-
 		final boolean append = FileExistsMode.APPEND.equals(this.fileExistsMode);
 
 		WhileLockedProcessor whileLockedProcessor = new WhileLockedProcessor(this.lockRegistry,
@@ -757,6 +753,7 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 
 			@Override
 			protected void whileLocked() throws IOException {
+				FileState state = getFileState(fileToWriteTo, true);
 				BufferedWriter writer = null;
 				try {
 					writer = state != null ? state.writer : createWriter(fileToWriteTo, append);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4296

The `FileState.close()` method correctly acquires the lock to prevent closing while
writing. However, with a short flush interval, the close could occur between state
creation and the write operation acquiring the lock.

Move the state creation to within the scope of the lock acquired by the writer.

__cherry-pick to 4.3.x__