### PR TITLE
Optimize AbstractMessageSources

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
@@ -161,8 +161,7 @@ public abstract class AbstractRemoteFileStreamingMessageSource<F>
 						.setHeader(FileHeaders.REMOTE_DIRECTORY, file.getRemoteDirectory())
 						.setHeader(FileHeaders.REMOTE_FILE, file.getFilename())
 						.setHeader(FileHeaders.REMOTE_FILE_INFO,
-								this.fileInfoJson ? file.toJson() : file)
-						.build();
+								this.fileInfoJson ? file.toJson() : file);
 			}
 			catch (IOException e) {
 				throw new MessagingException("IOException when retrieving " + remotePath, e);


### PR DESCRIPTION
To avoid `Message` re-creation during `AbstractMessageSource.receive()`
logic, refactor `AbstractMessageSource` implementations
to return `AbstractIntegrationMessageBuilder`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
