### PR TITLE
INT-2260: JdbcPollingChA: rename prop to maxRows

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcPollingChannelAdapter.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcPollingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.jdbc.core.ColumnMapRowMapper;
 import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.RowMapperResultSetExtractor;
@@ -32,6 +33,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
 
 /**
  * A polling channel adapter that creates messages from the payload returned by
@@ -50,41 +52,38 @@ public class JdbcPollingChannelAdapter extends IntegrationObjectSupport implemen
 
 	private final String selectQuery;
 
-	private volatile RowMapper<?> rowMapper;
+	private RowMapper<?> rowMapper;
 
-	private volatile SqlParameterSource sqlQueryParameterSource;
+	private SqlParameterSource sqlQueryParameterSource;
 
-	private volatile boolean updatePerRow = false;
+	private boolean updatePerRow = false;
 
-	private volatile String updateSql;
+	private String updateSql;
 
-	private volatile SqlParameterSourceFactory sqlParameterSourceFactory =
-			new ExpressionEvaluatingSqlParameterSourceFactory();
+	private SqlParameterSourceFactory sqlParameterSourceFactory = new ExpressionEvaluatingSqlParameterSourceFactory();
 
-	private volatile boolean sqlParameterSourceFactorySet;
+	private boolean sqlParameterSourceFactorySet;
 
-	private volatile int maxRowsPerPoll = 0;
+	private int maxRows = 0;
 
 	/**
 	 * Constructor taking {@link DataSource} from which the DB Connection can be
 	 * obtained and the select query to execute to retrieve new rows.
-	 *
 	 * @param dataSource Must not be null
 	 * @param selectQuery query to execute
 	 */
 	public JdbcPollingChannelAdapter(DataSource dataSource, String selectQuery) {
-		this.jdbcOperations = new NamedParameterJdbcTemplate(dataSource);
-		this.selectQuery = selectQuery;
+		this(new JdbcTemplate(dataSource), selectQuery);
 	}
 
 	/**
 	 * Constructor taking {@link JdbcOperations} instance to use for query
 	 * execution and the select query to execute to retrieve new rows.
-	 *
 	 * @param jdbcOperations instance to use for query execution
 	 * @param selectQuery query to execute
 	 */
 	public JdbcPollingChannelAdapter(JdbcOperations jdbcOperations, String selectQuery) {
+		Assert.hasText(selectQuery, "'selectQuery' must be specified.");
 		this.jdbcOperations = new NamedParameterJdbcTemplate(jdbcOperations);
 		this.selectQuery = selectQuery;
 	}
@@ -108,7 +107,6 @@ public class JdbcPollingChannelAdapter extends IntegrationObjectSupport implemen
 
 	/**
 	 * A source of parameters for the select query used for polling.
-	 *
 	 * @param sqlQueryParameterSource the sql query parameter source to set
 	 */
 	public void setSelectSqlParameterSource(SqlParameterSource sqlQueryParameterSource) {
@@ -119,19 +117,29 @@ public class JdbcPollingChannelAdapter extends IntegrationObjectSupport implemen
 	 * The maximum number of rows to pull out of the query results per poll (if
 	 * greater than zero, otherwise all rows will be packed into the outgoing
 	 * message). Default is zero.
-	 *
 	 * @param maxRows the max rows to set
+	 * @deprecated since 5.1 in favor of {@link #setMaxRows(int)}
 	 */
+	@Deprecated
 	public void setMaxRowsPerPoll(int maxRows) {
-		this.maxRowsPerPoll = maxRows;
+		setMaxRows(maxRows);
+	}
+
+	/**
+	 * The maximum number of rows to query. Default is zero - select all records.
+	 * @param maxRows the max rows to set
+	 * @since 5.1
+	 */
+	public void setMaxRows(int maxRows) {
+		this.maxRows = maxRows;
 	}
 
 	@Override
 	protected void onInit() throws Exception {
 		super.onInit();
-		if (!this.sqlParameterSourceFactorySet && this.getBeanFactory() != null) {
+		if (!this.sqlParameterSourceFactorySet && getBeanFactory() != null) {
 			((ExpressionEvaluatingSqlParameterSourceFactory) this.sqlParameterSourceFactory)
-					.setBeanFactory(this.getBeanFactory());
+					.setBeanFactory(getBeanFactory());
 		}
 	}
 
@@ -148,7 +156,9 @@ public class JdbcPollingChannelAdapter extends IntegrationObjectSupport implemen
 		if (payload == null) {
 			return null;
 		}
-		return this.getMessageBuilderFactory().withPayload(payload).build();
+		return getMessageBuilderFactory()
+				.withPayload(payload)
+				.build();
 	}
 
 	/**
@@ -183,11 +193,11 @@ public class JdbcPollingChannelAdapter extends IntegrationObjectSupport implemen
 		final RowMapper<?> rowMapper = this.rowMapper == null ? new ColumnMapRowMapper() : this.rowMapper;
 		ResultSetExtractor<List<Object>> resultSetExtractor;
 
-		if (this.maxRowsPerPoll > 0) {
+		if (this.maxRows > 0) {
 			resultSetExtractor = rs -> {
-				List<Object> results = new ArrayList<Object>(JdbcPollingChannelAdapter.this.maxRowsPerPoll);
+				List<Object> results = new ArrayList<Object>(JdbcPollingChannelAdapter.this.maxRows);
 				int rowNum = 0;
-				while (rs.next() && rowNum < JdbcPollingChannelAdapter.this.maxRowsPerPoll) {
+				while (rs.next() && rowNum < JdbcPollingChannelAdapter.this.maxRows) {
 					results.add(rowMapper.mapRow(rs, rowNum++));
 				}
 				return results;

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParser.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,21 +72,18 @@ public class JdbcOutboundGatewayParser extends AbstractConsumerEndpointParser {
 				"request-prepared-statement-setter");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "row-mapper");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "max-rows-per-poll");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "max-rows");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "keys-generated");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "requires-reply");
-
-		String replyChannel = element.getAttribute("reply-channel");
-		if (StringUtils.hasText(replyChannel)) {
-			builder.addPropertyReference("outputChannel", replyChannel);
-		}
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel", "outputChannel");
 
 		return builder;
-
 	}
 
 	@Override
 	protected String getInputChannelAttributeName() {
 		return "request-channel";
 	}
+
 }

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParser.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParser.java
@@ -71,7 +71,24 @@ public class JdbcOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
 				"request-prepared-statement-setter");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "row-mapper");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "max-rows-per-poll");
+
+
+		// TODO remove deprecated option in the next version
+		boolean hasMaxRowsPerPoll = element.hasAttribute("max-rows-per-poll");
+		boolean hasMaxRows = element.hasAttribute("max-rows");
+
+		if (hasMaxRowsPerPoll) {
+			parserContext.getReaderContext()
+					.warning("The 'max-rows-per-poll' is deprecated in favor of 'max-rows'", element);
+
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "max-rows-per-poll");
+
+			if (hasMaxRows) {
+				parserContext.getReaderContext()
+						.warning("The 'max-rows' has a precedence over 'max-rows-per-poll'", element);
+			}
+		}
+
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "max-rows");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "keys-generated");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcPollingChannelAdapterParser.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcPollingChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,9 +28,11 @@ import org.springframework.integration.jdbc.JdbcPollingChannelAdapter;
 import org.springframework.util.StringUtils;
 
 /**
- * Parser for {@link org.springframework.integration.jdbc.JdbcPollingChannelAdapter}.
+ * Parser for {@link JdbcPollingChannelAdapter}.
  *
  * @author Jonas Partner
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class JdbcPollingChannelAdapterParser extends AbstractPollingInboundChannelAdapterParser {
@@ -59,9 +61,8 @@ public class JdbcPollingChannelAdapterParser extends AbstractPollingInboundChann
 		}
 		String query = IntegrationNamespaceUtils.getTextFromAttributeOrNestedElement(element, "query", parserContext);
 		if (!StringUtils.hasText(query)) {
-			throw new BeanCreationException("The query attrbitue is required");
+			throw new BeanCreationException("The query attribute is required");
 		}
-		String update = IntegrationNamespaceUtils.getTextFromAttributeOrNestedElement(element, "update", parserContext);
 		if (refToDataSourceSet) {
 			builder.addConstructorArgReference(dataSourceRef);
 		}
@@ -69,14 +70,15 @@ public class JdbcPollingChannelAdapterParser extends AbstractPollingInboundChann
 			builder.addConstructorArgReference(jdbcOperationsRef);
 		}
 		builder.addConstructorArgValue(query);
+
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "row-mapper");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "update-sql-parameter-source-factory");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "select-sql-parameter-source");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "max-rows-per-poll");
-		if (update != null) {
-			builder.addPropertyValue("updateSql", update);
-		}
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "max-rows");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "update", "updateSql");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "update-per-row");
+
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-5.1.xsd
+++ b/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-5.1.xsd
@@ -174,9 +174,17 @@
 					<xsd:attribute name="max-rows-per-poll" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
-								Limits the number of rows extracted per query (otherwise all rows
-								are extracted into the
-								outgoing message).
+								[DEPRECATED] Limits the number of rows extracted per query (otherwise all rows
+								are extracted into the outgoing message).
+								Deprecated since 5.1 in favor of 'max-rows'.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="max-rows" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Limits the number of rows extracted per query.
+								Otherwise all rows are extracted into the outgoing message.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
@@ -362,11 +370,22 @@
 					<xsd:attribute name="max-rows-per-poll" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
+								[DEPRECATED] When using a select query, you can set a
+								custom limit regarding the number of rows
+								extracted. Otherwise by default only the first
+								row will be extracted into the outgoing message.
+								If set to '0' all rows are extracted.
+								Deprecated since 5.1 in favor of 'max-rows'.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="max-rows" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
 								When using a select query, you can set a
 								custom limit regarding the number of rows
 								extracted. Otherwise by default only the first
 								row will be extracted into the outgoing message.
-
 								If set to '0' all rows are extracted.
 							</xsd:documentation>
 						</xsd:annotation>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcOutboundGatewayTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,14 +60,14 @@ public class JdbcOutboundGatewayTests {
 		JdbcOutboundGateway jdbcOutboundGateway = new JdbcOutboundGateway(dataSource, "update something");
 
 		try {
-			jdbcOutboundGateway.setMaxRowsPerPoll(10);
+			jdbcOutboundGateway.setMaxRows(10);
 			jdbcOutboundGateway.setBeanFactory(mock(BeanFactory.class));
 			jdbcOutboundGateway.afterPropertiesSet();
 
 			fail("Expected an IllegalArgumentException to be thrown.");
 		}
 		catch (IllegalArgumentException e) {
-			assertEquals("If you want to set 'maxRowsPerPoll', then you must provide a 'selectQuery'.", e.getMessage());
+			assertEquals("If you want to set 'maxRows', then you must provide a 'selectQuery'.", e.getMessage());
 		}
 
 		dataSource.shutdown();
@@ -99,7 +99,8 @@ public class JdbcOutboundGatewayTests {
 			fail("Expected an IllegalArgumentException to be thrown.");
 		}
 		catch (IllegalArgumentException e) {
-			Assert.assertEquals("The 'updateQuery' and the 'selectQuery' must not both be null or empty.", e.getMessage());
+			Assert.assertEquals("The 'updateQuery' and the 'selectQuery' must not both be null or empty.",
+					e.getMessage());
 		}
 	}
 
@@ -108,12 +109,12 @@ public class JdbcOutboundGatewayTests {
 		JdbcOutboundGateway jdbcOutboundGateway = new JdbcOutboundGateway(dataSource, "select * from DOES_NOT_EXIST");
 
 		try {
-			jdbcOutboundGateway.setMaxRowsPerPoll(null);
+			jdbcOutboundGateway.setMaxRows(null);
 
 			fail("Expected an IllegalArgumentException to be thrown.");
 		}
 		catch (IllegalArgumentException e) {
-			assertEquals("MaxRowsPerPoll must not be null.", e.getMessage());
+			assertEquals("'maxRows' must not be null.", e.getMessage());
 		}
 	}
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcPollingChannelAdapterIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcPollingChannelAdapterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -204,7 +204,7 @@ public class JdbcPollingChannelAdapterIntegrationTests {
 				"select * from item where id not in (select id from copy)");
 		adapter.setUpdateSql("insert into copy values(:id,10)");
 		adapter.setUpdatePerRow(true);
-		adapter.setMaxRowsPerPoll(1);
+		adapter.setMaxRows(1);
 		adapter.setRowMapper(new ItemRowMapper());
 		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();
@@ -234,7 +234,7 @@ public class JdbcPollingChannelAdapterIntegrationTests {
 				"select * from item where status=2");
 		adapter.setUpdateSql("update item set status = 10 where id = :id");
 		adapter.setUpdatePerRow(true);
-		adapter.setMaxRowsPerPoll(1);
+		adapter.setMaxRows(1);
 		adapter.setRowMapper(new ItemRowMapper());
 		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.afterPropertiesSet();

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/MessageGroupQueueTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/MessageGroupQueueTests.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.logging.LogFactory;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -44,7 +43,7 @@ import org.springframework.messaging.support.GenericMessage;
  */
 public class MessageGroupQueueTests {
 
-	@ClassRule
+//	@ClassRule
 	public static LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Test

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/MessageGroupQueueTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/MessageGroupQueueTests.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.logging.LogFactory;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -43,7 +44,7 @@ import org.springframework.messaging.support.GenericMessage;
  */
 public class MessageGroupQueueTests {
 
-//	@ClassRule
+	@ClassRule
 	public static LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 	@Test

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParserTests.java
@@ -209,7 +209,7 @@ public class JdbcOutboundGatewayParserTests {
 		accessor = new DirectFieldAccessor(source);
 		source = accessor.getPropertyValue("poller"); //JdbcPollingChannelAdapter
 		accessor = new DirectFieldAccessor(source);
-		Integer maxRowsPerPoll = (Integer) accessor.getPropertyValue("maxRowsPerPoll");
+		Integer maxRowsPerPoll = (Integer) accessor.getPropertyValue("maxRows");
 		assertEquals("maxRowsPerPoll should default to 1", Integer.valueOf(1),  maxRowsPerPoll);
 
 	}
@@ -225,7 +225,7 @@ public class JdbcOutboundGatewayParserTests {
 		accessor = new DirectFieldAccessor(source);
 		source = accessor.getPropertyValue("poller"); //JdbcPollingChannelAdapter
 		accessor = new DirectFieldAccessor(source);
-		Integer maxRowsPerPoll = (Integer) accessor.getPropertyValue("maxRowsPerPoll");
+		Integer maxRowsPerPoll = (Integer) accessor.getPropertyValue("maxRows");
 		assertEquals("maxRowsPerPoll should default to 10", Integer.valueOf(10),  maxRowsPerPoll);
 	}
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayWithPoller2Test-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayWithPoller2Test-context.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/integration/jdbc http://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd
 		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd"
-	xmlns:int="http://www.springframework.org/schema/integration"
-	xmlns:int-jdbc="http://www.springframework.org/schema/integration/jdbc"
-	xmlns:jdbc="http://www.springframework.org/schema/jdbc">
+	   xmlns:int="http://www.springframework.org/schema/integration"
+	   xmlns:int-jdbc="http://www.springframework.org/schema/integration/jdbc"
+	   xmlns:jdbc="http://www.springframework.org/schema/jdbc">
 
 
 	<int:channel id="target">
@@ -15,26 +15,28 @@
 	</int:channel>
 
 	<int:channel id="output">
-		<int:queue />
+		<int:queue/>
 	</int:channel>
 
-	<int-jdbc:outbound-gateway query="select * from bazz where id=:headers[id]" update="insert into bazz (id, status, name) values (:headers[id], 0, :payload[foo])"
-		request-channel="target" reply-channel="output" data-source="dataSource" auto-startup="true" max-rows-per-poll="10">
+	<int-jdbc:outbound-gateway query="select * from bazz where id=:headers[id]"
+							   update="insert into bazz (id, status, name) values (:headers[id], 0, :payload[foo])"
+							   request-channel="target" reply-channel="output" data-source="dataSource"
+							   auto-startup="true" max-rows="10">
 		<int:poller fixed-rate="1000"/>
 	</int-jdbc:outbound-gateway>
 
-    <jdbc:embedded-database id="dataSource" type="H2"/>
+	<jdbc:embedded-database id="dataSource" type="H2"/>
 
-    <jdbc:initialize-database data-source="dataSource">
-        <jdbc:script location="classpath:org/springframework/integration/jdbc/config/outboundPollerSchema.sql"/>
-    </jdbc:initialize-database>
+	<jdbc:initialize-database data-source="dataSource">
+		<jdbc:script location="classpath:org/springframework/integration/jdbc/config/outboundPollerSchema.sql"/>
+	</jdbc:initialize-database>
 
 	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
 		<property name="dataSource" ref="dataSource"/>
 	</bean>
 
 	<bean id="jdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
-		<constructor-arg ref="dataSource" />
+		<constructor-arg ref="dataSource"/>
 	</bean>
 
 </beans>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/pollingWithMaxRowsJdbcInboundChannelAdapterTest.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/pollingWithMaxRowsJdbcInboundChannelAdapterTest.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans xmlns="http://www.springframework.org/schema/integration/jdbc"
-	xmlns:beans="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans
+			 xmlns:beans="http://www.springframework.org/schema/beans"
+			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			 xsi:schemaLocation="http://www.springframework.org/schema/beans
 			http://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration/jdbc
 			http://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd">
 
-	<beans:import resource="jdbcInboundChannelAdapterCommonConfig.xml" />
+	<beans:import resource="jdbcInboundChannelAdapterCommonConfig.xml"/>
 
 	<inbound-channel-adapter query="select * from item where status=2"
-		channel="target" data-source="dataSource" max-rows-per-poll="2"
-		update="update item set status=10 where id in (:id)" />
+							 channel="target" data-source="dataSource" max-rows="2"
+							 update="update item set status=10 where id in (:id)"/>
 
 
 </beans:beans>

--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -150,6 +150,9 @@ In contrast, the `max-rows` attribute, if greater than _0_, specifies the maximu
 If the attribute is set to _0_, then all rows will be included in the resulting message.
 If not explicitly set, the attribute defaults to _0_.
 
+NOTE: It is recommended to use result set limiting via vendor-specific query option, for example MySQL `LIMIT` or SQL Server `TOP` or Oracle's `ROWNUM`.
+See more information the particular vendor documentation.
+
 [[jdbc-outbound-channel-adapter]]
 === Outbound Channel Adapter
 

--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -131,14 +131,14 @@ The transaction manager configuration is not shown, but as long as it is aware o
 A common use case is for the downstream channels to be direct channels (the default), so that the endpoints are invoked in the same thread, and hence the same transaction.
 Then if any of them fail, the transaction rolls back and the input data is reverted to its original state.
 
-[[jdbc-max-rows-per-poll-versus-max-messages-per-poll]]
-==== Max-rows-per-poll versus Max-messages-per-poll
+[[jdbc-max-rows-versus-max-messages-per-poll]]
+==== Max-rows versus Max-messages-per-poll
 
-The _JDBC Inbound Channel Adapter_ defines an attribute `max-rows-per-poll`.
+The _JDBC Inbound Channel Adapter_ defines an attribute `max-rows`.
 When you specify the adapter's _Poller_, you can also define a property called `max-messages-per-poll`.
 While these two attributes look similar, their meaning is quite different.
 
-`max-messages-per-poll` specifies the number of times the query is executed per polling interval, whereas `max-rows-per-poll` specifies the number of rows returned for each execution.
+`max-messages-per-poll` specifies the number of times the query is executed per polling interval, whereas `max-rows` specifies the number of rows returned for each execution.
 
 Under normal circumstances, you would likely not want to set the Poller's `max-messages-per-poll` property when using the _JDBC Inbound Channel Adapter_.
 Its default value is _1_, which means that the _JDBC Inbound Channel Adapter_'s https://docs.spring.io/spring-integration/api/org/springframework/integration/jdbc/JdbcPollingChannelAdapter.html#receive()[`receive()`] method is executed exactly once for each poll interval.
@@ -146,7 +146,7 @@ Its default value is _1_, which means that the _JDBC Inbound Channel Adapter_'s 
 Setting the `max-messages-per-poll` attribute to a larger value means that the query is executed that many times back to back.
 For more information regarding the `max-messages-per-poll` attribute, please see <<channel-adapter-namespace-inbound>>.
 
-In contrast, the `max-rows-per-poll` attribute, if greater than _0_, specifies the maximum number of rows that will be used from the query result set, per execution of the `receive()` method.
+In contrast, the `max-rows` attribute, if greater than _0_, specifies the maximum number of rows that will be used from the query result set, per execution of the `receive()` method.
 If the attribute is set to _0_, then all rows will be included in the resulting message.
 If not explicitly set, the attribute defaults to _0_.
 
@@ -302,8 +302,8 @@ The reply message is then generated from the result, like the inbound adapter, a
 [IMPORTANT]
 ====
 By default the component for the SELECT query returns only one, first row from the cursor.
-This can be adjusted with the `max-rows-per-poll` option.
-Consider to specify `max-rows-per-poll="0"` if you need to return all the rows from the SELECT.
+This can be adjusted with the `max-rows` option.
+Consider to specify `max-rows="0"` if you need to return all the rows from the SELECT.
 ====
 
 As with the channel adapters, there is also the option to provide `SqlParameterSourceFactory` instances for request and reply.
@@ -810,7 +810,7 @@ Furthermore, if you need even more control over how parameters are retrieved, co
                                    id=""
                                    ignore-column-meta-data="false"
                                    is-function="false"
-                                   max-rows-per-poll=""                          <2>
+                                   max-rows=""                          <2>
                                    skip-undeclared-results=""                    <3>
                                    return-value-required="false"                 <4>
     <int:poller/>
@@ -844,7 +844,7 @@ _Optional_.
 Since _Spring Integration 3.0_. _Optional_.
 
 NOTE: When you declare a Poller, you may notice the Poller's `max-messages-per-poll` attribute.
-For information about how it relates to the `max-rows-per-poll` attribute of the _Stored Procedure Inbound Channel Adapter_, please see <<jdbc-max-rows-per-poll-versus-max-messages-per-poll>> for a thorough discussion.
+For information about how it relates to the `max-rows` attribute of the _Stored Procedure Inbound Channel Adapter_, please see <<jdbc-max-rows-versus-max-messages-per-poll>> for a thorough discussion.
 The meaning of the attributes is the same as for the _JDBC Inbound Channel Adapter_.
 
 [[stored-procedure-outbound-channel-adapter]]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -58,3 +58,9 @@ See the note near the bottom of <<amqp-message-headers>> for more information.
 
 The `contentType` header is no longer incorrectly mapped as an entry in the general headers map.
 See <<amqp-content-type>> for more information.
+
+==== JDBC Changes
+
+A confusing `max-rows-per-poll` property on the JDBC Inbound Channel Adapter and JDBC Outbound Gateway has been deprecated in favor newly introduced `max-rows` property.
+
+See <<jdbc>>  for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-2260

Having a feedback about confusing with the `max-rows-per-poll` property
name and its responsibility it would be better do not mention `per-poll`
at all

* Deprecate `max-rows-per-poll` in favor of new `max-rows`
* Some code style polishing, tests improvements
* Docs polishing on the matter

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
