### PR TITLE
INT-4499: Add JdbcMetadataStore.setLockHint()

### DIFF
--- a/spring-integration-file/src/test/java/org/springframework/integration/file/filters/PersistentAcceptOnceFileListFilterExternalStoreTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/filters/PersistentAcceptOnceFileListFilterExternalStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class PersistentAcceptOnceFileListFilterExternalStoreTests extends RedisA
 	@Test
 	@RedisAvailable
 	public void testFileSystemWithRedisMetadataStore() throws Exception {
-		RedisTemplate<String, ?> template = new RedisTemplate<String, Object>();
+		RedisTemplate<String, ?> template = new RedisTemplate<>();
 		template.setConnectionFactory(this.getConnectionFactoryForTest());
 		template.setKeySerializer(new StringRedisSerializer());
 		template.afterPropertiesSet();
@@ -87,6 +87,7 @@ public class PersistentAcceptOnceFileListFilterExternalStoreTests extends RedisA
 				.build();
 
 		JdbcMetadataStore metadataStore = new JdbcMetadataStore(dataSource);
+		metadataStore.setLockHint("");
 		metadataStore.afterPropertiesSet();
 
 		try {

--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -320,6 +320,7 @@ The following example show to use the `query` attribute:
     reply-channel="output"
     data-source="dataSource"/>
 ----
+====
 
 [IMPORTANT]
 ====
@@ -327,10 +328,6 @@ By default, the component for the `SELECT` query returns only one (the first) ro
 You can adjust this behavior with the `max-rows` option.
 If you need to return all the rows from the SELECT, consider specifying `max-rows="0"`.
 ====
-
-IMPORTANT: By default, the component for the `SELECT` query returns only the first row from the cursor.
-You can adjust this by setting the `max-rows-per-poll` option.
-If you need to return all the rows from the `SELECT`, you can set `max-rows-per-poll="0"`.
 
 As with the channel adapters, you can also provide `SqlParameterSourceFactory` instances for request and reply.
 The default is the same as for the outbound adapter, so the request message is available as the root of an expression.
@@ -1111,3 +1108,7 @@ Transaction management must use `JdbcMetadataStore`.
 Inbound channel adapters can be supplied with a reference to the `TransactionManager` in the poller configuration.
 Unlike non-transactional `MetadataStore` implementations, with `JdbcMetadataStore`, the entry appears in the target table only after the transaction commits.
 When a rollback occurs, no entries are added to the `INT_METADATA_STORE` table.
+
+Since version 5.0.7, the `JdbcMetadataStore` can be configured with the RDBMS vendor-specific `lockHint` option for lock-based queries on metadata store entries.
+It is `FOR UPDATE` by default and can be configured with an empty string, if the target data base doesn't support row locking functionality.
+Please, consult with your vendor for particular possible hint in the `SELECT` expression for locking rows before updates.


### PR DESCRIPTION
JIRA https://jira.spring.io/browse/INT-4499
Fixes https://github.com/spring-projects/spring-integration/issues/2483

To allow to reconfigure a `SELECT ... FOR UPDATE` for particular RDBMS
vendor, we need an option to specify possible hint for the target data base.

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
