### PR TITLE
INT-4301: Make CircuitBreakerOpenException as ME

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerCircuitBreakerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerCircuitBreakerAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 
 /**
  * A circuit breaker that stops calling a failing service after threshold
@@ -28,6 +29,8 @@ import org.springframework.messaging.Message;
  * call resets the failure counter.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.2
  *
  */
@@ -56,7 +59,7 @@ public class RequestHandlerCircuitBreakerAdvice extends AbstractRequestHandlerAd
 		}
 		if (metadata.getFailures().get() >= this.threshold &&
 				System.currentTimeMillis() - metadata.getLastFailure() < this.halfOpenAfter) {
-			throw new CircuitBreakerOpenException("Circuit Breaker is Open for " + target);
+			throw new CircuitBreakerOpenException(message, "Circuit Breaker is Open for " + target);
 		}
 		try {
 			Object result = callback.execute();
@@ -99,12 +102,12 @@ public class RequestHandlerCircuitBreakerAdvice extends AbstractRequestHandlerAd
 	/**
 	 * An exception thrown when the circuit breaker is in an open state.
 	 */
-	public static final class CircuitBreakerOpenException extends RuntimeException {
+	public static final class CircuitBreakerOpenException extends MessagingException {
 
 		private static final long serialVersionUID = 1L;
 
-		CircuitBreakerOpenException(String message) {
-			super(message);
+		public CircuitBreakerOpenException(Message<?> message, String description) {
+			super(message, description);
 		}
 
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -85,6 +85,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.2
  */
 @ContextConfiguration
@@ -110,7 +111,7 @@ public class AdvisedMessageHandlerTests {
 			fail("expected exception");
 		}
 		catch (RuntimeException e) {
-			assertThat(e.getMessage(), containsString("(myService)]"));
+			assertThat(e.getMessage(), containsString("Circuit Breaker is Open for"));
 		}
 	}
 
@@ -402,7 +403,8 @@ public class AdvisedMessageHandlerTests {
 			fail("Expected failure");
 		}
 		catch (Exception e) {
-			assertEquals("Circuit Breaker is Open for baz", e.getCause().getMessage());
+			assertEquals("Circuit Breaker is Open for baz", e.getMessage());
+			assertSame(message, ((MessagingException) e).getFailedMessage());
 		}
 
 		Map metadataMap = TestUtils.getPropertyValue(advice, "metadataMap", Map.class);
@@ -425,7 +427,7 @@ public class AdvisedMessageHandlerTests {
 			fail("Expected failure");
 		}
 		catch (Exception e) {
-			assertEquals("Circuit Breaker is Open for baz", e.getCause().getMessage());
+			assertEquals("Circuit Breaker is Open for baz", e.getMessage());
 		}
 
 		// Simulate some timeout in between requests
@@ -453,7 +455,7 @@ public class AdvisedMessageHandlerTests {
 			fail("Expected failure");
 		}
 		catch (Exception e) {
-			assertEquals("Circuit Breaker is Open for baz", e.getCause().getMessage());
+			assertEquals("Circuit Breaker is Open for baz", e.getMessage());
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4301

To keep the context of the `failedMessage` and avoid extra wrapping
to the `MessagingException` make
`CircuitBreakerOpenException extends MessagingException` directly