### PR TITLE
INT-4437: Scatter-Gather: reinstate replyChannel

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/scattergather/ScatterGatherHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/scattergather/ScatterGatherHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,7 +147,11 @@ public class ScatterGatherHandler extends AbstractReplyProducingMessageHandler i
 
 		Message<?> gatherResult = gatherResultChannel.receive(this.gatherTimeout);
 		if (gatherResult != null) {
-			return gatherResult;
+			return getMessageBuilderFactory()
+					.fromMessage(gatherResult)
+					.removeHeader(GATHER_RESULT_CHANNEL)
+					.setHeader(MessageHeaders.REPLY_CHANNEL, requestMessage.getHeaders().getReplyChannel())
+					.build();
 		}
 
 		return null;

--- a/spring-integration-core/src/test/java/org/springframework/integration/scattergather/config/ScatterGatherTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/scattergather/config/ScatterGatherTests-context.xml
@@ -54,9 +54,11 @@
 
 	<gateway id="gateway" default-request-channel="gatewayAuction"/>
 
-	<scatter-gather input-channel="gatewayAuction" scatter-channel="auctionChannel">
+	<scatter-gather input-channel="gatewayAuction" output-channel="bridgeChannel" scatter-channel="auctionChannel">
 		<gatherer release-strategy-expression="messages.^[payload gt 5] != null or size() == 3"/>
 	</scatter-gather>
+
+	<bridge input-channel="bridgeChannel"/>
 
 	<chain input-channel="scatterGatherWithinChain" output-channel="output">
 		<scatter-gather scatter-channel="auctionChannel"/>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4437

The `ScatterGatherHandler` overrides a `replyChannel` header for the
scatter message to its internal queue and doesn't reinstate the original
`replyChannel` header when producer a gather result message

* Rebuild gather result message with population a proper `replyChannel`
header from the request message and removing a `gatherResultChannel`
header

**Cherry-pick to 5.0.3 and 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
