### PR TITLE
Expose scan-each-poll for File Inbound Ch Adapter

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileInboundChannelAdapterParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ public class FileInboundChannelAdapterParser extends AbstractPollingInboundChann
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "directory");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "auto-create-directory");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "queue-size");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "scan-each-poll");
 		String filterBeanName = this.registerFilter(element, parserContext);
 		String lockerBeanName = registerLocker(element, parserContext);
 		if (filterBeanName != null) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileReadingMessageSourceFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileReadingMessageSourceFactoryBean.java
@@ -70,7 +70,6 @@ public class FileReadingMessageSourceFactoryBean implements FactoryBean<FileRead
 
 	private final Object initializationMonitor = new Object();
 
-
 	public void setDirectory(File directory) {
 		this.directory = directory;
 	}

--- a/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
+++ b/spring-integration-file/src/main/resources/org/springframework/integration/file/config/spring-integration-file-5.0.xsd
@@ -182,6 +182,17 @@ Only files matching this regular expression will be picked up by this adapter.
                   </xsd:documentation>
                 </xsd:annotation>
             </xsd:attribute>
+			<xsd:attribute name="scan-each-poll" default="false">
+				<xsd:annotation>
+					<xsd:documentation>
+						Set this flag if you want to make sure the internal queue is
+						refreshed with the latest content of the input directory on each poll.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
         </xsd:complexType>
     </xsd:element>
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests-context.xml
@@ -22,6 +22,7 @@
 							 ignore-hidden="false"
 							 auto-startup="false"
 							 use-watch-service="true"
+							 scan-each-poll="true"
 							 watch-events="MODIFY, DELETE"> <!-- CREATE by default -->
 		<integration:poller fixed-rate="5000">
 			<integration:transactional synchronization-factory="syncFactory"/>

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.file.config;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -80,7 +81,7 @@ public class FileInboundChannelAdapterParserTests {
 
 	@Before
 	public void init() {
-		accessor = new DirectFieldAccessor(inputDirPollerSource);
+		this.accessor = new DirectFieldAccessor(inputDirPollerSource);
 	}
 
 	@Test
@@ -100,8 +101,9 @@ public class FileInboundChannelAdapterParserTests {
 	@Test
 	public void inputDirectory() {
 		File expected = new File(System.getProperty("java.io.tmpdir"));
-		File actual = (File) accessor.getPropertyValue("directory");
+		File actual = (File) this.accessor.getPropertyValue("directory");
 		assertEquals("'directory' should be set", expected, actual);
+		assertThat(this.accessor.getPropertyValue("scanEachPoll"), is(Boolean.TRUE));
 	}
 
 	@Test


### PR DESCRIPTION
The `scan-each-poll` XML attribute is missing for the
`<int-file:inbound-channel-adapter>`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
