### PR TITLE
INT-4320: Fix AMQP channels to declare on demand

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
@@ -35,11 +35,9 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.junit.Test;
 
-import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageListener;
-import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
@@ -55,6 +53,7 @@ import com.rabbitmq.client.Channel;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.1
  *
  */
@@ -103,15 +102,8 @@ public class DispatcherHasNoSubscribersTests {
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
 		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
-		final Queue queue = new Queue("noSubscribersQueue");
 		PublishSubscribeAmqpChannel amqpChannel = new PublishSubscribeAmqpChannel("noSubscribersChannel",
-				container, amqpTemplate) {
-			@Override
-			protected String obtainQueueName(AmqpAdmin admin,
-					String channelName) {
-				return queue.getName();
-			}
-		};
+				container, amqpTemplate);
 		amqpChannel.setBeanName("noSubscribersChannel");
 		amqpChannel.setBeanFactory(mock(BeanFactory.class));
 		amqpChannel.afterPropertiesSet();

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests-context.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:amqp="http://www.springframework.org/schema/integration/amqp"
-	xmlns:int="http://www.springframework.org/schema/integration"
-	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit.xsd
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:amqp="http://www.springframework.org/schema/integration/amqp"
+	   xsi:schemaLocation="http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<amqp:channel id="channelWithInterceptor">
@@ -18,26 +14,36 @@
 	<bean id="rabbitConnectionFactory" class="org.springframework.integration.amqp.StubRabbitConnectionFactory"/>
 
 	<amqp:channel id="channelWithSubscriberLimit" max-subscribers="1" missing-queues-fatal="false"
-			template-channel-transacted="true" consumers-per-queue="2" />
+				  template-channel-transacted="true" consumers-per-queue="2"
+				  recovery-interval="0"
+				  shutdown-timeout="0"/>
 
-	<amqp:publish-subscribe-channel id="pubSub" />
+	<amqp:publish-subscribe-channel id="pubSub"
+									recovery-interval="0"
+									shutdown-timeout="0"/>
 
 	<amqp:channel id="withEP" extract-payload="true" default-delivery-mode="NON_PERSISTENT"
-		inbound-header-mapper="inMapper" outbound-header-mapper="outMapper" />
+				  inbound-header-mapper="inMapper" outbound-header-mapper="outMapper"
+				  recovery-interval="0"
+				  shutdown-timeout="0"/>
 
 	<amqp:channel id="pollableWithEP" extract-payload="true" message-driven="false"
-		headers-last="true"
-		inbound-header-mapper="inMapper" outbound-header-mapper="outMapper" />
+				  headers-last="true"
+				  inbound-header-mapper="inMapper" outbound-header-mapper="outMapper"
+				  recovery-interval="0"
+				  shutdown-timeout="0"/>
 
 	<amqp:publish-subscribe-channel id="pubSubWithEP" extract-payload="true"
-		inbound-header-mapper="inMapper" outbound-header-mapper="outMapper" />
+									inbound-header-mapper="inMapper" outbound-header-mapper="outMapper"
+									recovery-interval="0"
+									shutdown-timeout="0"/>
 
 	<bean id="inMapper" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.integration.amqp.support.AmqpHeaderMapper" />
+		<constructor-arg value="org.springframework.integration.amqp.support.AmqpHeaderMapper"/>
 	</bean>
 
 	<bean id="outMapper" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.integration.amqp.support.AmqpHeaderMapper" />
+		<constructor-arg value="org.springframework.integration.amqp.support.AmqpHeaderMapper"/>
 	</bean>
 
 </beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4320

To avoid "fail fast" situation when Broker isn't available during
application init phase, move all the declarations in
the AMQP Message Channels to the `ConnectionListener.onCreate()`.
In addition call the declaration from the `Lifecycle.start()`