### PR TITLE
INT-4523: Add DSL `convert(Class<> cls)` operator

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -588,6 +588,21 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	}
 
 	/**
+	 * Populate the {@link MessageTransformingHandler} instance
+	 * for the provided {@code payloadType} to convert at runtime.
+	 * @param payloadType the {@link Class} for expected payload type.
+	 * @param <P> the payload type - 'convert to'.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 5.1
+	 * @see MethodInvokingTransformer
+	 * @see LambdaMessageProcessor
+	 */
+	public <P> B convert(Class<P> payloadType) {
+		return transform(payloadType, p -> p);
+	}
+
+
+	/**
 	 * Populate the {@link MessageTransformingHandler} instance for the provided {@link GenericTransformer}
 	 * for the specific {@code payloadType} to convert at runtime.
 	 * @param payloadType the {@link Class} for expected payload type.
@@ -599,7 +614,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @see LambdaMessageProcessor
 	 */
 	public <P, T> B transform(Class<P> payloadType, GenericTransformer<P, T> genericTransformer) {
-		return this.transform(payloadType, genericTransformer, null);
+		return transform(payloadType, genericTransformer, null);
 	}
 
 	/**
@@ -617,6 +632,25 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	public <S, T> B transform(GenericTransformer<S, T> genericTransformer,
 			Consumer<GenericEndpointSpec<MessageTransformingHandler>> endpointConfigurer) {
 		return this.transform(null, genericTransformer, endpointConfigurer);
+	}
+
+	/**
+	 * Populate the {@link MessageTransformingHandler} instance
+	 * for the provided {@code payloadType} to convert at runtime.
+	 * In addition accept options for the integration endpoint using {@link GenericEndpointSpec}.
+	 * @param payloadType the {@link Class} for expected payload type.
+	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
+	 * @param <P> the payload type - 'transform to'.
+	 * @return the current {@link IntegrationFlowDefinition}.
+	 * @since 5.1
+	 * @see MethodInvokingTransformer
+	 * @see LambdaMessageProcessor
+	 * @see GenericEndpointSpec
+	 */
+	public <P> B convert(Class<P> payloadType,
+			Consumer<GenericEndpointSpec<MessageTransformingHandler>> endpointConfigurer) {
+
+		return transform(payloadType, p -> p, endpointConfigurer);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/converter/ConfigurableCompositeMessageConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/converter/ConfigurableCompositeMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.springframework.integration.support.json.Jackson2JsonObjectMapper;
 import org.springframework.integration.support.json.JacksonPresent;
 import org.springframework.messaging.converter.ByteArrayMessageConverter;
 import org.springframework.messaging.converter.CompositeMessageConverter;
@@ -78,7 +79,10 @@ public class ConfigurableCompositeMessageConverter extends CompositeMessageConve
 		List<MessageConverter> converters = new LinkedList<>();
 
 		if (JacksonPresent.isJackson2Present()) {
-			converters.add(new MappingJackson2MessageConverter());
+			MappingJackson2MessageConverter mappingJackson2MessageConverter = new MappingJackson2MessageConverter();
+			mappingJackson2MessageConverter.setStrictContentTypeMatch(true);
+			mappingJackson2MessageConverter.setObjectMapper(new Jackson2JsonObjectMapper().getObjectMapper());
+			converters.add(mappingJackson2MessageConverter);
 		}
 		converters.add(new ByteArrayMessageConverter());
 		converters.add(new ObjectStringMessageConverter());

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/LambdaMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/LambdaMessageProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,20 +20,25 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.handler.GenericHandler;
 import org.springframework.integration.handler.LambdaMessageProcessor;
+import org.springframework.integration.support.converter.ConfigurableCompositeMessageConverter;
 import org.springframework.integration.transformer.GenericTransformer;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.support.GenericMessage;
 
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 5.0
  */
@@ -69,12 +74,22 @@ public class LambdaMessageProcessorTests {
 
 	private void handle(GenericHandler<?> h) {
 		LambdaMessageProcessor lmp = new LambdaMessageProcessor(h, String.class);
-		lmp.setBeanFactory(mock(BeanFactory.class));
+		lmp.setBeanFactory(getBeanFactory());
+
 		lmp.processMessage(new GenericMessage<>("foo"));
 	}
 
 	private Message<?> messageTransformer(Message<?> message) {
 		return message;
+	}
+
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory mockBeanFactory = mock(BeanFactory.class);
+		given(mockBeanFactory.getBean(IntegrationContextUtils.ARGUMENT_RESOLVER_MESSAGE_CONVERTER_BEAN_NAME,
+				MessageConverter.class))
+				.willReturn(new ConfigurableCompositeMessageConverter());
+		return mockBeanFactory;
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4523

* Change the `LambdaMessageProcessor` to rely on the `MessageConverter`
populated by the `IntegrationContextUtils.ARGUMENT_RESOLVER_MESSAGE_CONVERTER_BEAN_NAME`
This way all the Lambda-based handlers are going to work the same way
as POJO-based via `MessagingMethodInvokerHelper`
* Add `convert(Class<P> payloadType)` EIP-operator to perform similar
to POJO-based method invocation argument conversion

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
