### PR TITLE
GH-2559: Fix InboundChannelAdapter's javadoc

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/InboundChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/InboundChannelAdapter.java
@@ -67,9 +67,10 @@ public @interface InboundChannelAdapter {
 	@AliasFor("value")
 	String channel() default "";
 
-	/*
-	 {@code SmartLifecycle} options.
-	 Can be specified as 'property placeholder', e.g. {@code ${foo.autoStartup}}.
+	/**
+	 * {@code SmartLifecycle} options.
+	 * Can be specified as 'property placeholder', e.g. {@code ${foo.autoStartup}}.
+	 * @return if the channel adapter is started automatically or not.
 	 */
 	String autoStartup() default "true";
 


### PR DESCRIPTION
GitHub: https://github.com/spring-projects/spring-integration/issues/2559

* Fixed minor typo that does not let generate the expected javadoc
for a attribute/method

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
