### PR TITLE
Add Reactive mode for AbstractPollingEndpoint

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
@@ -72,6 +72,8 @@ public abstract class AbstractPollingEndpoint extends AbstractEndpoint implement
 
 	private Executor taskExecutor = new SyncTaskExecutor();
 
+	private boolean syncExecutor = true;
+
 	private ClassLoader beanClassLoader = ClassUtils.getDefaultClassLoader();
 
 	private Trigger trigger = new PeriodicTrigger(10);

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/PollingConsumer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/PollingConsumer.java
@@ -21,8 +21,11 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 
+import org.reactivestreams.Subscriber;
+
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.channel.ExecutorChannelInterceptorAware;
+import org.springframework.integration.channel.ReactiveStreamsSubscribableChannel;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.router.MessageRouter;
 import org.springframework.integration.support.utils.IntegrationUtils;
@@ -95,6 +98,12 @@ public class PollingConsumer extends AbstractPollingEndpoint implements Integrat
 	@Override
 	public MessageHandler getHandler() {
 		return this.handler;
+	}
+
+	@Override
+	protected boolean isReactive() {
+		return getOutputChannel() instanceof ReactiveStreamsSubscribableChannel &&
+				this.handler instanceof Subscriber;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
@@ -30,7 +30,6 @@ import org.springframework.context.Lifecycle;
 import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.integration.acks.AckUtils;
 import org.springframework.integration.acks.AcknowledgmentCallback;
-import org.springframework.integration.aop.AbstractMessageSourceAdvice;
 import org.springframework.integration.aop.MessageSourceMutator;
 import org.springframework.integration.channel.ReactiveStreamsSubscribableChannel;
 import org.springframework.integration.context.ExpressionCapable;

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -523,7 +523,7 @@ public class EnableIntegrationTests {
 		assertTrue(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class));
 		assertEquals(23, TestUtils.getPropertyValue(consumer, "phase"));
 		assertSame(context.getBean("annInput1"), TestUtils.getPropertyValue(consumer, "inputChannel"));
-		assertEquals("annOutput", TestUtils.getPropertyValue(consumer, "handler.outputChannelName"));
+		assertEquals("annOutput", TestUtils.getPropertyValue(consumer, "handler.outputChannel.beanName"));
 		assertSame(context.getBean("annAdvice1"), TestUtils.getPropertyValue(consumer,
 				"handler.adviceChain", List.class).get(0));
 		assertEquals(2000L, TestUtils.getPropertyValue(consumer, "trigger.period"));

--- a/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/PollingTransactionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/PollingTransactionTests.java
@@ -89,8 +89,7 @@ public class PollingTransactionTests {
 		List<Advice> adviceChain = TestUtils.getPropertyValue(advisedPoller, "adviceChain", List.class);
 		assertEquals(4, adviceChain.size());
 		advisedPoller.start();
-		Runnable poller = TestUtils.getPropertyValue(advisedPoller, "poller", Runnable.class);
-		Callable<?> pollingTask = TestUtils.getPropertyValue(poller, "pollingTask", Callable.class);
+		Callable<?> pollingTask = TestUtils.getPropertyValue(advisedPoller, "pollingTask", Callable.class);
 		assertTrue("Poller is not Advised", pollingTask instanceof Advised);
 		Advisor[] advisors = ((Advised) pollingTask).getAdvisors();
 		assertEquals(4, advisors.length);

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ReactiveInboundChannelAdapterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ReactiveInboundChannelAdapterTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.endpoint;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.integration.annotation.InboundChannelAdapter;
+import org.springframework.integration.annotation.Poller;
+import org.springframework.integration.channel.FluxMessageChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 5.1
+ */
+@SpringJUnitConfig
+@DirtiesContext
+public class ReactiveInboundChannelAdapterTests {
+
+	@Autowired
+	private FluxMessageChannel fluxMessageChannel;
+
+	@Test
+	public void testReactiveInboundChannelAdapter() {
+		Flux<Integer> testFlux =
+				Flux.from(this.fluxMessageChannel)
+						.map(Message::getPayload)
+						.cast(Integer.class);
+
+		StepVerifier.create(testFlux)
+				.expectNext(2, 4, 6, 8, 10, 12, 14, 16)
+				.thenCancel()
+				.verify();
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class Config {
+
+		@Bean
+		public AtomicInteger counter() {
+			return new AtomicInteger();
+		}
+
+		@Bean
+		public TaskExecutor taskExecutor() {
+			return new SimpleAsyncTaskExecutor();
+		}
+
+		@Bean
+		@InboundChannelAdapter(value = "fluxChannel",
+				poller = @Poller(fixedDelay = "100", maxMessagesPerPoll = "3", taskExecutor = "taskExecutor"))
+		public Supplier<Integer> counterMessageSupplier() {
+			return () -> {
+				int i = counter().incrementAndGet();
+				return i % 2 == 0 ? i : null;
+			};
+		}
+
+		@Bean
+		public MessageChannel fluxChannel() {
+			return new FluxMessageChannel();
+		}
+
+	}
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -99,7 +99,7 @@ public class AdvisedMessageHandlerTests {
 
 	@Test
 	public void circuitBreakerExceptionText() {
-		GenericMessage<String> message = new GenericMessage<String>("foo");
+		GenericMessage<String> message = new GenericMessage<>("foo");
 		try {
 			input.send(message);
 			fail("expected exception");
@@ -353,7 +353,7 @@ public class AdvisedMessageHandlerTests {
 
 	@Test
 	@SuppressWarnings("rawtypes")
-	public void circuitBreakerTests() throws Exception {
+	public void circuitBreakerTests() {
 		final AtomicBoolean doFail = new AtomicBoolean();
 		AbstractReplyProducingMessageHandler handler = new AbstractReplyProducingMessageHandler() {
 
@@ -384,7 +384,7 @@ public class AdvisedMessageHandlerTests {
 		handler.afterPropertiesSet();
 
 		doFail.set(true);
-		Message<String> message = new GenericMessage<String>("Hello, world!");
+		Message<String> message = new GenericMessage<>("Hello, world!");
 		try {
 			handler.handleMessage(message);
 			fail("Expected failure");
@@ -483,7 +483,7 @@ public class AdvisedMessageHandlerTests {
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
-		Message<String> message = new GenericMessage<String>("Hello, world!");
+		Message<String> message = new GenericMessage<>("Hello, world!");
 		handler.handleMessage(message);
 		assertTrue(counter.get() == -1);
 		Message<?> reply = replies.receive(10000);
@@ -511,13 +511,13 @@ public class AdvisedMessageHandlerTests {
 
 		advice.setRetryStateGenerator(message -> new DefaultRetryState(message.getHeaders().getId()));
 
-		List<Advice> adviceChain = new ArrayList<Advice>();
+		List<Advice> adviceChain = new ArrayList<>();
 		adviceChain.add(advice);
 		handler.setAdviceChain(adviceChain);
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
-		Message<String> message = new GenericMessage<String>("Hello, world!");
+		Message<String> message = new GenericMessage<>("Hello, world!");
 		for (int i = 0; i < 3; i++) {
 			try {
 				handler.handleMessage(message);
@@ -583,13 +583,13 @@ public class AdvisedMessageHandlerTests {
 			AbstractReplyProducingMessageHandler handler, QueueChannel replies, RequestHandlerRetryAdvice advice) {
 		advice.setRecoveryCallback(context -> "baz");
 
-		List<Advice> adviceChain = new ArrayList<Advice>();
+		List<Advice> adviceChain = new ArrayList<>();
 		adviceChain.add(advice);
 		handler.setAdviceChain(adviceChain);
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
-		Message<String> message = new GenericMessage<String>("Hello, world!");
+		Message<String> message = new GenericMessage<>("Hello, world!");
 		for (int i = 0; i < 4; i++) {
 			try {
 				handler.handleMessage(message);
@@ -617,13 +617,13 @@ public class AdvisedMessageHandlerTests {
 		ErrorMessageSendingRecoverer recoverer = new ErrorMessageSendingRecoverer(errors);
 		advice.setRecoveryCallback(recoverer);
 
-		List<Advice> adviceChain = new ArrayList<Advice>();
+		List<Advice> adviceChain = new ArrayList<>();
 		adviceChain.add(advice);
 		handler.setAdviceChain(adviceChain);
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
-		Message<String> message = new GenericMessage<String>("Hello, world!");
+		Message<String> message = new GenericMessage<>("Hello, world!");
 		handler.handleMessage(message);
 		Message<?> error = errors.receive(10000);
 		assertNotNull(error);
@@ -658,13 +658,13 @@ public class AdvisedMessageHandlerTests {
 		advice.setBeanFactory(mock(BeanFactory.class));
 		advice.afterPropertiesSet();
 
-		List<Advice> adviceChain = new ArrayList<Advice>();
+		List<Advice> adviceChain = new ArrayList<>();
 		adviceChain.add(advice);
 		handler.setAdviceChain(adviceChain);
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
-		Message<String> message = new GenericMessage<String>("Hello, world!");
+		Message<String> message = new GenericMessage<>("Hello, world!");
 		handler.handleMessage(message);
 		Message<?> error = errors.receive(10000);
 		assertNotNull(error);
@@ -685,7 +685,7 @@ public class AdvisedMessageHandlerTests {
 			}
 		};
 
-		List<Advice> adviceChain = new ArrayList<Advice>();
+		List<Advice> adviceChain = new ArrayList<>();
 
 		adviceChain.add(new RequestHandlerRetryAdvice());
 		adviceChain.add((MethodInterceptor) invocation -> {
@@ -698,7 +698,7 @@ public class AdvisedMessageHandlerTests {
 		handler.afterPropertiesSet();
 
 		try {
-			handler.handleMessage(new GenericMessage<String>("test"));
+			handler.handleMessage(new GenericMessage<>("test"));
 		}
 		catch (Exception e) {
 			Throwable cause = e.getCause();
@@ -724,7 +724,7 @@ public class AdvisedMessageHandlerTests {
 		QueueChannel replies = new QueueChannel();
 		handler.setOutputChannel(replies);
 
-		List<Advice> adviceChain = new ArrayList<Advice>();
+		List<Advice> adviceChain = new ArrayList<>();
 
 		ExpressionEvaluatingRequestHandlerAdvice expressionAdvice = new ExpressionEvaluatingRequestHandlerAdvice();
 		expressionAdvice.setBeanFactory(mock(BeanFactory.class));
@@ -750,7 +750,7 @@ public class AdvisedMessageHandlerTests {
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
-		handler.handleMessage(new GenericMessage<String>("test"));
+		handler.handleMessage(new GenericMessage<>("test"));
 		Message<?> receive = replies.receive(10000);
 		assertNotNull(receive);
 		assertEquals("intentional: 3", receive.getPayload());
@@ -772,7 +772,7 @@ public class AdvisedMessageHandlerTests {
 
 		QueueChannel errors = new QueueChannel();
 
-		List<Advice> adviceChain = new ArrayList<Advice>();
+		List<Advice> adviceChain = new ArrayList<>();
 
 		ExpressionEvaluatingRequestHandlerAdvice expressionAdvice = new ExpressionEvaluatingRequestHandlerAdvice();
 		expressionAdvice.setBeanFactory(mock(BeanFactory.class));
@@ -790,7 +790,7 @@ public class AdvisedMessageHandlerTests {
 		handler.afterPropertiesSet();
 
 		try {
-			handler.handleMessage(new GenericMessage<String>("test"));
+			handler.handleMessage(new GenericMessage<>("test"));
 		}
 		catch (Exception e) {
 			assertEquals("intentional: 3", e.getCause().getMessage());
@@ -833,7 +833,7 @@ public class AdvisedMessageHandlerTests {
 		Method method = AbstractReplyProducingMessageHandler.class.getDeclaredMethod("handleRequestMessage",
 				Message.class);
 		when(methodInvocation.getMethod()).thenReturn(method);
-		when(methodInvocation.getArguments()).thenReturn(new Object[] { new GenericMessage<String>("foo") });
+		when(methodInvocation.getArguments()).thenReturn(new Object[] { new GenericMessage<>("foo") });
 		try {
 			doAnswer(invocation -> {
 				throw theThrowable;
@@ -851,7 +851,7 @@ public class AdvisedMessageHandlerTests {
 	 * ThrowableHolderException from the output message.
 	 */
 	@Test
-	public void throwableProperlyPropagatedAndReported() throws Exception {
+	public void throwableProperlyPropagatedAndReported() {
 		QueueChannel errors = new QueueChannel();
 
 		ExpressionEvaluatingRequestHandlerAdvice expressionAdvice = new ExpressionEvaluatingRequestHandlerAdvice();
@@ -866,7 +866,7 @@ public class AdvisedMessageHandlerTests {
 		Bar fooHandler = (Bar) proxyFactory.getProxy();
 
 		try {
-			fooHandler.handleRequestMessage(new GenericMessage<String>("foo"));
+			fooHandler.handleRequestMessage(new GenericMessage<>("foo"));
 			fail("Expected throwable");
 		}
 		catch (Throwable t) {
@@ -898,12 +898,12 @@ public class AdvisedMessageHandlerTests {
 		consumer.setTaskScheduler(mock(TaskScheduler.class));
 		consumer.start();
 
-		Callable<?> pollingTask = TestUtils.getPropertyValue(consumer, "poller.pollingTask", Callable.class);
+		Callable<?> pollingTask = TestUtils.getPropertyValue(consumer, "pollingTask", Callable.class);
 		assertTrue(AopUtils.isAopProxy(pollingTask));
 		Log logger = TestUtils.getPropertyValue(advice, "logger", Log.class);
 		logger = spy(logger);
 		when(logger.isWarnEnabled()).thenReturn(Boolean.TRUE);
-		final AtomicReference<String> logMessage = new AtomicReference<String>();
+		final AtomicReference<String> logMessage = new AtomicReference<>();
 		doAnswer(invocation -> {
 			logMessage.set(invocation.getArgument(0));
 			return null;
@@ -925,7 +925,7 @@ public class AdvisedMessageHandlerTests {
 		MessageFilter filter = new MessageFilter(message -> false);
 		QueueChannel discardChannel = new QueueChannel();
 		filter.setDiscardChannel(discardChannel);
-		filter.handleMessage(new GenericMessage<String>("foo"));
+		filter.handleMessage(new GenericMessage<>("foo"));
 		assertNotNull(discardChannel.receive(0));
 	}
 
@@ -948,7 +948,7 @@ public class AdvisedMessageHandlerTests {
 		filter.setAdviceChain(adviceChain);
 		filter.setBeanFactory(mock(BeanFactory.class));
 		filter.afterPropertiesSet();
-		filter.handleMessage(new GenericMessage<String>("foo"));
+		filter.handleMessage(new GenericMessage<>("foo"));
 		assertNotNull(discardedWithinAdvice.get());
 		assertNull(discardChannel.receive(0));
 	}
@@ -958,7 +958,7 @@ public class AdvisedMessageHandlerTests {
 		MessageFilter filter = new MessageFilter(message -> false);
 		final QueueChannel discardChannel = new QueueChannel();
 		filter.setDiscardChannel(discardChannel);
-		List<Advice> adviceChain = new ArrayList<Advice>();
+		List<Advice> adviceChain = new ArrayList<>();
 		final AtomicReference<Message<?>> discardedWithinAdvice = new AtomicReference<Message<?>>();
 		final AtomicBoolean adviceCalled = new AtomicBoolean();
 		adviceChain.add(new AbstractRequestHandlerAdvice() {
@@ -975,7 +975,7 @@ public class AdvisedMessageHandlerTests {
 		filter.setDiscardWithinAdvice(false);
 		filter.setBeanFactory(mock(BeanFactory.class));
 		filter.afterPropertiesSet();
-		filter.handleMessage(new GenericMessage<String>("foo"));
+		filter.handleMessage(new GenericMessage<>("foo"));
 		assertTrue(adviceCalled.get());
 		assertNull(discardedWithinAdvice.get());
 		assertNotNull(discardChannel.receive(0));
@@ -1022,13 +1022,13 @@ public class AdvisedMessageHandlerTests {
 
 		advice.setRetryTemplate(retryTemplate);
 
-		List<Advice> adviceChain = new ArrayList<Advice>();
+		List<Advice> adviceChain = new ArrayList<>();
 		adviceChain.add(advice);
 		handler.setAdviceChain(adviceChain);
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
-		Message<String> message = new GenericMessage<String>("Hello, world!");
+		Message<String> message = new GenericMessage<>("Hello, world!");
 		try {
 			handler.handleMessage(message);
 			fail("MessagingException expected.");
@@ -1042,7 +1042,7 @@ public class AdvisedMessageHandlerTests {
 	}
 
 	@Test
-	public void enhancedRecoverer() throws Exception {
+	public void enhancedRecoverer() {
 		QueueChannel channel = new QueueChannel();
 		ErrorMessageSendingRecoverer recoverer = new ErrorMessageSendingRecoverer(channel);
 		recoverer.publish(new GenericMessage<>("foo"), new GenericMessage<>("bar"), new RuntimeException("baz"));

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpsInboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpsInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -49,16 +50,16 @@ public class FtpsInboundChannelAdapterParserTests {
 	private MessageChannel ftpChannel;
 
 	@Test
-	public void testFtpsInboundChannelAdapterComplete() throws Exception {
+	public void testFtpsInboundChannelAdapterComplete() {
 		assertEquals("ftpInbound", ftpInbound.getComponentName());
 		assertEquals("ftp:inbound-channel-adapter", ftpInbound.getComponentType());
-		assertNotNull(TestUtils.getPropertyValue(ftpInbound, "poller"));
+		assertNotNull(TestUtils.getPropertyValue(ftpInbound, "pollingTask"));
 		assertEquals(this.ftpChannel, TestUtils.getPropertyValue(ftpInbound, "outputChannel"));
 		FtpInboundFileSynchronizingMessageSource inbound =
-			(FtpInboundFileSynchronizingMessageSource) TestUtils.getPropertyValue(ftpInbound, "source");
+				(FtpInboundFileSynchronizingMessageSource) TestUtils.getPropertyValue(ftpInbound, "source");
 
 		FtpInboundFileSynchronizer fisync =
-			(FtpInboundFileSynchronizer) TestUtils.getPropertyValue(inbound, "synchronizer");
+				(FtpInboundFileSynchronizer) TestUtils.getPropertyValue(inbound, "synchronizer");
 		assertNotNull(TestUtils.getPropertyValue(fisync, "filter"));
 
 	}


### PR DESCRIPTION
* When `SourcePollingChannelAdapter.outputChannel` is a
`ReactiveStreamsSubscribableChannel`, use `Flux.generate()` for polling
* Refactor `AbstractPollingEndpoint` to remove redundant `Poller` class
in favor of lambda
* Extract `pollForMessage()` method to handle TX states instead of
`Poller` class previously

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
