### PR TITLE
GH-2478: RecursiveDScanner: Files.walk().close()

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/RecursiveDirectoryScanner.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/RecursiveDirectoryScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,12 +70,13 @@ public class RecursiveDirectoryScanner extends DefaultDirectoryScanner {
 	public List<File> listFiles(File directory) throws IllegalArgumentException {
 		FileListFilter<File> filter = getFilter();
 		boolean supportAcceptFilter = filter instanceof AbstractFileListFilter;
-		try {
-			Stream<File> fileStream = Files.walk(directory.toPath(), this.maxDepth, this.fileVisitOptions)
-					.skip(1)
-					.map(Path::toFile)
-					.filter(file -> !supportAcceptFilter
-							|| ((AbstractFileListFilter<File>) filter).accept(file));
+		try (Stream<Path> pathStream = Files.walk(directory.toPath(), this.maxDepth, this.fileVisitOptions);) {
+			Stream<File> fileStream =
+					pathStream
+							.skip(1)
+							.map(Path::toFile)
+							.filter(file -> !supportAcceptFilter
+									|| ((AbstractFileListFilter<File>) filter).accept(file));
 
 			if (supportAcceptFilter) {
 				return fileStream.collect(Collectors.toList());


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2478

The `Files.walk()` stream must be closed in the end after usage

* Wrap `Files.walk()` to the `try-with-resources`

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
