### PR TITLE
INT-4509: Fix memory leak for static beans stores

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -29,7 +29,9 @@ import org.reactivestreams.Publisher;
 
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.config.DestructionAwareBeanPostProcessor;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.aggregator.AggregatingMessageHandler;
@@ -120,9 +122,9 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 
 	protected final Map<Object, String> integrationComponents = new LinkedHashMap<>();
 
-	protected MessageChannel currentMessageChannel;
+	private MessageChannel currentMessageChannel;
 
-	protected Object currentComponent;
+	private Object currentComponent;
 
 	private StandardIntegrationFlow integrationFlow;
 
@@ -479,7 +481,9 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 * @see ExpressionEvaluatingTransformer
 	 */
-	public B transform(String expression, Consumer<GenericEndpointSpec<MessageTransformingHandler>> endpointConfigurer) {
+	public B transform(String expression,
+			Consumer<GenericEndpointSpec<MessageTransformingHandler>> endpointConfigurer) {
+
 		Assert.hasText(expression, "'expression' must not be empty");
 		return transform(new ExpressionEvaluatingTransformer(PARSER.parseExpression(expression)),
 				endpointConfigurer);
@@ -2769,6 +2773,23 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 						+ replyHandler
 						+ ") - use @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE) on @Bean definition.");
 		REFERENCED_REPLY_PRODUCERS.add(replyHandler);
+	}
+
+	public static final class ReplyProducerCleaner implements DestructionAwareBeanPostProcessor {
+
+		private ReplyProducerCleaner() {
+		}
+
+		@Override
+		public boolean requiresDestruction(Object bean) {
+			return IntegrationFlowDefinition.REFERENCED_REPLY_PRODUCERS.contains(bean);
+		}
+
+		@Override
+		public void postProcessBeforeDestruction(Object bean, String beanName) throws BeansException {
+			IntegrationFlowDefinition.REFERENCED_REPLY_PRODUCERS.remove(bean);
+		}
+
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/DslIntegrationConfigurationInitializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/DslIntegrationConfigurationInitializer.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.integration.config.IntegrationConfigurationInitializer;
 import org.springframework.integration.dsl.IntegrationComponentSpec;
+import org.springframework.integration.dsl.IntegrationFlowDefinition;
 import org.springframework.util.Assert;
 
 /**
@@ -46,6 +47,9 @@ public class DslIntegrationConfigurationInitializer implements IntegrationConfig
 	private static final String INTEGRATION_FLOW_CONTEXT_BEAN_NAME =
 			Introspector.decapitalize(IntegrationFlowContext.class.getName());
 
+	private static final String INTEGRATION_FLOW_REPLY_PRODUCER_CLEANER_BEAN_NAME =
+			Introspector.decapitalize(IntegrationFlowDefinition.ReplyProducerCleaner.class.getName());
+
 	@Override
 	public void initialize(ConfigurableListableBeanFactory configurableListableBeanFactory) throws BeansException {
 		Assert.isInstanceOf(BeanDefinitionRegistry.class, configurableListableBeanFactory,
@@ -59,6 +63,8 @@ public class DslIntegrationConfigurationInitializer implements IntegrationConfig
 					new RootBeanDefinition(IntegrationFlowBeanPostProcessor.class));
 			registry.registerBeanDefinition(INTEGRATION_FLOW_CONTEXT_BEAN_NAME,
 					new RootBeanDefinition(StandardIntegrationFlowContext.class));
+			registry.registerBeanDefinition(INTEGRATION_FLOW_REPLY_PRODUCER_CLEANER_BEAN_NAME,
+					new RootBeanDefinition(IntegrationFlowDefinition.ReplyProducerCleaner.class));
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -64,6 +65,7 @@ import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlowAdapter;
+import org.springframework.integration.dsl.IntegrationFlowBuilder;
 import org.springframework.integration.dsl.IntegrationFlowDefinition;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.MessageChannels;
@@ -73,8 +75,10 @@ import org.springframework.integration.dsl.context.IntegrationFlowContext;
 import org.springframework.integration.dsl.context.IntegrationFlowContext.IntegrationFlowRegistration;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.handler.BridgeHandler;
 import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.support.SmartLifecycleRoleController;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.transformer.MessageTransformingHandler;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -111,6 +115,7 @@ public class ManualFlowTests {
 	private SmartLifecycleRoleController roleController;
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testWithAnonymousMessageProducerStart() {
 		final AtomicBoolean started = new AtomicBoolean();
 		MessageProducerSupport producer = new MessageProducerSupport() {
@@ -123,13 +128,26 @@ public class ManualFlowTests {
 
 		};
 		QueueChannel channel = new QueueChannel();
-		IntegrationFlow flow = IntegrationFlows.from(producer)
-				.channel(channel)
-				.get();
+		IntegrationFlowBuilder flowBuilder = IntegrationFlows.from(producer);
+
+		BridgeHandler bridgeHandler = new BridgeHandler();
+
+		IntegrationFlow flow =
+				flowBuilder.handle(bridgeHandler)
+						.channel(channel)
+						.get();
 		IntegrationFlowRegistration flowRegistration = this.integrationFlowContext.registration(flow).register();
 		assertTrue(started.get());
 
+
+		Set<MessageProducer> replyProducers =
+				TestUtils.getPropertyValue(flowBuilder, "REFERENCED_REPLY_PRODUCERS", Set.class);
+
+		assertTrue(replyProducers.contains(bridgeHandler));
+
 		flowRegistration.destroy();
+
+		assertFalse(replyProducers.contains(bridgeHandler));
 	}
 
 	@Test
@@ -184,12 +202,13 @@ public class ManualFlowTests {
 						.addBean(additionalBean)
 						.register();
 
+		String flowRegistrationId = flowRegistration.getId();
 		BeanFactoryHandler bean =
-				this.beanFactory.getBean(flowRegistration.getId() + BeanFactoryHandler.class.getName() + "#0",
+				this.beanFactory.getBean(flowRegistrationId + BeanFactoryHandler.class.getName() + "#0",
 						BeanFactoryHandler.class);
 		assertSame(additionalBean, bean);
 		assertSame(this.beanFactory, bean.beanFactory);
-		bean = this.beanFactory.getBean(flowRegistration.getId() + "." + "anId.handler", BeanFactoryHandler.class);
+		bean = this.beanFactory.getBean(flowRegistrationId + "." + "anId.handler", BeanFactoryHandler.class);
 
 		MessagingTemplate messagingTemplate = flowRegistration.getMessagingTemplate();
 		messagingTemplate.setReceiveTimeout(10000);
@@ -211,9 +230,9 @@ public class ManualFlowTests {
 
 		flowRegistration.destroy();
 
-		assertFalse(this.beanFactory.containsBean(flowRegistration.getId()));
-		assertFalse(this.beanFactory.containsBean(flowRegistration.getId() + ".input"));
-		assertFalse(this.beanFactory.containsBean(flowRegistration.getId() + BeanFactoryHandler.class.getName() + "#0"));
+		assertFalse(this.beanFactory.containsBean(flowRegistrationId));
+		assertFalse(this.beanFactory.containsBean(flowRegistrationId + ".input"));
+		assertFalse(this.beanFactory.containsBean(flowRegistrationId + BeanFactoryHandler.class.getName() + "#0"));
 
 		ThreadPoolTaskScheduler taskScheduler = this.beanFactory.getBean(ThreadPoolTaskScheduler.class);
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4509

To avoid a re-usage of the `AbstractReplyProducingMessageHandler`,
the `IntegrationFlowDefinition` and `AbstractStandardMessageHandlerFactoryBean`
have a `static Set<>` to store already used producers and check it for
newly provided.
These stores are not cleaned when beans are destroyed leading to memory
leaks

* Implements a `DisposableBean` for the `AbstractStandardMessageHandlerFactoryBean`
to remove its `replyHandler` from the `referencedReplyProducers` on
`destroy()`
* Introduce a `IntegrationFlowDefinition.ReplyProducerCleaner` - an
`DestructionAwareBeanPostProcessor` to clean up removing `MessageProducer`
from the `IntegrationFlowDefinition.REFERENCED_REPLY_PRODUCERS`

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
