### PR TITLE
INT-4452: expire immediately when group timeout<0

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -100,7 +100,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 
 	private final Map<UUID, ScheduledFuture<?>> expireGroupScheduledFutures = new ConcurrentHashMap<>();
 
-	private final Set<Object> groupIds =  ConcurrentHashMap.newKeySet();
+	private final Set<Object> groupIds = ConcurrentHashMap.newKeySet();
 
 	private MessageGroupProcessor outputProcessor;
 
@@ -144,15 +144,23 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 
 	public AbstractCorrelatingMessageHandler(MessageGroupProcessor processor, MessageGroupStore store,
 			CorrelationStrategy correlationStrategy, ReleaseStrategy releaseStrategy) {
+
 		Assert.notNull(processor, "'processor' must not be null");
 		Assert.notNull(store, "'store' must not be null");
 
 		setMessageStore(store);
 		this.outputProcessor = processor;
-		this.correlationStrategy = (correlationStrategy == null
-				? new HeaderAttributeCorrelationStrategy(IntegrationMessageHeaderAccessor.CORRELATION_ID)
-				: correlationStrategy);
-		this.releaseStrategy = releaseStrategy == null ? new SimpleSequenceSizeReleaseStrategy() : releaseStrategy;
+
+		this.correlationStrategy =
+				correlationStrategy == null
+						? new HeaderAttributeCorrelationStrategy(IntegrationMessageHeaderAccessor.CORRELATION_ID)
+						: correlationStrategy;
+
+		this.releaseStrategy =
+				releaseStrategy == null
+						? new SimpleSequenceSizeReleaseStrategy()
+						: releaseStrategy;
+
 		this.releaseStrategySet = releaseStrategy != null;
 		this.sequenceAware = this.releaseStrategy instanceof SequenceSizeReleaseStrategy;
 	}
@@ -195,7 +203,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 	}
 
 	public void setForceReleaseAdviceChain(List<Advice> forceReleaseAdviceChain) {
-		Assert.notNull(forceReleaseAdviceChain, "forceReleaseAdviceChain must not be null");
+		Assert.notNull(forceReleaseAdviceChain, "'forceReleaseAdviceChain' must not be null");
 		this.forceReleaseAdviceChain = forceReleaseAdviceChain;
 	}
 
@@ -242,7 +250,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		}
 
 		if (this.releasePartialSequences) {
-			Assert.isInstanceOf(SequenceSizeReleaseStrategy.class, this.releaseStrategy,
+			Assert.isInstanceOf(SequenceSizeReleaseStrategy.class, this.releaseStrategy, () ->
 					"Release strategy of type [" + this.releaseStrategy.getClass().getSimpleName() +
 							"] cannot release partial sequences. Use a SequenceSizeReleaseStrategy instead.");
 			((SequenceSizeReleaseStrategy) this.releaseStrategy)
@@ -519,7 +527,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		 * When 'groupTimeout' is evaluated to 'null' we do nothing.
 		 * The 'MessageGroupStoreReaper' can be used to 'forceComplete' message groups.
 		 */
-		if (groupTimeout != null && groupTimeout >= 0) {
+		if (groupTimeout != null) {
 			if (groupTimeout > 0) {
 				final Object groupId = messageGroup.getGroupId();
 				final long timestamp = messageGroup.getTimestamp();

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
@@ -42,7 +42,7 @@
 
 	<aggregator input-channel="groupTimeoutExpressionAggregatorInput" output-channel="output" discard-channel="discard"
 				send-partial-result-on-expiry="true"
-				group-timeout-expression="size() ge 2 ? 100 : -1"
+				group-timeout-expression="size() ge 2 ? 100 : null"
 			    release-strategy-expression="messages[0].headers.sequenceNumber == messages[0].headers.sequenceSize"/>
 
 	<aggregator input-channel="zeroGroupTimeoutExpressionAggregatorInput" output-channel="output" discard-channel="discard"

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,8 +45,7 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author Iwein Fuld
@@ -55,8 +54,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Artem Bilan
  * @author Gary Russell
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
+@RunWith(SpringRunner.class)
 @DirtiesContext
 public class AggregatorIntegrationTests {
 
@@ -91,10 +89,10 @@ public class AggregatorIntegrationTests {
 	private QueueChannel errors;
 
 	@Test
-	public void testVanillaAggregation() throws Exception {
+	public void testVanillaAggregation() {
 		for (int i = 0; i < 5; i++) {
 			Map<String, Object> headers = stubHeaders(i, 5, 1);
-			input.send(new GenericMessage<Integer>(i, headers));
+			input.send(new GenericMessage<>(i, headers));
 		}
 		Message<?> receive = output.receive(10000);
 		assertNotNull(receive);
@@ -102,10 +100,10 @@ public class AggregatorIntegrationTests {
 	}
 
 	@Test
-	public void testNonExpiringAggregator() throws Exception {
+	public void testNonExpiringAggregator() {
 		for (int i = 0; i < 5; i++) {
 			Map<String, Object> headers = stubHeaders(i, 5, 1);
-			nonExpiringAggregatorInput.send(new GenericMessage<Integer>(i, headers));
+			nonExpiringAggregatorInput.send(new GenericMessage<>(i, headers));
 		}
 		assertNotNull(output.receive(0));
 
@@ -113,7 +111,7 @@ public class AggregatorIntegrationTests {
 
 		for (int i = 5; i < 10; i++) {
 			Map<String, Object> headers = stubHeaders(i, 5, 1);
-			nonExpiringAggregatorInput.send(new GenericMessage<Integer>(i, headers));
+			nonExpiringAggregatorInput.send(new GenericMessage<>(i, headers));
 		}
 		assertNull(output.receive(0));
 
@@ -125,10 +123,10 @@ public class AggregatorIntegrationTests {
 	}
 
 	@Test
-	public void testExpiringAggregator() throws Exception {
+	public void testExpiringAggregator() {
 		for (int i = 0; i < 5; i++) {
 			Map<String, Object> headers = stubHeaders(i, 5, 1);
-			expiringAggregatorInput.send(new GenericMessage<Integer>(i, headers));
+			expiringAggregatorInput.send(new GenericMessage<>(i, headers));
 		}
 		assertNotNull(output.receive(0));
 
@@ -136,7 +134,7 @@ public class AggregatorIntegrationTests {
 
 		for (int i = 5; i < 10; i++) {
 			Map<String, Object> headers = stubHeaders(i, 5, 1);
-			expiringAggregatorInput.send(new GenericMessage<Integer>(i, headers));
+			expiringAggregatorInput.send(new GenericMessage<>(i, headers));
 		}
 		assertNotNull(output.receive(0));
 
@@ -148,7 +146,7 @@ public class AggregatorIntegrationTests {
 	public void testGroupTimeoutScheduling() throws Exception {
 		for (int i = 0; i < 5; i++) {
 			Map<String, Object> headers = stubHeaders(i, 5, 1);
-			this.groupTimeoutAggregatorInput.send(new GenericMessage<Integer>(i, headers));
+			this.groupTimeoutAggregatorInput.send(new GenericMessage<>(i, headers));
 
 			//Wait until 'group-timeout' does its stuff.
 			MessageGroupStore mgs = TestUtils.getPropertyValue(this.context.getBean("gta.handler"), "messageStore",
@@ -166,11 +164,11 @@ public class AggregatorIntegrationTests {
 	@Test
 	public void testGroupTimeoutReschedulingOnMessageDeliveryException() throws Exception {
 		for (int i = 0; i < 5; i++) {
-			this.output.send(new GenericMessage<String>("fake message"));
+			this.output.send(new GenericMessage<>("fake message"));
 		}
 
 		Map<String, Object> headers = stubHeaders(1, 2, 1);
-		this.groupTimeoutAggregatorInput.send(new GenericMessage<Integer>(1, headers));
+		this.groupTimeoutAggregatorInput.send(new GenericMessage<>(1, headers));
 
 		//Wait until 'group-timeout' does its stuff.
 		MessageGroupStore mgs = TestUtils.getPropertyValue(this.context.getBean("gta.handler"), "messageStore",
@@ -190,14 +188,14 @@ public class AggregatorIntegrationTests {
 	}
 
 	@Test
-	public void testGroupTimeoutExpressionScheduling() throws Exception {
-		// Since group-timeout-expression="size() >= 2 ? 100 : -1". The first message won't be scheduled to 'forceComplete'
-		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(1, stubHeaders(1, 6, 1)));
+	public void testGroupTimeoutExpressionScheduling() {
+		// Since group-timeout-expression="size() >= 2 ? 100 : null". The first message won't be scheduled to 'forceComplete'
+		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<>(1, stubHeaders(1, 6, 1)));
 		assertNull(this.output.receive(0));
 		assertNull(this.discard.receive(0));
 
 		// As far as 'group.size() >= 2' it will be scheduled to 'forceComplete'
-		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(2, stubHeaders(2, 6, 1)));
+		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<>(2, stubHeaders(2, 6, 1)));
 		assertNull(this.output.receive(0));
 		Message<?> receive = this.output.receive(10000);
 		assertNotNull(receive);
@@ -205,15 +203,15 @@ public class AggregatorIntegrationTests {
 		assertNull(this.discard.receive(0));
 
 		// The same with these three messages
-		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(3, stubHeaders(3, 6, 1)));
+		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<>(3, stubHeaders(3, 6, 1)));
 		assertNull(this.output.receive(0));
 		assertNull(this.discard.receive(0));
 
-		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(4, stubHeaders(4, 6, 1)));
+		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<>(4, stubHeaders(4, 6, 1)));
 		assertNull(this.output.receive(0));
 		assertNull(this.discard.receive(0));
 
-		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(5, stubHeaders(5, 6, 1)));
+		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<>(5, stubHeaders(5, 6, 1)));
 		assertNull(this.output.receive(0));
 		receive = this.output.receive(10000);
 		assertNotNull(receive);
@@ -221,7 +219,7 @@ public class AggregatorIntegrationTests {
 		assertNull(this.discard.receive(0));
 
 		// The last message in the sequence - normal release by provided 'ReleaseStrategy'
-		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(6, stubHeaders(6, 6, 1)));
+		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<>(6, stubHeaders(6, 6, 1)));
 		receive = this.output.receive(10000);
 		assertNotNull(receive);
 		assertEquals(1, ((Collection<?>) receive.getPayload()).size());
@@ -229,17 +227,17 @@ public class AggregatorIntegrationTests {
 	}
 
 	@Test
-	public void testZeroGroupTimeoutExpressionScheduling() throws Exception {
+	public void testZeroGroupTimeoutExpressionScheduling() {
 		try {
 			this.output.purge(null);
 			this.errors.purge(null);
-			GenericMessage<String> message = new GenericMessage<String>("foo");
+			GenericMessage<String> message = new GenericMessage<>("foo");
 			this.output.send(message);
 			this.output.send(message);
 			this.output.send(message);
 			this.output.send(message);
 			this.output.send(message);
-			this.zeroGroupTimeoutExpressionAggregatorInput.send(new GenericMessage<Integer>(1, stubHeaders(1, 2, 1)));
+			this.zeroGroupTimeoutExpressionAggregatorInput.send(new GenericMessage<>(1, stubHeaders(1, 2, 1)));
 			ErrorMessage em = (ErrorMessage) this.errors.receive(10000);
 			assertNotNull(em);
 			assertThat(em.getPayload().getMessage().toLowerCase(),
@@ -263,7 +261,7 @@ public class AggregatorIntegrationTests {
 	}
 
 	private Map<String, Object> stubHeaders(int sequenceNumber, int sequenceSize, int correlationId) {
-		Map<String, Object> headers = new HashMap<String, Object>();
+		Map<String, Object> headers = new HashMap<>();
 		headers.put(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, sequenceNumber);
 		headers.put(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, sequenceSize);
 		headers.put(IntegrationMessageHeaderAccessor.CORRELATION_ID, correlationId);

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ControlBusTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ControlBusTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 @ContextConfiguration
@@ -92,7 +93,7 @@ public class ControlBusTests {
 				"ControlBusLifecycleTests-context.xml", this.getClass());
 		MessageChannel inputChannel = context.getBean("inputChannel", MessageChannel.class);
 		PollableChannel outputChannel = context.getBean("outputChannel", PollableChannel.class);
-		assertNull(outputChannel.receive(1000));
+		assertNull(outputChannel.receive(10));
 		Message<?> message = MessageBuilder.withPayload("@adapter.start()").build();
 		inputChannel.send(message);
 		assertNotNull(outputChannel.receive(1000));
@@ -109,7 +110,7 @@ public class ControlBusTests {
 		assertEquals(0, result.getPayload());
 		this.registry.channelToChannelName(new DirectChannel());
 		// Sleep a bit to be sure that we aren't reaped by registry TTL as 60000
-		Thread.sleep(100);
+		Thread.sleep(10);
 		messagingTemplate.convertAndSend(input, "@integrationHeaderChannelRegistry.size()");
 		result = this.output.receive(0);
 		assertNotNull(result);

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollerAdviceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollerAdviceTests.java
@@ -152,7 +152,7 @@ public class PollerAdviceTests {
 		adapter.setAdviceChain(adviceChain);
 		adapter.afterPropertiesSet();
 		adapter.start();
-		assertFalse(latch.await(1, TimeUnit.SECONDS));
+		assertFalse(latch.await(10, TimeUnit.MILLISECONDS));
 		adapter.stop();
 		skipper.reset();
 		latch = new CountDownLatch(1);

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayRequiresReplyTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayRequiresReplyTests-context.xml
@@ -13,7 +13,7 @@
 			 default-request-channel="requestChannel"
 			 default-reply-timeout="3000"
 			 service-interface="org.springframework.integration.gateway.GatewayRequiresReplyTests$TestService" />
-	
+
 
 	<service-activator input-channel="requestChannel"
 					   expression="payload == 'foo' ? 'bar' : null"
@@ -21,16 +21,16 @@
 
 	<gateway id="timeoutGateway"
 			 default-request-channel="timeoutChannel"
-			 default-reply-timeout="1000"
+			 default-reply-timeout="10"
 			 service-interface="org.springframework.integration.gateway.GatewayRequiresReplyTests$TestService" />
-			 
+
 	<channel id="timeoutChannel">
 		<dispatcher task-executor="executor"/>
 	</channel>
-			 
+
 	<service-activator input-channel="timeoutChannel">
 		<beans:bean class="org.springframework.integration.gateway.GatewayRequiresReplyTests.LongRunningService"/>
 	</service-activator>
-	
+
 	<task:executor id="executor" pool-size="5"/>
 </beans:beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayRequiresReplyTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayRequiresReplyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.gateway;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,6 +31,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Mark Fisher
  * @author Gunnar Hillert
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 @ContextConfiguration
@@ -43,34 +45,38 @@ public class GatewayRequiresReplyTests {
 
 	@Test
 	public void replyReceived() {
-		TestService gateway = (TestService) applicationContext.getBean("gateway");
+		TestService gateway =  this.applicationContext.getBean("gateway", TestService.class);
 		String result = gateway.test("foo");
 		assertEquals("bar", result);
 	}
 
 	@Test(expected = ReplyRequiredException.class)
 	public void noReplyReceived() {
-		TestService gateway = (TestService) applicationContext.getBean("gateway");
+		TestService gateway = this.applicationContext.getBean("gateway", TestService.class);
 		gateway.test("bad");
 	}
 
 	@Test
 	public void timedOutGateway() {
-		TestService gateway = (TestService) applicationContext.getBean("timeoutGateway");
+		TestService gateway = this.applicationContext.getBean("timeoutGateway", TestService.class);
 		String result = gateway.test("hello");
 		assertNull(result);
 	}
 
 
 	public interface TestService {
+
 		String test(String s);
+
 	}
 
 	public static class LongRunningService {
+
 		public String echo(String value) throws Exception {
 			Thread.sleep(5000);
 			return value;
 		}
+
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
@@ -425,17 +425,17 @@ public class DelayHandlerTests {
 	 It's difficult to test it from real ctx, because any async process from 'inbound-channel-adapter'
 	 can't achieve the DelayHandler before the main thread emits 'ContextRefreshedEvent'.
 	 */
-	public void testRescheduleAndHandleAtTheSameTime() throws Exception {
+	public void testRescheduleAndHandleAtTheSameTime() {
 		QueueChannel results = new QueueChannel();
 		delayHandler.setOutputChannel(results);
-		this.delayHandler.setDefaultDelay(100);
+		this.delayHandler.setDefaultDelay(10);
 		startDelayerHandler();
 
 		this.input.send(new GenericMessage<>("foo"));
 		this.delayHandler.reschedulePersistedMessages();
 		Message<?> message = results.receive(10000);
 		assertNotNull(message);
-		message = results.receive(500);
+		message = results.receive(50);
 		assertNull(message);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/RouterConcurrencyTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/RouterConcurrencyTest.java
@@ -42,6 +42,7 @@ import org.springframework.messaging.MessageChannel;
 
 /**
  * @author Gary Russell
+ *
  * @since 3.0
  *
  */
@@ -61,11 +62,11 @@ public class RouterConcurrencyTest {
 			protected void setConversionService(ConversionService conversionService) {
 				try {
 					if (count.incrementAndGet() > 1) {
-						Thread.sleep(2000);
+						Thread.sleep(20);
 					}
 					super.setConversionService(conversionService);
 					semaphore.release();
-					Thread.sleep(1000);
+					Thread.sleep(10);
 				}
 				catch (InterruptedException e) {
 					Thread.currentThread().interrupt();
@@ -85,8 +86,7 @@ public class RouterConcurrencyTest {
 		router.setBeanFactory(beanFactory);
 
 		ExecutorService exec = Executors.newFixedThreadPool(2);
-		final List<ConversionService> returns = Collections.synchronizedList(
-				new ArrayList<ConversionService>());
+		final List<ConversionService> returns = Collections.synchronizedList(new ArrayList<>());
 		Runnable runnable = () -> {
 			ConversionService requiredConversionService = router.getRequiredConversionService();
 			returns.add(requiredConversionService);

--- a/src/reference/asciidoc/aggregator.adoc
+++ b/src/reference/asciidoc/aggregator.adoc
@@ -477,8 +477,8 @@ See <<redis-lock-registry>>, <<gemfire-lock-registry>>, <<zk-lock-registry>> for
 This attribute provides a built-in _Time-base Release Strategy_ for the aggregator, when there is a need to emit a partial result (or discard the group), if a new Message does not arrive for the `MessageGroup` within the timeout.
 When a new Message arrives at the aggregator, any existing `ScheduledFuture<?>` for its `MessageGroup` is canceled.
 If the `ReleaseStrategy` returns `false` (don't release) and the `groupTimeout > 0` a new task will be scheduled to expire the group.
-Setting this attribute to zero is not advised because it will effectively disable the aggregator because every message group will be immediately completed.
-It is possible, however to conditionally set it to zero using an expression; see `group-timeout-expression` for information.
+Setting this attribute to zero (or negative value) is not advised because it will effectively disable the aggregator because every message group will be immediately completed.
+It is possible, however to conditionally set it to zero (or negative value) using an expression; see `group-timeout-expression` for information.
 The action taken during the completion depends on the `ReleaseStrategy` and the `send-partial-group-on-expiry` attribute.
 See <<agg-and-group-to>> for more information.
 Mutually exclusive with 'group-timeout-expression' attribute.
@@ -486,7 +486,7 @@ Mutually exclusive with 'group-timeout-expression' attribute.
 
 <22> The SpEL expression that evaluates to a `groupTimeout` with the `MessageGroup` as the `#root` evaluation context object.
 Used for scheduling the `MessageGroup` to be forced complete.
-If the expression evaluates to null or `< 0`, the completion is not scheduled.
+If the expression evaluates to `null`, the completion is not scheduled.
 If it evaluates to zero, the group is completed immediately on the current thread.
 In effect, this provides a dynamic `group-timeout` property.
 See `group-timeout` for more information.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -63,4 +63,11 @@ See <<amqp-content-type>> for more information.
 
 A confusing `max-rows-per-poll` property on the JDBC Inbound Channel Adapter and JDBC Outbound Gateway has been deprecated in favor newly introduced `max-rows` property.
 
-See <<jdbc>>  for more information.
+See <<jdbc>> for more information.
+
+==== Aggregator Changes
+
+An aggregator now expires group immediately, when `groupTimeout` is evaluated to the negative value.
+Only `null` is considered as a signal do nothing for the current message.
+
+See <<aggregator>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4452

This is pretty typical in practice to get a `groupTimeout` to be
evaluated to a negative value: some business decisions, sensitive
calculations and so on.

* Treat any non-positive `groupTimeout` as a signal to expire group
immediately without scheduling.
Only `null` is considered as a signal do nothing for the current message
* Polishing for some tests for better performance - saves some execution
time

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
