### PR TITLE
INT-4378: TCP Fix CF Name in Intercepted Events

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,6 +104,11 @@ public abstract class TcpConnectionInterceptorSupport extends TcpConnectionSuppo
 	@Override
 	public SocketInfo getSocketInfo() {
 		return this.theConnection.getSocketInfo();
+	}
+
+	@Override
+	public String getConnectionFactoryName() {
+		return this.theConnection.getConnectionFactoryName();
 	}
 
 	@Override

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2016 the original author or authors.
+ * Copyright 2001-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -328,6 +328,10 @@ public abstract class TcpConnectionSupport implements TcpConnection {
 		return this.socketInfo;
 	}
 
+	public String getConnectionFactoryName() {
+		return this.connectionFactoryName;
+	}
+
 	protected boolean isNoReadErrorOnClose() {
 		return this.noReadErrorOnClose;
 	}
@@ -347,19 +351,19 @@ public abstract class TcpConnectionSupport implements TcpConnection {
 
 	protected void publishConnectionOpenEvent() {
 		TcpConnectionEvent event = new TcpConnectionOpenEvent(this,
-				this.connectionFactoryName);
+				getConnectionFactoryName());
 		doPublish(event);
 	}
 
 	protected void publishConnectionCloseEvent() {
 		TcpConnectionEvent event = new TcpConnectionCloseEvent(this,
-				this.connectionFactoryName);
+				getConnectionFactoryName());
 		doPublish(event);
 	}
 
 	protected void publishConnectionExceptionEvent(Throwable t) {
 		TcpConnectionEvent event = new TcpConnectionExceptionEvent(this,
-				this.connectionFactoryName, t);
+				getConnectionFactoryName(), t);
 		doPublish(event);
 	}
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/InterceptedSharedConnectionTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/InterceptedSharedConnectionTests-context.xml
@@ -71,4 +71,6 @@
 
 	<int:channel id="loop" />
 
+	<bean class="org.springframework.integration.ip.tcp.InterceptedSharedConnectionTests$Listener" />
+
 </beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4378

Events (e.g. `TcpConnectionOpenEvent`) from intercepted connections contain an
'unknown' connection factory name.

Delegate to the underlying connection's factory name.

__cherry-pick to 4.3.x__