### PR TITLE
INT-4485: Don't register bean twice for DSL Specs

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowBeanPostProcessor.java
@@ -309,7 +309,6 @@ public class IntegrationFlowBeanPostProcessor
 	}
 
 	private void processIntegrationComponentSpec(IntegrationComponentSpec<?, ?> bean) {
-		registerComponent(bean.get(), generateBeanName(bean.get(), bean.getId()));
 		if (bean instanceof ComponentsRegistration) {
 			Map<Object, String> componentsToRegister = ((ComponentsRegistration) bean).getComponentsToRegister();
 			if (!CollectionUtils.isEmpty(componentsToRegister)) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/correlation/CorrelationHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/correlation/CorrelationHandlerTests.java
@@ -43,6 +43,7 @@ import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
+import org.springframework.integration.dsl.MessageChannelSpec;
 import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.integration.handler.MessageTriggerAction;
 import org.springframework.integration.support.MessageBuilder;
@@ -176,11 +177,16 @@ public class CorrelationHandlerTests {
 		}
 
 		@Bean
+		public MessageChannelSpec<?, ?> executorChannel() {
+			return MessageChannels.executor(taskExecutor());
+		}
+
+		@Bean
 		@SuppressWarnings("rawtypes")
-		public IntegrationFlow splitResequenceFlow() {
+		public IntegrationFlow splitResequenceFlow(MessageChannel executorChannel) {
 			return f -> f.enrichHeaders(s -> s.header("FOO", "BAR"))
 					.split("testSplitterData", "buildList", c -> c.applySequence(false))
-					.channel(MessageChannels.executor(taskExecutor()))
+					.channel(executorChannel)
 					.split(Message.class, Message::getPayload, c -> c.applySequence(false))
 					.channel(MessageChannels.executor(taskExecutor()))
 					.split(s -> s
@@ -230,6 +236,11 @@ public class CorrelationHandlerTests {
 		}
 
 		@Bean
+		public MessageChannelSpec<?, ?> barrierResults() {
+			return MessageChannels.queue("barrierResults");
+		}
+
+		@Bean
 		public IntegrationFlow barrierFlow() {
 			return f -> f
 					.barrier(10000, b -> b
@@ -240,13 +251,18 @@ public class CorrelationHandlerTests {
 											.skip(1)
 											.findFirst()
 											.get()))
-					.channel(MessageChannels.queue("barrierResults"));
+					.channel("barrierResults");
+		}
+
+		@Bean
+		public MessageChannelSpec<?, ?> releaseChannel() {
+			return MessageChannels.queue("releaseChannel");
 		}
 
 		@Bean
 		@DependsOn("barrierFlow")
 		public IntegrationFlow releaseBarrierFlow(MessageTriggerAction barrierTriggerAction) {
-			return IntegrationFlows.from(MessageChannels.queue("releaseChannel"))
+			return IntegrationFlows.from(releaseChannel())
 					.trigger(barrierTriggerAction,
 							e -> e.poller(p -> p.fixedDelay(100)))
 					.get();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4485

The `IntegrationFlowBeanPostProcessor` performs extra bean registration
for the `IntegrationComponentSpec.get()` result.
Essentially it is going to be the same object in the end, but during
bean registration phase we end up with names conflict.

* Remove an explicit `registerComponent()` for the
`IntegrationComponentSpec.get()`
* Modify `CorrelationHandlerTests` for all possible usage for the
`MessageChannelSpec`, which is essentially a `FactoryBean`

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
