### PR TITLE
INT-4402: Apply global interceptors at runtime

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationProperties.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,12 @@ public final class IntegrationProperties {
 	 * Specifies the value of {@link org.springframework.integration.endpoint.AbstractEndpoint#autoStartup}.
 	 */
 	public static final String ENDPOINTS_NO_AUTO_STARTUP = INTEGRATION_PROPERTIES_PREFIX + "endpoints.noAutoStartup";
+
+	/**
+	 * Whether {@link org.springframework.beans.factory.config.BeanPostProcessor}s should process beans registered at runtime.
+	 * Will be removed in 5.1.
+	 */
+	public static final String POST_PROCESS_DYNAMIC_BEANS = INTEGRATION_PROPERTIES_PREFIX + "postProcessDynamicBeans";
 
 
 	private static Properties defaults;

--- a/spring-integration-core/src/main/resources/META-INF/spring.integration.default.properties
+++ b/spring-integration-core/src/main/resources/META-INF/spring.integration.default.properties
@@ -6,3 +6,4 @@ spring.integration.messagingTemplate.throwExceptionOnLateReply=false
 # Defaults to MessageHeaders.ID and MessageHeaders.TIMESTAMP
 spring.integration.readOnly.headers=
 spring.integration.endpoints.noAutoStartup=
+spring.integration.postProcessDynamicBeans=false

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalChannelInterceptorTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalChannelInterceptorTests-context.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:int="http://www.springframework.org/schema/integration"
-	xmlns:p="http://www.springframework.org/schema/p"
-	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int="http://www.springframework.org/schema/integration"
+	   xmlns:p="http://www.springframework.org/schema/p"
+	   xmlns:aop="http://www.springframework.org/schema/aop" xmlns:util="http://www.springframework.org/schema/util"
+	   xmlns:beans="http://www.springframework.org/schema/c"
+	   xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+	<util:properties id="integrationGlobalProperties">
+		<prop key="spring.integration.postProcessDynamicBeans">true</prop>
+	</util:properties>
 
 	<int:channel id="inputA">
 		<int:interceptors>

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalChannelInterceptorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalChannelInterceptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 package org.springframework.integration.channel.interceptor;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -31,9 +33,11 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.ApplicationContext;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.Ordered;
 import org.springframework.integration.channel.ChannelInterceptorAware;
+import org.springframework.integration.channel.DirectChannel;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -54,7 +58,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class GlobalChannelInterceptorTests {
 
 	@Autowired
-	ApplicationContext applicationContext;
+	ConfigurableApplicationContext applicationContext;
 
 	@Autowired
 	@Qualifier("inputC")
@@ -143,6 +147,18 @@ public class GlobalChannelInterceptorTests {
 		assertTrue(interceptorNames.contains("interceptor-eleven"));
 	}
 
+	@Test
+	public void testDynamicMessageChannelBeanWithAutoGlobalChannelInterceptor() {
+		DirectChannel testChannel = new DirectChannel();
+		ConfigurableListableBeanFactory beanFactory = this.applicationContext.getBeanFactory();
+		beanFactory.initializeBean(testChannel, "testChannel");
+
+		List<ChannelInterceptor> channelInterceptors = testChannel.getChannelInterceptors();
+
+		assertEquals(2, channelInterceptors.size());
+		assertThat(channelInterceptors.get(0), instanceOf(SampleInterceptor.class));
+		assertThat(channelInterceptors.get(0), instanceOf(SampleInterceptor.class));
+	}
 
 	public static class SampleInterceptor extends ChannelInterceptorAdapter {
 

--- a/src/reference/asciidoc/channel.adoc
+++ b/src/reference/asciidoc/channel.adoc
@@ -734,6 +734,9 @@ To inject a global interceptor _BEFORE_ the existing interceptors, use a negativ
 NOTE: Note that both the `order` and `pattern` attributes are optional.
 The default value for `order` will be 0 and for `pattern`, the default is '*' (to match all channels).
 
+Starting with _version 4.3.15_, you can configure a property `spring.integration.postProcessDynamicBeans = true` to apply global interceptor to the dynamically created `MessageChannel` beans.
+See <<global-properties>> for more information.
+
 [[channel-wiretap]]
 ===== Wire Tap
 

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -223,6 +223,7 @@ spring.integration.taskScheduler.poolSize=10 <4>
 spring.integration.messagingTemplate.throwExceptionOnLateReply=false <5>
 spring.integration.readOnly.headers= <6>
 spring.integration.endpoints.noAutoStartup= <7>
+spring.integration.postProcessDynamicBeans=false <8>
 ----
 
 <1> When true, `input-channel` s will be automatically declared as `DirectChannel` s when not explicitly found in the
@@ -245,10 +246,15 @@ expecting a reply - because the sending thread has timed out, or already receive
 The list is used by the `DefaultMessageBuilderFactory` bean and propagated to the `IntegrationMessageHeaderAccessor` instances (see <<message-header-accessor>>), used to build messages via `MessageBuilder` (see <<message-builder>>).
 By default only `MessageHeaders.ID` and `MessageHeaders.TIMESTAMP` are not copied during message building.
 _Since version 4.3.2_
+
 <7> A comma-separated list of `AbstractEndpoint` bean names patterns (`xxx*`, `*xxx`, `*xxx*` or `xxx*yyy`) which should not be started automatically during application startup.
 These endpoints can be started later manually by their bean name via `Control Bus` (see <<control-bus>>), by their role using the `SmartLifecycleRoleController` (see <<endpoint-roles>>) or via simple `Lifecycle` bean injection.
 The effect of this global property can be explicitly overridden by specifying `auto-startup` XML or `autoStartup` annotation attribute, or via call to the `AbstractEndpoint.setAutoStartup()` in bean definition.
 _Since version 4.3.12_
+
+<7> A boolean flag to indicate that `BeanPostProcessor` s should post-process beans registered at runtime, e.g. message channels created via `IntegrationFlowContext` can be supplied with global channel interceptors.
+_Since version 4.3.15_
+
 
 These properties can be overridden by adding a file `/META-INF/spring.integration.properties` to the classpath.
 It is not necessary to provide all the properties, just those that you want to override.
@@ -586,7 +592,7 @@ public class MyFlowConfiguration {
     public Supplier<String> pojoSupplier() {
         return () -> "foo";
     }
-	
+
     @Bean
     @InboundChannelAdapter(value = "inputChannel", poller = @Poller(fixedDelay = "1000"))
     public Supplier<Message<String>> messageSupplier() {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4402

Make `GlobalChannelInterceptorProcessor` as a `BeanPostProcessor`,
so it can apply global `ChannelInterceptor`s to any initialized channel
beans, even those created at runtime, like in case of dynamic flows with
Java DSL

**Cherry-pick to 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
