### PR TITLE
INT-4448, INT-4449: Fix Gateway for no-arg method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
     - mongodb-3.0-precise
     packages:
     - mongodb-org-server
-    - oracle-java8-installer
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -487,10 +487,15 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 		int paramCount = method.getParameterTypes().length;
 		Object response = null;
 		boolean hasPayloadExpression = method.isAnnotationPresent(Payload.class);
-		if (!hasPayloadExpression && this.methodMetadataMap != null) {
+		if (!hasPayloadExpression) {
 			// check for the method metadata next
-			GatewayMethodMetadata metadata = this.methodMetadataMap.get(method.getName());
-			hasPayloadExpression = (metadata != null) && StringUtils.hasText(metadata.getPayloadExpression());
+			if (this.methodMetadataMap != null) {
+				GatewayMethodMetadata metadata = this.methodMetadataMap.get(method.getName());
+				hasPayloadExpression = (metadata != null) && StringUtils.hasText(metadata.getPayloadExpression());
+			}
+			else if (this.globalMethodMetadata != null) {
+				hasPayloadExpression = StringUtils.hasText(this.globalMethodMetadata.getPayloadExpression());
+			}
 		}
 		if (paramCount == 0 && !hasPayloadExpression) {
 			Long receiveTimeout = null;

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests-context.xml
@@ -10,7 +10,7 @@
 	</int:channel>
 
 	<int:gateway id="sampleGateway"
-			service-interface="org.springframework.integration.gateway.GatewayInterfaceTests.Bar"
+			service-interface="org.springframework.integration.gateway.GatewayInterfaceTests$Bar"
 			default-request-channel="requestChannelBaz"
 			error-channel="errorChannel">
 		<int:default-header name="name" expression="#gatewayMethod.name"/>
@@ -34,9 +34,14 @@
 	<int:channel id="requestChannelBaz"/>
 
 	<int:gateway id="customMappedGateway"
-			service-interface="org.springframework.integration.gateway.GatewayInterfaceTests.Baz"
+			service-interface="org.springframework.integration.gateway.GatewayInterfaceTests$Baz"
 			default-request-channel="requestChannelBaz" mapper="mapper"/>
 
 	<bean id="mapper" class="org.springframework.integration.gateway.GatewayInterfaceTests$BazMapper"/>
+
+	<int:gateway id="sampleGateway2"
+				 service-interface="org.springframework.integration.gateway.GatewayInterfaceTests$NoArgumentsGateway"
+				 default-request-channel="requestChannelBar"
+				 default-payload-expression="'foo'"/>
 
 </beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,7 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.IntegrationProperties;
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.BridgeHandler;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
@@ -487,6 +488,26 @@ public class GatewayInterfaceTests {
 		((SubscribableChannel) this.errorChannel).unsubscribe(messageHandler);
 	}
 
+	@Test
+	public void testGatewayWithNoArgsMethod() {
+		ConfigurableApplicationContext ac =
+				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
+
+		DirectChannel channel = ac.getBean("requestChannelBar", DirectChannel.class);
+		channel.subscribe(new AbstractReplyProducingMessageHandler() {
+
+			@Override
+			protected Object handleRequestMessage(Message<?> requestMessage) {
+				assertEquals("foo", requestMessage.getPayload());
+				return "FOO";
+			}
+
+		});
+
+		NoArgumentsGateway noArgumentsGateway = ac.getBean(NoArgumentsGateway.class);
+		assertEquals("FOO", noArgumentsGateway.pullData());
+		ac.close();
+	}
 
 	public interface Foo {
 
@@ -518,6 +539,11 @@ public class GatewayInterfaceTests {
 	public interface Baz {
 
 		void baz(String payload);
+	}
+
+	public interface NoArgumentsGateway {
+
+		String pullData();
 	}
 
 	public static class BazMapper implements MethodArgsMessageMapper {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4448
JIRA: https://jira.spring.io/browse/INT-4449

When we are not interested in the `payload` to send, we use a gateway
method without any args, but in this case for send operation (or
send-and-receive) we should specify a default `payloadExpression`

The `MessagingGatewayRegistrar` fails with `NPE` if we don't have a
any global headers and have `defaultPayloadExpression`

Also in this case the `GatewayProxyFactoryBean` fails to send
and fallbacks to receive with the meaning "no args, not payloadExpression"

* Fix `MessagingGatewayRegistrar` to check `hasDefaultHeaders` before
processing them
* Fix `GatewayProxyFactoryBean` to consult `this.globalMethodMetadata`
if there is no `payloadExpression` for the method specific metadata

**Cherry-pick to 5.0.x and 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
