### PR TITLE
INT-4407: Add merge option to Log4j2LevelAdjuster

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AsyncAmqpGatewayTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AsyncAmqpGatewayTests.java
@@ -79,8 +79,7 @@ public class AsyncAmqpGatewayTests {
 	@Rule
 	public Log4j2LevelAdjuster adjuster =
 			Log4j2LevelAdjuster.trace()
-					.categories("org.springframework.integration",
-							"org.springframework.amqp");
+					.categories(true, "org.springframework.amqp");
 
 	@AfterClass
 	public static void tearDown() {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 4.3
  *
  */
@@ -74,8 +75,9 @@ public class FtpStreamingMessageSourceTests extends FtpTestSupport {
 	private SourcePollingChannelAdapter adapter;
 
 	@Rule
-	public Log4j2LevelAdjuster adjuster = Log4j2LevelAdjuster.debug()
-		.categories("org.springframework.integration", "org.apache.commons");
+	public Log4j2LevelAdjuster adjuster =
+			Log4j2LevelAdjuster.debug()
+					.categories(true, "org.apache.commons");
 
 	@SuppressWarnings("unchecked")
 	@Test

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsOutboundGatewayTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/JmsOutboundGatewayTests.java
@@ -75,7 +75,7 @@ public class JmsOutboundGatewayTests extends ActiveMQMultiContextTests {
 	@Rule
 	public Log4j2LevelAdjuster adjuster =
 			Log4j2LevelAdjuster.trace()
-					.categories("org.springframework.integration", "org.springframework.jms", "org.apache");
+					.categories(true, "org.springframework.jms", "org.apache");
 
 	@Test
 	public void testContainerBeanNameWhenNoGatewayBeanName() {

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests.java
@@ -60,8 +60,7 @@ public class DelayerHandlerRescheduleIntegrationTests extends RedisAvailableTest
 	@Rule
 	public Log4j2LevelAdjuster adjuster =
 			Log4j2LevelAdjuster.trace()
-					.categories("org.springframework.integration",
-							"org.springframework.data.redis");
+					.categories(true, "org.springframework.data.redis");
 
 	@Test
 	@RedisAvailable

--- a/spring-integration-stomp/src/test/java/org/springframework/integration/stomp/client/StompServerIntegrationTests.java
+++ b/spring-integration-stomp/src/test/java/org/springframework/integration/stomp/client/StompServerIntegrationTests.java
@@ -81,8 +81,7 @@ public class StompServerIntegrationTests {
 	@Rule
 	public Log4j2LevelAdjuster adjuster =
 			Log4j2LevelAdjuster.trace()
-					.categories("org.springframework",
-							"org.springframework.integration",
+					.categories(true, "org.springframework",
 							"org.apache.activemq.broker",
 							"reactor.ipc",
 							"io.netty");

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/rule/Log4j2LevelAdjuster.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/rule/Log4j2LevelAdjuster.java
@@ -163,7 +163,22 @@ public class Log4j2LevelAdjuster implements MethodRule {
 	 * @return a Log4j2LevelAdjuster copy with the provided classes
 	 */
 	public Log4j2LevelAdjuster classes(Class<?>... classes) {
-		return new Log4j2LevelAdjuster(this.level, classes, this.categories);
+		return classes(false, classes);
+	}
+
+	/**
+	 * Specify the classes for logging level adjusting configured before.
+	 * A new copy Log4j2LevelAdjuster instance is produced by this method.
+	 * The provided classes parameter can be merged with existing value in the {@link #classes}.
+	 * @param merge to merge or not with previously configured {@link #classes}
+	 * @param classes the classes to use for logging level adjusting
+	 * @return a Log4j2LevelAdjuster copy with the provided classes
+	 * @since 5.0.2
+	 */
+	public Log4j2LevelAdjuster classes(boolean merge, Class<?>... classes) {
+		return new Log4j2LevelAdjuster(this.level,
+				merge ? Stream.of(this.classes, classes).flatMap(Stream::of).toArray(Class<?>[]::new) : classes,
+				this.categories);
 	}
 
 	/**
@@ -174,7 +189,21 @@ public class Log4j2LevelAdjuster implements MethodRule {
 	 * @return a Log4j2LevelAdjuster copy with the provided categories
 	 */
 	public Log4j2LevelAdjuster categories(String... categories) {
-		return new Log4j2LevelAdjuster(this.level, this.classes, categories);
+		return categories(false, categories);
+	}
+
+	/**
+	 * Specify the categories for logging level adjusting configured before.
+	 * A new copy Log4j2LevelAdjuster instance is produced by this method.
+	 * The provided categories parameter can be merged with existing value in the {@link #categories}.
+	 * @param merge to merge or not with previously configured {@link #categories}
+	 * @param categories the categories to use for logging level adjusting
+	 * @return a Log4j2LevelAdjuster copy with the provided categories
+	 * @since 5.0.2
+	 */
+	public Log4j2LevelAdjuster categories(boolean merge, String... categories) {
+		return new Log4j2LevelAdjuster(this.level, this.classes,
+				merge ? Stream.of(this.categories, categories).flatMap(Stream::of).toArray(String[]::new) : categories);
 	}
 
 	/**


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4407

To make a `Log4j2LevelAdjuster` more builder friendly, add a `merge`
option to the overloaded `classes()` and `categories()` methods.
This way the existing (or previously configured) `categories` and
`classes` are merged with the provided values and default
`org.springframework.integration` category can be reuse.

Note: this behavior can be reconsidered as default one in the `5.1`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
