### PR TITLE
INT-4484: Fix SyndEntryPublishedDateComparator

### DIFF
--- a/spring-integration-feed/src/main/java/org/springframework/integration/feed/inbound/FeedEntryMessageSource.java
+++ b/spring-integration-feed/src/main/java/org/springframework/integration/feed/inbound/FeedEntryMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -279,7 +279,7 @@ public class FeedEntryMessageSource extends IntegrationObjectSupport implements 
 			if (date1 == null && date2 == null) {
 				return 0;
 			}
-			return (date2 == null) ? 1 : 0;
+			return date2 == null ? -1 : 1;
 		}
 
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4484

Fix the `SyndEntryPublishedDateComparator` to move entries without a
date into the end of the sorted list

**Cherry-pick to 5.0.x and 4.3.x**

Fixes spring-projects/spring-integration#2473