### PR TITLE
INT-4464 Check ZKMetadataStore.running before use

### DIFF
--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/metadata/ZookeeperMetadataStore.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/metadata/ZookeeperMetadataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class ZookeeperMetadataStore implements ListenableMetadataStore, SmartLif
 
 	private volatile int phase = Integer.MAX_VALUE;
 
-	public ZookeeperMetadataStore(CuratorFramework client) throws Exception {
+	public ZookeeperMetadataStore(CuratorFramework client) {
 		Assert.notNull(client, "Client cannot be null");
 		this.client = client;
 	}
@@ -203,6 +203,7 @@ public class ZookeeperMetadataStore implements ListenableMetadataStore, SmartLif
 	@Override
 	public String get(String key) {
 		Assert.notNull(key, "'key' must not be null.");
+		Assert.state(isRunning(), "ZookeeperMetadataStore has to be started before using.");
 		synchronized (this.updateMap) {
 			ChildData currentData = this.cache.getCurrentData(getPath(key));
 			if (currentData == null) {

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/metadata/ZookeeperMetadataStoreTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/metadata/ZookeeperMetadataStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,10 @@ public class ZookeeperMetadataStoreTests extends ZookeeperTestSupport {
 				IntegrationUtils.bytesToString(client.getData().forPath(metadataStore.getPath(testKey2)), "UTF-8"));
 		assertEquals("Integration-2", otherMetadataStore.get(testKey2));
 		assertThat("Integration-2", eventually(equalsResult(() -> otherMetadataStore.get(testKey2))));
+
+		otherMetadataStore.stop();
 		CloseableUtils.closeQuietly(otherClient);
+
 	}
 
 	@Test
@@ -143,6 +146,8 @@ public class ZookeeperMetadataStoreTests extends ZookeeperTestSupport {
 				IntegrationUtils.bytesToString(client.getData().forPath(metadataStore.getPath(testKey)), "UTF-8"));
 		assertThat("Integration-2", eventually(equalsResult(() -> metadataStore.get(testKey))));
 		assertEquals("Integration-2", otherMetadataStore.get(testKey));
+
+		otherMetadataStore.stop();
 		CloseableUtils.closeQuietly(otherClient);
 	}
 
@@ -202,7 +207,6 @@ public class ZookeeperMetadataStoreTests extends ZookeeperTestSupport {
 		String testValue = "Integration";
 		metadataStore.put(testKey, testValue);
 		assertEquals(testValue, metadataStore.remove(testKey));
-		Thread.sleep(1000);
 		assertNull(metadataStore.remove(testKey));
 	}
 
@@ -276,10 +280,6 @@ public class ZookeeperMetadataStoreTests extends ZookeeperTestSupport {
 		waitAtBarrier("remove", barriers);
 		assertThat(notifiedChanges, hasSize(4));
 		assertThat(notifiedChanges.get(3), IsIterableContainingInOrder.contains("remove", testKey, "Integration-3"));
-
-		// sleep and try to see if there were any other updates
-		Thread.sleep(1000);
-		assertThat(notifiedChanges, hasSize(4));
 	}
 
 	@Test
@@ -348,9 +348,9 @@ public class ZookeeperMetadataStoreTests extends ZookeeperTestSupport {
 		assertThat(notifiedChanges, hasSize(4));
 		assertThat(notifiedChanges.get(3), IsIterableContainingInOrder.contains("remove", testKey, "Integration-3"));
 
-		// sleep and try to see if there were any other updates - if there any pending updates, we should catch them by now
-		Thread.sleep(1000);
-		assertThat(notifiedChanges, hasSize(4));
+		otherMetadataStore.stop();
+		CloseableUtils.closeQuietly(otherClient);
+
 	}
 
 	@Test
@@ -367,6 +367,19 @@ public class ZookeeperMetadataStoreTests extends ZookeeperTestSupport {
 		assertThat(listeners, IsIterableContainingInOrder.contains(mockListener));
 		metadataStore.removeListener(mockListener);
 		assertThat(listeners, hasSize(0));
+	}
+
+	@Test
+	public void testEnsureStarted() {
+		ZookeeperMetadataStore zookeeperMetadataStore = new ZookeeperMetadataStore(this.client);
+
+		try {
+			zookeeperMetadataStore.get("foo");
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(IllegalStateException.class));
+			assertThat(e.getMessage(), containsString("ZookeeperMetadataStore has to be started before using."));
+		}
 	}
 
 	private void waitAtBarrier(String barrierName, Map<String, CyclicBarrier> barriers) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4464

A `ZookeeperMetadataStore.get()` is based on the `this.cache` variable.
This one is initialized in the `start()`.

* Assert `isRunning()` in the `get()` before using.

**Cherry-pick to 5.0.x and 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
