### PR TITLE
Fix SimpleJsonSerializer when exception on prop

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/json/SimpleJsonSerializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/SimpleJsonSerializer.java
@@ -33,6 +33,8 @@ import org.springframework.beans.BeanUtils;
  * properties accessed by getters.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
@@ -66,10 +68,19 @@ public final class SimpleJsonSerializer {
 					result = readMethod.invoke(bean, emptyArgs);
 				}
 				catch (InvocationTargetException | IllegalAccessException | IllegalArgumentException e) {
-					if (logger.isDebugEnabled()) {
-						logger.debug("Failed to serialize property " + propertyName, e);
+					Throwable exception = e;
+					if (e instanceof InvocationTargetException) {
+						exception = e.getCause();
 					}
-					result = e.getMessage();
+
+					if (logger.isDebugEnabled()) {
+						logger.debug("Failed to serialize property " + propertyName, exception);
+					}
+
+					result =
+							exception.getMessage() != null
+									? exception.getMessage()
+									: exception.toString();
 				}
 				stringBuilder.append(toElement(result)).append(",");
 			}
@@ -89,7 +100,7 @@ public final class SimpleJsonSerializer {
 			return result.toString();
 		}
 		else {
-			return "\"" + result.toString() + "\"";
+			return "\"" + (result == null ? "null" : result.toString()) + "\"";
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/SimpleJsonSerializerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/SimpleJsonSerializerTests.java
@@ -26,6 +26,8 @@ import org.springframework.integration.support.json.JsonObjectMapperProvider;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
@@ -81,6 +83,10 @@ public class SimpleJsonSerializerTests {
 
 		public String fileInfo() {
 			return this.fileInfo;
+		}
+
+		public String getPermissions() {
+			throw new UnsupportedOperationException("Permissions are not supported");
 		}
 
 	}


### PR DESCRIPTION
When the target Java Bean reader throws an exception it is wrapped to
the `InvocationTargetException` which `getMessage()` returns `null`.

* Extract the `cause` when `InvocationTargetException` and check the
`message` for null anyway.
* Also check for `null` before calling `toString()` in the
`SimpleJsonSerializer.toElement()`