### PR TITLE
INT-4410 CollArgResolver only for group processor

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -463,10 +463,13 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar, Bean
 		resolvers.add(new RootBeanDefinition(PayloadExpressionArgumentResolver.class));
 		resolvers.add(new RootBeanDefinition(PayloadsArgumentResolver.class));
 		resolvers.add(new RootBeanDefinition(MapArgumentResolver.class));
-		resolvers.add(
-				BeanDefinitionBuilder.genericBeanDefinition(CollectionArgumentResolver.class)
-						.addConstructorArgValue(listCapable)
-						.getBeanDefinition());
+
+		if (listCapable) {
+			resolvers.add(
+					BeanDefinitionBuilder.genericBeanDefinition(CollectionArgumentResolver.class)
+							.addConstructorArgValue(true)
+							.getBeanDefinition());
+		}
 
 		return BeanDefinitionBuilder.genericBeanDefinition(HandlerMethodArgumentResolversHolder.class)
 				.addConstructorArgValue(resolvers)

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingMethodInvokerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -577,17 +577,19 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 		PayloadsArgumentResolver payloadsArgumentResolver = new PayloadsArgumentResolver();
 		payloadsArgumentResolver.setBeanFactory(getBeanFactory());
 
-		CollectionArgumentResolver collectionArgumentResolver =
-				new CollectionArgumentResolver(this.canProcessMessageList);
-		collectionArgumentResolver.setBeanFactory(getBeanFactory());
-
 		MapArgumentResolver mapArgumentResolver = new MapArgumentResolver();
 		mapArgumentResolver.setBeanFactory(getBeanFactory());
 
 		List<HandlerMethodArgumentResolver> customArgumentResolvers = new LinkedList<>();
 		customArgumentResolvers.add(payloadExpressionArgumentResolver);
 		customArgumentResolvers.add(payloadsArgumentResolver);
-		customArgumentResolvers.add(collectionArgumentResolver);
+
+		if (this.canProcessMessageList) {
+			CollectionArgumentResolver collectionArgumentResolver = new CollectionArgumentResolver(true);
+			collectionArgumentResolver.setBeanFactory(getBeanFactory());
+			customArgumentResolvers.add(collectionArgumentResolver);
+		}
+
 		customArgumentResolvers.add(mapArgumentResolver);
 
 		this.messageHandlerMethodFactory.setCustomArgumentResolvers(customArgumentResolvers);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4410

The `CollectionArgumentResolver` has been introduced especially for the
cases to work with `MessageGroupProcessor` (an aggregator)
when the payload is a `Collection<Message<?>>`.

This use-case doesn't apply for the general collection parameter use-case.

* Register `CollectionArgumentResolver` only when `listCapable` option.
For all other collection-based use-cases fallback to the standard
`PayloadArgumentResolver` with an appropriate configured `MessageConverter`

Note: this is for backward compatibility.
In the `5.1` we may reconsider to use `MessageConverter` in the
`CollectionArgumentResolver` as well, or just remove it altogether with
an appropriate logic in the `PayloadArgumentResolver`, since this
`CollectionArgumentResolver` solution isn't robust

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
