### PR TITLE
INT-4328: AMQP: Returns/Nacks: Create ErrorMessage

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParser.java
@@ -81,6 +81,7 @@ public class AmqpOutboundChannelAdapterParser extends AbstractOutboundChannelAda
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "confirm-ack-channel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "confirm-nack-channel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "return-channel");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-message-strategy");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "delay-expression",
 				"delayExpressionString");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "headers-last", "headersMappedLast");

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParser.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParser.java
@@ -94,6 +94,7 @@ public class AmqpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "confirm-ack-channel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "confirm-nack-channel");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-message-strategy");
 
 		BeanDefinitionBuilder mapperBuilder = BeanDefinitionBuilder
 				.genericBeanDefinition(DefaultAmqpHeaderMapper.class);

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/AmqpMessageHeaderErrorMessageStrategy.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/AmqpMessageHeaderErrorMessageStrategy.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.amqp.support;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.amqp.support.AmqpHeaders;
@@ -43,11 +44,11 @@ public class AmqpMessageHeaderErrorMessageStrategy implements ErrorMessageStrate
 	 */
 	public static final String AMQP_RAW_MESSAGE = AmqpHeaders.PREFIX + "raw_message";
 
-	@SuppressWarnings("deprecation")
 	@Override
 	public ErrorMessage buildErrorMessage(Throwable throwable, AttributeAccessor context) {
-		Object inputMessage = context.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
-		Map<String, Object> headers =
+		Object inputMessage = context == null ? null
+				: context.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
+		Map<String, Object> headers = context == null ? new HashMap<String, Object>() :
 				Collections.singletonMap(AMQP_RAW_MESSAGE, context.getAttribute(AMQP_RAW_MESSAGE));
 		return new ErrorMessage(throwable, headers, inputMessage instanceof Message ? (Message<?>) inputMessage : null);
 	}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/NackedAmqpMessageException.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/NackedAmqpMessageException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.amqp.support;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+
+/**
+ * An exception representing a negatively acknowledged message from a
+ * publisher confirm.
+ *
+ * @author Gary Russell
+ * @since 4.3.12
+ *
+ */
+public class NackedAmqpMessageException extends MessagingException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Object correlationData;
+
+	private final String nackReason;
+
+	public NackedAmqpMessageException(Message<?> message, Object correlationData, String nackReason) {
+		super(message);
+		this.correlationData = correlationData;
+		this.nackReason = nackReason;
+	}
+
+	public Object getCorrelationData() {
+		return this.correlationData;
+	}
+
+	public String getNackReason() {
+		return this.nackReason;
+	}
+
+	@Override
+	public String toString() {
+		return super.toString() + " [correlationData=" + this.correlationData + ", nackReason=" + this.nackReason
+				+ "]";
+	}
+
+}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/ReturnedAmqpMessageException.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/ReturnedAmqpMessageException.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.amqp.support;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.messaging.MessagingException;
+
+/**
+ * A MessagingException for a returned message.
+ *
+ * @author Gary Russell
+ * @since 4.3.12
+ *
+ */
+public class ReturnedAmqpMessageException extends MessagingException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Message amqpMessage;
+
+	private final int replyCode;
+
+	private final String replyText;
+
+	private final String exchange;
+
+	private final String routingKey;
+
+	public ReturnedAmqpMessageException(org.springframework.messaging.Message<?> message, Message amqpMessage,
+			int replyCode, String replyText, String exchange, String routingKey) {
+		super(message);
+		this.amqpMessage = amqpMessage;
+		this.replyCode = replyCode;
+		this.replyText = replyText;
+		this.exchange = exchange;
+		this.routingKey = routingKey;
+	}
+
+	public Message getAmqpMessage() {
+		return this.amqpMessage;
+	}
+
+	public int getReplyCode() {
+		return this.replyCode;
+	}
+
+	public String getReplyText() {
+		return this.replyText;
+	}
+
+	public String getExchange() {
+		return this.exchange;
+	}
+
+	public String getRoutingKey() {
+		return this.routingKey;
+	}
+
+	@Override
+	public String toString() {
+		return super.toString() + " [amqpMessage=" + this.amqpMessage + ", replyCode=" + this.replyCode
+				+ ", replyText=" + this.replyText + ", exchange=" + this.exchange + ", routingKey=" + this.routingKey
+				+ "]";
+	}
+
+}

--- a/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-5.0.xsd
+++ b/spring-integration-amqp/src/main/resources/org/springframework/integration/amqp/config/spring-integration-amqp-5.0.xsd
@@ -544,6 +544,19 @@ property set to TRUE.
 				</xsd:appinfo>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="error-message-strategy" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+					A 'ErrorMessageStrategy' implementation to build an error message for
+					returned or negatively acked messages.
+							]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.integration.support.ErrorMessageStrategy"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="delay-expression" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests-context.xml
@@ -51,7 +51,10 @@
 								   auto-startup="false"
 								   amqp-template="amqpTemplateConfirms"
 								   confirm-correlation-expression="headers['amqp_confirmCorrelationData']"
-								   confirm-ack-channel="ackChannel"/>
+								   confirm-ack-channel="ackChannel"
+								   error-message-strategy="ems"/>
+
+	<bean id="ems" class="org.springframework.integration.support.DefaultErrorMessageStrategy" />
 
 	<int:channel id="pcRequestChannel"/>
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
@@ -179,6 +179,7 @@ public class AmqpOutboundChannelAdapterParserTests {
 		MessageChannel ackChannel = context.getBean("ackChannel", MessageChannel.class);
 		assertSame(ackChannel, TestUtils.getPropertyValue(endpoint, "confirmAckChannel"));
 		assertSame(nullChannel, TestUtils.getPropertyValue(endpoint, "confirmNackChannel"));
+		assertSame(context.getBean("ems"), TestUtils.getPropertyValue(endpoint, "errorMessageStrategy"));
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests-context.xml
@@ -18,9 +18,12 @@
 		delay-expression="42"
 		auto-startup="false"
 		order="5"
-		return-channel="returnChannel">
+		return-channel="returnChannel"
+		error-message-strategy="ems">
 		<int:poller fixed-delay="100"/>
 	</amqp:outbound-gateway>
+
+	<bean id="ems" class="org.springframework.integration.support.DefaultErrorMessageStrategy" />
 
 	<rabbit:template id="amqpTemplate" connection-factory="connectionFactory"/>
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
@@ -77,6 +77,7 @@ public class AmqpOutboundGatewayParserTests {
 		assertEquals("amqp:outbound-async-gateway", async.getComponentType());
 		checkGWProps(context, async);
 		assertSame(context.getBean("asyncTemplate"), TestUtils.getPropertyValue(async, "template"));
+		assertSame(context.getBean("ems"), TestUtils.getPropertyValue(gateway, "errorMessageStrategy"));
 
 		context.close();
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultErrorMessageStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultErrorMessageStrategy.java
@@ -37,7 +37,8 @@ public class DefaultErrorMessageStrategy implements ErrorMessageStrategy {
 
 	@Override
 	public ErrorMessage buildErrorMessage(Throwable throwable, AttributeAccessor attributes) {
-		Object inputMessage = attributes.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
+		Object inputMessage = attributes == null ? null
+				: attributes.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
 		return new ErrorMessage(throwable, inputMessage instanceof Message ? (Message<?>) inputMessage : null);
 	}
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -505,9 +505,10 @@ A configuration sample for an AMQP Outbound Channel Adapter is shown below.
                                confirm-ack-channel="" <11>
                                confirm-nack-channel="" <12>
                                return-channel="" <13>
-                               header-mapper="" <14>
-                               mapped-request-headers="" <15>
-                               lazy-connect="true" /> <16>
+                               error-message-strategy="" <14>
+                               header-mapper="" <15>
+                               mapped-request-headers="" <16>
+                               lazy-connect="true" /> <17>
 
 ----
 
@@ -574,21 +575,25 @@ Previously, a new message was created with the correlation data as its payload, 
 _Optional_.
 
 <11> The channel to which positive (ack) publisher confirms are sent; payload is the correlation data defined by the _confirm-correlation-expression_.
+If the expression is `#root` or `#this`, the message is built from the original message, with the `amqp_publishConfirm` header set to `true`.
 _Optional, default=nullChannel_.
 
 
-<12> The channel to which negative (nack) publisher confirms are sent; payload is the correlation data defined by the _confirm-correlation-expression_.
+<12> The channel to which negative (nack) publisher confirms are sent; payload is the correlation data defined by the _confirm-correlation-expression_ (if there is no `ErrorMessageStrategy` configured).
+If the expression is `#root` or `#this`, the message is built from the original message, with the `amqp_publishConfirm` header set to `false`.
+When there is an `ErrorMessageStrategy`, the message will be an `ErrorMessage` with a `NackedAmqpMessageException` payload.
 _Optional, default=nullChannel_.
 
 
 <13> The channel to which returned messages are sent.
 When provided, the underlying amqp template is configured to return undeliverable messages to the adapter.
-The message will be constructed from the data received from amqp, with the following additional headers: _amqp_returnReplyCode,
-                amqp_returnReplyText, amqp_returnExchange, amqp_returnRoutingKey_.
+When there is no `ErrorMessageStrategy` configured, the message will be constructed from the data received from amqp, with the following additional headers: _amqp_returnReplyCode, amqp_returnReplyText, amqp_returnExchange, amqp_returnRoutingKey_.
+When there is an `ErrorMessageStrategy`, the message will be an `ErrorMessage` with a `ReturnedAmqpMessageException` payload.
 _Optional_.
 
+<14> A reference to an `ErrorMessageStrategy` implementation used to build `ErrorMessage` s when sending returned or negatively acknowedged messages.
 
-<14> A reference to an `AmqpHeaderMapper` to use when sending AMQP Messages.
+<15> A reference to an `AmqpHeaderMapper` to use when sending AMQP Messages.
 By default only standard AMQP properties (e.g.
 `contentType`) will be copied to the Spring Integration `MessageHeaders`.
 Any user-defined headers will NOT be copied to the Message by the default`DefaultAmqpHeaderMapper`.
@@ -596,12 +601,12 @@ Not allowed if 'request-header-names' is provided.
 _Optional_.
 
 
-<15> Comma-separated list of names of AMQP Headers to be mapped from the `MessageHeaders` to the AMQP Message.
+<16> Comma-separated list of names of AMQP Headers to be mapped from the `MessageHeaders` to the AMQP Message.
 Not allowed if the 'header-mapper' reference is provided.
 The values in this list can also be simple patterns to be matched against the header names (e.g. `"\*"` or `"foo*, bar"` or `"*foo"`).
 
 
-<16> When set to `false`, the endpoint will attempt to connect to the broker during application context initialization.
+<17> When set to `false`, the endpoint will attempt to connect to the broker during application context initialization.
 This allows "fail fast" detection of bad configuration, but will also cause initialization to fail if the broker is down.
 When true (default), the connection is established (if it doesn't already exist because some other component established it) when the first message is sent.
 
@@ -718,7 +723,8 @@ Configuration for an AMQP Outbound Gateway is shown below.
                            confirm-ack-channel="" <14>
                            confirm-nack-channel="" <15>
                            return-channel="" <16>
-                           lazy-connect="true" /> <17>
+                           error-message-strategy="" <17>
+                           lazy-connect="true" /> <18>
 
 ----
 
@@ -795,20 +801,24 @@ emitted on the ack/nack channel is based on that message, with the additional he
 Previously, a new message was created with the correlation data as its payload, regardless of type.
 _Optional_.
 
-<14> Since _version 4.2_. The channel to which positive (ack) publisher confirms are sent; payload is the correlation data defined by the _confirm-correlation-expression_.
+<14> The channel to which positive (ack) publisher confirms are sent; payload is the correlation data defined by the _confirm-correlation-expression_.
+If the expression is `#root` or `#this`, the message is built from the original message, with the `amqp_publishConfirm` header set to `true`.
 _Optional, default=nullChannel_.
 
-<15> Since _version 4.2_. The channel to which negative (nack) publisher confirms are sent; payload is the correlation data defined by the _confirm-correlation-expression_.
+<15> The channel to which negative (nack) publisher confirms are sent; payload is the correlation data defined by the _confirm-correlation-expression_ (if there is no `ErrorMessageStrategy` configured).
+If the expression is `#root` or `#this`, the message is built from the original message, with the `amqp_publishConfirm` header set to `false`.
+When there is an `ErrorMessageStrategy`, the message will be an `ErrorMessage` with a `NackedAmqpMessageException` payload.
 _Optional, default=nullChannel_.
 
 <16> The channel to which returned messages are sent.
-When provided, the underlying amqp template is configured to return undeliverable messages to the gateway.
-The message will be constructed from the data received from amqp, with the following additional headers: _amqp_returnReplyCode,
-                amqp_returnReplyText, amqp_returnExchange, amqp_returnRoutingKey_.
+When provided, the underlying amqp template is configured to return undeliverable messages to the adapter.
+When there is no `ErrorMessageStrategy` configured, the message will be constructed from the data received from amqp, with the following additional headers: _amqp_returnReplyCode, amqp_returnReplyText, amqp_returnExchange, amqp_returnRoutingKey_.
+When there is an `ErrorMessageStrategy`, the message will be an `ErrorMessage` with a `ReturnedAmqpMessageException` payload.
 _Optional_.
 
+<17> A reference to an `ErrorMessageStrategy` implementation used to build `ErrorMessage` s when sending returned or negatively acknowedged messages.
 
-<17> When set to `false`, the endpoint will attempt to connect to the broker during application context initialization.
+<18> When set to `false`, the endpoint will attempt to connect to the broker during application context initialization.
 This allows "fail fast" detection of bad configuration, by logging an error message if the broker is down.
 When true (default), the connection is established (if it doesn't already exist because some other component established it) when the first message is sent.
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4328

Add support for sending `ErrorMessage`s to the return and nack channels.

__cherry-pick to 4.3.x, but change default EMS to `null` (will require minor adjustment to test - set the EMS in `adapterWithReturnsAndErrorMessageStrategy`)__
