### PR TITLE
INT-4445: Fix JDBC tests for Derby

### DIFF
--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/AggregatorIntegrationTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/AggregatorIntegrationTests-context.xml
@@ -21,7 +21,7 @@
 	<jdbc:embedded-database id="dataSource" type="DERBY"/>
 
 	<jdbc:initialize-database data-source="dataSource"
-							  ignore-failures="DROPS">
+							  ignore-failures="ALL">
 		<jdbc:script location="${int.drop.script}"/>
 		<jdbc:script location="${int.schema.script}"/>
 	</jdbc:initialize-database>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/metadata/JdbcMetadataStoreTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/metadata/JdbcMetadataStoreTests-context.xml
@@ -9,7 +9,7 @@
 
 	<jdbc:embedded-database id="dataSource" type="DERBY"/>
 
-	<jdbc:initialize-database data-source="dataSource" ignore-failures="DROPS">
+	<jdbc:initialize-database data-source="dataSource" ignore-failures="ALL">
 		<jdbc:script location="${int.drop.script}"/>
 		<jdbc:script location="${int.schema.script}"/>
 	</jdbc:initialize-database>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/JdbcMessageStoreChannelIntegrationTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/JdbcMessageStoreChannelIntegrationTests-context.xml
@@ -16,7 +16,7 @@
 
 	<jdbc:embedded-database id="dataSource" type="DERBY"/>
 
-	<jdbc:initialize-database data-source="dataSource" ignore-failures="DROPS">
+	<jdbc:initialize-database data-source="dataSource" ignore-failures="ALL">
 		<jdbc:script location="${int.drop.script}"/>
 		<jdbc:script location="${int.schema.script}"/>
 	</jdbc:initialize-database>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/JdbcMessageStoreChannelOnePollerIntegrationTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/JdbcMessageStoreChannelOnePollerIntegrationTests-context.xml
@@ -16,7 +16,7 @@
 	<jdbc:embedded-database id="dataSource" type="DERBY" />
 
 	<jdbc:initialize-database data-source="dataSource"
-		ignore-failures="DROPS">
+		ignore-failures="ALL">
 		<jdbc:script location="${int.drop.script}" />
 		<jdbc:script location="${int.schema.script}" />
 	</jdbc:initialize-database>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/JdbcMessageStoreChannelTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/JdbcMessageStoreChannelTests-context.xml
@@ -14,7 +14,7 @@
 
 	<jdbc:embedded-database id="dataSource" type="DERBY" />
 
-	<jdbc:initialize-database data-source="dataSource" ignore-failures="DROPS">
+	<jdbc:initialize-database data-source="dataSource" ignore-failures="ALL">
 		<jdbc:script location="${int.drop.script}" />
 		<jdbc:script location="${int.schema.script}" />
 	</jdbc:initialize-database>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/JdbcMessageStoreChannelTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/JdbcMessageStoreChannelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,14 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
@@ -37,6 +41,14 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.transaction.BeforeTransaction;
 import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Dave Syer
+ * @author Mark Fisher
+ * @author Oleg Zhurakousky
+ * @author Gary Russell
+ * @author Artem Bilan
+ */
 
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -49,6 +61,21 @@ public class JdbcMessageStoreChannelTests {
 	@Autowired
 	private JdbcMessageStore messageStore;
 
+	@Autowired
+	@Qualifier("service-activator")
+	private AbstractEndpoint serviceActivator;
+
+	@Before
+	public void init() {
+		Service.reset(1);
+		this.serviceActivator.start();
+	}
+
+	@After
+	public void tearDown() {
+		this.serviceActivator.stop();
+	}
+
 	@BeforeTransaction
 	public void clear() {
 		for (MessageGroup group : messageStore) {
@@ -58,8 +85,7 @@ public class JdbcMessageStoreChannelTests {
 
 	@Test
 	public void testSendAndActivate() throws Exception {
-		Service.reset(1);
-		input.send(new GenericMessage<String>("foo"));
+		input.send(new GenericMessage<>("foo"));
 		Service.await(10000);
 		assertEquals(1, Service.messages.size());
 		assertEquals(0, messageStore.getMessageGroup("JdbcMessageStoreChannelTests").size());
@@ -67,9 +93,8 @@ public class JdbcMessageStoreChannelTests {
 
 	@Test
 	public void testSendAndActivateWithRollback() throws Exception {
-		Service.reset(1);
 		Service.fail = true;
-		input.send(new GenericMessage<String>("foo"));
+		input.send(new GenericMessage<>("foo"));
 		Service.await(10000);
 		assertEquals(1, Service.messages.size());
 		// After a rollback in the poller the message is still waiting to be delivered
@@ -77,13 +102,12 @@ public class JdbcMessageStoreChannelTests {
 	}
 
 	@Test
-	@Transactional
+	@Transactional(timeout = 1)
 	public void testSendAndActivateTransactionalSend() throws Exception {
-		Service.reset(1);
-		input.send(new GenericMessage<String>("foo"));
+		input.send(new GenericMessage<>("foo"));
 		// This will time out because the transaction has not committed yet
 		try {
-			Service.await(10000);
+			Service.await(10);
 			fail("Expected timeout");
 		}
 		catch (IllegalStateException e) {
@@ -96,21 +120,28 @@ public class JdbcMessageStoreChannelTests {
 	}
 
 	public static class Service {
+
 		private static boolean fail = false;
+
 		private static boolean alreadyFailed = false;
-		private static List<String> messages = new CopyOnWriteArrayList<String>();
+
+		private static List<String> messages = new CopyOnWriteArrayList<>();
+
 		private static CountDownLatch latch = new CountDownLatch(0);
+
 		public static void reset(int count) {
 			fail = false;
 			alreadyFailed = false;
 			messages.clear();
 			latch = new CountDownLatch(count);
 		}
+
 		public static void await(long timeout) throws InterruptedException {
 			if (!latch.await(timeout, TimeUnit.MILLISECONDS)) {
 				throw new IllegalStateException("Timed out waiting for message");
 			}
 		}
+
 		public String echo(String input) {
 			if (!alreadyFailed) {
 				messages.add(input);
@@ -122,6 +153,7 @@ public class JdbcMessageStoreChannelTests {
 			}
 			return input;
 		}
+
 	}
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/JdbcMessageStoreTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/JdbcMessageStoreTests-context.xml
@@ -9,7 +9,7 @@
 
 	<jdbc:embedded-database id="dataSource" type="DERBY"/>
 
-	<jdbc:initialize-database data-source="dataSource" ignore-failures="DROPS">
+	<jdbc:initialize-database data-source="dataSource" ignore-failures="ALL">
 		<jdbc:script location="${int.drop.script}"/>
 		<jdbc:script location="${int.schema.script}"/>
 	</jdbc:initialize-database>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/DataSource-derby-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/DataSource-derby-context.xml
@@ -16,7 +16,7 @@
 		/> <property name="username" value="int" /> <property name="password" value="int"
 		/> </bean> -->
 
-	<jdbc:initialize-database data-source="dataSource">
+	<jdbc:initialize-database data-source="dataSource" ignore-failures="ALL">
 		<jdbc:script location="classpath:org/springframework/integration/jdbc/schema-derby.sql" />
 	</jdbc:initialize-database>
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4445

Looks like `/dataSource` temporary directory is busy in between different
tests.
The thought is like a high-frequently polling endpoint keeps DB resource
from removing.

* Explicitly `stop()` endpoint in the `JdbcMessageStoreChannelTests`
* Optimize
`JdbcMessageStoreChannelTests.testSendAndActivateTransactionalSend()`
to rely on the short `1` millisecond TX timeout.
This safes for us 10 seconds of the tests executions.
* Configure all the embedded DB beans for the `ignore-failures="ALL"`
as a fallback option if polling endpoint is not a cause of the concurrent
resource access.

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
