### PR TITLE
INT-4500: The DefaultAmqpHeaderMapper was ignoring the correlationId …

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -126,7 +126,7 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 				headers.put(AmqpHeaders.CONTENT_TYPE, contentType);
 			}
 			String correlationId = amqpMessageProperties.getCorrelationId();
-			if (StringUtils.hasText(contentType)) {
+			if (StringUtils.hasText(correlationId)) {
 				headers.put(AmqpHeaders.CORRELATION_ID, correlationId);
 			}
 			MessageDeliveryMode receivedDeliveryMode = amqpMessageProperties.getReceivedDeliveryMode();

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
@@ -227,7 +227,6 @@ public class DefaultAmqpHeaderMapperTests {
     }
 
 	
-	
 	@Test
 	public void testToHeadersConsumerMetadata() {
 		DefaultAmqpHeaderMapper headerMapper = DefaultAmqpHeaderMapper.inboundMapper();

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
@@ -214,6 +214,22 @@ public class DefaultAmqpHeaderMapperTests {
 	}
 
 	@Test
+    public void toHeadersNonContentype() {
+        DefaultAmqpHeaderMapper headerMapper = DefaultAmqpHeaderMapper.inboundMapper();
+        MessageProperties amqpProperties = new MessageProperties();
+        amqpProperties.setAppId("test.appId");
+        amqpProperties.setClusterId("test.clusterId");
+        amqpProperties.setContentType(null);
+        String testCorrelationId = "foo";
+        amqpProperties.setCorrelationId(testCorrelationId);
+        Map<String, Object> headerMap = headerMapper.toHeadersFromReply(amqpProperties);
+        assertEquals(testCorrelationId, headerMap.get(AmqpHeaders.CORRELATION_ID));
+       
+    }
+
+	
+	
+	@Test
 	public void testToHeadersConsumerMetadata() {
 		DefaultAmqpHeaderMapper headerMapper = DefaultAmqpHeaderMapper.inboundMapper();
 		MessageProperties amqpProperties = new MessageProperties();

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
@@ -224,7 +224,6 @@ public class DefaultAmqpHeaderMapperTests {
         amqpProperties.setCorrelationId(testCorrelationId);
         Map<String, Object> headerMap = headerMapper.toHeadersFromReply(amqpProperties);
         assertEquals(testCorrelationId, headerMap.get(AmqpHeaders.CORRELATION_ID));
-       
     }
 
 	


### PR DESCRIPTION


JIRA https://jira.spring.io/browse/INT-4500

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
