### PR TITLE
Fix ThreadAffinityClientConnectionFactory

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/ThreadAffinityClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/ThreadAffinityClientConnectionFactory.java
@@ -299,21 +299,6 @@ public class ThreadAffinityClientConnectionFactory extends AbstractClientConnect
 	}
 
 	@Override
-	public boolean isSingleUse() {
-		return this.connectionFactory.isSingleUse();
-	}
-
-	@Override
-	public void setSingleUse(boolean singleUse) {
-		this.connectionFactory.setSingleUse(singleUse);
-	}
-
-	@Override
-	public void setLeaveOpen(boolean leaveOpen) {
-		this.connectionFactory.setLeaveOpen(leaveOpen);
-	}
-
-	@Override
 	public void setInterceptorFactoryChain(TcpConnectionInterceptorFactoryChain interceptorFactoryChain) {
 		this.connectionFactory.setInterceptorFactoryChain(interceptorFactoryChain);
 	}
@@ -370,7 +355,7 @@ public class ThreadAffinityClientConnectionFactory extends AbstractClientConnect
 
 	@Override
 	public boolean closeConnection(String connectionId) {
-		return this.connectionFactory.closeConnection(connectionId);
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
`isSingleUse()` should return `false` by default - the whole point is
to bind a connection to a thread. The TACCF should have its own flag
not return the delegate's.

Also, the `TcpReceivingChanneladapter` calls `closeConnection(connectionId)`.
This should be a no-op for the TACCF since the proper way to close a connection
is to call `releaseConnection()` on the thread to which the connection is bound.

**cherry-pick to 5.0.x**