### PR TITLE
INT-4507: Use UNLINK in RedisMessageStore if any

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.store;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -39,7 +40,7 @@ public class MessageGroupMetadata implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private List<UUID> messageIds = new LinkedList<UUID>();
+	private List<UUID> messageIds = new LinkedList<>();
 
 	private long timestamp;
 
@@ -66,6 +67,10 @@ public class MessageGroupMetadata implements Serializable {
 
 	public void remove(UUID messageId) {
 		this.messageIds.remove(messageId);
+	}
+
+	public void removeAll(Collection<UUID> messageIds) {
+		this.messageIds.removeAll(messageIds);
 	}
 
 	boolean add(UUID messageId) {

--- a/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/store/GemfireMessageStore.java
+++ b/spring-integration-gemfire/src/main/java/org/springframework/integration/gemfire/store/GemfireMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,6 +94,11 @@ public class GemfireMessageStore extends AbstractKeyValueMessageStore {
 	protected Object doRemove(Object id) {
 		Assert.notNull(id, "'id' must not be null");
 		return this.messageStoreRegion.remove(id);
+	}
+
+	@Override
+	protected void doRemoveAll(Collection<Object> ids) {
+		this.messageStoreRegion.removeAll(ids);
 	}
 
 	@Override

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -302,11 +302,10 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 			}
 			try {
 				if (Thread.currentThread().isInterrupted()) {
-					RedisLockRegistry.this.executor.execute(() ->
-							RedisLockRegistry.this.redisTemplate.delete(this.lockKey));
+					RedisLockRegistry.this.executor.execute(this::removeLockKey);
 				}
 				else {
-					RedisLockRegistry.this.redisTemplate.delete(this.lockKey);
+					removeLockKey();
 				}
 
 				if (logger.isDebugEnabled()) {
@@ -318,6 +317,15 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 			}
 			finally {
 				this.localLock.unlock();
+			}
+		}
+
+		private void removeLockKey() {
+			if (RedisUtils.isUnlinkAvailable(RedisLockRegistry.this.redisTemplate)) {
+				RedisLockRegistry.this.redisTemplate.unlink(this.lockKey);
+			}
+			else {
+				RedisLockRegistry.this.redisTemplate.delete(this.lockKey);
 			}
 		}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisUtils.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.redis.util;
+
+import java.util.Properties;
+
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisOperations;
+
+/**
+ * A set of utility methods for common Redis functions.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.1
+ */
+public final class RedisUtils {
+
+	private static final String SECTION = "server";
+
+	private static final String VERSION_PROPERTY = "redis_version";
+
+	private static final int MAJOR_VERSION_TO_COMPARE = 4;
+
+	private static Boolean unlinkAvailable;
+
+	/**
+	 * Perform an {@code INFO} command on the provided {@link RedisOperations} to check
+	 * the Redis server version to be sure that {@code UNLINK} is available or not.
+	 * @param redisOperations the {@link RedisOperations} to perform {@code INFO} command.
+	 * @return true or false if {@code UNLINK} Redis command is available or not.
+	 * @throws IllegalStateException when {@code INFO} returns null from the Redis.
+	 */
+	public static boolean isUnlinkAvailable(RedisOperations<?, ?> redisOperations) {
+		if (unlinkAvailable == null) {
+			Properties info = redisOperations.execute(
+					(RedisCallback<Properties>) connection -> connection.serverCommands().info(SECTION));
+			if (info != null) {
+				int majorVersion = Integer.parseInt(info.getProperty(VERSION_PROPERTY).split("\\.")[0]);
+				unlinkAvailable = majorVersion >= MAJOR_VERSION_TO_COMPARE;
+			}
+			else {
+				throw new IllegalStateException("The INFO command cannot be used in pipeline/transaction.");
+			}
+		}
+		return unlinkAvailable;
+	}
+
+	private RedisUtils() {
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4507

* Add `RedisUtils` with the `isUnlinkAvailable()` to check the Redis
server version to be sure that `UNLINK` is available or not
* Use `RedisUtils.isUnlinkAvailable()` in the `RedisMessageStore` and
`RedisLockRegistry` when a removal functionality is performed
* Add `AbstractKeyValueMessageStore.doRemoveAll(Collection<Object> ids)`
for optimization
* Implement `doRemoveAll()` in the `RedisMessageStore` and
`GemfireMessageStore`