### PR TITLE
INT-4365: Improve notPropagatedHeaders function

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/FilterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/FilterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Gary Russell
  * @author David Liu
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class FilterFactoryBean extends AbstractStandardMessageHandlerFactoryBean {
@@ -41,8 +43,6 @@ public class FilterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 	private volatile MessageChannel discardChannel;
 
 	private volatile Boolean throwExceptionOnRejection;
-
-	private volatile Long sendTimeout;
 
 	private volatile Boolean discardWithinAdvice;
 
@@ -52,10 +52,6 @@ public class FilterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 
 	public void setThrowExceptionOnRejection(Boolean throwExceptionOnRejection) {
 		this.throwExceptionOnRejection = throwExceptionOnRejection;
-	}
-
-	public void setSendTimeout(Long sendTimeout) {
-		this.sendTimeout = sendTimeout;
 	}
 
 	public void setDiscardWithinAdvice(boolean discardWithinAdvice) {
@@ -113,12 +109,12 @@ public class FilterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 
 	@Override
 	protected void postProcessReplyProducer(AbstractMessageProducingHandler handler) {
-		if (this.sendTimeout != null) {
-			handler.setSendTimeout(this.sendTimeout);
-		}
+		super.postProcessReplyProducer(handler);
+
 		if (!(handler instanceof MessageFilter)) {
-			Assert.isNull(this.throwExceptionOnRejection, "Cannot set throwExceptionOnRejection if the referenced bean is "
-					+ "an AbstractReplyProducingMessageHandler, but not a MessageFilter");
+			Assert.isNull(this.throwExceptionOnRejection,
+					"Cannot set throwExceptionOnRejection if the referenced bean is "
+							+ "an AbstractReplyProducingMessageHandler, but not a MessageFilter");
 			Assert.isNull(this.discardChannel, "Cannot set discardChannel if the referenced bean is "
 					+ "an AbstractReplyProducingMessageHandler, but not a MessageFilter");
 			Assert.isNull(this.discardWithinAdvice, "Cannot set discardWithinAdvice if the referenced bean is "
@@ -137,8 +133,8 @@ public class FilterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 	protected boolean canBeUsedDirect(AbstractMessageProducingHandler handler) {
 		return handler instanceof MessageFilter
 				|| (!(handler instanceof MessageSelector)
-						&& this.discardChannel == null && this.throwExceptionOnRejection == null
-						&& this.discardWithinAdvice == null);
+				&& this.discardChannel == null && this.throwExceptionOnRejection == null
+				&& this.discardWithinAdvice == null);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Gary Russell
  * @author David Liu
+ * @author Artem Bilan
  */
 public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean {
 
@@ -46,8 +47,6 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 	private volatile MessageChannel defaultOutputChannel;
 
 	private volatile String defaultOutputChannelName;
-
-	private volatile Long sendTimeout;
 
 	private volatile Boolean resolutionRequired;
 
@@ -61,10 +60,6 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 
 	public void setDefaultOutputChannelName(String defaultOutputChannelName) {
 		this.defaultOutputChannelName = defaultOutputChannelName;
-	}
-
-	public void setSendTimeout(Long timeout) {
-		this.sendTimeout = timeout;
 	}
 
 	public void setResolutionRequired(Boolean resolutionRequired) {
@@ -124,8 +119,8 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 		if (this.defaultOutputChannelName != null) {
 			router.setDefaultOutputChannelName(this.defaultOutputChannelName);
 		}
-		if (this.sendTimeout != null) {
-			router.setSendTimeout(this.sendTimeout);
+		if (getSendTimeout() != null) {
+			router.setSendTimeout(getSendTimeout());
 		}
 		if (this.applySequence != null) {
 			router.setApplySequence(this.applySequence);
@@ -155,7 +150,7 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 
 	protected boolean noRouterAttributesProvided() {
 		return this.channelMappings == null && this.defaultOutputChannel == null
-				&& this.sendTimeout == null && this.resolutionRequired == null && this.applySequence == null
+				&& getSendTimeout() == null && this.resolutionRequired == null && this.applySequence == null
 				&& this.ignoreSendFailures == null;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ServiceActivatorFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ServiceActivatorFactoryBean.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 
 import org.springframework.expression.Expression;
 import org.springframework.integration.handler.AbstractMessageProducingHandler;
-import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
 import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.handler.ReplyProducingMessageHandlerWrapper;
@@ -40,19 +39,7 @@ import org.springframework.util.StringUtils;
  */
 public class ServiceActivatorFactoryBean extends AbstractStandardMessageHandlerFactoryBean {
 
-	private volatile Long sendTimeout;
-
-	private volatile Boolean requiresReply;
-
 	private String[] headers;
-
-	public void setSendTimeout(Long sendTimeout) {
-		this.sendTimeout = sendTimeout;
-	}
-
-	public void setRequiresReply(Boolean requiresReply) {
-		this.requiresReply = requiresReply;
-	}
 
 	public void setNotPropagatedHeaders(String... headers) {
 		this.headers = Arrays.copyOf(headers, headers.length);
@@ -127,22 +114,10 @@ public class ServiceActivatorFactoryBean extends AbstractStandardMessageHandlerF
 
 	@Override
 	protected void postProcessReplyProducer(AbstractMessageProducingHandler handler) {
-		if (this.sendTimeout != null) {
-			handler.setSendTimeout(this.sendTimeout);
-		}
+		super.postProcessReplyProducer(handler);
+
 		if (this.headers != null) {
 			handler.setNotPropagatedHeaders(this.headers);
-		}
-		if (this.requiresReply != null) {
-			if (handler instanceof AbstractReplyProducingMessageHandler) {
-				((AbstractReplyProducingMessageHandler) handler).setRequiresReply(this.requiresReply);
-			}
-			else {
-				if (this.requiresReply && logger.isDebugEnabled()) {
-					logger.debug("requires-reply can only be set to AbstractReplyProducingMessageHandler or its subclass, "
-							+ handler.getComponentName() + " doesn't support it.");
-				}
-			}
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ServiceActivatorFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ServiceActivatorFactoryBean.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.config;
 
+import java.util.Arrays;
+
 import org.springframework.expression.Expression;
 import org.springframework.integration.handler.AbstractMessageProducingHandler;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
@@ -42,12 +44,18 @@ public class ServiceActivatorFactoryBean extends AbstractStandardMessageHandlerF
 
 	private volatile Boolean requiresReply;
 
+	private String[] headers;
+
 	public void setSendTimeout(Long sendTimeout) {
 		this.sendTimeout = sendTimeout;
 	}
 
 	public void setRequiresReply(Boolean requiresReply) {
 		this.requiresReply = requiresReply;
+	}
+
+	public void setNotPropagatedHeaders(String... headers) {
+		this.headers = Arrays.copyOf(headers, headers.length);
 	}
 
 	@Override
@@ -121,6 +129,9 @@ public class ServiceActivatorFactoryBean extends AbstractStandardMessageHandlerF
 	protected void postProcessReplyProducer(AbstractMessageProducingHandler handler) {
 		if (this.sendTimeout != null) {
 			handler.setSendTimeout(this.sendTimeout);
+		}
+		if (this.headers != null) {
+			handler.setNotPropagatedHeaders(this.headers);
 		}
 		if (this.requiresReply != null) {
 			if (handler instanceof AbstractReplyProducingMessageHandler) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/SplitterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/SplitterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.springframework.integration.config;
 
 import org.springframework.expression.Expression;
 import org.springframework.integration.handler.AbstractMessageProducingHandler;
-import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.splitter.AbstractMessageSplitter;
 import org.springframework.integration.splitter.DefaultMessageSplitter;
 import org.springframework.integration.splitter.ExpressionEvaluatingSplitter;
@@ -34,29 +33,13 @@ import org.springframework.util.StringUtils;
  * @author Iwein Fuld
  * @author Gary Russell
  * @author David Liu
+ * @author Artem Bilan
  */
 public class SplitterFactoryBean extends AbstractStandardMessageHandlerFactoryBean {
-
-	private volatile Long sendTimeout;
-
-	private volatile Boolean requiresReply;
 
 	private volatile Boolean applySequence;
 
 	private volatile String delimiters;
-
-
-	public void setSendTimeout(Long sendTimeout) {
-		this.sendTimeout = sendTimeout;
-	}
-
-	public boolean isRequiresReply() {
-		return this.requiresReply;
-	}
-
-	public void setRequiresReply(boolean requiresReply) {
-		this.requiresReply = requiresReply;
-	}
 
 	public void setApplySequence(boolean applySequence) {
 		this.applySequence = applySequence;
@@ -116,18 +99,8 @@ public class SplitterFactoryBean extends AbstractStandardMessageHandlerFactoryBe
 
 	@Override
 	protected void postProcessReplyProducer(AbstractMessageProducingHandler handler) {
-		if (this.sendTimeout != null) {
-			handler.setSendTimeout(this.sendTimeout);
-		}
-		if (this.requiresReply != null) {
-			if (handler instanceof AbstractReplyProducingMessageHandler) {
-				((AbstractReplyProducingMessageHandler) handler).setRequiresReply(this.requiresReply);
-			}
-			else if (this.requiresReply && logger.isDebugEnabled()) {
-				logger.debug("requires-reply can only be set to AbstractReplyProducingMessageHandler or its subclass, "
-						+ handler.getComponentName() + " doesn't support it.");
-			}
-		}
+		super.postProcessReplyProducer(handler);
+
 		if (!(handler instanceof AbstractMessageSplitter)) {
 			Assert.isNull(this.applySequence, "Cannot set applySequence if the referenced bean is "
 					+ "an AbstractReplyProducingMessageHandler, but not an AbstractMessageSplitter");

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/TransformerFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/TransformerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,13 +32,12 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Gary Russell
  * @author David Liu
+ * @author Artem Bilan
  */
 public class TransformerFactoryBean extends AbstractStandardMessageHandlerFactoryBean {
 
-	private volatile Long sendTimeout;
-
-	public void setSendTimeout(Long sendTimeout) {
-		this.sendTimeout = sendTimeout;
+	public TransformerFactoryBean() {
+		setRequiresReply(true);
 	}
 
 	@Override
@@ -72,13 +71,6 @@ public class TransformerFactoryBean extends AbstractStandardMessageHandlerFactor
 		MessageTransformingHandler handler = new MessageTransformingHandler(transformer);
 		this.postProcessReplyProducer(handler);
 		return handler;
-	}
-
-	@Override
-	protected void postProcessReplyProducer(AbstractMessageProducingHandler handler) {
-		if (this.sendTimeout != null) {
-			handler.setSendTimeout(this.sendTimeout);
-		}
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ServiceActivatorParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ServiceActivatorParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.integration.config.ServiceActivatorFactoryBean;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artme Bilan
  */
 public class ServiceActivatorParser extends AbstractDelegatingConsumerEndpointParser {
 
@@ -44,6 +45,7 @@ public class ServiceActivatorParser extends AbstractDelegatingConsumerEndpointPa
 	@Override
 	void postProcess(BeanDefinitionBuilder builder, Element element, ParserContext parserContext) {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "async");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "not-propagated-headers");
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
@@ -249,6 +249,25 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 		return _this();
 	}
 
+	/**
+	 * Set header patterns ("xxx*", "*xxx", "*xxx*" or "xxx*yyy")
+	 * that will NOT be copied from the inbound message.
+	 * '*' means do not copy headers at all.
+	 * @param headerPatterns the headers to not propagate from the inbound message.
+	 * @return the endpoint spec.
+	 * @see AbstractMessageProducingHandler#setNotPropagatedHeaders(String...)
+	 */
+	public S notPropagatedHeaders(String... headerPatterns) {
+		assertHandler();
+		if (this.handler instanceof AbstractMessageProducingHandler) {
+			((AbstractMessageProducingHandler) this.handler).setNotPropagatedHeaders(headerPatterns);
+		}
+		else {
+			logger.warn("'async' can be applied only for AbstractMessageProducingHandler");
+		}
+		return _this();
+	}
+
 	@Override
 	protected Tuple2<ConsumerEndpointFactoryBean, H> doGet() {
 		this.endpointFactoryBean.setHandler(this.handler);

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
@@ -187,7 +187,7 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 			((AbstractReplyProducingMessageHandler) this.handler).setRequiresReply(requiresReply);
 		}
 		else {
-			logger.warn("'requiresReply' can be applied only for AbstractReplyProducingMessageHandler");
+			this.logger.warn("'requiresReply' can be applied only for AbstractReplyProducingMessageHandler");
 		}
 		return _this();
 	}
@@ -207,7 +207,7 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 			((AbstractMessageRouter) this.handler).setSendTimeout(sendTimeout);
 		}
 		else {
-			logger.warn("'sendTimeout' can be applied only for AbstractMessageProducingHandler");
+			this.logger.warn("'sendTimeout' can be applied only for AbstractMessageProducingHandler");
 		}
 		return _this();
 	}
@@ -223,7 +223,7 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 			((AbstractMessageHandler) this.handler).setOrder(order);
 		}
 		else {
-			logger.warn("'order' can be applied only for AbstractMessageHandler");
+			this.logger.warn("'order' can be applied only for AbstractMessageHandler");
 		}
 		return _this();
 	}
@@ -244,7 +244,7 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 			((AbstractMessageProducingHandler) this.handler).setAsync(async);
 		}
 		else {
-			logger.warn("'async' can be applied only for AbstractMessageProducingHandler");
+			this.logger.warn("'async' can be applied only for AbstractMessageProducingHandler");
 		}
 		return _this();
 	}
@@ -252,7 +252,7 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 	/**
 	 * Set header patterns ("xxx*", "*xxx", "*xxx*" or "xxx*yyy")
 	 * that will NOT be copied from the inbound message.
-	 * '*' means do not copy headers at all.
+	 * At least one pattern as "*" means do not copy headers at all.
 	 * @param headerPatterns the headers to not propagate from the inbound message.
 	 * @return the endpoint spec.
 	 * @see AbstractMessageProducingHandler#setNotPropagatedHeaders(String...)
@@ -263,7 +263,7 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 			((AbstractMessageProducingHandler) this.handler).setNotPropagatedHeaders(headerPatterns);
 		}
 		else {
-			logger.warn("'async' can be applied only for AbstractMessageProducingHandler");
+			this.logger.warn("'headerPatterns' can be applied only for AbstractMessageProducingHandler");
 		}
 		return _this();
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -43,6 +43,7 @@ import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.PatternMatchUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
@@ -64,17 +65,19 @@ import reactor.core.publisher.Mono;
 public abstract class AbstractMessageProducingHandler extends AbstractMessageHandler
 		implements MessageProducer, HeaderPropagationAware {
 
-	private final Set<String> notPropagatedHeaders = new HashSet<String>();
+	private final Set<String> notPropagatedHeaders = new HashSet<>();
 
 	protected final MessagingTemplate messagingTemplate = new MessagingTemplate();
 
-	private volatile MessageChannel outputChannel;
-
-	private volatile String outputChannelName;
-
-	private volatile boolean async;
+	private boolean async;
 
 	private boolean selectiveHeaderPropagation;
+
+	private boolean shouldCopyRequestHeaders = true;
+
+	private String outputChannelName;
+
+	private volatile MessageChannel outputChannel;
 
 	/**
 	 * Set the timeout for sending reply Messages.
@@ -115,10 +118,13 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	}
 
 	/**
-	 * Set headers that will NOT be copied from the inbound message if
+	 * Set header patterns ("xxx*", "*xxx", "*xxx*" or "xxx*yyy")
+	 * that will NOT be copied from the inbound message if
 	 * {@link #shouldCopyRequestHeaders() shouldCopyRequestHeaaders} is true.
+	 * '*' means do not copy headers at all.
 	 * @param headers the headers to not propagate from the inbound message.
 	 * @since 4.3.10
+	 * @see org.springframework.util.PatternMatchUtils
 	 */
 	@Override
 	public void setNotPropagatedHeaders(String... headers) {
@@ -134,14 +140,17 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 			this.notPropagatedHeaders.addAll(Arrays.asList(headers));
 		}
 		this.selectiveHeaderPropagation = this.notPropagatedHeaders.size() > 0;
+
+		this.shouldCopyRequestHeaders = !this.notPropagatedHeaders.contains("*");
 	}
 
 	/**
-	 * Get the header names this handler doesn't propagate.
+	 * Get the header patterns this handler doesn't propagate.
 	 * @return an immutable {@link java.util.Collection} of headers that will not be
 	 * copied from the inbound message if {@link #shouldCopyRequestHeaders()} is true.
 	 * @since 4.3.10
 	 * @see #setNotPropagatedHeaders(String...)
+	 * @see org.springframework.util.PatternMatchUtils
 	 */
 	@Override
 	public Collection<String> getNotPropagatedHeaders() {
@@ -149,7 +158,8 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	}
 
 	/**
-	 * Add headers that will NOT be copied from the inbound message if
+	 * Add header patterns ("xxx*", "*xxx", "*xxx*" or "xxx*yyy")
+	 * that will NOT be copied from the inbound message if
 	 * {@link #shouldCopyRequestHeaders()} is true, instead of overwriting the existing
 	 * set.
 	 * @param headers the headers to not propagate from the inbound message.
@@ -344,7 +354,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	protected Message<?> createOutputMessage(Object output, MessageHeaders requestHeaders) {
 		AbstractIntegrationMessageBuilder<?> builder = null;
 		if (output instanceof Message<?>) {
-			if (!this.shouldCopyRequestHeaders()) {
+			if (!shouldCopyRequestHeaders()) {
 				return (Message<?>) output;
 			}
 			builder = this.getMessageBuilderFactory().fromMessage((Message<?>) output);
@@ -355,12 +365,15 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 		else {
 			builder = this.getMessageBuilderFactory().withPayload(output);
 		}
-		if (this.shouldCopyRequestHeaders()) {
+		if (shouldCopyRequestHeaders()) {
 			if (this.selectiveHeaderPropagation) {
-				Map<String, Object> headersToCopy = new HashMap<String, Object>(requestHeaders);
-				for (String header : this.notPropagatedHeaders) {
-					headersToCopy.remove(header);
-				}
+				String[] patterns = this.notPropagatedHeaders.toArray(new String[this.notPropagatedHeaders.size()]);
+
+				Map<String, Object> headersToCopy = new HashMap<>(requestHeaders);
+
+				headersToCopy.entrySet()
+						.removeIf(entry -> PatternMatchUtils.simpleMatch(patterns, entry.getKey()));
+
 				builder.copyHeadersIfAbsent(headersToCopy);
 			}
 			else {
@@ -414,7 +427,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	 * @return true if the request headers should be copied.
 	 */
 	protected boolean shouldCopyRequestHeaders() {
-		return true;
+		return this.shouldCopyRequestHeaders;
 	}
 
 	protected void sendErrorMessage(final Message<?> requestMessage, Throwable ex) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -75,6 +75,8 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 
 	private String[] notPropagatedHeaders;
 
+	private boolean selectiveHeaderPropagation;
+
 	private boolean noHeadersPropagation;
 
 	/**
@@ -148,6 +150,8 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 			this.notPropagatedHeaders = new String[] { "*" };
 			this.noHeadersPropagation = true;
 		}
+
+		this.selectiveHeaderPropagation = this.notPropagatedHeaders.length > 0;
 	}
 
 	/**
@@ -372,7 +376,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 			builder = this.getMessageBuilderFactory().withPayload(output);
 		}
 		if (!this.noHeadersPropagation && shouldCopyRequestHeaders()) {
-			if (this.notPropagatedHeaders.length > 0) {
+			if (this.selectiveHeaderPropagation) {
 				Map<String, Object> headersToCopy = new HashMap<>(requestHeaders);
 
 				headersToCopy.entrySet()

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -142,6 +142,8 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 			Assert.noNullElements(headers, "null elements are not allowed in 'headers'");
 
 			headerPatterns.addAll(Arrays.asList(headers));
+
+			this.notPropagatedHeaders = headerPatterns.toArray(new String[headerPatterns.size()]);
 		}
 
 		boolean hasAsterisk = headerPatterns.contains("*");
@@ -164,7 +166,9 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	 */
 	@Override
 	public Collection<String> getNotPropagatedHeaders() {
-		return Collections.unmodifiableList(Arrays.asList(this.notPropagatedHeaders));
+		return this.notPropagatedHeaders != null
+				? Collections.unmodifiableSet(new HashSet<>(Arrays.asList(this.notPropagatedHeaders)))
+				: Collections.emptyList();
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -121,7 +121,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	 * Set header patterns ("xxx*", "*xxx", "*xxx*" or "xxx*yyy")
 	 * that will NOT be copied from the inbound message if
 	 * {@link #shouldCopyRequestHeaders() shouldCopyRequestHeaaders} is true.
-	 * '*' means do not copy headers at all.
+	 * At least one pattern as "*" means do not copy headers at all.
 	 * @param headers the headers to not propagate from the inbound message.
 	 * @since 4.3.10
 	 * @see org.springframework.util.PatternMatchUtils
@@ -139,9 +139,16 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 			}
 			this.notPropagatedHeaders.addAll(Arrays.asList(headers));
 		}
+		boolean hasAsterisk = this.notPropagatedHeaders.contains("*");
+
+		if (hasAsterisk) {
+			this.notPropagatedHeaders.clear();
+			this.notPropagatedHeaders.add("*");
+		}
+
 		this.selectiveHeaderPropagation = this.notPropagatedHeaders.size() > 0;
 
-		this.shouldCopyRequestHeaders = !this.notPropagatedHeaders.contains("*");
+		this.shouldCopyRequestHeaders = !hasAsterisk;
 	}
 
 	/**

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration-5.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration-5.0.xsd
@@ -1212,15 +1212,6 @@
 	<xsd:complexType name="serviceActivatorType">
 		<xsd:complexContent>
 			<xsd:extension base="expressionOrInnerEndpointDefinitionAware">
-				<xsd:attribute name="requires-reply">
-					<xsd:annotation>
-						<xsd:documentation>
-							Specify whether the service method must return a non-null value. This value will be
-							'false' by default, but if set to 'true', a ReplyRequiredException will be thrown when
-							the underlying service method (or expression) returns a null value.
-						</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
 				<xsd:attribute name="async">
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
@@ -3626,15 +3617,6 @@
 	<xsd:complexType name="splitter-type">
 		<xsd:complexContent>
 			<xsd:extension base="expressionOrInnerEndpointDefinitionAware">
-				<xsd:attribute name="requires-reply" type="xsd:string" use="optional">
-					<xsd:annotation>
-						<xsd:documentation>
-							Specify whether the service method must return a non-null value. This value will be
-							'false' by default, but if set to 'true', a ReplyRequiredException will be thrown when
-							the underlying service method (or expression) returns a null value.
-						</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
 				<xsd:attribute name="apply-sequence" type="xsd:string" use="optional">
 					<xsd:annotation>
 						<xsd:documentation>
@@ -4198,6 +4180,20 @@
 							A SpEL expression to be evaluated against the input Message as its root object.
 						</xsd:documentation>
 					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="requires-reply">
+					<xsd:annotation>
+						<xsd:documentation>
+							If set to 'true', a reply must return a non-null value.
+							By setting 'requires-reply' to 'true', a 'ReplyRequiredException'
+							will be raised for null reply messages. If 'requires-reply' is set
+							to false, those messages are silently dropped.
+							This attribute defaults to 'true' for 'transformer'.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:simpleType>
+						<xsd:union memberTypes="xsd:boolean xsd:string" />
+					</xsd:simpleType>
 				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration-5.0.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration-5.0.xsd
@@ -1212,7 +1212,7 @@
 	<xsd:complexType name="serviceActivatorType">
 		<xsd:complexContent>
 			<xsd:extension base="expressionOrInnerEndpointDefinitionAware">
-				<xsd:attribute name="requires-reply" type="xsd:string" use="optional">
+				<xsd:attribute name="requires-reply">
 					<xsd:annotation>
 						<xsd:documentation>
 							Specify whether the service method must return a non-null value. This value will be
@@ -1221,7 +1221,7 @@
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
-				<xsd:attribute name="async" type="xsd:string" use="optional">
+				<xsd:attribute name="async">
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
 							If the service method returns a ListenableFuture<?> and this flag is 'true', the calling
@@ -1229,6 +1229,15 @@
 							the future. If 'false' (default), the future will be sent as the payload of the result
 							message. This has no effect with any other type of return.
 						]]></xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+				<xsd:attribute name="not-propagated-headers">
+					<xsd:annotation>
+						<xsd:documentation>
+							Header patterns ("xxx*", "*xxx", "*xxx*" or "xxx*yyy")
+							that will NOT be copied from the inbound message.
+							'*' means do not copy headers at all.
+						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandlerTests.java
@@ -46,6 +46,7 @@ import org.springframework.messaging.support.GenericMessage;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Marius Bogoevici
+ * @author Artem Bilan
  */
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractReplyProducingMessageHandlerTests {
@@ -80,19 +81,20 @@ public class AbstractReplyProducingMessageHandlerTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testNotPropagate() {
 		AbstractReplyProducingMessageHandler handler = new AbstractReplyProducingMessageHandler() {
 
 			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
-				return new GenericMessage<String>("world", Collections.singletonMap("bar", "RAB"));
+				return new GenericMessage<>("world", Collections.singletonMap("bar", "RAB"));
 			}
 
 		};
 		assertThat(handler.getNotPropagatedHeaders(), emptyCollectionOf(String.class));
-		handler.setNotPropagatedHeaders("foo", "bar");
+		handler.setNotPropagatedHeaders("f*", "*r");
 		handler.setOutputChannel(this.channel);
-		assertThat(handler.getNotPropagatedHeaders(), containsInAnyOrder("foo", "bar"));
+		assertThat(handler.getNotPropagatedHeaders(), containsInAnyOrder("f*", "*r"));
 		ArgumentCaptor<Message<?>> captor = ArgumentCaptor.forClass(Message.class);
 		willReturn(true).given(this.channel).send(captor.capture());
 		handler.handleMessage(MessageBuilder.withPayload("hello")
@@ -120,9 +122,9 @@ public class AbstractReplyProducingMessageHandlerTests {
 		};
 		assertThat(handler.getNotPropagatedHeaders(), emptyCollectionOf(String.class));
 		handler.setNotPropagatedHeaders("foo");
-		handler.addNotPropagatedHeaders("bar");
+		handler.addNotPropagatedHeaders("b*r");
 		handler.setOutputChannel(this.channel);
-		assertThat(handler.getNotPropagatedHeaders(), containsInAnyOrder("foo", "bar"));
+		assertThat(handler.getNotPropagatedHeaders(), containsInAnyOrder("foo", "b*r"));
 		ArgumentCaptor<Message<?>> captor =
 				(ArgumentCaptor<Message<?>>) (ArgumentCaptor<?>) ArgumentCaptor.forClass(Message.class);
 		willReturn(true).given(this.channel).send(captor.capture());

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/ServiceActivatorDefaultFrameworkMethodTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/ServiceActivatorDefaultFrameworkMethodTests-context.xml
@@ -38,7 +38,10 @@
 			class="org.springframework.integration.handler.ServiceActivatorDefaultFrameworkMethodTests$TestMessageHandler"/>
 	</service-activator>
 
-	<service-activator id="processorTestService" input-channel="processorTestInputChannel" ref="testMessageProcessor"/>
+	<service-activator id="processorTestService"
+					   input-channel="processorTestInputChannel"
+					   ref="testMessageProcessor"
+					   not-propagated-headers="*"/>
 
 	<gateway id="gateway" default-request-channel="requestChannel" default-reply-channel="replyChannel"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/ServiceActivatorDefaultFrameworkMethodTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/ServiceActivatorDefaultFrameworkMethodTests.java
@@ -19,6 +19,7 @@ package org.springframework.integration.handler;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -27,6 +28,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.springframework.integration.test.matcher.HeaderMatcher.hasHeaderKey;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -189,18 +191,20 @@ public class ServiceActivatorDefaultFrameworkMethodTests {
 		this.handlerTestInputChannel.send(message);
 	}
 
-	//	INT-2399
 	@Test
 	public void testMessageProcessor() {
 		Object processor = TestUtils.getPropertyValue(processorTestService, "handler.processor");
 		assertSame(testMessageProcessor, processor);
 
 		QueueChannel replyChannel = new QueueChannel();
-		Message<?> message = MessageBuilder.withPayload("bar").setReplyChannel(replyChannel).build();
+		Message<?> message = MessageBuilder.withPayload("bar")
+				.setReplyChannel(replyChannel)
+				.setHeader("foo", "foo")
+				.build();
 		this.processorTestInputChannel.send(message);
 		Message<?> reply = replyChannel.receive(0);
 		assertEquals("foo:bar", reply.getPayload());
-		assertEquals("processorTestInputChannel,processorTestService", reply.getHeaders().get("history").toString());
+		assertThat(reply, not(hasHeaderKey("foo")));
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/TransformerContextTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/TransformerContextTests-context.xml
@@ -25,7 +25,8 @@
 		<beans:bean class="org.springframework.integration.transformer.TransformerContextTests$Bar"/>
 	</transformer>
 
-	<transformer input-channel="directRef" output-channel="output" ref="trans" method="handleMessage"/>
+	<transformer input-channel="directRef" output-channel="output" ref="trans" method="handleMessage"
+				 requires-reply="false"/>
 
 	<beans:bean id="trans" class="org.springframework.integration.transformer.TransformerContextTests$Bar"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/TransformerContextTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/TransformerContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.transformer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -90,6 +91,9 @@ public class TransformerContextTests {
 		assertFalse(this.testBean.isRunning());
 		this.pojoTransformer.start();
 		assertTrue(this.testBean.isRunning());
+
+		this.directRef.send(new GenericMessage<String>("bar"));
+		assertNull(this.output.receive(0));
 	}
 
 	public static class FooAdvice extends AbstractRequestHandlerAdvice {
@@ -106,6 +110,9 @@ public class TransformerContextTests {
 
 		@Override
 		protected Object handleRequestMessage(Message<?> requestMessage) {
+			if ("bar".equals(requestMessage.getPayload())) {
+				return null;
+			}
 			Exception e = new RuntimeException();
 			StackTraceElement[] st = e.getStackTrace();
 			return MessageBuilder.withPayload(requestMessage.getPayload().toString().toUpperCase())

--- a/src/reference/asciidoc/message.adoc
+++ b/src/reference/asciidoc/message.adoc
@@ -399,7 +399,7 @@ You can also globally suppress propagation of specific message headers by settin
 
 Starting with _version 5.0_, the `setNotPropagatedHeaders()` implementation on the `AbstractMessageProducingHandler` applies the simple patterns (`xxx*`, `*xxx`, `*xxx*` or `xxx*yyy`) to allow to filter header with common suffix or prefix.
 See `PatternMatchUtils` JavaDocs for more information.
-When `*` (asterisk) is used, no any headers are propagated.
+When one of the patterns is `*` (asterisk), no headers are propagated; all other patterns are ignored.
 In this case the Service Activator behaves the same way as Transformer and any required headers must be supplied in the `Message` returned from the service method.
 The option `notPropagatedHeaders()` is available in the `ConsumerEndpointSpec` for Java DSL, as well as for XML configuration of the `<service-activator>` component as a `not-propagated-headers` attribute.
 

--- a/src/reference/asciidoc/message.adoc
+++ b/src/reference/asciidoc/message.adoc
@@ -394,9 +394,16 @@ Also, a header is only propagated if it does not already exist in the outbound m
 
 Starting with _version 4.3.10_, you can configure message handlers (that modify messages and produce output) to suppress the propagation of specific headers.
 Call the `setNotPropagatedHeaders()` or `addNotPropagatedHeaders()` methods on the `MessageProducingMessageHandler` abstract class, to configure the header(s) you don't want to be copied.
+
 You can also globally suppress propagation of specific message headers by setting the `readOnlyHeaders` property in `META-INF/spring.integration.properties` to a comma-delimited list of headers.
 
-IMPORTANT: Header propagation suppression does not apply to those endpoints that don't modify the message, e.g. <<bridge, bridges>> and <<router, routers>>
+Starting with _version 5.0_, the `setNotPropagatedHeaders()` implementation on the `AbstractMessageProducingHandler` applies the simple patterns (`xxx*`, `*xxx`, `*xxx*` or `xxx*yyy`) to allow to filter header with common suffix or prefix.
+See `PatternMatchUtils` JavaDocs for more information.
+When `*` (asterisk) is used, no any headers are propagated.
+In this case the Service Activator behaves the same way as Transformer and any required headers must be supplied in the `Message` returned from the service method.
+The option `notPropagatedHeaders()` is available in the `ConsumerEndpointSpec` for Java DSL, as well as for XML configuration of the `<service-activator>` component as a `not-propagated-headers` attribute.
+
+IMPORTANT: Header propagation suppression does not apply to those endpoints that don't modify the message, e.g. <<bridge, bridges>> and <<router, routers>>.
 
 
 [[message-implementations]]

--- a/src/reference/asciidoc/message.adoc
+++ b/src/reference/asciidoc/message.adoc
@@ -397,7 +397,7 @@ Call the `setNotPropagatedHeaders()` or `addNotPropagatedHeaders()` methods on t
 
 You can also globally suppress propagation of specific message headers by setting the `readOnlyHeaders` property in `META-INF/spring.integration.properties` to a comma-delimited list of headers.
 
-Starting with _version 5.0_, the `setNotPropagatedHeaders()` implementation on the `AbstractMessageProducingHandler` applies the simple patterns (`xxx*`, `*xxx`, `*xxx*` or `xxx*yyy`) to allow to filter header with common suffix or prefix.
+Starting with _version 5.0_, the `setNotPropagatedHeaders()` implementation on the `AbstractMessageProducingHandler` applies the simple patterns (`xxx*`, `*xxx`, `*xxx*` or `xxx*yyy`) to allow filtering headers with a common suffix or prefix.
 See `PatternMatchUtils` JavaDocs for more information.
 When one of the patterns is `*` (asterisk), no headers are propagated; all other patterns are ignored.
 In this case the Service Activator behaves the same way as Transformer and any required headers must be supplied in the `Message` returned from the service method.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4365

It is much useful to configure the `notPropagatedHeaders` as a set of
patterns to match.
In this case we can filter a group of headers with the common prefix or
suffix

* Allow to configure `AbstractMessageProducingHandler.setNotPropagatedHeaders`
as simple patterns; the `*` means filter all - not copy request headers
at all - similar to `transformer` behavior
* Add `ConsumerEndpointSpec.notPropagatedHeaders()` for Java DSL
* Add `not-propagated-headers` to the `<service-activator>`