### PR TITLE
INT-4313 - Adds ListenableMetadataStore implementation in GemfireMetadataStore

### DIFF
--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStore.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStore.java
@@ -16,11 +16,18 @@
 
 package org.springframework.integration.gemfire.metadata;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.EntryEvent;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.Scope;
+import org.apache.geode.cache.util.CacheListenerAdapter;
 
 import org.springframework.integration.metadata.ConcurrentMetadataStore;
+import org.springframework.integration.metadata.ListenableMetadataStore;
+import org.springframework.integration.metadata.MetadataStoreListener;
 import org.springframework.util.Assert;
 
 /**
@@ -30,22 +37,27 @@ import org.springframework.util.Assert;
  * restarts.
  *
  * @author Artem Bilan
+ * @author Venil Noronha
  * @since 4.0
  */
-public class GemfireMetadataStore implements ConcurrentMetadataStore {
+public class GemfireMetadataStore implements ConcurrentMetadataStore, ListenableMetadataStore {
 
 	public static final String KEY = "MetaData";
+
+	private GemfireCacheListener cacheListener = new GemfireCacheListener();
 
 	private final Region<String, String> region;
 
 	public GemfireMetadataStore(Cache cache) {
 		Assert.notNull(cache, "'cache' must not be null");
 		this.region = cache.<String, String>createRegionFactory().setScope(Scope.LOCAL).create(KEY);
+		this.region.getAttributesMutator().addCacheListener(this.cacheListener);
 	}
 
 	public GemfireMetadataStore(Region<String, String> region) {
 		Assert.notNull(region, "'region' must not be null");
 		this.region = region;
+		this.region.getAttributesMutator().addCacheListener(this.cacheListener);
 	}
 
 	@Override
@@ -80,6 +92,55 @@ public class GemfireMetadataStore implements ConcurrentMetadataStore {
 	public String remove(String key) {
 		Assert.notNull(key, "'key' must not be null.");
 		return this.region.remove(key);
+	}
+
+	@Override
+	public void addListener(MetadataStoreListener listener) {
+		Assert.notNull(listener, "'listener' must not be null");
+		this.cacheListener.listeners.add(listener);
+	}
+
+	@Override
+	public void removeListener(MetadataStoreListener listener) {
+		this.cacheListener.listeners.remove(listener);
+	}
+
+	private static class GemfireCacheListener extends CacheListenerAdapter<String, String> {
+
+		private final List<MetadataStoreListener> listeners = new CopyOnWriteArrayList<MetadataStoreListener>();
+
+		GemfireCacheListener() {
+			super();
+		}
+
+		@Override
+		public void afterCreate(EntryEvent<String, String> event) {
+			for (MetadataStoreListener listener : this.listeners) {
+				listener.onAdd(event.getKey(), event.getNewValue());
+			}
+		}
+
+		@Override
+		public void afterUpdate(EntryEvent<String, String> event) {
+			for (MetadataStoreListener listener : this.listeners) {
+				listener.onUpdate(event.getKey(), event.getNewValue());
+			}
+		}
+
+		@Override
+		public void afterInvalidate(EntryEvent<String, String> event) {
+			for (MetadataStoreListener listener : this.listeners) {
+				listener.onRemove(event.getKey(), event.getOldValue());
+			}
+		}
+
+		@Override
+		public void afterDestroy(EntryEvent<String, String> event) {
+			for (MetadataStoreListener listener : this.listeners) {
+				listener.onRemove(event.getKey(), event.getOldValue());
+			}
+		}
+
 	}
 
 }

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStore.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStore.java
@@ -44,7 +44,7 @@ public class GemfireMetadataStore implements ConcurrentMetadataStore, Listenable
 
 	public static final String KEY = "MetaData";
 
-	private GemfireCacheListener cacheListener = new GemfireCacheListener();
+	private final GemfireCacheListener cacheListener = new GemfireCacheListener();
 
 	private final Region<String, String> region;
 
@@ -124,13 +124,6 @@ public class GemfireMetadataStore implements ConcurrentMetadataStore, Listenable
 		public void afterUpdate(EntryEvent<String, String> event) {
 			for (MetadataStoreListener listener : this.listeners) {
 				listener.onUpdate(event.getKey(), event.getNewValue());
-			}
-		}
-
-		@Override
-		public void afterInvalidate(EntryEvent<String, String> event) {
-			for (MetadataStoreListener listener : this.listeners) {
-				listener.onRemove(event.getKey(), event.getOldValue());
 			}
 		}
 

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStoreCacheListenerTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStoreCacheListenerTests.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
@@ -79,13 +80,13 @@ public class GemfireMetadataStoreCacheListenerTests {
 		String testValue = "value";
 
 		CountDownLatch latch = new CountDownLatch(1);
-		StringBuilder actualKey = new StringBuilder();
-		StringBuilder actualValue = new StringBuilder();
+		AtomicReference<String> actualKey = new AtomicReference<String>();
+		AtomicReference<String> actualValue = new AtomicReference<String>();
 		metadataStore.addListener(new MetadataStoreListenerAdapter() {
 			@Override
 			public void onAdd(String key, String value) {
-				actualKey.append(key);
-				actualValue.append(value);
+				actualKey.set(key);
+				actualValue.set(value);
 				latch.countDown();
 			}
 		});
@@ -94,8 +95,8 @@ public class GemfireMetadataStoreCacheListenerTests {
 		latch.await(2, TimeUnit.SECONDS);
 
 		assertEquals(0, latch.getCount());
-		assertEquals(testKey, actualKey.toString());
-		assertEquals(testValue, actualValue.toString());
+		assertEquals(testKey, actualKey.get());
+		assertEquals(testValue, actualValue.get());
 	}
 
 	@Test
@@ -104,13 +105,13 @@ public class GemfireMetadataStoreCacheListenerTests {
 		String testValue = "value";
 
 		CountDownLatch latch = new CountDownLatch(1);
-		StringBuilder actualKey = new StringBuilder();
-		StringBuilder actualValue = new StringBuilder();
+		AtomicReference<String> actualKey = new AtomicReference<String>();
+		AtomicReference<String> actualValue = new AtomicReference<String>();
 		metadataStore.addListener(new MetadataStoreListenerAdapter() {
 			@Override
 			public void onRemove(String key, String oldValue) {
-				actualKey.append(key);
-				actualValue.append(oldValue);
+				actualKey.set(key);
+				actualValue.set(oldValue);
 				latch.countDown();
 			}
 		});
@@ -120,8 +121,8 @@ public class GemfireMetadataStoreCacheListenerTests {
 		latch.await(2, TimeUnit.SECONDS);
 
 		assertEquals(0, latch.getCount());
-		assertEquals(testKey, actualKey.toString());
-		assertEquals(testValue, actualValue.toString());
+		assertEquals(testKey, actualKey.get());
+		assertEquals(testValue, actualValue.get());
 	}
 
 	@Test
@@ -131,13 +132,13 @@ public class GemfireMetadataStoreCacheListenerTests {
 		String testNewValue = "new-value";
 
 		CountDownLatch latch = new CountDownLatch(1);
-		StringBuilder actualKey = new StringBuilder();
-		StringBuilder actualValue = new StringBuilder();
+		AtomicReference<String> actualKey = new AtomicReference<String>();
+		AtomicReference<String> actualValue = new AtomicReference<String>();
 		metadataStore.addListener(new MetadataStoreListenerAdapter() {
 			@Override
 			public void onUpdate(String key, String newValue) {
-				actualKey.append(key);
-				actualValue.append(newValue);
+				actualKey.set(key);
+				actualValue.set(newValue);
 				latch.countDown();
 			}
 		});
@@ -147,8 +148,8 @@ public class GemfireMetadataStoreCacheListenerTests {
 		latch.await(2, TimeUnit.SECONDS);
 
 		assertEquals(0, latch.getCount());
-		assertEquals(testKey, actualKey.toString());
-		assertEquals(testNewValue, actualValue.toString());
+		assertEquals(testKey, actualKey.get());
+		assertEquals(testNewValue, actualValue.get());
 	}
 
 }

--- a/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStoreCacheListenerTests.java
+++ b/spring-integration-gemfire/src/test/java/org/springframework/integration/gemfire/metadata/GemfireMetadataStoreCacheListenerTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.gemfire.metadata;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.Region;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.springframework.integration.metadata.MetadataStoreListenerAdapter;
+import org.springframework.util.Assert;
+
+/**
+ * @author Venil Noronha
+ * @since 5.0
+ *
+ */
+public class GemfireMetadataStoreCacheListenerTests {
+
+	private static Cache cache;
+
+	private static GemfireMetadataStore metadataStore;
+
+	private static Region<Object, Object> region;
+
+	@BeforeClass
+	public static void startUp() throws Exception {
+		cache = new CacheFactory().create();
+		metadataStore = new GemfireMetadataStore(cache);
+		region = cache.getRegion(GemfireMetadataStore.KEY);
+	}
+
+	@AfterClass
+	public static void cleanUp() {
+		if (region != null) {
+			region.close();
+		}
+		if (cache != null) {
+			cache.close();
+			Assert.isTrue(cache.isClosed(), "Cache did not close after close() call");
+		}
+	}
+
+	@Before
+	@After
+	public void setup() {
+		if (region != null) {
+			region.clear();
+		}
+	}
+
+	@Test
+	public void testAdd() throws InterruptedException {
+		String testKey = "key";
+		String testValue = "value";
+
+		CountDownLatch latch = new CountDownLatch(1);
+		StringBuilder actualKey = new StringBuilder();
+		StringBuilder actualValue = new StringBuilder();
+		metadataStore.addListener(new MetadataStoreListenerAdapter() {
+			@Override
+			public void onAdd(String key, String value) {
+				actualKey.append(key);
+				actualValue.append(value);
+				latch.countDown();
+			}
+		});
+
+		metadataStore.put(testKey, testValue);
+		latch.await(2, TimeUnit.SECONDS);
+
+		assertEquals(0, latch.getCount());
+		assertEquals(testKey, actualKey.toString());
+		assertEquals(testValue, actualValue.toString());
+	}
+
+	@Test
+	public void testRemove() throws InterruptedException {
+		String testKey = "key";
+		String testValue = "value";
+
+		CountDownLatch latch = new CountDownLatch(1);
+		StringBuilder actualKey = new StringBuilder();
+		StringBuilder actualValue = new StringBuilder();
+		metadataStore.addListener(new MetadataStoreListenerAdapter() {
+			@Override
+			public void onRemove(String key, String oldValue) {
+				actualKey.append(key);
+				actualValue.append(oldValue);
+				latch.countDown();
+			}
+		});
+
+		metadataStore.put(testKey, testValue);
+		metadataStore.remove(testKey);
+		latch.await(2, TimeUnit.SECONDS);
+
+		assertEquals(0, latch.getCount());
+		assertEquals(testKey, actualKey.toString());
+		assertEquals(testValue, actualValue.toString());
+	}
+
+	@Test
+	public void testUpdate() throws InterruptedException {
+		String testKey = "key";
+		String testValue = "value";
+		String testNewValue = "new-value";
+
+		CountDownLatch latch = new CountDownLatch(1);
+		StringBuilder actualKey = new StringBuilder();
+		StringBuilder actualValue = new StringBuilder();
+		metadataStore.addListener(new MetadataStoreListenerAdapter() {
+			@Override
+			public void onUpdate(String key, String newValue) {
+				actualKey.append(key);
+				actualValue.append(newValue);
+				latch.countDown();
+			}
+		});
+
+		metadataStore.put(testKey, testValue);
+		metadataStore.put(testKey, testNewValue);
+		latch.await(2, TimeUnit.SECONDS);
+
+		assertEquals(0, latch.getCount());
+		assertEquals(testKey, actualKey.toString());
+		assertEquals(testNewValue, actualValue.toString());
+	}
+
+}

--- a/src/reference/asciidoc/gemfire.adoc
+++ b/src/reference/asciidoc/gemfire.adoc
@@ -211,4 +211,4 @@ NOTE: The `GemfireMetadataStore` also implements `ConcurrentMetadataStore`, allo
 These methods give various levels of concurrency guarantees based on the scope and data policy of the region.
 They are implemented in the peer cache and client/server cache but are disallowed in peer Regions having NORMAL or EMPTY data policies.
 
-NOTE: Since _Spring Integration 5.0_, the `GemfireMetadataStore` also implements `ListenableMetadataStore`, allowing users to listen to cache events by providing `MetadataStoreListener` instances to the store.
+NOTE: Since _version 5.0_, the `GemfireMetadataStore` also implements `ListenableMetadataStore`, allowing users to listen to cache events by providing `MetadataStoreListener` instances to the store.

--- a/src/reference/asciidoc/gemfire.adoc
+++ b/src/reference/asciidoc/gemfire.adoc
@@ -210,3 +210,5 @@ The _Twitter Inbound Channel Adapter_ and the _Feed Inbound Channel Adapter_ wil
 NOTE: The `GemfireMetadataStore` also implements `ConcurrentMetadataStore`, allowing it to be reliably shared across multiple application instances where only one instance will be allowed to store or modify a key's value.
 These methods give various levels of concurrency guarantees based on the scope and data policy of the region.
 They are implemented in the peer cache and client/server cache but are disallowed in peer Regions having NORMAL or EMPTY data policies.
+
+NOTE: Since _Spring Integration 5.0_, the `GemfireMetadataStore` also implements `ListenableMetadataStore`, allowing users to listen to cache events by providing `MetadataStoreListener` instances to the store.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -278,3 +278,9 @@ See <<ip>> for more information.
 The `@GlobalChannelInterceptor` annotation and `<int:channel-interceptor>` now support negative patterns (via `!` prepending) for component names matching.
 
 See <<global-channel-configuration-interceptors>> for more information.
+
+==== Gemfire Changes
+
+The `GemfireMetadataStore` now implements `ListenableMetadataStore`, allowing users to listen to cache events by providing `MetadataStoreListener` instances to the store.
+
+See <<gemfire>> for more information.


### PR DESCRIPTION
This PR implements the `ListenableMetadataStore` interface by introducing `GemfireCacheListener` to listen to events in `GemfireMetadataStore`.