### PR TITLE
INT-4394: Fix compatibility with Jackson JSON

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ subprojects { subproject ->
 		hibernateVersion = '5.2.10.Final'
 		hsqldbVersion = '2.4.0'
 		h2Version = '1.4.196'
-		jackson2Version = '2.9.1'
+		jackson2Version = '2.9.4'
 		javaxActivationVersion = '1.1.1'
 		javaxMailVersion = '1.6.0'
 		jedisVersion = '2.9.0'

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AggregateMessageDeliveryException.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AggregateMessageDeliveryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.dispatcher;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.messaging.Message;
@@ -28,6 +28,8 @@ import org.springframework.util.StringUtils;
  * that may try multiple handler invocations within a single dispatch operation.
  *
  * @author Mark Fisher
+ * @author Artem Bilan
+ *
  * @since 1.0.3
  */
 @SuppressWarnings("serial")
@@ -38,13 +40,18 @@ public class AggregateMessageDeliveryException extends MessageDeliveryException 
 
 	public AggregateMessageDeliveryException(Message<?> undeliveredMessage,
 			String description, List<? extends Exception> aggregatedExceptions) {
+
 		super(undeliveredMessage, description);
 		this.initCause(aggregatedExceptions.get(0));
-		this.aggregatedExceptions = aggregatedExceptions;
+		this.aggregatedExceptions = new ArrayList<Exception>(aggregatedExceptions);
 	}
 
+	/**
+	 * Obtain a list aggregated target exceptions.
+	 * @return the list of target exceptions
+	 */
 	public List<? extends Exception> getAggregatedExceptions() {
-		return Collections.unmodifiableList(this.aggregatedExceptions);
+		return new ArrayList<Exception>(this.aggregatedExceptions);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.integration.store;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -92,8 +91,13 @@ public class MessageGroupMetadata implements Serializable {
 		return null;
 	}
 
+	/**
+	 * Obtain a {@link LinkedList} copy of the {@link #messageIds}
+	 * stored in the group.
+	 * @return the list of messages ids stored in the group
+	 */
 	public List<UUID> getMessageIds() {
-		return Collections.unmodifiableList(this.messageIds);
+		return new LinkedList<UUID>(this.messageIds);
 	}
 
 	void complete() {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4394

Looks like Jackson has became much smarter and now it stores
the target type for the object, not returned interface.

We can't use Jackson annotations on the Framework classes and
we can't restrict the `messagingAwareMapper()` `ObjectMapper` just
to use fields for all the object passed through it.

As a compromise solution we shouldn't use
`Collections.unmodifiableList()` in the getter.
The copy of the internal collection is pretty enough to protect
our object from mutation.

**Cherry-pick to 4.3.x (excluding `build.gradle` change)**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
