### PR TITLE
INT-4381: MessageSources refactoring

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MethodInvokingMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MethodInvokingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,8 +68,7 @@ public class MethodInvokingMessageSource extends AbstractMessageSource<Object>
 	}
 
 	@Override
-	public void afterPropertiesSet() throws Exception {
-		super.afterPropertiesSet();
+	protected void onInit() {
 		synchronized (this.initializationMonitor) {
 			if (this.initialized) {
 				return;

--- a/spring-integration-core/src/main/java/org/springframework/integration/resource/ResourceRetrievingMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/resource/ResourceRetrievingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,8 @@ import org.springframework.util.ObjectUtils;
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.1
  */
 public class ResourceRetrievingMessageSource extends AbstractMessageSource<Resource[]>
@@ -79,8 +81,7 @@ public class ResourceRetrievingMessageSource extends AbstractMessageSource<Resou
 
 
 	@Override
-	public void afterPropertiesSet() throws Exception {
-		super.afterPropertiesSet();
+	protected void onInit() {
 		if (this.patternResolver == null) {
 			this.patternResolver = this.applicationContext;
 		}
@@ -100,7 +101,7 @@ public class ResourceRetrievingMessageSource extends AbstractMessageSource<Resou
 					resources = null;
 				}
 				else {
-					resources = filteredResources.toArray(new Resource[filteredResources.size()]);
+					resources = filteredResources.toArray(new Resource[0]);
 				}
 			}
 			return resources;

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/AbstractExpressionEvaluator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/AbstractExpressionEvaluator.java
@@ -88,11 +88,13 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 	}
 
 	@Override
-	public void afterPropertiesSet() throws Exception {
+	public final void afterPropertiesSet() throws Exception {
 		getEvaluationContext();
 		if (this.beanFactory != null) {
 			this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.beanFactory);
 		}
+
+		onInit();
 	}
 
 	protected StandardEvaluationContext getEvaluationContext() {
@@ -167,6 +169,10 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 
 	protected <T> T evaluateExpression(Expression expression, Object input, Class<T> expectedType) {
 		return expression.getValue(this.getEvaluationContext(), input, expectedType);
+	}
+
+	protected void onInit() {
+
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/HeaderEnricherTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/HeaderEnricherTests-context.xml
@@ -30,7 +30,7 @@
 	</channel>
 
 	<header-enricher input-channel="errorChannelInput" output-channel="failInput">
-		<poller max-messages-per-poll="1" fixed-delay="3000"/>
+		<poller max-messages-per-poll="1" fixed-delay="10"/>
 		<error-channel ref="testErrorChannel"/>
 	</header-enricher>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/HeaderEnricherTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/HeaderEnricherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 @ContextConfiguration
@@ -63,8 +64,8 @@ public class HeaderEnricherTests {
 	public void replyChannel() {
 		PollableChannel replyChannel = context.getBean("testReplyChannel", PollableChannel.class);
 		MessageChannel inputChannel = context.getBean("replyChannelInput", MessageChannel.class);
-		inputChannel.send(new GenericMessage<String>("test"));
-		Message<?> result = replyChannel.receive(0);
+		inputChannel.send(new GenericMessage<>("test"));
+		Message<?> result = replyChannel.receive(10000);
 		assertNotNull(result);
 		assertEquals("TEST", result.getPayload());
 		assertEquals(replyChannel, result.getHeaders().getReplyChannel());
@@ -74,8 +75,8 @@ public class HeaderEnricherTests {
 	public void replyChannelName() {
 		PollableChannel replyChannel = context.getBean("testReplyChannel", PollableChannel.class);
 		MessageChannel inputChannel = context.getBean("replyChannelNameInput", MessageChannel.class);
-		inputChannel.send(new GenericMessage<String>("test"));
-		Message<?> result = replyChannel.receive(0);
+		inputChannel.send(new GenericMessage<>("test"));
+		Message<?> result = replyChannel.receive(10000);
 		assertNotNull(result);
 		assertEquals("TEST", result.getPayload());
 		assertEquals("testReplyChannel", result.getHeaders().getReplyChannel());
@@ -85,8 +86,8 @@ public class HeaderEnricherTests {
 	public void replyChannelExpression() {
 		PollableChannel replyChannel = context.getBean("testReplyChannel", PollableChannel.class);
 		MessageChannel inputChannel = context.getBean("replyChannelExpressionInput", MessageChannel.class);
-		inputChannel.send(new GenericMessage<String>("test"));
-		Message<?> result = replyChannel.receive(0);
+		inputChannel.send(new GenericMessage<>("test"));
+		Message<?> result = replyChannel.receive(10000);
 		assertNotNull(result);
 		assertEquals("TEST", result.getPayload());
 		assertEquals(replyChannel, result.getHeaders().getReplyChannel());
@@ -96,8 +97,8 @@ public class HeaderEnricherTests {
 	public void errorChannel() {
 		PollableChannel errorChannel = context.getBean("testErrorChannel", PollableChannel.class);
 		MessageChannel inputChannel = context.getBean("errorChannelInput", MessageChannel.class);
-		inputChannel.send(new GenericMessage<String>("test"));
-		Message<?> errorMessage = errorChannel.receive(1000);
+		inputChannel.send(new GenericMessage<>("test"));
+		Message<?> errorMessage = errorChannel.receive(10000);
 		assertNotNull(errorMessage);
 		Object errorPayload = errorMessage.getPayload();
 		assertEquals(MessageTransformationException.class, errorPayload.getClass());
@@ -110,7 +111,7 @@ public class HeaderEnricherTests {
 	public void correlationIdValue() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("correlationIdValueInput", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		assertEquals("ABC", new IntegrationMessageHeaderAccessor(result).getCorrelationId());
 	}
@@ -119,7 +120,7 @@ public class HeaderEnricherTests {
 	public void correlationIdValueWithType() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("correlationIdValueWithTypeInput", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		Object correlationId = new IntegrationMessageHeaderAccessor(result).getCorrelationId();
 		assertEquals(Long.class, correlationId.getClass());
@@ -130,7 +131,7 @@ public class HeaderEnricherTests {
 	public void correlationIdRef() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("correlationIdRefInput", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		assertEquals(123, new IntegrationMessageHeaderAccessor(result).getCorrelationId());
 	}
@@ -139,7 +140,7 @@ public class HeaderEnricherTests {
 	public void expirationDateValue() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("expirationDateValueInput", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		assertEquals(new Long(1111), new IntegrationMessageHeaderAccessor(result).getExpirationDate());
 	}
@@ -148,7 +149,7 @@ public class HeaderEnricherTests {
 	public void expirationDateRef() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("expirationDateRefInput", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		assertEquals(new Long(9999), new IntegrationMessageHeaderAccessor(result).getExpirationDate());
 	}
@@ -157,7 +158,7 @@ public class HeaderEnricherTests {
 	public void priority() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("priorityInput", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		assertEquals(new Integer(42), new IntegrationMessageHeaderAccessor(result).getPriority());
 	}
@@ -167,7 +168,7 @@ public class HeaderEnricherTests {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("priorityExpressionInput", MessageChannel.class);
 		Message<?> result = template.sendAndReceive(channel,
-				new GenericMessage<Map<String, String>>(Collections.singletonMap("priority", "-10")));
+				new GenericMessage<>(Collections.singletonMap("priority", "-10")));
 		assertNotNull(result);
 		assertEquals(new Integer(-10), new IntegrationMessageHeaderAccessor(result).getPriority());
 	}
@@ -176,7 +177,7 @@ public class HeaderEnricherTests {
 	public void expressionUsingPayload() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("payloadExpressionInput", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<TestBean>(new TestBean("foo")));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>(new TestBean("foo")));
 		assertNotNull(result);
 		assertEquals("foobar", result.getHeaders().get("testHeader"));
 	}
@@ -195,7 +196,7 @@ public class HeaderEnricherTests {
 	public void expressionWithDateType() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("expressionWithDateTypeInput", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		Object headerValue = result.getHeaders().get("currentDate");
 		assertEquals(Date.class, headerValue.getClass());
@@ -207,7 +208,7 @@ public class HeaderEnricherTests {
 	public void expressionWithLongType() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("expressionWithLongTypeInput", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		assertEquals(Long.class, result.getHeaders().get("number").getClass());
 		assertEquals(12345L, result.getHeaders().get("number"));
@@ -217,7 +218,7 @@ public class HeaderEnricherTests {
 	public void refWithMethod() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("refWithMethod", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		assertEquals(String.class, result.getHeaders().get("testHeader").getClass());
 		assertEquals("testBeanForMethodInvoker", result.getHeaders().get("testHeader"));
@@ -227,7 +228,7 @@ public class HeaderEnricherTests {
 	public void ref() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("ref", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		assertEquals(TestBean.class, result.getHeaders().get("testHeader").getClass());
 		TestBean testBeanForRef = context.getBean("testBean1", TestBean.class);
@@ -238,7 +239,7 @@ public class HeaderEnricherTests {
 	public void innerBean() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("innerBean", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		assertEquals(TestBean.class, result.getHeaders().get("testHeader").getClass());
 		TestBean testBeanForInnerBean = new TestBean("testBeanForInnerBean");
@@ -249,7 +250,7 @@ public class HeaderEnricherTests {
 	public void innerBeanWithMethod() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("innerBeanWithMethod", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		assertEquals(String.class, result.getHeaders().get("testHeader").getClass());
 		assertEquals("testBeanForInnerBeanWithMethod", result.getHeaders().get("testHeader"));
@@ -265,7 +266,7 @@ public class HeaderEnricherTests {
 	public void testRoutingSlip() {
 		MessagingTemplate template = new MessagingTemplate();
 		MessageChannel channel = context.getBean("routingSlipInput", MessageChannel.class);
-		Message<?> result = template.sendAndReceive(channel, new GenericMessage<String>("test"));
+		Message<?> result = template.sendAndReceive(channel, new GenericMessage<>("test"));
 		assertNotNull(result);
 		Object routingSlip = new IntegrationMessageHeaderAccessor(result)
 				.getHeader(IntegrationMessageHeaderAccessor.ROUTING_SLIP);
@@ -311,6 +312,7 @@ public class HeaderEnricherTests {
 		public int hashCode() {
 			return name != null ? name.hashCode() : 0;
 		}
+
 	}
 
 }

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FeedEntryMessageSourceTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FeedEntryMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ public class FeedEntryMessageSourceTests {
 	public void testReceiveFeedWithEntriesSorted() throws Exception {
 		ClassPathResource resource = new ClassPathResource("org/springframework/integration/feed/sample.rss");
 		FeedEntryMessageSource source = new FeedEntryMessageSource(resource, "foo");
-		source.setComponentName("feedReader");
+		source.setBeanName("feedReader");
 		source.setBeanFactory(mock(BeanFactory.class));
 		source.afterPropertiesSet();
 		Message<SyndEntry> message1 = source.receive();

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
@@ -46,15 +46,14 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.aggregator.ResequencingMessageGroupProcessor;
-import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.core.MessageSource;
+import org.springframework.integration.endpoint.AbstractMessageSource;
 import org.springframework.integration.file.filters.AcceptOnceFileListFilter;
 import org.springframework.integration.file.filters.DiscardAwareFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.filters.ResettableFileListFilter;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
 
 /**
@@ -85,7 +84,8 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Artem Bilan
  */
-public class FileReadingMessageSource extends IntegrationObjectSupport implements MessageSource<File>, Lifecycle {
+public class FileReadingMessageSource extends AbstractMessageSource<File>
+		implements Lifecycle {
 
 	private static final int DEFAULT_INTERNAL_QUEUE_CAPACITY = 5;
 
@@ -350,21 +350,6 @@ public class FileReadingMessageSource extends IntegrationObjectSupport implement
 	}
 
 	@Override
-	public Message<File> receive() throws MessagingException {
-		AbstractIntegrationMessageBuilder<File> messageBuilder = doReceive();
-
-		Message<File> message = null;
-
-		if (messageBuilder != null) {
-			message = messageBuilder.build();
-			if (logger.isInfoEnabled()) {
-				logger.info("Created message: [" + message + "]");
-			}
-		}
-
-		return message;
-	}
-
 	protected AbstractIntegrationMessageBuilder<File> doReceive() {
 		// rescan only if needed or explicitly configured
 		if (this.scanEachPoll || this.toBeReceived.isEmpty()) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileInboundChannelAdapterSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileInboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,23 +66,7 @@ public class FileInboundChannelAdapterSpec
 	}
 
 	FileInboundChannelAdapterSpec(Comparator<File> receptionOrderComparator) {
-		this.target = new FileReadingMessageSource(receptionOrderComparator) {
-
-			@Override
-			protected void onInit() {
-				if (FileInboundChannelAdapterSpec.this.scanner == null ||
-						FileInboundChannelAdapterSpec.this.filtersSet) {
-					try {
-						setFilter(FileInboundChannelAdapterSpec.this.fileListFilterFactoryBean.getObject());
-					}
-					catch (Exception e) {
-						throw new BeanCreationException("The bean for the [" + this + "] can not be instantiated.", e);
-					}
-				}
-				super.onInit();
-			}
-
-		};
+		this.target = new FileReadingMessageSource(receptionOrderComparator);
 	}
 
 	/**
@@ -275,6 +259,15 @@ public class FileInboundChannelAdapterSpec
 
 	@Override
 	public Map<Object, String> getComponentsToRegister() {
+		if (this.scanner == null || this.filtersSet) {
+			try {
+				this.target.setFilter(this.fileListFilterFactoryBean.getObject());
+			}
+			catch (Exception e) {
+				throw new BeanCreationException("The bean for the [" + this + "] can not be instantiated.", e);
+			}
+		}
+
 		if (this.expressionFileListFilter != null) {
 			return Collections.singletonMap(this.expressionFileListFilter, null);
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
@@ -136,7 +136,7 @@ public abstract class AbstractRemoteFileStreamingMessageSource<F>
 	}
 
 	@Override
-	public final void afterPropertiesSet() {
+	public final void onInit() {
 		Assert.state(this.remoteDirectoryExpression != null, "'remoteDirectoryExpression' must not be null");
 		doInit();
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
@@ -173,8 +173,7 @@ public abstract class AbstractInboundFileSynchronizingMessageSource<F>
 	}
 
 	@Override
-	public void afterPropertiesSet() throws Exception {
-		super.afterPropertiesSet();
+	protected void onInit() {
 		Assert.notNull(this.localDirectory, "localDirectory must not be null");
 		try {
 			if (!this.localDirectory.exists()) {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/AutoCreateDirectoryTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/AutoCreateDirectoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class AutoCreateDirectoryTests {
 	}
 
 	@Test
-	public void autoCreateForInboundEnabledByDefault() {
+	public void autoCreateForInboundEnabledByDefault() throws Exception {
 		FileReadingMessageSource source = new FileReadingMessageSource();
 		source.setDirectory(new File(INBOUND_PATH));
 		source.setBeanFactory(mock(BeanFactory.class));
@@ -68,7 +68,7 @@ public class AutoCreateDirectoryTests {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void autoCreateForInboundDisabled() {
+	public void autoCreateForInboundDisabled() throws Exception {
 		FileReadingMessageSource source = new FileReadingMessageSource();
 		source.setDirectory(new File(INBOUND_PATH));
 		source.setAutoCreateDirectory(false);

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
@@ -137,7 +137,7 @@ public class StreamingInboundTests {
 	}
 
 	@Test
-	public void testExceptionOnFetch() {
+	public void testExceptionOnFetch() throws Exception {
 		exception.expect(MessagingException.class);
 		StringSessionFactory sessionFactory = new StringSessionFactory();
 		Streamer streamer = new Streamer(new StringRemoteFileTemplate(sessionFactory), null);

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Comparator;
 import java.util.concurrent.ConcurrentHashMap;
@@ -128,7 +127,7 @@ public class FtpStreamingMessageSourceTests extends FtpTestSupport {
 	}
 
 	@Test
-	public void testMaxFetch() throws IOException {
+	public void testMaxFetch() throws Exception {
 		FtpStreamingMessageSource messageSource = buildSource();
 		messageSource.setFilter(new AcceptAllFileListFilter<>());
 		messageSource.afterPropertiesSet();
@@ -143,7 +142,7 @@ public class FtpStreamingMessageSourceTests extends FtpTestSupport {
 	}
 
 	@Test
-	public void testMaxFetchNoFilter() throws IOException {
+	public void testMaxFetchNoFilter() throws Exception {
 		FtpStreamingMessageSource messageSource = buildSource();
 		messageSource.setFilter(null);
 		messageSource.afterPropertiesSet();

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/ExpressionEvaluatingSqlParameterSourceFactory.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/ExpressionEvaluatingSqlParameterSourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,9 +158,8 @@ public class ExpressionEvaluatingSqlParameterSourceFactory extends AbstractExpre
 	}
 
 	@Override
-	public void afterPropertiesSet() throws Exception {
-		super.afterPropertiesSet();
-		this.getEvaluationContext().setVariable("staticParameters", this.staticParameters);
+	protected void onInit() {
+		getEvaluationContext().setVariable("staticParameters", this.staticParameters);
 	}
 
 	private final class ExpressionEvaluatingSqlParameterSource extends AbstractSqlParameterSource {

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/StoredProcPollingChannelAdapter.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/StoredProcPollingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,7 @@ package org.springframework.integration.jdbc;
 import java.sql.CallableStatement;
 import java.util.Map;
 
-import org.springframework.integration.context.IntegrationObjectSupport;
-import org.springframework.integration.core.MessageSource;
+import org.springframework.integration.endpoint.AbstractMessageSource;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
@@ -32,9 +31,11 @@ import org.springframework.util.Assert;
  * processed rows.
  *
  * @author Gunnar Hillert
+ * @author Artem Bilan
+ *
  * @since 2.1
  */
-public class StoredProcPollingChannelAdapter extends IntegrationObjectSupport implements MessageSource<Object> {
+public class StoredProcPollingChannelAdapter extends AbstractMessageSource<Object> {
 
 	private final StoredProcExecutor executor;
 
@@ -42,30 +43,31 @@ public class StoredProcPollingChannelAdapter extends IntegrationObjectSupport im
 
 	/**
 	 * Constructor taking {@link StoredProcExecutor}.
-	 *
 	 * @param storedProcExecutor Must not be null.
-	 *
 	 */
 	public StoredProcPollingChannelAdapter(StoredProcExecutor storedProcExecutor) {
-
 		Assert.notNull(storedProcExecutor, "storedProcExecutor must not be null.");
 		this.executor = storedProcExecutor;
 
 	}
 
 	/**
-	 * Executes the query. If a query result set contains one or more rows, the
-	 * Message payload will contain either a List of Maps for each row or, if a
-	 * RowMapper has been provided, the values mapped from those rows. If the
-	 * query returns no rows, this method will return <code>null</code>.
+	 * This parameter indicates that only one result object shall be returned from
+	 * the Stored Procedure/Function Call. If set to true, a resultMap that contains
+	 * only 1 element, will have that 1 element extracted and returned as payload.
+	 * If the resultMap contains more than 1 element and expectSingleResult is true,
+	 * then a {@link MessagingException} is thrown.
+	 * Otherwise the complete resultMap is returned as the {@link Message} payload.
+	 * Important Note: Several databases such as H2 are not fully supported.
+	 * The H2 database, for example, does not fully support the {@link CallableStatement}
+	 * semantics and when executing function calls against H2, a result list is
+	 * returned rather than a single value.
+	 * Therefore, even if you set expectSingleResult = true, you may end up with
+	 * a collection being returned.
+	 * @param expectSingleResult true if a single result is expected.
 	 */
-	@Override
-	public Message<Object> receive() {
-		Object payload = poll();
-		if (payload == null) {
-			return null;
-		}
-		return this.getMessageBuilderFactory().withPayload(payload).build();
+	public void setExpectSingleResult(boolean expectSingleResult) {
+		this.expectSingleResult = expectSingleResult;
 	}
 
 	/**
@@ -73,68 +75,35 @@ public class StoredProcPollingChannelAdapter extends IntegrationObjectSupport im
 	 * rows returned by the select query. If a RowMapper has been provided, the
 	 * mapped results are returned.
 	 */
-	private Object poll() {
+	@Override
+	protected Object doReceive() {
+		Object payload;
 
-		final Object payload;
-
-		Map<String, ?> resultMap = doPoll();
+		Map<String, ?> resultMap = this.executor.executeStoredProcedure();
 
 		if (resultMap.isEmpty()) {
 			payload = null;
 		}
 		else {
-
 			if (this.expectSingleResult && resultMap.size() == 1) {
 				payload = resultMap.values().iterator().next();
 			}
 			else if (this.expectSingleResult && resultMap.size() > 1) {
-
 				throw new MessagingException(
 						"Stored Procedure/Function call returned more than "
-								+ "1 result object and expectSingleResult was 'true'. ");
-
+								+ "1 result object and expectSingleResult was 'true'.");
 			}
 			else {
 				payload = resultMap;
 			}
-
 		}
 
 		return payload;
-
-	}
-
-	protected Map<String, ?> doPoll() {
-		return this.executor.executeStoredProcedure();
 	}
 
 	@Override
 	public String getComponentType() {
 		return "stored-proc:inbound-channel-adapter";
-	}
-
-	/**
-	 * This parameter indicates that only one result object shall be returned from
-	 * the Stored Procedure/Function Call. If set to true, a resultMap that contains
-	 * only 1 element, will have that 1 element extracted and returned as payload.
-	 *
-	 * If the resultMap contains more than 1 element and expectSingleResult is true,
-	 * then a {@link MessagingException} is thrown.
-	 *
-	 * Otherwise the complete resultMap is returned as the {@link Message} payload.
-	 *
-	 * Important Note: Several databases such as H2 are not fully supported.
-	 * The H2 database, for example, does not fully support the {@link CallableStatement}
-	 * semantics and when executing function calls against H2, a result list is
-	 * returned rather than a single value.
-	 *
-	 * Therefore, even if you set expectSingleResult = true, you may end up with
-	 * a collection being returned.
-	 *
-	 * @param expectSingleResult true if a single result is expected.
-	 */
-	public void setExpectSingleResult(boolean expectSingleResult) {
-		this.expectSingleResult = expectSingleResult;
 	}
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcPollingChannelAdapterIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/JdbcPollingChannelAdapterIntegrationTests.java
@@ -142,7 +142,7 @@ public class JdbcPollingChannelAdapterIntegrationTests {
 	}
 
 	@Test
-	public void testSimplePollForListWithRowMapperAndOneUpdate() {
+	public void testSimplePollForListWithRowMapperAndOneUpdate() throws Exception {
 		JdbcPollingChannelAdapter adapter = new JdbcPollingChannelAdapter(embeddedDatabase,
 				"select * from item where status=2");
 		adapter.setUpdateSql("update item set status = 10 where id in (:id)");
@@ -170,7 +170,7 @@ public class JdbcPollingChannelAdapterIntegrationTests {
 	}
 
 	@Test
-	public void testSimplePollForListWithRowMapperAndUpdatePerRow() {
+	public void testSimplePollForListWithRowMapperAndUpdatePerRow() throws Exception {
 		JdbcPollingChannelAdapter adapter = new JdbcPollingChannelAdapter(embeddedDatabase,
 				"select * from item where status=2");
 		adapter.setUpdateSql("update item set status = 10 where id = :id");
@@ -199,7 +199,7 @@ public class JdbcPollingChannelAdapterIntegrationTests {
 	}
 
 	@Test
-	public void testSimplePollForListWithRowMapperAndInsertPerRowAndMaxRows() {
+	public void testSimplePollForListWithRowMapperAndInsertPerRowAndMaxRows() throws Exception {
 		JdbcPollingChannelAdapter adapter = new JdbcPollingChannelAdapter(embeddedDatabase,
 				"select * from item where id not in (select id from copy)");
 		adapter.setUpdateSql("insert into copy values(:id,10)");
@@ -229,7 +229,7 @@ public class JdbcPollingChannelAdapterIntegrationTests {
 	}
 
 	@Test
-	public void testSimplePollForListWithRowMapperAndUpdatePerRowWithMaxRows() {
+	public void testSimplePollForListWithRowMapperAndUpdatePerRowWithMaxRows() throws Exception {
 		JdbcPollingChannelAdapter adapter = new JdbcPollingChannelAdapter(embeddedDatabase,
 				"select * from item where status=2");
 		adapter.setUpdateSql("update item set status = 10 where id = :id");

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/jdbcInboundChannelAdapterCommonConfig.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/jdbcInboundChannelAdapterCommonConfig.xml
@@ -10,7 +10,7 @@
 		<si:queue />
 	</si:channel>
 
-	<si:poller default="true" fixed-rate="100"/>
+	<si:poller default="true" fixed-delay="100"/>
 
 	<jdbc:embedded-database type="HSQL" id="dataSource">
 		<jdbc:script location="org/springframework/integration/jdbc/config/inboundSchema.sql" />

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsInboundChannelAdapterParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,10 +47,6 @@ public class JmsInboundChannelAdapterParser extends AbstractPollingInboundChanne
 	@Override
 	protected BeanMetadataElement parseSource(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(JmsDestinationPollingSource.class);
-		String componentName =  this.resolveId(element, builder.getBeanDefinition(), parserContext);
-		if (StringUtils.hasText(componentName)) {
-			builder.addPropertyValue("componentName", componentName);
-		}
 		String jmsTemplate = element.getAttribute(JmsParserUtils.JMS_TEMPLATE_ATTRIBUTE);
 		String destination = element.getAttribute(JmsParserUtils.DESTINATION_ATTRIBUTE);
 		String destinationName = element.getAttribute(JmsParserUtils.DESTINATION_NAME_ATTRIBUTE);

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/inbound/JpaPollingChannelAdapter.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/inbound/JpaPollingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 
 package org.springframework.integration.jpa.inbound;
 
-import org.springframework.integration.context.IntegrationObjectSupport;
-import org.springframework.integration.core.MessageSource;
+import org.springframework.integration.endpoint.AbstractMessageSource;
 import org.springframework.integration.jpa.core.JpaExecutor;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
@@ -44,11 +43,12 @@ import org.springframework.util.Assert;
  *
  * @author Amol Nayak
  * @author Gunnar Hillert
+ * @author Artem Bilan
  *
  * @since 2.2
  *
  */
-public class JpaPollingChannelAdapter extends IntegrationObjectSupport implements MessageSource<Object> {
+public class JpaPollingChannelAdapter extends AbstractMessageSource<Object> {
 
 	private final JpaExecutor jpaExecutor;
 
@@ -59,7 +59,6 @@ public class JpaPollingChannelAdapter extends IntegrationObjectSupport implement
 	 * @param jpaExecutor Must not be null.
 	 */
 	public JpaPollingChannelAdapter(JpaExecutor jpaExecutor) {
-		super();
 		Assert.notNull(jpaExecutor, "jpaExecutor must not be null.");
 		this.jpaExecutor = jpaExecutor;
 	}
@@ -68,26 +67,18 @@ public class JpaPollingChannelAdapter extends IntegrationObjectSupport implement
 	 * Check for mandatory attributes
 	 */
 	@Override
-	protected void onInit() throws Exception {
-		super.onInit();
-		this.jpaExecutor.setBeanFactory(this.getBeanFactory());
+	protected void onInit() {
+		this.jpaExecutor.setBeanFactory(getBeanFactory());
 	}
 
 	/**
-	 * Uses {@link JpaExecutor#poll()} to executes the JPA operation.
-	 *
+	 * Use {@link JpaExecutor#poll()} to executes the JPA operation.
 	 * If {@link JpaExecutor#poll()} returns null, this method will return
 	 * <code>null</code>. Otherwise, a new {@link Message} is constructed and returned.
 	 */
-	public Message<Object> receive() {
-
-		final Object payload = this.jpaExecutor.poll();
-
-		if (payload == null) {
-			return null;
-		}
-
-		return this.getMessageBuilderFactory().withPayload(payload).build();
+	@Override
+	protected Object doReceive() {
+		return this.jpaExecutor.poll();
 	}
 
 	@Override

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -120,7 +119,7 @@ public class SftpStreamingMessageSourceTests extends SftpTestSupport {
 	}
 
 	@Test
-	public void testMaxFetch() throws IOException {
+	public void testMaxFetch() throws Exception {
 		SftpStreamingMessageSource messageSource = buildSource();
 		messageSource.setFilter(new AcceptAllFileListFilter<>());
 		messageSource.afterPropertiesSet();
@@ -133,7 +132,7 @@ public class SftpStreamingMessageSourceTests extends SftpTestSupport {
 	}
 
 	@Test
-	public void testMaxFetchNoFilter() throws IOException {
+	public void testMaxFetchNoFilter() throws Exception {
 		SftpStreamingMessageSource messageSource = buildSource();
 		messageSource.setFilter(null);
 		messageSource.afterPropertiesSet();
@@ -146,9 +145,9 @@ public class SftpStreamingMessageSourceTests extends SftpTestSupport {
 	}
 
 	@Test
-	public void testMaxFetchLambdaFilter() throws IOException {
+	public void testMaxFetchLambdaFilter() throws Exception {
 		SftpStreamingMessageSource messageSource = buildSource();
-		messageSource.setFilter(f -> Arrays.asList(f));
+		messageSource.setFilter(Arrays::asList);
 		messageSource.afterPropertiesSet();
 		Message<InputStream> received = messageSource.receive();
 		assertNotNull(received);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4381

* Make all the out-of-the-box `MessageSource` implementations based
on the `AbstractMessageSource`
* Fix `JdbcPollingChannelAdapterIntegrationTests` for sporadic failure
because of `fixed-rate` for the poller

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
