### PR TITLE
Destroy RmiInboundGateway.RmiServiceExporter

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractInboundGatewayParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractInboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,12 +31,14 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public abstract class AbstractInboundGatewayParser extends AbstractSimpleBeanDefinitionParser {
 
 	@Override
 	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
 			throws BeanDefinitionStoreException {
+
 		String id = super.resolveId(element, definition, parserContext);
 		if (!StringUtils.hasText(id)) {
 			id = element.getAttribute("name");
@@ -58,21 +60,20 @@ public abstract class AbstractInboundGatewayParser extends AbstractSimpleBeanDef
 	protected final void postProcess(BeanDefinitionBuilder builder, Element element) {
 		String requestChannelRef = element.getAttribute("request-channel");
 		Assert.hasText(requestChannelRef, "a 'request-channel' reference is required");
-		builder.addPropertyReference("requestChannel", requestChannelRef);
+		builder.addPropertyValue("requestChannelName", requestChannelRef);
 		String replyChannel = element.getAttribute("reply-channel");
 		if (StringUtils.hasText(replyChannel)) {
-			builder.addPropertyReference("replyChannel", replyChannel);
+			builder.addPropertyValue("replyChannelName", replyChannel);
 		}
 		String errorChannel = element.getAttribute("error-channel");
 		if (StringUtils.hasText(errorChannel)) {
-			builder.addPropertyReference("errorChannel", errorChannel);
+			builder.addPropertyValue("errorChannelName", errorChannel);
 		}
 		this.doPostProcess(builder, element);
 	}
 
 	/**
 	 * Subclasses may add to the bean definition by overriding this method.
-	 *
 	 * @param builder The builder.
 	 * @param element The element.
 	 */

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -372,7 +372,12 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 		return this.requestChannel;
 	}
 
-	protected MessageChannel getReplyChannel() {
+	/**
+	 * Return this gateway's reply channel if any.
+	 * @return the reply channel instance
+	 * @since 5.1
+	 */
+	public MessageChannel getReplyChannel() {
 		if (this.replyChannelName != null) {
 			synchronized (this) {
 				if (this.replyChannelName != null) {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -444,7 +444,7 @@ public class ParserUnitTests {
 		assertEquals(456L, dfa.getPropertyValue("replyTimeout"));
 		assertEquals("inGateway1", tcpInboundGateway1.getComponentName());
 		assertEquals("ip:tcp-inbound-gateway", tcpInboundGateway1.getComponentType());
-		assertEquals(errorChannel, dfa.getPropertyValue("errorChannel"));
+		assertEquals(errorChannel, tcpInboundGateway1.getErrorChannel());
 		assertTrue(cfS2.isLookupHost());
 		assertFalse(tcpInboundGateway1.isAutoStartup());
 		assertEquals(126, tcpInboundGateway1.getPhase());

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -499,11 +499,6 @@ public class ChannelPublishingJmsMessageListener
 
 		GatewayDelegate() {
 			super();
-		}
-
-		@Override
-		public MessageChannel getErrorChannel() {
-			return super.getErrorChannel();
 		}
 
 		@Override

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundGatewayParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundGatewayParserTests.java
@@ -73,8 +73,8 @@ public class RedisQueueInboundGatewayParserTests {
 		assertFalse(TestUtils.getPropertyValue(this.defaultGateway, "extractPayload", Boolean.class));
 		assertSame(this.serializer, TestUtils.getPropertyValue(this.defaultGateway, "serializer"));
 		assertTrue(TestUtils.getPropertyValue(this.defaultGateway, "serializerExplicitlySet", Boolean.class));
-		assertSame(this.receiveChannel, TestUtils.getPropertyValue(this.defaultGateway, "replyChannel"));
-		assertSame(this.requestChannel, TestUtils.getPropertyValue(this.defaultGateway, "requestChannel"));
+		assertSame(this.receiveChannel, this.defaultGateway.getReplyChannel());
+		assertSame(this.requestChannel, this.defaultGateway.getRequestChannel());
 		assertEquals(2000L, TestUtils.getPropertyValue(this.defaultGateway, "replyTimeout"));
 		assertNotNull(TestUtils.getPropertyValue(this.defaultGateway, "taskExecutor"));
 		assertFalse(TestUtils.getPropertyValue(this.defaultGateway, "autoStartup", Boolean.class));

--- a/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/BackToBackTests-context.xml
+++ b/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/BackToBackTests-context.xml
@@ -29,7 +29,7 @@
 	</int:channel>
 
 	<bean id="port" class="java.lang.Integer">
-		<constructor-arg value="#{T(org.springframework.integration.test.util.SocketUtils).findAvailableServerSocket(11099)}" />
+		<constructor-arg value="#{T(org.springframework.integration.test.util.SocketUtils).findAvailableServerSocket()}" />
 	</bean>
 
 	<!-- Bad -->

--- a/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/config/RmiInboundGatewayParserTests-context.xml
+++ b/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/config/RmiInboundGatewayParserTests-context.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans xmlns="http://www.springframework.org/schema/integration"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:beans="http://www.springframework.org/schema/beans"
-	xmlns:rmi="http://www.springframework.org/schema/integration/rmi"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans
+			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			 xmlns:beans="http://www.springframework.org/schema/beans"
+			 xmlns:rmi="http://www.springframework.org/schema/integration/rmi"
+			 xsi:schemaLocation="http://www.springframework.org/schema/beans
 			http://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
 			http://www.springframework.org/schema/integration/spring-integration.xsd
@@ -16,18 +16,22 @@
 
 	<channel id="testErrorChannel"/>
 
-	<rmi:inbound-gateway id="gatewayWithDefaults" request-channel="testChannel"/>
+	<rmi:inbound-gateway id="gatewayWithDefaults" request-channel="testChannel" auto-startup="false"/>
 
 	<rmi:inbound-gateway id="gatewayWithCustomProperties" request-channel="testChannel"
-			expect-reply="false" request-timeout="123" reply-timeout="456"/>
+						 expect-reply="false" request-timeout="123" reply-timeout="456" auto-startup="false"/>
 
 	<rmi:inbound-gateway id="gatewayWithHostAndErrorChannel" request-channel="testChannel" registry-host="localhost"
-		error-channel="testErrorChannel"/>
+						 error-channel="testErrorChannel" auto-startup="false"/>
 
-	<rmi:inbound-gateway id="gatewayWithPort" request-channel="testChannel" registry-port="1234"/>
+	<rmi:inbound-gateway id="gatewayWithPort" request-channel="testChannel" registry-port="1234" auto-startup="false"/>
 
-	<rmi:inbound-gateway id="gatewayWithExecutorRef" request-channel="testChannel" remote-invocation-executor="invocationExecutor"/>
+	<rmi:inbound-gateway id="gatewayWithExecutorRef"
+						 request-channel="testChannel"
+						 remote-invocation-executor="invocationExecutor"
+						 auto-startup="false"/>
 
-	<beans:bean id="invocationExecutor" class="org.springframework.integration.rmi.config.StubRemoteInvocationExecutor"/>
+	<beans:bean id="invocationExecutor"
+				class="org.springframework.integration.rmi.config.StubRemoteInvocationExecutor"/>
 
 </beans:beans>

--- a/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/config/RmiInboundGatewayParserTests.java
+++ b/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/config/RmiInboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class RmiInboundGatewayParserTests {
 		assertEquals("gatewayWithDefaults", gateway.getComponentName());
 		assertEquals("rmi:inbound-gateway", gateway.getComponentType());
 		assertTrue(TestUtils.getPropertyValue(gateway, "expectReply", Boolean.class));
-		assertSame(this.channel, TestUtils.getPropertyValue(gateway, "requestChannel"));
+		assertSame(this.channel, gateway.getRequestChannel());
 		assertEquals(1000L, TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout"));
 		assertEquals(1000L, TestUtils.getPropertyValue(gateway, "messagingTemplate.receiveTimeout"));
 	}
@@ -69,7 +69,7 @@ public class RmiInboundGatewayParserTests {
 		RmiInboundGateway gateway = (RmiInboundGateway) context.getBean("gatewayWithCustomProperties");
 
 		assertFalse(TestUtils.getPropertyValue(gateway, "expectReply", Boolean.class));
-		assertSame(this.channel, TestUtils.getPropertyValue(gateway, "requestChannel"));
+		assertSame(this.channel, gateway.getRequestChannel());
 		assertEquals(123L, TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout"));
 		assertEquals(456L, TestUtils.getPropertyValue(gateway, "messagingTemplate.receiveTimeout"));
 	}
@@ -78,7 +78,7 @@ public class RmiInboundGatewayParserTests {
 	public void gatewayWithHost() {
 		RmiInboundGateway gateway = (RmiInboundGateway) context.getBean("gatewayWithHostAndErrorChannel");
 		assertEquals("localhost", TestUtils.getPropertyValue(gateway, "registryHost"));
-		assertSame(context.getBean("testErrorChannel"), TestUtils.getPropertyValue(gateway, "errorChannel"));
+		assertSame(context.getBean("testErrorChannel"), gateway.getErrorChannel());
 	}
 
 	@Test

--- a/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/config/RmiOutboundGatewayParserTests-context.xml
+++ b/spring-integration-rmi/src/test/java/org/springframework/integration/rmi/config/RmiOutboundGatewayParserTests-context.xml
@@ -17,7 +17,8 @@
 						  request-channel="localChannel"
 						  remote-channel="testChannel"
 						  configurer="configurer"
-						  host="localhost"/>
+						  host="localhost"
+						  port="#{T(org.springframework.integration.rmi.config.RmiOutboundGatewayParserTests).port}"/>
 
 	<channel id="advisedChannel"/>
 
@@ -25,28 +26,33 @@
 						  request-channel="advisedChannel"
 						  remote-channel="testChannel"
 						  requires-reply="false"
-						  host="localhost">
+						  host="localhost"
+						  port="#{T(org.springframework.integration.rmi.config.RmiOutboundGatewayParserTests).port}">
 		<rmi:request-handler-advice-chain>
-			<beans:ref bean="advice" />
+			<beans:ref bean="advice"/>
 		</rmi:request-handler-advice-chain>
 	</rmi:outbound-gateway>
 
 	<beans:bean id="configurer" class="org.mockito.Mockito" factory-method="mock">
 		<beans:constructor-arg
-				value="org.springframework.integration.rmi.RmiOutboundGateway$RmiProxyFactoryBeanConfigurer" />
+				value="org.springframework.integration.rmi.RmiOutboundGateway$RmiProxyFactoryBeanConfigurer"/>
 	</beans:bean>
 
 	<beans:bean id="advice"
-			class="org.springframework.integration.rmi.config.RmiOutboundGatewayParserTests$FooAdvice" />
+				class="org.springframework.integration.rmi.config.RmiOutboundGatewayParserTests$FooAdvice"/>
 
 	<chain input-channel="rmiOutboundGatewayInsideChain">
-		<rmi:outbound-gateway remote-channel="testChannel" host="localhost" requires-reply="false"/>
+		<rmi:outbound-gateway remote-channel="testChannel"
+							  host="localhost"
+							  port="#{T(org.springframework.integration.rmi.config.RmiOutboundGatewayParserTests).port}"
+							  requires-reply="false"/>
 	</chain>
 
 
 	<channel id="remoteChannel"/>
 
-	<rmi:inbound-gateway request-channel="remoteChannel"/>
+	<rmi:inbound-gateway request-channel="remoteChannel"
+						 registry-port="#{T(org.springframework.integration.rmi.config.RmiOutboundGatewayParserTests).port}"/>
 
 	<service-activator input-channel="remoteChannel" expression="payload.toUpperCase()"/>
 
@@ -56,7 +62,9 @@
 	</channel>
 
 	<chain input-channel="requestReplyRmiWithChainChannel" output-channel="replyChannel">
-		<rmi:outbound-gateway remote-channel="remoteChannel" host="localhost"/>
+		<rmi:outbound-gateway remote-channel="remoteChannel"
+							  host="localhost"
+							  port="#{T(org.springframework.integration.rmi.config.RmiOutboundGatewayParserTests).port}"/>
 	</chain>
 
 </beans:beans>


### PR DESCRIPTION
The internal instance `RmiServiceExporter` of the `RmiInboundGateway`
has to be destroyed together with the outer instance to unbind `service`
from the RMI registry

* Perform some polishing for the `RmiInboundGateway` and optimize
a `AbstractInboundGatewayParser` for late channels binding

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
