### PR TITLE
    INT-4432: fix output channel not correctly set bug.

### DIFF
--- a/spring-integration-test/src/main/java/org/springframework/integration/test/context/MockIntegrationContext.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/context/MockIntegrationContext.java
@@ -139,8 +139,7 @@ public class MockIntegrationContext implements BeanFactoryAware {
 
 		if (mockMessageHandler instanceof MessageProducer) {
 			if (targetMessageHandler instanceof MessageProducer) {
-				MessageChannel outputChannel = TestUtils.getPropertyValue(targetMessageHandler, "outputChannel",
-						MessageChannel.class);
+				MessageChannel outputChannel = ((MessageProducer) targetMessageHandler).getOutputChannel();
 				((MessageProducer) mockMessageHandler).setOutputChannel(outputChannel);
 			}
 			else {


### PR DESCRIPTION
    JIRA: https://jira.spring.io/browse/INT-4432

    The `MockIntegrationContext.substituteMessageHandlerFor()` method
    cannot get the correct output channel of target message handler
    since the `outputChannel` property is not initialized.

    * Use `getOutputChannel()` method instead of directly accessing
    the `outputChannel` property. The `getOutputChannel()` method
    guarantees the correct value is retrieved.