### PR TITLE
INT-4397: Fix headers filtering for @Transformer

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -19,7 +19,6 @@ package org.springframework.integration.handler;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +42,6 @@ import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
-import org.springframework.util.PatternMatchUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
@@ -139,7 +137,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	 * @param merge true to merge with existing patterns; false to replace.
 	 * @since 5.0.2
 	 */
-	protected void updateNotPropagatedHeaders(String[] headers, boolean merge) {
+	protected final void updateNotPropagatedHeaders(String[] headers, boolean merge) {
 		Set<String> headerPatterns = new HashSet<>();
 
 		if (merge && this.notPropagatedHeaders != null) {
@@ -388,17 +386,8 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 			builder = this.getMessageBuilderFactory().withPayload(output);
 		}
 		if (!this.noHeadersPropagation && shouldCopyRequestHeaders()) {
-			if (this.selectiveHeaderPropagation) {
-				Map<String, Object> headersToCopy = new HashMap<>(requestHeaders);
-
-				headersToCopy.entrySet()
-						.removeIf(entry -> PatternMatchUtils.simpleMatch(this.notPropagatedHeaders, entry.getKey()));
-
-				builder.copyHeadersIfAbsent(headersToCopy);
-			}
-			else {
-				builder.copyHeadersIfAbsent(requestHeaders);
-			}
+			builder.filterAndCopyHeadersIfAbsent(requestHeaders,
+					this.selectiveHeaderPropagation ? this.notPropagatedHeaders : null);
 		}
 		return builder.build();
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -139,7 +139,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	 * @param merge true to merge with existing patterns; false to replace.
 	 * @since 5.0.2
 	 */
-	protected final void updateNotPropagatedHeaders(String[] headers, boolean merge) {
+	protected void updateNotPropagatedHeaders(String[] headers, boolean merge) {
 		Set<String> headerPatterns = new HashSet<>();
 
 		if (merge && this.notPropagatedHeaders != null) {
@@ -151,7 +151,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 
 			headerPatterns.addAll(Arrays.asList(headers));
 
-			this.notPropagatedHeaders = headerPatterns.toArray(new String[headerPatterns.size()]);
+			this.notPropagatedHeaders = headerPatterns.toArray(new String[0]);
 		}
 
 		boolean hasAsterisk = headerPatterns.contains("*");

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/AbstractMessageProcessingTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/AbstractMessageProcessingTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,23 @@
 
 package org.springframework.integration.transformer;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.handler.MessageProcessor;
+import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.PatternMatchUtils;
 
 /**
  * Base class for Message Transformers that delegate to a {@link MessageProcessor}.
@@ -37,11 +45,15 @@ public abstract class AbstractMessageProcessingTransformer
 
 	private final MessageProcessor<?> messageProcessor;
 
-	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
-
-	private volatile boolean messageBuilderFactorySet;
-
 	private BeanFactory beanFactory;
+
+	private MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
+
+	private boolean messageBuilderFactorySet;
+
+	private String[] notPropagatedHeaders;
+
+	private boolean selectiveHeaderPropagation;
 
 	protected AbstractMessageProcessingTransformer(MessageProcessor<?> messageProcessor) {
 		Assert.notNull(messageProcessor, "messageProcessor must not be null");
@@ -85,6 +97,22 @@ public abstract class AbstractMessageProcessingTransformer
 		return !(this.messageProcessor instanceof Lifecycle) || ((Lifecycle) this.messageProcessor).isRunning();
 	}
 
+	/**
+	 * Set headers that will NOT be copied from the inbound message if
+	 * the handler is configured to copy headers.
+	 * @param headers the headers to not propagate from the inbound message.
+	 * @since 5.1
+	 */
+	public void setNotPropagatedHeaders(String... headers) {
+		if (!ObjectUtils.isEmpty(headers)) {
+			Assert.noNullElements(headers, "null elements are not allowed in 'headers'");
+
+			this.notPropagatedHeaders = Arrays.copyOf(headers, headers.length);
+		}
+
+		this.selectiveHeaderPropagation = !ObjectUtils.isEmpty(this.notPropagatedHeaders);
+	}
+
 	@Override
 	public final Message<?> transform(Message<?> message) {
 		Object result = this.messageProcessor.processMessage(message);
@@ -94,7 +122,26 @@ public abstract class AbstractMessageProcessingTransformer
 		if (result instanceof Message<?>) {
 			return (Message<?>) result;
 		}
-		return getMessageBuilderFactory().withPayload(result).copyHeaders(message.getHeaders()).build();
+
+		MessageHeaders requestHeaders = message.getHeaders();
+
+		AbstractIntegrationMessageBuilder<?> messageBuilder =
+				getMessageBuilderFactory()
+						.withPayload(result);
+
+		if (this.selectiveHeaderPropagation) {
+			Map<String, Object> headersToCopy = new HashMap<>(requestHeaders);
+
+			headersToCopy.entrySet()
+					.removeIf(entry -> PatternMatchUtils.simpleMatch(this.notPropagatedHeaders, entry.getKey()));
+
+			messageBuilder.copyHeadersIfAbsent(headersToCopy);
+		}
+		else {
+			messageBuilder.copyHeadersIfAbsent(requestHeaders);
+		}
+
+		return messageBuilder.build();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.integration.transformer;
+
+import java.util.Collection;
 
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.context.Lifecycle;
@@ -61,6 +63,18 @@ public class MessageTransformingHandler extends AbstractReplyProducingMessageHan
 	protected void doInit() {
 		if (this.getBeanFactory() != null && this.transformer instanceof BeanFactoryAware) {
 			((BeanFactoryAware) this.transformer).setBeanFactory(this.getBeanFactory());
+		}
+	}
+
+	@Override
+	protected void updateNotPropagatedHeaders(String[] headers, boolean merge) {
+		super.updateNotPropagatedHeaders(headers, merge);
+
+		Collection<String> notPropagatedHeaders = getNotPropagatedHeaders();
+
+		if (this.transformer instanceof AbstractMessageProcessingTransformer && !notPropagatedHeaders.isEmpty()) {
+			((AbstractMessageProcessingTransformer) this.transformer)
+					.setNotPropagatedHeaders(notPropagatedHeaders.toArray(new String[0]));
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
@@ -60,16 +60,21 @@ public class MessageTransformingHandler extends AbstractReplyProducingMessageHan
 	}
 
 	@Override
+	public void addNotPropagatedHeaders(String... headers) {
+		super.addNotPropagatedHeaders(headers);
+		populateNotPropagatedHeadersIfAny();
+	}
+
+	@Override
 	protected void doInit() {
 		if (this.getBeanFactory() != null && this.transformer instanceof BeanFactoryAware) {
 			((BeanFactoryAware) this.transformer).setBeanFactory(this.getBeanFactory());
 		}
+
+		populateNotPropagatedHeadersIfAny();
 	}
 
-	@Override
-	protected void updateNotPropagatedHeaders(String[] headers, boolean merge) {
-		super.updateNotPropagatedHeaders(headers, merge);
-
+	private void populateNotPropagatedHeadersIfAny() {
 		Collection<String> notPropagatedHeaders = getNotPropagatedHeaders();
 
 		if (this.transformer instanceof AbstractMessageProcessingTransformer && !notPropagatedHeaders.isEmpty()) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4397

The `AbstractMessageProcessingTransformer` doesn't honor a configured
`notPropagatedHeaders` and copies all the request headers to the
message to return

* Add `setNotPropagatedHeaders()` into the `AbstractMessageProcessingTransformer`
and implement there a logic to filter headers, similar to what we have
in the `AbstractMessageProducingHandler`
* Overrider `updateNotPropagatedHeaders()` in the `MessageTransformingHandler`
to propagate `notPropagatedHeaders` to the `AbstractMessageProcessingTransformer`
delegate

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
