### PR TITLE
GH-2207: Clarify RedisMetadataStore in cluster

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/metadata/RedisMetadataStore.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/metadata/RedisMetadataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,11 +26,17 @@ import org.springframework.integration.metadata.MetadataStore;
 import org.springframework.util.Assert;
 
 /**
- * Redis implementation of {@link MetadataStore}. Use this {@link MetadataStore}
- * to achieve meta-data persistence across application restarts.
+ * Redis implementation of {@link MetadataStore}.
+ * Use this {@link MetadataStore} to achieve meta-data
+ * persistence across application restarts.
+ * <p>
+ * This implementation is based on the {@link RedisProperties}
+ * and its {@link #replace(String, String, String)} can't be used with
+ * Redis clustered connection because of unsupported {@code WATCH} command.
  *
  * @author Gunnar Hillert
  * @author Artem Bilan
+ *
  * @since 3.0
  */
 public class RedisMetadataStore implements ConcurrentMetadataStore {

--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -418,6 +418,8 @@ By default this `key` has the value `MetaData`.
 
 Starting with _version 4.0_, this store now implements `ConcurrentMetadataStore`, allowing it to be reliably shared across multiple application instances where only one instance will be allowed to store or modify a key's value.
 
+IMPORTANT: The `RedisMetadataStore.replace()` (for example in the `AbstractPersistentAcceptOnceFileListFilter`) can't be used with clustered Redis connections since the `WATCH` command for atomicity isn't supported there.
+
 [[redis-store-inbound-channel-adapter]]
 === RedisStore Inbound Channel Adapter
 


### PR DESCRIPTION
Resolves: spring-projects/spring-integration#2207

* Since the `WATCH` command isn't supported on clustered connections,
the `RedisMetadataStore.replace()` operation can't be used there.
Document this limitation