### PR TITLE
INT-4474: ConsumerEndpointFactoryBean: Fix phase

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,13 @@ import org.springframework.util.StringUtils;
 
 
 /**
+ * The {@link FactoryBean} implementation for {@link AbstractEndpoint} population.
+ * Controls all the necessary properties and lifecycle.
+ * According the provided {@link MessageChannel} implementation populates
+ * a {@link PollingConsumer} for the {@link PollableChannel},
+ * an {@link EventDrivenConsumer} for the {@link SubscribableChannel}
+ * and {@link ReactiveStreamsConsumer} for all other channel implementations.
+ *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Josh Long
@@ -310,9 +317,15 @@ public class ConsumerEndpointFactoryBean
 				this.endpoint.setAutoStartup(this.autoStartup);
 			}
 			int phase = this.phase;
-			if (!this.isPhaseSet && this.endpoint instanceof PollingConsumer) {
-				phase = Integer.MAX_VALUE / 2;
+			if (!this.isPhaseSet) {
+				if (this.endpoint instanceof PollingConsumer) {
+					phase = Integer.MAX_VALUE / 2;
+				}
+				else {
+					phase = Integer.MIN_VALUE;
+				}
 			}
+
 			this.endpoint.setPhase(phase);
 			this.endpoint.setRole(this.role);
 			if (this.taskScheduler != null) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ServiceActivatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ServiceActivatorParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.core.MessagingTemplate;
+import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.handler.ServiceActivatingHandler;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
 import org.springframework.messaging.Message;
@@ -38,6 +39,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 @ContextConfiguration
@@ -74,6 +77,10 @@ public class ServiceActivatorParserTests {
 	@Autowired
 	@Qualifier("testAlias.handler")
 	private ServiceActivatingHandler testAlias;
+
+	@Autowired
+	@Qualifier("testAlias")
+	private EventDrivenConsumer testAliasEndpoint;
 
 	@Test
 	public void literalExpression() {
@@ -200,6 +207,11 @@ public class ServiceActivatorParserTests {
 		}
 	}
 
+	@Test
+	public void testConsumerEndpointFactoryBeanDefaultPhase() {
+		assertEquals(Integer.MIN_VALUE, this.testAliasEndpoint.getPhase());
+	}
+
 	private Object sendAndReceive(MessageChannel channel, Object payload) {
 		MessagingTemplate template = new MessagingTemplate();
 		template.setDefaultDestination(channel);
@@ -222,6 +234,7 @@ public class ServiceActivatorParserTests {
 		public String concat(String s1, String s2) {
 			return s1 + s2;
 		}
+
 	}
 
 
@@ -235,6 +248,7 @@ public class ServiceActivatorParserTests {
 		public String getSimpleClassName(Object o) {
 			return o.getClass().getSimpleName();
 		}
+
 	}
 
 
@@ -257,6 +271,7 @@ public class ServiceActivatorParserTests {
 		public String getLastName() {
 			return lastName;
 		}
+
 	}
 
 	public static class BarAdvice extends AbstractRequestHandlerAdvice {
@@ -268,4 +283,5 @@ public class ServiceActivatorParserTests {
 		}
 
 	}
+
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4474

* Populate proper `Integer.MIN_VALUE` phase for non-`PollingConsumer`s
in the `ConsumerEndpointFactoryBean`

**Cherry-pick to 5.0.x and 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
