### PR TITLE
GH-2301: Add SimpMessageGrFactory.GroupType.LIST

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,11 +71,12 @@ public class SimpleMessageGroup implements MessageGroup {
 
 	public SimpleMessageGroup(Collection<? extends Message<?>> messages, Object groupId, long timestamp,
 			boolean complete) {
-		this(new LinkedHashSet<Message<?>>(), messages, groupId, timestamp, complete, false);
+		this(new LinkedHashSet<>(), messages, groupId, timestamp, complete, false);
 	}
 
-	protected SimpleMessageGroup(Collection<Message<?>> internalStore, Collection<? extends Message<?>> messages,
+	public SimpleMessageGroup(Collection<Message<?>> internalStore, Collection<? extends Message<?>> messages,
 			Object groupId, long timestamp, boolean complete, boolean storePreLoaded) {
+
 		Assert.notNull(internalStore, "'internalStore' must not be null");
 		this.messages = internalStore;
 		this.groupId = groupId;

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroupFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.store;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -29,6 +30,7 @@ import org.springframework.messaging.Message;
  * The {@link GroupType#HASH_SET} is the default type.
  *
  * @author Artem Bilan
+ *
  * @since 4.3
  */
 public class SimpleMessageGroupFactory implements MessageGroupFactory {
@@ -45,7 +47,7 @@ public class SimpleMessageGroupFactory implements MessageGroupFactory {
 
 	@Override
 	public MessageGroup create(Object groupId) {
-		return create(Collections.<Message<?>>emptyList(), groupId);
+		return create(Collections.emptyList(), groupId);
 	}
 
 	@Override
@@ -56,6 +58,7 @@ public class SimpleMessageGroupFactory implements MessageGroupFactory {
 	@Override
 	public MessageGroup create(Collection<? extends Message<?>> messages, Object groupId, long timestamp,
 			boolean complete) {
+
 		return new SimpleMessageGroup(this.type.get(), messages, groupId, timestamp, complete, false);
 	}
 
@@ -72,7 +75,7 @@ public class SimpleMessageGroupFactory implements MessageGroupFactory {
 	@Override
 	public MessageGroup create(MessageGroupStore messageGroupStore, Object groupId, long timestamp, boolean complete) {
 		if (GroupType.PERSISTENT.equals(this.type)) {
-			SimpleMessageGroup original = new SimpleMessageGroup(Collections.<Message<?>>emptyList(), groupId,
+			SimpleMessageGroup original = new SimpleMessageGroup(Collections.emptyList(), groupId,
 					timestamp, complete);
 			return new PersistentMessageGroup(messageGroupStore, original);
 		}
@@ -83,28 +86,44 @@ public class SimpleMessageGroupFactory implements MessageGroupFactory {
 
 	public enum GroupType {
 
+		LIST {
+
+			@Override
+			Collection<Message<?>> get() {
+				return new ArrayList<>();
+			}
+
+		},
+
 		BLOCKING_QUEUE {
+
 			@Override
 			Collection<Message<?>> get() {
-				return new LinkedBlockingQueue<Message<?>>();
+				return new LinkedBlockingQueue<>();
 			}
 
 		},
+
 		HASH_SET {
+
 			@Override
 			Collection<Message<?>> get() {
-				return new LinkedHashSet<Message<?>>();
+				return new LinkedHashSet<>();
 			}
 
 		},
+
 		SYNCHRONISED_SET {
+
 			@Override
 			Collection<Message<?>> get() {
 				return Collections.synchronizedSet(new LinkedHashSet<>());
 			}
 
 		},
+
 		PERSISTENT {
+
 			@Override
 			Collection<Message<?>> get() {
 				return HASH_SET.get();

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ public class AggregatorTests {
 		SimpleMessageStore store = new SimpleMessageStore();
 
 		SimpleMessageGroupFactory messageGroupFactory =
-				new SimpleMessageGroupFactory(SimpleMessageGroupFactory.GroupType.BLOCKING_QUEUE);
+				new SimpleMessageGroupFactory(SimpleMessageGroupFactory.GroupType.LIST);
 
 		store.setMessageGroupFactory(messageGroupFactory);
 

--- a/src/reference/asciidoc/message-store.adoc
+++ b/src/reference/asciidoc/message-store.adoc
@@ -95,6 +95,7 @@ This defaults to a `SimpleMessageGroupFactory` which produces `SimpleMessageGrou
 Other possible options are `SYNCHRONISED_SET` and `BLOCKING_QUEUE`, where the last one can be used to reinstate the
 previous `SimpleMessageGroup` behavior.
 Also the `PERSISTENT` option is available. See the next section for more information.
+Starting with __version 5.0.1_, the `LIST` option is also available for use-cases when the order and uniqueness of messages in the group doesn't matter.
 
 [[lazy-load-message-group]]
 ==== Persistence MessageGroupStore and Lazy-Load


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2301

* For non-ordered, without deduplication logic use-case the `ArrayList`
option for internal `SimpleMessageGroup` collection is added
* Make `SimpleMessageGroup` `protected` ctor as `public` for better
reuse in case of custom `MessageGroupFactory`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
