### PR TITLE
INT-4409: Do not override soapAction to if empty

### DIFF
--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,10 +114,12 @@ public class DefaultSoapHeaderMapper extends AbstractHeaderMapper<SoapMessage> i
 	@Override
 	protected void populateStandardHeaders(Map<String, Object> headers, SoapMessage target) {
 		String soapAction = getHeaderIfAvailable(headers, WebServiceHeaders.SOAP_ACTION, String.class);
-		if (!StringUtils.hasText(soapAction)) {
-			soapAction = "\"\"";
+		if (StringUtils.hasText(soapAction)) {
+			target.setSoapAction(soapAction);
 		}
-		target.setSoapAction(soapAction);
+		else if (!StringUtils.hasText(target.getSoapAction())) {
+			target.setSoapAction("\"\"");
+		}
 	}
 
 	@Override


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4409

The `SoapMessage` may come as a `payload` and be already with the
`soapAction` header.
Right now it is overridden independently of the value from the headers.

* Do not override `soapAction` in the `SoapMessage` if header doesn't
have value

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
