### PR TITLE
INT-4430: Make Iterator-based FileSplitter close it's underlying Read…

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CloseableIterator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CloseableIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,16 +25,7 @@ import java.util.Iterator;
  *
  * @author Ruslan Stelmachenko
  *
- * @since 4.3.15, 5.0.4
+ * @since 4.3.15
  */
 public interface CloseableIterator<E> extends Iterator<E>, Closeable {
-
-	/**
-	 * Closes this iterator and releases any system resources associated
-	 * with it. If the iterator is already closed then invoking this
-	 * method has no effect.
-	 */
-	@Override
-	void close();
-
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CloseableIterator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CloseableIterator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.util;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+/**
+ * A {@link CloseableIterator} is intended to be used when it may hold resources (such as file or socket handles).
+ * This allows implementations to clean up any resources they need to keep open to iterate over elements.
+ *
+ * @author Ruslan Stelmachenko
+ *
+ * @since 4.3.15, 5.0.4
+ */
+public interface CloseableIterator<E> extends Iterator<E>, Closeable {
+
+	/**
+	 * Closes this iterator and releases any system resources associated
+	 * with it. If the iterator is already closed then invoking this
+	 * method has no effect.
+	 */
+	@Override
+	void close();
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/FunctionIterator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/FunctionIterator.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
  * @author Ruslan Stelmachenko
  * @since 4.1
  */
-public class FunctionIterator<T, V> implements Iterator<V>, Closeable {
+public class FunctionIterator<T, V> implements CloseableIterator<V> {
 
 	private final Iterator<T> iterator;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/FunctionIterator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/FunctionIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.util;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.function.Function;
 
@@ -24,9 +26,10 @@ import java.util.function.Function;
  * {@link #iterator} to a new object applying the {@link #function} on {@link #next()}.
  *
  * @author Artem Bilan
+ * @author Ruslan Stelmachenko
  * @since 4.1
  */
-public class FunctionIterator<T, V> implements Iterator<V> {
+public class FunctionIterator<T, V> implements Iterator<V>, Closeable {
 
 	private final Iterator<T> iterator;
 
@@ -56,5 +59,11 @@ public class FunctionIterator<T, V> implements Iterator<V> {
 		return this.function.apply(this.iterator.next());
 	}
 
-}
+	@Override
+	public void close() throws IOException {
+		if (this.iterator instanceof Closeable) {
+			((Closeable) this.iterator).close();
+		}
+	}
 
+}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/splitter/FileSplitter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/splitter/FileSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.springframework.integration.splitter.AbstractMessageSplitter;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.json.JsonObjectMapper;
 import org.springframework.integration.support.json.JsonObjectMapperProvider;
+import org.springframework.integration.util.CloseableIterator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.util.Assert;
@@ -68,6 +69,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Ruslan Stelmachenko
  *
  * @since 4.1.2
  */
@@ -243,7 +245,7 @@ public class FileSplitter extends AbstractMessageSplitter {
 			firstLineAsHeader = null;
 		}
 
-		Iterator<Object> iterator = new Iterator<Object>() {
+		Iterator<Object> iterator = new CloseableIterator<Object>() {
 
 			boolean markers = FileSplitter.this.markers;
 
@@ -263,7 +265,7 @@ public class FileSplitter extends AbstractMessageSplitter {
 			public boolean hasNext() {
 				this.hasNextCalled = true;
 				try {
-					if (this.line == null && !this.done) {
+					if (!this.done && this.line == null) {
 						this.line = bufferedReader.readLine();
 					}
 					boolean ready = !this.done && this.line != null;
@@ -280,8 +282,8 @@ public class FileSplitter extends AbstractMessageSplitter {
 				}
 				catch (IOException e) {
 					try {
-						bufferedReader.close();
 						this.done = true;
+						bufferedReader.close();
 					}
 					catch (IOException e1) {
 						// ignored
@@ -342,6 +344,17 @@ public class FileSplitter extends AbstractMessageSplitter {
 				}
 				return getMessageBuilderFactory().withPayload(payload)
 						.setHeader(FileHeaders.MARKER, fileMarker.mark.name());
+			}
+
+			@Override
+			public void close() {
+				try {
+					this.done = true;
+					bufferedReader.close();
+				}
+				catch (IOException e) {
+					// ignored
+				}
 			}
 
 		};

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
@@ -172,7 +172,7 @@ public class StreamingInboundTests {
 		assertNull(out.receive(0));
 
 		// close by list, splitter
-		verify(new IntegrationMessageHeaderAccessor(receivedStream).getCloseableResource(), times(2)).close();
+		verify(new IntegrationMessageHeaderAccessor(receivedStream).getCloseableResource(), times(3)).close();
 
 		receivedStream = streamer.receive();
 		splitter.handleMessage(receivedStream);
@@ -187,7 +187,7 @@ public class StreamingInboundTests {
 		assertNull(out.receive(0));
 
 		// close by splitter
-		verify(new IntegrationMessageHeaderAccessor(receivedStream).getCloseableResource(), times(3)).close();
+		verify(new IntegrationMessageHeaderAccessor(receivedStream).getCloseableResource(), times(5)).close();
 	}
 
 	public static class Streamer extends AbstractRemoteFileStreamingMessageSource<String> {


### PR DESCRIPTION
…er when exception happens in downstream flow

JIRA: https://jira.spring.io/browse/INT-4430

When Iterator-based FileSplitter splits the file, and an exception throws in downstream flow (in the same thread), the exception propagates to the caller leaving underlying file reader opened.

This commit changes AbstractMessageSplitter the way, that, when any exception happens, if Iterator implements java.io.Closeable, it's close() method will be called before propagating exception.

Also FileSplitter's underlying iterator implements Closeable now.

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
