### PR TITLE
INT-4446 Improve EmbeddedJsonHeadersMessageMapper

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/EmbeddedJsonHeadersMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/EmbeddedJsonHeadersMessageMapper.java
@@ -167,7 +167,7 @@ public class EmbeddedJsonHeadersMessageMapper implements BytesMessageMapper {
 		else {
 			Message<?> messageToEncode = message;
 
-			if (!allHeaders) {
+			if (!this.allHeaders) {
 				if (!headersToEncode.containsKey(MessageHeaders.ID)) {
 					headersToEncode.put(MessageHeaders.ID, MessageHeaders.ID_VALUE_NONE);
 				}
@@ -183,17 +183,17 @@ public class EmbeddedJsonHeadersMessageMapper implements BytesMessageMapper {
 	}
 
 	private Map<String, Object> pruneHeaders(MessageHeaders messageHeaders) {
-		Map<String, Object> headersToEmbed =
-				messageHeaders
-						.entrySet()
-						.stream()
-						.filter(e ->
-								Boolean.TRUE.equals(this.caseSensitive
-										? PatternMatchUtils.smartMatch(e.getKey(), this.headerPatterns)
-										: PatternMatchUtils.smartMatchIgnoreCase(e.getKey(), this.headerPatterns)))
-						.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+		return messageHeaders
+				.entrySet()
+				.stream()
+				.filter(e -> matchHeader(e.getKey()))
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+	}
 
-		return headersToEmbed;
+	private boolean matchHeader(String header) {
+		return Boolean.TRUE.equals(this.caseSensitive
+				? PatternMatchUtils.smartMatch(header, this.headerPatterns)
+				: PatternMatchUtils.smartMatchIgnoreCase(header, this.headerPatterns));
 	}
 
 	private byte[] fromBytesPayload(byte[] payload, Map<String, Object> headersToEncode) throws Exception {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/utils/PatternMatchUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/utils/PatternMatchUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
 
 package org.springframework.integration.support.utils;
 
+import java.util.Arrays;
+
 /**
  * Utility methods for pattern matching.
  * This utilities provide support of negative pattern matching as well
  * unlike {@link org.springframework.util.PatternMatchUtils}.
  *
  * @author Meherzad Lahewala
+ * @author Artem Bilan
  *
  * @since 5.0
  *
@@ -30,6 +33,28 @@ package org.springframework.integration.support.utils;
 public final class PatternMatchUtils {
 
 	private PatternMatchUtils() { }
+
+	/**
+	 * Pattern match against the supplied patterns ignoring case; also supports negated ('!')
+	 * patterns. First match wins (positive or negative).
+	 * To match the names starting with {@code !} symbol,
+	 * you have to escape it prepending with the {@code \} symbol in the pattern definition.
+	 * @param str the string to match.
+	 * @param patterns the patterns.
+	 * @return true for positive match; false for negative; null if no pattern matches.
+	 * @see org.springframework.util.PatternMatchUtils#simpleMatch(String[], String)
+	 * @since 5.0.5
+	 */
+	public static Boolean smartMatchIgnoreCase(String str, String... patterns) {
+		if (patterns != null) {
+			return smartMatch(str.toLowerCase(),
+					Arrays.stream(patterns)
+							.map(String::toLowerCase)
+							.toArray(String[]::new));
+		}
+
+		return null; //NOSONAR - intentional null return
+	}
 
 	/**
 	 * Pattern match against the supplied patterns; also supports negated ('!')
@@ -58,6 +83,7 @@ public final class PatternMatchUtils {
 				}
 			}
 		}
+
 		return null; //NOSONAR - intentional null return
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4446

* Do not recreate message if not necessarily
* Do not let to generate `id` and `timestamp` if they are not mapped
* Use `smartMatch` to allow to configure negative patterns
* Introduce `PatternMatchUtils.smartMatchIgnoreCase()` for convenience

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
