### PR TITLE
INT-4519: Improve JMS inbound-c-a receiveTimeout

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/DynamicJmsTemplate.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/DynamicJmsTemplate.java
@@ -31,6 +31,8 @@ import org.springframework.util.Assert;
  */
 public class DynamicJmsTemplate extends JmsTemplate {
 
+	private static final long NO_CACHING_RECEIVE_TIMEOUT = 1000L;
+
 	private boolean receiveTimeoutExplicitlySet;
 
 	@Override
@@ -48,7 +50,7 @@ public class DynamicJmsTemplate extends JmsTemplate {
 				super.setReceiveTimeout(JmsDestinationAccessor.RECEIVE_TIMEOUT_NO_WAIT);
 			}
 			else {
-				super.setReceiveTimeout(1000);
+				super.setReceiveTimeout(NO_CACHING_RECEIVE_TIMEOUT);
 			}
 		}
 	}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsInboundChannelAdapterParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsInboundChannelAdapterParser.java
@@ -50,7 +50,6 @@ public class JmsInboundChannelAdapterParser extends AbstractPollingInboundChanne
 		String jmsTemplate = element.getAttribute(JmsParserUtils.JMS_TEMPLATE_ATTRIBUTE);
 		String destination = element.getAttribute(JmsParserUtils.DESTINATION_ATTRIBUTE);
 		String destinationName = element.getAttribute(JmsParserUtils.DESTINATION_NAME_ATTRIBUTE);
-		String headerMapper = element.getAttribute(JmsParserUtils.HEADER_MAPPER_ATTRIBUTE);
 		boolean hasJmsTemplate = StringUtils.hasText(jmsTemplate);
 		boolean hasDestinationRef = StringUtils.hasText(destination);
 		boolean hasDestinationName = StringUtils.hasText(destinationName);
@@ -80,9 +79,7 @@ public class JmsInboundChannelAdapterParser extends AbstractPollingInboundChanne
 					+ JmsParserUtils.DESTINATION_NAME_ATTRIBUTE +
 					"' attributes must be provided for a polling JMS adapter", parserContext.extractSource(element));
 		}
-		if (StringUtils.hasText(headerMapper)) {
-			builder.addPropertyReference(JmsParserUtils.HEADER_MAPPER_PROPERTY, headerMapper);
-		}
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, JmsParserUtils.HEADER_MAPPER_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "selector", "messageSelector");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "extract-payload");
 		return builder.getBeanDefinition();

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundChannelAdapterParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class JmsOutboundChannelAdapterParser extends AbstractOutboundChannelAdapterParser {
 
@@ -42,7 +43,6 @@ public class JmsOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 		String destination = element.getAttribute(JmsParserUtils.DESTINATION_ATTRIBUTE);
 		String destinationName = element.getAttribute(JmsParserUtils.DESTINATION_NAME_ATTRIBUTE);
 		String destinationExpression = element.getAttribute(JmsParserUtils.DESTINATION_EXPRESSION_ATTRIBUTE);
-		String headerMapper = element.getAttribute(JmsParserUtils.HEADER_MAPPER_ATTRIBUTE);
 		boolean hasJmsTemplate = StringUtils.hasText(jmsTemplate);
 		boolean hasDestinationRef = StringUtils.hasText(destination);
 		boolean hasDestinationName = StringUtils.hasText(destinationName);
@@ -79,9 +79,8 @@ public class JmsOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 					JmsParserUtils.DESTINATION_EXPRESSION_ATTRIBUTE +
 					"' attributes must be provided", parserContext.extractSource(element));
 		}
-		if (StringUtils.hasText(headerMapper)) {
-			builder.addPropertyReference(JmsParserUtils.HEADER_MAPPER_PROPERTY, headerMapper);
-		}
+
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, JmsParserUtils.HEADER_MAPPER_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "extract-payload");
 		return builder.getBeanDefinition();
 	}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsParserUtils.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsParserUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.jms.DynamicJmsTemplate;
-import org.springframework.jms.core.JmsTemplate;
 import org.springframework.util.StringUtils;
 
 /**
@@ -31,6 +30,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 abstract class JmsParserUtils {
 
@@ -63,7 +63,7 @@ abstract class JmsParserUtils {
 	static final String HEADER_MAPPER_PROPERTY = "headerMapper";
 
 	private static final String[] JMS_TEMPLATE_ATTRIBUTES = {
-		"connection-factory", "message-converter", "destination-resolver", "pub-sub-domain",
+			CONNECTION_FACTORY_ATTRIBUTE, "message-converter", "destination-resolver", PUB_SUB_DOMAIN_ATTRIBUTE,
 		"time-to-live", "priority", "delivery-persistent", "explicit-qos-enabled", "acknowledge",
 		"receive-timeout", "session-transacted"
 	};
@@ -86,18 +86,12 @@ abstract class JmsParserUtils {
 				determineConnectionFactoryBeanName(element, parserContext));
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "destination-resolver");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "pub-sub-domain");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, PUB_SUB_DOMAIN_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "time-to-live");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "priority");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "delivery-persistent");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "explicit-qos-enabled");
-		String receiveTimeout = element.getAttribute("receive-timeout");
-		if (StringUtils.hasText(receiveTimeout)) {
-			builder.addPropertyValue("receiveTimeout", receiveTimeout);
-		}
-		else {
-			builder.addPropertyValue("receiveTimeout", JmsTemplate.RECEIVE_TIMEOUT_NO_WAIT);
-		}
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "receive-timeout");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "session-transacted");
 		return builder.getBeanDefinition();
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
@@ -60,6 +60,7 @@ import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.integration.dsl.Pollers;
 import org.springframework.integration.endpoint.MethodInvokingMessageSource;
+import org.springframework.integration.jms.JmsDestinationPollingSource;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
@@ -107,6 +108,9 @@ public class JmsTests {
 	@Autowired
 	@Qualifier("jmsOutboundInboundReplyChannel")
 	private PollableChannel jmsOutboundInboundReplyChannel;
+
+	@Autowired
+	private JmsDestinationPollingSource jmsDestinationPollingSource;
 
 	@Autowired
 	@Qualifier("jmsOutboundGatewayFlow.input")
@@ -161,6 +165,11 @@ public class JmsTests {
 
 	@Test
 	public void testJmsOutboundInboundFlow() {
+		JmsTemplate jmsTemplate =
+				TestUtils.getPropertyValue(this.jmsDestinationPollingSource, "jmsTemplate", JmsTemplate.class);
+
+		assertEquals(JmsTemplate.RECEIVE_TIMEOUT_NO_WAIT, jmsTemplate.getReceiveTimeout());
+
 		this.jmsOutboundInboundChannel.send(MessageBuilder.withPayload("hello THROUGH the JMS")
 				.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "jmsInbound")
 				.build());

--- a/src/reference/asciidoc/jms.adoc
+++ b/src/reference/asciidoc/jms.adoc
@@ -63,6 +63,8 @@ If you prefer to have the raw JMS message as the Spring Integration message's pa
 ----
 ====
 
+Starting with version 5.1, a default value of the `receive-timeout` is `-1` (no wait) for the `org.springframework.jms.connection.CachingConnectionFactory` and `cacheConsumers`, otherwise it is 1 second.
+
 [[jms-ib-transactions]]
 ==== Transactions
 
@@ -513,7 +515,7 @@ The default is a `SimpleMessageConverter`.
 Overridden by the message priority header, if present.
 Its range is `0` to `9`.
 This setting takes effect only if `explicit-qos-enabled` is `true`.
-<11> The time (in millseconds) to wait for a reply.
+<11> The time (in milliseconds) to wait for a reply.
 The default is `5000` (five seconds).
 <12> The channel to which the reply message is sent.
 <13> A reference to a `Destination`, which is set as the `JMSReplyTo` header.

--- a/src/reference/asciidoc/jms.adoc
+++ b/src/reference/asciidoc/jms.adoc
@@ -63,7 +63,7 @@ If you prefer to have the raw JMS message as the Spring Integration message's pa
 ----
 ====
 
-Starting with version 5.1, a default value of the `receive-timeout` is `-1` (no wait) for the `org.springframework.jms.connection.CachingConnectionFactory` and `cacheConsumers`, otherwise it is 1 second.
+Starting with version 5.0.8, a default value of the `receive-timeout` is `-1` (no wait) for the `org.springframework.jms.connection.CachingConnectionFactory` and `cacheConsumers`, otherwise it is 1 second.
 
 [[jms-ib-transactions]]
 ==== Transactions


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4519

* Modify `DynamicJmsTemplate` to default for `-1` if we get
`CachingConnectionFactory` and it is with `cacheConsumers`, otherwise
1 second
* Polishing for some JMS XML parsers, in particular remove
`receiveTimeout` population

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
