### PR TITLE
INT-4495: (S)FTP: fix max-fetch with directories

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileUtils.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileUtils.java
@@ -16,16 +16,9 @@
 
 package org.springframework.integration.file.support;
 
-import java.lang.reflect.Array;
 import java.nio.file.FileSystems;
 import java.util.Arrays;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.function.Predicate;
-
-import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
 
 /**
  * Utilities for operations on Files.
@@ -43,46 +36,15 @@ public final class FileUtils {
 	 * @param fileArray the array.
 	 * @param predicate the predicate.
 	 * @param <F> the file type.
-	 * @return the array (modified or not), or null if all elements are removed.
+	 * @return the array of remaining elements.
 	 * @since 5.0.7
 	 */
-	public @Nullable static <F> F[] purgeUnwantedElements(F[] fileArray, Predicate<F> predicate) {
-		List<F> files = new LinkedList<>(Arrays.asList(fileArray));
-		Iterator<F> iterator = files.iterator();
-		boolean removed = false;
-		while (iterator.hasNext()) {
-			F next = iterator.next();
-			if (predicate.test(next)) {
-				iterator.remove();
-				removed = true;
-			}
-		}
-		if (!removed) {
-			return fileArray;
-		}
-		else if (files.size() == 0) {
-			return null;
-		}
-		else {
-			return toGenericArray(files);
-		}
-	}
-
-	/**
-	 * Create an array of generic type from a list. Must have at least one entry.
-	 * @param files the list.
-	 * @param <F> the file type.
-	 * @return the array.
-	 * @since 5.0.7
-	 */
-	public static <F> F[] toGenericArray(List<F> files) {
-		Assert.isTrue(files.size() > 0, "file list must have at least one entry");
-		@SuppressWarnings("unchecked")
-		F[] array = (F[]) Array.newInstance(files.get(0).getClass(), files.size());
-		for (int i = 0; i < files.size(); i++) {
-			array[i] = files.get(i);
-		}
-		return array;
+	@SuppressWarnings("unchecked")
+	public static <F> F[] purgeUnwantedElements(F[] fileArray, Predicate<F> predicate) {
+		Object[] files = Arrays.stream(fileArray)
+				.filter(predicate.negate())
+				.toArray();
+		return (F[]) files;
 	}
 
 	private FileUtils() {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileUtils.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileUtils.java
@@ -21,6 +21,8 @@ import java.nio.file.FileSystems;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
+import org.springframework.util.ObjectUtils;
+
 /**
  * Utilities for operations on Files.
  *
@@ -42,13 +44,22 @@ public final class FileUtils {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <F> F[] purgeUnwantedElements(F[] fileArray, Predicate<F> predicate) {
-		return Arrays.stream(fileArray)
-				.filter(predicate.negate())
-				.toArray(size -> (F[]) Array.newInstance(fileArray[0].getClass(), size));
+		if (ObjectUtils.isEmpty(fileArray)) {
+			return fileArray;
+		}
+		else {
+			return Arrays.stream(fileArray)
+					.filter(predicate.negate())
+					.toArray(size -> (F[]) Array.newInstance(fileArray[0].getClass(), size));
+		}
 	}
 
 	private FileUtils() {
 		super();
+	}
+
+	public static void main(String[] args) {
+		purgeUnwantedElements(new String[0], s -> true);
 	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileUtils.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileUtils.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.file.support;
 
+import java.lang.reflect.Array;
 import java.nio.file.FileSystems;
 import java.util.Arrays;
 import java.util.function.Predicate;
@@ -41,9 +42,9 @@ public final class FileUtils {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <F> F[] purgeUnwantedElements(F[] fileArray, Predicate<F> predicate) {
-		return (F[]) Arrays.stream(fileArray)
+		return Arrays.stream(fileArray)
 				.filter(predicate.negate())
-				.toArray();
+				.toArray(size -> (F[]) Array.newInstance(fileArray[0].getClass(), size));
 	}
 
 	private FileUtils() {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileUtils.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileUtils.java
@@ -41,10 +41,9 @@ public final class FileUtils {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <F> F[] purgeUnwantedElements(F[] fileArray, Predicate<F> predicate) {
-		Object[] files = Arrays.stream(fileArray)
+		return (F[]) Arrays.stream(fileArray)
 				.filter(predicate.negate())
 				.toArray();
-		return (F[]) files;
 	}
 
 	private FileUtils() {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileUtils.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/support/FileUtils.java
@@ -58,8 +58,4 @@ public final class FileUtils {
 		super();
 	}
 
-	public static void main(String[] args) {
-		purgeUnwantedElements(new String[0], s -> true);
-	}
-
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -208,6 +208,11 @@ public class StreamingInboundTests {
 				infos.add(new StringFileInfo(file));
 			}
 			return infos;
+		}
+
+		@Override
+		protected boolean isDirectory(String file) {
+			return false;
 		}
 
 	}

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSource.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,11 @@ public class FtpStreamingMessageSource extends AbstractRemoteFileStreamingMessag
 			canonicalFiles.add(new FtpFileInfo(file));
 		}
 		return canonicalFiles;
+	}
+
+	@Override
+	protected boolean isDirectory(FTPFile file) {
+		return file != null && file.isDirectory();
 	}
 
 }

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpMessageSourceTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpMessageSourceTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.ftp.inbound;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.file.FileHeaders;
+import org.springframework.integration.ftp.FtpTestSupport;
+import org.springframework.messaging.Message;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author Gary Russell
+ * @since 5.0.7
+ *
+ */
+@RunWith(SpringRunner.class)
+@DirtiesContext
+public class FtpMessageSourceTests extends FtpTestSupport {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Test
+	public void testMaxFetch() throws Exception {
+		FtpInboundFileSynchronizingMessageSource messageSource = buildSource();
+		Message<?> received = messageSource.receive();
+		assertNotNull(received);
+		assertThat(received.getHeaders().get(FileHeaders.FILENAME), equalTo(" ftpSource1.txt"));
+	}
+
+	private FtpInboundFileSynchronizingMessageSource buildSource() throws Exception {
+		FtpInboundFileSynchronizer sync = new FtpInboundFileSynchronizer(sessionFactory());
+		sync.setRemoteDirectory("ftpSource/");
+		sync.setBeanFactory(this.context);
+		FtpInboundFileSynchronizingMessageSource messageSource = new FtpInboundFileSynchronizingMessageSource(sync);
+		messageSource.setLocalDirectory(getTargetLocalDirectory());
+		messageSource.setMaxFetchSize(1);
+		messageSource.setBeanFactory(this.context);
+		messageSource.setBeanName("source");
+		messageSource.afterPropertiesSet();
+		return messageSource;
+	}
+
+	@Configuration
+	public static class Config {
+
+	}
+
+}

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSource.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,11 @@ public class SftpStreamingMessageSource extends AbstractRemoteFileStreamingMessa
 			canonicalFiles.add(new SftpFileInfo(file));
 		}
 		return canonicalFiles;
+	}
+
+	@Override
+	protected boolean isDirectory(LsEntry file) {
+		return file != null && file.getAttrs().isDir();
 	}
 
 }

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpMessageSourceTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpMessageSourceTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.sftp.inbound;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.file.FileHeaders;
+import org.springframework.integration.sftp.SftpTestSupport;
+import org.springframework.messaging.Message;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author Gary Russell
+ * @since 5.0.7
+ *
+ */
+@RunWith(SpringRunner.class)
+@DirtiesContext
+public class SftpMessageSourceTests extends SftpTestSupport {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Test
+	public void testMaxFetch() throws Exception {
+		SftpInboundFileSynchronizingMessageSource messageSource = buildSource();
+		Message<?> received = messageSource.receive();
+		assertNotNull(received);
+		assertThat(received.getHeaders().get(FileHeaders.FILENAME), equalTo(" sftpSource1.txt"));
+	}
+
+	private SftpInboundFileSynchronizingMessageSource buildSource() throws Exception {
+		SftpInboundFileSynchronizer sync = new SftpInboundFileSynchronizer(sessionFactory());
+		sync.setRemoteDirectory("sftpSource/");
+		sync.setBeanFactory(this.context);
+		SftpInboundFileSynchronizingMessageSource messageSource = new SftpInboundFileSynchronizingMessageSource(sync);
+		messageSource.setLocalDirectory(getTargetLocalDirectory());
+		messageSource.setMaxFetchSize(1);
+		messageSource.setBeanFactory(this.context);
+		messageSource.setBeanName("source");
+		messageSource.afterPropertiesSet();
+		return messageSource;
+	}
+
+	@Configuration
+	public static class Config {
+
+	}
+
+}

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Comparator;
 
 import org.junit.Test;
@@ -130,6 +131,16 @@ public class SftpStreamingMessageSourceTests extends SftpTestSupport {
 	public void testMaxFetchNoFilter() {
 		SftpStreamingMessageSource messageSource = buildSource();
 		messageSource.setFilter(null);
+		messageSource.afterPropertiesSet();
+		Message<InputStream> received = messageSource.receive();
+		assertNotNull(received);
+		assertThat(received.getHeaders().get(FileHeaders.REMOTE_FILE), equalTo(" sftpSource1.txt"));
+	}
+
+	@Test
+	public void testMaxFetchLambdaFilter() {
+		SftpStreamingMessageSource messageSource = buildSource();
+		messageSource.setFilter(f -> Arrays.asList(f));
 		messageSource.afterPropertiesSet();
 		Message<InputStream> received = messageSource.receive();
 		assertNotNull(received);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4495

Previously, `maxFetch` was applied before directories were removed from
the fetch list.

Remove the directories before filtering and applying `maxFetch`.

**cherry-pick to 5.0.x**

**suggest reviewing on GitHub with `?w=1`**