### PR TITLE
Add @NonNullApi where appropriate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 	}
 	dependencies {
 		classpath 'io.spring.gradle:docbook-reference-plugin:0.3.1'
-		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
+		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.8'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 		classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"
 	}
@@ -97,6 +97,7 @@ subprojects { subproject ->
 		derbyVersion = '10.13.1.1'
 		eclipseLinkVersion = '2.7.1'
 		ftpServerVersion = '1.1.1'
+		googleJsr305Version = '3.0.2'
 		groovyVersion = '2.4.15'
 		guavaVersion = '20.0'
 		hamcrestVersion = '1.3'
@@ -161,7 +162,8 @@ subprojects { subproject ->
 		}
 
 		// JSR-305 only used for non-required meta-annotations
-		compileOnly("com.google.code.findbugs:jsr305:3.0.2")
+		compileOnly("com.google.code.findbugs:jsr305:$googleJsr305Version")
+		testCompile("com.google.code.findbugs:jsr305:$googleJsr305Version")
 
 		testCompile "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
 		testRuntime "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
@@ -760,16 +762,16 @@ asciidoctor {
 	logDocuments = true
 	options = [
 		doctype: 'book',
-		attributes: [
-			docinfo: '',
-			toc2: '',
-			'compat-mode': '',
-			imagesdir: '',
-			stylesdir: "stylesheets/",
-			stylesheet: 'golo.css',
-			'spring-integration-version': "$version",
-			'source-highlighter': 'highlightjs'
-		]
+	]
+	attributes = [
+		docinfo: '',
+		toc2: '',
+		'compat-mode': '',
+		imagesdir: '',
+		stylesdir: "stylesheets/",
+		stylesheet: 'golo.css',
+		'spring-integration-version': "$version",
+		'source-highlighter': 'highlightjs'
 	]
 }
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/package-info.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Base package for AMQP support.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.integration.amqp;

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/AmqpMessageHeaderErrorMessageStrategy.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/AmqpMessageHeaderErrorMessageStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.core.AttributeAccessor;
 import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.ErrorMessage;
 
@@ -45,7 +46,7 @@ public class AmqpMessageHeaderErrorMessageStrategy implements ErrorMessageStrate
 	public static final String AMQP_RAW_MESSAGE = AmqpHeaders.PREFIX + "raw_message";
 
 	@Override
-	public ErrorMessage buildErrorMessage(Throwable throwable, AttributeAccessor context) {
+	public ErrorMessage buildErrorMessage(Throwable throwable, @Nullable AttributeAccessor context) {
 		Object inputMessage = context == null ? null
 				: context.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
 		Map<String, Object> headers = context == null ? new HashMap<String, Object>() :

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/MappingUtils.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/MappingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.amqp.support.converter.ContentTypeDelegatingMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.MimeType;
@@ -94,7 +95,7 @@ public final class MappingUtils {
 	 * @param defaultDeliveryMode the default delivery mode.
 	 */
 	public static void checkDeliveryMode(Message<?> requestMessage, MessageProperties messageProperties,
-			MessageDeliveryMode defaultDeliveryMode) {
+			@Nullable MessageDeliveryMode defaultDeliveryMode) {
 		if (defaultDeliveryMode != null &&
 				requestMessage.getHeaders().get(AmqpHeaders.DELIVERY_MODE) == null) {
 			messageProperties.setDeliveryMode(defaultDeliveryMode);

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/NackedAmqpMessageException.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/NackedAmqpMessageException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.amqp.support;
 
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 
@@ -35,7 +36,7 @@ public class NackedAmqpMessageException extends MessagingException {
 
 	private final String nackReason;
 
-	public NackedAmqpMessageException(Message<?> message, Object correlationData, String nackReason) {
+	public NackedAmqpMessageException(Message<?> message, @Nullable Object correlationData, String nackReason) {
 		super(message);
 		this.correlationData = correlationData;
 		this.nackReason = nackReason;

--- a/spring-integration-core/src/main/java/org/springframework/integration/acks/AckUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/acks/AckUtils.java
@@ -50,7 +50,7 @@ public final class AckUtils {
 	 * and is not already ack'd.
 	 * @param ackCallback the callback.
 	 */
-	public static void autoAck(AcknowledgmentCallback ackCallback) {
+	public static void autoAck(@Nullable AcknowledgmentCallback ackCallback) {
 		if (ackCallback != null && ackCallback.isAutoAck() && !ackCallback.isAcknowledged()) {
 			ackCallback.acknowledge(Status.ACCEPT);
 		}
@@ -61,7 +61,7 @@ public final class AckUtils {
 	 * and is not already ack'd.
 	 * @param ackCallback the callback.
 	 */
-	public static void autoNack(AcknowledgmentCallback ackCallback) {
+	public static void autoNack(@Nullable AcknowledgmentCallback ackCallback) {
 		if (ackCallback != null && ackCallback.isAutoAck() && !ackCallback.isAcknowledged()) {
 			ackCallback.acknowledge(Status.REJECT);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/acks/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/acks/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes related to message acknowledgment.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.integration.acks;

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractPollableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractPollableChannel.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.springframework.integration.support.management.PollableChannelManagement;
 import org.springframework.integration.support.management.metrics.CounterFacade;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -71,6 +72,7 @@ public abstract class AbstractPollableChannel extends AbstractMessageChannel
 	 * receiving thread is interrupted.
 	 */
 	@Override
+	@Nullable
 	public Message<?> receive() {
 		return receive(-1);
 	}
@@ -89,6 +91,7 @@ public abstract class AbstractPollableChannel extends AbstractMessageChannel
 	 * interrupted.
 	 */
 	@Override
+	@Nullable
 	public Message<?> receive(long timeout) {
 		ChannelInterceptorList interceptorList = getInterceptors();
 		Deque<ChannelInterceptor> interceptorStack = null;

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes representing various channel types.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.integration.channel;

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes supporting messaging gateways.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.integration.gateway;

--- a/spring-integration-core/src/main/java/org/springframework/integration/leader/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/leader/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Temporary package until s-c-c-core is released.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.integration.leader;

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes related to mapping to/from message headers.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.integration.mapping;

--- a/spring-integration-core/src/main/java/org/springframework/integration/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/package-info.java
@@ -3,4 +3,5 @@
  *
  * Provides fundamental classes.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.integration;

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Base core support package.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.integration.support;

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/support/package-info.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/support/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides various support classes used across Spring Integration File Components.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.integration.file.support;

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/package-info.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/package-info.java
@@ -2,5 +2,6 @@
  * All things related to tcp connections - client and
  * server factories; listener and sender interfaces.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.integration.ip.tcp.connection;
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/package-info.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Base package for UDP support.
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.integration.ip.udp;

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/dsl/MongoDbTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/dsl/MongoDbTests.java
@@ -59,6 +59,7 @@ import com.mongodb.client.MongoCollection;
 
 /**
  * @author Xavier Padró
+ * @author Gary Russell
  *
  * @since 5.0
  */
@@ -314,7 +315,7 @@ public class MongoDbTests extends MongoDbAvailableTests {
 		@Bean
 		public IntegrationFlow gatewayCollectionCallbackFlow() {
 			return f -> f
-					.handle(collectionCallbackOutboundGateway(MongoCollection::count))
+					.handle(collectionCallbackOutboundGateway(MongoCollection::countDocuments))
 					.channel(getResultChannel());
 		}
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGatewayTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ import com.mongodb.client.MongoCollection;
 
 /**
  * @author Xavier Padró
+ * @author Gary Russell
  * @since 5.0
  */
 @ContextConfiguration
@@ -313,7 +314,7 @@ public class MongoDbOutboundGatewayTests extends MongoDbAvailableTests {
 		gateway.setEntityClass(Person.class);
 		gateway.setCollectionNameExpression(new LiteralExpression("data"));
 
-		gateway.setCollectionCallback(MongoCollection::count);
+		gateway.setCollectionCallback(MongoCollection::countDocuments);
 		gateway.afterPropertiesSet();
 
 		long result = (long) gateway.handleRequestMessage(message);

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisUtils.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisUtils.java
@@ -18,6 +18,7 @@ package org.springframework.integration.redis.util;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.springframework.data.redis.core.RedisCallback;
@@ -41,9 +42,8 @@ public final class RedisUtils {
 	private static final Map<RedisOperations<?, ?>, Boolean> unlinkAvailable =
 			new LinkedHashMap<RedisOperations<?, ?>, Boolean>() {
 
-				@SuppressWarnings("rawtypes")
 				@Override
-				protected boolean removeEldestEntry(Map.Entry eldest) {
+				protected boolean removeEldestEntry(Entry<RedisOperations<?, ?>, Boolean> eldest) {
 					return size() > 100;
 				}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisUtils.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisUtils.java
@@ -27,6 +27,7 @@ import org.springframework.data.redis.core.RedisOperations;
  * A set of utility methods for common Redis functions.
  *
  * @author Artem Bilan
+ * @author Gary Russell
  *
  * @since 5.1
  */
@@ -36,9 +37,11 @@ public final class RedisUtils {
 
 	private static final String VERSION_PROPERTY = "redis_version";
 
+	@SuppressWarnings("serial")
 	private static final Map<RedisOperations<?, ?>, Boolean> unlinkAvailable =
 			new LinkedHashMap<RedisOperations<?, ?>, Boolean>() {
 
+				@SuppressWarnings("rawtypes")
 				@Override
 				protected boolean removeEldestEntry(Map.Entry eldest) {
 					return size() > 100;

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests.java
@@ -118,7 +118,7 @@ public class DelayerHandlerRescheduleIntegrationTests extends RedisAvailableTest
 
 		assertEquals(1, messageStore.getMessageGroupCount());
 		int n = 0;
-		while (n++ < 200 && messageStore.messageGroupSize(delayerMessageGroupId) > 0) {
+		while (n++ < 300 && messageStore.messageGroupSize(delayerMessageGroupId) > 0) {
 			Thread.sleep(100);
 		}
 		assertEquals(0, messageStore.messageGroupSize(delayerMessageGroupId));


### PR DESCRIPTION
Packages with `@Nullable` annotations need to have `@NonNulApi` at the package level.

There may be classes in these packages that have nullable arguments/returns that are
not currently marked as `@Nullable`. These will be fixed over time.

Also suppress JSR305 warnings when compiling tests.

 