### PR TITLE
Add option for MutableMB do not generate headers

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessage.java
@@ -37,6 +37,7 @@ import org.springframework.util.ObjectUtils;
  * @author Artem Bilan
  * @author Stuart Williams
  * @author David Turanski
+ *
  * @since 4.0
  *
  */
@@ -53,12 +54,15 @@ public class MutableMessage<T> implements Message<T>, Serializable {
 	}
 
 	public MutableMessage(T payload, Map<String, Object> headers) {
-		Assert.notNull(payload, "payload must not be null");
-		this.payload = payload;
-
-		this.headers = new MutableMessageHeaders(headers);
+		this(payload, new MutableMessageHeaders(headers));
 	}
 
+	protected MutableMessage(T payload, MutableMessageHeaders headers) {
+		Assert.notNull(payload, "payload must not be null");
+		Assert.notNull(headers, "headers must not be null");
+		this.payload = payload;
+		this.headers = headers;
+	}
 
 	@Override
 	public MutableMessageHeaders getHeaders() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessage.java
@@ -50,7 +50,7 @@ public class MutableMessage<T> implements Message<T>, Serializable {
 	private final MutableMessageHeaders headers;
 
 	public MutableMessage(T payload) {
-		this(payload, null);
+		this(payload, (Map<String, Object>) null);
 	}
 
 	public MutableMessage(T payload, Map<String, Object> headers) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageBuilder.java
@@ -23,6 +23,7 @@ import java.util.Map.Entry;
 
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.util.StringUtils;
@@ -65,6 +66,39 @@ public final class MutableMessageBuilder<T> extends AbstractIntegrationMessageBu
 	}
 
 	/**
+	 * Create a builder for a new {@link Message} instance with the provided payload.
+	 * @param payload the payload for the new message
+	 * @param <T> The type of the payload.
+	 * @return A MutableMessageBuilder.
+	 */
+	public static <T> MutableMessageBuilder<T> withPayload(T payload) {
+		return withPayload(payload, true);
+	}
+
+	/**
+	 * Create a builder for a new {@link Message} instance with the provided payload.
+	 * The {@code generateHeaders} flag allows to disable {@link MessageHeaders#ID}
+	 * and {@link MessageHeaders#TIMESTAMP} headers generation.
+	 * @param payload the payload for the new message
+	 * @param generateHeaders whether generate {@link MessageHeaders#ID}
+	 * and {@link MessageHeaders#TIMESTAMP} headers
+	 * @param <T> The type of the payload.
+	 * @return A MutableMessageBuilder.
+	 * @since 5.0
+	 */
+	public static <T> MutableMessageBuilder<T> withPayload(T payload, boolean generateHeaders) {
+		MutableMessage<T> message;
+		if (generateHeaders) {
+			message = new MutableMessage<>(payload);
+		}
+		else {
+			message = new MutableMessage<>(payload, new MutableMessageHeaders(null, MessageHeaders.ID_VALUE_NONE, -1L));
+		}
+
+		return fromMessage(message);
+	}
+
+	/**
 	 * Create a builder for a new {@link Message} instance pre-populated with all of the headers copied from the
 	 * provided message. The payload of the provided Message will also be used as the payload for the new message.
 	 * @param message the Message from which the payload and all headers will be copied
@@ -74,16 +108,6 @@ public final class MutableMessageBuilder<T> extends AbstractIntegrationMessageBu
 	public static <T> MutableMessageBuilder<T> fromMessage(Message<T> message) {
 		Assert.notNull(message, "'message' must not be null");
 		return new MutableMessageBuilder<T>(message);
-	}
-
-	/**
-	 * Create a builder for a new {@link Message} instance with the provided payload.
-	 * @param payload the payload for the new message
-	 * @param <T> The type of the payload.
-	 * @return A MessageBuilder.
-	 */
-	public static <T> MutableMessageBuilder<T> withPayload(T payload) {
-		return new MutableMessageBuilder<T>(new MutableMessage<T>(payload));
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageHeaders.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageHeaders.java
@@ -19,6 +19,7 @@ package org.springframework.integration.support;
 import java.util.Map;
 import java.util.UUID;
 
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageHeaders;
 
 
@@ -36,14 +37,18 @@ public class MutableMessageHeaders extends MessageHeaders {
 
 	private static final long serialVersionUID = 3084692953798643018L;
 
-	public MutableMessageHeaders(Map<String, Object> headers) {
-		super(headers,
+	public MutableMessageHeaders(@Nullable Map<String, Object> headers) {
+		this(headers,
 				(headers != null ?
 						(UUID) headers.get(MessageHeaders.ID)
 						: null),
 				(headers != null ?
 						(Long) headers.get(MessageHeaders.TIMESTAMP)
 						: null));
+	}
+
+	protected MutableMessageHeaders(@Nullable Map<String, Object> headers, @Nullable UUID id, @Nullable Long timestamp) {
+		super(headers, id, timestamp);
 	}
 
 	@Override

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/MessageBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,15 @@
 
 package org.springframework.integration.message;
 
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.springframework.integration.test.matcher.HeaderMatcher.hasHeaderKey;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -34,6 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.MessageBuilderFactory;
+import org.springframework.integration.support.MutableMessage;
 import org.springframework.integration.support.MutableMessageBuilder;
 import org.springframework.integration.support.MutableMessageBuilderFactory;
 import org.springframework.messaging.Message;
@@ -47,6 +52,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -76,7 +82,7 @@ public class MessageBuilderTests {
 	public void testHeaderValues() {
 		Message<String> message = MessageBuilder.withPayload("test")
 				.setHeader("foo", "bar")
-				.setHeader("count", new Integer(123))
+				.setHeader("count", 123)
 				.build();
 		assertEquals("bar", message.getHeaders().get("foo", String.class));
 		assertEquals(new Integer(123), message.getHeaders().get("count", Integer.class));
@@ -145,11 +151,11 @@ public class MessageBuilderTests {
 
 	@Test
 	public void mutate() {
-		assertTrue(messageBuilderFactory instanceof MutableMessageBuilderFactory);
-		in.send(new GenericMessage<String>("foo"));
+		assertTrue(this.messageBuilderFactory instanceof MutableMessageBuilderFactory);
+		in.send(new GenericMessage<>("foo"));
 		Message<?> m1 = out.receive(0);
 		Message<?> m2 = out.receive(0);
-		assertEquals("org.springframework.integration.support.MutableMessage", m1.getClass().getName());
+		assertThat(m1, instanceOf(MutableMessage.class));
 		assertTrue(m1 == m2);
 	}
 
@@ -189,17 +195,17 @@ public class MessageBuilderTests {
 	@Test
 	public void testPriority() {
 		Message<Integer> importantMessage = MessageBuilder.withPayload(1)
-			.setPriority(123).build();
+				.setPriority(123).build();
 		assertEquals(new Integer(123), new IntegrationMessageHeaderAccessor(importantMessage).getPriority());
 	}
 
 	@Test
 	public void testNonDestructiveSet() {
 		Message<Integer> message1 = MessageBuilder.withPayload(1)
-			.setPriority(42).build();
+				.setPriority(42).build();
 		Message<Integer> message2 = MessageBuilder.fromMessage(message1)
-			.setHeaderIfAbsent(IntegrationMessageHeaderAccessor.PRIORITY, 13)
-			.build();
+				.setHeaderIfAbsent(IntegrationMessageHeaderAccessor.PRIORITY, 13)
+				.build();
 		assertEquals(new Integer(42), new IntegrationMessageHeaderAccessor(message2).getPriority());
 	}
 
@@ -222,20 +228,20 @@ public class MessageBuilderTests {
 	@Test
 	public void testRemove() {
 		Message<Integer> message1 = MessageBuilder.withPayload(1)
-			.setHeader("foo", "bar").build();
+				.setHeader("foo", "bar").build();
 		Message<Integer> message2 = MessageBuilder.fromMessage(message1)
-			.removeHeader("foo")
-			.build();
+				.removeHeader("foo")
+				.build();
 		assertFalse(message2.getHeaders().containsKey("foo"));
 	}
 
 	@Test
 	public void testSettingToNullRemoves() {
 		Message<Integer> message1 = MessageBuilder.withPayload(1)
-			.setHeader("foo", "bar").build();
+				.setHeader("foo", "bar").build();
 		Message<Integer> message2 = MessageBuilder.fromMessage(message1)
-			.setHeader("foo", null)
-			.build();
+				.setHeader("foo", null)
+				.build();
 		assertFalse(message2.getHeaders().containsKey("foo"));
 	}
 
@@ -351,4 +357,18 @@ public class MessageBuilderTests {
 		assertEquals(original, result);
 	}
 
+	@Test
+	public void testNoIdAndTimestampHeaders() {
+		Message<String> message =
+				MutableMessageBuilder.withPayload("foo", false)
+						.pushSequenceDetails("bar", 1, 1)
+						.build();
+
+		assertThat(message, hasHeaderKey(IntegrationMessageHeaderAccessor.CORRELATION_ID));
+		assertThat(message, hasHeaderKey(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER));
+		assertThat(message, hasHeaderKey(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE));
+		assertThat(message, not(hasHeaderKey(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS)));
+		assertThat(message, not(hasHeaderKey(MessageHeaders.ID)));
+		assertThat(message, not(hasHeaderKey(MessageHeaders.TIMESTAMP)));
+	}
 }


### PR DESCRIPTION
Since `MutableMessage` can be mutated, the `ID` and `TIMESTAMP` headers
can be added lately.
Or there might be some scenarios which don't care about those headers at
all.
Plus we get a performance gain when we skip their generation