### PR TITLE
INT-4305: (S)FTP: remove localFile before rename

### DIFF
--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/RemoteFileTestSupport.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/RemoteFileTestSupport.java
@@ -60,27 +60,27 @@ public abstract class RemoteFileTestSupport {
 	protected volatile File targetLocalDirectory;
 
 	public File getSourceRemoteDirectory() {
-		return sourceRemoteDirectory;
+		return this.sourceRemoteDirectory;
 	}
 
 	public File getTargetRemoteDirectory() {
-		return targetRemoteDirectory;
+		return this.targetRemoteDirectory;
 	}
 
 	public String getTargetRemoteDirectoryName() {
-		return targetRemoteDirectory.getAbsolutePath() + File.separator;
+		return this.targetRemoteDirectory.getAbsolutePath() + File.separator;
 	}
 
 	public File getSourceLocalDirectory() {
-		return sourceLocalDirectory;
+		return this.sourceLocalDirectory;
 	}
 
 	public File getTargetLocalDirectory() {
-		return targetLocalDirectory;
+		return this.targetLocalDirectory;
 	}
 
 	public String getTargetLocalDirectoryName() {
-		return targetLocalDirectory.getAbsolutePath() + File.separator;
+		return this.targetLocalDirectory.getAbsolutePath() + File.separator;
 	}
 
 	/**

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
@@ -70,12 +70,13 @@ public class AbstractRemoteFileSynchronizerTests {
 			}
 
 			@Override
-			protected void copyFileToLocalDirectory(String remoteDirectoryPath, String remoteFile, File localDirectory,
-					Session<String> session) throws IOException {
+			protected boolean copyFileToLocalDirectory(String remoteDirectoryPath, String remoteFile,
+					File localDirectory, Session<String> session) throws IOException {
 				if ("bar".equals(remoteFile) && failWhenCopyingBar.getAndSet(false)) {
 					throw new IOException("fail");
 				}
 				count.incrementAndGet();
+				return true;
 			}
 
 		};
@@ -162,9 +163,10 @@ public class AbstractRemoteFileSynchronizerTests {
 			}
 
 			@Override
-			protected void copyFileToLocalDirectory(String remoteDirectoryPath, String remoteFile, File localDirectory,
-					Session<String> session) throws IOException {
+			protected boolean copyFileToLocalDirectory(String remoteDirectoryPath, String remoteFile,
+					File localDirectory, Session<String> session) throws IOException {
 				count.incrementAndGet();
+				return true;
 			}
 
 		};

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
@@ -26,6 +26,9 @@ import static org.junit.Assert.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -58,6 +61,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.FileCopyUtils;
 
 /**
  * @author Artem Bilan
@@ -73,7 +77,7 @@ public class FtpTests extends FtpTestSupport {
 	private IntegrationFlowContext flowContext;
 
 	@Test
-	public void testFtpInboundFlow() {
+	public void testFtpInboundFlow() throws IOException {
 		QueueChannel out = new QueueChannel();
 		IntegrationFlow flow = IntegrationFlows.from(Ftp.inboundAdapter(sessionFactory())
 						.preserveTimestamp(true)
@@ -102,6 +106,10 @@ public class FtpTests extends FtpTestSupport {
 		assertNull(out.receive(10));
 
 		File remoteFile = new File(this.sourceRemoteDirectory, " " + prefix() + "Source1.txt");
+
+		FileOutputStream fos = new FileOutputStream(remoteFile);
+		fos.write("New content".getBytes());
+		fos.close();
 		remoteFile.setLastModified(System.currentTimeMillis() - 1000 * 60 * 60 * 24);
 
 		message = out.receive(10_000);
@@ -110,6 +118,7 @@ public class FtpTests extends FtpTestSupport {
 		assertThat(payload, instanceOf(File.class));
 		file = (File) payload;
 		assertEquals(" FTPSOURCE1.TXT.a", file.getName());
+		assertEquals("New content", FileCopyUtils.copyToString(new FileReader(file)));
 
 		registration.destroy();
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4305

The `File.renameTo()` operation may fail, therefore the content of the
local file isn't changed, but since we change `setLastModified()` anyway,
this file might be eligible for local polling.
So, we end up with the same content from local file in a new message,
meanwhile we expect a new content from the remote file

* Check the `File.renameTo()` result and attempt to `delete()`
for existing local file
* When file isn't renames remove the remote file from the `filter` to let
it be transferred one more time on the next poll.
The local file might be opened for processing, so this way we postpone a fresh
remote file for the future poll rounds
* Modify `copyFileToLocalDirectory()` to return `boolean` to reflect the fact of copy.
This way we check the real number of transferred files

**Cherry-pick to 4.3.x**