### PR TITLE
Remove use of deprecated ChannelInterceptorAdapter

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ import org.springframework.integration.amqp.channel.PublishSubscribeAmqpChannel;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -119,7 +119,7 @@ public class AmqpChannelParserTests {
 		assertTrue(TestUtils.getPropertyValue(channel, "extractPayload", Boolean.class));
 	}
 
-	private static class TestInterceptor extends ChannelInterceptorAdapter {
+	private static class TestInterceptor implements ChannelInterceptor {
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/MessageSelectingInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/MessageSelectingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import org.springframework.integration.core.MessageSelector;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageDeliveryException;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 
 /**
  * A {@link org.springframework.messaging.support.ChannelInterceptor ChannelInterceptor} that
@@ -31,8 +31,9 @@ import org.springframework.messaging.support.ChannelInterceptorAdapter;
  * whether a {@link Message} should be accepted on the {@link MessageChannel}.
  *
  * @author Mark Fisher
+ * @author Gary Russell
  */
-public class MessageSelectingInterceptor extends ChannelInterceptorAdapter {
+public class MessageSelectingInterceptor implements ChannelInterceptor {
 
 	private final List<MessageSelector> selectors;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/ThreadStatePropagationChannelInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/ThreadStatePropagationChannelInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessageHeaders;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.ExecutorChannelInterceptor;
 
 /**
@@ -51,7 +51,7 @@ import org.springframework.messaging.support.ExecutorChannelInterceptor;
  * @since 4.2
  */
 public abstract class ThreadStatePropagationChannelInterceptor<S>
-		extends ChannelInterceptorAdapter implements ExecutorChannelInterceptor {
+		implements ChannelInterceptor, ExecutorChannelInterceptor {
 
 	@Override
 	public final Message<?> preSend(Message<?> message, MessageChannel channel) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/WireTap.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/WireTap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.util.Assert;
 
 /**
@@ -44,8 +43,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  */
 @ManagedResource
-public class WireTap extends ChannelInterceptorAdapter
-		implements Lifecycle, VetoCapableInterceptor, BeanFactoryAware {
+public class WireTap implements ChannelInterceptor, Lifecycle, VetoCapableInterceptor, BeanFactoryAware {
 
 	private static final Log logger = LogFactory.getLog(WireTap.class);
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/ExecutorChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/ExecutorChannelTests.java
@@ -46,7 +46,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.messaging.support.ExecutorChannelInterceptor;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.concurrent.ConcurrentTaskExecutor;
@@ -262,8 +261,7 @@ public class ExecutorChannelTests {
 		}
 	}
 
-	private static class BeforeHandleInterceptor extends ChannelInterceptorAdapter
-			implements ExecutorChannelInterceptor {
+	private static class BeforeHandleInterceptor implements ExecutorChannelInterceptor {
 
 		private final AtomicInteger counter = new AtomicInteger();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.converter.MessageConverter;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -290,7 +290,7 @@ public class ChannelParserTests {
 		assertTrue(threwException);
 	}
 
-	public static class TestInterceptor extends ChannelInterceptorAdapter {
+	public static class TestInterceptor implements ChannelInterceptor {
 
 		@Override
 		public Message<?> preSend(Message<?> message, MessageChannel channel) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ChannelInterceptorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ChannelInterceptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.messaging.support.ExecutorChannelInterceptor;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.StringUtils;
@@ -55,6 +54,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Gary Russell
  */
 public class ChannelInterceptorTests {
 
@@ -94,7 +94,8 @@ public class ChannelInterceptorTests {
 	@Test
 	public void testPostSendInterceptorWithSentMessage() {
 		final AtomicBoolean invoked = new AtomicBoolean(false);
-		channel.addInterceptor(new ChannelInterceptorAdapter() {
+		channel.addInterceptor(new ChannelInterceptor() {
+
 			@Override
 			public void postSend(Message<?> message, MessageChannel channel, boolean sent) {
 				assertNotNull(message);
@@ -103,6 +104,7 @@ public class ChannelInterceptorTests {
 				assertTrue(sent);
 				invoked.set(true);
 			}
+
 		});
 		channel.send(new GenericMessage<String>("test"));
 		assertTrue(invoked.get());
@@ -113,7 +115,8 @@ public class ChannelInterceptorTests {
 		final AtomicInteger invokedCounter = new AtomicInteger(0);
 		final AtomicInteger sentCounter = new AtomicInteger(0);
 		final QueueChannel singleItemChannel = new QueueChannel(1);
-		singleItemChannel.addInterceptor(new ChannelInterceptorAdapter() {
+		singleItemChannel.addInterceptor(new ChannelInterceptor() {
+
 			@Override
 			public void postSend(Message<?> message, MessageChannel channel, boolean sent) {
 				assertNotNull(message);
@@ -124,6 +127,7 @@ public class ChannelInterceptorTests {
 				}
 				invokedCounter.incrementAndGet();
 			}
+
 		});
 		assertEquals(0, invokedCounter.get());
 		assertEquals(0, sentCounter.get());
@@ -206,7 +210,8 @@ public class ChannelInterceptorTests {
 	public void testPostReceiveInterceptor() {
 		final AtomicInteger invokedCount = new AtomicInteger();
 		final AtomicInteger messageCount = new AtomicInteger();
-		channel.addInterceptor(new ChannelInterceptorAdapter() {
+		channel.addInterceptor(new ChannelInterceptor() {
+
 			@Override
 			public Message<?> postReceive(Message<?> message, MessageChannel channel) {
 				assertNotNull(channel);
@@ -217,6 +222,7 @@ public class ChannelInterceptorTests {
 				invokedCount.incrementAndGet();
 				return message;
 			}
+
 		});
 		channel.receive(0);
 		assertEquals(1, invokedCount.get());
@@ -295,7 +301,7 @@ public class ChannelInterceptorTests {
 		testApplicationContext.close();
 	}
 
-	public static class PreSendReturnsMessageInterceptor extends ChannelInterceptorAdapter {
+	public static class PreSendReturnsMessageInterceptor implements ChannelInterceptor {
 		private String foo;
 
 		private static AtomicInteger counter = new AtomicInteger();
@@ -329,7 +335,7 @@ public class ChannelInterceptorTests {
 	}
 
 
-	private static class PreSendReturnsNullInterceptor extends ChannelInterceptorAdapter {
+	private static class PreSendReturnsNullInterceptor implements ChannelInterceptor {
 
 		private static AtomicInteger counter = new AtomicInteger();
 
@@ -349,7 +355,7 @@ public class ChannelInterceptorTests {
 		}
 	}
 
-	private static class AfterCompletionTestInterceptor extends ChannelInterceptorAdapter {
+	private static class AfterCompletionTestInterceptor implements ChannelInterceptor {
 
 		private final AtomicInteger counter = new AtomicInteger();
 
@@ -391,7 +397,7 @@ public class ChannelInterceptorTests {
 
 	}
 
-	private static class PreReceiveReturnsTrueInterceptor extends ChannelInterceptorAdapter {
+	private static class PreReceiveReturnsTrueInterceptor implements ChannelInterceptor {
 
 		private final AtomicInteger counter = new AtomicInteger();
 
@@ -432,7 +438,7 @@ public class ChannelInterceptorTests {
 	}
 
 
-	private static class PreReceiveReturnsFalseInterceptor extends ChannelInterceptorAdapter {
+	private static class PreReceiveReturnsFalseInterceptor implements ChannelInterceptor {
 
 		private static AtomicInteger counter = new AtomicInteger();
 
@@ -448,8 +454,7 @@ public class ChannelInterceptorTests {
 
 	}
 
-	private static class TestExecutorInterceptor extends ChannelInterceptorAdapter
-			implements ExecutorChannelInterceptor {
+	private static class TestExecutorInterceptor implements ExecutorChannelInterceptor {
 
 		TestExecutorInterceptor() {
 			super();

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalChannelInterceptorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/GlobalChannelInterceptorTests.java
@@ -41,7 +41,6 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -160,7 +159,7 @@ public class GlobalChannelInterceptorTests {
 		assertThat(channelInterceptors.get(0), instanceOf(SampleInterceptor.class));
 	}
 
-	public static class SampleInterceptor extends ChannelInterceptorAdapter {
+	public static class SampleInterceptor implements ChannelInterceptor {
 
 		private String testIdentifier;
 
@@ -172,17 +171,21 @@ public class GlobalChannelInterceptorTests {
 			this.testIdentifier = testIdentifier;
 		}
 
+		@Override
 		public Message<?> postReceive(Message<?> message, MessageChannel channel) {
 			return null;
 		}
 
+		@Override
 		public void postSend(Message<?> message, MessageChannel channel, boolean sent) {
 		}
 
+		@Override
 		public boolean preReceive(MessageChannel channel) {
 			return false;
 		}
 
+		@Override
 		public Message<?> preSend(Message<?> message, MessageChannel channel) {
 			return null;
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ImplicitConsumerChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ImplicitConsumerChannelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import org.springframework.integration.channel.ChannelInterceptorAware;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -71,7 +70,7 @@ public class ImplicitConsumerChannelTests {
 		assertThat(bazInterceptors.get(1), anyOf(instanceOf(WireTap.class), instanceOf(Interceptor1.class)));
 	}
 
-	public static class Interceptor1 extends ChannelInterceptorAdapter implements VetoCapableInterceptor {
+	public static class Interceptor1 implements ChannelInterceptor, VetoCapableInterceptor {
 
 		private MessageChannel channel;
 
@@ -109,7 +108,7 @@ public class ImplicitConsumerChannelTests {
 
 	}
 
-	public static class Interceptor2 extends ChannelInterceptorAdapter implements VetoCapableInterceptor {
+	public static class Interceptor2 implements ChannelInterceptor, VetoCapableInterceptor {
 
 		private MessageChannel channel;
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/TestChannelInterceptor.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/TestChannelInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2008 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  */
-public class TestChannelInterceptor extends ChannelInterceptorAdapter {
+public class TestChannelInterceptor implements ChannelInterceptor {
 
 	private final AtomicInteger sendCount = new AtomicInteger();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.test.annotation.DirtiesContext;
@@ -195,12 +195,12 @@ public class GatewayParserTests {
 	public void testAsyncCompletable() throws Exception {
 		QueueChannel requestChannel = (QueueChannel) context.getBean("requestChannel");
 		final AtomicReference<Thread> thread = new AtomicReference<>();
-		requestChannel.addInterceptor(new ChannelInterceptorAdapter() {
+		requestChannel.addInterceptor(new ChannelInterceptor() {
 
 			@Override
 			public Message<?> preSend(Message<?> message, MessageChannel channel) {
 				thread.set(Thread.currentThread());
-				return super.preSend(message, channel);
+				return message;
 			}
 
 		});
@@ -218,12 +218,12 @@ public class GatewayParserTests {
 	public void testAsyncCompletableNoAsync() throws Exception {
 		QueueChannel requestChannel = (QueueChannel) context.getBean("requestChannel");
 		final AtomicReference<Thread> thread = new AtomicReference<>();
-		requestChannel.addInterceptor(new ChannelInterceptorAdapter() {
+		requestChannel.addInterceptor(new ChannelInterceptor() {
 
 			@Override
 			public Message<?> preSend(Message<?> message, MessageChannel channel) {
 				thread.set(Thread.currentThread());
-				return super.preSend(message, channel);
+				return message;
 			}
 
 		});
@@ -241,12 +241,12 @@ public class GatewayParserTests {
 	public void testCustomCompletableNoAsync() throws Exception {
 		QueueChannel requestChannel = (QueueChannel) context.getBean("requestChannel");
 		final AtomicReference<Thread> thread = new AtomicReference<>();
-		requestChannel.addInterceptor(new ChannelInterceptorAdapter() {
+		requestChannel.addInterceptor(new ChannelInterceptor() {
 
 			@Override
 			public Message<?> preSend(Message<?> message, MessageChannel channel) {
 				thread.set(Thread.currentThread());
-				return super.preSend(message, channel);
+				return message;
 			}
 
 		});
@@ -268,12 +268,12 @@ public class GatewayParserTests {
 		new DirectFieldAccessor(gateway).setPropertyValue("logger", logger);
 		QueueChannel requestChannel = (QueueChannel) context.getBean("requestChannel");
 		final AtomicReference<Thread> thread = new AtomicReference<>();
-		requestChannel.addInterceptor(new ChannelInterceptorAdapter() {
+		requestChannel.addInterceptor(new ChannelInterceptor() {
 
 			@Override
 			public Message<?> preSend(Message<?> message, MessageChannel channel) {
 				thread.set(Thread.currentThread());
-				return super.preSend(message, channel);
+				return message;
 			}
 
 		});
@@ -294,12 +294,12 @@ public class GatewayParserTests {
 	public void testAsyncCompletableMessage() throws Exception {
 		QueueChannel requestChannel = (QueueChannel) context.getBean("requestChannel");
 		final AtomicReference<Thread> thread = new AtomicReference<>();
-		requestChannel.addInterceptor(new ChannelInterceptorAdapter() {
+		requestChannel.addInterceptor(new ChannelInterceptor() {
 
 			@Override
 			public Message<?> preSend(Message<?> message, MessageChannel channel) {
 				thread.set(Thread.currentThread());
-				return super.preSend(message, channel);
+				return message;
 			}
 
 		});
@@ -317,12 +317,12 @@ public class GatewayParserTests {
 	public void testAsyncCompletableNoAsyncMessage() throws Exception {
 		QueueChannel requestChannel = (QueueChannel) context.getBean("requestChannel");
 		final AtomicReference<Thread> thread = new AtomicReference<>();
-		requestChannel.addInterceptor(new ChannelInterceptorAdapter() {
+		requestChannel.addInterceptor(new ChannelInterceptor() {
 
 			@Override
 			public Message<?> preSend(Message<?> message, MessageChannel channel) {
 				thread.set(Thread.currentThread());
-				return super.preSend(message, channel);
+				return message;
 			}
 
 		});
@@ -340,12 +340,12 @@ public class GatewayParserTests {
 	public void testCustomCompletableNoAsyncMessage() throws Exception {
 		QueueChannel requestChannel = (QueueChannel) context.getBean("requestChannel");
 		final AtomicReference<Thread> thread = new AtomicReference<>();
-		requestChannel.addInterceptor(new ChannelInterceptorAdapter() {
+		requestChannel.addInterceptor(new ChannelInterceptor() {
 
 			@Override
 			public Message<?> preSend(Message<?> message, MessageChannel channel) {
 				thread.set(Thread.currentThread());
-				return super.preSend(message, channel);
+				return message;
 			}
 
 		});

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -126,7 +126,6 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.annotation.Async;
@@ -820,13 +819,14 @@ public class EnableIntegrationTests {
 
 				@Override
 				protected ChannelInterceptor createInstance() throws Exception {
-					return new ChannelInterceptorAdapter() {
+					return new ChannelInterceptor() {
 
 						@Override
 						public Message<?> preSend(Message<?> message, MessageChannel channel) {
 							fbInterceptorCounter().incrementAndGet();
-							return super.preSend(message, channel);
+							return message;
 						}
+
 					};
 				}
 			};
@@ -930,7 +930,7 @@ public class EnableIntegrationTests {
 
 	@Component
 	@GlobalChannelInterceptor
-	public static class TestChannelInterceptor extends ChannelInterceptorAdapter {
+	public static class TestChannelInterceptor implements ChannelInterceptor {
 
 		private final AtomicInteger invoked = new AtomicInteger();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/AsyncGatewayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/AsyncGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ import org.springframework.integration.channel.QueueChannel;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
@@ -179,7 +179,7 @@ public class AsyncGatewayTests {
 	}
 
 	protected void addThreadEnricher(QueueChannel requestChannel) {
-		requestChannel.addInterceptor(new ChannelInterceptorAdapter() {
+		requestChannel.addInterceptor(new ChannelInterceptor() {
 
 			@Override
 			public Message<?> preSend(Message<?> message, MessageChannel channel) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -88,7 +88,7 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.stereotype.Component;
@@ -594,7 +594,7 @@ public class GatewayInterfaceTests {
 		@BridgeTo
 		public MessageChannel gatewayThreadChannel() {
 			DirectChannel channel = new DirectChannel();
-			channel.addInterceptor(new ChannelInterceptorAdapter() {
+			channel.addInterceptor(new ChannelInterceptor() {
 
 				@Override
 				public Message<?> preSend(Message<?> message, MessageChannel channel) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/TestChannelInterceptor.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/TestChannelInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  */
-public class TestChannelInterceptor extends ChannelInterceptorAdapter {
+public class TestChannelInterceptor implements ChannelInterceptor {
 
 	private final AtomicInteger sentCount = new AtomicInteger();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ContentTypeConversionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ContentTypeConversionTests.java
@@ -41,7 +41,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
@@ -94,12 +94,12 @@ public class ContentTypeConversionTests {
 		@Bean
 		public MessageChannel serviceChannel(final AtomicReference<Object> sendData) {
 			return MessageChannels.direct()
-					.interceptor(new ChannelInterceptorAdapter() {
+					.interceptor(new ChannelInterceptor() {
 
 						@Override
 						public Message<?> preSend(Message<?> message, MessageChannel channel) {
 							sendData.set(message.getPayload());
-							return super.preSend(message, channel);
+							return message;
 						}
 
 					})

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/RouterConcurrencyTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/RouterConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.router;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
@@ -93,7 +94,7 @@ public class RouterConcurrencyTest {
 		exec.execute(runnable);
 		exec.execute(runnable);
 		exec.shutdown();
-		exec.awaitTermination(10, TimeUnit.SECONDS);
+		assertTrue(exec.awaitTermination(30, TimeUnit.SECONDS));
 		assertEquals(2, returns.size());
 		assertNotNull(returns.get(0));
 		assertNotNull(returns.get(1));

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/PollableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/PollableJmsChannelTests.java
@@ -51,7 +51,6 @@ import org.springframework.jms.core.JmsTemplate;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.messaging.support.GenericMessage;
 
 /**
@@ -248,7 +247,7 @@ public class PollableJmsChannelTests extends ActiveMQMultiContextTests {
 		assertEquals("bar", result2.getPayload());
 	}
 
-	public static class SampleInterceptor extends ChannelInterceptorAdapter {
+	public static class SampleInterceptor implements ChannelInterceptor {
 
 		private final boolean preReceiveFlag;
 
@@ -257,23 +256,8 @@ public class PollableJmsChannelTests extends ActiveMQMultiContextTests {
 		}
 
 		@Override
-		public Message<?> preSend(Message<?> message, MessageChannel channel) {
-			return message;
-		}
-
-		@Override
-		public void postSend(Message<?> message, MessageChannel channel,
-				boolean sent) {
-		}
-
-		@Override
 		public boolean preReceive(MessageChannel channel) {
 			return this.preReceiveFlag;
-		}
-
-		@Override
-		public Message<?> postReceive(Message<?> message, MessageChannel channel) {
-			return message;
 		}
 
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/GlobalChannelInterceptorTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/GlobalChannelInterceptorTests.java
@@ -29,7 +29,6 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.channel.ChannelInterceptorAware;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
 
 /**
  * @author Oleg Zhurakousky
@@ -54,7 +53,7 @@ public class GlobalChannelInterceptorTests {
 	}
 
 
-	public static class SampleInterceptor extends ChannelInterceptorAdapter {
+	public static class SampleInterceptor implements ChannelInterceptor {
 	}
 
 }

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
@@ -45,7 +45,6 @@ import org.springframework.jms.listener.SimpleMessageListenerContainer;
 import org.springframework.jms.support.destination.DestinationResolver;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -333,7 +332,7 @@ public class JmsChannelParserTests {
 	}
 
 
-	static class TestInterceptor extends ChannelInterceptorAdapter {
+	static class TestInterceptor implements ChannelInterceptor {
 	}
 
 	static class CustomTestMessageListenerContainer extends DefaultMessageListenerContainer {

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
@@ -73,7 +73,7 @@ import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -344,12 +344,12 @@ public class JmsTests {
 		@Bean
 		public MessageChannel jmsMessageDrivenInputChannel() {
 			DirectChannel directChannel = new DirectChannel();
-			directChannel.addInterceptor(new ChannelInterceptorAdapter() {
+			directChannel.addInterceptor(new ChannelInterceptor() {
 
 				@Override
 				public Message<?> preSend(Message<?> message, MessageChannel channel) {
 					jmsMessageDrivenChannelCalled().set(true);
-					return super.preSend(message, channel);
+					return message;
 				}
 
 			});
@@ -397,12 +397,12 @@ public class JmsTests {
 		@Bean
 		public MessageChannel jmsInboundGatewayInputChannel() {
 			DirectChannel directChannel = new DirectChannel();
-			directChannel.addInterceptor(new ChannelInterceptorAdapter() {
+			directChannel.addInterceptor(new ChannelInterceptor() {
 
 				@Override
 				public Message<?> preSend(Message<?> message, MessageChannel channel) {
 					jmsInboundGatewayChannelCalled().set(true);
-					return super.preSend(message, channel);
+					return message;
 				}
 
 			});
@@ -444,7 +444,7 @@ public class JmsTests {
 
 	@Component
 	@GlobalChannelInterceptor(patterns = "flow1QueueChannel")
-	public static class TestChannelInterceptor extends ChannelInterceptorAdapter {
+	public static class TestChannelInterceptor implements ChannelInterceptor {
 
 		private final AtomicInteger invoked = new AtomicInteger();
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/IdempotentReceiverIntegrationTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/IdempotentReceiverIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,6 @@ import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
@@ -298,11 +297,10 @@ public class IdempotentReceiverIntegrationTests {
 		@Bean
 		@GlobalChannelInterceptor(patterns = "output")
 		public ChannelInterceptor txSuppliedChannelInterceptor(final AtomicBoolean txSupplied) {
-			return new ChannelInterceptorAdapter() {
+			return new ChannelInterceptor() {
 
 				@Override
 				public void postSend(Message<?> message, MessageChannel channel, boolean sent) {
-					super.postSend(message, channel, sent);
 					txSupplied.set(TransactionSynchronizationManager.isActualTransactionActive());
 				}
 

--- a/spring-integration-stomp/src/test/java/org/springframework/integration/stomp/outbound/StompMessageHandlerWebSocketIntegrationTests.java
+++ b/spring-integration-stomp/src/test/java/org/springframework/integration/stomp/outbound/StompMessageHandlerWebSocketIntegrationTests.java
@@ -70,7 +70,7 @@ import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Controller;
@@ -215,7 +215,6 @@ public class StompMessageHandlerWebSocketIntegrationTests {
 		}
 
 		@Bean
-		@SuppressWarnings("unchecked")
 		public ApplicationListener<ApplicationEvent> stompEventListener() {
 			ApplicationEventListeningMessageProducer producer = new ApplicationEventListeningMessageProducer();
 			producer.setEventTypes(StompIntegrationEvent.class);
@@ -273,7 +272,7 @@ public class StompMessageHandlerWebSocketIntegrationTests {
 
 		@Override
 		public void configureClientInboundChannel(ChannelRegistration registration) {
-			registration.interceptors(new ChannelInterceptorAdapter() {
+			registration.interceptors(new ChannelInterceptor() {
 
 				private final AtomicBoolean invoked = new AtomicBoolean();
 
@@ -281,7 +280,7 @@ public class StompMessageHandlerWebSocketIntegrationTests {
 				public Message<?> preSend(Message<?> message, MessageChannel channel) {
 					if (StompCommand.CONNECT.equals(StompHeaderAccessor.wrap(message).getCommand()) ||
 							this.invoked.compareAndSet(false, true)) {
-						return super.preSend(message, channel);
+						return message;
 					}
 					throw new RuntimeException("preSend intentional Exception");
 				}

--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/TestServerConfig.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/TestServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.springframework.integration.config.EnableIntegration;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
@@ -37,6 +37,7 @@ import org.springframework.web.socket.messaging.SubProtocolWebSocketHandler;
 
 /**
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 4.1
  */
 @Configuration
@@ -56,13 +57,15 @@ public class TestServerConfig implements WebSocketConfigurer {
 	@Bean
 	public AbstractSubscribableChannel clientOutboundChannel() {
 		DirectChannel directChannel = new DirectChannel();
-		directChannel.addInterceptor(new ChannelInterceptorAdapter() {
+		directChannel.addInterceptor(new ChannelInterceptor() {
+
 			@Override
 			public Message<?> preSend(Message<?> message, MessageChannel channel) {
 				SimpMessageHeaderAccessor headers = SimpMessageHeaderAccessor.wrap(message);
 				headers.setLeaveMutable(true);
 				return MessageBuilder.createMessage(message.getPayload(), headers.getMessageHeaders());
 			}
+
 		});
 		return directChannel;
 	}


### PR DESCRIPTION
Deprecated in favor of default methods on `ChannelInterceptor`.

