### PR TITLE
Revert to Spring Social Twitter 1.1.2.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ subprojects { subproject ->
 		springDataRedisVersion = '2.0.0.RELEASE'
 		springGemfireVersion = '2.0.0.RELEASE'
 		springSecurityVersion = '5.0.0.RC1'
-		springSocialTwitterVersion = '2.0.0.M4'
+		springSocialTwitterVersion = '1.1.2.RELEASE'
 		springRetryVersion = '1.2.1.RELEASE'
 		springVersion = project.hasProperty('springVersion') ? project.springVersion : '5.0.2.BUILD-SNAPSHOT'
 		springWsVersion = '3.0.0.RELEASE'

--- a/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/inbound/AbstractTwitterMessageSource.java
+++ b/spring-integration-twitter/src/main/java/org/springframework/integration/twitter/inbound/AbstractTwitterMessageSource.java
@@ -203,7 +203,7 @@ abstract class AbstractTwitterMessageSource<T> extends IntegrationObjectSupport 
 
 	private long getIdForTweet(T twitterMessage) {
 		if (twitterMessage instanceof Tweet) {
-			return Long.parseLong(((Tweet) twitterMessage).getId());
+			return ((Tweet) twitterMessage).getId();
 		}
 		else if (twitterMessage instanceof DirectMessage) {
 			return ((DirectMessage) twitterMessage).getId();

--- a/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceWithRedisTests.java
+++ b/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/inbound/SearchReceivingMessageSourceWithRedisTests.java
@@ -138,12 +138,12 @@ public class SearchReceivingMessageSourceWithRedisTests extends RedisAvailableTe
 		receive = this.tweets.receive(10000);
 		assertNotNull(receive);
 		assertThat(receive.getPayload(), instanceOf(Tweet.class));
-		assertEquals(((Tweet) receive.getPayload()).getId(), "2");
+		assertEquals(((Tweet) receive.getPayload()).getId(), 2L);
 
 		receive = this.tweets.receive(10000);
 		assertNotNull(receive);
 		assertThat(receive.getPayload(), instanceOf(Tweet.class));
-		assertEquals(((Tweet) receive.getPayload()).getId(), "3");
+		assertEquals(((Tweet) receive.getPayload()).getId(), 3L);
 
 		assertNull(this.tweets.receive(0));
 
@@ -162,17 +162,17 @@ public class SearchReceivingMessageSourceWithRedisTests extends RedisAvailableTe
 			SearchOperations so = mock(SearchOperations.class);
 
 			Tweet tweet3 = mock(Tweet.class);
-			given(tweet3.getId()).willReturn("3");
+			given(tweet3.getId()).willReturn(3L);
 			given(tweet3.getCreatedAt()).willReturn(new GregorianCalendar(2013, 2, 20).getTime());
 			given(tweet3.toString()).will(invocation -> "Mock for Tweet: " + tweet3.getId());
 
 			Tweet tweet1 = mock(Tweet.class);
-			given(tweet1.getId()).willReturn("1");
+			given(tweet1.getId()).willReturn(1L);
 			given(tweet1.getCreatedAt()).willReturn(new GregorianCalendar(2013, 0, 20).getTime());
 			given(tweet1.toString()).will(invocation -> "Mock for Tweet: " + tweet1.getId());
 
 			final Tweet tweet2 = mock(Tweet.class);
-			given(tweet2.getId()).willReturn("2");
+			given(tweet2.getId()).willReturn(2L);
 			given(tweet2.getCreatedAt()).willReturn(new GregorianCalendar(2013, 1, 20).getTime());
 			given(tweet2.toString()).will(invocation -> "Mock for Tweet: " + tweet2.getId());
 

--- a/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/outbound/StatusUpdatingMessageHandlerTests.java
+++ b/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/outbound/StatusUpdatingMessageHandlerTests.java
@@ -90,7 +90,7 @@ public class StatusUpdatingMessageHandlerTests {
 		this.in1.send(new GenericMessage<String>("foo"));
 
 		Mockito.verify(timelineOperations).updateStatus(argument.capture());
-		assertEquals("foo", argument.getValue().toTweetParameters().getFirst("status"));
+		assertEquals("foo", argument.getValue().toRequestParameters().getFirst("status"));
 
 		Mockito.reset(timelineOperations);
 
@@ -101,7 +101,7 @@ public class StatusUpdatingMessageHandlerTests {
 
 		Mockito.verify(timelineOperations).updateStatus(argument.capture());
 		TweetData tweetData = argument.getValue();
-		MultiValueMap<String, Object> requestParameters = tweetData.toTweetParameters();
+		MultiValueMap<String, Object> requestParameters = tweetData.toRequestParameters();
 		assertEquals("bar", requestParameters.getFirst("status"));
 		assertNull(requestParameters.getFirst("media"));
 		MultiValueMap<String, Object> uploadMediaParameters = tweetData.toUploadMediaParameters();


### PR DESCRIPTION
Reverts Spring Integration to build against Spring Social Twitter 1.1.2.RELEASE, as Spring Social Twitter 2.0.0 may not be ready in time for Spring Integration 5.0.0