### PR TITLE
INT-4456: Explicit methods for Kotlin lambdas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,12 @@
 buildscript {
+	ext.kotlinVersion = '1.2.31'
 	repositories {
 		maven { url 'https://repo.spring.io/plugins-release' }
 	}
 	dependencies {
 		classpath 'io.spring.gradle:docbook-reference-plugin:0.3.1'
 		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
+		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 	}
 }
 
@@ -58,6 +60,7 @@ subprojects { subproject ->
 	apply plugin: 'idea'
 	apply plugin: 'jacoco'
 	apply plugin: 'checkstyle'
+	apply plugin: 'kotlin'
 
 	sourceSets {
 		test {
@@ -72,11 +75,18 @@ subprojects { subproject ->
 		targetCompatibility = 1.8
 	}
 
+	compileKotlin {
+		kotlinOptions {
+			jvmTarget = "1.8"
+		}
+	}
+
 	ext {
 		activeMqVersion = '5.15.3'
 		apacheSshdVersion = '1.7.0'
 		aspectjVersion = '1.9.0'
 		assertjVersion = '3.9.1'
+		assertkVersion = '0.10'
 		boonVersion = '0.34'
 		commonsDbcp2Version = '2.2.0'
 		commonsIoVersion = '2.6'
@@ -161,6 +171,14 @@ subprojects { subproject ->
 
 		testRuntime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 		testRuntime "org.apache.logging.log4j:log4j-jcl:$log4jVersion"
+
+		testCompile("com.willowtreeapps.assertk:assertk:$assertkVersion") {
+				exclude group: 'org.jetbrains.kotlin', module: 'kotlin-reflect'
+		}
+
+		testCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+		testRuntime "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+
 	}
 
 	// enable all compiler warnings; individual projects may customize further

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-	ext.kotlinVersion = '1.2.31'
+	ext.kotlinVersion = '1.2.40'
 	repositories {
 		maven { url 'https://repo.spring.io/plugins-release' }
 	}
@@ -75,9 +75,9 @@ subprojects { subproject ->
 		targetCompatibility = 1.8
 	}
 
-	compileKotlin {
+	compileTestKotlin {
 		kotlinOptions {
-			jvmTarget = "1.8"
+			jvmTarget = '1.8'
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.dsl;
 
+import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -91,6 +92,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 import reactor.util.function.Tuple2;
@@ -112,6 +114,8 @@ import reactor.util.function.Tuple2;
  * @see org.springframework.integration.dsl.IntegrationFlowBeanPostProcessor
  */
 public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinition<B>> {
+
+	private static final Method FUNCTION_APPLY_METHOD = ReflectionUtils.findMethod(Function.class, "apply", (Class<?>[]) null);
 
 	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
 
@@ -1933,7 +1937,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 			Consumer<RouterSpec<T, MethodInvokingRouter>> routerConfigurer) {
 		MethodInvokingRouter methodInvokingRouter = isLambda(router)
 				? new MethodInvokingRouter(new LambdaMessageProcessor(router, payloadType))
-				: new MethodInvokingRouter(router);
+				: new MethodInvokingRouter(router, FUNCTION_APPLY_METHOD);
 		return route(new RouterSpec<>(methodInvokingRouter), routerConfigurer);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,62 @@
 
 package org.springframework.integration.util;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+
+import org.springframework.integration.core.GenericSelector;
+import org.springframework.integration.transformer.GenericTransformer;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public abstract class ClassUtils {
+
+	/**
+	 * The {@link Function#apply(Object)} method object.
+	 */
+	public static final Method FUNCTION_APPLY_METHOD =
+			ReflectionUtils.findMethod(Function.class, "apply", (Class<?>[]) null);
+
+	/**
+	 * The {@link GenericSelector#accept(Object)} method object.
+	 */
+	public static final Method SELECTOR_ACCEPT_METHOD =
+			ReflectionUtils.findMethod(GenericSelector.class, "accept", (Class<?>[]) null);
+
+	/**
+	 * The {@link GenericSelector#accept(Object)} method object.
+	 */
+	public static final Method TRANSFORMER_TRANSFORM_METHOD =
+			ReflectionUtils.findMethod(GenericTransformer.class, "transform", (Class<?>[]) null);
+
+	/**
+	 * The {@code org.springframework.integration.handler.GenericHandler#handle(Object, Map)} method object.
+	 */
+	public static final Method HANDLER_HANDLE_METHOD;
+
+	static {
+		Class<?> genericHandlerClass = null;
+		try {
+			genericHandlerClass =
+					org.springframework.util.ClassUtils.forName(
+							"org.springframework.integration.handler.GenericHandler",
+							org.springframework.util.ClassUtils.getDefaultClassLoader());
+		}
+		catch (ClassNotFoundException e) {
+			ReflectionUtils.rethrowRuntimeException(e);
+		}
+
+		HANDLER_HANDLE_METHOD = ReflectionUtils.findMethod(genericHandlerClass, "handle", (Class<?>[]) null);
+	}
+
 
 	/**
 	 * Map with primitive wrapper type as key and corresponding primitive

--- a/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/routers/RouterDslTests.kt
+++ b/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/routers/RouterDslTests.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.routers
+
+import assertk.all
+import assertk.assert
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.integration.config.EnableIntegration
+import org.springframework.integration.dsl.Channels
+import org.springframework.integration.dsl.IntegrationFlow
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.PollableChannel
+import org.springframework.messaging.support.GenericMessage
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 5.0.5
+ */
+@SpringJUnitConfig
+@DirtiesContext
+class RouterDslTests {
+
+    @Autowired
+    @Qualifier("routerTwoSubFlows.input")
+    private lateinit var routerTwoSubFlowsInput: MessageChannel
+
+    @Autowired
+    @Qualifier("routerTwoSubFlowsOutput")
+    private lateinit var routerTwoSubFlowsOutput: PollableChannel
+
+    @Test
+    fun `route to two subflows using lambda`() {
+
+        this.routerTwoSubFlowsInput.send(GenericMessage<Any>(listOf(1, 2, 3, 4, 5, 6)))
+        val receive = this.routerTwoSubFlowsOutput.receive(10000)
+
+        val payload = receive?.payload
+
+        assert(payload).isNotNull {
+            it.isInstanceOf(List::class.java)
+        }
+
+        assert(payload).isEqualTo(listOf(3, 4, 9, 8, 15, 12))
+    }
+
+
+    @Configuration
+    @EnableIntegration
+    open class Config {
+
+        @Bean
+        open fun routerTwoSubFlows() =
+                IntegrationFlow { f ->
+                    f.split()
+                            .route<Int, Boolean>({ p -> p % 2 == 0 },
+                                    { m ->
+                                        m.subFlowMapping(true, { sf -> sf.handle<Int> { p, _ -> p * 2 } })
+                                                .subFlowMapping(false, { sf -> sf.handle<Int> { p, _ -> p * 3 } })
+                                    })
+                            .aggregate()
+                            .channel { c: Channels -> c.queue("routerTwoSubFlowsOutput") }
+                }
+
+    }
+
+}

--- a/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/routers/RouterDslTests.kt
+++ b/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/routers/RouterDslTests.kt
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.dsl.routers
 
-import assertk.all
 import assertk.assert
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
@@ -27,7 +26,6 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.integration.config.EnableIntegration
-import org.springframework.integration.dsl.Channels
 import org.springframework.integration.dsl.IntegrationFlow
 import org.springframework.messaging.MessageChannel
 import org.springframework.messaging.PollableChannel
@@ -82,7 +80,7 @@ class RouterDslTests {
                                                 .subFlowMapping(false, { sf -> sf.handle<Int> { p, _ -> p * 3 } })
                                     })
                             .aggregate()
-                            .channel { c: Channels -> c.queue("routerTwoSubFlowsOutput") }
+                            .channel { c -> c.queue("routerTwoSubFlowsOutput") }
                 }
 
     }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4456

Since Kotlin compiles lambdas different way than Java, they are not
synthetic classes at runtime anymore.
Therefore we fallback to the method invocation logic, but since Java 8
interfaces has `default` methods as well the `MessagingMethodInvokerHelper`
can't select the target method for invocation

* Use explicit `Function.apply()` for non-synthetic implementations
* Add `RouterDslTests` Kotlin-based test-case

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
