### PR TITLE
INT-4289: Fix JMS DSL generic arguments coercion

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
@@ -235,10 +235,10 @@ public final class Jms {
 	JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C>
 	messageDrivenChannelAdapter(ConnectionFactory connectionFactory, Class<C> containerClass) {
 		try {
-			JmsListenerContainerSpec<S, C> spec =
+			S spec =
 					new JmsListenerContainerSpec<S, C>(containerClass)
 							.connectionFactory(connectionFactory);
-			return new JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C>(spec);
+			return new JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<>(spec);
 		}
 		catch (Exception e) {
 			throw new IllegalStateException(e);

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsMessageDrivenChannelAdapterSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsMessageDrivenChannelAdapterSpec.java
@@ -84,13 +84,13 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 	 * @param <C> the target {@link AbstractMessageListenerContainer} implementation type.
 	 */
 	public static class
-			JmsMessageDrivenChannelAdapterListenerContainerSpec<S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>
+	JmsMessageDrivenChannelAdapterListenerContainerSpec<S extends JmsListenerContainerSpec<S, C>, C extends AbstractMessageListenerContainer>
 			extends JmsMessageDrivenChannelAdapterSpec<JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C>>
 			implements ComponentsRegistration {
 
-		private final JmsListenerContainerSpec<S, C> spec;
+		private final S spec;
 
-		JmsMessageDrivenChannelAdapterListenerContainerSpec(JmsListenerContainerSpec<S, C> spec) {
+		JmsMessageDrivenChannelAdapterListenerContainerSpec(S spec) {
 			super(spec.get());
 			this.spec = spec;
 			this.spec.get().setAutoStartup(false);
@@ -125,7 +125,7 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 		 * @return the spec.
 		 */
 		public JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C> configureListenerContainer(
-				Consumer<JmsListenerContainerSpec<S, C>> configurer) {
+				Consumer<S> configurer) {
 			Assert.notNull(configurer, "'configurer' must not be null");
 			configurer.accept(this.spec);
 			return _this();

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -75,6 +76,7 @@ import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
 
 /**
  * @author Artem Bilan
@@ -408,7 +410,9 @@ public class JmsTests {
 					.from(Jms.messageDrivenChannelAdapter(jmsConnectionFactory())
 							.errorChannel(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME)
 							.destination("jmsMessageDrivenRedelivery")
-							.configureListenerContainer(c -> c.id("jmsMessageDrivenRedeliveryFlowContainer")))
+							.configureListenerContainer(c -> c
+									.transactionManager(mock(PlatformTransactionManager.class))
+									.id("jmsMessageDrivenRedeliveryFlowContainer")))
 					.<String, String>transform(p -> {
 						throw new RuntimeException("intentional");
 					})


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4289

We can't use `JmsDefaultListenerContainerSpec` methods from the first
place because we have restricted argument in the `configureListenerContainer()`

* Change the generic argument of the `Consumer<>` to the inferred `S`.
This way the target `Jms.messageDrivenChannelAdapter()` usage will
provide correct `JmsListenerContainerSpec` implementation for auto-completion