### PR TITLE
Fix AMQP MessageSource Tests

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpMessageSource.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpMessageSource.java
@@ -20,6 +20,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -199,6 +202,8 @@ public class AmqpMessageSource extends AbstractMessageSource<Object> {
 
 	public static class AmqpAckCallback implements AcknowledgmentCallback {
 
+		private static Log logger = LogFactory.getLog(AmqpAckCallback.class);
+
 		private final AmqpAckInfo ackInfo;
 
 		private boolean acknowledged;
@@ -235,6 +240,9 @@ public class AmqpMessageSource extends AbstractMessageSource<Object> {
 		@Override
 		public void acknowledge(Status status) {
 			Assert.notNull(status, "'status' cannot be null");
+			if (logger.isTraceEnabled()) {
+				logger.trace("acknowledge(" + status.name() + ") for " + this);
+			}
 			try {
 				long deliveryTag = this.ackInfo.getGetResponse().getEnvelope().getDeliveryTag();
 				switch (status) {
@@ -262,6 +270,12 @@ public class AmqpMessageSource extends AbstractMessageSource<Object> {
 				RabbitUtils.closeConnection(this.ackInfo.getConnection());
 				this.acknowledged = true;
 			}
+		}
+
+		@Override
+		public String toString() {
+			return "AmqpAckCallback [ackInfo=" + this.ackInfo + ", acknowledged=" + this.acknowledged
+					+ ", autoAckEnabled=" + this.autoAckEnabled + "]";
 		}
 
 	}
@@ -300,6 +314,12 @@ public class AmqpMessageSource extends AbstractMessageSource<Object> {
 
 		public GetResponse getGetResponse() {
 			return this.getResponse;
+		}
+
+		@Override
+		public String toString() {
+			return "AmqpAckInfo [connection=" + this.connection + ", channel=" + this.channel + ", transacted="
+					+ this.transacted + ", getResponse=" + this.getResponse + "]";
 		}
 
 	}

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpMessageSourceIntegrationTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpMessageSourceIntegrationTests.java
@@ -60,6 +60,7 @@ import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.Pollers;
+import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
@@ -132,8 +133,9 @@ public class AmqpMessageSourceIntegrationTests {
 		assertThat(this.config.fromDsl, equalTo("bar"));
 		assertThat(this.config.fromInterceptedSource, equalTo("BAZ"));
 		assertNull(template.receive(NOAUTOACK_QUEUE));
+		assertThat(this.config.requeueLatch.getCount(), equalTo(1L));
 		this.config.callback.acknowledge(Status.REQUEUE);
-		assertNotNull(template.receive(NOAUTOACK_QUEUE, 10_000));
+		assertTrue(this.config.requeueLatch.await(10, TimeUnit.SECONDS));
 	}
 
 	@Configuration
@@ -141,6 +143,8 @@ public class AmqpMessageSourceIntegrationTests {
 	public static class Config {
 
 		private final CountDownLatch latch = new CountDownLatch(5);
+
+		private final CountDownLatch requeueLatch = new CountDownLatch(2);
 
 		private volatile String received;
 
@@ -174,7 +178,18 @@ public class AmqpMessageSourceIntegrationTests {
 		@InboundChannelAdapter(channel = "noAutoAck", poller = @Poller(fixedDelay = "100"), autoStartup = "false")
 		@Bean
 		public MessageSource<?> noAutoAckSource() {
-			return new AmqpMessageSource(connectionFactory(), NOAUTOACK_QUEUE);
+			return new AmqpMessageSource(connectionFactory(), NOAUTOACK_QUEUE) {
+
+				@Override
+				protected AbstractIntegrationMessageBuilder<Object> doReceive() {
+					AbstractIntegrationMessageBuilder<Object> builder = super.doReceive();
+					if (builder != null) {
+						Config.this.requeueLatch.countDown();
+					}
+					return builder;
+				}
+
+			};
 		}
 
 		@ServiceActivator(inputChannel = "noAutoAck")


### PR DESCRIPTION
https://build.spring.io/browse/INT-MASTER-983/

Race between the poller and template to get the requeued message.

Also add trace logging to the acknowledgment.

**cherry-pick to 5.0.x**

