### PR TITLE
INT-4467: Fix `transformer-util` package tangles

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import org.springframework.integration.core.GenericSelector;
-import org.springframework.integration.transformer.GenericTransformer;
 import org.springframework.util.ReflectionUtils;
 
 /**
@@ -41,16 +39,14 @@ public abstract class ClassUtils {
 			ReflectionUtils.findMethod(Function.class, "apply", (Class<?>[]) null);
 
 	/**
-	 * The {@link GenericSelector#accept(Object)} method object.
+	 * The {@code org.springframework.integration.core.GenericSelector#accept(Object)} method object.
 	 */
-	public static final Method SELECTOR_ACCEPT_METHOD =
-			ReflectionUtils.findMethod(GenericSelector.class, "accept", (Class<?>[]) null);
+	public static final Method SELECTOR_ACCEPT_METHOD;
 
 	/**
-	 * The {@link GenericSelector#accept(Object)} method object.
+	 * The {@code org.springframework.integration.transformer.GenericTransformer#transform(Object)} method object.
 	 */
-	public static final Method TRANSFORMER_TRANSFORM_METHOD =
-			ReflectionUtils.findMethod(GenericTransformer.class, "transform", (Class<?>[]) null);
+	public static final Method TRANSFORMER_TRANSFORM_METHOD;
 
 	/**
 	 * The {@code org.springframework.integration.handler.GenericHandler#handle(Object, Map)} method object.
@@ -58,6 +54,33 @@ public abstract class ClassUtils {
 	public static final Method HANDLER_HANDLE_METHOD;
 
 	static {
+		Class<?> genericSelectorClass = null;
+		try {
+			genericSelectorClass =
+					org.springframework.util.ClassUtils.forName(
+							"org.springframework.integration.core.GenericSelector",
+							org.springframework.util.ClassUtils.getDefaultClassLoader());
+		}
+		catch (ClassNotFoundException e) {
+			ReflectionUtils.rethrowRuntimeException(e);
+		}
+
+		SELECTOR_ACCEPT_METHOD = ReflectionUtils.findMethod(genericSelectorClass, "accept", (Class<?>[]) null);
+
+		Class<?> genericTransformerClass = null;
+		try {
+			genericTransformerClass =
+					org.springframework.util.ClassUtils.forName(
+							"org.springframework.integration.transformer.GenericTransformer",
+							org.springframework.util.ClassUtils.getDefaultClassLoader());
+		}
+		catch (ClassNotFoundException e) {
+			ReflectionUtils.rethrowRuntimeException(e);
+		}
+
+		TRANSFORMER_TRANSFORM_METHOD =
+				ReflectionUtils.findMethod(genericTransformerClass, "transform", (Class<?>[]) null);
+
 		Class<?> genericHandlerClass = null;
 		try {
 			genericHandlerClass =
@@ -77,7 +100,7 @@ public abstract class ClassUtils {
 	 * Map with primitive wrapper type as key and corresponding primitive
 	 * type as value, for example: Integer.class -> int.class.
 	 */
-	private static final Map<Class<?>, Class<?>> primitiveWrapperTypeMap = new HashMap<Class<?>, Class<?>>(8);
+	private static final Map<Class<?>, Class<?>> primitiveWrapperTypeMap = new HashMap<>(8);
 
 
 	static {
@@ -102,8 +125,8 @@ public abstract class ClassUtils {
 			}
 			else if (failOnTie && typeDiffWeight < Integer.MAX_VALUE && (typeDiffWeight == minTypeDiffWeight)) {
 				throw new IllegalStateException("Unresolvable ambiguity while attempting to find closest match for [" +
-						type.getName() + "]. Candidate types [" + closestMatch.getName() + "] and [" + candidate.getName() +
-						"] have equal weight.");
+						type.getName() + "]. Candidate types [" + closestMatch.getName() + "] and [" +
+						candidate.getName() + "] have equal weight.");
 			}
 		}
 		return closestMatch;


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4467

The package tangles is caused by the explicit classes declarations.

* Since we use only method definitions from those classes, there is just
enough to use class names and use reflection to get class objects and
then get methods from them

_The fix is fully compatible for back-porting_

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
