### PR TITLE
Int 4316

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,7 @@ subprojects { subproject ->
 		tomcatVersion = "8.5.14"
 		xmlUnitVersion = '1.6'
 		xstreamVersion = '1.4.7'
+		jsr310Version = '2.8.9'
 	}
 
 	eclipse {
@@ -314,6 +315,7 @@ project('spring-integration-core') {
 		}
 		compile("io.fastjson:boon:$boonVersion", optional)
 		compile("com.esotericsoftware:kryo-shaded:$kryoShadedVersion", optional)
+		compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jsr310Version")
 
 		testCompile ("org.aspectj:aspectjweaver:$aspectjVersion")
 		testCompile "io.projectreactor:reactor-test:$reactorVersion"

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * </ul>
  *
  * @author Artem Bilan
+ * @author Vikas Prasad
  * @since 3.0
  */
 public class Jackson2JsonObjectMapper extends AbstractJacksonJsonObjectMapper<JsonNode, JsonParser, JavaType> {
@@ -57,6 +58,7 @@ public class Jackson2JsonObjectMapper extends AbstractJacksonJsonObjectMapper<Js
 		this.objectMapper = new ObjectMapper();
 		this.objectMapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
 		this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		this.objectMapper.findAndRegisterModules();	// handle JSR310
 	}
 
 	public Jackson2JsonObjectMapper(ObjectMapper objectMapper) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonObjectMapper.java
@@ -58,7 +58,7 @@ public class Jackson2JsonObjectMapper extends AbstractJacksonJsonObjectMapper<Js
 		this.objectMapper = new ObjectMapper();
 		this.objectMapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
 		this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-		this.objectMapper.findAndRegisterModules();	// handle JSR310
+		this.objectMapper.findAndRegisterModules();    // handle JSR310
 	}
 
 	public Jackson2JsonObjectMapper(ObjectMapper objectMapper) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapperProvider.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapperProvider.java
@@ -19,6 +19,8 @@ package org.springframework.integration.support.json;
 
 import org.springframework.util.ClassUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * Simple factory to provide {@linkplain JsonObjectMapper}
  * instances dependently of jackson-databind or boon libs in the classpath.
@@ -27,6 +29,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Vikas Prasad
  * @since 3.0
  *
  * @see Jackson2JsonObjectMapper
@@ -58,6 +61,17 @@ public final class JsonObjectMapperProvider {
 		else {
 			throw new IllegalStateException("Neither jackson-databind.jar, nor boon.jar is present in the classpath.");
 		}
+	}
+
+	/**
+	 * Return an instance of {@link Jackson2JsonObjectMapper} with the {@link Jackson2JsonObjectMapper#objectMapper}
+	 * field set as the mapper passed by the caller.
+	 * @param mapper the customized mapper that the caller wants to use
+	 * @return Jackson2JsonObjectMapper object that wraps within the customized mapper provided
+	 * @since 5.0.0
+	 */
+	public static JsonObjectMapper<?, ?> getCustomizedJacksonMapper(ObjectMapper mapper) {
+		return new Jackson2JsonObjectMapper(mapper);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ObjectToMapTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ObjectToMapTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ import org.springframework.integration.support.json.JsonObjectMapper;
 import org.springframework.integration.support.json.JsonObjectMapperProvider;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Will transform an object graph into a Map. It supports a conventional Map (map of maps) where complex attributes are
@@ -52,13 +54,22 @@ import org.springframework.util.StringUtils;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Vikas Prasad
  * @since 2.0
  */
 public class ObjectToMapTransformer extends AbstractPayloadTransformer<Object, Map<?, ?>> {
 
-	private final JsonObjectMapper<?, ?> jsonObjectMapper = JsonObjectMapperProvider.newInstance();
+	private final JsonObjectMapper<?, ?> jsonObjectMapper;
 
 	private volatile boolean shouldFlattenKeys = true;
+
+	public ObjectToMapTransformer() {
+		this.jsonObjectMapper = JsonObjectMapperProvider.newInstance();
+	}
+
+	public ObjectToMapTransformer(ObjectMapper objectMapper) {
+		this.jsonObjectMapper = JsonObjectMapperProvider.getCustomizedJacksonMapper(objectMapper);
+	}
 
 	public void setShouldFlattenKeys(boolean shouldFlattenKeys) {
 		this.shouldFlattenKeys = shouldFlattenKeys;

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/json/JsonObjectMapperProviderTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/json/JsonObjectMapperProviderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support.json;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ *
+ * @author Vikas Prasad
+ * @since 5.0.0
+ */
+public class JsonObjectMapperProviderTest {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Test
+	public void getCustomizedJacksonMapper_PassObjectMapper_ReturnsJackson2JsonObjectMapperObject() {
+		// arrange + act
+		JsonObjectMapper<?, ?> mapper = JsonObjectMapperProvider.getCustomizedJacksonMapper(new ObjectMapper());
+
+		// assert
+		Assert.assertNotNull("The method should return an instance of JsonObjectMapper", mapper);
+	}
+
+	@Test
+	public void getCustomizedJacksonMapper_PassNull_ThrowsException() {
+		this.expectedException.expect(IllegalArgumentException.class);
+		JsonObjectMapperProvider.getCustomizedJacksonMapper(null);
+	}
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/json/JsonObjectMapperProviderTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/json/JsonObjectMapperProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/ObjectToMapTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/ObjectToMapTransformerTests.java
@@ -19,6 +19,7 @@ package org.springframework.integration.transformer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -39,6 +40,9 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 /**
  *
@@ -176,6 +180,34 @@ public class ObjectToMapTransformerTests {
 		assertEquals("If JSR310 support is enabled by calling findAndRegisterModules() on the Jackson mapper, " +
 						"Instant field should not be broken. Thus the count should exactly be 1 here.",
 				1L, transformedMap.values().stream().filter(Objects::nonNull).count());
+	}
+
+	@Test
+	public void testCustomMapperSupport_DisableTimestampFlag_SerializesDateAsString() throws Exception {
+		// arrange
+		Employee employee = this.buildEmployee();
+
+		ObjectMapper customMapper = new ObjectMapper();
+		// customize your mapper as you want
+		// let us say you want to transform the object to map in such a way that the value of all Date fields come as ISO-8601 String,
+		// (by default it comes as Long timestamp)
+		customMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);    // don't write Date as Long
+
+		// act
+		Map<String, Object> transformedMap = new ObjectToMapTransformer(customMapper).transformPayload(employee);
+
+		// assert
+		assertTrue("As WRITE_DATES_AS_TIMESTAMPS is set to false, Date should be serialized as String",
+				transformedMap.get("listOfDates[0][0]") instanceof String);
+
+		assertTrue("As WRITE_DATES_AS_TIMESTAMPS is set to false, Date should be serialized as String",
+				transformedMap.get("listOfDates[0][1]") instanceof String);
+
+		assertTrue("As WRITE_DATES_AS_TIMESTAMPS is set to false, Date should be serialized as String",
+				transformedMap.get("listOfDates[1][0]") instanceof String);
+
+		assertTrue("As WRITE_DATES_AS_TIMESTAMPS is set to false, Date should be serialized as String",
+				transformedMap.get("listOfDates[1][1]") instanceof String);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION
This PR is for the issue https://jira.spring.io/browse/INT-4316

The PR provides improvements/features inspired from the discussion at https://stackoverflow.com/questions/44991488/how-to-set-date-format-for-jsonobjectmapper-in-spring-integration

The improvements/features added are:

- It enables the default Jackson `ObjectMapper` instance being used by `ObjectToMapTransformer` to identify Java 8 `Instant` fields. As of now `Instant` fields are not treated correctly, resulting two entries per `Instant` field in the map. This issue is fixed by calling `findAndRegisterModules()` on the default mapper and adding the `jackson-datatype-jsr310` dependency, thus enabling it to handle `Instant` fields

- It adds overloaded constructor to `ObjectToMapTransformer` to enable the caller to provide their own customized mapper to be used for the conversion. This will be useful when the caller needs to make changes to a lot of configurations for conversion. The caller can instantiate `ObjectToMapTransformer` using `new ObjectToMapTransformer(customizedMapper)`, where `customizedMapper` will be an instance of `com.fasterxml.jackson.databind.ObjectMapper` with all the custom configuration set by the caller. One such example is provided in JUnit test case. If the caller needs to use the default mapper the caller can always use the default constructor `new ObjectToMapTransformer()`

All tests have been run with success using the command `gradlew build` before creating this PR.