### PR TITLE
INT-4350: Handle ResponseEntity in HTTP Inbounds

### DIFF
--- a/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests.java
@@ -19,7 +19,6 @@ package org.springframework.integration.http;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.isNull;
 
@@ -144,8 +143,8 @@ public class HttpProxyScenarioTests {
 
 		this.handlerAdapter.handle(request, response, handler);
 
-		assertNull(response.getHeaderValue("If-Modified-Since"));
-		assertNull(response.getHeaderValue("If-Unmodified-Since"));
+		assertEquals(ifModifiedSinceValue, response.getHeaderValue("If-Modified-Since"));
+		assertEquals(ifUnmodifiedSinceValue, response.getHeaderValue("If-Unmodified-Since"));
 		assertEquals("close", response.getHeaderValue("Connection"));
 		assertEquals(contentDispositionValue, response.getHeader("Content-Disposition"));
 		assertEquals("text/plain", response.getContentType());

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
@@ -33,16 +33,15 @@ import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseEntity;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
-import org.springframework.integration.http.HttpHeaders;
 import org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandler;
 import org.springframework.integration.security.channel.ChannelSecurityInterceptor;
 import org.springframework.integration.security.channel.SecuredChannel;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.access.vote.AffirmativeBased;
 import org.springframework.security.access.vote.RoleVoter;
@@ -177,9 +176,7 @@ public class HttpDslTests {
 			return f -> f
 					.transform(Throwable::getCause)
 					.<HttpClientErrorException>handle((p, h) ->
-							MessageBuilder.withPayload(p.getResponseBodyAsString())
-									.setHeader(HttpHeaders.STATUS_CODE, p.getStatusCode())
-									.build());
+							new ResponseEntity<>(p.getResponseBodyAsString(), p.getStatusCode()));
 		}
 
 		@Bean


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4350

Spring MVC and Spring WebFlux handles `ResponseEntity` via appropriate
`ReturnValue` handlers.
This way all the headers and status code are fully up to end-user.
The body is handled by the appropriate converter/writer as before

* Add `ResponseEntity` handling to the `HttpRequestHandlingMessagingGateway`
and `WebFluxInboundEndpoint`.
The logic mostly compy/pasted from the `ResponseEntityResultHandler`