### PR TITLE
Fix LockRegLeaderIn for interrupted Thread.sleep

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
@@ -416,7 +416,13 @@ public class LockRegistryLeaderInitiator implements SmartLifecycle, DisposableBe
 						else {
 							if (isRunning()) {
 								// Give it a chance to elect some other leader.
-								Thread.sleep(LockRegistryLeaderInitiator.this.busyWaitMillis);
+								try {
+									Thread.sleep(LockRegistryLeaderInitiator.this.busyWaitMillis);
+								}
+								catch (InterruptedException e1) {
+									// Ignore interruption and let it to be caught on the next cycle.
+									Thread.currentThread().interrupt();
+								}
 							}
 							if (logger.isDebugEnabled()) {
 								logger.debug("Error acquiring the lock for " + this.context +

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
@@ -397,10 +397,6 @@ public class LockRegistryLeaderInitiator implements SmartLifecycle, DisposableBe
 							}
 							// The lock was broken and we are no longer leader
 							handleRevoked();
-							if (isRunning()) {
-								// Give it a chance to elect some other leader.
-								Thread.sleep(LockRegistryLeaderInitiator.this.busyWaitMillis);
-							}
 						}
 
 						if (e instanceof InterruptedException || Thread.currentThread().isInterrupted()) {
@@ -417,9 +413,15 @@ public class LockRegistryLeaderInitiator implements SmartLifecycle, DisposableBe
 							}
 							return null;
 						}
-						else if (logger.isDebugEnabled()) {
-							logger.debug("Error acquiring the lock for " + this.context +
-									". " + (isRunning() ? "Retrying..." : ""), e);
+						else {
+							if (isRunning()) {
+								// Give it a chance to elect some other leader.
+								Thread.sleep(LockRegistryLeaderInitiator.this.busyWaitMillis);
+							}
+							if (logger.isDebugEnabled()) {
+								logger.debug("Error acquiring the lock for " + this.context +
+										". " + (isRunning() ? "Retrying..." : ""), e);
+							}
 						}
 					}
 				}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/leader/RedisLockRegistryLeaderInitiatorTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/leader/RedisLockRegistryLeaderInitiatorTests.java
@@ -37,7 +37,6 @@ import org.springframework.integration.redis.rules.RedisAvailableTests;
 import org.springframework.integration.redis.util.RedisLockRegistry;
 import org.springframework.integration.support.leader.LockRegistryLeaderInitiator;
 import org.springframework.integration.test.rule.Log4j2LevelAdjuster;
-import org.springframework.integration.test.support.LongRunningIntegrationTest;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 
 /**
@@ -48,9 +47,6 @@ import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
  * @since 4.3.9
  */
 public class RedisLockRegistryLeaderInitiatorTests extends RedisAvailableTests {
-
-	@Rule
-	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Rule
 	public Log4j2LevelAdjuster adjuster =


### PR DESCRIPTION
https://build.spring.io/browse/INT-FATS5IC-517

If current thread is interrupted, the `Thread.sleep()` interrupts
immediately.
In the catch block of the main loop in the `LockRegistryLeaderInitiator`
we have such a dangerous `sleep()` and don't restart election in this
candidate any more

* Move `Thread.sleep()` to else after checking the current thread for
interrupted state
* Remove `LongRunningIntegrationTest` rule from the
`RedisLockRegistryLeaderInitiatorTests` since it now works much faster
after proper `busy-wait` handling

**Cherry-pick to master**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
