### PR TITLE
INT-4420 spring-integration-test-support hamcrest-all dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -267,13 +267,10 @@ subprojects { subproject ->
 project('spring-integration-test-support') {
 	description = 'Spring Integration Test Support - **No SI Dependencies Allowed**'
 	dependencies {
-		compile ("junit:junit:$junitVersion") {
-			exclude group: 'org.hamcrest', module: 'hamcrest-core'
-		}
-		compile "org.hamcrest:hamcrest-all:$hamcrestVersion"
-		compile ("org.mockito:mockito-core:$mockitoVersion") {
-			exclude group: 'org.hamcrest', module: 'hamcrest-core'
-		}
+		compile "org.hamcrest:hamcrest-core:$hamcrestVersion"
+		compile "org.hamcrest:hamcrest-library:$hamcrestVersion"
+		compile "junit:junit:$junitVersion"
+		compile "org.mockito:mockito-core:$mockitoVersion"
 		compile "org.assertj:assertj-core:$assertjVersion"
 		compile "org.springframework:spring-context:$springVersion"
 		compile "org.springframework:spring-messaging:$springVersion"


### PR DESCRIPTION
Use hamcrest-core and hamcrest-library in place of hamcrest-all to match behaviour of other spring projects and avoid multiple JARs containing the same classes.

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
