### PR TITLE
INT-4488: Require @EnablePublisher

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/EnablePublisher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/EnablePublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,12 +27,10 @@ import org.springframework.context.annotation.Import;
 /**
  * Provides the registration for the {@link org.springframework.integration.aop.PublisherAnnotationBeanPostProcessor}
  * to allow the use of the {@link org.springframework.integration.annotation.Publisher} annotation.
- * In addition the {@code default-publisher-channel} name has to be configured as the {@code value} of this annotation.
- * <p>
- * Note: the {@link org.springframework.integration.annotation.Publisher} annotation is enabled by default via
- * {@link EnableIntegration} processing, but there is no hook to configure the {@code default-publisher-channel}.
+ * In addition the {@code default-publisher-channel} name can be configured as the {@code value} of this annotation.
  *
  * @author Artem Bilan
+ *
  * @since 4.0
  */
 @Target(ElementType.TYPE)
@@ -44,5 +42,5 @@ public @interface EnablePublisher {
 	/**
 	 * @return the {@code default-publisher-channel} name.
 	 */
-	String value();
+	String value() default "";
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
@@ -391,7 +391,10 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar, Bean
 					builder.getBeanDefinition());
 		}
 
-		new PublisherRegistrar().registerBeanDefinitions(meta, registry);
+		if (meta.getAnnotationAttributes(EnablePublisher.class.getName()) != null) {
+			new PublisherRegistrar().
+					registerBeanDefinitions(meta, registry);
+		}
 	}
 
 	/**
@@ -399,7 +402,9 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar, Bean
 	 * to process the external Integration infrastructure.
 	 */
 	private void registerIntegrationConfigurationBeanFactoryPostProcessor(BeanDefinitionRegistry registry) {
-		if (!registry.containsBeanDefinition(IntegrationContextUtils.INTEGRATION_CONFIGURATION_POST_PROCESSOR_BEAN_NAME)) {
+		if (!registry.containsBeanDefinition(
+				IntegrationContextUtils.INTEGRATION_CONFIGURATION_POST_PROCESSOR_BEAN_NAME)) {
+
 			BeanDefinitionBuilder postProcessorBuilder = BeanDefinitionBuilder
 					.genericBeanDefinition(IntegrationConfigurationBeanFactoryPostProcessor.class)
 					.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration-5.1.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration-5.1.xsd
@@ -20,18 +20,24 @@
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
-			<xsd:attribute name="default-publisher-channel" type="xsd:string" use="optional">
-				<xsd:annotation>
-					<xsd:documentation>
-						Default output channel for the @Publisher annotation support.
-					</xsd:documentation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.messaging.MessageChannel" />
-						</tool:annotation>
-					</xsd:appinfo>
-				</xsd:annotation>
-			</xsd:attribute>
+			<xsd:sequence>
+				<xsd:element name="enable-publisher" minOccurs="0">
+					<xsd:complexType>
+						<xsd:attribute name="default-publisher-channel" type="xsd:string">
+							<xsd:annotation>
+								<xsd:documentation>
+									Default output channel for the @Publisher annotation support.
+								</xsd:documentation>
+								<xsd:appinfo>
+									<tool:annotation kind="ref">
+										<tool:expected-type type="org.springframework.messaging.MessageChannel" />
+									</tool:annotation>
+								</xsd:appinfo>
+							</xsd:annotation>
+						</xsd:attribute>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:sequence>
 		</xsd:complexType>
 	</xsd:element>
 
@@ -53,22 +59,22 @@
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:sequence>
-					<xsd:element name="before-commit" minOccurs="0" maxOccurs="1">
-						<xsd:complexType>
-							<xsd:attributeGroup ref="synchronizationAttributeGroup"/>
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="after-commit" minOccurs="0" maxOccurs="1">
-						<xsd:complexType>
-							<xsd:attributeGroup ref="synchronizationAttributeGroup"/>
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="after-rollback" minOccurs="0" maxOccurs="1">
-						<xsd:complexType>
-							<xsd:attributeGroup ref="synchronizationAttributeGroup"/>
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:sequence>
+				<xsd:element name="before-commit" minOccurs="0" maxOccurs="1">
+					<xsd:complexType>
+						<xsd:attributeGroup ref="synchronizationAttributeGroup"/>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="after-commit" minOccurs="0" maxOccurs="1">
+					<xsd:complexType>
+						<xsd:attributeGroup ref="synchronizationAttributeGroup"/>
+					</xsd:complexType>
+				</xsd:element>
+				<xsd:element name="after-rollback" minOccurs="0" maxOccurs="1">
+					<xsd:complexType>
+						<xsd:attributeGroup ref="synchronizationAttributeGroup"/>
+					</xsd:complexType>
+				</xsd:element>
+			</xsd:sequence>
 			<xsd:attribute name="id" type="xsd:string" use="required"/>
 		</xsd:complexType>
 	</xsd:element>
@@ -134,7 +140,7 @@
 		<xsd:annotation>
 			<xsd:documentation>
 				Defines a Point-to-Point MessageChannel.
-				See 'PointToPointChannelParser' source code for 'MessageChannel' implementaitons.
+				See 'PointToPointChannelParser' source code for 'MessageChannel' implementations.
 			</xsd:documentation>
 			<xsd:appinfo>
 				<tool:annotation>

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/BarrierMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/BarrierMessageHandlerTests.java
@@ -55,6 +55,7 @@ import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.config.EnablePublisher;
 import org.springframework.integration.handler.ReplyRequiredException;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
@@ -72,6 +73,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 4.2
  *
  */
@@ -263,6 +265,7 @@ public class BarrierMessageHandlerTests {
 
 	@Configuration
 	@EnableIntegration
+	@EnablePublisher
 	public static class Config {
 
 		@Bean

--- a/spring-integration-core/src/test/java/org/springframework/integration/aop/AnnotationConfigRegistrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aop/AnnotationConfigRegistrationTests-context.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd"
 	xmlns:si="http://www.springframework.org/schema/integration">
 
@@ -17,6 +15,8 @@
 		<si:queue />
 	</si:channel>
 
-	<si:annotation-config default-publisher-channel="defaultChannel"/>
+	<si:annotation-config>
+		<si:enable-publisher default-publisher-channel="defaultChannel"/>
+	</si:annotation-config>
 
 </beans>

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests-context.xml
@@ -14,7 +14,9 @@
 
 	<message-history tracked-components="publishedChannel,input,annotationTestService*"/>
 
-	<annotation-config default-publisher-channel="publishedChannel"/>
+	<annotation-config>
+		<enable-publisher default-publisher-channel="publishedChannel"/>
+	</annotation-config>
 
 	<channel-interceptor pattern="none">
 		<wire-tap channel="bar" />

--- a/src/reference/asciidoc/message-publishing.adoc
+++ b/src/reference/asciidoc/message-publishing.adoc
@@ -15,6 +15,8 @@ Spring Integration provides two approaches: XML and Annotation-driven.
 ==== Annotation-driven approach via @Publisher annotation
 
 The annotation-driven approach allows you to annotate any method with the `@Publisher` annotation, specifying a 'channel' attribute.
+Starting with _version 5.1_, to switch this functionality on, the `@EnablePublisher` annotation must be provided on some `@Configuration` class.
+See <<configuration-enable-integration>> for more information.
 The Message will be constructed from the return value of the method invocation and sent to a channel specified by the 'channel' attribute.
 To further manage message structure, you can also use a combination of both `@Payload` and `@Header` annotations.
 
@@ -105,10 +107,24 @@ As with most other annotation-driven features in Spring, you will need to regist
 You can instead use namespace support for a more concise configuration:
 [source,xml]
 ----
-<int:annotation-config default-publisher-channel="defaultChannel"/>
+<int:annotation-config>
+    <int:enable-publisher default-publisher-channel="defaultChannel"/>
+</int:annotation-config>
 ----
 
-Similar to other Spring annotations (@Component, @Scheduled, etc.), `@Publisher` can also be used as a meta-annotation.
+For Java & Annotation Spring configuration, the `@EnablePublisher` annotation must be used:
+
+[source,java]
+----
+@Configuration
+@EnableIntegration
+@EnablePublisher("defaultChannel")
+public class IntegrationConfiguration {
+    ...
+}
+----
+
+Similar to other Spring annotations (`@Component`, `@Scheduled`, etc.), `@Publisher` can also be used as a meta-annotation.
 That means you can define your own annotations that will be treated in the same way as the `@Publisher` itself.
 
 [source,java]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -51,7 +51,13 @@ Starting with _version 5.0.5_, generated bean names for the components in an `In
 
 See <<java-dsl-flows>> for more information.
 
-==== AMQP Changes
+==== @Publisher annotation changes
+
+Starting with _version 5.1, the `@Publisher` AOP functionality has to be turned on explicitly via `@EnablePublisher` or via `<int:enable-publisher>` sub-element on the `<int:annotation-config>`.
+
+See <<publisher-annotation>> for more information.
+
+=== AMQP Changes
 
 `ID` and `Timestamp` header mapping changes in the `DefaultAmqpHeaderMapper`.
 See the note near the bottom of <<amqp-message-headers>> for more information.
@@ -59,7 +65,7 @@ See the note near the bottom of <<amqp-message-headers>> for more information.
 The `contentType` header is no longer incorrectly mapped as an entry in the general headers map.
 See <<amqp-content-type>> for more information.
 
-==== JDBC Changes
+=== JDBC Changes
 
 A confusing `max-rows-per-poll` property on the JDBC Inbound Channel Adapter and JDBC Outbound Gateway has been deprecated in favor newly introduced `max-rows` property.
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4488

Since `PublisherAnnotationBeanPostProcessor` is quite expensive
(1.5x the CPU used by `MessagingAnnotationPostProcessor` in a simple
application)

* So not register a `PublisherAnnotationBeanPostProcessor` by default.
The `@EnablePublisher` has to be presented on the `@Configuration`
to allow the `@Publisher` AOP
* Change the `<int:annotation-config>` to require a new
`<int:enable-publisher>` sub-element for similar purpose - do not
register `PublisherAnnotationBeanPostProcessor` by default

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
