### PR TITLE
INT-4366: Fix MulticastSendingMessageHandler

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpOutboundGatewayTests.java
@@ -43,7 +43,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -61,6 +60,8 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.serializer.DefaultDeserializer;
 import org.springframework.core.serializer.DefaultSerializer;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -90,6 +91,8 @@ public class TcpOutboundGatewayTests {
 
 	private static final Log logger = LogFactory.getLog(TcpOutboundGatewayTests.class);
 
+	private AsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
+
 	@ClassRule
 	public static LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
@@ -101,13 +104,13 @@ public class TcpOutboundGatewayTests {
 	public void testGoodNetSingle() throws Exception {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<>();
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0, 100);
 				serverSocket.set(server);
 				latch.countDown();
-				List<Socket> sockets = new ArrayList<Socket>();
+				List<Socket> sockets = new ArrayList<>();
 				int i = 0;
 				while (true) {
 					Socket socket = server.accept();
@@ -165,8 +168,8 @@ public class TcpOutboundGatewayTests {
 	public void testGoodNetMultiplex() throws Exception {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<>();
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0, 10);
 				serverSocket.set(server);
@@ -220,8 +223,8 @@ public class TcpOutboundGatewayTests {
 	public void testGoodNetTimeout() throws Exception {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<>();
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -260,12 +263,12 @@ public class TcpOutboundGatewayTests {
 		Future<Integer>[] results = (Future<Integer>[]) new Future<?>[2];
 		for (int i = 0; i < 2; i++) {
 			final int j = i;
-			results[j] = (Executors.newSingleThreadExecutor().submit(() -> {
+			results[j] = (this.executor.submit(() -> {
 				gateway.handleMessage(MessageBuilder.withPayload("Test" + j).build());
 				return 0;
 			}));
 		}
-		Set<String> replies = new HashSet<String>();
+		Set<String> replies = new HashSet<>();
 		int timeouts = 0;
 		for (int i = 0; i < 2; i++) {
 			try {
@@ -344,7 +347,7 @@ public class TcpOutboundGatewayTests {
 		final AtomicReference<String> lastReceived = new AtomicReference<String>();
 		final CountDownLatch serverLatch = new CountDownLatch(2);
 
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				latch.countDown();
 				int i = 0;
@@ -398,7 +401,7 @@ public class TcpOutboundGatewayTests {
 
 		for (int i = 0; i < 2; i++) {
 			final int j = i;
-			results[j] = (Executors.newSingleThreadExecutor().submit(() -> {
+			results[j] = (this.executor.submit(() -> {
 				gateway.handleMessage(MessageBuilder.withPayload("Test" + j).build());
 				return j;
 			}));
@@ -442,7 +445,7 @@ public class TcpOutboundGatewayTests {
 		final AtomicBoolean done = new AtomicBoolean();
 		final CountDownLatch serverLatch = new CountDownLatch(1);
 
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -517,12 +520,12 @@ public class TcpOutboundGatewayTests {
 
 	@Test
 	public void testFailoverCached() throws Exception {
-		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
 		final CountDownLatch serverLatch = new CountDownLatch(1);
 
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -667,11 +670,11 @@ public class TcpOutboundGatewayTests {
 			final ServerSocket server) throws Exception {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		final AtomicReference<String> lastReceived = new AtomicReference<String>();
+		final AtomicReference<String> lastReceived = new AtomicReference<>();
 		final CountDownLatch serverLatch = new CountDownLatch(1);
 
-		Executors.newSingleThreadExecutor().execute(() -> {
-			List<Socket> sockets = new ArrayList<Socket>();
+		this.executor.execute(() -> {
+			List<Socket> sockets = new ArrayList<>();
 			try {
 				latch.countDown();
 				while (!done.get()) {
@@ -793,8 +796,8 @@ public class TcpOutboundGatewayTests {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
 
-		Executors.newSingleThreadExecutor().execute(() -> {
-			List<Socket> sockets = new ArrayList<Socket>();
+		this.executor.execute(() -> {
+			List<Socket> sockets = new ArrayList<>();
 			try {
 				latch.countDown();
 				while (!done.get()) {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -46,6 +45,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.serializer.DefaultDeserializer;
 import org.springframework.core.serializer.DefaultSerializer;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.handler.ServiceActivatingHandler;
@@ -64,6 +64,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTests {
 
@@ -97,27 +98,24 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 
 	@Test
 	public void testNetClientMode() throws Exception {
-		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<>();
 		final CountDownLatch latch1 = new CountDownLatch(1);
 		final CountDownLatch latch2 = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(new Runnable() {
-			@Override
-			public void run() {
-				try {
-					ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0, 10);
-					serverSocket.set(server);
-					latch1.countDown();
-					Socket socket = server.accept();
-					socket.getOutputStream().write("Test1\r\nTest2\r\n".getBytes());
-					latch2.await();
-					socket.close();
-					server.close();
-				}
-				catch (Exception e) {
-					if (!done.get()) {
-						e.printStackTrace();
-					}
+		new SimpleAsyncTaskExecutor().execute(() -> {
+			try {
+				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0, 10);
+				serverSocket.set(server);
+				latch1.countDown();
+				Socket socket = server.accept();
+				socket.getOutputStream().write("Test1\r\nTest2\r\n".getBytes());
+				latch2.await();
+				socket.close();
+				server.close();
+			}
+			catch (Exception e) {
+				if (!done.get()) {
+					e.printStackTrace();
 				}
 			}
 		});
@@ -416,7 +414,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		handler.setConnectionFactory(scf);
 		TcpReceivingChannelAdapter adapter = new TcpReceivingChannelAdapter();
 		adapter.setConnectionFactory(scf);
-		Executor te = Executors.newCachedThreadPool();
+		Executor te = new SimpleAsyncTaskExecutor();
 		scf.setTaskExecutor(te);
 		scf.start();
 		QueueChannel channel = new QueueChannel();
@@ -650,6 +648,7 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 	}
 
 	private class FailingService {
+
 		@SuppressWarnings("unused")
 		public String serviceMethod(byte[] bytes) {
 			throw new RuntimeException("Failed");

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandlerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -54,6 +52,8 @@ import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.core.serializer.DefaultDeserializer;
 import org.springframework.core.serializer.DefaultSerializer;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.ip.tcp.connection.AbstractClientConnectionFactory;
@@ -79,12 +79,14 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTests {
 
 	private static final Log logger = LogFactory.getLog(TcpSendingMessageHandlerTests.class);
 
+	private AsyncTaskExecutor executor = new SimpleAsyncTaskExecutor();
 
 	private void readFully(InputStream is, byte[] buff) throws IOException {
 		for (int i = 0; i < buff.length; i++) {
@@ -97,7 +99,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -150,7 +152,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -215,7 +217,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -271,7 +273,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -324,7 +326,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -377,10 +379,10 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 
 	@Test
 	public void testNetLength() throws Exception {
-		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -436,7 +438,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -495,7 +497,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -544,10 +546,10 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 
 	@Test
 	public void testNioSerial() throws Exception {
-		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
+		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -598,12 +600,12 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 	}
 
 	@Test
-	public void testNetSingleUseNoInbound() throws Exception  {
+	public void testNetSingleUseNoInbound() throws Exception {
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final Semaphore semaphore = new Semaphore(0);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -645,12 +647,12 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 	}
 
 	@Test
-	public void testNioSingleUseNoInbound() throws Exception  {
+	public void testNioSingleUseNoInbound() throws Exception {
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final Semaphore semaphore = new Semaphore(0);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -692,12 +694,12 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 	}
 
 	@Test
-	public void testNetSingleUseWithInbound() throws Exception  {
+	public void testNetSingleUseWithInbound() throws Exception {
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final Semaphore semaphore = new Semaphore(0);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -752,12 +754,12 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 	}
 
 	@Test
-	public void testNioSingleUseWithInbound() throws Exception  {
+	public void testNioSingleUseWithInbound() throws Exception {
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final Semaphore semaphore = new Semaphore(0);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -812,14 +814,13 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 	}
 
 	@Test
-	public void testNioSingleUseWithInboundMany() throws Exception  {
+	public void testNioSingleUseWithInboundMany() throws Exception {
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final Semaphore semaphore = new Semaphore(0);
 		final AtomicBoolean done = new AtomicBoolean();
 		final List<Socket> serverSockets = new ArrayList<Socket>();
-		final ExecutorService exec = Executors.newCachedThreadPool();
-		exec.execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0, 100);
 				serverSocket.set(server);
@@ -828,7 +829,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 					final Socket socket = server.accept();
 					serverSockets.add(socket);
 					final int j = i;
-					exec.execute(() -> {
+					this.executor.execute(() -> {
 						semaphore.release();
 						byte[] b = new byte[9];
 						try {
@@ -843,7 +844,8 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 							try {
 								socket.close();
 							}
-							catch (IOException e2) { }
+							catch (IOException e2) {
+							}
 						}
 					});
 				}
@@ -864,7 +866,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		ccf.setDeserializer(serializer);
 		ccf.setSoTimeout(10000);
 		ccf.setSingleUse(true);
-		ccf.setTaskExecutor(Executors.newCachedThreadPool());
+		ccf.setTaskExecutor(this.executor);
 		ccf.start();
 		TcpSendingMessageHandler handler = new TcpSendingMessageHandler();
 		handler.setConnectionFactory(ccf);
@@ -902,7 +904,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -973,7 +975,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -1010,7 +1012,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		ccf.setDeserializer(new DefaultDeserializer());
 		ccf.setSoTimeout(10000);
 		TcpConnectionInterceptorFactoryChain fc = new TcpConnectionInterceptorFactoryChain();
-		fc.setInterceptors(new TcpConnectionInterceptorFactory[] {newInterceptorFactory()});
+		fc.setInterceptors(new TcpConnectionInterceptorFactory[] { newInterceptorFactory() });
 		ccf.setInterceptorFactoryChain(fc);
 		ccf.start();
 		TcpSendingMessageHandler handler = new TcpSendingMessageHandler();
@@ -1042,7 +1044,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);
 				serverSocket.set(server);
@@ -1099,7 +1101,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		final AtomicReference<ServerSocket> serverSocket = new AtomicReference<ServerSocket>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean done = new AtomicBoolean();
-		Executors.newSingleThreadExecutor().execute(() -> {
+		this.executor.execute(() -> {
 			int i = 0;
 			try {
 				ServerSocket server = ServerSocketFactory.getDefault().createServerSocket(0);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.ip.tcp.TcpOutboundGateway;
@@ -782,7 +783,7 @@ public class CachingClientConnectionFactoryTests {
 				invocation.callRealMethod();
 				String log = invocation.getArgument(0);
 				if (log.startsWith("Response")) {
-					Executors.newSingleThreadScheduledExecutor()
+					new SimpleAsyncTaskExecutor()
 							.execute(() -> gate.handleMessage(new GenericMessage<>("bar")));
 					// hold up the first thread until the second has added its pending reply
 					latch.await(10, TimeUnit.SECONDS);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryTests.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
@@ -52,6 +51,7 @@ import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.ip.config.TcpConnectionFactoryFactoryBean;
@@ -233,7 +233,8 @@ public class ConnectionFactoryTests {
 		factory.start();
 		assertTrue("missing info log", latch1.await(10, TimeUnit.SECONDS));
 		// stop on a different thread because it waits for the executor
-		Executors.newSingleThreadExecutor().execute(() -> factory.stop());
+		new SimpleAsyncTaskExecutor()
+				.execute(factory::stop);
 		int n = 0;
 		DirectFieldAccessor accessor = new DirectFieldAccessor(factory);
 		while (n++ < 200 && accessor.getPropertyValue(property) != null) {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -48,6 +47,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.handler.BridgeHandler;
@@ -548,8 +548,9 @@ public class FailoverClientConnectionFactoryTests {
 	}
 
 	private Holder setupAndStartServers(AbstractServerConnectionFactory server1,
-			AbstractServerConnectionFactory server2) throws Exception {
-		Executor exec = Executors.newCachedThreadPool();
+			AbstractServerConnectionFactory server2) {
+
+		Executor exec = new SimpleAsyncTaskExecutor();
 		server1.setTaskExecutor(exec);
 		server2.setTaskExecutor(exec);
 		server1.setBeanName("server1");

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/DeserializationTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/DeserializationTests.java
@@ -33,8 +33,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ServerSocketFactory;
@@ -46,6 +45,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.serializer.DefaultDeserializer;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.ip.tcp.TcpInboundGateway;
 import org.springframework.integration.ip.tcp.TcpOutboundGateway;
@@ -62,6 +62,7 @@ import org.springframework.messaging.support.GenericMessage;
 /**
  * @author Gary Russell
  * @author Gavin Gray
+ *
  * @since 2.0
  */
 public class DeserializationTests {
@@ -419,7 +420,7 @@ public class DeserializationTests {
 				// eat SocketTimeoutException. Doesn't matter for this test
 			}
 		};
-		ExecutorService exec = Executors.newSingleThreadExecutor();
+		Executor exec = new SimpleAsyncTaskExecutor();
 
 		Message<?> message;
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketMulticastSendingHandlerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketMulticastSendingHandlerTests.java
@@ -27,7 +27,6 @@ import java.net.InetSocketAddress;
 import java.net.MulticastSocket;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -35,6 +34,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
@@ -89,7 +89,7 @@ public class DatagramPacketMulticastSendingHandlerTests {
 				e.printStackTrace();
 			}
 		};
-		Executor executor = Executors.newFixedThreadPool(2);
+		Executor executor = new SimpleAsyncTaskExecutor();
 		executor.execute(catcher);
 		executor.execute(catcher);
 		assertTrue(listening.await(10000, TimeUnit.MILLISECONDS));
@@ -159,7 +159,7 @@ public class DatagramPacketMulticastSendingHandlerTests {
 				e.printStackTrace();
 			}
 		};
-		Executor executor = Executors.newFixedThreadPool(2);
+		Executor executor = new SimpleAsyncTaskExecutor();
 		executor.execute(catcher);
 		executor.execute(catcher);
 		assertTrue(listening.await(10000, TimeUnit.MILLISECONDS));

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -42,6 +41,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.handler.ServiceActivatingHandler;
@@ -56,6 +56,7 @@ import org.springframework.messaging.SubscribableChannel;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Marcin Pilaczynski
+ *
  * @since 2.0
  *
  */
@@ -185,18 +186,19 @@ public class UdpChannelAdapterTests {
 		final CountDownLatch receiverReadyLatch = new CountDownLatch(1);
 		final CountDownLatch replyReceivedLatch = new CountDownLatch(1);
 		//main thread sends the reply using the headers, this thread will receive it
-		Executors.newSingleThreadExecutor().execute(() -> {
-			DatagramPacket answer = new DatagramPacket(new byte[2000], 2000);
-			try {
-				receiverReadyLatch.countDown();
-				socket.receive(answer);
-				theAnswer.set(answer);
-				replyReceivedLatch.countDown();
-			}
-			catch (IOException e) {
-				e.printStackTrace();
-			}
-		});
+		new SimpleAsyncTaskExecutor()
+				.execute(() -> {
+					DatagramPacket answer = new DatagramPacket(new byte[2000], 2000);
+					try {
+						receiverReadyLatch.countDown();
+						socket.receive(answer);
+						theAnswer.set(answer);
+						replyReceivedLatch.countDown();
+					}
+					catch (IOException e) {
+						e.printStackTrace();
+					}
+				});
 		Message<byte[]> receivedMessage = (Message<byte[]>) channel.receive(10000);
 		assertEquals(new String(message.getPayload()), new String(receivedMessage.getPayload()));
 		String replyString = "reply:" + System.currentTimeMillis();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4366

Fix race condition in the `MulticastSendingMessageHandler` around
`multicastSocket` and super `socket` properties.

* Synchronize around `this` and check for the `multicastSocket == null`.
This let the `MulticastSendingMessageHandler` to fully configure and
prepare the socket for use.
* Remove `socket.setInterface(whichNic)` since it is populated by the
`InetSocketAddress` ctor before

**Cherry-pick to 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
