### PR TITLE
GH-2268: Add RedisHeaders.MESSAGE_SOURCE header

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.gateway;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -792,11 +793,14 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 		}
 
 		@Override
-		public Message<?> toMessage(Object object) throws Exception {
+		public Message<?> toMessage(Object object, @Nullable Map<String, Object> headers) throws Exception {
 			if (object instanceof Message<?>) {
 				return (Message<?>) object;
 			}
-			return (object != null) ? this.messageBuilderFactory.withPayload(object).build() : null;
+
+			return object != null
+					? this.messageBuilderFactory.withPayload(object).copyHeadersIfAbsent(headers).build()
+					: null;
 		}
 
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/InboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/InboundMessageMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,39 @@
 
 package org.springframework.integration.mapping;
 
+import java.util.Map;
+
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 
 /**
  * Strategy interface for mapping from an Object to a{@link Message}.
  *
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 @FunctionalInterface
 public interface InboundMessageMapper<T> {
 
-	Message<?> toMessage(T object) throws Exception;
+	/**
+	 * Convert a provided object to the {@link Message}.
+	 * @param object the object for message payload or some other conversion logic
+	 * @return the message as a result of mapping
+	 * @throws Exception the exception thrown by the underlying mapper implementation
+	 */
+	default Message<?> toMessage(T object) throws Exception {
+		return toMessage(object, null);
+	}
+
+	/**
+	 * Convert a provided object to the {@link Message}
+	 * and supply with headers if necessary and provided.
+	 * @param object the object for message payload or some other conversion logic
+	 * @param headers additional headers for building message. Can be null
+	 * @return the message as a result of mapping
+	 * @throws Exception the exception thrown by the underlying mapper implementation
+	 * @since 5.0
+	 */
+	Message<?> toMessage(T object, @Nullable Map<String, Object> headers) throws Exception;
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/AbstractIntegrationMessageBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/AbstractIntegrationMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
@@ -31,6 +32,8 @@ import org.springframework.util.Assert;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 4.0
  *
  */
@@ -47,7 +50,7 @@ public abstract class AbstractIntegrationMessageBuilder<T> {
 	 * @param headerValue The header value.
 	 * @return this.
 	 */
-	public abstract AbstractIntegrationMessageBuilder<T> setHeader(String headerName, Object headerValue);
+	public abstract AbstractIntegrationMessageBuilder<T> setHeader(String headerName, @Nullable Object headerValue);
 
 	/**
 	 * Set the value for the given header name only if the header name is not already associated with a value.
@@ -86,7 +89,7 @@ public abstract class AbstractIntegrationMessageBuilder<T> {
 	 * @see MessageHeaders#ID
 	 * @see MessageHeaders#TIMESTAMP
 	 */
-	public abstract AbstractIntegrationMessageBuilder<T> copyHeaders(Map<String, ?> headersToCopy);
+	public abstract AbstractIntegrationMessageBuilder<T> copyHeaders(@Nullable Map<String, ?> headersToCopy);
 
 	/**
 	 * Copy the name-value pairs from the provided Map. This operation will <em>not</em> overwrite any existing values.
@@ -94,7 +97,7 @@ public abstract class AbstractIntegrationMessageBuilder<T> {
 	 * @param headersToCopy The headers to copy.
 	 * @return this.
 	 */
-	public abstract AbstractIntegrationMessageBuilder<T> copyHeadersIfAbsent(Map<String, ?> headersToCopy);
+	public abstract AbstractIntegrationMessageBuilder<T> copyHeadersIfAbsent(@Nullable Map<String, ?> headersToCopy);
 
 	public AbstractIntegrationMessageBuilder<T> setExpirationDate(Long expirationDate) {
 		return this.setHeader(IntegrationMessageHeaderAccessor.EXPIRATION_DATE, expirationDate);

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MessageBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MessageBuilder.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
@@ -52,6 +53,7 @@ public final class MessageBuilder<T> extends AbstractIntegrationMessageBuilder<T
 
 	private final IntegrationMessageHeaderAccessor headerAccessor;
 
+	@Nullable
 	private final Message<T> originalMessage;
 
 	private volatile boolean modified;
@@ -113,7 +115,7 @@ public final class MessageBuilder<T> extends AbstractIntegrationMessageBuilder<T
 	 * @return this MessageBuilder.
 	 */
 	@Override
-	public MessageBuilder<T> setHeader(String headerName, Object headerValue) {
+	public MessageBuilder<T> setHeader(String headerName, @Nullable Object headerValue) {
 		this.headerAccessor.setHeader(headerName, headerValue);
 		return this;
 	}
@@ -173,7 +175,7 @@ public final class MessageBuilder<T> extends AbstractIntegrationMessageBuilder<T
 	 * @see MessageHeaders#TIMESTAMP
 	 */
 	@Override
-	public MessageBuilder<T> copyHeaders(Map<String, ?> headersToCopy) {
+	public MessageBuilder<T> copyHeaders(@Nullable Map<String, ?> headersToCopy) {
 		this.headerAccessor.copyHeaders(headersToCopy);
 		return this;
 	}
@@ -185,7 +187,7 @@ public final class MessageBuilder<T> extends AbstractIntegrationMessageBuilder<T
 	 * @return this MessageBuilder.
 	 */
 	@Override
-	public MessageBuilder<T> copyHeadersIfAbsent(Map<String, ?> headersToCopy) {
+	public MessageBuilder<T> copyHeadersIfAbsent(@Nullable Map<String, ?> headersToCopy) {
 		if (headersToCopy != null) {
 			for (Map.Entry<String, ?> entry : headersToCopy.entrySet()) {
 				String headerName = entry.getKey();

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessage.java
@@ -85,17 +85,16 @@ public class MutableMessage<T> implements Message<T>, Serializable {
 		return this.headers.getRawHeaders();
 	}
 
-	@Override
 	public String toString() {
-		StringBuilder sb = new StringBuilder();
+		StringBuilder sb = new StringBuilder(getClass().getSimpleName());
+		sb.append(" [payload=");
 		if (this.payload instanceof byte[]) {
-			sb.append("[Payload byte[").append(((byte[]) this.payload).length).append("]]");
+			sb.append("byte[").append(((byte[]) this.payload).length).append("]");
 		}
 		else {
-			sb.append("[Payload ").append(this.payload.getClass().getSimpleName());
-			sb.append(" content=").append(this.payload).append("]");
+			sb.append(this.payload);
 		}
-		sb.append("[Headers=").append(this.headers).append("]");
+		sb.append(", headers=").append(this.headers).append("]");
 		return sb.toString();
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageBuilder.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
@@ -121,7 +122,7 @@ public final class MutableMessageBuilder<T> extends AbstractIntegrationMessageBu
 	}
 
 	@Override
-	public AbstractIntegrationMessageBuilder<T> setHeader(String headerName, Object headerValue) {
+	public AbstractIntegrationMessageBuilder<T> setHeader(String headerName, @Nullable Object headerValue) {
 		Assert.notNull(headerName, "'headerName' must not be null");
 		if (headerValue == null) {
 			this.removeHeader(headerName);
@@ -180,7 +181,7 @@ public final class MutableMessageBuilder<T> extends AbstractIntegrationMessageBu
 	}
 
 	@Override
-	public AbstractIntegrationMessageBuilder<T> copyHeaders(Map<String, ?> headersToCopy) {
+	public AbstractIntegrationMessageBuilder<T> copyHeaders(@Nullable Map<String, ?> headersToCopy) {
 		if (headersToCopy != null) {
 			this.headers.putAll(headersToCopy);
 		}
@@ -188,7 +189,7 @@ public final class MutableMessageBuilder<T> extends AbstractIntegrationMessageBu
 	}
 
 	@Override
-	public AbstractIntegrationMessageBuilder<T> copyHeadersIfAbsent(Map<String, ?> headersToCopy) {
+	public AbstractIntegrationMessageBuilder<T> copyHeadersIfAbsent(@Nullable Map<String, ?> headersToCopy) {
 		if (headersToCopy != null) {
 			for (Entry<String, ?> entry : headersToCopy.entrySet()) {
 				setHeaderIfAbsent(entry.getKey(), entry.getValue());

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/converter/MapMessageConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/converter/MapMessageConverter.java
@@ -106,7 +106,9 @@ public class MapMessageConverter implements MessageConverter, BeanFactoryAware {
 			}
 			messageBuilder.copyHeaders(headers);
 		}
-		return messageBuilder.build();
+		return messageBuilder
+				.copyHeadersIfAbsent(messageHeaders)
+				.build();
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/converter/MapMessageConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/converter/MapMessageConverter.java
@@ -26,6 +26,7 @@ import org.springframework.integration.support.AbstractIntegrationMessageBuilder
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.utils.IntegrationUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.MessageConverter;
@@ -90,8 +91,9 @@ public class MapMessageConverter implements MessageConverter, BeanFactoryAware {
 		this.filterHeadersInToMessage = filterHeadersInToMessage;
 	}
 
+	@Nullable
 	@Override
-	public Message<?> toMessage(Object object, MessageHeaders messageHeaders) {
+	public Message<?> toMessage(Object object, @Nullable MessageHeaders messageHeaders) {
 		Assert.isInstanceOf(Map.class, object, "This converter expects a Map");
 		@SuppressWarnings("unchecked")
 		Map<String, ?> map = (Map<String, ?>) object;
@@ -111,6 +113,7 @@ public class MapMessageConverter implements MessageConverter, BeanFactoryAware {
 				.build();
 	}
 
+	@Nullable
 	@Override
 	public Object fromMessage(Message<?> message, Class<?> clazz) {
 		Map<String, Object> map = new HashMap<String, Object>();

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/converter/SimpleMessageConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/converter/SimpleMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,14 +28,16 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.support.MessageBuilder;
 
 /**
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
-@SuppressWarnings({"unchecked", "rawtypes"})
+@SuppressWarnings({ "unchecked", "rawtypes" })
 public class SimpleMessageConverter implements MessageConverter, BeanFactoryAware {
 
 	private volatile InboundMessageMapper inboundMessageMapper;
@@ -103,7 +105,14 @@ public class SimpleMessageConverter implements MessageConverter, BeanFactoryAwar
 	@Override
 	public Message<?> toMessage(Object object, MessageHeaders headers) {
 		try {
-			return this.inboundMessageMapper.toMessage(object);
+			Message message = this.inboundMessageMapper.toMessage(object);
+			if (headers != null) {
+				message =
+						MessageBuilder.fromMessage(message)
+								.copyHeadersIfAbsent(headers)
+								.build();
+			}
+			return message;
 		}
 		catch (Exception e) {
 			throw new MessageConversionException("failed to convert object to Message", e);

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/converter/SimpleMessageConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/converter/SimpleMessageConverter.java
@@ -104,8 +104,9 @@ public class SimpleMessageConverter implements MessageConverter, BeanFactoryAwar
 		return this.messageBuilderFactory;
 	}
 
+	@Nullable
 	@Override
-	public Message<?> toMessage(Object object, MessageHeaders headers) {
+	public Message<?> toMessage(Object object, @Nullable MessageHeaders headers) {
 		try {
 			return this.inboundMessageMapper.toMessage(object, headers);
 		}
@@ -114,6 +115,7 @@ public class SimpleMessageConverter implements MessageConverter, BeanFactoryAwar
 		}
 	}
 
+	@Nullable
 	@Override
 	public Object fromMessage(Message<?> message, Class<?> targetClass) {
 		try {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/converter/SimpleMessageConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/converter/SimpleMessageConverter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.support.converter;
 
+import java.util.Map;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -24,11 +26,11 @@ import org.springframework.integration.mapping.OutboundMessageMapper;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.utils.IntegrationUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.messaging.converter.MessageConverter;
-import org.springframework.messaging.support.MessageBuilder;
 
 /**
  * @author Mark Fisher
@@ -105,14 +107,7 @@ public class SimpleMessageConverter implements MessageConverter, BeanFactoryAwar
 	@Override
 	public Message<?> toMessage(Object object, MessageHeaders headers) {
 		try {
-			Message message = this.inboundMessageMapper.toMessage(object);
-			if (headers != null) {
-				message =
-						MessageBuilder.fromMessage(message)
-								.copyHeadersIfAbsent(headers)
-								.build();
-			}
-			return message;
+			return this.inboundMessageMapper.toMessage(object, headers);
 		}
 		catch (Exception e) {
 			throw new MessageConversionException("failed to convert object to Message", e);
@@ -137,14 +132,17 @@ public class SimpleMessageConverter implements MessageConverter, BeanFactoryAwar
 		}
 
 		@Override
-		public Message<?> toMessage(Object object) throws Exception {
+		public Message<?> toMessage(Object object, @Nullable Map<String, Object> headers) throws Exception {
 			if (object == null) {
 				return null;
 			}
 			if (object instanceof Message<?>) {
 				return (Message<?>) object;
 			}
-			return getMessageBuilderFactory().withPayload(object).build();
+			return getMessageBuilderFactory()
+					.withPayload(object)
+					.copyHeadersIfAbsent(headers)
+					.build();
 		}
 
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/AbstractJacksonJsonMessageParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/AbstractJacksonJsonMessageParser.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.utils.IntegrationUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 
 /**
@@ -69,7 +70,7 @@ abstract class AbstractJacksonJsonMessageParser<P> implements JsonInboundMessage
 
 	@Override
 	public Message<?> doInParser(JsonInboundMessageMapper messageMapper, String jsonMessage,
-			Map<String, Object> headers) throws Exception {
+			@Nullable Map<String, Object> headers) throws Exception {
 
 		if (this.messageMapper == null) {
 			this.messageMapper = messageMapper;
@@ -110,7 +111,7 @@ abstract class AbstractJacksonJsonMessageParser<P> implements JsonInboundMessage
 	}
 
 	protected abstract Message<?> parseWithHeaders(P parser, String jsonMessage,
-			Map<String, Object> headers) throws Exception;
+			@Nullable Map<String, Object> headers) throws Exception;
 
 	protected abstract P createJsonParser(String jsonMessage) throws Exception;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonMessageParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonMessageParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.core.JsonToken;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ *
  * @since 3.0
  */
 public class Jackson2JsonMessageParser extends AbstractJacksonJsonMessageParser<JsonParser> {
@@ -52,7 +53,9 @@ public class Jackson2JsonMessageParser extends AbstractJacksonJsonMessageParser<
 	}
 
 	@Override
-	protected Message<?> parseWithHeaders(JsonParser parser, String jsonMessage) throws Exception {
+	protected Message<?> parseWithHeaders(JsonParser parser, String jsonMessage, Map<String, Object> headersToAdd)
+			throws Exception {
+
 		String error = AbstractJsonInboundMessageMapper.MESSAGE_FORMAT_ERROR + jsonMessage;
 		Assert.isTrue(JsonToken.START_OBJECT == parser.nextToken(), error);
 		Map<String, Object> headers = null;
@@ -72,7 +75,12 @@ public class Jackson2JsonMessageParser extends AbstractJacksonJsonMessageParser<
 			}
 		}
 		Assert.notNull(headers, error);
-		return this.getMessageBuilderFactory().withPayload(payload).copyHeaders(headers).build();
+
+		return getMessageBuilderFactory()
+				.withPayload(payload)
+				.copyHeaders(headers)
+				.copyHeadersIfAbsent(headersToAdd)
+				.build();
 	}
 
 	private Map<String, Object> readHeaders(JsonParser parser, String jsonMessage) throws Exception {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonMessageParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonMessageParser.java
@@ -20,6 +20,7 @@ package org.springframework.integration.support.json;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
@@ -53,8 +54,8 @@ public class Jackson2JsonMessageParser extends AbstractJacksonJsonMessageParser<
 	}
 
 	@Override
-	protected Message<?> parseWithHeaders(JsonParser parser, String jsonMessage, Map<String, Object> headersToAdd)
-			throws Exception {
+	protected Message<?> parseWithHeaders(JsonParser parser, String jsonMessage,
+			@Nullable Map<String, Object> headersToAdd) throws Exception {
 
 		String error = AbstractJsonInboundMessageMapper.MESSAGE_FORMAT_ERROR + jsonMessage;
 		Assert.isTrue(JsonToken.START_OBJECT == parser.nextToken(), error);
@@ -84,7 +85,7 @@ public class Jackson2JsonMessageParser extends AbstractJacksonJsonMessageParser<
 	}
 
 	private Map<String, Object> readHeaders(JsonParser parser, String jsonMessage) throws Exception {
-		Map<String, Object> headers = new LinkedHashMap<String, Object>();
+		Map<String, Object> headers = new LinkedHashMap<>();
 		while (JsonToken.END_OBJECT != parser.nextToken()) {
 			String headerName = parser.getCurrentName();
 			parser.nextToken();

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonInboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonInboundMessageMapper.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Map;
 
 import org.springframework.integration.support.json.JsonInboundMessageMapper.JsonMessageParser;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
@@ -34,6 +35,7 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ *
  * @since 2.0
  */
 public class JsonInboundMessageMapper extends AbstractJsonInboundMessageMapper<JsonMessageParser<?>> {
@@ -63,8 +65,8 @@ public class JsonInboundMessageMapper extends AbstractJsonInboundMessageMapper<J
 	}
 
 	@Override
-	public Message<?> toMessage(String jsonMessage) throws Exception {
-		return this.messageParser.doInParser(this, jsonMessage);
+	public Message<?> toMessage(String jsonMessage, @Nullable Map<String, Object> headers) throws Exception {
+		return this.messageParser.doInParser(this, jsonMessage, headers);
 	}
 
 	@Override
@@ -81,7 +83,8 @@ public class JsonInboundMessageMapper extends AbstractJsonInboundMessageMapper<J
 
 	public interface JsonMessageParser<P> {
 
-		Message<?> doInParser(JsonInboundMessageMapper messageMapper, String jsonMessage) throws Exception;
+		Message<?> doInParser(JsonInboundMessageMapper messageMapper, String jsonMessage, Map<String, Object> headers)
+				throws Exception;
 
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonInboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonInboundMessageMapper.java
@@ -83,8 +83,8 @@ public class JsonInboundMessageMapper extends AbstractJsonInboundMessageMapper<J
 
 	public interface JsonMessageParser<P> {
 
-		Message<?> doInParser(JsonInboundMessageMapper messageMapper, String jsonMessage, Map<String, Object> headers)
-				throws Exception;
+		Message<?> doInParser(JsonInboundMessageMapper messageMapper, String jsonMessage,
+				@Nullable Map<String, Object> headers) throws Exception;
 
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/EndpointParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/EndpointParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.TimeUnit;
 
@@ -30,6 +31,7 @@ import org.springframework.messaging.support.GenericMessage;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class EndpointParserTests {
 
@@ -41,8 +43,8 @@ public class EndpointParserTests {
 		MessageChannel channel = (MessageChannel) context.getBean("endpointParserTestInput");
 		TestHandler handler = (TestHandler) context.getBean("testHandler");
 		assertNull(handler.getMessageString());
-		channel.send(new GenericMessage<String>("test"));
-		handler.getLatch().await(500, TimeUnit.MILLISECONDS);
+		channel.send(new GenericMessage<>("test"));
+		assertTrue(handler.getLatch().await(10000, TimeUnit.MILLISECONDS));
 		assertEquals("test", handler.getMessageString());
 		context.close();
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -78,6 +78,7 @@ import org.springframework.integration.context.IntegrationProperties;
 import org.springframework.integration.handler.BridgeHandler;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
@@ -522,8 +523,10 @@ public class GatewayInterfaceTests {
 	public static class BazMapper implements MethodArgsMessageMapper {
 
 		@Override
-		public Message<?> toMessage(MethodArgsHolder object) throws Exception {
-			return MessageBuilder.withPayload("fizbuz").build();
+		public Message<?> toMessage(MethodArgsHolder object, @Nullable Map<String, Object> headers) throws Exception {
+			return MessageBuilder.withPayload("fizbuz")
+					.copyHeadersIfAbsent(headers)
+					.build();
 		}
 
 	}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/support/RedisHeaders.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/support/RedisHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ package org.springframework.integration.redis.support;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.2
  */
 public final class RedisHeaders {
@@ -42,5 +43,7 @@ public final class RedisHeaders {
 	public static final String ZSET_INCREMENT_SCORE = PREFIX + "zsetIncrementScore";
 
 	public static final String COMMAND = PREFIX + "command";
+
+	public static final String MESSAGE_SOURCE = PREFIX + "messageSource";
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapterTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2016 the original author or authors.
+ * Copyright 2007-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package org.springframework.integration.redis.inbound;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import org.hamcrest.Matchers;
@@ -33,6 +33,7 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.redis.rules.RedisAvailable;
 import org.springframework.integration.redis.rules.RedisAvailableTests;
+import org.springframework.integration.redis.support.RedisHeaders;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 
@@ -40,6 +41,7 @@ import org.springframework.messaging.Message;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ *
  * @since 2.1
  */
 public class RedisInboundChannelAdapterTests extends RedisAvailableTests {
@@ -83,7 +85,8 @@ public class RedisInboundChannelAdapterTests extends RedisAvailableTests {
 				throw new RuntimeException("Failed to receive message # " + i + " iteration " + iteration);
 			}
 			assertNotNull(message);
-			assertTrue(message.getPayload().toString().startsWith("test-"));
+			assertThat(message.getPayload().toString(), startsWith("test-"));
+			assertEquals("testRedisInboundChannelAdapterChannel", message.getHeaders().get(RedisHeaders.MESSAGE_SOURCE));
 			counter++;
 		}
 		assertEquals(numToTest, counter);
@@ -119,7 +122,7 @@ public class RedisInboundChannelAdapterTests extends RedisAvailableTests {
 			Object payload = message.getPayload();
 			assertThat(payload, Matchers.instanceOf(byte[].class));
 
-			assertTrue(new String((byte[]) payload).startsWith("test-"));
+			assertThat(new String((byte[]) payload), startsWith("test-"));
 			counter++;
 		}
 

--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -103,7 +103,7 @@ Instead those Messages are passed through Redis allowing you to rely on its supp
 [[redis-inbound-channel-adapter]]
 ==== Redis Inbound Channel Adapter
 
-The Redis-based Inbound Channel Adapter adapts incoming Redis messages into Spring Integration Messages in the same way as other inbound adapters.
+The Redis-based Inbound Channel Adapter (`RedisInboundChannelAdapter`) adapts incoming Redis messages into Spring Integration Messages in the same way as other inbound adapters.
 It receives platform-specific messages (Redis in this case) and converts them to Spring Integration Messages using a `MessageConverter` strategy.
 [source,xml]
 ----
@@ -141,6 +141,8 @@ The `serializer` attribute of the `<int-redis:inbound-channel-adapter>` can be s
 In this case the raw `byte[]` bodies of Redis Messages are provided as the message payloads.
 
 Since _version 5.0_, an `Executor` instance can be provided to the Inbound Adapter via the `task-executor` attribute of the `<int-redis:inbound-channel-adapter>`.
+Also the received Spring Integration Messages have now `RedisHeaders.MESSAGE_SOURCE` header to indicate the source of the published message - topic or pattern.
+This can be used downstream for routing logic.
 
 [[redis-outbound-channel-adapter]]
 ==== Redis Outbound Channel Adapter

--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -103,8 +103,8 @@ Instead those Messages are passed through Redis allowing you to rely on its supp
 [[redis-inbound-channel-adapter]]
 ==== Redis Inbound Channel Adapter
 
-The Redis-based Inbound Channel Adapter (`RedisInboundChannelAdapter`) adapts incoming Redis messages into Spring Integration Messages in the same way as other inbound adapters.
-It receives platform-specific messages (Redis in this case) and converts them to Spring Integration Messages using a `MessageConverter` strategy.
+The Redis-based Inbound Channel Adapter (`RedisInboundChannelAdapter`) adapts incoming Redis messages into Spring Messages in the same way as other inbound adapters.
+It receives platform-specific messages (Redis in this case) and converts them to Spring Messages using a `MessageConverter` strategy.
 [source,xml]
 ----
 <int-redis:inbound-channel-adapter id="redisAdapter"

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -273,6 +273,7 @@ The `zsetIncrementExpression` can now be configured on the `RedisStoreWritingMes
 In addition this property has been changed from `true` to `false` since `INCR` option on `ZADD` Redis command is optional.
 
 The `RedisInboundChannelAdapter` can now be supplied with an `Executor` for executing Redis listener invokers.
+In addition the received messages now contains a `RedisHeaders.MESSAGE_SOURCE` header to indicate the source of the message - topic or pattern.
 
 See <<redis>> for more information.
 


### PR DESCRIPTION
Resolves: /spring-projects/spring-integration#2268

* To indicate the source the Redis message in the `RedisInboundChannelAdapter`
populate the `RedisHeaders.MESSAGE_SOURCE` header to the messages to produce
* Fix the `SimpleMessageConverter` to populate the provided `MessageHeaders`
to the message to produce