### PR TITLE
INT-4489: MessageHistory: Allow runtime beans

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -58,6 +59,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.config.EnableMessageHistory;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.dsl.IntegrationFlow;
@@ -71,6 +73,7 @@ import org.springframework.integration.dsl.context.IntegrationFlowContext;
 import org.springframework.integration.dsl.context.IntegrationFlowContext.IntegrationFlowRegistration;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.support.SmartLifecycleRoleController;
 import org.springframework.integration.transformer.MessageTransformingHandler;
 import org.springframework.messaging.Message;
@@ -253,6 +256,12 @@ public class ManualFlowTests {
 		Message<?> receive = resultChannel.receive(1000);
 		assertNotNull(receive);
 		assertEquals("test", receive.getPayload());
+
+		MessageHistory messageHistory = MessageHistory.read(receive);
+		assertNotNull(messageHistory);
+		String messageHistoryString = messageHistory.toString();
+		assertThat(messageHistoryString, Matchers.containsString("dynamicFlow.input"));
+		assertThat(messageHistoryString, Matchers.containsString("dynamicFlow.subFlow#0.channel#1"));
 
 		this.integrationFlowContext.remove("dynamicFlow");
 	}
@@ -475,6 +484,7 @@ public class ManualFlowTests {
 
 	@Configuration
 	@EnableIntegration
+	@EnableMessageHistory
 	public static class RootConfiguration {
 
 		@Bean

--- a/src/reference/asciidoc/message-history.adoc
+++ b/src/reference/asciidoc/message-history.adoc
@@ -73,8 +73,7 @@ This feature might be useful to temporarily turn on history to analyze a system.
 The MBean's object name is `"<domain>:name=messageHistoryConfigurer,type=MessageHistoryConfigurer"`.
 
 IMPORTANT: If multiple beans (declared by `@EnableMessageHistory` and/or `<message-history/>`) they all must have identical component name patterns (when trimmed and sorted).
-*Do not use a generic
-	`<bean/>` definition for the `MessageHistoryConfigurer`*.
+*Do not use a generic `<bean/>` definition for the `MessageHistoryConfigurer`*.
 
 NOTE: Remember that by definition the Message History header is immutable (you can't re-write history, although some try).
 Therefore, when writing Message History values, the components are either creating brand new Messages (when the component is an origin), or they are copying the history from a request Message, modifying it and setting the new list on a reply Message.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4489

Make `MessageHistoryConfigurer` as a `BeanPostProcessor` and apply
tracking logic to processed beans if it is already started.

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
