### PR TITLE
INT-4428: MethodParam usage: fix race condition

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/CollectionArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/CollectionArgumentResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class CollectionArgumentResolver extends AbstractExpressionEvaluator
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception {
+	public Object resolveArgument(MethodParameter parameter, Message<?> message) {
 		Object value = message.getPayload();
 
 		if (this.canProcessMessageList) {
@@ -75,8 +75,7 @@ public class CollectionArgumentResolver extends AbstractExpressionEvaluator
 
 			Collection<Message<?>> messages = (Collection<Message<?>>) value;
 
-			parameter.increaseNestingLevel();
-			if (Message.class.isAssignableFrom(parameter.getNestedParameterType())) {
+			if (Message.class.isAssignableFrom(parameter.nested().getNestedParameterType())) {
 				value = messages;
 			}
 			else {
@@ -84,7 +83,6 @@ public class CollectionArgumentResolver extends AbstractExpressionEvaluator
 						.map(Message::getPayload)
 						.collect(Collectors.toList());
 			}
-			parameter.decreaseNestingLevel();
 		}
 
 		if (Iterator.class.isAssignableFrom(parameter.getParameterType())) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -1242,9 +1242,7 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 			}
 			this.targetParameterTypeDescriptor = targetParameterType;
 			if (Message.class.isAssignableFrom(targetParameterType.getObjectType())) {
-				methodParameter.increaseNestingLevel();
-				this.targetParameterType = methodParameter.getNestedParameterType();
-				methodParameter.decreaseNestingLevel();
+				this.targetParameterType = methodParameter.nested().getNestedParameterType();
 			}
 			else {
 				this.targetParameterType = targetParameterType.getObjectType();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4428

Using `increaseNestingLevel()` and `decreaseNestingLevel()` is not
thread-safe and may cause a race conditions

* Use `MethodParameter.nested()` instead which creates and cache a new
`MethodParameter` for the nested generic type

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
