### PR TITLE
Move LeaderInitiators to later phase

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
@@ -151,7 +151,7 @@ public class LockRegistryLeaderInitiator implements SmartLifecycle, DisposableBe
 	/**
 	 * @see SmartLifecycle which is an extension of org.springframework.context.Phased
 	 */
-	private int phase;
+	private int phase = Integer.MAX_VALUE - 1000;
 
 	/**
 	 * Flag that indicates whether the leadership election for this {@link #candidate} is

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/CuratorFrameworkFactoryBean.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/CuratorFrameworkFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,11 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.util.Assert;
 
 /**
- * A spring-friendly way to build a {@link CuratorFramework} and implementing {@link SmartLifecycle}.
+ * A Spring-friendly way to build a {@link CuratorFramework} and implementing {@link SmartLifecycle}.
  *
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 4.2
  */
 public class CuratorFrameworkFactoryBean implements FactoryBean<CuratorFramework>, SmartLifecycle {
@@ -42,17 +43,17 @@ public class CuratorFrameworkFactoryBean implements FactoryBean<CuratorFramework
 	/**
 	 * @see SmartLifecycle
 	 */
-	private volatile boolean autoStartup = true;
+	private boolean autoStartup = true;
+
+	/**
+	 * @see SmartLifecycle
+	 */
+	private int phase = Integer.MIN_VALUE + 1000;
 
 	/**
 	 * @see SmartLifecycle
 	 */
 	private volatile boolean running;
-
-	/**
-	 * @see SmartLifecycle
-	 */
-	private volatile int phase;
 
 
 	/**
@@ -135,7 +136,7 @@ public class CuratorFrameworkFactoryBean implements FactoryBean<CuratorFramework
 	}
 
 	@Override
-	public CuratorFramework getObject() throws Exception {
+	public CuratorFramework getObject() {
 		return this.client;
 	}
 

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/LeaderInitiatorFactoryBean.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/LeaderInitiatorFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.integration.zookeeper.leader.LeaderInitiator;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 4.2
  */
 public class LeaderInitiatorFactoryBean
@@ -51,7 +52,7 @@ public class LeaderInitiatorFactoryBean
 
 	private boolean autoStartup = true;
 
-	private int phase;
+	private int phase = Integer.MAX_VALUE - 1000;
 
 	private ApplicationEventPublisher applicationEventPublisher;
 
@@ -136,11 +137,11 @@ public class LeaderInitiatorFactoryBean
 		if (this.leaderInitiator != null) {
 			return this.leaderInitiator.getPhase();
 		}
-		return 0;
+		return this.phase;
 	}
 
 	@Override
-	public void afterPropertiesSet() throws Exception {
+	public void afterPropertiesSet() {
 		if (this.leaderInitiator == null) {
 			this.leaderInitiator = new LeaderInitiator(this.client, this.candidate, this.path);
 			this.leaderInitiator.setPhase(this.phase);
@@ -156,7 +157,7 @@ public class LeaderInitiatorFactoryBean
 	}
 
 	@Override
-	public synchronized LeaderInitiator getObject() throws Exception {
+	public synchronized LeaderInitiator getObject() {
 		return this.leaderInitiator;
 	}
 

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/leader/LeaderInitiator.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/leader/LeaderInitiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ public class LeaderInitiator implements SmartLifecycle {
 	/**
 	 * @see SmartLifecycle which is an extension of org.springframework.context.Phased
 	 */
-	private volatile int phase;
+	private volatile int phase = Integer.MAX_VALUE - 1000;
 
 	/**
 	 * Flag that indicates whether the leadership election for


### PR DESCRIPTION
There is a race condition when Zookeeper `LeaderInitiator` may start
earlier than `CuratorFramework` it depends on.
This is because both of them are configured for the same default `phase` (`0`)

* Make `LeaderInitiator` and `LockRegistryLeaderInitiator` to be started
in the `Integer.MAX_VALUE - 1000` phase by default - as late as possible
* Make `CuratorFrameworkFactoryBean` to start in the `Integer.MIN_VALUE + 1000`
phase - as early as possible
* Alight lifecycle properties from the `LeaderInitiatorFactoryBean` with
defaults in the `LeaderInitiator`
* Simplify a `LeaderListenerParser` to rely on the `LeaderInitiatorFactoryBean`

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
