### PR TITLE
INT-4354: Add beanClassLoader support to RedisMS

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisMessageStore.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisMessageStore.java
@@ -18,6 +18,7 @@ package org.springframework.integration.redis.store;
 
 import java.util.Collection;
 
+import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.BoundValueOperations;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -39,9 +40,11 @@ import org.springframework.util.Assert;
  *
  * @since 2.1
  */
-public class RedisMessageStore extends AbstractKeyValueMessageStore {
+public class RedisMessageStore extends AbstractKeyValueMessageStore implements BeanClassLoaderAware {
 
 	private final RedisTemplate<Object, Object> redisTemplate;
+
+	private boolean valueSerializerSet;
 
 	/**
 	 * Construct {@link RedisMessageStore} based on the provided
@@ -70,9 +73,17 @@ public class RedisMessageStore extends AbstractKeyValueMessageStore {
 		this.redisTemplate.afterPropertiesSet();
 	}
 
+	@Override
+	public void setBeanClassLoader(ClassLoader classLoader) {
+		if (!this.valueSerializerSet) {
+			this.redisTemplate.setValueSerializer(new JdkSerializationRedisSerializer(classLoader));
+		}
+	}
+
 	public void setValueSerializer(RedisSerializer<?> valueSerializer) {
 		Assert.notNull(valueSerializer, "'valueSerializer' must not be null");
 		this.redisTemplate.setValueSerializer(valueSerializer);
+		this.valueSerializerSet = true;
 	}
 
 	@Override


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4354

It's hard to test different ClassLoader in unit tests, so the fix
comes without them

**Cherry-pick to 4.3.x**