### PR TITLE
Added transactional support in FileList filter

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentCommittableAcceptOnceFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentCommittableAcceptOnceFileListFilter.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.file.filters;
+
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.integration.file.support.FileProcessingRecord;
+import org.springframework.integration.file.support.FileProcessingRecordSerializer;
+import org.springframework.integration.file.support.FileProcessingStatus;
+import org.springframework.integration.metadata.ConcurrentMetadataStore;
+import org.springframework.util.Assert;
+
+/**
+ * Stores "seen" files in a MetadataStore to survive application restarts.
+ * The default key is 'prefix' plus the absolute file name; value is the timestamp of the file.
+ * Files are deemed as already 'seen' if they exist in the store and have the
+ * flag set to PROCESSED. In case that files are REJECTED in store files are already 'seen'.
+ * If file is marked as PROCESSING, file is marked as 'seen' up to processingTTL time. After this
+ * time, file is selected for re-processing.
+ *
+ * @author Bojan Vukasovic
+ * @since 5.0
+ *
+ */
+public abstract class AbstractPersistentCommittableAcceptOnceFileListFilter<F>
+		implements ResettableFileListFilter<F>, CommittableFilter<F>, Closeable {
+
+	protected final ConcurrentMetadataStore store;
+
+	protected final Flushable flushableStore;
+
+	protected final String prefix;
+
+	protected volatile boolean flushOnUpdate;
+
+	private final Object monitor = new Object();
+
+	protected int maxRetries = -1;	//default - unlimited
+
+	protected long processingTTL = 30000;	//default - 30 seconds
+
+	protected int acceptedFilesPerRun = -1;	//default - unlimited
+
+	public AbstractPersistentCommittableAcceptOnceFileListFilter(ConcurrentMetadataStore store, String prefix) {
+		Assert.notNull(store, "'store' cannot be null");
+		Assert.notNull(prefix, "'prefix' cannot be null");
+		this.store = store;
+		this.prefix = prefix;
+		if (store instanceof Flushable) {
+			this.flushableStore = (Flushable) store;
+		}
+		else {
+			this.flushableStore = null;
+		}
+	}
+
+	/**
+	 * Determine whether the metadataStore should be flushed on each update (if {@link Flushable}).
+	 * @param flushOnUpdate true to flush.
+	 */
+	public void setFlushOnUpdate(boolean flushOnUpdate) {
+		this.flushOnUpdate = flushOnUpdate;
+	}
+
+	/**
+	 * Set maximum number of retries for file that has been rejected to be re-processed again.
+	 * Default value is -1 which means unlimited number of retries.
+	 * @param maxRetries number of retries.
+	 */
+	public void setMaxRetries(int maxRetries) {
+		this.maxRetries = maxRetries;
+	}
+
+	/**
+	 * Set minimal number of time to wait before file that is flagged as PROCESSING is removed
+	 * from list, and taken for re-processing. Useful in case when thread that processes file is
+	 * killed in mid of processing.
+	 * @param processingTTL time to wait for PROCESSING flag to be removed and file re-examined.
+	 * @param timeUnit unit of processingTTL.
+	 */
+	public void setProcessingTTL(int processingTTL, TimeUnit timeUnit) {
+		this.processingTTL = timeUnit.toMillis(processingTTL);
+	}
+
+	/**
+	 * Limits number of files that are accepted per each run.
+	 * @param acceptedFilesPerRun number of files that should be accepted per run.
+	 */
+	public void setAcceptedFilesPerRun(int acceptedFilesPerRun) {
+		this.acceptedFilesPerRun = acceptedFilesPerRun;
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (this.store instanceof Closeable) {
+			((Closeable) this.store).close();
+		}
+	}
+
+	@Override
+	public void commit(F file) {
+		String key = buildKey(file);
+		synchronized (this.monitor) {
+			while (true) {
+				String oldValue = this.store.get(key);
+				FileProcessingRecord record;
+
+				if (oldValue != null) {
+					record = FileProcessingRecordSerializer.deserialize(oldValue);
+					if (record.getStatus() == FileProcessingStatus.PROCESSED) {
+						//if another process finished processing this file and marked it as processed, that means that
+						//we just processed it one more time - this can happen only for parallel workers on same files
+						return;
+					}
+				}
+				else {
+					//should never happen - we finished processing file that is not marked for processing at all
+					//meaning - somebody during the process manually deleted record from store
+					record = new FileProcessingRecord(FileProcessingStatus.PROCESSED, modified(file), 0);
+				}
+				record.markAsProcessed();
+				String newValue = FileProcessingRecordSerializer.serialize(record);
+				boolean replaced = this.store.replace(key, oldValue, newValue);    //if not replaced - we have to try to add it
+				if (!replaced) {
+					oldValue = this.store.putIfAbsent(key, newValue);
+					if (oldValue != null) {
+						//means that somebody inserted it in table in the meantime - try replacing again
+						continue;
+					}
+				}
+				break;	//if we get here - it is replaced
+			}
+		}
+	}
+
+	@Override
+	public boolean remove(F f) {
+		String oldValue = this.store.remove(buildKey(f));
+		flushIfNeeded();
+		return oldValue != null;
+	}
+
+	@Override
+	public List<F> filterFiles(F[] files) {
+		List<F> accepted = new ArrayList<>();
+		if (files != null) {
+			int acceptedSoFar = 0;
+			for (F file : files) {
+				if (this.acceptedFilesPerRun > -1 && this.acceptedFilesPerRun > acceptedSoFar) {
+					break;
+				}
+				if (this.accept(file)) {
+					accepted.add(file);
+					acceptedSoFar++;
+				}
+			}
+		}
+		return accepted;
+	}
+
+	public boolean accept(F file) {
+		String key = buildKey(file);
+		synchronized (this.monitor) {
+
+			FileProcessingRecord record;
+			while (true) {
+				long currentTimestamp = System.currentTimeMillis();
+
+				record = new FileProcessingRecord(FileProcessingStatus.PROCESSING, modified(file), currentTimestamp);
+
+				String newValue = FileProcessingRecordSerializer.serialize(record);
+				String oldValue = this.store.putIfAbsent(key, newValue);    //try to store if not already there
+
+				if (oldValue != null) {
+					//means that this file was already processed before (or possibly processed currently in parallel)
+					oldValue = this.store.get(key);
+					record = FileProcessingRecordSerializer.deserialize(oldValue);
+					if (record.getStatus() == FileProcessingStatus.PROCESSED
+							|| record.getStatus() == FileProcessingStatus.REJECTED) {
+						return false;    //file has been already processed successfully or rejected
+					}
+					else if ((currentTimestamp - record.getLastRetry()) < this.processingTTL) {
+						return false;    //file is probably still being processed (wait ttl to possibly retry)
+					}
+					if (this.maxRetries > 0 && record.getNumberOfRetries() >= this.maxRetries) {
+						record.markAsRejected();    //if we exhausted retries, mark file as rejected
+					}
+					else {
+						record.retriedAt(currentTimestamp);    //mark file as retried at this point in time
+					}
+					newValue = FileProcessingRecordSerializer.serialize(record);
+					boolean replaced = this.store.replace(key, oldValue, newValue);	//if false - not replaced, so try to add again
+					if (!replaced) {
+						continue;	//means that somebody in between calls removed key from store
+					}
+				}
+				break;
+			}
+
+			return record.getStatus() == FileProcessingStatus.PROCESSING;
+		}
+	}
+
+	/**
+	 * The default key is the {@link #prefix} plus the full filename.
+	 * @param file The file.
+	 * @return The key.
+	 */
+	protected String buildKey(F file) {
+		return this.prefix + this.fileName(file);
+	}
+
+	/**
+	 * Flush the store if it's a {@link Flushable} and
+	 * {@link #setFlushOnUpdate(boolean) flushOnUpdate} is true.
+	 */
+	protected void flushIfNeeded() {
+		if (this.flushOnUpdate && this.flushableStore != null) {
+			try {
+				this.flushableStore.flush();
+			}
+			catch (IOException e) {
+				// store's responsibility to log
+			}
+		}
+	}
+
+	protected abstract long modified(F file);
+
+	protected abstract String fileName(F file);
+}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CommittableFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CommittableFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.file.filters;
+
+/**
+ *
+ * A {@link FileListFilter} that allows the caller to commit state
+ * changes.
+ *
+ * @author Bojan Vukasovic
+ * @since 5.0
+ *
+ */
+public interface CommittableFilter<F> extends FileListFilter<F> {
+	/**
+	 * In order to flag file as PROCESSED, we have to know
+	 * when transaction finished. On transaction commit, we call this.
+	 * @param file The files.
+	 */
+	void commit(F file);
+}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileSystemPersistentCommittableAcceptOnceFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileSystemPersistentCommittableAcceptOnceFileListFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.file.filters;
+
+import java.io.File;
+
+import org.springframework.integration.metadata.ConcurrentMetadataStore;
+
+/**
+ * @author Bojan Vukasovic
+ * @since 5.0
+ *
+ */
+public class FileSystemPersistentCommittableAcceptOnceFileListFilter extends AbstractPersistentCommittableAcceptOnceFileListFilter<File> {
+
+	public FileSystemPersistentCommittableAcceptOnceFileListFilter(ConcurrentMetadataStore store, String prefix) {
+		super(store, prefix);
+	}
+
+	@Override
+	protected long modified(File file) {
+		return file.lastModified();
+	}
+
+	@Override
+	protected String fileName(File file) {
+		return file.getAbsolutePath();
+	}
+}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileProcessingRecord.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileProcessingRecord.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.file.support;
+
+/**
+ * When writing processing file, this record stores all metadata info
+ * about the file that is currently being processed.
+ *
+ * @author Bojan Vukasovic
+ * @since 5.0
+ *
+ */
+public class FileProcessingRecord {
+	private FileProcessingStatus status;
+	private int numberOfRetries;
+	private long modified;
+	private long lastRetry;
+
+	private FileProcessingRecord() {
+		super();
+	}
+
+	public FileProcessingRecord(FileProcessingStatus status, long modified, long lastRetry) {
+		this.status = status;
+		this.modified = modified;
+		this.lastRetry = lastRetry;
+	}
+
+	public FileProcessingStatus getStatus() {
+		return this.status;
+	}
+
+	public int getNumberOfRetries() {
+		return this.numberOfRetries;
+	}
+
+	public long getModified() {
+		return this.modified;
+	}
+
+	public long getLastRetry() {
+		return this.lastRetry;
+	}
+
+	public void markAsRejected() {
+		this.status = FileProcessingStatus.REJECTED;
+	}
+
+	public void markAsProcessed() {
+		this.status = FileProcessingStatus.PROCESSED;
+	}
+
+	public void retriedAt(long timestamp) {
+		this.lastRetry = timestamp;
+		this.numberOfRetries++;
+	}
+}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileProcessingRecordSerializer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileProcessingRecordSerializer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.file.support;
+
+import java.io.IOException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Serializer for serialization/deserialization of FileProcessingRecord.
+ *
+ * @author Bojan Vukasovic
+ * @since 5.0
+ *
+ */
+public final class FileProcessingRecordSerializer {
+	private static final ObjectMapper mapper = new ObjectMapper();
+	private static final Log logger = LogFactory.getLog(FileProcessingRecordSerializer.class);
+
+	private FileProcessingRecordSerializer() {
+		super();
+	}
+
+	public static String serialize(FileProcessingRecord record) {
+		String value = "";
+		try {
+			value = mapper.writeValueAsString(record);
+		}
+		catch (JsonProcessingException e) {
+			logger.warn("Exception during serialization of FileProcessingRecord. ", e);
+		}
+		return value;
+	}
+
+	public static FileProcessingRecord deserialize(String value) {
+		FileProcessingRecord record = null;
+		try {
+			record = mapper.readValue(value, FileProcessingRecord.class);
+		}
+		catch (IOException e) {
+			logger.warn("Exception during deserialization of FileProcessingRecord. ", e);
+		}
+		return record;
+	}
+}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileProcessingStatus.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileProcessingStatus.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.file.support;
+
+/**
+ * Possible status of file that is being processed.
+ *
+ * @author Bojan Vukasovic
+ * @since 5.0
+ *
+ */
+public enum FileProcessingStatus {
+
+	/**
+	 * File is accepted by FileListFilter and is ready to be processed in the transaction.
+	 */
+	PROCESSING,
+
+	/**
+	 * In case that transaction committed successfully, status is transitioned to processed.
+	 */
+	PROCESSED,
+
+	/**
+	 * In case that we reached maximum number of retries for file processing, file is flagged
+	 * so that we don't take it again for processing.
+	 */
+	REJECTED
+}

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/filters/FtpPersistentCommittableAcceptOnceFileListFilter.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/filters/FtpPersistentCommittableAcceptOnceFileListFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.ftp.filters;
+
+import org.apache.commons.net.ftp.FTPFile;
+import org.springframework.integration.file.filters.AbstractPersistentCommittableAcceptOnceFileListFilter;
+import org.springframework.integration.metadata.ConcurrentMetadataStore;
+
+/**
+ * Persistent file list filter using the FileProcessingRecord to see if we already
+ * 'seen' this file.
+ *
+ * @author Bojan Vukasovic
+ * @since 5.0
+ *
+ */
+public class FtpPersistentCommittableAcceptOnceFileListFilter extends AbstractPersistentCommittableAcceptOnceFileListFilter<FTPFile> {
+
+	public FtpPersistentCommittableAcceptOnceFileListFilter(ConcurrentMetadataStore store, String prefix) {
+		super(store, prefix);
+	}
+
+	@Override
+	protected long modified(FTPFile file) {
+		return file.getTimestamp().getTimeInMillis();
+	}
+
+	@Override
+	protected String fileName(FTPFile file) {
+		return file.getName();
+	}
+}


### PR DESCRIPTION
Before I complete this, just want to check if this is needed at all. Situation is:

- Connect to FTP and pull some files
- Files are marked as PROCESSING
- If at any point in time JVM is crashed, files will stay in processing and be reprocessed
- When files are processed, they are flagged as PROCESSED
- In case there is some error in file processing, we can set max number of retries and when reached flag file as REJECTED

I needed this since currently all files are market up-front as processed. Then if JVM fails those files will be lost basically. The use-case is common one -  I need to pull files from ftp server and put them to DB. If there is an error in processing or JVM is killed (server loses power etc.) I need to be able to re-process that file on next run. Currently all filters write to log, and then try to remove the file if it is not processed sucessfully. This does not handle properly situtation with JVM crash or hardware error.

In this case, I would just need to add this:

                   @Bean
		   public FtpPersistentCommittableAcceptOnceFileListFilter acceptOnceFileListFilter(){
			FtpPersistentCommittableAcceptOnceFileListFilter filter = new FtpPersistentCommittableAcceptOnceFileListFilter(metadataStore(), "remote");
			filter.setFlushOnUpdate(true);
			filter.setMaxRetries(3);
			filter.setProcessingTTL(5, TimeUnit.MINUTES);
			return filter;
		}

and this triggers for current transaction

                    @Bean
		public TransactionSynchronizationProcessor synchronizationProcessor(){
			return new TransactionSynchronizationProcessor() {

				@Autowired
				FtpPersistentCommittableAcceptOnceFileListFilter filter;

				@Override
				public void processBeforeCommit(IntegrationResourceHolder holder) {

				}

				@Override
				public void processAfterCommit(IntegrationResourceHolder holder) {
					Message<?> message = holder.getMessage();
					if(message!=null) {	//can happen if on pull we have nothing
						FTPFile file = new FTPFile();
						file.setName(String.valueOf(message.getHeaders().get(FileHeaders.REMOTE_FILE)));
						filter.commit(file);
					}
				}

				@Override
				public void processAfterRollback(IntegrationResourceHolder holder) {
					Message<?> message = holder.getMessage();
					FTPFile file = new FTPFile();
					file.setName(String.valueOf(message.getHeaders().get(FileHeaders.REMOTE_FILE)));
					filter.remove(file);
				}
			};
		}
