### PR TITLE
Add StaticMessageHeaderAccessor

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/IntegrationMessageHeaderAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/IntegrationMessageHeaderAccessor.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageHeaderAccessor;
@@ -35,7 +36,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Andy Wilkinson
  * @author Artem Bilan
- * @author Gary Russel
+ * @author Gary Russell
  *
  * @since 4.0
  *
@@ -81,10 +82,12 @@ public class IntegrationMessageHeaderAccessor extends MessageHeaderAccessor {
 		}
 	}
 
+	@Nullable
 	public Long getExpirationDate() {
 		return this.getHeader(EXPIRATION_DATE, Long.class);
 	}
 
+	@Nullable
 	public Object getCorrelationId() {
 		return this.getHeader(CORRELATION_ID);
 	}
@@ -99,6 +102,7 @@ public class IntegrationMessageHeaderAccessor extends MessageHeaderAccessor {
 		return (sequenceSize != null ? sequenceSize.intValue() : 0);
 	}
 
+	@Nullable
 	public Integer getPriority() {
 		Number priority = this.getHeader(PRIORITY, Number.class);
 		return (priority != null ? priority.intValue() : null);
@@ -113,11 +117,13 @@ public class IntegrationMessageHeaderAccessor extends MessageHeaderAccessor {
 	 * @return the {@link Closeable}.
 	 * @since 4.3
 	 */
+	@Nullable
 	public Closeable getCloseableResource() {
 		return this.getHeader(CLOSEABLE_RESOURCE, Closeable.class);
 	}
 
 	@SuppressWarnings("unchecked")
+	@Nullable
 	public <T> T getHeader(String key, Class<T> type) {
 		Object value = getHeader(key);
 		if (value == null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/StaticMessageHeaderAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/StaticMessageHeaderAccessor.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support;
+
+import java.io.Closeable;
+import java.util.UUID;
+
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.util.MimeType;
+
+/**
+ * Lightweight type-safe header accessor avoiding object
+ * creation just to access a header.
+ *
+ * @author Gary Russell
+ * @since 5.0.1
+ *
+ * @see IntegrationMessageHeaderAccessor
+ */
+public final class StaticMessageHeaderAccessor {
+
+	private StaticMessageHeaderAccessor() {
+		super();
+	}
+
+	@Nullable
+	public static UUID getId(Message<?> message) {
+		Object value = message.getHeaders().get(MessageHeaders.ID);
+		if (value == null) {
+			return null;
+		}
+		return (value instanceof UUID ? (UUID) value : UUID.fromString(value.toString()));
+	}
+
+	@Nullable
+	public static Long getTimestamp(Message<?> message) {
+		Object value = message.getHeaders().get(MessageHeaders.TIMESTAMP);
+		if (value == null) {
+			return null;
+		}
+		return (value instanceof Long ? (Long) value : Long.parseLong(value.toString()));
+	}
+
+	@Nullable
+	public static MimeType getContentType(Message<?> message) {
+		Object value = message.getHeaders().get(MessageHeaders.CONTENT_TYPE);
+		if (value == null) {
+			return null;
+		}
+		return (value instanceof MimeType ? (MimeType) value : MimeType.valueOf(value.toString()));
+	}
+
+	@Nullable
+	public static Long getExpirationDate(Message<?> message) {
+		return message.getHeaders().get(IntegrationMessageHeaderAccessor.EXPIRATION_DATE, Long.class);
+	}
+
+	public static int getSequenceNumber(Message<?> message) {
+		Number sequenceNumber = message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER,
+				Number.class);
+		return (sequenceNumber != null ? sequenceNumber.intValue() : 0);
+	}
+
+	public static int getSequenceSize(Message<?> message) {
+		Number sequenceSize = message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, Number.class);
+		return (sequenceSize != null ? sequenceSize.intValue() : 0);
+	}
+
+	@Nullable
+	public static Integer getPriority(Message<?> message) {
+		Number priority = message.getHeaders().get(IntegrationMessageHeaderAccessor.PRIORITY, Number.class);
+		return (priority != null ? priority.intValue() : null);
+	}
+
+	@Nullable
+	public static Closeable getCloseableResource(Message<?> message) {
+		return message.getHeaders().get(IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE, Closeable.class);
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/StreamTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/StreamTransformer.java
@@ -20,7 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.InputStream;
 
-import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.support.StaticMessageHeaderAccessor;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
@@ -60,7 +60,7 @@ public class StreamTransformer extends AbstractTransformer {
 		InputStream stream = (InputStream) message.getPayload();
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		FileCopyUtils.copy(stream, baos);
-		Closeable closeableResource = new IntegrationMessageHeaderAccessor(message).getCloseableResource();
+		Closeable closeableResource = StaticMessageHeaderAccessor.getCloseableResource(message);
 		if (closeableResource != null) {
 			closeableResource.close();
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/splitter/FileSplitter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/splitter/FileSplitter.java
@@ -34,11 +34,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.splitter.FileSplitter.FileMarker.Mark;
 import org.springframework.integration.splitter.AbstractMessageSplitter;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
+import org.springframework.integration.support.StaticMessageHeaderAccessor;
 import org.springframework.integration.support.json.JsonObjectMapper;
 import org.springframework.integration.support.json.JsonObjectMapperProvider;
 import org.springframework.messaging.Message;
@@ -220,8 +220,7 @@ public class FileSplitter extends AbstractMessageSplitter {
 					super.close();
 				}
 				finally {
-					Closeable closeableResource = new IntegrationMessageHeaderAccessor(message)
-							.getCloseableResource();
+					Closeable closeableResource = StaticMessageHeaderAccessor.getCloseableResource(message);
 					if (closeableResource != null) {
 						closeableResource.close();
 					}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
@@ -47,6 +47,7 @@ import org.springframework.integration.file.filters.AcceptOnceFileListFilter;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.splitter.FileSplitter;
+import org.springframework.integration.support.StaticMessageHeaderAccessor;
 import org.springframework.integration.transformer.StreamTransformer;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
@@ -85,7 +86,7 @@ public class StreamingInboundTests {
 		assertThat(fileInfo, containsString("link\":false"));
 
 		// close after list, transform
-		verify(new IntegrationMessageHeaderAccessor(received).getCloseableResource(), times(2)).close();
+		verify(StaticMessageHeaderAccessor.getCloseableResource(received), times(2)).close();
 
 		received = (Message<byte[]>) this.transformer.transform(streamer.receive());
 		assertEquals("baz\nqux", new String(received.getPayload()));
@@ -101,7 +102,7 @@ public class StreamingInboundTests {
 		assertThat(fileInfo, containsString("link\":false"));
 
 		// close after transform
-		verify(new IntegrationMessageHeaderAccessor(received).getCloseableResource(), times(3)).close();
+		verify(StaticMessageHeaderAccessor.getCloseableResource(received), times(3)).close();
 
 		verify(sessionFactory.getSession()).list("/foo");
 	}
@@ -122,7 +123,7 @@ public class StreamingInboundTests {
 		assertEquals("foo", received.getHeaders().get(FileHeaders.REMOTE_FILE));
 
 		// close after list, transform
-		verify(new IntegrationMessageHeaderAccessor(received).getCloseableResource(), times(2)).close();
+		verify(StaticMessageHeaderAccessor.getCloseableResource(received), times(2)).close();
 
 		received = (Message<byte[]>) this.transformer.transform(streamer.receive());
 		assertEquals("baz\nqux", new String(received.getPayload()));


### PR DESCRIPTION
- avoids object creation when getting type-safe well-known headers.