### PR TITLE
Make configureContainer public for AdapterSpecs

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterDMLCSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterDMLCSpec.java
@@ -36,7 +36,7 @@ public class AmqpInboundChannelAdapterDMLCSpec
 		super(new DirectMessageListenerContainerSpec(listenerContainer));
 	}
 
-	AmqpInboundChannelAdapterDMLCSpec configureContainer(Consumer<DirectMessageListenerContainerSpec> configurer) {
+	public AmqpInboundChannelAdapterDMLCSpec configureContainer(Consumer<DirectMessageListenerContainerSpec> configurer) {
 		configurer.accept((DirectMessageListenerContainerSpec) this.listenerContainerSpec);
 		return this;
 	}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterSMLCSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterSMLCSpec.java
@@ -36,7 +36,7 @@ public class AmqpInboundChannelAdapterSMLCSpec
 		super(new SimpleMessageListenerContainerSpec(listenerContainer));
 	}
 
-	AmqpInboundChannelAdapterSMLCSpec configureContainer(Consumer<SimpleMessageListenerContainerSpec> configurer) {
+	public AmqpInboundChannelAdapterSMLCSpec configureContainer(Consumer<SimpleMessageListenerContainerSpec> configurer) {
 		configurer.accept((SimpleMessageListenerContainerSpec) this.listenerContainerSpec);
 		return this;
 	}


### PR DESCRIPTION
configureContainer is already public in the GatewaySpec, therefore
making it also public in the AdapterSpecs.

We came across this problem when we were testing M7.

I thought the change is trivial and therefore did not create a JIRA Issue.