### PR TITLE
LockRegistryLeaderInitiator: Add DEBUG for errors

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
@@ -400,6 +400,9 @@ public class LockRegistryLeaderInitiator implements SmartLifecycle, DisposableBe
 							}
 							return null;
 						}
+						else if (logger.isDebugEnabled()) {
+							logger.debug("Error to acquire the lock. " + (isRunning() ? "Retrying..." : ""), e);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
For better traceability for errors during lock acquiring add DEBUG
logging message in the `catch` block before returning back to the main
loop for the next acquiring attempt

**Cherry-pick to 5.0.x and 4.3.x**

/CC @vpavic 