### PR TITLE
Fixed issue where the Java DSL will always create NIO connection factories regardless of which type you specified.

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/Tcp.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/Tcp.java
@@ -23,6 +23,7 @@ import org.springframework.integration.ip.tcp.connection.AbstractConnectionFacto
  * Factory methods for TCP.
  *
  * @author Gary Russell
+ * @author Tim Ysewyn
  * @since 5.0
  *
  */
@@ -37,7 +38,7 @@ public final class Tcp {
 	 * Boolean indicating the connection factory should not use NIO
 	 * (default).
 	 */
-	public static final boolean NET = true;
+	public static final boolean NET = false;
 
 	private Tcp() {
 		super();

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/Tcp.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/Tcp.java
@@ -31,13 +31,19 @@ public final class Tcp {
 
 	/**
 	 * Boolean indicating the connection factory should use NIO.
+	 *
+	 * @deprecated This isn't used anymore within the framework and will be removed in a future release.
 	 */
+	@Deprecated
 	public static final boolean NIO = true;
 
 	/**
 	 * Boolean indicating the connection factory should not use NIO
 	 * (default).
+	 *
+	 * @deprecated This isn't used anymore within the framework and will be removed in a future release.
 	 */
+	@Deprecated
 	public static final boolean NET = false;
 
 	private Tcp() {
@@ -50,7 +56,7 @@ public final class Tcp {
 	 * @return the spec.
 	 */
 	public static TcpServerConnectionFactorySpec nioServer(int port) {
-		return new TcpServerConnectionFactorySpec(port, NIO);
+		return new TcpServerConnectionFactorySpec(port, true);
 	}
 
 	/**
@@ -59,7 +65,7 @@ public final class Tcp {
 	 * @return the spec.
 	 */
 	public static TcpServerConnectionFactorySpec netServer(int port) {
-		return new TcpServerConnectionFactorySpec(port, NET);
+		return new TcpServerConnectionFactorySpec(port, false);
 	}
 
 	/**
@@ -69,7 +75,7 @@ public final class Tcp {
 	 * @return the spec.
 	 */
 	public static TcpClientConnectionFactorySpec nioClient(String host, int port) {
-		return new TcpClientConnectionFactorySpec(host, port, NIO);
+		return new TcpClientConnectionFactorySpec(host, port, true);
 	}
 
 	/**
@@ -79,7 +85,7 @@ public final class Tcp {
 	 * @return the spec.
 	 */
 	public static TcpClientConnectionFactorySpec netClient(String host, int port) {
-		return new TcpClientConnectionFactorySpec(host, port, NET);
+		return new TcpClientConnectionFactorySpec(host, port, false);
 	}
 
 	/**

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/ConnectionFacforyTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/ConnectionFacforyTests.java
@@ -28,6 +28,10 @@ import org.junit.Test;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.integration.ip.tcp.connection.AbstractClientConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory;
+import org.springframework.integration.ip.tcp.connection.TcpNetClientConnectionFactory;
+import org.springframework.integration.ip.tcp.connection.TcpNetServerConnectionFactory;
+import org.springframework.integration.ip.tcp.connection.TcpNioClientConnectionFactory;
+import org.springframework.integration.ip.tcp.connection.TcpNioServerConnectionFactory;
 import org.springframework.integration.ip.util.TestingUtilities;
 import org.springframework.integration.transformer.ObjectToStringTransformer;
 import org.springframework.messaging.Message;
@@ -35,6 +39,7 @@ import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Gary Russell
+ * @author Tim Ysewyn
  * @since 5.0
  *
  */
@@ -64,6 +69,24 @@ public class ConnectionFacforyTests {
 		assertEquals("foo", received.get().getPayload());
 		client.stop();
 		server.stop();
+	}
+
+	@Test
+	public void shouldReturnNioFlavor() throws Exception {
+		AbstractServerConnectionFactory server = Tcp.nioServer(0).get();
+		assertTrue(server instanceof TcpNioServerConnectionFactory);
+
+		AbstractClientConnectionFactory client = Tcp.nioClient("localhost", server.getPort()).get();
+		assertTrue(client instanceof TcpNioClientConnectionFactory);
+	}
+
+	@Test
+	public void shouldReturnNetFlavor() throws Exception {
+		AbstractServerConnectionFactory server = Tcp.netServer(0).get();
+		assertTrue(server instanceof TcpNetServerConnectionFactory);
+
+		AbstractClientConnectionFactory client = Tcp.netClient("localhost", server.getPort()).get();
+		assertTrue(client instanceof TcpNetClientConnectionFactory);
 	}
 
 }


### PR DESCRIPTION
Fixes #2346