### PR TITLE
INT-4486: Properly implement stop(Runnable)

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/AbstractSubscribableAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/AbstractSubscribableAmqpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -233,6 +233,9 @@ abstract class AbstractSubscribableAmqpChannel extends AbstractAmqpChannel
 		if (this.container != null) {
 			this.container.stop(callback);
 			this.declared = false;
+		}
+		else {
+			callback.run();
 		}
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpChannelFactoryBean.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/config/AmqpChannelFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,10 +66,11 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.1
  */
-public class AmqpChannelFactoryBean extends AbstractFactoryBean<AbstractAmqpChannel> implements SmartLifecycle,
-		DisposableBean, BeanNameAware {
+public class AmqpChannelFactoryBean extends AbstractFactoryBean<AbstractAmqpChannel>
+		implements SmartLifecycle, DisposableBean, BeanNameAware {
 
 	private volatile AbstractAmqpChannel channel;
 
@@ -516,13 +517,14 @@ public class AmqpChannelFactoryBean extends AbstractFactoryBean<AbstractAmqpChan
 		if (this.channel instanceof SmartLifecycle) {
 			((SmartLifecycle) this.channel).stop(callback);
 		}
+		else {
+			callback.run();
+		}
 	}
 
 	@Override
 	protected void destroyInstance(AbstractAmqpChannel instance) throws Exception {
-		if (instance instanceof DisposableBean) {
-			((DisposableBean) this.channel).destroy();
-		}
+		this.channel.destroy();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
@@ -375,6 +375,9 @@ public class ConsumerEndpointFactoryBean
 		if (this.endpoint != null) {
 			this.endpoint.stop(callback);
 		}
+		else {
+			callback.run();
+		}
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,6 +246,9 @@ public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<Sourc
 	public void stop(Runnable callback) {
 		if (this.adapter != null) {
 			this.adapter.stop(callback);
+		}
+		else {
+			callback.run();
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowAdapter.java
@@ -98,6 +98,9 @@ public abstract class IntegrationFlowAdapter implements IntegrationFlow, SmartLi
 		if (this.running.getAndSet(false)) {
 			this.targetIntegrationFlow.stop(callback);
 		}
+		else {
+			callback.run();
+		}
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,6 +198,9 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 				if (logger.isInfoEnabled()) {
 					logger.info("stopped " + this);
 				}
+			}
+			else {
+				callback.run();
 			}
 		}
 		finally {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Ali Shahbour
+ *
  * @since 3.0
  *
  */
@@ -191,6 +192,9 @@ public class FileTailInboundChannelAdapterFactoryBean extends AbstractFactoryBea
 	public void stop(Runnable callback) {
 		if (this.adapter != null) {
 			this.adapter.stop(callback);
+		}
+		else {
+			callback.run();
 		}
 	}
 

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,9 +43,12 @@ import org.springframework.util.Assert;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
-public class SubscribableJmsChannel extends AbstractJmsChannel implements SubscribableChannel, SmartLifecycle, DisposableBean {
+public class SubscribableJmsChannel extends AbstractJmsChannel
+		implements SubscribableChannel, SmartLifecycle, DisposableBean {
 
 	private final AbstractMessageListenerContainer container;
 
@@ -72,13 +75,15 @@ public class SubscribableJmsChannel extends AbstractJmsChannel implements Subscr
 
 	@Override
 	public boolean subscribe(MessageHandler handler) {
-		Assert.state(this.dispatcher != null, "'MessageDispatcher' must not be null. This channel might not have been initialized");
+		Assert.state(this.dispatcher != null,
+				"'MessageDispatcher' must not be null. This channel might not have been initialized");
 		return this.dispatcher.addHandler(handler);
 	}
 
 	@Override
 	public boolean unsubscribe(MessageHandler handler) {
-		Assert.state(this.dispatcher != null, "'MessageDispatcher' must not be null. This channel might not have been initialized");
+		Assert.state(this.dispatcher != null,
+				"'MessageDispatcher' must not be null. This channel might not have been initialized");
 		return this.dispatcher.removeHandler(handler);
 	}
 
@@ -126,7 +131,7 @@ public class SubscribableJmsChannel extends AbstractJmsChannel implements Subscr
 
 	@Override
 	public boolean isAutoStartup() {
-		return (this.container != null) ? this.container.isAutoStartup() : false;
+		return (this.container != null) && this.container.isAutoStartup();
 	}
 
 	@Override
@@ -136,7 +141,7 @@ public class SubscribableJmsChannel extends AbstractJmsChannel implements Subscr
 
 	@Override
 	public boolean isRunning() {
-		return (this.container != null) ? this.container.isRunning() : false;
+		return (this.container != null) && this.container.isRunning();
 	}
 
 	@Override
@@ -157,6 +162,9 @@ public class SubscribableJmsChannel extends AbstractJmsChannel implements Subscr
 	public void stop(Runnable callback) {
 		if (this.container != null) {
 			this.container.stop(callback);
+		}
+		else {
+			callback.run();
 		}
 	}
 
@@ -226,6 +234,7 @@ public class SubscribableJmsChannel extends AbstractJmsChannel implements Subscr
 				throw new MessagingException("failed to handle incoming JMS Message", e);
 			}
 		}
+
 	}
 
 }

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -547,6 +547,9 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 	public void stop(Runnable callback) {
 		if (this.channel instanceof SubscribableJmsChannel) {
 			((SubscribableJmsChannel) this.channel).stop(callback);
+		}
+		else {
+			callback.run();
 		}
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import org.springframework.util.StringUtils;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 @SuppressWarnings("rawtypes")
@@ -105,7 +106,6 @@ public class SubscribableRedisChannel extends AbstractMessageChannel
 	/**
 	 * Specify the maximum number of subscribers supported by the
 	 * channel's dispatcher.
-	 *
 	 * @param maxSubscribers The maximum number of subscribers allowed.
 	 */
 	public void setMaxSubscribers(int maxSubscribers) {
@@ -168,45 +168,37 @@ public class SubscribableRedisChannel extends AbstractMessageChannel
 
 	@Override
 	public boolean isAutoStartup() {
-		return (this.container != null) && this.container.isAutoStartup();
+		return this.container.isAutoStartup();
 	}
 
 	@Override
 	public int getPhase() {
-		return (this.container != null) ? this.container.getPhase() : 0;
+		return this.container.getPhase();
 	}
 
 	@Override
 	public boolean isRunning() {
-		return (this.container != null) && this.container.isRunning();
+		return this.container.isRunning();
 	}
 
 	@Override
 	public void start() {
-		if (this.container != null) {
-			this.container.start();
-		}
+		this.container.start();
 	}
 
 	@Override
 	public void stop() {
-		if (this.container != null) {
-			this.container.stop();
-		}
+		this.container.stop();
 	}
 
 	@Override
 	public void stop(Runnable callback) {
-		if (this.container != null) {
-			this.container.stop(callback);
-		}
+		this.container.stop(callback);
 	}
 
 	@Override
 	public void destroy() throws Exception {
-		if (this.container != null) {
-			this.container.destroy();
-		}
+		this.container.destroy();
 	}
 
 	private class MessageListenerDelegate {
@@ -230,6 +222,7 @@ public class SubscribableRedisChannel extends AbstractMessageChannel
 						+ "' (" + SubscribableRedisChannel.this.getFullChannelName() + ").", e);
 			}
 		}
+
 	}
 
 }

--- a/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/config/SyslogReceivingChannelAdapterFactoryBean.java
+++ b/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/config/SyslogReceivingChannelAdapterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,10 @@ import org.springframework.util.Assert;
 
 /**
  * Factory bean to create syslog inbound adapters (UDP or TCP).
+ *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 3.0
  *
  */
@@ -162,6 +165,9 @@ public class SyslogReceivingChannelAdapterFactoryBean extends AbstractFactoryBea
 	public void stop(Runnable callback) {
 		if (this.adapter != null) {
 			this.adapter.stop(callback);
+		}
+		else {
+			callback.run();
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4486

The `SmartLifecycle.stop(Runnable callback)` must always call the
`callback` in the end independently of the internal state

* Revise all the `SmartLifecycle` implementations for the proper
`callback` handling

**Cherry-pick to 5.0.x and 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
