### PR TITLE
INT-4503: Fix assertion in HttpMessageHandlerSpec

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpMessageHandlerSpec.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpMessageHandlerSpec.java
@@ -34,6 +34,7 @@ import org.springframework.web.client.RestTemplate;
  *
  * @author Artem Bilan
  * @author Shiliang Li
+ * @author Oleksii Komlyk
  *
  * @since 5.0
  *
@@ -63,8 +64,7 @@ public class HttpMessageHandlerSpec
 	 * @return the spec
 	 */
 	public HttpMessageHandlerSpec requestFactory(ClientHttpRequestFactory requestFactory) {
-		Assert.isNull(this.restTemplate,
-				"the 'requestFactory' must be specified on the provided 'restTemplate': " + this.restTemplate);
+		Assert.isTrue(!isClientSet(), "the 'requestFactory' must be specified on the provided 'restTemplate'");
 		this.target.setRequestFactory(requestFactory);
 		return this;
 	}
@@ -75,8 +75,7 @@ public class HttpMessageHandlerSpec
 	 * @return the spec
 	 */
 	public HttpMessageHandlerSpec errorHandler(ResponseErrorHandler errorHandler) {
-		Assert.isTrue(this.isClientSet(),
-				"the 'errorHandler' must be specified on the provided 'restTemplate'");
+		Assert.isTrue(!isClientSet(), "the 'errorHandler' must be specified on the provided 'restTemplate'");
 		this.target.setErrorHandler(errorHandler);
 		return _this();
 	}
@@ -88,7 +87,7 @@ public class HttpMessageHandlerSpec
 	 * @return the spec
 	 */
 	public HttpMessageHandlerSpec messageConverters(HttpMessageConverter<?>... messageConverters) {
-		Assert.isTrue(!isClientSet(), "the 'messageConverters' must be specified on the provided restTemplate");
+		Assert.isTrue(!isClientSet(), "the 'messageConverters' must be specified on the provided 'restTemplate'");
 		this.target.setMessageConverters(Arrays.asList(messageConverters));
 		return _this();
 	}

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
@@ -22,6 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,11 +30,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
@@ -59,14 +61,15 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.client.MockMvcClientHttpRequestFactory;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
  * @author Artem Bilan
  * @author Shiliang Li
  * @author Gary Russell
+ * @author Oleksii Komlyk
  *
  * @since 5.0
  */
@@ -97,9 +100,8 @@ public class HttpDslTests {
 
 	@Test
 	public void testHttpProxyFlow() throws Exception {
-		RestTemplate mockMvcRestTemplate = new RestTemplate(new MockMvcClientHttpRequestFactory(this.mockMvc));
-		new DirectFieldAccessor(this.serviceInternalGatewayHandler)
-				.setPropertyValue("restTemplate", mockMvcRestTemplate);
+		ClientHttpRequestFactory mockRequestFactory = new MockMvcClientHttpRequestFactory(this.mockMvc);
+		this.serviceInternalGatewayHandler.setRequestFactory(mockRequestFactory);
 
 		this.mockMvc.perform(
 				get("/service")
@@ -115,7 +117,10 @@ public class HttpDslTests {
 						.param("name", "name"))
 				.andExpect(
 						status()
-								.isForbidden());
+								.isForbidden())
+				.andExpect(
+						content()
+								.string("Error"));
 	}
 
 	@Test
@@ -213,7 +218,8 @@ public class HttpDslTests {
 							.errorChannel("httpProxyErrorFlow.input"))
 					.handle(Http.outboundGateway("/service/internal?{params}")
 									.uriVariable("params", "payload")
-									.expectedResponseType(String.class),
+									.expectedResponseType(String.class)
+									.errorHandler(new HttpProxyResponseErrorHandler()),
 							e -> e.id("serviceInternalGateway"))
 					.get();
 		}
@@ -238,6 +244,17 @@ public class HttpDslTests {
 			channelSecurityInterceptor.setAuthenticationManager(authenticationManager());
 			channelSecurityInterceptor.setAccessDecisionManager(accessDecisionManager);
 			return channelSecurityInterceptor;
+		}
+
+	}
+
+	public static class HttpProxyResponseErrorHandler extends DefaultResponseErrorHandler {
+
+		@Override
+		protected byte[] getResponseBody(ClientHttpResponse response) {
+			Charset charset = getCharset(response);
+			String content = "Error";
+			return charset != null ? content.getBytes(charset) : content.getBytes();
 		}
 
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4503

Custom ErrorHandler can't be used if external RestTemplate is provided

* Replace isClientSet() with !isClientSet() for isTrue assertion in errorHandler method