### PR TITLE
Fix LambdaMessageProcessor for Map payload

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/LambdaMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/LambdaMessageProcessor.java
@@ -100,7 +100,7 @@ public class LambdaMessageProcessor implements MessageProcessor<Object>, BeanFac
 				args[i] = message;
 			}
 			else if (Map.class.isAssignableFrom(parameterType)) {
-				if (message.getPayload() instanceof Map) {
+				if (message.getPayload() instanceof Map && this.parameterTypes.length == 1) {
 					args[i] = message.getPayload();
 				}
 				else {

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/dsl/WebFluxDslTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/dsl/WebFluxDslTests.java
@@ -299,8 +299,10 @@ public class WebFluxDslTests {
 		public IntegrationFlow sseFlow() {
 			return IntegrationFlows
 					.from(WebFlux.inboundGateway("/sse")
-							.requestMapping(m -> m.produces(MediaType.TEXT_EVENT_STREAM_VALUE)))
-					.handle((p, h) -> Flux.just("foo", "bar", "baz"))
+							.requestMapping(m -> m.produces(MediaType.TEXT_EVENT_STREAM_VALUE))
+							.mappedResponseHeaders("*"))
+					.enrichHeaders(Collections.singletonMap("aHeader", new String[] { "foo", "bar", "baz" }))
+					.handle((p, h) -> Flux.fromArray((String[]) h.get("aHeader")))
 					.get();
 		}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4478

When we use a `GenericHandler` and an incoming payload is a `Map`, we
copy it into both arguments into the `Object` for the payload
and `Map` for the headers.
This way we lose headers in the target lambda

* Check a size of arguments on the target lambda and don't set a
payload into the `Map` argument if we have more than 1 arguments

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
