### PR TITLE
INT-4461: Support byte[] in #jsonPath

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPathUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPathUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springframework.integration.json;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Predicate;
@@ -27,16 +29,61 @@ import com.jayway.jsonpath.Predicate;
  * Utility class to {@link #evaluate} a jsonPath on the provided object.
  * Delegates evaluation to <a href="http://code.google.com/p/json-path">JsonPath</a>.
  * Note {@link #evaluate} is used as {@code #jsonPath()} SpEL function.
+ * Note: selecting the charset for a byte[] conversion is not supported via SpEL.
  *
  * @author Artem Bilan
+ * @author Gary Russell
  *
  * @since 3.0
  */
 public final class JsonPathUtils {
 
+	private static final Charset UTF8 = StandardCharsets.UTF_8;
+
+	/**
+	 * Evaluate the Json Path; if the json is a byte[], UTF-8 is used for conversion.
+	 * @param json the json.
+	 * @param jsonPath the path.
+	 * @param predicates the predicates.
+	 * @return the value.
+	 * @throws Exception if an exception occurs.
+	 */
 	public static <T> T evaluate(Object json, String jsonPath, Predicate... predicates) throws Exception {
+		return evaluate(json, jsonPath, UTF8, predicates);
+	}
+
+	/**
+	 * Evaluate the Json Path.
+	 * @param json the json.
+	 * @param jsonPath the path.
+	 * @param charset the charset to convert from byte[] to String.
+	 * @param predicates the predicates.
+	 * @return the value.
+	 * @throws Exception if an exception occurs.
+	 * @since 4.3.16
+	 */
+	public static <T> T evaluate(Object json, String jsonPath, String charset, Predicate... predicates)
+			throws Exception {
+		return evaluate(json, jsonPath, Charset.forName(charset), predicates);
+	}
+
+	/**
+	 * Evaluate the Json Path.
+	 * @param json the json.
+	 * @param jsonPath the path.
+	 * @param charset the charset to convert from byte[] to String.
+	 * @param predicates the predicates.
+	 * @return the value.
+	 * @throws Exception if an exception occurs.
+	 * @since 4.3.16
+	 */
+	public static <T> T evaluate(Object json, String jsonPath, Charset charset, Predicate... predicates)
+			throws Exception {
 		if (json instanceof String) {
 			return JsonPath.read((String) json, jsonPath, predicates);
+		}
+		else if (json instanceof byte[]) {
+			return JsonPath.read(new String((byte[]) json, charset == null ? UTF8 : charset), jsonPath, predicates);
 		}
 		else if (json instanceof File) {
 			return JsonPath.read((File) json, jsonPath, predicates);

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPathUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPathUtils.java
@@ -16,11 +16,10 @@
 
 package org.springframework.integration.json;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Predicate;
@@ -29,7 +28,6 @@ import com.jayway.jsonpath.Predicate;
  * Utility class to {@link #evaluate} a jsonPath on the provided object.
  * Delegates evaluation to <a href="http://code.google.com/p/json-path">JsonPath</a>.
  * Note {@link #evaluate} is used as {@code #jsonPath()} SpEL function.
- * Note: selecting the charset for a byte[] conversion is not supported via SpEL.
  *
  * @author Artem Bilan
  * @author Gary Russell
@@ -38,52 +36,12 @@ import com.jayway.jsonpath.Predicate;
  */
 public final class JsonPathUtils {
 
-	private static final Charset UTF8 = StandardCharsets.UTF_8;
-
-	/**
-	 * Evaluate the Json Path; if the json is a byte[], UTF-8 is used for conversion.
-	 * @param json the json.
-	 * @param jsonPath the path.
-	 * @param predicates the predicates.
-	 * @return the value.
-	 * @throws Exception if an exception occurs.
-	 */
 	public static <T> T evaluate(Object json, String jsonPath, Predicate... predicates) throws Exception {
-		return evaluate(json, jsonPath, UTF8, predicates);
-	}
-
-	/**
-	 * Evaluate the Json Path.
-	 * @param json the json.
-	 * @param jsonPath the path.
-	 * @param charset the charset to convert from byte[] to String.
-	 * @param predicates the predicates.
-	 * @return the value.
-	 * @throws Exception if an exception occurs.
-	 * @since 4.3.16
-	 */
-	public static <T> T evaluate(Object json, String jsonPath, String charset, Predicate... predicates)
-			throws Exception {
-		return evaluate(json, jsonPath, Charset.forName(charset), predicates);
-	}
-
-	/**
-	 * Evaluate the Json Path.
-	 * @param json the json.
-	 * @param jsonPath the path.
-	 * @param charset the charset to convert from byte[] to String.
-	 * @param predicates the predicates.
-	 * @return the value.
-	 * @throws Exception if an exception occurs.
-	 * @since 4.3.16
-	 */
-	public static <T> T evaluate(Object json, String jsonPath, Charset charset, Predicate... predicates)
-			throws Exception {
 		if (json instanceof String) {
 			return JsonPath.read((String) json, jsonPath, predicates);
 		}
 		else if (json instanceof byte[]) {
-			return JsonPath.read(new String((byte[]) json, charset == null ? UTF8 : charset), jsonPath, predicates);
+			return JsonPath.read(new ByteArrayInputStream((byte[]) json), jsonPath, predicates);
 		}
 		else if (json instanceof File) {
 			return JsonPath.read((File) json, jsonPath, predicates);

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/JsonPathTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/JsonPathTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,6 +129,11 @@ public class JsonPathTests {
 		assertNotNull(receive);
 		assertEquals("Nigel Rees", receive.getPayload());
 
+		this.transformerInput.send(new GenericMessage<>(JSON.getBytes()));
+		receive = this.output.receive(10000);
+		assertNotNull(receive);
+		assertEquals("Nigel Rees", receive.getPayload());
+
 		this.transformerInput.send(new GenericMessage<File>(JSON_FILE));
 		receive = this.output.receive(1000);
 		assertNotNull(receive);
@@ -230,6 +235,12 @@ public class JsonPathTests {
 
 		assertNotNull(receive);
 		assertEquals("Nigel Rees", receive.getPayload());
+	}
+
+	@Test
+	public void testJsonInByteArray() throws Exception {
+		byte[] json = "{\"foo\":\"bar\"}".getBytes();
+		assertEquals("bar", JsonPathUtils.evaluate(json, "$.foo"));
 	}
 
 	@Configuration


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4461

Convert `byte[]` to `String` using `URF-8` by default.

Add optional evaluate methods to JsonPathUtils with a Charset to use when
converting `byte[]` to `String`.

This is not currently exposed using SpEL. It can be done, but probably not worth
the effort until somebody asks for it.

**cherry-pick to 5.0.x, 4.3.x**
