### PR TITLE
GH-2197: Rely on the Document creation for Source

### DIFF
--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/DefaultXmlPayloadConverter.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/DefaultXmlPayloadConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 
 import org.springframework.messaging.MessagingException;
-import org.springframework.xml.transform.StringSource;
 
 /**
  * Default implementation of {@link XmlPayloadConverter}. Supports
@@ -133,18 +132,14 @@ public class DefaultXmlPayloadConverter implements XmlPayloadConverter {
 	public Source convertToSource(Object object) {
 		Source source = null;
 		if (object instanceof Source) {
-			source = (Source) object;
+			return (Source) object;
 		}
 		else if (object instanceof Document) {
-			source = new DOMSource((Document) object);
-		}
-		else if (object instanceof String) {
-			source = new StringSource((String) object);
+			return new DOMSource((Document) object);
 		}
 		else {
-			throw new MessagingException("unsupported payload type [" + object.getClass().getName() + "]");
+			return convertToSource(convertToDocument(object));
 		}
-		return source;
 	}
 
 	protected synchronized DocumentBuilder getDocumentBuilder() {

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/config/XmlPayloadValidatingFilterParser.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/config/XmlPayloadValidatingFilterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class XmlPayloadValidatingFilterParser extends AbstractConsumerEndpointPa
 		String schemaLocation = element.getAttribute("schema-location");
 		boolean validatorDefined = StringUtils.hasText(validator);
 		boolean schemaLocationDefined = StringUtils.hasText(schemaLocation);
-		if (!(validatorDefined ^ schemaLocationDefined)) {
+		if (validatorDefined == schemaLocationDefined) {
 			throw new BeanDefinitionStoreException(
 					"Exactly one of 'xml-validator' or 'schema-location' is allowed on the 'validating-filter' element");
 		}
@@ -59,8 +59,11 @@ public class XmlPayloadValidatingFilterParser extends AbstractConsumerEndpointPa
 			selectorBuilder.addConstructorArgReference(validator);
 		}
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(selectorBuilder, element, "throw-exception-on-rejection");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(selectorBuilder, element, "xml-converter", "converter");
+
 		filterBuilder.addPropertyValue("targetObject", selectorBuilder.getBeanDefinition());
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(filterBuilder, element, "send-timeout");
+
 		return filterBuilder;
 	}
 

--- a/spring-integration-xml/src/main/resources/org/springframework/integration/xml/config/spring-integration-xml-5.0.xsd
+++ b/spring-integration-xml/src/main/resources/org/springframework/integration/xml/config/spring-integration-xml-5.0.xsd
@@ -812,6 +812,18 @@
 							</xsd:appinfo>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="xml-converter" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Reference to a custom 'org.springframework.integration.xml.XmlPayloadConverter' strategy
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type type="org.springframework.integration.xml.XmlPayloadConverter" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attribute name="schema-location"/>
 					<xsd:attribute name="schema-type" default="xml-schema">
 						<xsd:simpleType>

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/DefaultXmlPayloadConverterTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/DefaultXmlPayloadConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ import org.xml.sax.InputSource;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.messaging.MessagingException;
-import org.springframework.xml.transform.StringSource;
 
 /**
  *
@@ -105,7 +104,7 @@ public class DefaultXmlPayloadConverterTests {
 	@Test
 	public void testGetSourcePassingString() throws Exception {
 		Source source = converter.convertToSource(TEST_DOCUMENT_AS_STRING);
-		assertEquals(StringSource.class, source.getClass());
+		assertEquals(DOMSource.class, source.getClass());
 	}
 
 	@Test

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XmlPayloadValidatingFilterParserTests-context.xml
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XmlPayloadValidatingFilterParserTests-context.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:int="http://www.springframework.org/schema/integration"
-	xmlns:int-xml="http://www.springframework.org/schema/integration/xml"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int="http://www.springframework.org/schema/integration"
+	   xmlns:int-xml="http://www.springframework.org/schema/integration/xml"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xmlns:util="http://www.springframework.org/schema/util"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
         http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
@@ -15,7 +15,12 @@
 
 	<util:properties id="props">
 		<prop key="xmlSchema">xml-schema</prop>
- 	</util:properties>
+	</util:properties>
+
+	<bean id="xmlPayloadConverter" class="org.springframework.integration.xml.DefaultXmlPayloadConverter">
+		<constructor-arg
+				value="#{T (org.springframework.integration.xml.config.XmlPayloadValidatingFilterParserTests).DOCUMENT_BUILDER_FACTORY}"/>
+	</bean>
 
 	<int-xml:validating-filter id="parseOnly"
 							   order="2"
@@ -34,6 +39,7 @@
 							   input-channel="inputChannelA"
 							   output-channel="validOutputChannel"
 							   discard-channel="invalidOutputChannel"
+							   xml-converter="xmlPayloadConverter"
 							   schema-location="org/springframework/integration/xml/config/validationTestsSchema.xsd"/>
 
 	<int-xml:validating-filter id="filterB"
@@ -49,7 +55,8 @@
 							   discard-channel="invalidOutputChannel"
 							   xml-validator="xmlValidator"/>
 
-	<bean id="xmlValidator" class="org.springframework.xml.validation.XmlValidatorFactory" factory-method="createValidator">
+	<bean id="xmlValidator" class="org.springframework.xml.validation.XmlValidatorFactory"
+		  factory-method="createValidator">
 		<constructor-arg value="classpath:org/springframework/integration/xml/config/validationTestsSchema.xsd"/>
 		<constructor-arg value="http://www.w3.org/2001/XMLSchema"/>
 	</bean>

--- a/src/reference/asciidoc/xml.adoc
+++ b/src/reference/asciidoc/xml.adoc
@@ -1033,8 +1033,9 @@ Please see below for an overview of all available configuration parameters:
                            schema-location=""                    <5>
                            schema-type="xml-schema"              <6>
                            throw-exception-on-rejection="false"  <7>
-                           xml-validator="">                     <8>
-    <int:poller .../>                                            <9>
+                           xml-converter=""                      <8>
+                           xml-validator="">                     <9>
+    <int:poller .../>                                            <10>
 </int-xml:validating-filter>
 ----
 
@@ -1069,10 +1070,11 @@ If not set it defaults to `xml-schema` which internally translates to `org.sprin
 <7> If `true` a `MessageRejectedException` is thrown in case validation fails for the provided Message's payload._Optional_.
 Defaults to `false` if not set.
 
+<8> Reference to a custom `org.springframework.integration.xml.XmlPayloadConverter` strategy.
+_Optional_.
 
 <8> Reference to a custom `sorg.springframework.xml.validation.XmlValidator` strategy.
 You can set this attribute or the `schema-location` attribute but not both.
 _Optional_.
 
-
-<9> _Optional_.
+<10> _Optional_.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/2197

Sometime we would like to avoid some XML definition features (e.g. loading of the DTD).
The `XmlValidatingMessageSelector` doesn't allow to do that easily because it doesn't
rely on the `Document` creation via `DocumentBuilderFactory`, but directly
manipulates with `Source`

* Change `DefaultXmlPayloadConverter.convertToSource()` to fallback to the `convertToDocument()`
for non-Document payloads.
This way we can configure `DefaultXmlPayloadConverter` with custom `DocumentBuilderFactory` and
bypass DTD loading, for example
* Expose `xml-converter` option for the `<int-xml:validating-filter>`  component