### PR TITLE
Fix IntComponentSpec for ctx hooks

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationComponentSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationComponentSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@ package org.springframework.integration.dsl;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**
@@ -33,7 +35,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  * @since 5.0
  */
 public abstract class IntegrationComponentSpec<S extends IntegrationComponentSpec<S, T>, T>
-		implements FactoryBean<T> {
+		implements FactoryBean<T>, InitializingBean, DisposableBean {
 
 	protected final static SpelExpressionParser PARSER = new SpelExpressionParser();
 
@@ -81,6 +83,20 @@ public abstract class IntegrationComponentSpec<S extends IntegrationComponentSpe
 	@Override
 	public boolean isSingleton() {
 		return true;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		if (this.target instanceof InitializingBean) {
+			((InitializingBean) this.target).afterPropertiesSet();
+		}
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		if (this.target instanceof DisposableBean) {
+			((DisposableBean) this.target).destroy();
+		}
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/lifecycle/IntegrationComponentSpecLifecycleTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/lifecycle/IntegrationComponentSpecLifecycleTests.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceAware;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.dsl.IntegrationComponentSpec;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.StringValueResolver;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 5.0.7
+ */
+@RunWith(SpringRunner.class)
+@DirtiesContext
+public class IntegrationComponentSpecLifecycleTests {
+
+	@Autowired
+	private MyComponent myComponent;
+
+	@Test
+	public void testIntegrationComponentSpecLifecycle() {
+		assertThat(this.myComponent.initialized).isTrue();
+		assertThat(this.myComponent.name).isEqualTo("testSpec");
+		assertThat(this.myComponent.applicationContext).isNotNull();
+		assertThat(this.myComponent.beanFactory).isNotNull();
+		assertThat(this.myComponent.applicationEventPublisher).isNotNull();
+		assertThat(this.myComponent.classLoader).isNotNull();
+		assertThat(this.myComponent.environment).isNotNull();
+		assertThat(this.myComponent.messageSource).isNotNull();
+		assertThat(this.myComponent.resolver).isNotNull();
+		assertThat(this.myComponent.resourceLoader).isNotNull();
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class ContextConfiguration {
+
+		@Bean
+		public IntegrationComponentSpec<?, ?> testSpec() {
+			return new MyIntegrationComponentSpec();
+		}
+
+	}
+
+	private static final class MyIntegrationComponentSpec
+			extends IntegrationComponentSpec<MyIntegrationComponentSpec, MyComponent> {
+
+		MyIntegrationComponentSpec() {
+			this.target = new MyComponent();
+		}
+
+	}
+
+	private static final class MyComponent
+			implements InitializingBean, BeanNameAware, BeanFactoryAware, ApplicationContextAware,
+			BeanClassLoaderAware, EnvironmentAware, EmbeddedValueResolverAware, ResourceLoaderAware,
+			ApplicationEventPublisherAware, MessageSourceAware {
+
+		private boolean initialized;
+
+		private ClassLoader classLoader;
+
+		private BeanFactory beanFactory;
+
+		private String name;
+
+		private ApplicationContext applicationContext;
+
+		private ApplicationEventPublisher applicationEventPublisher;
+
+		private StringValueResolver resolver;
+
+		private Environment environment;
+
+		private MessageSource messageSource;
+
+		private ResourceLoader resourceLoader;
+
+		@Override
+		public void setBeanClassLoader(ClassLoader classLoader) {
+			this.classLoader = classLoader;
+		}
+
+		@Override
+		public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+			this.beanFactory = beanFactory;
+		}
+
+		@Override
+		public void setBeanName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+			this.applicationContext = applicationContext;
+		}
+
+		@Override
+		public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+			this.applicationEventPublisher = applicationEventPublisher;
+		}
+
+		@Override
+		public void setEmbeddedValueResolver(StringValueResolver resolver) {
+			this.resolver = resolver;
+		}
+
+		@Override
+		public void setEnvironment(Environment environment) {
+			this.environment = environment;
+		}
+
+		@Override
+		public void setMessageSource(MessageSource messageSource) {
+			this.messageSource = messageSource;
+		}
+
+		@Override
+		public void setResourceLoader(ResourceLoader resourceLoader) {
+			this.resourceLoader = resourceLoader;
+		}
+
+		@Override
+		public void afterPropertiesSet() {
+			this.initialized = true;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Since `IntegrationComponentSpec` is a `FactoryBean`, we need to care
about `Aware` and `init` & `destroy` hooks our selves or delegate
them through the `FactoryBean` wrapper

* Implement `InitializingBean` and `DisposableBean` on the
`IntegrationComponentSpec`
* Call the `Aware` hooks from the `IntegrationFlowBeanPostProcessor`

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
