### PR TITLE
INT-4466: Do not force release groups if no match

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,11 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 	@Override
 	public final void setExpireGroupsUponTimeout(boolean expireGroupsUponTimeout) {
 		super.setExpireGroupsUponTimeout(expireGroupsUponTimeout);
+	}
+
+	@Override
+	public String getComponentType() {
+		return "resequencer";
 	}
 
 	@Override


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4466

When we schedule group for force complete in the
`AbstractCorrelatingMessageHandler`, we don't track a group `timestamp`
and its `lastModified` before the scheduled task.
This way, in the cluster environment, we may schedule several tasks
for different messages and the first started may release the group too
early.
Just because we extract a `MessageGroup` from the store already in the
task per se.

* Propagate the actual `timestamp` and `lastModified` from group before
scheduling task.
Compare these value with the actual group metadata in the
`processForceRelease()` before performing real `forceRelease()`.
This way we restore behavior before fixing memory leak, when we
propagated full `MessageGroup` to the scheduled task
* Implement `ResequencingMessageHandler.getComponentType()` for
consistency
* Remove unnecessary overhead with the `volatile` on many
`AbstractCorrelatingMessageHandler` properties, which hardly ever can be
changed at runtime

**Cherry-pick to 5.0.x and 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
