### PR TITLE
INT-4280: Add `taskScheduler()` to Java DSL

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
@@ -164,7 +164,6 @@ public class ConsumerEndpointFactoryBean
 	}
 
 	public void setTaskScheduler(TaskScheduler taskScheduler) {
-		Assert.notNull(taskScheduler, "taskScheduler must not be null");
 		this.taskScheduler = taskScheduler;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
@@ -49,6 +49,7 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.core.BeanFactoryMessageChannelDestinationResolver;
 import org.springframework.messaging.core.DestinationResolver;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -98,6 +99,8 @@ public class ConsumerEndpointFactoryBean
 	private volatile List<Advice> adviceChain;
 
 	private volatile DestinationResolver<MessageChannel> channelResolver;
+
+	private TaskScheduler taskScheduler;
 
 	public void setHandler(MessageHandler handler) {
 		Assert.notNull(handler, "handler must not be null");
@@ -158,6 +161,11 @@ public class ConsumerEndpointFactoryBean
 	public void setAdviceChain(List<Advice> adviceChain) {
 		Assert.notNull(adviceChain, "adviceChain must not be null");
 		this.adviceChain = adviceChain;
+	}
+
+	public void setTaskScheduler(TaskScheduler taskScheduler) {
+		Assert.notNull(taskScheduler, "taskScheduler must not be null");
+		this.taskScheduler = taskScheduler;
 	}
 
 	@Override
@@ -296,6 +304,9 @@ public class ConsumerEndpointFactoryBean
 				phase = Integer.MAX_VALUE / 2;
 			}
 			this.endpoint.setPhase(phase);
+			if (this.taskScheduler != null) {
+				this.endpoint.setTaskScheduler(this.taskScheduler);
+			}
 			this.endpoint.afterPropertiesSet();
 			this.initialized = true;
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.aopalliance.aop.Advice;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.handler.AbstractMessageProducingHandler;
@@ -30,6 +31,7 @@ import org.springframework.integration.router.AbstractMessageRouter;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.integration.transaction.TransactionInterceptorBuilder;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
@@ -75,6 +77,20 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 	@Override
 	public S poller(PollerMetadata pollerMetadata) {
 		this.endpointFactoryBean.setPollerMetadata(pollerMetadata);
+		return _this();
+	}
+
+	/**
+	 * Configure a {@link TaskScheduler} for scheduling tasks, for example in the
+	 * Polling Consumer. By default the global {@code ThreadPoolTaskScheduler} bean is used.
+	 * This configuration is useful when there are requirements to dedicate particular threads
+	 * for polling task, for example.
+	 * @param taskScheduler the {@link TaskScheduler} to use.
+	 * @return the endpoint spec.
+	 * @see org.springframework.integration.context.IntegrationContextUtils#getTaskScheduler(BeanFactory)
+	 */
+	public S taskScheduler(TaskScheduler taskScheduler) {
+		this.endpointFactoryBean.setTaskScheduler(taskScheduler);
 		return _this();
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import org.aopalliance.aop.Advice;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.handler.AbstractMessageProducingHandler;
@@ -35,6 +34,7 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
+import org.springframework.util.Assert;
 
 import reactor.util.function.Tuple2;
 
@@ -87,9 +87,10 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 	 * for polling task, for example.
 	 * @param taskScheduler the {@link TaskScheduler} to use.
 	 * @return the endpoint spec.
-	 * @see org.springframework.integration.context.IntegrationContextUtils#getTaskScheduler(BeanFactory)
+	 * @see org.springframework.integration.context.IntegrationContextUtils#getTaskScheduler
 	 */
 	public S taskScheduler(TaskScheduler taskScheduler) {
+		Assert.notNull(taskScheduler, "taskScheduler must not be null");
 		this.endpointFactoryBean.setTaskScheduler(taskScheduler);
 		return _this();
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/CorrelationHandlerSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/CorrelationHandlerSpec.java
@@ -135,6 +135,7 @@ public abstract class CorrelationHandlerSpec<S extends CorrelationHandlerSpec<S,
 	 * @see AbstractCorrelatingMessageHandler#setTaskScheduler(TaskScheduler)
 	 */
 	public S taskScheduler(TaskScheduler taskScheduler) {
+		Assert.notNull(taskScheduler, "taskScheduler must not be null");
 		super.taskScheduler(taskScheduler);
 		this.handler.setTaskScheduler(taskScheduler);
 		return _this();

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/CorrelationHandlerSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/CorrelationHandlerSpec.java
@@ -135,7 +135,7 @@ public abstract class CorrelationHandlerSpec<S extends CorrelationHandlerSpec<S,
 	 * @see AbstractCorrelatingMessageHandler#setTaskScheduler(TaskScheduler)
 	 */
 	public S taskScheduler(TaskScheduler taskScheduler) {
-		Assert.notNull(taskScheduler, "'taskScheduler' must not be null.");
+		super.taskScheduler(taskScheduler);
 		this.handler.setTaskScheduler(taskScheduler);
 		return _this();
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4280

To let end-user easily to inject custom `TaskScheduler` to the endpoint
add `ConsumerEndpointSpec.taskScheduler()` option