### PR TITLE
INT-4462: WebFluxInbound: cope with empty body

### DIFF
--- a/src/reference/asciidoc/webflux.adoc
+++ b/src/reference/asciidoc/webflux.adoc
@@ -6,7 +6,7 @@
 
 The WebFlux Spring Integration module (`spring-integration-webflux`) allows for the execution of HTTP requests and the processing of inbound HTTP requests in Reactive manner.
 The WebFlux support consists of the following gateway implementations: `WebFluxInboundEndpoint`, `WebFluxRequestExecutingMessageHandler`.
-The implementation is fully based on the Spring http://docs.spring.io/spring/docs/5.0.0.RC3/spring-framework-reference/web.html#web-reactive[WebFlux] and https://projectreactor.io/[Project Reactor] foundations.
+The implementation is fully based on the Spring https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html#spring-webflux[WebFlux] and https://projectreactor.io/[Project Reactor] foundations.
 Also see <<http>> for more information since many options are shared between reactive and regular HTTP components.
 
 [[webflux-inbound]]
@@ -64,6 +64,8 @@ public IntegrationFlow sseFlow() {
 ----
 
 Also see <<http-request-mapping>> and <<http-cors>> for more possible configuration options.
+
+When the request body is empty, or `payloadExpression` returns `null`, the request params `MultiValueMap<String, String>` is used for a `payload` of the target message to process.
 
 [[webflux-outbound]]
 === WebFlux Outbound Components


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4462

When the HTTP request body is empty, the `HttpMessageReader` ends up
with the empty `Mono` which can't be evaluated to any reasonable value.

* Add fallback to `requestParams` when `Mono` for body is empty and
also when `payloadExpression` returns null

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
