### PR TITLE
GH-2300: Add Flux support in WebFluxRequestExecMH

### DIFF
--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParser.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParser.java
@@ -21,6 +21,7 @@ import org.w3c.dom.Element;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.http.config.HttpOutboundGatewayParser;
 import org.springframework.integration.webflux.outbound.WebFluxRequestExecutingMessageHandler;
 import org.springframework.util.StringUtils;
@@ -46,6 +47,7 @@ public class WebFluxOutboundGatewayParser extends HttpOutboundGatewayParser {
 					.addIndexedArgumentValue(1, new RuntimeBeanReference(webClientRef));
 		}
 
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-to-flux");
 		return builder;
 	}
 

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/outbound/WebFluxRequestExecutingMessageHandler.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/outbound/WebFluxRequestExecutingMessageHandler.java
@@ -29,6 +29,7 @@ import org.springframework.expression.common.LiteralExpression;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ReactiveHttpInputMessage;
 import org.springframework.http.ResponseEntity;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.http.outbound.AbstractHttpRequestExecutingMessageHandler;
@@ -36,12 +37,14 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.util.Assert;
 import org.springframework.util.MimeType;
+import org.springframework.web.reactive.function.BodyExtractor;
 import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -58,6 +61,8 @@ import reactor.core.publisher.Mono;
 public class WebFluxRequestExecutingMessageHandler extends AbstractHttpRequestExecutingMessageHandler {
 
 	private final WebClient webClient;
+
+	private boolean replyToFlux;
 
 	/**
 	 * Create a handler that will send requests to the provided URI.
@@ -108,6 +113,20 @@ public class WebFluxRequestExecutingMessageHandler extends AbstractHttpRequestEx
 		super(uriExpression);
 		this.webClient = (webClient == null ? WebClient.create() : webClient);
 		this.setAsync(true);
+	}
+
+	/**
+	 * The boolean flag t identify if the reply payload should be as a {@link Flux} from the response body
+	 * or as resolved value from the {@link Mono} of the response body.
+	 * Defaults to {@code false} - simple value is pushed downstream.
+	 * Makes sense when {@code expectedResponseType} is configured.
+	 * @param replyToFlux represent reply payload as a {@link Flux} or as a value from the {@link Mono}.
+	 * @since 5.0.1
+	 * @see #setExpectedResponseType(Class)
+	 * @see #setExpectedResponseTypeExpression(Expression)
+	 */
+	public void setReplyToFlux(boolean replyToFlux) {
+		this.replyToFlux = replyToFlux;
 	}
 
 	@Override
@@ -169,13 +188,35 @@ public class WebFluxRequestExecutingMessageHandler extends AbstractHttpRequestEx
 										ResponseEntity.status(response.statusCode())
 												.headers(response.headers().asHttpHeaders());
 
-								Mono<?> bodyMono = Mono.empty();
+								Mono<?> bodyMono;
 
-								if (expectedResponseType instanceof ParameterizedTypeReference<?>) {
-									bodyMono = response.body(BodyExtractors.toMono((ParameterizedTypeReference<?>) expectedResponseType));
+								if (expectedResponseType != null) {
+									if (this.replyToFlux) {
+										BodyExtractor<? extends Flux<?>, ReactiveHttpInputMessage> extractor;
+										if (expectedResponseType instanceof ParameterizedTypeReference<?>) {
+											extractor = BodyExtractors.toFlux(
+													(ParameterizedTypeReference<?>) expectedResponseType);
+										}
+										else {
+											extractor = BodyExtractors.toFlux((Class<?>) expectedResponseType);
+										}
+										Flux<?> flux = response.body(extractor);
+										bodyMono = Mono.just(flux);
+									}
+									else {
+										BodyExtractor<? extends Mono<?>, ReactiveHttpInputMessage> extractor;
+										if (expectedResponseType instanceof ParameterizedTypeReference<?>) {
+											extractor = BodyExtractors.toMono(
+													(ParameterizedTypeReference<?>) expectedResponseType);
+										}
+										else {
+											extractor = BodyExtractors.toMono((Class<?>) expectedResponseType);
+										}
+										bodyMono = response.body(extractor);
+									}
 								}
-								else if (expectedResponseType != null) {
-									bodyMono = response.body(BodyExtractors.toMono((Class<?>) expectedResponseType));
+								else {
+									bodyMono = Mono.empty();
 								}
 
 								return bodyMono

--- a/spring-integration-webflux/src/main/resources/org/springframework/integration/webflux/config/spring-integration-webflux-5.0.xsd
+++ b/spring-integration-webflux/src/main/resources/org/springframework/integration/webflux/config/spring-integration-webflux-5.0.xsd
@@ -10,7 +10,7 @@
 	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
 	<xsd:import namespace="http://www.springframework.org/schema/integration"
-				schemaLocation="http://www.springframework.org/schema/integration/spring-integration-5.0.xsd" />
+				schemaLocation="http://www.springframework.org/schema/integration/spring-integration-5.0.xsd"/>
 	<xsd:import namespace="http://www.springframework.org/schema/integration/http"
 				schemaLocation="http://www.springframework.org/schema/integration/http/spring-integration-http-5.0.xsd"/>
 
@@ -82,7 +82,8 @@
 			<xsd:complexContent>
 				<xsd:extension base="int-http:gatewayType">
 					<xsd:choice minOccurs="0" maxOccurs="3">
-						<xsd:element name="uri-variable" type="int-http:uriVariableType" minOccurs="0" maxOccurs="unbounded">
+						<xsd:element name="uri-variable" type="int-http:uriVariableType" minOccurs="0"
+									 maxOccurs="unbounded">
 							<xsd:annotation>
 								<xsd:documentation>
 									Specify an expression for URI variable placeholder within 'url'.
@@ -126,7 +127,7 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
-					<xsd:attribute name="transfer-cookies" type="xsd:string" default="false">
+					<xsd:attribute name="transfer-cookies" default="false">
 						<xsd:annotation>
 							<xsd:documentation><![CDATA[
 	When set to "true", if a response contains a 'Set-Cookie' header, it will be mapped to a 'Cookie' header.
@@ -134,6 +135,9 @@
 	supplied by the server. Default is "false".
 							]]></xsd:documentation>
 						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="xsd:boolean xsd:string"/>
+						</xsd:simpleType>
 					</xsd:attribute>
 					<xsd:attribute name="reply-timeout" type="xsd:string">
 						<xsd:annotation>
@@ -172,6 +176,19 @@
 								which is used to send to send the HTTP Requests reactive manner.
 							</xsd:documentation>
 						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="reply-to-flux" default="false">
+						<xsd:annotation>
+							<xsd:documentation>
+								When set to "true", the response is converted to the Flux which is sent as a reply
+								message payload.
+								The downstream flow might have a splitter to walk through that Flux.
+								Default is "false".
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="xsd:boolean xsd:string"/>
+						</xsd:simpleType>
 					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests-context.xml
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests-context.xml
@@ -20,22 +20,23 @@
 	</si:channel>
 
 	<outbound-gateway id="reactiveMinimalConfig" url="http://localhost/test1" request-channel="requests"
-							   web-client="webClient"/>
+					  web-client="webClient"/>
 
 	<outbound-gateway id="reactiveFullConfig"
-							   url="http://localhost/test2"
-							   http-method="PUT"
-							   request-channel="requests"
-							   reply-timeout="1234"
-							   extract-request-payload="false"
-							   expected-response-type="java.lang.String"
-							   mapped-request-headers="requestHeader1, requestHeader2"
-							   mapped-response-headers="responseHeader"
-							   reply-channel="replies"
-							   charset="UTF-8"
-							   order="77"
-							   auto-startup="false"
-							   transfer-cookies="true">
+					  url="http://localhost/test2"
+					  http-method="PUT"
+					  request-channel="requests"
+					  reply-timeout="1234"
+					  extract-request-payload="false"
+					  expected-response-type="java.lang.String"
+					  mapped-request-headers="requestHeader1, requestHeader2"
+					  mapped-response-headers="responseHeader"
+					  reply-channel="replies"
+					  charset="UTF-8"
+					  order="77"
+					  auto-startup="false"
+					  transfer-cookies="true"
+					  reply-to-flux="true">
 		<uri-variable name="foo" expression="headers.bar"/>
 	</outbound-gateway>
 

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests.java
@@ -82,6 +82,7 @@ public class WebFluxOutboundGatewayParserTests {
 		assertEquals(Charset.forName("UTF-8"), handlerAccessor.getPropertyValue("charset"));
 		assertEquals(true, handlerAccessor.getPropertyValue("extractPayload"));
 		assertEquals(false, handlerAccessor.getPropertyValue("transferCookies"));
+		assertEquals(false, handlerAccessor.getPropertyValue("replyToFlux"));
 	}
 
 	@Test
@@ -123,6 +124,7 @@ public class WebFluxOutboundGatewayParserTests {
 		assertTrue(ObjectUtils.containsElement(mappedRequestHeaders, "requestHeader2"));
 		assertEquals("responseHeader", mappedResponseHeaders[0]);
 		assertEquals(true, handlerAccessor.getPropertyValue("transferCookies"));
+		assertEquals(true, handlerAccessor.getPropertyValue("replyToFlux"));
 	}
 
 }

--- a/src/reference/asciidoc/webflux.adoc
+++ b/src/reference/asciidoc/webflux.adoc
@@ -95,10 +95,13 @@ You can configure a `WebClient` instance to use:
 </bean>
 ----
 
-The `WebClient` `exchange()` operation returns a `Mono<ClientResponse>` which is mapped to the `AbstractIntegrationMessageBuilder` reactive support (using `Mono.map()`) as the output from the `WebFluxRequestExecutingMessageHandler`.
+The `WebClient` `exchange()` operation returns a `Mono<ClientResponse>` which is mapped (using several `Mono.map()` steps) to the `AbstractIntegrationMessageBuilder` as the output from the `WebFluxRequestExecutingMessageHandler`.
 Together with the `ReactiveChannel` as an `outputChannel`, the `Mono<ClientResponse>` evaluation is deferred until a downstream subscription is made.
 Otherwise, it is treated as an `async` mode and the `Mono` response is adapted to an `SettableListenableFuture` for an asynchronous reply from the `WebFluxRequestExecutingMessageHandler`.
-
+The target payload of the output message depends on the `WebFluxRequestExecutingMessageHandler` configuration.
+The `setExpectedResponseType(Class<?>)` or `setExpectedResponseTypeExpression(Expression)` identifies the target type of the response body element conversion.
+If `replyToFlux` is set to `true`, the response body is converted to the `Flux` with provided `expectedResponseType` for each element and this `Flux` is sent as a payload downstream.
+The <<splitter,splitter>> afterwards can be used to iterate over this `Flux` in reactive manner.
 
 Also see <<http-outbound>> for more possible configuration options.
 


### PR DESCRIPTION
Fixes: spring-projects/spring-integration#2300

To allow to consume a streaming HTTP response downstream expose
`replyToFlux` option on the `WebFluxRequestExecutingMessageHandler`.
This way the body of the HTTP response can be converted now to the
`Flux` for subsequent output message.
The option is `false` by default; can be changed to `true` in the `5.1`