### PR TITLE
INT-4487: Allow to reconfigure ARPMH.adviceChain

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,25 +75,27 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 
 	private final ConversionService defaultConversionService = DefaultConversionService.getSharedInstance();
 
-	private volatile DestinationResolver<MessageChannel> channelResolver;
+	private DestinationResolver<MessageChannel> channelResolver;
 
-	private volatile String beanName;
+	private String beanName;
 
-	private volatile String componentName;
+	private String componentName;
 
-	private volatile BeanFactory beanFactory;
+	private BeanFactory beanFactory;
 
-	private volatile TaskScheduler taskScheduler;
+	private TaskScheduler taskScheduler;
 
-	private volatile Properties integrationProperties = IntegrationProperties.defaults();
+	private Properties integrationProperties = IntegrationProperties.defaults();
 
-	private volatile ConversionService conversionService;
+	private ConversionService conversionService;
 
-	private volatile ApplicationContext applicationContext;
+	private ApplicationContext applicationContext;
 
-	private volatile MessageBuilderFactory messageBuilderFactory;
+	private MessageBuilderFactory messageBuilderFactory;
 
 	private Expression expression;
+
+	private boolean initialized;
 
 	@Override
 	public final void setBeanName(String beanName) {
@@ -181,6 +183,8 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 			}
 			throw new BeanInitializationException("failed to initialize", e);
 		}
+
+		this.initialized = true;
 	}
 
 	/**
@@ -188,6 +192,14 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 	 * @throws Exception Any exception.
 	 */
 	protected void onInit() throws Exception {
+	}
+
+	/**
+	 * Return the status of this component if it has been initialized already.
+	 * @return the flag if this component has been initialized already.
+	 */
+	protected boolean isInitialized() {
+		return this.initialized;
 	}
 
 	protected BeanFactory getBeanFactory() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BarrierSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BarrierSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,9 @@ public class BarrierSpec extends ConsumerEndpointSpec<BarrierSpec, BarrierMessag
 	@Override
 	public Tuple2<ConsumerEndpointFactoryBean, BarrierMessageHandler> doGet() {
 		this.handler = new BarrierMessageHandler(this.timeout, this.outputProcessor, this.correlationStrategy);
-		this.handler.setAdviceChain(this.adviceChain);
+		if (!this.adviceChain.isEmpty()) {
+			this.handler.setAdviceChain(this.adviceChain);
+		}
 		this.handler.setRequiresReply(this.requiresReply);
 		this.handler.setSendTimeout(this.sendTimeout);
 		this.handler.setAsync(this.async);

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
@@ -267,7 +267,7 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 	@Override
 	protected Tuple2<ConsumerEndpointFactoryBean, H> doGet() {
 		this.endpointFactoryBean.setAdviceChain(this.adviceChain);
-		if (this.handler instanceof AbstractReplyProducingMessageHandler) {
+		if (this.handler instanceof AbstractReplyProducingMessageHandler && !this.adviceChain.isEmpty()) {
 			((AbstractReplyProducingMessageHandler) this.handler).setAdviceChain(this.adviceChain);
 		}
 		this.endpointFactoryBean.setHandler(this.handler);

--- a/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/config/TwitterSearchOutboundGatewayParserTests.java
+++ b/spring-integration-twitter/src/test/java/org/springframework/integration/twitter/config/TwitterSearchOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -39,6 +39,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 4.0
  *
  */
@@ -75,7 +77,7 @@ public class TwitterSearchOutboundGatewayParserTests {
 	@Test
 	public void testAdvised() {
 		assertSame(twitter, TestUtils.getPropertyValue(polledAndAdvisedTSOG, "handler.twitter"));
-		assertThat(TestUtils.getPropertyValue(polledAndAdvisedTSOG, "handler.adviceChain", ArrayList.class).get(0),
+		assertThat(TestUtils.getPropertyValue(polledAndAdvisedTSOG, "handler.adviceChain", List.class).get(0),
 				Matchers.instanceOf(RequestHandlerRetryAdvice.class));
 	}
 

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -236,6 +236,26 @@ public IntegrationFlow flow2() {
 
 In addition the `EndpointSpec` provides an `id()` method to allow you to register an endpoint bean with a  given bean name, rather than a generated one.
 
+If the `MessageHandler` is referenced as a bean, then its own `adviceChain` configuration is overridden by the provided in DSL definition:
+
+[source,java]
+----
+@Bean
+public TcpOutboundGateway tcpOut() {
+    TcpOutboundGateway gateway = new TcpOutboundGateway();
+    gateway.setConnectionFactory(cf());
+    gateway.setAdviceChain(Collections.singletonList(fooAdvice()));
+    return gateway;
+}
+
+@Bean
+public IntegrationFlow clientTcpFlow() {
+    return f -> f
+        .handle(tcpOut(), e -> e.advice(testAdvice()))
+        .transform(Transformers.objectToString());
+}
+----
+
 [[java-dsl-transformers]]
 === Transformers
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4487

Currently the `AbstractReplyProducingMessageHandler` applies advices
only in the `afterPropertiesSet()` phase.
When we use bean references for `MessageHandler`s in Java DSL, the
`.advice()` provided in the flow definition is not applied to the
`AbstractReplyProducingMessageHandler`.

* For consistency with the endpoint configured by the DSL definition,
override and reconfigure advices in the `AbstractReplyProducingMessageHandler`
bean reference during DSL parsing and processing.

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
