### PR TITLE
Minor Fixes

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPropertyAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPropertyAccessor.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * @author Eric Bottard
  * @author Artem Bilan
  * @author Paul Martin
+ * @author Gary Russell
  *
  * @since 3.0
  */
@@ -164,6 +165,7 @@ public class JsonPropertyAccessor implements PropertyAccessor {
 		}
 	}
 
+	@SuppressWarnings("rawtypes")
 	public static WrappedJsonNode wrap(JsonNode json) {
 		if (json == null) {
 			return null;
@@ -243,6 +245,7 @@ public class JsonPropertyAccessor implements PropertyAccessor {
 	 * An {@link AbstractList} implementation around {@link ArrayNode} with {@link WrappedJsonNode} aspect.
 	 * @since 5.0
 	 */
+	@SuppressWarnings("rawtypes")
 	public static class ArrayNodeAsList extends AbstractList<WrappedJsonNode> implements WrappedJsonNode<ArrayNode> {
 
 		private final ArrayNode node;

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpTestSupport.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/FtpTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.ftp;
 
 import java.util.Arrays;
 
+import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.ftpserver.FtpServer;
 import org.apache.ftpserver.FtpServerFactory;
@@ -85,6 +86,7 @@ public class FtpTestSupport extends RemoteFileTestSupport {
 		sf.setPort(port);
 		sf.setUsername("foo");
 		sf.setPassword("foo");
+		sf.setClientMode(FTPClient.PASSIVE_LOCAL_DATA_CONNECTION_MODE);
 
 		return new CachingSessionFactory<FTPFile>(sf);
 	}


### PR DESCRIPTION
- suppress `rawtypes` compiler warning
- use passive mode for FTP tests (acive fails on one of my machines for some reason)

