### PR TITLE
INT-4345: ServerWebSocketContainer: Fix Lifecycle

### DIFF
--- a/spring-integration-stomp/src/test/java/org/springframework/integration/stomp/outbound/StompMessageHandlerWebSocketIntegrationTests.java
+++ b/spring-integration-stomp/src/test/java/org/springframework/integration/stomp/outbound/StompMessageHandlerWebSocketIntegrationTests.java
@@ -91,6 +91,7 @@ import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ *
  * @since 4.2
  */
 @ContextConfiguration(classes = StompMessageHandlerWebSocketIntegrationTests.ContextConfiguration.class)
@@ -269,7 +270,7 @@ public class StompMessageHandlerWebSocketIntegrationTests extends LogAdjustingTe
 
 		@Override
 		public void configureClientInboundChannel(ChannelRegistration registration) {
-			registration.setInterceptors(new ChannelInterceptorAdapter() {
+			registration.interceptors(new ChannelInterceptorAdapter() {
 
 				private final AtomicBoolean invoked = new AtomicBoolean();
 

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
@@ -61,6 +61,7 @@ import org.springframework.web.socket.messaging.SessionConnectedEvent;
 
 /**
  * @author Artem Bilan
+ *
  * @since 4.1
  */
 public class WebSocketInboundChannelAdapter extends MessageProducerSupport
@@ -255,6 +256,9 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 	@Override
 	protected void doStop() {
 		this.active = false;
+		if (this.webSocketContainer instanceof Lifecycle) {
+			((Lifecycle) this.webSocketContainer).stop();
+		}
 	}
 
 	private boolean isActive() {

--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/server/WebSocketServerTests.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/server/WebSocketServerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -41,6 +43,7 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.Lifecycle;
 import org.springframework.context.PayloadApplicationEvent;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -86,12 +89,16 @@ import org.springframework.web.socket.handler.WebSocketHandlerDecorator;
 import org.springframework.web.socket.handler.WebSocketHandlerDecoratorFactory;
 import org.springframework.web.socket.messaging.StompSubProtocolHandler;
 import org.springframework.web.socket.messaging.SubProtocolHandler;
+import org.springframework.web.socket.server.RequestUpgradeStrategy;
+import org.springframework.web.socket.server.standard.TomcatRequestUpgradeStrategy;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 import org.springframework.web.socket.sockjs.client.SockJsClient;
 import org.springframework.web.socket.sockjs.client.Transport;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
 /**
  * @author Artem Bilan
+ *
  * @since 4.1
  */
 @ContextConfiguration(classes = WebSocketServerTests.ContextConfiguration.class)
@@ -114,6 +121,9 @@ public class WebSocketServerTests {
 
 	@Value("#{server.serverContext.getBean('webSocketEvents')}")
 	private PollableChannel webSocketEvents;
+
+	@Value("#{server.serverContext.getBean('requestUpgradeStrategy')}")
+	private Lifecycle requestUpgradeStrategy;
 
 	@Test
 	public void testWebSocketOutboundMessageHandler() throws Exception {
@@ -151,6 +161,8 @@ public class WebSocketServerTests {
 		Message<?> event = this.webSocketEvents.receive(10000);
 		assertNotNull(event);
 		assertThat(event.getPayload(), instanceOf(WebSocketSession.class));
+
+		verify(this.requestUpgradeStrategy).start();
 	}
 
 	@Test
@@ -251,8 +263,19 @@ public class WebSocketServerTests {
 		}
 
 		@Bean
+		public RequestUpgradeStrategy requestUpgradeStrategy() {
+			return spy(new MyTomcatRequestUpgradeStrategy());
+		}
+
+		@Bean
+		public DefaultHandshakeHandler handshakeHandler() {
+			return new DefaultHandshakeHandler(requestUpgradeStrategy());
+		}
+
+		@Bean
 		public ServerWebSocketContainer serverWebSocketContainer() {
 			return new ServerWebSocketContainer("/ws")
+					.setHandshakeHandler(handshakeHandler())
 					.setDecoratorFactories(testWebSocketHandlerDecoratorFactory())
 					.setAllowedOrigins("http://foo.com")
 					.withSockJs();
@@ -349,6 +372,25 @@ public class WebSocketServerTests {
 				applicationEventPublisher.publishEvent(session);
 			}
 
+		}
+
+	}
+
+	public static class MyTomcatRequestUpgradeStrategy extends TomcatRequestUpgradeStrategy implements Lifecycle {
+
+		@Override
+		public void start() {
+
+		}
+
+		@Override
+		public void stop() {
+
+		}
+
+		@Override
+		public boolean isRunning() {
+			return true;
 		}
 
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4345

Resolves https://github.com/spring-projects/spring-integration/issues/2238

The `DefaultHandshakeHandler` doesn't implement `SmartLifecycle`
(just `Lifecycle`) there it doesn't delegate its `start()` to the
`RequestUpgradeStrategy`, e.g. `JettyRequestUpgradeStrategy`.
On the other hand `DefaultHandshakeHandler` can be started as a dependant
`Lifecycle` from some other `SmartLifecycle`, like it happens with the
`WebSocketHandlerMapping`

* Implement `SmartLifecycle` for the `ServerWebSocketContainer` and
delegate its lifecycle to the provided `HandshakeHandler`
* Fix `WebSocketInboundChannelAdapter` to properly implement `doStop()`
with the propagation to the provided `webSocketContainer`
* Fix deprecation warning in the `StompMessageHandlerWebSocketIntegrationTests`

**Cherry-pick to 4.3.x**