### PR TITLE
Fix DynamicPeriodicTrigger

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/SimpleActiveIdleMessageSourceAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/SimpleActiveIdleMessageSourceAdvice.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.aop;
 
+import java.time.Duration;
+
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.util.DynamicPeriodicTrigger;
 import org.springframework.messaging.Message;
@@ -32,15 +34,15 @@ public class SimpleActiveIdleMessageSourceAdvice extends AbstractMessageSourceAd
 
 	private final DynamicPeriodicTrigger trigger;
 
-	private volatile long idlePollPeriod;
+	private volatile Duration idlePollPeriod;
 
-	private volatile long activePollPeriod;
+	private volatile Duration activePollPeriod;
 
 
 	public SimpleActiveIdleMessageSourceAdvice(DynamicPeriodicTrigger trigger) {
 		this.trigger = trigger;
-		this.idlePollPeriod = trigger.getPeriod();
-		this.activePollPeriod = trigger.getPeriod();
+		this.idlePollPeriod = trigger.getDuration();
+		this.activePollPeriod = trigger.getDuration();
 	}
 
 	/**
@@ -49,7 +51,7 @@ public class SimpleActiveIdleMessageSourceAdvice extends AbstractMessageSourceAd
 	 * @param idlePollPeriod the period in milliseconds.
 	 */
 	public void setIdlePollPeriod(long idlePollPeriod) {
-		this.idlePollPeriod = idlePollPeriod;
+		this.idlePollPeriod = Duration.ofMillis(idlePollPeriod);
 	}
 
 	/**
@@ -58,16 +60,16 @@ public class SimpleActiveIdleMessageSourceAdvice extends AbstractMessageSourceAd
 	 * @param activePollPeriod the period in milliseconds.
 	 */
 	public void setActivePollPeriod(long activePollPeriod) {
-		this.activePollPeriod = activePollPeriod;
+		this.activePollPeriod = Duration.ofMillis(activePollPeriod);
 	}
 
 	@Override
 	public Message<?> afterReceive(Message<?> result, MessageSource<?> source) {
 		if (result == null) {
-			this.trigger.setPeriod(this.idlePollPeriod);
+			this.trigger.setDuration(this.idlePollPeriod);
 		}
 		else {
-			this.trigger.setPeriod(this.activePollPeriod);
+			this.trigger.setDuration(this.activePollPeriod);
 		}
 		return result;
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollerAdviceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollerAdviceTests.java
@@ -257,7 +257,7 @@ public class PollerAdviceTests {
 		final LinkedList<Long> triggerPeriods = new LinkedList<>();
 		final DynamicPeriodicTrigger trigger = new DynamicPeriodicTrigger(10);
 		adapter.setSource(() -> {
-			triggerPeriods.add(trigger.getPeriod());
+			triggerPeriods.add(trigger.getDuration().toMillis());
 			Message<Object> m = null;
 			if (latch.getCount() % 2 == 0) {
 				m = new GenericMessage<>("foo");


### PR DESCRIPTION
- inconsistent use of internal `TimeUnit`
- `setPeriod()` applied the unit, but `getPeriod()` did not

This test failed...

```java
@Test
public void testTriggerConsistency() {
	final DynamicPeriodicTrigger trigger = new DynamicPeriodicTrigger(10, TimeUnit.SECONDS);
	trigger.setPeriod(trigger.getPeriod());
	assertThat(trigger.getPeriod(), equalTo(10_000));
}
```

Change the trigger to use `Duration` and deprecate the other methods.
