### PR TITLE
INT-4367: Fix MessagingMethodInvHelper for CGLIB

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
@@ -702,7 +702,8 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 			}
 			HandlerMethod handlerMethod1;
 			try {
-				method1 = org.springframework.util.ClassUtils.getMostSpecificMethod(method1, targetObject.getClass());
+				method1 = AopUtils.selectInvocableMethod(method1,
+						org.springframework.util.ClassUtils.getUserClass(targetObject));
 				InvocableHandlerMethod invocableHandlerMethod =
 						this.messageHandlerMethodFactory.createInvocableHandlerMethod(targetObject, method1);
 				handlerMethod1 = new HandlerMethod(invocableHandlerMethod, this.canProcessMessageList);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4367

When CGLIB proxy is used for messaging POJO invocation,
the `InvocableHandlerMethod` doesn't recognize method parameter
annotations and therefore the logic is wrong at runtime or just
rejected during method processing

* Use `AopUtils.selectInvocableMethod()` to select the proper method to
call according the provided proxy type