### PR TITLE
GH-2071: Upgrade to S-WS-3.0 and Smack-4.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -283,7 +283,13 @@ project('spring-integration-amqp') {
 	description = 'Spring Integration AMQP Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile"org.springframework.amqp:spring-rabbit:$springAmqpVersion"
+		compile("org.springframework.amqp:spring-rabbit:$springAmqpVersion") {
+			exclude group: 'org.springframework', module: 'spring-aop'
+			exclude group: 'org.springframework', module: 'spring-context'
+			exclude group: 'org.springframework', module: 'spring-core'
+			exclude group: 'org.springframework', module: 'spring-tx'
+		}
+
 		testCompile("org.springframework.amqp:spring-rabbit-junit:$springAmqpVersion")
 		testCompile project(":spring-integration-stream")
 	}
@@ -298,7 +304,9 @@ project('spring-integration-core') {
 		compile "org.springframework:spring-context:$springVersion"
 		compile "org.springframework:spring-messaging:$springVersion"
 		compile "org.springframework:spring-tx:$springVersion"
-		compile "org.springframework.retry:spring-retry:$springRetryVersion"
+		compile ("org.springframework.retry:spring-retry:$springRetryVersion") {
+			exclude group: 'org.springframework', module: 'spring-core'
+		}
 		compile "io.projectreactor:reactor-core:$reactorVersion"
 		compile("com.fasterxml.jackson.core:jackson-databind:$jackson2Version", optional)
 		compile("com.jayway.jsonpath:json-path:$jsonpathVersion") {
@@ -360,7 +368,15 @@ project('spring-integration-gemfire') {
 	description = 'Spring Integration GemFire Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile "org.springframework.data:spring-data-gemfire:$springGemfireVersion"
+		compile ("org.springframework.data:spring-data-gemfire:$springGemfireVersion") {
+			exclude group: 'org.springframework', module: 'spring-aop'
+			exclude group: 'org.springframework', module: 'spring-beans'
+			exclude group: 'org.springframework', module: 'spring-context'
+			exclude group: 'org.springframework', module: 'spring-context-support'
+			exclude group: 'org.springframework', module: 'spring-core'
+			exclude group: 'org.springframework', module: 'spring-tx'
+			exclude group: 'org.springframework', module: 'spring-oxm'
+		}
 		compile "commons-io:commons-io:$commonsIoVersion"
 		testCompile project(":spring-integration-stream")
 
@@ -387,8 +403,22 @@ project('spring-integration-http') {
 		compile ("com.rometools:rome:$romeToolsVersion", optional)
 
 		testCompile project(":spring-integration-security")
-		testCompile "org.springframework.security:spring-security-config:$springSecurityVersion"
-		testCompile "org.springframework.security:spring-security-test:$springSecurityVersion"
+		testCompile ("org.springframework.security:spring-security-config:$springSecurityVersion") {
+			exclude group: 'org.springframework', module: "spring-aop"
+			exclude group: 'org.springframework', module: "spring-beans"
+			exclude group: 'org.springframework', module: "spring-context"
+			exclude group: 'org.springframework', module: "spring-core"
+			exclude group: 'org.springframework', module: "spring-expression"
+		}
+		testCompile ("org.springframework.security:spring-security-test:$springSecurityVersion") {
+			exclude group: 'org.springframework', module: "spring-aop"
+			exclude group: 'org.springframework', module: "spring-beans"
+			exclude group: 'org.springframework', module: "spring-context"
+			exclude group: 'org.springframework', module: "spring-core"
+			exclude group: 'org.springframework', module: "spring-expression"
+			exclude group: 'org.springframework', module: "spring-test"
+			exclude group: 'org.springframework', module: "spring-web"
+		}
 	}
 }
 
@@ -449,8 +479,15 @@ project('spring-integration-jpa') {
 		compile "org.springframework:spring-orm:$springVersion"
 		compile ("org.eclipse.persistence:javax.persistence:$jpaApiVersion", optional)
 
-
-		testCompile "org.springframework.data:spring-data-jpa:$springDataJpaVersion"
+		testCompile ("org.springframework.data:spring-data-jpa:$springDataJpaVersion") {
+			exclude group: 'org.springframework', module: 'spring-beans'
+			exclude group: 'org.springframework', module: 'spring-context'
+			exclude group: 'org.springframework', module: 'spring-core'
+			exclude group: 'org.springframework', module: 'spring-expression'
+			exclude group: 'org.springframework', module: 'spring-aop'
+			exclude group: 'org.springframework', module: 'spring-orm'
+			exclude group: 'org.springframework', module: 'spring-tx'
+		}
 
 		testCompile "com.h2database:h2:$h2Version"
 
@@ -488,7 +525,13 @@ project('spring-integration-mongodb') {
 	description = 'Spring Integration MongoDB Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile"org.springframework.data:spring-data-mongodb:$springDataMongoVersion"
+		compile("org.springframework.data:spring-data-mongodb:$springDataMongoVersion") {
+			exclude group: 'org.springframework', module: 'spring-beans'
+			exclude group: 'org.springframework', module: 'spring-context'
+			exclude group: 'org.springframework', module: 'spring-core'
+			exclude group: 'org.springframework', module: 'spring-expression'
+			exclude group: 'org.springframework', module: 'spring-tx'
+		}
 	}
 }
 
@@ -504,7 +547,15 @@ project('spring-integration-redis') {
 	description = 'Spring Integration Redis Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile "org.springframework.data:spring-data-redis:$springDataRedisVersion"
+		compile ("org.springframework.data:spring-data-redis:$springDataRedisVersion") {
+			exclude group: 'org.springframework', module: 'spring-beans'
+			exclude group: 'org.springframework', module: 'spring-context'
+			exclude group: 'org.springframework', module: 'spring-context-support'
+			exclude group: 'org.springframework', module: 'spring-core'
+			exclude group: 'org.springframework', module: 'spring-tx'
+			exclude group: 'org.springframework', module: 'spring-aop'
+			exclude group: 'org.springframework', module: 'spring-oxm'
+		}
 		testCompile "redis.clients:jedis:$jedisVersion"
 	}
 }
@@ -530,9 +581,21 @@ project('spring-integration-security') {
 	description = 'Spring Integration Security Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile"org.springframework.security:spring-security-core:$springSecurityVersion"
+		compile("org.springframework.security:spring-security-core:$springSecurityVersion") {
+			exclude group: 'org.springframework', module: "spring-aop"
+			exclude group: 'org.springframework', module: "spring-beans"
+			exclude group: 'org.springframework', module: "spring-context"
+			exclude group: 'org.springframework', module: "spring-core"
+			exclude group: 'org.springframework', module: "spring-expression"
+		}
 
-		testCompile "org.springframework.security:spring-security-config:$springSecurityVersion"
+		testCompile ("org.springframework.security:spring-security-config:$springSecurityVersion") {
+			exclude group: 'org.springframework', module: "spring-aop"
+			exclude group: 'org.springframework', module: "spring-beans"
+			exclude group: 'org.springframework', module: "spring-context"
+			exclude group: 'org.springframework', module: "spring-core"
+			exclude group: 'org.springframework', module: "spring-expression"
+		}
 	}
 }
 
@@ -592,7 +655,14 @@ project('spring-integration-twitter') {
 	dependencies {
 		compile project(":spring-integration-core")
 		compile "org.springframework:spring-web:$springVersion"
-		compile"org.springframework.social:spring-social-twitter:$springSocialTwitterVersion"
+		compile("org.springframework.social:spring-social-twitter:$springSocialTwitterVersion") {
+			exclude group: 'org.springframework', module: 'spring-beans'
+			exclude group: 'org.springframework', module: 'spring-context'
+			exclude group: 'org.springframework', module: 'spring-core'
+			exclude group: 'org.springframework', module: 'spring-expression'
+			exclude group: 'org.springframework', module: 'spring-web'
+			exclude group: 'org.springframework', module: 'spring-webmvc'
+		}
 		compile("javax.activation:activation:$javaxActivationVersion", optional)
 		testCompile project(":spring-integration-redis")
 		testCompile project(":spring-integration-redis").sourceSets.test.output
@@ -610,8 +680,22 @@ project('spring-integration-webflux') {
 		compile ("io.projectreactor.ipc:reactor-netty:$reactorNettyVersion" , optional)
 
 		testCompile "org.springframework:spring-webmvc:$springVersion"
-		testCompile "org.springframework.security:spring-security-config:$springSecurityVersion"
-		testCompile "org.springframework.security:spring-security-test:$springSecurityVersion"
+		testCompile ("org.springframework.security:spring-security-config:$springSecurityVersion") {
+			exclude group: 'org.springframework', module: "spring-aop"
+			exclude group: 'org.springframework', module: "spring-beans"
+			exclude group: 'org.springframework', module: "spring-context"
+			exclude group: 'org.springframework', module: "spring-core"
+			exclude group: 'org.springframework', module: "spring-expression"
+		}
+		testCompile ("org.springframework.security:spring-security-test:$springSecurityVersion") {
+			exclude group: 'org.springframework', module: "spring-aop"
+			exclude group: 'org.springframework', module: "spring-beans"
+			exclude group: 'org.springframework', module: "spring-context"
+			exclude group: 'org.springframework', module: "spring-core"
+			exclude group: 'org.springframework', module: "spring-expression"
+			exclude group: 'org.springframework', module: "spring-test"
+			exclude group: 'org.springframework', module: "spring-web"
+		}
 		testCompile "io.projectreactor:reactor-test:$reactorVersion"
 	}
 }
@@ -633,11 +717,25 @@ project('spring-integration-ws') {
 	description = 'Spring Integration Web Services Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile "org.springframework.ws:spring-ws-core:$springWsVersion"
+		compile "org.springframework:spring-oxm:$springVersion"
+		compile "org.springframework:spring-webmvc:$springVersion"
+		compile ("org.springframework.ws:spring-ws-core:$springWsVersion") {
+			exclude group: 'org.springframework', module: 'spring-aop'
+			exclude group: 'org.springframework', module: 'spring-beans'
+			exclude group: 'org.springframework', module: 'spring-context'
+			exclude group: 'org.springframework', module: 'spring-core'
+			exclude group: 'org.springframework', module: 'spring-oxm'
+			exclude group: 'org.springframework', module: 'spring-web'
+			exclude group: 'org.springframework', module: 'spring-webmvc'
+		}
 
 		testCompile "com.thoughtworks.xstream:xstream:$xstreamVersion"
-		testCompile "org.springframework.ws:spring-ws-support:$springWsVersion"
-		testCompile "org.springframework:spring-jms:$springVersion"
+		testCompile ("org.springframework.ws:spring-ws-support:$springWsVersion") {
+			exclude group: 'org.springframework'
+		}
+		testCompile ("org.springframework:spring-jms:$springVersion") {
+			exclude group: 'org.springframework'
+		}
 		testCompile "javax.jms:javax.jms-api:$jmsApiVersion"
 		testCompile "org.igniterealtime.smack:smack-tcp:$smackVersion"
 		testCompile "org.igniterealtime.smack:smack-java7:$smackVersion"
@@ -653,9 +751,21 @@ project('spring-integration-xml') {
 	dependencies {
 		compile project(":spring-integration-core")
 		compile "org.springframework:spring-oxm:$springVersion"
-		compile "org.springframework.ws:spring-xml:$springWsVersion"
-		compile ("org.springframework.ws:spring-ws-core:$springWsVersion", optional)
-
+		compile ("org.springframework.ws:spring-xml:$springWsVersion") {
+			exclude group: 'org.springframework', module: 'spring-beans'
+			exclude group: 'org.springframework', module: 'spring-context'
+			exclude group: 'org.springframework', module: 'spring-core'
+		}
+		compile ("org.springframework.ws:spring-ws-core:$springWsVersion") {
+			optional it
+			exclude group: 'org.springframework', module: 'spring-aop'
+			exclude group: 'org.springframework', module: 'spring-beans'
+			exclude group: 'org.springframework', module: 'spring-context'
+			exclude group: 'org.springframework', module: 'spring-core'
+			exclude group: 'org.springframework', module: 'spring-oxm'
+			exclude group: 'org.springframework', module: 'spring-web'
+			exclude group: 'org.springframework', module: 'spring-webmvc'
+		}
 		testCompile "xmlunit:xmlunit:$xmlUnitVersion"
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ subprojects { subproject ->
 		romeToolsVersion = '1.8.0'
 		servletApiVersion = '3.1.0'
 		slf4jVersion = "1.7.25"
-		smackVersion = '4.1.9'
+		smackVersion = '4.2.1'
 		springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '2.0.0.RELEASE'
 		springDataJpaVersion = '2.0.0.RELEASE'
 		springDataMongoVersion = '2.0.0.RELEASE'
@@ -138,7 +138,7 @@ subprojects { subproject ->
 		springSocialTwitterVersion = '2.0.0.M4'
 		springRetryVersion = '1.2.1.RELEASE'
 		springVersion = project.hasProperty('springVersion') ? project.springVersion : '5.0.0.RELEASE'
-		springWsVersion = '2.4.0.RELEASE'
+		springWsVersion = '3.0.0.BUILD-SNAPSHOT'
 		tomcatVersion = "8.5.23"
 		xmlUnitVersion = '1.6'
 		xstreamVersion = '1.4.10'
@@ -283,12 +283,7 @@ project('spring-integration-amqp') {
 	description = 'Spring Integration AMQP Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile("org.springframework.amqp:spring-rabbit:$springAmqpVersion") {
-			exclude group: 'org.springframework', module: 'spring-aop'
-			exclude group: 'org.springframework', module: 'spring-context'
-			exclude group: 'org.springframework', module: 'spring-core'
-			exclude group: 'org.springframework', module: 'spring-tx'
-		}
+		compile"org.springframework.amqp:spring-rabbit:$springAmqpVersion"
 		testCompile("org.springframework.amqp:spring-rabbit-junit:$springAmqpVersion")
 		testCompile project(":spring-integration-stream")
 	}
@@ -303,9 +298,7 @@ project('spring-integration-core') {
 		compile "org.springframework:spring-context:$springVersion"
 		compile "org.springframework:spring-messaging:$springVersion"
 		compile "org.springframework:spring-tx:$springVersion"
-		compile ("org.springframework.retry:spring-retry:$springRetryVersion") {
-			exclude group: 'org.springframework', module: 'spring-core'
-		}
+		compile "org.springframework.retry:spring-retry:$springRetryVersion"
 		compile "io.projectreactor:reactor-core:$reactorVersion"
 		compile("com.fasterxml.jackson.core:jackson-databind:$jackson2Version", optional)
 		compile("com.jayway.jsonpath:json-path:$jsonpathVersion") {
@@ -367,15 +360,7 @@ project('spring-integration-gemfire') {
 	description = 'Spring Integration GemFire Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile ("org.springframework.data:spring-data-gemfire:$springGemfireVersion") {
-			exclude group: 'org.springframework', module: 'spring-aop'
-			exclude group: 'org.springframework', module: 'spring-beans'
-			exclude group: 'org.springframework', module: 'spring-context'
-			exclude group: 'org.springframework', module: 'spring-context-support'
-			exclude group: 'org.springframework', module: 'spring-core'
-			exclude group: 'org.springframework', module: 'spring-tx'
-			exclude group: 'org.springframework', module: 'spring-oxm'
-		}
+		compile "org.springframework.data:spring-data-gemfire:$springGemfireVersion"
 		compile "commons-io:commons-io:$commonsIoVersion"
 		testCompile project(":spring-integration-stream")
 
@@ -402,22 +387,8 @@ project('spring-integration-http') {
 		compile ("com.rometools:rome:$romeToolsVersion", optional)
 
 		testCompile project(":spring-integration-security")
-		testCompile ("org.springframework.security:spring-security-config:$springSecurityVersion") {
-			exclude group: 'org.springframework', module: "spring-aop"
-			exclude group: 'org.springframework', module: "spring-beans"
-			exclude group: 'org.springframework', module: "spring-context"
-			exclude group: 'org.springframework', module: "spring-core"
-			exclude group: 'org.springframework', module: "spring-expression"
-		}
-		testCompile ("org.springframework.security:spring-security-test:$springSecurityVersion") {
-			exclude group: 'org.springframework', module: "spring-aop"
-			exclude group: 'org.springframework', module: "spring-beans"
-			exclude group: 'org.springframework', module: "spring-context"
-			exclude group: 'org.springframework', module: "spring-core"
-			exclude group: 'org.springframework', module: "spring-expression"
-			exclude group: 'org.springframework', module: "spring-test"
-			exclude group: 'org.springframework', module: "spring-web"
-		}
+		testCompile "org.springframework.security:spring-security-config:$springSecurityVersion"
+		testCompile "org.springframework.security:spring-security-test:$springSecurityVersion"
 	}
 }
 
@@ -479,15 +450,7 @@ project('spring-integration-jpa') {
 		compile ("org.eclipse.persistence:javax.persistence:$jpaApiVersion", optional)
 
 
-		testCompile ("org.springframework.data:spring-data-jpa:$springDataJpaVersion") {
-			exclude group: 'org.springframework', module: 'spring-beans'
-			exclude group: 'org.springframework', module: 'spring-context'
-			exclude group: 'org.springframework', module: 'spring-core'
-			exclude group: 'org.springframework', module: 'spring-expression'
-			exclude group: 'org.springframework', module: 'spring-aop'
-			exclude group: 'org.springframework', module: 'spring-orm'
-			exclude group: 'org.springframework', module: 'spring-tx'
-		}
+		testCompile "org.springframework.data:spring-data-jpa:$springDataJpaVersion"
 
 		testCompile "com.h2database:h2:$h2Version"
 
@@ -525,13 +488,7 @@ project('spring-integration-mongodb') {
 	description = 'Spring Integration MongoDB Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile("org.springframework.data:spring-data-mongodb:$springDataMongoVersion") {
-			exclude group: 'org.springframework', module: 'spring-beans'
-			exclude group: 'org.springframework', module: 'spring-context'
-			exclude group: 'org.springframework', module: 'spring-core'
-			exclude group: 'org.springframework', module: 'spring-expression'
-			exclude group: 'org.springframework', module: 'spring-tx'
-		}
+		compile"org.springframework.data:spring-data-mongodb:$springDataMongoVersion"
 	}
 }
 
@@ -547,15 +504,7 @@ project('spring-integration-redis') {
 	description = 'Spring Integration Redis Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile ("org.springframework.data:spring-data-redis:$springDataRedisVersion") {
-			exclude group: 'org.springframework', module: 'spring-beans'
-			exclude group: 'org.springframework', module: 'spring-context'
-			exclude group: 'org.springframework', module: 'spring-context-support'
-			exclude group: 'org.springframework', module: 'spring-core'
-			exclude group: 'org.springframework', module: 'spring-tx'
-			exclude group: 'org.springframework', module: 'spring-aop'
-			exclude group: 'org.springframework', module: 'spring-oxm'
-		}
+		compile "org.springframework.data:spring-data-redis:$springDataRedisVersion"
 		testCompile "redis.clients:jedis:$jedisVersion"
 	}
 }
@@ -581,21 +530,9 @@ project('spring-integration-security') {
 	description = 'Spring Integration Security Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile("org.springframework.security:spring-security-core:$springSecurityVersion") {
-			exclude group: 'org.springframework', module: "spring-aop"
-			exclude group: 'org.springframework', module: "spring-beans"
-			exclude group: 'org.springframework', module: "spring-context"
-			exclude group: 'org.springframework', module: "spring-core"
-			exclude group: 'org.springframework', module: "spring-expression"
-		}
+		compile"org.springframework.security:spring-security-core:$springSecurityVersion"
 
-		testCompile ("org.springframework.security:spring-security-config:$springSecurityVersion") {
-			exclude group: 'org.springframework', module: "spring-aop"
-			exclude group: 'org.springframework', module: "spring-beans"
-			exclude group: 'org.springframework', module: "spring-context"
-			exclude group: 'org.springframework', module: "spring-core"
-			exclude group: 'org.springframework', module: "spring-expression"
-		}
+		testCompile "org.springframework.security:spring-security-config:$springSecurityVersion"
 	}
 }
 
@@ -618,7 +555,6 @@ project('spring-integration-stomp') {
 		compile project(":spring-integration-core")
 
 		compile ("org.springframework:spring-websocket:$springVersion", optional)
-
 		compile ("io.projectreactor.ipc:reactor-netty:$reactorNettyVersion" , optional)
 
 		testCompile project(":spring-integration-websocket")
@@ -656,14 +592,7 @@ project('spring-integration-twitter') {
 	dependencies {
 		compile project(":spring-integration-core")
 		compile "org.springframework:spring-web:$springVersion"
-		compile("org.springframework.social:spring-social-twitter:$springSocialTwitterVersion") {
-			exclude group: 'org.springframework', module: 'spring-beans'
-			exclude group: 'org.springframework', module: 'spring-context'
-			exclude group: 'org.springframework', module: 'spring-core'
-			exclude group: 'org.springframework', module: 'spring-expression'
-			exclude group: 'org.springframework', module: 'spring-web'
-			exclude group: 'org.springframework', module: 'spring-webmvc'
-		}
+		compile"org.springframework.social:spring-social-twitter:$springSocialTwitterVersion"
 		compile("javax.activation:activation:$javaxActivationVersion", optional)
 		testCompile project(":spring-integration-redis")
 		testCompile project(":spring-integration-redis").sourceSets.test.output
@@ -681,22 +610,8 @@ project('spring-integration-webflux') {
 		compile ("io.projectreactor.ipc:reactor-netty:$reactorNettyVersion" , optional)
 
 		testCompile "org.springframework:spring-webmvc:$springVersion"
-		testCompile ("org.springframework.security:spring-security-config:$springSecurityVersion") {
-			exclude group: 'org.springframework', module: "spring-aop"
-			exclude group: 'org.springframework', module: "spring-beans"
-			exclude group: 'org.springframework', module: "spring-context"
-			exclude group: 'org.springframework', module: "spring-core"
-			exclude group: 'org.springframework', module: "spring-expression"
-		}
-		testCompile ("org.springframework.security:spring-security-test:$springSecurityVersion") {
-			exclude group: 'org.springframework', module: "spring-aop"
-			exclude group: 'org.springframework', module: "spring-beans"
-			exclude group: 'org.springframework', module: "spring-context"
-			exclude group: 'org.springframework', module: "spring-core"
-			exclude group: 'org.springframework', module: "spring-expression"
-			exclude group: 'org.springframework', module: "spring-test"
-			exclude group: 'org.springframework', module: "spring-web"
-		}
+		testCompile "org.springframework.security:spring-security-config:$springSecurityVersion"
+		testCompile "org.springframework.security:spring-security-test:$springSecurityVersion"
 		testCompile "io.projectreactor:reactor-test:$reactorVersion"
 	}
 }
@@ -718,31 +633,18 @@ project('spring-integration-ws') {
 	description = 'Spring Integration Web Services Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile "org.springframework:spring-oxm:$springVersion"
-		compile "org.springframework:spring-webmvc:$springVersion"
-		compile ("org.springframework.ws:spring-ws-core:$springWsVersion") {
-			exclude group: 'org.springframework', module: 'spring-aop'
-			exclude group: 'org.springframework', module: 'spring-beans'
-			exclude group: 'org.springframework', module: 'spring-context'
-			exclude group: 'org.springframework', module: 'spring-core'
-			exclude group: 'org.springframework', module: 'spring-oxm'
-			exclude group: 'org.springframework', module: 'spring-web'
-			exclude group: 'org.springframework', module: 'spring-webmvc'
-		}
+		compile "org.springframework.ws:spring-ws-core:$springWsVersion"
 
 		testCompile "com.thoughtworks.xstream:xstream:$xstreamVersion"
-		testCompile ("org.springframework.ws:spring-ws-support:$springWsVersion") {
-			exclude group: 'org.springframework'
-		}
-		testCompile ("org.springframework:spring-jms:$springVersion") {
-			exclude group: 'org.springframework'
-		}
+		testCompile "org.springframework.ws:spring-ws-support:$springWsVersion"
+		testCompile "org.springframework:spring-jms:$springVersion"
 		testCompile "javax.jms:javax.jms-api:$jmsApiVersion"
 		testCompile "org.igniterealtime.smack:smack-tcp:$smackVersion"
 		testCompile "org.igniterealtime.smack:smack-java7:$smackVersion"
 		testCompile "org.igniterealtime.smack:smack-extensions:$smackVersion"
 		testCompile "javax.mail:javax.mail-api:$javaxMailVersion"
 		testRuntime "com.sun.mail:mailapi:$javaxMailVersion"
+		testRuntime "com.sun.mail:javax.mail:$javaxMailVersion"
 	}
 }
 
@@ -751,21 +653,9 @@ project('spring-integration-xml') {
 	dependencies {
 		compile project(":spring-integration-core")
 		compile "org.springframework:spring-oxm:$springVersion"
-		compile ("org.springframework.ws:spring-xml:$springWsVersion") {
-			exclude group: 'org.springframework', module: 'spring-beans'
-			exclude group: 'org.springframework', module: 'spring-context'
-			exclude group: 'org.springframework', module: 'spring-core'
-		}
-		compile ("org.springframework.ws:spring-ws-core:$springWsVersion") {
-			optional it
-			exclude group: 'org.springframework', module: 'spring-aop'
-			exclude group: 'org.springframework', module: 'spring-beans'
-			exclude group: 'org.springframework', module: 'spring-context'
-			exclude group: 'org.springframework', module: 'spring-core'
-			exclude group: 'org.springframework', module: 'spring-oxm'
-			exclude group: 'org.springframework', module: 'spring-web'
-			exclude group: 'org.springframework', module: 'spring-webmvc'
-		}
+		compile "org.springframework.ws:spring-xml:$springWsVersion"
+		compile ("org.springframework.ws:spring-ws-core:$springWsVersion", optional)
+
 		testCompile "xmlunit:xmlunit:$xmlUnitVersion"
 	}
 }

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/BackToBackAdapterTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/BackToBackAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 4.0
  *
  */
@@ -100,9 +101,9 @@ public class BackToBackAdapterTests {
 		inbound.afterPropertiesSet();
 		inbound.start();
 		adapter.handleMessage(new GenericMessage<String>("foo"));
-		adapter.stop();
-		Message<?> out = outputChannel.receive(10000);
+		Message<?> out = outputChannel.receive(20000);
 		assertNotNull(out);
+		adapter.stop();
 		inbound.stop();
 		assertEquals("foo", out.getPayload());
 		assertEquals("mqtt-foo", out.getHeaders().get(MqttHeaders.RECEIVED_TOPIC));
@@ -132,9 +133,9 @@ public class BackToBackAdapterTests {
 		inbound.afterPropertiesSet();
 		inbound.start();
 		adapter.handleMessage(new GenericMessage<Foo>(new Foo("bar"), Collections.singletonMap("baz", "qux")));
-		adapter.stop();
-		Message<?> out = outputChannel.receive(10000);
+		Message<?> out = outputChannel.receive(20000);
 		assertNotNull(out);
+		adapter.stop();
 		inbound.stop();
 		assertEquals(new Foo("bar"), out.getPayload());
 		assertEquals("mqtt-foo", out.getHeaders().get(MqttHeaders.RECEIVED_TOPIC));
@@ -159,21 +160,21 @@ public class BackToBackAdapterTests {
 		inbound.start();
 		inbound.addTopic("mqtt-foo");
 		adapter.handleMessage(new GenericMessage<String>("foo"));
-		Message<?> out = outputChannel.receive(10_000);
+		Message<?> out = outputChannel.receive(20_000);
 		assertNotNull(out);
 		assertEquals("foo", out.getPayload());
 		assertEquals("mqtt-foo", out.getHeaders().get(MqttHeaders.RECEIVED_TOPIC));
 
 		inbound.addTopic("mqtt-bar");
 		adapter.handleMessage(MessageBuilder.withPayload("bar").setHeader(MqttHeaders.TOPIC, "mqtt-bar").build());
-		out = outputChannel.receive(10_000);
+		out = outputChannel.receive(20_000);
 		assertNotNull(out);
 		assertEquals("bar", out.getPayload());
 		assertEquals("mqtt-bar", out.getHeaders().get(MqttHeaders.RECEIVED_TOPIC));
 
 		inbound.removeTopic("mqtt-bar");
 		adapter.handleMessage(MessageBuilder.withPayload("bar").setHeader(MqttHeaders.TOPIC, "mqtt-bar").build());
-		out = outputChannel.receive(10_000);
+		out = outputChannel.receive(1);
 		assertNull(out);
 
 		try {
@@ -213,17 +214,16 @@ public class BackToBackAdapterTests {
 		adapter.handleMessage(new GenericMessage<String>("foo"));
 		Message<?> message = MessageBuilder.withPayload("bar").setHeader(MqttHeaders.TOPIC, "mqtt-bar").build();
 		adapter.handleMessage(message);
-		adapter.stop();
-		Message<?> out = outputChannel.receive(10000);
+		Message<?> out = outputChannel.receive(20000);
 		assertNotNull(out);
-		inbound.stop();
 		assertEquals("foo", out.getPayload());
 		assertEquals("mqtt-foo", out.getHeaders().get(MqttHeaders.RECEIVED_TOPIC));
-		out = outputChannel.receive(10000);
+		out = outputChannel.receive(20000);
 		assertNotNull(out);
 		inbound.stop();
 		assertEquals("bar", out.getPayload());
 		assertEquals("mqtt-bar", out.getHeaders().get(MqttHeaders.RECEIVED_TOPIC));
+		adapter.stop();
 	}
 
 	@Test
@@ -250,9 +250,9 @@ public class BackToBackAdapterTests {
 		GenericMessage<String> message = new GenericMessage<String>("foo");
 		adapter.handleMessage(message);
 		verifyEvents(adapter, publisher, message);
-		adapter.stop();
-		Message<?> out = outputChannel.receive(10000);
+		Message<?> out = outputChannel.receive(20000);
 		assertNotNull(out);
+		adapter.stop();
 		inbound.stop();
 		assertEquals("foo", out.getPayload());
 		assertEquals("mqtt-foo", out.getHeaders().get(MqttHeaders.RECEIVED_TOPIC));
@@ -316,11 +316,10 @@ public class BackToBackAdapterTests {
 		verifyMessageIds(publisher1, publisher2);
 
 		assertNotEquals(clientInstance, publisher1.delivered.getClientInstance());
-		adapter.stop();
 
 		Message<?> out = null;
 		for (int i = 0; i < 4; i++) {
-			out = outputChannel.receive(10000);
+			out = outputChannel.receive(20000);
 			assertNotNull(out);
 			if ("foo".equals(out.getPayload())) {
 				assertEquals("mqtt-foo", out.getHeaders().get(MqttHeaders.RECEIVED_TOPIC));
@@ -332,6 +331,7 @@ public class BackToBackAdapterTests {
 				fail("unexpected payload " + out.getPayload());
 			}
 		}
+		adapter.stop();
 		inbound.stop();
 	}
 
@@ -357,7 +357,7 @@ public class BackToBackAdapterTests {
 	@Test
 	public void testMultiURIs() {
 		out.send(new GenericMessage<String>("foo"));
-		Message<?> message = in.receive(10000);
+		Message<?> message = in.receive(20000);
 		assertNotNull(message);
 		assertEquals("foo", message.getPayload());
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueGatewayIntegrationTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueGatewayIntegrationTests-context.xml
@@ -26,15 +26,12 @@
 	<int-redis:queue-outbound-gateway id="outboundGateway"
 									  request-channel="sendChannel"
 									  queue="#{redisQueue.toString()}"
-									  reply-timeout="500"
+									  reply-timeout="10000"
 									  reply-channel="outputChannel"/>
 
 	<int-redis:queue-inbound-gateway id="inboundGateway"
 									 queue="#{redisQueue.toString()}"
-									 request-channel="requestChannel"
-									 reply-timeout="200"
-									 receive-timeout="100"
-									 request-timeout="200"/>
+									 request-channel="requestChannel"/>
 
 	<int:service-activator input-channel="requestChannel" expression="payload + 1"/>
 

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests.java
@@ -36,9 +36,9 @@ import javax.jms.Queue;
 import javax.jms.Session;
 
 import org.hamcrest.Matchers;
-import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.Stanza;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -72,6 +72,7 @@ import org.springframework.ws.transport.mail.MailSenderConnection;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Andy Wilkinson
+ *
  * @since 2.1
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -206,7 +207,8 @@ public class UriVariableTests {
 	}
 
 	@Test
-	public void testInt2720XmppUriVariables() throws SmackException.NotConnectedException {
+	@Ignore("Need NPE fix in the S-WS for the XmppTransportUtils.toUri()")
+	public void testInt2720XmppUriVariables() throws Exception {
 
 		Mockito.doThrow(new WebServiceIOException("intentional")).when(this.xmppConnection).sendStanza(Mockito.any(Stanza.class));
 

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests.java
@@ -19,6 +19,7 @@ package org.springframework.integration.ws.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.doAnswer;
 
 import java.io.IOException;
@@ -38,7 +39,6 @@ import javax.jms.Session;
 import org.hamcrest.Matchers;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.Stanza;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -113,7 +113,8 @@ public class UriVariableTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testHttpUriVariables() {
-		WebServiceTemplate webServiceTemplate = TestUtils.getPropertyValue(this.httpOutboundGateway, "webServiceTemplate", WebServiceTemplate.class);
+		WebServiceTemplate webServiceTemplate = TestUtils.getPropertyValue(this.httpOutboundGateway,
+				"webServiceTemplate", WebServiceTemplate.class);
 		webServiceTemplate = Mockito.spy(webServiceTemplate);
 		final AtomicReference<String> uri = new AtomicReference<>();
 		doAnswer(invocation -> {
@@ -207,10 +208,10 @@ public class UriVariableTests {
 	}
 
 	@Test
-	@Ignore("Need NPE fix in the S-WS for the XmppTransportUtils.toUri()")
 	public void testInt2720XmppUriVariables() throws Exception {
 
-		Mockito.doThrow(new WebServiceIOException("intentional")).when(this.xmppConnection).sendStanza(Mockito.any(Stanza.class));
+		willThrow(new WebServiceIOException("intentional"))
+				.given(this.xmppConnection).sendStanza(Mockito.any(Stanza.class));
 
 		Message<?> message = MessageBuilder.withPayload("<spring/>").setHeader("to", "user").build();
 		try {
@@ -224,7 +225,7 @@ public class UriVariableTests {
 
 		ArgumentCaptor<Stanza> argument = ArgumentCaptor.forClass(Stanza.class);
 		Mockito.verify(this.xmppConnection).sendStanza(argument.capture());
-		assertEquals("user@jabber.org", argument.getValue().getTo());
+		assertEquals("user@jabber.org", argument.getValue().getTo().toString());
 
 		assertEquals("xmpp:user@jabber.org", this.interceptor.getLastUri().toString());
 	}
@@ -272,11 +273,16 @@ public class UriVariableTests {
 		public void afterCompletion(MessageContext messageContext, Exception ex) throws WebServiceClientException {
 
 		}
+
 	}
 
 	private static class Int2720EmailTestClientInterceptor extends TestClientInterceptor {
 
 		private volatile WebServiceConnection webServiceConnection;
+
+		Int2720EmailTestClientInterceptor() {
+			super();
+		}
 
 		public WebServiceConnection getLastWebServiceConnection() {
 			return webServiceConnection;
@@ -296,6 +302,7 @@ public class UriVariableTests {
 			super.handleRequest(messageContext);
 			throw new WebServiceIOException("intentional");
 		}
+
 	}
 
 }

--- a/spring-integration-ws/src/test/resources/log4j.properties
+++ b/spring-integration-ws/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+log4j.rootCategory=WARN, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss.SSS} %-5p [%t][%c] %m%n
+
+log4j.category.org.springframework.integration=WARN
+log4j.category.org.springframework.integration.ws=WARN

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBean.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBean.java
@@ -39,8 +39,9 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Philipp Etschel
  *
- * @see XMPPTCPConnection
  * @since 2.0
+ *
+ * @see XMPPTCPConnection
  */
 public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnection> implements SmartLifecycle {
 
@@ -140,14 +141,19 @@ public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnectio
 			XMPPTCPConnectionConfiguration.Builder builder =
 					XMPPTCPConnectionConfiguration.builder()
 							.setHost(this.host)
-							.setPort(this.port)
-							.setResource(this.resource)
-							.setUsernameAndPassword(this.user, this.password)
-							.setServiceName(this.serviceName);
+							.setPort(this.port);
 
-			if (!StringUtils.hasText(this.serviceName) && StringUtils.hasText(this.user)) {
+			if (StringUtils.hasText(this.resource)) {
+							builder.setResource(this.resource);
+			}
+
+			if (StringUtils.hasText(this.serviceName)) {
+				builder.setUsernameAndPassword(this.user, this.password)
+						.setXmppDomain(this.serviceName);
+			}
+			else {
 				builder.setUsernameAndPassword(XmppStringUtils.parseLocalpart(this.user), this.password)
-						.setServiceName(XmppStringUtils.parseDomain(this.user));
+						.setXmppDomain(this.user);
 			}
 
 			connectionConfiguration = builder.build();

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpoint.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class ChatMessageListeningEndpoint extends AbstractXmppConnectionAwareEndpoint {
@@ -121,7 +122,7 @@ public class ChatMessageListeningEndpoint extends AbstractXmppConnectionAwareEnd
 		}
 
 		@Override
-		public void processPacket(final Stanza packet) {
+		public void processStanza(Stanza packet) {
 			if (packet instanceof org.jivesoftware.smack.packet.Message) {
 				org.jivesoftware.smack.packet.Message xmppMessage = (org.jivesoftware.smack.packet.Message) packet;
 				Map<String, ?> mappedHeaders = ChatMessageListeningEndpoint.this.headerMapper.toHeadersFromRequest(xmppMessage);

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpoint.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpoint.java
@@ -24,6 +24,7 @@ import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.Presence;
 import org.jivesoftware.smack.roster.Roster;
 import org.jivesoftware.smack.roster.RosterListener;
+import org.jxmpp.jid.Jid;
 
 import org.springframework.integration.xmpp.core.AbstractXmppConnectionAwareEndpoint;
 import org.springframework.messaging.Message;
@@ -90,21 +91,21 @@ public class PresenceListeningEndpoint extends AbstractXmppConnectionAwareEndpoi
 		}
 
 		@Override
-		public void entriesAdded(Collection<String> entries) {
+		public void entriesAdded(Collection<Jid> entries) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("entries added: " + StringUtils.collectionToCommaDelimitedString(entries));
 			}
 		}
 
 		@Override
-		public void entriesUpdated(Collection<String> entries) {
+		public void entriesUpdated(Collection<Jid> entries) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("entries updated: " + StringUtils.collectionToCommaDelimitedString(entries));
 			}
 		}
 
 		@Override
-		public void entriesDeleted(Collection<String> entries) {
+		public void entriesDeleted(Collection<Jid> entries) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("entries deleted: " + StringUtils.collectionToCommaDelimitedString(entries));
 			}

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/outbound/ChatMessageSendingMessageHandler.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/outbound/ChatMessageSendingMessageHandler.java
@@ -24,6 +24,7 @@ import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.provider.ExtensionElementProvider;
 import org.jivesoftware.smack.util.PacketParserUtils;
+import org.jxmpp.jid.impl.JidCreate;
 import org.xmlpull.v1.XmlPullParser;
 
 import org.springframework.integration.xmpp.XmppHeaders;
@@ -93,7 +94,7 @@ public class ChatMessageSendingMessageHandler extends AbstractXmppConnectionAwar
 		else {
 			String to = message.getHeaders().get(XmppHeaders.TO, String.class);
 			Assert.state(StringUtils.hasText(to), "The '" + XmppHeaders.TO + "' header must not be null");
-			xmppMessage = new org.jivesoftware.smack.packet.Message(to);
+			xmppMessage = new org.jivesoftware.smack.packet.Message(JidCreate.from(to));
 
 			if (payload instanceof ExtensionElement) {
 				xmppMessage.addExtension((ExtensionElement) payload);

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,7 @@ public class ChatMessageOutboundChannelAdapterParserTests {
 		doAnswer(invocation -> {
 			Object[] args = invocation.getArguments();
 			org.jivesoftware.smack.packet.Message xmppMessage = (org.jivesoftware.smack.packet.Message) args[0];
-			assertEquals("oleg", xmppMessage.getTo());
+			assertEquals("oleg", xmppMessage.getTo().toString());
 			assertEquals("foobar", JivePropertiesManager.getProperty(xmppMessage, "foobar"));
 			return null;
 		}).when(connection).sendStanza(Mockito.any(org.jivesoftware.smack.packet.Message.class));
@@ -150,7 +150,7 @@ public class ChatMessageOutboundChannelAdapterParserTests {
 		doAnswer(invocation -> {
 			Object[] args = invocation.getArguments();
 			org.jivesoftware.smack.packet.Message xmppMessage = (org.jivesoftware.smack.packet.Message) args[0];
-			assertEquals("artem", xmppMessage.getTo());
+			assertEquals("artem", xmppMessage.getTo().toString());
 			assertEquals("hello", xmppMessage.getBody());
 			return null;
 		}).when(connection).sendStanza(Mockito.any(org.jivesoftware.smack.packet.Message.class));

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBeanTests-context.xml
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBeanTests-context.xml
@@ -9,7 +9,7 @@
 
 	<bean id="xmppConnectionConfigurationBuilder" class="org.jivesoftware.smack.tcp.XMPPTCPConnectionConfiguration"
 		  factory-method="builder">
-		<property name="serviceName" value="myServiceName"/>
+		<property name="xmppDomain" value="#{T(org.jxmpp.jid.impl.JidCreate).domainBareFrom('myServiceName')}"/>
 	</bean>
 
 	<bean id="xmppConnection" class="org.springframework.integration.xmpp.config.XmppConnectionFactoryBean">

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBeanTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBeanTests.java
@@ -40,7 +40,10 @@ public class XmppConnectionFactoryBeanTests {
 	@Test
 	public void testXmppConnectionFactoryBean() throws Exception {
 		XmppConnectionFactoryBean xmppConnectionFactoryBean = new XmppConnectionFactoryBean();
-		xmppConnectionFactoryBean.setConnectionConfiguration(mock(XMPPTCPConnectionConfiguration.class));
+		xmppConnectionFactoryBean.setConnectionConfiguration(
+				XMPPTCPConnectionConfiguration.builder()
+						.setXmppDomain("foo")
+						.build());
 		XMPPConnection connection = xmppConnectionFactoryBean.createInstance();
 		assertNotNull(connection);
 	}

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.integration.xmpp.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import org.jivesoftware.smack.XMPPConnection;
 import org.junit.Test;
@@ -42,7 +41,7 @@ public class XmppConnectionParserTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("XmppConnectionParserTests-simple.xml", this.getClass());
 		XMPPConnection connection  = ac.getBean("connection", XMPPConnection.class);
-		assertEquals("my.domain", connection.getServiceName());
+		assertEquals("my.domain", connection.getXMPPServiceDomain().toString());
 		assertFalse(connection.isConnected());
 		XmppConnectionFactoryBean xmppFb = ac.getBean("&connection", XmppConnectionFactoryBean.class);
 		assertEquals("happy.user@my.domain", TestUtils.getPropertyValue(xmppFb, "user"));
@@ -57,19 +56,11 @@ public class XmppConnectionParserTests {
 	}
 
 	@Test
-	public void testDefaultConnectionName() {
-		ConfigurableApplicationContext ac =
-				new ClassPathXmlApplicationContext("XmppConnectionParserTests-simple.xml", this.getClass());
-		assertTrue(ac.containsBean("xmppConnection"));
-		ac.close();
-	}
-
-	@Test
 	public void testCompleteConfiguration() {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("XmppConnectionParserTests-complete.xml", this.getClass());
 		XMPPConnection connection  = ac.getBean("connection", XMPPConnection.class);
-		assertEquals("foogle.com", connection.getServiceName());
+		assertEquals("foogle.com", connection.getXMPPServiceDomain().toString());
 		assertFalse(connection.isConnected());
 		XmppConnectionFactoryBean xmppFb = ac.getBean("&connection", XmppConnectionFactoryBean.class);
 		assertEquals("happy.user", TestUtils.getPropertyValue(xmppFb, "user"));

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/ignore/SmackMessageSampleTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/ignore/SmackMessageSampleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springframework.integration.xmpp.ignore;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.messaging.Message;
@@ -27,25 +29,26 @@ import org.springframework.messaging.support.GenericMessage;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class SmackMessageSampleTests {
 
 	@Test
 	@Ignore
-	public void validateSmackMessageSent() {
+	public void validateSmackMessageSent() throws XmppStringprepException {
 		ClassPathXmlApplicationContext ac = new ClassPathXmlApplicationContext("SmackMessageSampleTest-context.xml",
 				this.getClass());
+
 		MessageChannel xmppInput = ac.getBean("xmppInput", MessageChannel.class);
 
-
-		org.jivesoftware.smack.packet.Message smackMessage = new org.jivesoftware.smack.packet.Message(
-				"springintegration@gmail.com");
+		org.jivesoftware.smack.packet.Message smackMessage =
+				new org.jivesoftware.smack.packet.Message(JidCreate.from("springintegration@gmail.com"));
 		smackMessage.setBody("Message sent as Smack Message");
 
-		Message<org.jivesoftware.smack.packet.Message> message =
-			new GenericMessage<org.jivesoftware.smack.packet.Message>(smackMessage);
+		Message<org.jivesoftware.smack.packet.Message> message = new GenericMessage<>(smackMessage);
 
 		xmppInput.send(message);
 		ac.close();
 	}
+
 }

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpointTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpointTests.java
@@ -44,6 +44,8 @@ import org.jivesoftware.smack.tcp.XMPPTCPConnection;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smackx.gcm.packet.GcmPacketExtension;
 import org.junit.Test;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.stringprep.XmppStringprepException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.xmlpull.v1.XmlPullParser;
@@ -126,7 +128,7 @@ public class ChatMessageListeningEndpointTests {
 	}
 
 	@Test
-	public void testWithErrorChannel() throws NotConnectedException {
+	public void testWithErrorChannel() throws NotConnectedException, XmppStringprepException, InterruptedException {
 		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
 		XMPPConnection connection = mock(XMPPConnection.class);
 		bf.registerSingleton(XmppContextUtils.XMPP_CONNECTION_BEAN_NAME, connection);
@@ -143,10 +145,10 @@ public class ChatMessageListeningEndpointTests {
 		endpoint.setErrorChannel(errorChannel);
 		endpoint.afterPropertiesSet();
 		StanzaListener listener = (StanzaListener) TestUtils.getPropertyValue(endpoint, "stanzaListener");
-		Message smackMessage = new Message("kermit@frog.com");
+		Message smackMessage = new Message(JidCreate.from("kermit@frog.com"));
 		smackMessage.setBody("hello");
 		smackMessage.setThread("1234");
-		listener.processPacket(smackMessage);
+		listener.processStanza(smackMessage);
 
 		ErrorMessage msg =
 				(ErrorMessage) errorChannel.receive();
@@ -170,7 +172,7 @@ public class ChatMessageListeningEndpointTests {
 		Message smackMessage = new Message();
 		smackMessage.setBody("foo");
 
-		XmlPullParser xmlPullParser = PacketParserUtils.newXmppParser(new StringReader(smackMessage.toString()));
+		XmlPullParser xmlPullParser = PacketParserUtils.newXmppParser(new StringReader(smackMessage.toXML().toString()));
 		xmlPullParser.next();
 		testXMPPConnection.parseAndProcessStanza(xmlPullParser);
 
@@ -196,7 +198,7 @@ public class ChatMessageListeningEndpointTests {
 		endpoint.setPayloadExpression(null);
 
 		smackMessage = new Message();
-		xmlPullParser = PacketParserUtils.newXmppParser(new StringReader(smackMessage.toString()));
+		xmlPullParser = PacketParserUtils.newXmppParser(new StringReader(smackMessage.toXML().toString()));
 		xmlPullParser.next();
 		testXMPPConnection.parseAndProcessStanza(xmlPullParser);
 
@@ -239,7 +241,7 @@ public class ChatMessageListeningEndpointTests {
 		endpoint.afterPropertiesSet();
 		endpoint.start();
 
-		XmlPullParser xmlPullParser = PacketParserUtils.newXmppParser(new StringReader(smackMessage.toString()));
+		XmlPullParser xmlPullParser = PacketParserUtils.newXmppParser(new StringReader(smackMessage.toXML().toString()));
 		xmlPullParser.next();
 		testXMPPConnection.parseAndProcessStanza(xmlPullParser);
 

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpointTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpointTests.java
@@ -19,12 +19,8 @@ package org.springframework.integration.xmpp.inbound;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import org.jivesoftware.smack.XMPPConnection;
@@ -57,21 +53,11 @@ public class PresenceListeningEndpointTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testEndpointLifecycle() {
-		final Set<RosterListener> rosterSet = new HashSet<RosterListener>();
 		XMPPConnection connection = mock(XMPPConnection.class);
-		Roster roster = mock(Roster.class);
-		Map<XMPPConnection, Roster> instances = TestUtils.getPropertyValue(roster, "INSTANCES", Map.class);
-		instances.put(connection, roster);
+		Roster roster = Roster.getInstanceFor(connection);
 
-		doAnswer(invocation -> {
-			rosterSet.add(invocation.getArgument(0));
-			return null;
-		}).when(roster).addRosterListener(any(RosterListener.class));
+		Set<RosterListener> rosterSet = TestUtils.getPropertyValue(roster, "rosterListeners", Set.class);
 
-		doAnswer(invocation -> {
-			rosterSet.remove((RosterListener) invocation.getArgument(0));
-			return null;
-		}).when(roster).removeRosterListener(any(RosterListener.class));
 		PresenceListeningEndpoint rosterEndpoint = new PresenceListeningEndpoint(connection);
 		rosterEndpoint.setOutputChannel(new QueueChannel());
 		rosterEndpoint.setBeanFactory(mock(BeanFactory.class));
@@ -93,9 +79,6 @@ public class PresenceListeningEndpointTests {
 	@SuppressWarnings("unchecked")
 	public void testRosterPresenceChangeEvent() {
 		XMPPConnection connection = mock(XMPPConnection.class);
-		Roster roster = mock(Roster.class);
-		Map<XMPPConnection, Roster> instances = TestUtils.getPropertyValue(roster, "INSTANCES", Map.class);
-		instances.put(connection, roster);
 		PresenceListeningEndpoint rosterEndpoint = new PresenceListeningEndpoint(connection);
 		QueueChannel channel = new QueueChannel();
 		rosterEndpoint.setOutputChannel(channel);

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/outbound/ChatMessageSendingMessageHandlerTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/outbound/ChatMessageSendingMessageHandlerTests.java
@@ -30,6 +30,7 @@ import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smackx.gcm.packet.GcmPacketExtension;
 import org.jivesoftware.smackx.gcm.provider.GcmExtensionProvider;
 import org.junit.Test;
+import org.jxmpp.jid.impl.JidCreate;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -112,7 +113,8 @@ public class ChatMessageSendingMessageHandlerTests {
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
-		org.jivesoftware.smack.packet.Message smackMessage = new org.jivesoftware.smack.packet.Message("kermit@frog.com");
+		org.jivesoftware.smack.packet.Message smackMessage =
+				new org.jivesoftware.smack.packet.Message(JidCreate.from("kermit@frog.com"));
 		smackMessage.setBody("Test Message");
 
 
@@ -123,7 +125,7 @@ public class ChatMessageSendingMessageHandlerTests {
 		verify(connection, times(1)).sendStanza(smackMessage);
 
 		// assuming we know thread ID although currently we do not provide this capability
-		smackMessage = new org.jivesoftware.smack.packet.Message("kermit@frog.com");
+		smackMessage = new org.jivesoftware.smack.packet.Message(JidCreate.from("kermit@frog.com"));
 		smackMessage.setBody("Hello Kitty");
 		smackMessage.setThread("123");
 		message = MessageBuilder.withPayload(smackMessage).build();
@@ -159,7 +161,7 @@ public class ChatMessageSendingMessageHandlerTests {
 		org.jivesoftware.smack.packet.Message smackMessage = argumentCaptor.getValue();
 
 		assertNull(smackMessage.getBody());
-		assertEquals("kermit@frog.com", smackMessage.getTo());
+		assertEquals("kermit@frog.com", smackMessage.getTo().toString());
 		GcmPacketExtension gcmPacketExtension = GcmPacketExtension.from(smackMessage);
 		assertNotNull(gcmPacketExtension);
 		assertEquals(json, gcmPacketExtension.getJson());
@@ -171,13 +173,13 @@ public class ChatMessageSendingMessageHandlerTests {
 	@Test(expected = MessageHandlingException.class)
 	public void validateFailureNoChatToUser() throws Exception {
 		ChatMessageSendingMessageHandler handler = new ChatMessageSendingMessageHandler(mock(XMPPConnection.class));
-		handler.handleMessage(new GenericMessage<String>("hello"));
+		handler.handleMessage(new GenericMessage<>("hello"));
 	}
 
 	@Test(expected = MessageHandlingException.class)
 	public void validateMessageWithUnsupportedPayload() throws Exception {
 		ChatMessageSendingMessageHandler handler = new ChatMessageSendingMessageHandler(mock(XMPPConnection.class));
-		handler.handleMessage(new GenericMessage<Integer>(123));
+		handler.handleMessage(new GenericMessage<>(123));
 	}
 
 	@Test

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapperTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapperTests.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smackx.jiveproperties.JivePropertiesManager;
 import org.junit.Test;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 import org.springframework.integration.xmpp.XmppHeaders;
 import org.springframework.messaging.MessageHeaders;
@@ -32,6 +34,8 @@ import org.springframework.messaging.MessageHeaders;
 /**
  * @author Mark Fisher
  * @author Florian Schmaus
+ * @author Artem Bilan
+ *
  * @since 2.1
  */
 public class DefaultXmppHeaderMapperTests {
@@ -39,7 +43,7 @@ public class DefaultXmppHeaderMapperTests {
 	@Test
 	public void fromHeadersStandardOutbound() {
 		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper();
-		Map<String, Object> headerMap = new HashMap<String, Object>();
+		Map<String, Object> headerMap = new HashMap<>();
 		headerMap.put("userDefined1", "foo");
 		headerMap.put("userDefined2", "bar");
 		headerMap.put(XmppHeaders.THREAD, "test.thread");
@@ -53,8 +57,8 @@ public class DefaultXmppHeaderMapperTests {
 
 		// "standard" XMPP headers
 		assertEquals("test.thread", target.getThread());
-		assertEquals("test.to", target.getTo());
-		assertEquals("test.from", target.getFrom());
+		assertEquals("test.to", target.getTo().toString());
+		assertEquals("test.from", target.getFrom().toString());
 		assertEquals("test.subject", target.getSubject());
 		assertEquals(Message.Type.headline, target.getType());
 
@@ -70,7 +74,7 @@ public class DefaultXmppHeaderMapperTests {
 	@Test
 	public void fromHeadersUserDefinedOnly() {
 		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper();
-		mapper.setRequestHeaderNames(new String[] { "userDefined1", "userDefined2" });
+		mapper.setRequestHeaderNames("userDefined1", "userDefined2");
 		Map<String, Object> headerMap = new HashMap<String, Object>();
 		headerMap.put("userDefined1", "foo");
 		headerMap.put("userDefined2", "bar");
@@ -104,17 +108,17 @@ public class DefaultXmppHeaderMapperTests {
 	}
 
 	@Test
-	public void toHeadersStandardOnly() {
+	public void toHeadersStandardOnly() throws XmppStringprepException {
 		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper();
-		Message source = new Message("test.to", Message.Type.headline);
-		source.setFrom("test.from");
+		Message source = new Message(JidCreate.from("test.to"), Message.Type.headline);
+		source.setFrom(JidCreate.from("test.from"));
 		source.setSubject("test.subject");
 		source.setThread("test.thread");
 		JivePropertiesManager.addProperty(source, "userDefined1", "foo");
 		JivePropertiesManager.addProperty(source, "userDefined2", "bar");
 		Map<String, Object> headers = mapper.toHeadersFromRequest(source);
-		assertEquals("test.to", headers.get(XmppHeaders.TO));
-		assertEquals("test.from", headers.get(XmppHeaders.FROM));
+		assertEquals("test.to", headers.get(XmppHeaders.TO).toString());
+		assertEquals("test.from", headers.get(XmppHeaders.FROM).toString());
 		assertEquals("test.subject", headers.get(XmppHeaders.SUBJECT));
 		assertEquals("test.thread", headers.get(XmppHeaders.THREAD));
 		assertEquals(Message.Type.headline, headers.get(XmppHeaders.TYPE));
@@ -123,11 +127,11 @@ public class DefaultXmppHeaderMapperTests {
 	}
 
 	@Test
-	public void toHeadersUserDefinedOnly() {
+	public void toHeadersUserDefinedOnly() throws XmppStringprepException {
 		DefaultXmppHeaderMapper mapper = new DefaultXmppHeaderMapper();
-		mapper.setReplyHeaderNames(new String[] { "userDefined*" });
-		Message source = new Message("test.to", Message.Type.headline);
-		source.setFrom("test.from");
+		mapper.setReplyHeaderNames("userDefined*");
+		Message source = new Message(JidCreate.from("test.to"), Message.Type.headline);
+		source.setFrom(JidCreate.from("test.from"));
 		source.setSubject("test.subject");
 		source.setThread("test.thread");
 		JivePropertiesManager.addProperty(source, "userDefined1", "foo");


### PR DESCRIPTION
Fixes: spring-projects/spring-integration#2071

* Clean up `build.gradle` for redundant excludes
* Add `javax.mail` dependency to WS module to avoid WARN about missed providers
* Refactoring for the XMPP module according changes in the latest Smack
* Polishing for the `BackToBackAdapterTests` to avoid extra wait for `null`
on the channel and some race conditions when client is closed during by the
`stop()` during publishing