### PR TITLE
INT-4481: Add licence and notice to each artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -279,6 +279,13 @@ subprojects { subproject ->
 					'Automatic-Module-Name': subproject.name.replace('-', '.')  // for Jigsaw
 			)
 		}
+
+		from("${rootProject.projectDir}/src/dist") {
+			include "license.txt"
+			include "notice.txt"
+			into "META-INF"
+			expand(copyright: new Date().format("yyyy"), version: project.version)
+		}
 	}
 
 	check.dependsOn javadoc
@@ -894,6 +901,7 @@ task distZip(type: Zip, dependsOn: [docsZip, schemaZip]) {
 		include 'license.txt'
 		include 'notice.txt'
 		into "${baseDir}"
+		expand(copyright: new Date().format("yyyy"), version: project.version)
 	}
 
 	from(zipTree(docsZip.archivePath)) {

--- a/src/dist/notice.txt
+++ b/src/dist/notice.txt
@@ -1,21 +1,11 @@
-   ========================================================================
-   == NOTICE file corresponding to section 4 d of the Apache License,    ==
-   == Version 2.0, in this case for the Spring Integration distribution. ==
-   ========================================================================
+Spring Integration Framework ${version}
+Copyright (c) 2009-${copyright} Pivotal, Inc.
 
-   This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.
 
-   The end-user documentation included with a redistribution, if any,
-   must include the following acknowledgement:
-
-     "This product includes software developed by the Spring Framework
-      Project (http://www.springframework.org)."
-
-   Alternatively, this acknowledgement may appear in the software itself,
-   if and wherever such third-party acknowledgements normally appear.
-
-   The names "Spring", "Spring Framework", and "Spring Integration" must
-   not be used to endorse or promote products derived from this software
-   without prior written permission. For written permission, please contact
-   enquiries@springsource.com.
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of the source code for
+these subcomponents is subject to the terms and conditions of the
+subcomponent's license, as noted in the license.txt file.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4481

* Now each generated jar has `licence.txt` and `notice.txt` entries in
its `META-INF`
* Copy `notice.txt` from the Spring Framework with an appropriate
polishing

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
