### PR TITLE
INT-4482: AMQP: Fix Double ErrorMessage

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -201,9 +201,9 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 		@SuppressWarnings("unchecked")
 		@Override
 		public void onMessage(final Message message, final Channel channel) throws Exception {
-			boolean retryEnabled = AmqpInboundChannelAdapter.this.retryTemplate == null;
+			boolean retryDisabled = AmqpInboundChannelAdapter.this.retryTemplate == null;
 			try {
-				if (retryEnabled) {
+				if (retryDisabled) {
 					createAndSend(message, channel);
 				}
 				else {
@@ -228,7 +228,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 				}
 			}
 			finally {
-				if (retryEnabled) {
+				if (retryDisabled) {
 					attributesHolder.remove();
 				}
 			}

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
@@ -239,17 +239,11 @@ public class InboundEndpointTests {
 		adapter.setOutputChannel(outputChannel);
 		QueueChannel errorChannel = new QueueChannel();
 		adapter.setErrorChannel(errorChannel);
-		adapter.setMessageConverter(new MessageConverter() {
-
-			@Override
-			public org.springframework.amqp.core.Message toMessage(Object object, MessageProperties messageProperties)
-					throws MessageConversionException {
-				throw new MessageConversionException("intended");
-			}
+		adapter.setMessageConverter(new SimpleMessageConverter() {
 
 			@Override
 			public Object fromMessage(org.springframework.amqp.core.Message message) throws MessageConversionException {
-				return null;
+				throw new MessageConversionException("intended");
 			}
 
 		});

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/StringObjectMapBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/StringObjectMapBuilder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support;
+
+/**
+ * A map builder creating a map with String keys and values.
+ *
+ * @author Gary Russell
+ *
+ * @since 4.3.17
+ */
+public class StringObjectMapBuilder extends MapBuilder<StringObjectMapBuilder, String, Object> {
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/StringObjectMapBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/StringObjectMapBuilder.java
@@ -21,7 +21,7 @@ package org.springframework.integration.support;
  *
  * @author Gary Russell
  *
- * @since 4.3.17
+ * @since 5.0.6
  */
 public class StringObjectMapBuilder extends MapBuilder<StringObjectMapBuilder, String, Object> {
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4482

The outer try/catch sends an `ErrorMessage` for all exceptions; it should
only do so for `MessageConversionException`. Integration flow exceptions
will have been already handled by `MessageProducerSupport`.

Also, populate the raw message header consistently - previously it only
was populated for flow exceptions. Although the LEFE contains the raw
message, it should be in the `ErrorMessage` header for consistency.

**cherry-pick to 5.0.x, 4.3.x**
