### PR TITLE
INT-4318: Register Jackson modules if available

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/AbstractJacksonJsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/AbstractJacksonJsonObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.util.ClassUtils;
  * @param <J> - The expected type of Java Type representation.
  *
  * @author Artem Bilan
+ *
  * @since 3.0
  */
 public abstract class AbstractJacksonJsonObjectMapper<N, P, J> extends JsonObjectMapperAdapter<N, P>
@@ -49,6 +50,10 @@ public abstract class AbstractJacksonJsonObjectMapper<N, P, J> extends JsonObjec
 	@Override
 	public void setBeanClassLoader(ClassLoader classLoader) {
 		this.classLoader = classLoader;
+	}
+
+	protected ClassLoader getClassLoader() {
+		return this.classLoader;
 	}
 
 	@Override


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4318

Do not `ObjectMApper.findAndRegisterModules()` unconditionally.
If there is no the target module library in classpath, we end up
with the `NoClassDefFoundError`

* Copy-paste the well-known modules registration logic from the
`org.springframework.http.converter.json.Jackson2ObjectMapperBuilder`
since we can't add `spring-web`  dependency to the `SI-core`


Tested on the SI Samples reverting commit: https://github.com/spring-projects/spring-integration-samples/commit/68377fedd186e0f12ea8ad5cf00cc233f6e44f04