### PR TITLE
INT-4344: AbstRemoteFileOutGw: Add assert for NPE

### DIFF
--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -809,7 +809,7 @@ public class RemoteFileOutboundGatewayTests {
 		template.setRemoteDirectoryExpression(new LiteralExpression("foo/"));
 		template.setBeanFactory(mock(BeanFactory.class));
 		template.afterPropertiesSet();
-		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(template, "put", null);
+		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(template, "put", "payload");
 		FileTransferringMessageHandler<TestLsEntry> handler = new FileTransferringMessageHandler<TestLsEntry>(sessionFactory);
 		handler.setRemoteDirectoryExpression(new LiteralExpression("foo/"));
 		handler.setBeanFactory(mock(BeanFactory.class));
@@ -844,7 +844,7 @@ public class RemoteFileOutboundGatewayTests {
 		template.setRemoteDirectoryExpression(new LiteralExpression("foo/"));
 		template.setBeanFactory(mock(BeanFactory.class));
 		template.afterPropertiesSet();
-		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(template, "put", null);
+		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(template, "put", "payload");
 		FileTransferringMessageHandler<TestLsEntry> handler = new FileTransferringMessageHandler<TestLsEntry>(sessionFactory);
 		handler.setRemoteDirectoryExpression(new LiteralExpression("foo/"));
 		handler.setBeanFactory(mock(BeanFactory.class));
@@ -905,7 +905,7 @@ public class RemoteFileOutboundGatewayTests {
 		template.setRemoteDirectoryExpression(new LiteralExpression("foo/"));
 		template.setBeanFactory(mock(BeanFactory.class));
 		template.afterPropertiesSet();
-		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(template, "mput", null);
+		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(template, "mput", "payload");
 		gw.afterPropertiesSet();
 		when(sessionFactory.getSession()).thenReturn(session);
 		final AtomicReference<String> written = new AtomicReference<String>();

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
@@ -102,8 +102,8 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 	}
 
 	/**
-	 * Construct an instance with the supplied session factory, a command ('ls', 'get'
-	 * etc).
+	 * Construct an instance with the supplied session factory
+	 * and command ('ls', 'nlst', 'put' or 'mput').
 	 * <p> The {@code remoteDirectory} expression is {@code null} assuming to use
 	 * the {@code workingDirectory} from the FTP Client.
 	 * @param sessionFactory the session factory.
@@ -115,8 +115,8 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 	}
 
 	/**
-	 * Construct an instance with the supplied remote file template, a command ('ls',
-	 * 'get' etc).
+	 * Construct an instance with the supplied remote file template
+	 * and command ('ls', 'nlst', 'put' or 'mput').
 	 * <p> The {@code remoteDirectory} expression is {@code null} assuming to use
 	 * the {@code workingDirectory} from the FTP Client.
 	 * @param remoteFileTemplate the remote file template.

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -831,7 +831,8 @@ directories, which is achievable using the `FileInfo` objects.
 Starting with _version 4.3_, the `FtpSession` supports `null` for the `list()` and `listNames()` methods,
 therefore the `expression` attribute can be omitted.
 From Java perspective there are two new constructor without `expression` argument for convenience.
-The `null` for `LS` command is treated as an Client working directory according to the FTP protocol.
+The `null` for `LS`, `NLST`, `PUT` and `MPUT` commands is treated as an Client working directory according to the FTP protocol.
+All other commands must be supplied with the `expression` to evaluate remote path against request message.
 The working directory can be set via the `FTPClient.changeWorkingDirectory()` function when you extend the `DefaultFtpSessionFactory` and implement `postProcessClientAfterConnect()` callback.
 
 *nlst*


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4344

The `FtpOutboundGateway` provides ctors without expression for remote path.
In this case it is treated as a `working directory` but only for the
`LS`, `NLST`, `PUT` and `MPUT` commands.

* Add assertion in the `AbstractRemoteFileOutboundGateway` to discard
configuration for all other commands when `expression` is `null`

**Cherry-pick to 4.3.x**