### PR TITLE
INT-4518: Channel late-binding in Messaging Anns

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/BridgeFromAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/BridgeFromAnnotationPostProcessor.java
@@ -73,9 +73,8 @@ public class BridgeFromAnnotationPostProcessor extends AbstractMethodAnnotationP
 	@Override
 	protected MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations) {
 		BridgeHandler handler = new BridgeHandler();
-		Object outputChannel = resolveTargetBeanFromMethodWithBeanAnnotation(method);
-		Assert.isInstanceOf(MessageChannel.class, outputChannel);
-		handler.setOutputChannel((MessageChannel) outputChannel);
+		String outputChannelName = resolveTargetBeanName(method);
+		handler.setOutputChannelName(outputChannelName);
 		return handler;
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/BridgeFromIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/BridgeFromIntegrationTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.config.annotation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.integration.annotation.BridgeFrom;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 5.0.8
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = BridgeFromIntegrationTests.RootTestConfiguration.class)
+public class BridgeFromIntegrationTests {
+
+	@Autowired
+	private MessageChannel gatewayChannel;
+
+	@Autowired
+	private PollableChannel outputChannel;
+
+	@Test
+	public void testBridgeFromConfiguration() {
+		this.gatewayChannel.send(new GenericMessage<>("world"));
+
+		Message<?> receive = this.outputChannel.receive(10_000);
+
+		assertNotNull(receive);
+		assertEquals("hello world", receive.getPayload());
+	}
+
+
+	@Configuration
+	@EnableIntegration
+	@ComponentScan(
+			basePackageClasses = BridgeFromIntegrationTests.class,
+			useDefaultFilters = false,
+			includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+					classes = { AnnotatedTestService.class, ScannedTestConfiguration.class }))
+	public static class RootTestConfiguration {
+
+	}
+
+	@Configuration
+	public static class ScannedTestConfiguration {
+
+		@Bean
+		@BridgeFrom("gatewayChannel")
+		public DirectChannel inputChannel() {
+			return new DirectChannel();
+		}
+
+
+		@Bean
+		public DirectChannel gatewayChannel() {
+			return new DirectChannel();
+		}
+
+
+		@Bean
+		public PollableChannel outputChannel() {
+			return new QueueChannel();
+		}
+
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4518

* Fix `BridgeFromAnnotationPostProcessor` do not resolve `outputChannel`
for the target `BridgeHandler`
* Rework logic in the `AbstractMethodAnnotationPostProcessor` to do not
resolve a `MessageHandler` bean from the `@Bean` method when we can
just check a method return type.
* Check `BeanDefinition` instead of real bean when we consult for
conditions

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
