### PR TITLE
RedisQueue* classes can now have a receive timeout of 0 and block indefinitely

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueInboundGateway.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueInboundGateway.java
@@ -126,7 +126,7 @@ public class RedisQueueInboundGateway extends MessagingGatewaySupport implements
 	 * @param receiveTimeout Must be non-negative. Specified in milliseconds.
 	 */
 	public void setReceiveTimeout(long receiveTimeout) {
-		Assert.isTrue(receiveTimeout > 0, "'receiveTimeout' must be > 0.");
+		Assert.isTrue(receiveTimeout >= 0, "'receiveTimeout' must be >= 0.");
 		this.receiveTimeout = receiveTimeout;
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
@@ -132,7 +132,7 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport impl
 	 * @param receiveTimeout Must be non-negative. Specified in milliseconds.
 	 */
 	public void setReceiveTimeout(long receiveTimeout) {
-		Assert.isTrue(receiveTimeout > 0, "'receiveTimeout' must be > 0.");
+		Assert.isTrue(receiveTimeout >= 0, "'receiveTimeout' must be >= 0.");
 		this.receiveTimeout = receiveTimeout;
 	}
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests-context.xml
@@ -11,7 +11,8 @@
 
 	<bean id="redisConnectionFactory"
 		  class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory">
-		<property name="port" value="#{T(org.springframework.integration.redis.rules.RedisAvailableRule).REDIS_PORT}"/>
+		<property name="port"
+				  value="#{T(org.springframework.integration.redis.rules.RedisAvailableRule).REDIS_PORT}"/>
 	</bean>
 
 	<bean id="customRedisConnectionFactory" parent="redisConnectionFactory"/>
@@ -21,22 +22,29 @@
 	<int:channel id="sendChannel"/>
 
 	<int-redis:queue-inbound-channel-adapter id="customAdapter"
-											  queue="si.test.Int3017.Inbound2"
-											  channel="sendChannel"
-											  connection-factory="customRedisConnectionFactory"
-											  expect-message="true"
-											  serializer="serializer"
-											  error-channel="errorChannel"
-											  receive-timeout="2000"
-											  recovery-interval="3000"
-											  task-executor="executor"
-											  auto-startup="false"
-											  phase="100"
-											  right-pop="false"/>
+											 queue="si.test.Int3017.Inbound2"
+											 channel="sendChannel"
+											 connection-factory="customRedisConnectionFactory"
+											 expect-message="true"
+											 serializer="serializer"
+											 error-channel="errorChannel"
+											 receive-timeout="2000"
+											 recovery-interval="3000"
+											 task-executor="executor"
+											 auto-startup="false"
+											 phase="100"
+											 right-pop="false"/>
+
+	<int-redis:queue-inbound-channel-adapter id="zeroReceiveTimeoutAdapter"
+											 queue="si.test.Int3017.Inbound2"
+											 channel="sendChannel"
+											 connection-factory="customRedisConnectionFactory"
+											 receive-timeout="0"/>
 
 	<bean id="executor" class="org.springframework.integration.util.ErrorHandlingTaskExecutor">
 		<constructor-arg ref="threadPoolTaskExecutor"/>
-		<constructor-arg value="#{T(org.springframework.scheduling.support.TaskUtils).LOG_AND_SUPPRESS_ERROR_HANDLER}"/>
+		<constructor-arg
+				value="#{T(org.springframework.scheduling.support.TaskUtils).LOG_AND_SUPPRESS_ERROR_HANDLER}"/>
 	</bean>
 
 	<task:executor id="threadPoolTaskExecutor" pool-size="5"/>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests.java
@@ -41,6 +41,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+
 /**
  * @author Artem Bilan
  * @author Gary Russell
@@ -73,6 +74,10 @@ public class RedisQueueInboundChannelAdapterParserTests {
 	private RedisQueueMessageDrivenEndpoint customAdapter;
 
 	@Autowired
+	@Qualifier("zeroReceiveTimeoutAdapter")
+	private RedisQueueMessageDrivenEndpoint zeroReceiveTimeoutAdapter;
+
+	@Autowired
 	@Qualifier("errorChannel")
 	private MessageChannel errorChannel;
 
@@ -88,11 +93,13 @@ public class RedisQueueInboundChannelAdapterParserTests {
 	@Autowired
 	private RedisSerializer<?> serializer;
 
+
 	@Test
 	public void testInt3017DefaultConfig() {
 		assertSame(this.connectionFactory,
 				TestUtils.getPropertyValue(this.defaultAdapter, "boundListOperations.ops.template.connectionFactory"));
-		assertEquals("si.test.Int3017.Inbound1", TestUtils.getPropertyValue(this.defaultAdapter, "boundListOperations.key"));
+		assertEquals("si.test.Int3017.Inbound1",
+				TestUtils.getPropertyValue(this.defaultAdapter, "boundListOperations.key"));
 		assertFalse(TestUtils.getPropertyValue(this.defaultAdapter, "expectMessage", Boolean.class));
 		assertEquals(1000L, TestUtils.getPropertyValue(this.defaultAdapter, "receiveTimeout"));
 		assertEquals(5000L, TestUtils.getPropertyValue(this.defaultAdapter, "recoveryInterval"));
@@ -107,11 +114,13 @@ public class RedisQueueInboundChannelAdapterParserTests {
 		assertTrue(TestUtils.getPropertyValue(this.defaultAdapter, "rightPop", Boolean.class));
 	}
 
+
 	@Test
 	public void testInt3017CustomConfig() {
 		assertSame(this.customRedisConnectionFactory,
 				TestUtils.getPropertyValue(this.customAdapter, "boundListOperations.ops.template.connectionFactory"));
-		assertEquals("si.test.Int3017.Inbound2", TestUtils.getPropertyValue(this.customAdapter, "boundListOperations.key"));
+		assertEquals("si.test.Int3017.Inbound2",
+				TestUtils.getPropertyValue(this.customAdapter, "boundListOperations.key"));
 		assertTrue(TestUtils.getPropertyValue(this.customAdapter, "expectMessage", Boolean.class));
 		assertEquals(2000L, TestUtils.getPropertyValue(this.customAdapter, "receiveTimeout"));
 		assertEquals(3000L, TestUtils.getPropertyValue(this.customAdapter, "recoveryInterval"));
@@ -122,6 +131,12 @@ public class RedisQueueInboundChannelAdapterParserTests {
 		assertEquals(100, TestUtils.getPropertyValue(this.customAdapter, "phase"));
 		assertSame(this.sendChannel, TestUtils.getPropertyValue(this.customAdapter, "outputChannel"));
 		assertFalse(TestUtils.getPropertyValue(this.customAdapter, "rightPop", Boolean.class));
+	}
+
+
+	@Test
+	public void testInt4341ZeroReceiveTimeoutConfig() {
+		assertEquals(0L, TestUtils.getPropertyValue(this.zeroReceiveTimeoutAdapter, "receiveTimeout"));
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundGatewayParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundGatewayParserTests-context.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:int="http://www.springframework.org/schema/integration"
-	xmlns:int-redis="http://www.springframework.org/schema/integration/redis"
-	xmlns:task="http://www.springframework.org/schema/task"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int="http://www.springframework.org/schema/integration"
+	   xmlns:int-redis="http://www.springframework.org/schema/integration/redis"
+	   xmlns:task="http://www.springframework.org/schema/task"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
 		http://www.springframework.org/schema/integration/redis http://www.springframework.org/schema/integration/redis/spring-integration-redis.xsd">
 
 	<int-redis:queue-inbound-gateway id="inboundGateway"
-		request-channel="requestChannel"
-		connection-factory="redisConnectionFactory"
-		reply-channel="receiveChannel"
-		request-timeout="3000"
-		reply-timeout="2000"
-		queue="si.test.queue"
-		task-executor="executor"
-		serializer="serializer"
-		auto-startup="false"
-		extract-payload="false"
-		phase="3"/>
+									 request-channel="requestChannel"
+									 connection-factory="redisConnectionFactory"
+									 reply-channel="receiveChannel"
+									 request-timeout="3000"
+									 reply-timeout="2000"
+									 queue="si.test.queue"
+									 task-executor="executor"
+									 serializer="serializer"
+									 auto-startup="false"
+									 extract-payload="false"
+									 phase="3"/>
 
 	<int:channel id="si.test.queue">
 		<int:queue/>
@@ -35,12 +35,18 @@
 	</int:channel>
 
 	<bean id="redisConnectionFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.redis.connection.jedis.JedisConnectionFactory">
+		<constructor-arg
+				value="org.springframework.data.redis.connection.jedis.JedisConnectionFactory">
 		</constructor-arg>
 	</bean>
 
 	<bean id="serializer" class="org.springframework.data.redis.serializer.StringRedisSerializer"/>
 
 	<task:executor id="executor" pool-size="10"/>
+
+	<int-redis:queue-inbound-gateway id="zeroReceiveTimeoutGateway"
+									 request-channel="requestChannel"
+									 receive-timeout="0"
+									 queue="si.test.queue"/>
 
 </beans>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundGatewayParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundGatewayParserTests.java
@@ -35,6 +35,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+
 /**
  * @author David Liu
  * @author Artem Bilan
@@ -50,6 +51,10 @@ public class RedisQueueInboundGatewayParserTests {
 	private RedisQueueInboundGateway defaultGateway;
 
 	@Autowired
+	@Qualifier("zeroReceiveTimeoutGateway")
+	private RedisQueueInboundGateway zeroReceiveTimeoutGateway;
+
+	@Autowired
 	@Qualifier("receiveChannel")
 	private MessageChannel receiveChannel;
 
@@ -59,6 +64,7 @@ public class RedisQueueInboundGatewayParserTests {
 
 	@Autowired
 	private RedisSerializer<?> serializer;
+
 
 	@Test
 	public void testDefaultConfig() throws Exception {
@@ -71,6 +77,11 @@ public class RedisQueueInboundGatewayParserTests {
 		assertNotNull(TestUtils.getPropertyValue(this.defaultGateway, "taskExecutor"));
 		assertFalse(TestUtils.getPropertyValue(this.defaultGateway, "autoStartup", Boolean.class));
 		assertEquals(3, TestUtils.getPropertyValue(this.defaultGateway, "phase"));
+	}
+
+	@Test
+	public void testZeroReceiveTimeoutConfig() throws Exception {
+		assertEquals(0L, TestUtils.getPropertyValue(this.zeroReceiveTimeoutGateway, "receiveTimeout"));
 	}
 
 }


### PR DESCRIPTION
INT-4341: Allow RedisQueue* classes to have 0 receive timeout.

    JIRA: https://jira.spring.io/browse/INT-4341