### PR TITLE
GH-2464: WebFlux: Get rid of Mono.block()

### DIFF
--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/inbound/WebFluxInboundEndpoint.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/inbound/WebFluxInboundEndpoint.java
@@ -289,12 +289,12 @@ public class WebFluxInboundEndpoint extends BaseHttpInboundEndpoint implements W
 			payload = requestParams;
 		}
 
-		AbstractIntegrationMessageBuilder<?> messageBuilder;
+		AbstractIntegrationMessageBuilder<Object> messageBuilder;
 
 		if (payload instanceof Message<?>) {
 			messageBuilder =
 					getMessageBuilderFactory()
-							.fromMessage((Message<?>) payload)
+							.fromMessage((Message<Object>) payload)
 							.copyHeadersIfAbsent(headers);
 		}
 		else {
@@ -312,8 +312,9 @@ public class WebFluxInboundEndpoint extends BaseHttpInboundEndpoint implements W
 		return exchange.getPrincipal()
 				.map(principal ->
 						messageBuilder
-								.setHeader(org.springframework.integration.http.HttpHeaders.USER_PRINCIPAL, principal)
-								.build());
+								.setHeader(org.springframework.integration.http.HttpHeaders.USER_PRINCIPAL, principal))
+				.defaultIfEmpty(messageBuilder)
+				.map(AbstractIntegrationMessageBuilder::build);
 	}
 
 	private Mono<Void> populateResponse(ServerWebExchange exchange, Message<?> replyMessage) {

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/inbound/WebFluxInboundEndpoint.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/inbound/WebFluxInboundEndpoint.java
@@ -152,7 +152,7 @@ public class WebFluxInboundEndpoint extends BaseHttpInboundEndpoint implements W
 				.doOnSubscribe(s -> this.activeCount.incrementAndGet())
 				.switchIfEmpty(Mono.just(exchange.getRequest().getQueryParams()))
 				.map(body -> new HttpEntity<>(body, exchange.getRequest().getHeaders()))
-				.map(entity -> buildMessage(entity, exchange))
+				.flatMap(entity -> buildMessage(entity, exchange))
 				.flatMap(requestMessage -> {
 					if (this.expectReply) {
 						return sendAndReceiveMessageReactive(requestMessage)
@@ -235,7 +235,7 @@ public class WebFluxInboundEndpoint extends BaseHttpInboundEndpoint implements W
 	}
 
 	@SuppressWarnings("unchecked")
-	private Message<?> buildMessage(HttpEntity<?> httpEntity, ServerWebExchange exchange) {
+	private Mono<Message<?>> buildMessage(HttpEntity<?> httpEntity, ServerWebExchange exchange) {
 		ServerHttpRequest request = exchange.getRequest();
 		HttpHeaders requestHeaders = request.getHeaders();
 		Map<String, Object> exchangeAttributes = exchange.getAttributes();
@@ -304,11 +304,16 @@ public class WebFluxInboundEndpoint extends BaseHttpInboundEndpoint implements W
 							.copyHeaders(headers);
 		}
 
-		return messageBuilder
+		messageBuilder
 				.setHeader(org.springframework.integration.http.HttpHeaders.REQUEST_URL, request.getURI().toString())
-				.setHeader(org.springframework.integration.http.HttpHeaders.REQUEST_METHOD, request.getMethod().toString())
-				.setHeader(org.springframework.integration.http.HttpHeaders.USER_PRINCIPAL, exchange.getPrincipal().block())
-				.build();
+				.setHeader(org.springframework.integration.http.HttpHeaders.REQUEST_METHOD,
+						request.getMethod().toString());
+
+		return exchange.getPrincipal()
+				.map(principal ->
+						messageBuilder
+								.setHeader(org.springframework.integration.http.HttpHeaders.USER_PRINCIPAL, principal)
+								.build());
 	}
 
 	private Mono<Void> populateResponse(ServerWebExchange exchange, Message<?> replyMessage) {

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -104,7 +104,9 @@
 				org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*,
 				org.springframework.test.web.servlet.result.MockMvcResultMatchers.*,
 				org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*,
-				org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*" />
+				org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*,
+				org.springframework.web.reactive.function.client.ExchangeFilterFunctions.*,
+				org.springframework.web.reactive.function.client.ExchangeFilterFunctions.Credentials.*"	/>
 		</module>
 		<module name="IllegalImport" />
 		<module name="RedundantImport" />


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2464

The `WebFluxInboundEndpoint` resolves a `Principal` via `Mono.block()`
operation.
This is prohibited situation in the non-blocking thread, like Reactor
Netty

* Defer `Mono<Principal>` resolution to the message header via
deferring the whole `Message` creating via `flatMap()` operation on the
main `doHandle()` `Mono`

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
