### PR TITLE
Fix memory leak in MHistorConfig & MBeanExpHelper

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/history/MessageHistoryConfigurer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/history/MessageHistoryConfigurer.java
@@ -56,7 +56,7 @@ public class MessageHistoryConfigurer implements SmartLifecycle, BeanFactoryAwar
 
 	private final Set<TrackableComponent> currentlyTrackedComponents = ConcurrentHashMap.newKeySet();
 
-	private String[] componentNamePatterns = new String[] { "*" };
+	private String[] componentNamePatterns = new String[]{ "*" };
 
 	private boolean componentNamePatternsExplicitlySet;
 
@@ -98,7 +98,7 @@ public class MessageHistoryConfigurer implements SmartLifecycle, BeanFactoryAwar
 	 */
 	@ManagedAttribute(description = "comma-delimited list of patterns; must invoke stop() before changing.")
 	public void setComponentNamePatternsString(String componentNamePatterns) {
-		this.setComponentNamePatterns(StringUtils.delimitedListToStringArray(componentNamePatterns, ",", " "));
+		setComponentNamePatterns(StringUtils.delimitedListToStringArray(componentNamePatterns, ",", " "));
 	}
 
 	@ManagedAttribute

--- a/spring-integration-core/src/main/java/org/springframework/integration/history/MessageHistoryConfigurer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/history/MessageHistoryConfigurer.java
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.ListableBeanFactory;
-import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.config.DestructionAwareBeanPostProcessor;
 import org.springframework.beans.factory.support.BeanDefinitionValidationException;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.integration.support.management.IntegrationManagedResource;
@@ -50,7 +50,7 @@ import org.springframework.util.StringUtils;
  */
 @ManagedResource
 @IntegrationManagedResource
-public class MessageHistoryConfigurer implements SmartLifecycle, BeanFactoryAware, BeanPostProcessor {
+public class MessageHistoryConfigurer implements SmartLifecycle, BeanFactoryAware, DestructionAwareBeanPostProcessor {
 
 	private final Log logger = LogFactory.getLog(this.getClass());
 
@@ -158,6 +158,16 @@ public class MessageHistoryConfigurer implements SmartLifecycle, BeanFactoryAwar
 				this.logger.info("Enabling MessageHistory tracking for component '" + componentName + "'");
 			}
 		}
+	}
+
+	@Override
+	public boolean requiresDestruction(Object bean) {
+		return bean instanceof TrackableComponent;
+	}
+
+	@Override
+	public void postProcessBeforeDestruction(Object bean, String beanName) throws BeansException {
+		this.currentlyTrackedComponents.remove(bean);
 	}
 
 	/*


### PR DESCRIPTION
The `MessageHistoryConfigurer` is a `BeanPostProcessor` which keeps a
store of the `TrackableComponent`.
Something similar we have with the `MBeanExporterHelper` and its local
stores populated by the `postProcessBeforeInitialization()`

* Implement `DestructionAwareBeanPostProcessor` in the
`MessageHistoryConfigurer` and `MBeanExporterHelper` to remove destroyed
beans from their caches

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
