### PR TITLE
Polished ErrorMessageSendingRecoverer

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -55,19 +55,22 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 	 * @param channel the message channel to publish error messages on recovery action.
 	 */
 	public ErrorMessageSendingRecoverer(MessageChannel channel) {
-		this(channel, new DefaultErrorMessageStrategy());
+		this(channel, null);
 	}
 
 	/**
 	 * Construct instance based on the provided message channel and {@link ErrorMessageStrategy}.
+	 * In the event provided {@link ErrorMessageStrategy} is null, the {@link DefaultErrorMessageStrategy}
+	 * will be used.
 	 * @param channel the message channel to publish error messages on recovery action.
 	 * @param errorMessageStrategy the {@link ErrorMessageStrategy}
-	 * to build error message for publishing.
+	 * to build error message for publishing. Can be null at which point the
+	 * {@link DefaultErrorMessageStrategy} is used.
 	 * @since 4.3.10
 	 */
 	public ErrorMessageSendingRecoverer(MessageChannel channel, ErrorMessageStrategy errorMessageStrategy) {
 		setChannel(channel);
-		setErrorMessageStrategy(errorMessageStrategy);
+		setErrorMessageStrategy(errorMessageStrategy == null ? new DefaultErrorMessageStrategy() : errorMessageStrategy);
 	}
 
 	@Override


### PR DESCRIPTION
- delegated creation of 'DefaultErrorMessageStrategy' to another constructor in cases where user provided null
- see https://github.com/spring-cloud/spring-cloud-stream/pull/1038#discussion_r132707905 for more details and justification