### PR TITLE
INT-2364 fix intermittent failing test

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollingConsumerEndpointTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollingConsumerEndpointTests.java
@@ -45,6 +45,7 @@ import org.springframework.util.ErrorHandler;
 /**
  * @author Iwein Fuld
  * @author Mark Fisher
+ * @author Kiel Boatman
  */
 @SuppressWarnings("unchecked")
 public class PollingConsumerEndpointTests {
@@ -63,13 +64,14 @@ public class PollingConsumerEndpointTests {
 
 	private final TestErrorHandler errorHandler = new TestErrorHandler();
 
-	private final PollableChannel channelMock = Mockito.mock(PollableChannel.class);
+	private PollableChannel channelMock;
 
 	private final ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 
 
 	@Before
 	public void init() throws Exception {
+		channelMock = Mockito.mock(PollableChannel.class);
 		consumer.counter.set(0);
 		trigger.reset();
 		endpoint = new PollingConsumer(channelMock, consumer);
@@ -81,7 +83,6 @@ public class PollingConsumerEndpointTests {
 		endpoint.setReceiveTimeout(-1);
 		endpoint.afterPropertiesSet();
 		taskScheduler.afterPropertiesSet();
-		Mockito.reset(channelMock);
 	}
 
 	@After


### PR DESCRIPTION
Test updates to fix issue https://github.com/spring-projects/spring-integration/issues/2364

JUnit instantiates a new instance of the test class for each test method, so can simply create a new mock for each test rather than calling Mockito.reset