### PR TITLE
INT-4413: Don't register flow under the same id

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ import org.springframework.context.SmartLifecycle;
  * However, when we register an {@link IntegrationFlow} dynamically using the
  * {@link org.springframework.integration.dsl.context.IntegrationFlowContext} API,
  * the lifecycle processor from the application context is not involved;
- * therefore we should control the lifecyle of the beans manually, or rely on the
+ * therefore we should control the lifecycle of the beans manually, or rely on the
  * {@link org.springframework.integration.dsl.context.IntegrationFlowContext} API.
  * Its created registration <b>is</b> {@code autoStartup} by default and
  * starts the flow when it is registered. If you disable the registration's auto-
@@ -146,6 +146,11 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 		return 0;
 	}
 
+	@Override
+	public String toString() {
+		return "StandardIntegrationFlow{integrationComponents=" + this.integrationComponents + '}';
+	}
+
 	private static final class AggregatingCallback implements Runnable {
 
 		private final AtomicInteger count;
@@ -165,6 +170,5 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 		}
 
 	}
-
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowRegistration.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,6 +155,14 @@ public class IntegrationFlowRegistration {
 	 */
 	public void destroy() {
 		this.integrationFlowContext.remove(this.id);
+	}
+
+	@Override
+	public String toString() {
+		return "IntegrationFlowRegistration{integrationFlow=" + this.integrationFlow +
+				", id='" + this.id + '\'' +
+				", inputChannel=" + this.inputChannel +
+				'}';
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
@@ -32,6 +32,7 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,6 +55,7 @@ import org.springframework.integration.dsl.IntegrationFlowAdapter;
 import org.springframework.integration.dsl.IntegrationFlowDefinition;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.MessageProducerSpec;
+import org.springframework.integration.dsl.StandardIntegrationFlow;
 import org.springframework.integration.dsl.channel.MessageChannels;
 import org.springframework.integration.dsl.context.IntegrationFlowContext;
 import org.springframework.integration.dsl.context.IntegrationFlowRegistration;
@@ -389,6 +391,31 @@ public class ManualFlowTests {
 		}
 
 		assertNull(resultChannel.receive(0));
+	}
+
+	@Test
+	public void testRegistrationDuplicationRejected() {
+		String testId = "testId";
+
+		StandardIntegrationFlow testFlow =
+				IntegrationFlows.from(Supplier.class)
+						.get();
+
+		this.integrationFlowContext
+				.registration(testFlow)
+				.id(testId)
+				.register();
+
+		try {
+			this.integrationFlowContext
+					.registration(testFlow)
+					.id(testId)
+					.register();
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(IllegalArgumentException.class));
+			assertThat(e.getMessage(), containsString("with flowId '" + testId + "' is already registered."));
+		}
 	}
 
 	@Configuration


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4413

When we override entity in the `IntegrationFlowContext.registry`,
we may get dangling beans in the application context,
when the structure of a new `IntegrationFlow` is different.

* Fix `IntegrationFlowContext` to disallow to override the flow
registration under the same name
* Add JavaDocs to the `IntegrationFlowRegistrationBuilder` methods
* Add `toString()` to the `IntegrationFlowRegistration` and
`StandardIntegrationFlow` to make the logging of these components
friendlier

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
