### PR TITLE
Fix jdbc doc

### DIFF
--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -298,7 +298,6 @@ The reply message is then generated from the result, like the inbound adapter, a
     reply-channel="output"
     data-source="dataSource"/>
 ----
-====
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
We need to consider to replace docs for have just released version `5.0.7`.
Everything is broken after this section https://docs.spring.io/spring-integration/docs/5.0.7.RELEASE/reference/html/jdbc.html#jdbc-outbound-gateway