### PR TITLE
Fix SpelPropertyAccessorRegistrar

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/SpelPropertyAccessorRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/SpelPropertyAccessorRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 
 package org.springframework.integration.expression;
 
-import java.util.HashMap;
+import java.beans.Introspector;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.expression.PropertyAccessor;
@@ -34,7 +35,7 @@ import org.springframework.util.Assert;
  */
 public class SpelPropertyAccessorRegistrar {
 
-	private final Map<String, PropertyAccessor> propertyAccessors = new HashMap<String, PropertyAccessor>();
+	private final Map<String, PropertyAccessor> propertyAccessors = new LinkedHashMap<String, PropertyAccessor>();
 
 	public SpelPropertyAccessorRegistrar() {
 	}
@@ -48,7 +49,7 @@ public class SpelPropertyAccessorRegistrar {
 	public SpelPropertyAccessorRegistrar(PropertyAccessor... propertyAccessors) {
 		Assert.notEmpty(propertyAccessors, "'propertyAccessors' must not be empty");
 		for (PropertyAccessor propertyAccessor : propertyAccessors) {
-			this.propertyAccessors.put(propertyAccessors.getClass().getSimpleName(), propertyAccessor);
+			this.propertyAccessors.put(obtainAccessorKey(propertyAccessor), propertyAccessor);
 		}
 	}
 
@@ -95,9 +96,13 @@ public class SpelPropertyAccessorRegistrar {
 	public SpelPropertyAccessorRegistrar add(PropertyAccessor... propertyAccessors) {
 		Assert.notEmpty(propertyAccessors, "'propertyAccessors' must not be empty");
 		for (PropertyAccessor propertyAccessor : propertyAccessors) {
-			this.propertyAccessors.put(propertyAccessors.getClass().getSimpleName(), propertyAccessor);
+			this.propertyAccessors.put(obtainAccessorKey(propertyAccessor), propertyAccessor);
 		}
 		return this;
+	}
+
+	private static String obtainAccessorKey(PropertyAccessor propertyAccessor) {
+		return Introspector.decapitalize(propertyAccessor.getClass().getSimpleName());
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,9 +69,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
+import org.springframework.context.expression.EnvironmentAccessor;
+import org.springframework.context.expression.MapAccessor;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.serializer.support.SerializingConverter;
 import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.support.ReflectivePropertyAccessor;
 import org.springframework.integration.annotation.Aggregator;
 import org.springframework.integration.annotation.BridgeFrom;
 import org.springframework.integration.annotation.BridgeTo;
@@ -705,7 +708,11 @@ public class EnableIntegrationTests {
 	public void testIntegrationEvaluationContextCustomization() {
 		EvaluationContext evaluationContext = this.context.getBean(EvaluationContext.class);
 		List<?> propertyAccessors = TestUtils.getPropertyValue(evaluationContext, "propertyAccessors", List.class);
+		assertEquals(4, propertyAccessors.size());
 		assertThat(propertyAccessors.get(0), instanceOf(JsonPropertyAccessor.class));
+		assertThat(propertyAccessors.get(1), instanceOf(EnvironmentAccessor.class));
+		assertThat(propertyAccessors.get(2), instanceOf(MapAccessor.class));
+		assertThat(propertyAccessors.get(3), instanceOf(ReflectivePropertyAccessor.class));
 		Map<?, ?> variables = TestUtils.getPropertyValue(evaluationContext, "variables", Map.class);
 		Object testSpelFunction = variables.get("testSpelFunction");
 		assertEquals(ClassUtils.getStaticMethod(TestSpelFunction.class, "bar", Object.class), testSpelFunction);
@@ -1112,7 +1119,7 @@ public class EnableIntegrationTests {
 
 		@Bean
 		public SpelPropertyAccessorRegistrar spelPropertyAccessorRegistrar() {
-			return new SpelPropertyAccessorRegistrar(new JsonPropertyAccessor());
+			return new SpelPropertyAccessorRegistrar(new JsonPropertyAccessor(), new EnvironmentAccessor());
 		}
 
 	}


### PR DESCRIPTION
The `SpelPropertyAccessorRegistrar` ctor and
`add(PropertyAccessor... propertyAccessors)` method use wrong variable
to build a key for the provided `PropertyAccessor`.
Therefore during iteration the next `PropertyAccessor` overrides the
previous and we end up just only with one instance in the registry

* Extract `private static obtainAccessorKey()` method to build
decapitalized key for the `PropertyAccessor`
* Change the map store to the `LinkedHashMap` to keep order of the
provided `PropertyAccessor` s
* Modify `EnableIntegrationTests` to ensure that we support several
`PropertyAccessor` s and in the proper order

**Cherry-pick to 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
