### PR TITLE
Fix NPE in the TcpNetServerConnectionFactory

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetServerConnectionFactory.java
@@ -33,6 +33,8 @@ import org.springframework.util.Assert;
  * a {@link ServerSocket}. Must have a {@link TcpListener} registered.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  *
  */
@@ -181,12 +183,7 @@ public class TcpNetServerConnectionFactory extends AbstractServerConnectionFacto
 			else if (isActive()) {
 				logger.error("Error on ServerSocket; port = " + getPort(), e);
 				publishServerExceptionEvent(e);
-				try {
-					this.serverSocket.close();
-				}
-				catch (IOException e1) {
-					// empty
-				}
+				stop();
 			}
 		}
 		finally {
@@ -223,7 +220,8 @@ public class TcpNetServerConnectionFactory extends AbstractServerConnectionFacto
 		try {
 			this.serverSocket.close();
 		}
-		catch (IOException e) { }
+		catch (IOException e) {
+		}
 		this.serverSocket = null;
 		super.stop();
 	}


### PR DESCRIPTION
https://build.spring.io/browse/INTSAMPLES-NIGHTLY-2413

When we fail with the
`java.net.BindException: Address already in use (Bind failed)` in the
`TcpNetServerConnectionFactory.run()`, the `serverSocket` property
remains `null` and we get `NPE` in the `catch` block trying to `close()`
the socket.

* Call `stop()` instead which has all the required protections.

**Cherry-pick to 5.0.x and 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
