### PR TITLE
INT-4526: Fix Channel Interceptor NonNullApi Call

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PollableAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PollableAmqpChannel.java
@@ -188,30 +188,33 @@ public class PollableAmqpChannel extends AbstractAmqpChannel
 				}
 			}
 			Object object = performReceive(timeout);
+			Message<?> message = null;
 			if (object == null) {
 				if (isLoggingEnabled() && logger.isTraceEnabled()) {
 					logger.trace("postReceive on channel '" + this + "', message is null");
 				}
-				return null;
-			}
-			if (countsEnabled) {
-				getMetrics().afterReceive();
-				counted = true;
-			}
-			Message<?> message;
-			if (object instanceof Message<?>) {
-				message = (Message<?>) object;
 			}
 			else {
-				message = getMessageBuilderFactory()
-						.withPayload(object)
-						.build();
-			}
-			if (isLoggingEnabled() && logger.isDebugEnabled()) {
-				logger.debug("postReceive on channel '" + this + "', message: " + message);
+				if (countsEnabled) {
+					getMetrics().afterReceive();
+					counted = true;
+				}
+				if (object instanceof Message<?>) {
+					message = (Message<?>) object;
+				}
+				else {
+					message = getMessageBuilderFactory()
+							.withPayload(object)
+							.build();
+				}
+				if (isLoggingEnabled() && logger.isDebugEnabled()) {
+					logger.debug("postReceive on channel '" + this + "', message: " + message);
+				}
 			}
 			if (interceptorStack != null) {
-				message = interceptorList.postReceive(message, this);
+				if (message != null) {
+					message = interceptorList.postReceive(message, this);
+				}
 				interceptorList.afterReceiveCompletion(message, this, null, interceptorStack);
 			}
 			return message;

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractPollableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractPollableChannel.java
@@ -123,7 +123,9 @@ public abstract class AbstractPollableChannel extends AbstractMessageChannel
 				logger.trace("postReceive on channel '" + this + "', message is null");
 			}
 			if (!CollectionUtils.isEmpty(interceptorStack)) {
-				message = interceptorList.postReceive(message, this);
+				if (message != null) {
+					message = interceptorList.postReceive(message, this);
+				}
 				interceptorList.afterReceiveCompletion(message, this, null, interceptorStack);
 			}
 			return message;

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ChannelInterceptorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/interceptor/ChannelInterceptorTests.java
@@ -208,7 +208,6 @@ public class ChannelInterceptorTests {
 
 	@Test
 	public void testPostReceiveInterceptor() {
-		final AtomicInteger invokedCount = new AtomicInteger();
 		final AtomicInteger messageCount = new AtomicInteger();
 		channel.addInterceptor(new ChannelInterceptor() {
 
@@ -216,21 +215,16 @@ public class ChannelInterceptorTests {
 			public Message<?> postReceive(Message<?> message, MessageChannel channel) {
 				assertNotNull(channel);
 				assertSame(ChannelInterceptorTests.this.channel, channel);
-				if (message != null) {
-					messageCount.incrementAndGet();
-				}
-				invokedCount.incrementAndGet();
+				messageCount.incrementAndGet();
 				return message;
 			}
 
 		});
 		channel.receive(0);
-		assertEquals(1, invokedCount.get());
 		assertEquals(0, messageCount.get());
 		channel.send(new GenericMessage<String>("test"));
 		Message<?> result = channel.receive(0);
 		assertNotNull(result);
-		assertEquals(2, invokedCount.get());
 		assertEquals(1, messageCount.get());
 	}
 

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/PollableJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/PollableJmsChannel.java
@@ -95,28 +95,32 @@ public class PollableJmsChannel extends AbstractJmsChannel
 				object = getJmsTemplate().receiveSelectedAndConvert(this.messageSelector);
 			}
 
+			Message<?> message = null;
 			if (object == null) {
 				if (logger.isTraceEnabled()) {
 					logger.trace("postReceive on channel '" + this + "', message is null");
 				}
 				return null;
 			}
-			if (countsEnabled) {
-				getMetrics().afterReceive();
-				counted = true;
-			}
-			Message<?> message = null;
-			if (object instanceof Message<?>) {
-				message = (Message<?>) object;
-			}
 			else {
-				message = getMessageBuilderFactory().withPayload(object).build();
-			}
-			if (logger.isDebugEnabled()) {
-				logger.debug("postReceive on channel '" + this + "', message: " + message);
+				if (countsEnabled) {
+					getMetrics().afterReceive();
+					counted = true;
+				}
+				if (object instanceof Message<?>) {
+					message = (Message<?>) object;
+				}
+				else {
+					message = getMessageBuilderFactory().withPayload(object).build();
+				}
+				if (logger.isDebugEnabled()) {
+					logger.debug("postReceive on channel '" + this + "', message: " + message);
+				}
 			}
 			if (interceptorStack != null) {
-				message = interceptorList.postReceive(message, this);
+				if (message != null) {
+					message = interceptorList.postReceive(message, this);
+				}
 				interceptorList.afterReceiveCompletion(message, this, null, interceptorStack);
 			}
 			return message;

--- a/src/reference/asciidoc/channel.adoc
+++ b/src/reference/asciidoc/channel.adoc
@@ -273,7 +273,7 @@ Also, the `preReceive` method can return `false` to prevent the receive operatio
 
 NOTE: Keep in mind that `receive()` calls are only relevant for `PollableChannels`.
 In fact, the `SubscribableChannel` interface does not even define a `receive()` method.
-The reason for this is that when a `Message` is sent to a `SubscribableChannel`, it is sent directly to one or more subscribers, depending on the type of channel (for example,
+The reason for this is that when a `Message` is sent to a `SubscribableChannel`, it is sent directly to zero or more subscribers, depending on the type of channel (for example,
 a `PublishSubscribeChannel` sends to all of its subscribers).
 Therefore, the `preReceive(...)`, `postReceive(...)`, and `afterReceiveCompletion(...)` interceptor methods are invoked only when the interceptor is applied to a `PollableChannel`.
 
@@ -282,25 +282,7 @@ It is a simple interceptor that sends the `Message` to another channel without o
 It can be very useful for debugging and monitoring.
 An example is shown in <<channel-wiretap>>.
 
-Because it is rarely necessary to implement all of the interceptor methods, a `ChannelInterceptorAdapter` class is also available for sub-classing.
-It provides no-op methods (the `void` method is empty, the `Message`-returning methods return the `Message` as-is, and the `boolean` method returns `true`).
-Therefore, it is often easiest to extend that class and just implement the methods that you need, as the following example shows:
-
-====
-[source,java]
-----
-public class CountingChannelInterceptor extends ChannelInterceptorAdapter {
-
-    private final AtomicInteger sendCount = new AtomicInteger();
-
-    @Override
-    public Message<?> preSend(Message<?> message, MessageChannel channel) {
-        sendCount.incrementAndGet();
-        return message;
-    }
-}
-----
-====
+Because it is rarely necessary to implement all of the interceptor methods, the interface provides no-op methods (methods returning `void` method have no code, the `Message`-returning methods return the `Message` as-is, and the `boolean` method returns `true`).
 
 TIP: The order of invocation for the interceptor methods depends on the type of channel.
 As described earlier, the queue-based channels are the only ones where the receive method is intercepted in the first place.
@@ -317,6 +299,11 @@ Note that the channel invokes these methods on the `ChannelInterceptor` list in 
 
 Starting with version 5.1, global channel interceptors now apply to dynamically registered channels - such as through beans that are initialized by using `beanFactory.initializeBean()` or `IntegrationFlowContext` when using the Java DSL.
 Previously, interceptors were not applied when beans were created after the application context was refreshed.
+
+Also, starting with version 5.1, `ChannelInterceptor.postReceive()` is no longer called when no message is received; it is no longer necessary to check for a `null` `Message<?>`.
+Previously, the method was called.
+If you have an interceptor that relies on the previous behavior, implement `afterReceiveCompleted()` instead, since that method is invoked, regardless of whether a message is received or not.
+
 
 [[channel-template]]
 ==== `MessagingTemplate`

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -62,6 +62,13 @@ Previously:
 Global channel interceptors now apply to dynamically registered channels, such as through the `IntegrationFlowContext` when using the Java DSL or beans that are initialized using `beanFactory.initializeBean()`.
 Previously, when beans were created after the application context was refreshed, interceptors were not applied.
 
+[[x5.1-channel-interceptors]]
+==== Channel Interceptors
+
+`ChannelInterceptor.postReceive()` is no longer called when no message is received; it is no longer necessary to check for a `null` `Message<?>`.
+Previously, the method was called.
+If you have an interceptor that relies on the previous behavior, implement `afterReceiveCompleted()` instead, since that method is invoked, regardless of whether a message is received or not.
+
 [[x5.1-object-to-json-transformer]]
 ==== `ObjectToJsonTransformer`
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -68,6 +68,7 @@ Previously, when beans were created after the application context was refreshed,
 `ChannelInterceptor.postReceive()` is no longer called when no message is received; it is no longer necessary to check for a `null` `Message<?>`.
 Previously, the method was called.
 If you have an interceptor that relies on the previous behavior, implement `afterReceiveCompleted()` instead, since that method is invoked, regardless of whether a message is received or not.
+Furthermore, the `PolledAmqpChannel` and `PolledJmsChannel` previously did not invoke `afterReceiveCompleted()` with `null`; they now do.
 
 [[x5.1-object-to-json-transformer]]
 ==== `ObjectToJsonTransformer`


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4526

- `Message<?>` cannot be null in `postReceive()`.

