### PR TITLE
INT-4510: Test no memory leak in FluxMessageChannel

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/FluxMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/FluxMessageChannel.java
@@ -84,6 +84,7 @@ public class FluxMessageChannel extends AbstractMessageChannel
 						.handle((message, sink) -> sink.next(send(message)))
 						.onErrorContinue()
 						.doOnComplete(() -> this.publishers.remove(publisher))
+						.hide() // TODO remove after upgrade to Reactor 3.1.9.RELEASE or later
 						.publish();
 
 		this.publishers.put(publisher, connectableFlux);


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4510

Related to https://github.com/reactor/reactor-core/issues/1290

The `Flux.publish()` and subsequent `connect()` doesn't fuse a subscriber
for the hooks flow is interrupted (complete, or error, or disconnect).
In this case the `FluxMessageChannel.publishers` store is not cleared
from the finished publishers

* Add test-case to check the `FluxMessageChannel.publishers` store after
finishing the stream
* Add `hide()` operator with TODO to remove when an appropriate Reactor
version is ready

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
