### PR TITLE
INT-4324: File Outbound: parse preserve-timestamp

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerBeanDefinitionBuilder.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerBeanDefinitionBuilder.java
@@ -76,6 +76,7 @@ abstract class FileWritingMessageHandlerBeanDefinitionBuilder {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "flush-when-idle");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "flush-predicate");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "chmod");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "preserve-timestamp");
 		String remoteFileNameGenerator = element.getAttribute("filename-generator");
 		String remoteFileNameGeneratorExpression = element.getAttribute("filename-generator-expression");
 		boolean hasRemoteFileNameGenerator = StringUtils.hasText(remoteFileNameGenerator);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileWritingMessageHandlerFactoryBean.java
@@ -41,39 +41,41 @@ import org.springframework.integration.file.support.FileExistsMode;
 public class FileWritingMessageHandlerFactoryBean
 		extends AbstractSimpleMessageHandlerFactoryBean<FileWritingMessageHandler> {
 
-	private volatile File directory;
+	private File directory;
 
-	private volatile Expression directoryExpression;
+	private Expression directoryExpression;
 
-	private volatile String charset;
+	private String charset;
 
-	private volatile FileNameGenerator fileNameGenerator;
+	private FileNameGenerator fileNameGenerator;
 
-	private volatile Boolean deleteSourceFiles;
+	private Boolean deleteSourceFiles;
 
-	private volatile Boolean autoCreateDirectory;
+	private Boolean autoCreateDirectory;
 
-	private volatile Boolean requiresReply;
+	private Boolean requiresReply;
 
-	private volatile Long sendTimeout;
+	private Long sendTimeout;
 
-	private volatile String temporaryFileSuffix;
+	private String temporaryFileSuffix;
 
-	private volatile FileExistsMode fileExistsMode;
+	private FileExistsMode fileExistsMode;
 
-	private volatile boolean expectReply = true;
+	private boolean expectReply = true;
 
 	private Integer bufferSize;
 
-	private volatile Boolean appendNewLine;
+	private Boolean appendNewLine;
 
-	private volatile Long flushInterval;
+	private Long flushInterval;
 
-	private volatile Boolean flushWhenIdle;
+	private Boolean flushWhenIdle;
 
-	private volatile MessageFlushPredicate flushPredicate;
+	private MessageFlushPredicate flushPredicate;
 
 	private String chmod;
+
+	private Boolean preserveTimestamp;
 
 	public void setFileExistsMode(String fileExistsModeAsString) {
 		this.fileExistsMode = FileExistsMode.getForString(fileExistsModeAsString);
@@ -143,6 +145,10 @@ public class FileWritingMessageHandlerFactoryBean
 		this.chmod = chmod;
 	}
 
+	public void setPreserveTimestamp(Boolean preserveTimestamp) {
+		this.preserveTimestamp = preserveTimestamp;
+	}
+
 	@Override
 	protected FileWritingMessageHandler createHandler() {
 
@@ -203,6 +209,9 @@ public class FileWritingMessageHandlerFactoryBean
 		}
 		if (this.chmod != null) {
 			handler.setChmodOctal(this.chmod);
+		}
+		if (this.preserveTimestamp != null) {
+			handler.setPreserveTimestamp(this.preserveTimestamp);
 		}
 
 		return handler;

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests-context.xml
@@ -18,6 +18,7 @@
 								   directory="${java.io.tmpdir}"
 								   temporary-file-suffix=".foo"
 								   chmod="777"
+								   preserve-timestamp="true"
 								   filename-generator-expression="'foo.txt'"/>
 
 	<file:outbound-channel-adapter id="adapterWithCustomNameGenerator"

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundChannelAdapterParserTests.java
@@ -146,6 +146,7 @@ public class FileOutboundChannelAdapterParserTests {
 		if (FileUtils.IS_POSIX) {
 			assertThat(TestUtils.getPropertyValue(handler, "permissions", Set.class).size(), equalTo(9));
 		}
+		assertEquals(Boolean.TRUE, handlerAccessor.getPropertyValue("preserveTimestamp"));
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4324

The `preserve-timestamp` attribute for the
`<int-file:outbound-channel-adapter>` has been missed for parsing in
the `FileWritingMessageHandlerBeanDefinitionBuilder` and propagation
in the `FileWritingMessageHandlerFactoryBean`

**Cherry-pick to 4.3.x**