### PR TITLE
MQTT: completionTimeout should be long

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
@@ -51,21 +51,21 @@ import org.springframework.util.Assert;
 public class MqttPahoMessageDrivenChannelAdapter extends AbstractMqttMessageDrivenChannelAdapter
 		implements MqttCallback, ApplicationEventPublisherAware {
 
-	private static final int DEFAULT_COMPLETION_TIMEOUT = 30000;
+	public static final long DEFAULT_COMPLETION_TIMEOUT = 30000L;
 
 	private static final int DEFAULT_RECOVERY_INTERVAL = 10000;
 
 	private final MqttPahoClientFactory clientFactory;
 
-	private volatile IMqttClient client;
+	private IMqttClient client;
+
+	private long completionTimeout = DEFAULT_COMPLETION_TIMEOUT;
+
+	private int recoveryInterval = DEFAULT_RECOVERY_INTERVAL;
 
 	private volatile ScheduledFuture<?> reconnectFuture;
 
 	private volatile boolean connected;
-
-	private volatile int completionTimeout = DEFAULT_COMPLETION_TIMEOUT;
-
-	private volatile int recoveryInterval = DEFAULT_RECOVERY_INTERVAL;
 
 	private volatile boolean cleanSession;
 
@@ -114,11 +114,11 @@ public class MqttPahoMessageDrivenChannelAdapter extends AbstractMqttMessageDriv
 
 	/**
 	 * Set the completion timeout for operations. Not settable using the namespace.
-	 * Default 30000 milliseconds.
+	 * Default {@value #DEFAULT_COMPLETION_TIMEOUT} milliseconds.
 	 * @param completionTimeout The timeout.
 	 * @since 4.1
 	 */
-	public void setCompletionTimeout(int completionTimeout) {
+	public void setCompletionTimeout(long completionTimeout) {
 		this.completionTimeout = completionTimeout;
 	}
 

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/MqttPahoMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/MqttPahoMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,17 +45,17 @@ import org.springframework.util.Assert;
 public class MqttPahoMessageHandler extends AbstractMqttMessageHandler
 		implements MqttCallback, ApplicationEventPublisherAware {
 
-	private static final int DEFAULT_COMPLETION_TIMEOUT = 30000;
+	public static final long DEFAULT_COMPLETION_TIMEOUT = 30000L;
 
-	private volatile int completionTimeout = DEFAULT_COMPLETION_TIMEOUT;
+	private long completionTimeout = DEFAULT_COMPLETION_TIMEOUT;
 
 	private final MqttPahoClientFactory clientFactory;
 
-	private volatile IMqttAsyncClient client;
+	private IMqttAsyncClient client;
 
-	private volatile boolean async;
+	private boolean async;
 
-	private volatile boolean asyncEvents;
+	private boolean asyncEvents;
 
 	private volatile ApplicationEventPublisher applicationEventPublisher;
 
@@ -118,11 +118,11 @@ public class MqttPahoMessageHandler extends AbstractMqttMessageHandler
 
 	/**
 	 * Set the completion timeout for async operations. Not settable using the namespace.
-	 * Default 30000 milliseconds.
+	 * Default {@value #DEFAULT_COMPLETION_TIMEOUT} milliseconds.
 	 * @param completionTimeout The timeout.
 	 * @since 4.1
 	 */
-	public void setCompletionTimeout(int completionTimeout) {
+	public void setCompletionTimeout(long completionTimeout) {
 		this.completionTimeout = completionTimeout;
 	}
 


### PR DESCRIPTION
Incorrectly `int` - inconvenient cast required when using `Duration.toMillis()`.

**cherry-pick to 5.0.x**

