### PR TITLE
Fix NPE in the UnicastSendingMessageHandler

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/MulticastSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/MulticastSendingMessageHandler.java
@@ -201,4 +201,10 @@ public class MulticastSendingMessageHandler extends UnicastSendingMessageHandler
 		}
 	}
 
+	@Override
+	protected void closeSocketIfNeeded() {
+		this.multicastSocket = null;
+		super.closeSocketIfNeeded();
+	}
+
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/UnicastSendingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2017 the original author or authors.
+ * Copyright 2001-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -282,12 +282,7 @@ public class UnicastSendingMessageHandler extends
 			throw e;
 		}
 		catch (Exception e) {
-			try {
-				this.socket.close();
-			}
-			catch (Exception e1) {
-			}
-			this.socket = null;
+			closeSocketIfNeeded();
 			throw new MessageHandlingException(message, "failed to send UDP packet", e);
 		}
 		finally {
@@ -512,7 +507,7 @@ public class UnicastSendingMessageHandler extends
 		}
 		catch (IOException e) {
 			if (this.socket != null && !this.socket.isClosed()) {
-				logger.error("Error on UDP Acknowledge thread:" + e.getMessage());
+				logger.error("Error on UDP Acknowledge thread: " + e.getMessage());
 			}
 		}
 		finally {
@@ -528,7 +523,7 @@ public class UnicastSendingMessageHandler extends
 		this.taskExecutor.execute(this);
 	}
 
-	private void closeSocketIfNeeded() {
+	protected void closeSocketIfNeeded() {
 		if (this.socket != null) {
 			this.socket.close();
 			this.socket = null;

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
@@ -302,6 +302,8 @@ public class UdpChannelAdapterTests {
 		UnicastReceivingChannelAdapter adapter = new UnicastReceivingChannelAdapter(0);
 		adapter.setOutputChannel(channel);
 		ServiceActivatingHandler handler = new ServiceActivatingHandler(new FailingService());
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.afterPropertiesSet();
 		channel.subscribe(handler);
 		QueueChannel errorChannel = new QueueChannel();
 		adapter.setErrorChannel(errorChannel);


### PR DESCRIPTION
https://build.spring.io/browse/INT-MASTER-898
https://build.spring.io/browse/INT-SI43X-224

There are situations when `socket` is `null`'ed, but
`UnicastSendingMessageHandler.run()` method calls `getSocket()` which is
overridden in the `MulticastSendingMessageHandler`.
And that one has the logic around its `multicastSocket` what causes
missing the call for the `createSocket()` to refresh the `socket`
property.

* Override `closeSocketIfNeeded()` in the `MulticastSendingMessageHandler`
and `null` `multicastSocket` property, so the next `getSocket()` will
renew properties
* Fix "No `BeanFactory`" warning in the `UdpChannelAdapterTests`

**Cherry-pick to 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
