### PR TITLE
INT-4343 - Enables custom task executor setting in RedisInboundChannelAdapter

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParser.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Venil Noronha
  * @since 2.1
  */
 public class RedisInboundChannelAdapterParser extends AbstractChannelAdapterParser {
@@ -49,6 +50,7 @@ public class RedisInboundChannelAdapterParser extends AbstractChannelAdapterPars
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "serializer", true);
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "task-executor");
 
 		return builder.getBeanDefinition();
 	}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapter.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2016 the original author or authors.
+ * Copyright 2007-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.redis.inbound;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -39,6 +40,7 @@ import org.springframework.util.Assert;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Venil Noronha
  * @since 2.1
  */
 public class RedisInboundChannelAdapter extends MessageProducerSupport {
@@ -73,6 +75,11 @@ public class RedisInboundChannelAdapter extends MessageProducerSupport {
 	public void setMessageConverter(MessageConverter messageConverter) {
 		Assert.notNull(messageConverter, "messageConverter must not be null");
 		this.messageConverter = messageConverter;
+	}
+
+	public void setTaskExecutor(Executor taskExecutor) {
+		Assert.notNull(messageConverter, "taskExecutor must not be null");
+		this.container.setTaskExecutor(taskExecutor);
 	}
 
 	@Override

--- a/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-5.0.xsd
+++ b/spring-integration-redis/src/main/resources/org/springframework/integration/redis/config/spring-integration-redis-5.0.xsd
@@ -193,6 +193,19 @@
 					</xsd:appinfo>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="task-executor" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+						A reference to a Spring TaskExecutor (or standard JDK 1.5+ Executor) for executing
+						Redis listener invokers. Default is a SimpleAsyncTaskExecutor.
+					]]></xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="java.util.concurrent.Executor"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests-context.xml
@@ -9,7 +9,14 @@
 	<int-redis:inbound-channel-adapter
 		id="adapter" topics="foo" topic-patterns="f*, b*" channel="receiveChannel" error-channel="testErrorChannel"
 		message-converter="testConverter"
-		serializer="serializer"/>
+		serializer="serializer"
+		task-executor="executor" />
+
+	<bean id="executor" class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
+		<property name="corePoolSize" value="5" />
+		<property name="maxPoolSize" value="10" />
+		<property name="queueCapacity" value="25" />
+	</bean>
 
 	<int:channel id="receiveChannel">
 		<int:queue />

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
@@ -40,6 +40,7 @@ import org.springframework.integration.support.converter.SimpleMessageConverter;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -49,6 +50,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Gunnar Hillert
+ * @author Venil Noronha
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -75,6 +77,16 @@ public class RedisInboundChannelAdapterParserTests extends RedisAvailableTests {
 		Object converterBean = context.getBean("testConverter");
 		assertEquals(converterBean, accessor.getPropertyValue("messageConverter"));
 		assertEquals(context.getBean("serializer"), accessor.getPropertyValue("serializer"));
+
+		Object container = accessor.getPropertyValue("container");
+		DirectFieldAccessor containerAccessor = new DirectFieldAccessor(container);
+		Object taskExecutorObj = containerAccessor.getPropertyValue("taskExecutor");
+		assertEquals(ThreadPoolTaskExecutor.class, taskExecutorObj.getClass());
+		ThreadPoolTaskExecutor taskExecutor = (ThreadPoolTaskExecutor) taskExecutorObj;
+		assertEquals(5, taskExecutor.getCorePoolSize());
+		assertEquals(10, taskExecutor.getMaxPoolSize());
+		DirectFieldAccessor executorAccessor = new DirectFieldAccessor(taskExecutor);
+		assertEquals(25, executorAccessor.getPropertyValue("queueCapacity"));
 
 		Object bean = context.getBean("withoutSerializer.adapter");
 		assertNotNull(bean);

--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -132,13 +132,15 @@ The default is a `SimpleMessageConverter`.
 
 Inbound adapters can subscribe to multiple topic names hence the comma-delimited set of values in the `topics` attribute.
 
-Since _Spring Integration 3.0_, the Inbound Adapter, in addition to the existing `topics` attribute, now has the `topic-patterns` attribute.
+Since _version 3.0_, the Inbound Adapter, in addition to the existing `topics` attribute, now has the `topic-patterns` attribute.
 This attribute contains a comma-delimited set of Redis topic patterns.
 For more information regarding Redis publish/subscribe, see http://redis.io/topics/pubsub[Redis Pub/Sub].
 
 Inbound adapters can use a `RedisSerializer` to deserialize the body of Redis Messages.
 The `serializer` attribute of the `<int-redis:inbound-channel-adapter>` can be set to an empty string, which results in a `null` value for the `RedisSerializer` property.
 In this case the raw `byte[]` bodies of Redis Messages are provided as the message payloads.
+
+Since _version 5.0_, a `Executor` instance can be provided to the Inbound Adapter via the `task-executor` attribute of the `<int-redis:inbound-channel-adapter>`. 
 
 [[redis-outbound-channel-adapter]]
 ==== Redis Outbound Channel Adapter

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -265,6 +265,9 @@ The `RedisStoreWritingMessageHandler` is supplied now with additional String-bas
 The `zsetIncrementExpression` can now be configured on the `RedisStoreWritingMessageHandler`, as well.
 In addition this property has been changed from `true` to `false` since `INCR` option on `ZADD` Redis command is optional.
 
+The `RedisInboundChannelAdapter` can now be provided with an `Executor` for executing Redis listener invokers.
+The `Executor` instance can be provided by setting the `task-executor` attribute of the `<int-redis:inbound-channel-adapter>`.
+
 See <<redis>> for more information.
 
 ==== TCP Changes


### PR DESCRIPTION
This PR adds a new setter named `setTaskExecutor` in `RedisInboundChannelAdapter` to enable customization of the task `Executor` in `RedisMessageListenerContainer`.