### PR TITLE
GH-2467: JdbcLockRegistry should retry on DeadlockLoserDataAccessException

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
@@ -26,15 +26,12 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.springframework.dao.CannotAcquireLockException;
-import org.springframework.dao.CannotSerializeTransactionException;
 import org.springframework.dao.DataAccessResourceFailureException;
-import org.springframework.dao.DeadlockLoserDataAccessException;
-import org.springframework.dao.QueryTimeoutException;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.integration.support.locks.DefaultLockRegistry;
 import org.springframework.integration.support.locks.ExpirableLockRegistry;
 import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.integration.util.UUIDConverter;
-import org.springframework.transaction.TransactionTimedOutException;
 import org.springframework.util.Assert;
 
 /**
@@ -115,8 +112,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry {
 					}
 					break;
 				}
-				catch (CannotSerializeTransactionException | TransactionTimedOutException | QueryTimeoutException |
-						DeadlockLoserDataAccessException e) {
+				catch (TransientDataAccessException e) {
 					// try again
 				}
 				catch (InterruptedException e) {
@@ -150,8 +146,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry {
 					}
 					break;
 				}
-				catch (CannotSerializeTransactionException | TransactionTimedOutException | QueryTimeoutException |
-						DeadlockLoserDataAccessException e) {
+				catch (TransientDataAccessException e) {
 					// try again
 				}
 				catch (InterruptedException ie) {
@@ -195,8 +190,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry {
 					}
 					return acquired;
 				}
-				catch (CannotSerializeTransactionException | TransactionTimedOutException | QueryTimeoutException |
-						DeadlockLoserDataAccessException e) {
+				catch (TransientDataAccessException e) {
 					// try again
 				}
 				catch (Exception e) {

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
@@ -28,6 +28,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.CannotSerializeTransactionException;
 import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DeadlockLoserDataAccessException;
 import org.springframework.dao.QueryTimeoutException;
 import org.springframework.integration.support.locks.DefaultLockRegistry;
 import org.springframework.integration.support.locks.ExpirableLockRegistry;
@@ -47,6 +48,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Vedran Pavic
  * @author Kai Zimmermann
+ * @author Bartosz Rempuszewski
  *
  * @since 4.3
  */
@@ -113,7 +115,8 @@ public class JdbcLockRegistry implements ExpirableLockRegistry {
 					}
 					break;
 				}
-				catch (CannotSerializeTransactionException | TransactionTimedOutException | QueryTimeoutException e) {
+				catch (CannotSerializeTransactionException | TransactionTimedOutException | QueryTimeoutException |
+						DeadlockLoserDataAccessException e) {
 					// try again
 				}
 				catch (InterruptedException e) {
@@ -147,7 +150,8 @@ public class JdbcLockRegistry implements ExpirableLockRegistry {
 					}
 					break;
 				}
-				catch (CannotSerializeTransactionException | TransactionTimedOutException | QueryTimeoutException e) {
+				catch (CannotSerializeTransactionException | TransactionTimedOutException | QueryTimeoutException |
+						DeadlockLoserDataAccessException e) {
 					// try again
 				}
 				catch (InterruptedException ie) {
@@ -191,7 +195,8 @@ public class JdbcLockRegistry implements ExpirableLockRegistry {
 					}
 					return acquired;
 				}
-				catch (CannotSerializeTransactionException | TransactionTimedOutException | QueryTimeoutException e) {
+				catch (CannotSerializeTransactionException | TransactionTimedOutException | QueryTimeoutException |
+						DeadlockLoserDataAccessException e) {
 					// try again
 				}
 				catch (Exception e) {


### PR DESCRIPTION
Fixes #2467

MySQL 5.7.15 introduced setting `innodb_deadlock_detect` (enabled by
default). As a result MySQL JDBC driver throws
`DeadlockLoserDataAccessException` when deadlock is detected.
`JdbcLockRegistry` doesn't handle it causing lock to be lost.

* Retry `doLock()` on data access deadlock instead of loosing the lock
