### PR TITLE
Some Java DSL improvements

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,21 +69,10 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 
 	private final List<SmartLifecycle> lifecycles = new LinkedList<>();
 
-	private final boolean registerComponents = true; // NOSONAR
-
 	private boolean running;
 
 	StandardIntegrationFlow(Map<Object, String> integrationComponents) {
 		this.integrationComponents = new LinkedHashMap<>(integrationComponents);
-	}
-
-	//TODO Figure out some custom DestinationResolver when we don't register singletons - remove NOSONAR above when done
-	/*public void setRegisterComponents(boolean registerComponents) {
-		this.registerComponents = registerComponents;
-	}*/
-
-	public boolean isRegisterComponents() {
-		return this.registerComponents;
 	}
 
 	public void setIntegrationComponents(Map<Object, String> integrationComponents) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/AnnotationGatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/AnnotationGatewayProxyFactoryBean.java
@@ -47,13 +47,20 @@ public class AnnotationGatewayProxyFactoryBean extends GatewayProxyFactoryBean {
 
 	public AnnotationGatewayProxyFactoryBean(Class<?> serviceInterface) {
 		super(serviceInterface);
-		AnnotationAttributes gatewayAttributes = AnnotatedElementUtils.getMergedAnnotationAttributes(serviceInterface,
-				MessagingGateway.class.getName(), false, true);
+		AnnotationAttributes gatewayAttributes =
+				AnnotatedElementUtils.getMergedAnnotationAttributes(serviceInterface,
+						MessagingGateway.class.getName(), false, true);
 		if (gatewayAttributes == null) {
 			gatewayAttributes = AnnotationUtils.getAnnotationAttributes(
 					AnnotationUtils.synthesizeAnnotation(MessagingGateway.class), false, true);
 		}
+
 		this.gatewayAttributes = gatewayAttributes;
+
+		String id = gatewayAttributes.getString("name");
+		if (!StringUtils.hasText(id)) {
+			setBeanName(id);
+		}
 	}
 
 	@Override

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
@@ -444,6 +444,7 @@ public class IntegrationFlowTests {
 	}
 
 	@Autowired
+	@Qualifier("errorRecovererFunction")
 	private Function<String, String> errorRecovererFlowGateway;
 
 	@Test
@@ -789,7 +790,7 @@ public class IntegrationFlowTests {
 
 		@Bean
 		public IntegrationFlow errorRecovererFlow() {
-			return IntegrationFlows.from(Function.class)
+			return IntegrationFlows.from(Function.class, "errorRecovererFunction")
 					.handle((GenericHandler<?>) (p, h) -> {
 						throw new RuntimeException("intentional");
 					}, e -> e.advice(retryAdvice()))


### PR DESCRIPTION
* Register `BeanDefinition`s for DSL components.
That way we get a gain when the `BeanDefinition` is involved,
e.g. Spring Cloud Function uses this approach to determine the generics
of the target `Function` class
* This programmatic `BeanDefinition` registration approach
(available since SF-5.0) allows us to avoid some manual lifecycle processes:
bean initialization, autowiring, event listener registration etc.
* Rework `IntegrationFlowContext` to register and remove `BeanDefinition`s as well
* Remove unused `registerComponents`  flag from the `StandardIntegrationFlow`.
With the proper logic in the `IntegrationFlowContext` it does not make sense any more
* Remove redundant `AnnotationGatewayProxyFactoryBean` in the `IntegrationFlows`;
populate `defaultRequestChannel` directly to the `GatewayProxyFactoryBean` instance
* Add an overloaded `IntegrationFlows.from(Class, String)` to allow to specify an
explicit bean name for the target gateway proxy
* Extract and populate bean name from the `@MessagingGateway.name()` in the
`AnnotationGatewayProxyFactoryBean`
* Stop lifecycles in the `AmqpTests` after using for proper test suit shutdown