### PR TITLE
INT-4317: JMS: dynamic deliverMode and timeToLive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-	ext.kotlinVersion = '1.2.60'
+	ext.kotlinVersion = '1.2.61'
 	repositories {
 		maven { url 'https://repo.spring.io/plugins-release' }
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-	ext.kotlinVersion = '1.2.51'
+	ext.kotlinVersion = '1.2.60'
 	repositories {
 		maven { url 'https://repo.spring.io/plugins-release' }
 	}
@@ -88,7 +88,7 @@ subprojects { subproject ->
 		apacheSshdVersion = '1.7.0'
 		aspectjVersion = '1.9.0'
 		assertjVersion = '3.9.1'
-		assertkVersion = '0.10'
+		assertkVersion = '0.12'
 		boonVersion = '0.34'
 		commonsDbcp2Version = '2.2.0'
 		commonsIoVersion = '2.6'
@@ -178,9 +178,7 @@ subprojects { subproject ->
 		testRuntime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 		testRuntime "org.apache.logging.log4j:log4j-jcl:$log4jVersion"
 
-		testCompile("com.willowtreeapps.assertk:assertk:$assertkVersion") {
-				exclude group: 'org.jetbrains.kotlin', module: 'kotlin-reflect'
-		}
+		testCompile("com.willowtreeapps.assertk:assertk-jvm:$assertkVersion")
 
 		testCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
 		testRuntime "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,13 +68,33 @@ public class DefaultJmsHeaderMapper extends JmsHeaderMapper {
 
 	private volatile boolean mapInboundPriority = true;
 
+	private volatile boolean mapInboundDeliveryMode = false;
+
+	private volatile boolean mapInboundExpiration = false;
+
 	/**
 	 * Suppress the mapping of inbound priority by using this setter with 'false'.
-	 *
 	 * @param mapInboundPriority 'false' to suppress mapping the inbound priority.
 	 */
 	public void setMapInboundPriority(boolean mapInboundPriority) {
 		this.mapInboundPriority = mapInboundPriority;
+	}
+
+	/**
+	 * Map the inbound {@code deliveryMode} by using this setter with 'true'.
+	 * @param mapInboundDeliveryMode 'true' to map the inbound delivery mode.
+	 * @since 5.1
+	 */
+	public void setMapInboundDeliveryMode(boolean mapInboundDeliveryMode) {
+		this.mapInboundDeliveryMode = mapInboundDeliveryMode;
+	}
+	/**
+	 * Map the inbound {@code expiration} by using this setter with 'true'.
+	 * @param mapInboundExpiration 'true' to map the inbound expiration.
+	 * @since 5.1
+	 */
+	public void setMapInboundExpiration(boolean mapInboundExpiration) {
+		this.mapInboundExpiration = mapInboundExpiration;
 	}
 
 	/**
@@ -246,6 +266,22 @@ public class DefaultJmsHeaderMapper extends JmsHeaderMapper {
 				}
 				catch (Exception e) {
 					this.logger.info("failed to read JMSPriority property, skipping", e);
+				}
+			}
+			if (this.mapInboundDeliveryMode) {
+				try {
+					headers.put(JmsHeaders.DELIVERY_MODE, jmsMessage.getJMSDeliveryMode());
+				}
+				catch (Exception e) {
+					this.logger.info("failed to read JMSDeliveryMode property, skipping", e);
+				}
+			}
+			if (this.mapInboundExpiration) {
+				try {
+					headers.put(JmsHeaders.EXPIRATION, jmsMessage.getJMSExpiration());
+				}
+				catch (Exception e) {
+					this.logger.info("failed to read JMSExpiration property, skipping", e);
 				}
 			}
 			Enumeration<?> jmsPropertyNames = jmsMessage.getPropertyNames();

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/DynamicJmsTemplate.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/DynamicJmsTemplate.java
@@ -71,4 +71,16 @@ public class DynamicJmsTemplate extends JmsTemplate {
 		return (receiveTimeout != null) ? receiveTimeout : super.getReceiveTimeout();
 	}
 
+	@Override
+	public int getDeliveryMode() {
+		Integer deliveryMode = DynamicJmsTemplateProperties.getDeliveryMode();
+		return (deliveryMode != null) ? deliveryMode : super.getDeliveryMode();
+	}
+
+	@Override
+	public long getTimeToLive() {
+		Long timeToLive = DynamicJmsTemplateProperties.getTimeToLive();
+		return (timeToLive != null) ? timeToLive : super.getTimeToLive();
+	}
+
 }

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/DynamicJmsTemplateProperties.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/DynamicJmsTemplateProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,23 @@ package org.springframework.integration.jms;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
+ *
  * @since 2.0.2
  */
 abstract class DynamicJmsTemplateProperties {
 
-	private static final ThreadLocal<Integer> priorityHolder = new ThreadLocal<Integer>();
+	private static final ThreadLocal<Integer> priorityHolder = new ThreadLocal<>();
 
-	private static final ThreadLocal<Long> receiveTimeoutHolder = new ThreadLocal<Long>();
+	private static final ThreadLocal<Long> receiveTimeoutHolder = new ThreadLocal<>();
 
+	private static final ThreadLocal<Integer> deliverModeHolder = new ThreadLocal<>();
+
+	private static final ThreadLocal<Long> timeToLiveHolder = new ThreadLocal<>();
+
+
+	private DynamicJmsTemplateProperties() {
+	}
 
 	public static Integer getPriority() {
 		return priorityHolder.get();
@@ -49,6 +58,30 @@ abstract class DynamicJmsTemplateProperties {
 
 	public static void clearReceiveTimeout() {
 		receiveTimeoutHolder.remove();
+	}
+
+	public static Integer getDeliveryMode() {
+		return deliverModeHolder.get();
+	}
+
+	public static void setDeliveryMode(Integer deliveryMode) {
+		deliverModeHolder.set(deliveryMode);
+	}
+
+	public static void clearDeliveryMode() {
+		deliverModeHolder.remove();
+	}
+
+	public static Long getTimeToLive() {
+		return timeToLiveHolder.get();
+	}
+
+	public static void setTimeToLive(Long timeToLive) {
+		timeToLiveHolder.set(timeToLive);
+	}
+
+	public static void clearTimeToLive() {
+		timeToLiveHolder.remove();
 	}
 
 }

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundChannelAdapterParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsOutboundChannelAdapterParser.java
@@ -57,8 +57,10 @@ public class JmsOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 
 		if (hasDestinationRef || hasDestinationName || hasDestinationExpression) {
 			if (!(hasDestinationRef ^ hasDestinationName ^ hasDestinationExpression)) {
-				parserContext.getReaderContext().error("The 'destination', 'destination-name', and " +
-						"'destination-expression' attributes are mutually exclusive.", parserContext.extractSource(element));
+				parserContext.getReaderContext()
+						.error("The 'destination', 'destination-name', and 'destination-expression' " +
+										"attributes are mutually exclusive.",
+								parserContext.extractSource(element));
 			}
 			if (hasDestinationRef) {
 				builder.addPropertyReference(JmsParserUtils.DESTINATION_PROPERTY, destination);
@@ -66,22 +68,30 @@ public class JmsOutboundChannelAdapterParser extends AbstractOutboundChannelAdap
 			else if (hasDestinationName) {
 				builder.addPropertyValue(JmsParserUtils.DESTINATION_NAME_PROPERTY, destinationName);
 			}
-			else if (hasDestinationExpression) {
-				BeanDefinitionBuilder expressionBuilder = BeanDefinitionBuilder.genericBeanDefinition(ExpressionFactoryBean.class);
-				expressionBuilder.addConstructorArgValue(destinationExpression);
-				builder.addPropertyValue(JmsParserUtils.DESTINATION_EXPRESSION_PROPERTY, expressionBuilder.getBeanDefinition());
+			else {
+				BeanDefinitionBuilder expressionBuilder =
+						BeanDefinitionBuilder.genericBeanDefinition(ExpressionFactoryBean.class)
+								.addConstructorArgValue(destinationExpression);
+				builder.addPropertyValue(JmsParserUtils.DESTINATION_EXPRESSION_PROPERTY,
+						expressionBuilder.getBeanDefinition());
 			}
 		}
 		else if (!hasJmsTemplate) {
-			parserContext.getReaderContext().error("either a '" + JmsParserUtils.JMS_TEMPLATE_ATTRIBUTE +
-					"' or one of '" + JmsParserUtils.DESTINATION_ATTRIBUTE + "', '"
-					+ JmsParserUtils.DESTINATION_NAME_ATTRIBUTE + "', or '" +
-					JmsParserUtils.DESTINATION_EXPRESSION_ATTRIBUTE +
-					"' attributes must be provided", parserContext.extractSource(element));
+			parserContext.getReaderContext()
+					.error("either a '" + JmsParserUtils.JMS_TEMPLATE_ATTRIBUTE +
+							"' or one of '" + JmsParserUtils.DESTINATION_ATTRIBUTE + "', '"
+							+ JmsParserUtils.DESTINATION_NAME_ATTRIBUTE + "', or '" +
+							JmsParserUtils.DESTINATION_EXPRESSION_ATTRIBUTE +
+							"' attributes must be provided", parserContext.extractSource(element));
 		}
 
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, JmsParserUtils.HEADER_MAPPER_ATTRIBUTE);
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
+				JmsParserUtils.HEADER_MAPPER_ATTRIBUTE);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "extract-payload");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "delivery-mode-expression",
+				"deliveryModeExpressionString");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "time-to-live-expression",
+				"timeToLiveExpressionString");
 		return builder.getBeanDefinition();
 	}
 

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
@@ -195,6 +195,17 @@ public final class Jms {
 
 	/**
 	 * The factory to produce a {@link JmsMessageDrivenChannelAdapterSpec}.
+	 * @param jmsListenerContainerSpec the {@link JmsListenerContainerSpec} to build on
+	 * @return the {@link JmsMessageDrivenChannelAdapterSpec} instance
+	 */
+	public static JmsMessageDrivenChannelAdapterSpec<?> messageDrivenChannelAdapter(
+			JmsListenerContainerSpec<?, ? extends AbstractMessageListenerContainer> jmsListenerContainerSpec) {
+
+		return new JmsMessageDrivenChannelAdapterSpec<>(jmsListenerContainerSpec.get());
+	}
+
+	/**
+	 * The factory to produce a {@link JmsMessageDrivenChannelAdapterSpec}.
 	 * @param listenerContainer the {@link AbstractMessageListenerContainer} to build on
 	 * @return the {@link JmsMessageDrivenChannelAdapterSpec} instance
 	 */

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsOutboundChannelAdapterSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsOutboundChannelAdapterSpec.java
@@ -123,7 +123,53 @@ public class JmsOutboundChannelAdapterSpec<S extends JmsOutboundChannelAdapterSp
 	 * @see FunctionExpression
 	 */
 	public <P> S destination(Function<Message<P>, ?> destinationFunction) {
-		this.target.setDestinationExpression(new FunctionExpression<Message<P>>(destinationFunction));
+		this.target.setDestinationExpression(new FunctionExpression<>(destinationFunction));
+		return _this();
+	}
+
+	/**
+	 * Specify a SpEL expression to evaluate a {@code deliveryMode} for JMS message to send.
+	 * @param deliveryModeExpression to use
+	 * @return the spec
+	 * @since 5.1
+	 */
+	public S deliveryModeExpression(String deliveryModeExpression) {
+		this.target.setDeliveryModeExpressionString(deliveryModeExpression);
+		return _this();
+	}
+
+	/**
+	 * Specify a {@link Function} to resolve a {@code deliveryMode} for JMS message to send.
+	 * @param deliveryModeFunction to use
+	 * @return the spec
+	 * @since 5.1
+	 * @see FunctionExpression
+	 */
+	public <P> S deliveryModeFunction(Function<Message<P>, ?> deliveryModeFunction) {
+		this.target.setDeliveryModeExpression(new FunctionExpression<>(deliveryModeFunction));
+		return _this();
+	}
+
+	/**
+	 * Specify a SpEL expression to evaluate a {@code timeToLive} for JMS message to send.
+	 * @param timeToLiveExpression to use
+	 * @return the spec
+	 * @since 5.1
+	 */
+	public S timeToLiveExpression(String timeToLiveExpression) {
+		this.target.setTimeToLiveExpressionString(timeToLiveExpression);
+		return _this();
+	}
+
+	/**
+	 * Specify a {@link Function} to resolve a {@code timeToLive} for JMS message to send.
+	 * @param timeToLiveFunction to use
+	 * @return the spec
+	 * @see FunctionExpression
+	 * @since 5.1
+	 */
+	public <P> S timeToLiveFunction(Function<Message<P>, ?> timeToLiveFunction) {
+		this.target.setTimeToLiveExpression(new FunctionExpression<>(timeToLiveFunction));
 		return _this();
 	}
 

--- a/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-5.1.xsd
+++ b/spring-integration-jms/src/main/resources/org/springframework/integration/jms/config/spring-integration-jms-5.1.xsd
@@ -1259,6 +1259,28 @@
 							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="delivery-mode-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								A SpEL expression to be evaluated at runtime against each Spring Integration Message as
+								the root object. The result should be an integer representing the delivery mode.
+								If returns null, falls back to the 'delivery-persistent' or default.
+								The explicit-qos-enabled has to be enabled.
+								Note: the static delivery mode value can be specified on the JmsTemplate.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="time-to-live-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								A SpEL expression to be evaluated at runtime against each Spring Integration Message as
+								the root object. The result should be a long representing the time-to-live for the message.
+								If returns null, falls back to the 'time-to-live' or default.
+								The 'explicit-qos-enabled' has to be enabled.
+								Note: the static time-to-live value can be specified on the JmsTemplate.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsOutboundChannelAdapterParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.springframework.messaging.support.GenericMessage;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class JmsOutboundChannelAdapterParserTests {
 
@@ -134,13 +135,16 @@ public class JmsOutboundChannelAdapterParserTests {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"jmsOutboundWithJmsTemplateQos.xml", this.getClass());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("adapter");
-		DirectFieldAccessor handlerAccessor = new DirectFieldAccessor(new DirectFieldAccessor(endpoint).getPropertyValue("handler"));
+		Object handler = new DirectFieldAccessor(endpoint).getPropertyValue("handler");
+		DirectFieldAccessor handlerAccessor = new DirectFieldAccessor(handler);
 		JmsTemplate jmsTemplate = (JmsTemplate) handlerAccessor.getPropertyValue("jmsTemplate");
 		assertNotNull(jmsTemplate);
 		assertEquals(context.getBean("template"), jmsTemplate);
 		assertTrue(jmsTemplate.isExplicitQosEnabled());
 		assertEquals(7, jmsTemplate.getPriority());
 		assertEquals(12345, jmsTemplate.getTimeToLive());
+		assertEquals("1", TestUtils.getPropertyValue(handler, "deliveryModeExpression.expression", String.class));
+		assertEquals("100", TestUtils.getPropertyValue(handler, "timeToLiveExpression.expression", String.class));
 		context.close();
 	}
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundWithJmsTemplateQos.xml
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/jmsOutboundWithJmsTemplateQos.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:integration="http://www.springframework.org/schema/integration"
-	xmlns:jms="http://www.springframework.org/schema/integration/jms"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:integration="http://www.springframework.org/schema/integration"
+	   xmlns:jms="http://www.springframework.org/schema/integration/jms"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
 			http://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
 			http://www.springframework.org/schema/integration/spring-integration.xsd
@@ -12,9 +12,11 @@
 
 	<integration:channel id="input"/>
 
-	<jms:outbound-channel-adapter id="adapter" channel="input" jms-template="template"/>
+	<jms:outbound-channel-adapter id="adapter" channel="input" jms-template="template"
+								  delivery-mode-expression="1"
+								  time-to-live-expression="100"/>
 
-	<bean id="template" class="org.springframework.jms.core.JmsTemplate" >
+	<bean id="template" class="org.springframework.jms.core.JmsTemplate">
 		<property name="connectionFactory">
 			<bean class="org.springframework.jms.connection.SingleConnectionFactory">
 				<constructor-arg>

--- a/src/reference/asciidoc/jms.adoc
+++ b/src/reference/asciidoc/jms.adoc
@@ -171,6 +171,17 @@ If, on the other hand, you want to send the actual Spring Integration message to
 NOTE: Regardless of the boolean value for payload extraction, the Spring Integration `MessageHeaders` map to JMS properties, as long as you rely on the default converter or provide a reference to another instance of `HeaderMappingMessageConverter`.
 (The same holds true for 'inbound' adapters, except that, in those cases, the JMS properties map to Spring Integration `MessageHeaders`).
 
+Starting with version 5.1, the `<int-jms:outbound-channel-adapter>` (`JmsSendingMessageHandler`) can be configured with the `deliveryModeExpression` and `timeToLiveExpression` properties to evaluate an appropriate QoS values for JMS message to send at runtime against request Spring `Message`.
+The new `setMapInboundDeliveryMode(true)` and `setMapInboundExpiration(true)` options of the `DefaultJmsHeaderMapper` may facilitate as a source of the information for the dynamic `deliveryMode` and `timeToLive` from message headers:
+
+====
+[source,xml]
+----
+<int-jms:outbound-channel-adapter delivery-mode-expression="headers.jms_deliveryMode"
+                        time-to-live-expression="headers.jms_expiration - T(System).currentTimeMillis()"/>
+----
+====
+
 [[jms-ob-transactions]]
 ==== Transactions
 
@@ -585,6 +596,22 @@ On the inbound side, it is mapped as a `String`.
 This is independent of the `jms_correlationId` header, which is mapped to and from the `JMSCorrelationID` header.
 The `JMSCorrelationID` is generally used to correlate requests and replies, whereas the `correlationId` is often used to combine related messages into a group (such as with an aggregator or a resequencer).
 
+Starting with version 5.1, the `DefaultJmsHeaderMapper` can be configured for mapping inbound `JMSDeliveryMode` and `JMSExpiration` properties:
+ ====
+ [source,java]
+ ----
+ @Bean
+ public DefaultJmsHeaderMapper jmsHeaderMapper() {
+     DefaultJmsHeaderMapper mapper = new DefaultJmsHeaderMapper();
+     mapper.setMapInboundDeliveryMode(true)
+     mapper.setMapInboundExpiration(true)
+     return mapper;
+ }
+ ----
+ ====
+
+These JMS properties are mapped to the `JmsHeaders.DELIVERY_MODE` and `JmsHeaders.EXPIRATION` Spring Message headers respectively.
+
 [[jms-conversion-and-marshalling]]
 === Message Conversion, Marshalling, and Unmarshalling
 
@@ -593,6 +620,7 @@ To do so, provide the bean name of an instance of `MessageConverter` that is ava
 Also, to provide some consistency with marshaller and unmarshaller interfaces, Spring provides `MarshallingMessageConverter`, which you can configure with your own custom marshallers and unmarshallers.
 The following example shows how to do so
 
+====
 [source,xml]
 ----
 <int-jms:inbound-gateway request-destination="requestQueue"
@@ -609,6 +637,7 @@ The following example shows how to do so
     </constructor-arg>
 </bean>
 ----
+====
 
 NOTE: When you provide your own `MessageConverter` instance, it is still wrapped within the `HeaderMappingMessageConverter`.
 This means that the 'extract-request-payload' and 'extract-reply-payload' properties can affect the actual objects passed to your converter.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -152,3 +152,11 @@ In addition the key and trust store types can now be configured on the `DefaultT
 
 Since the Spring Social project has moved to https://spring.io/blog/2018/07/03/spring-social-end-of-life-announcement[end of life status], Twitter support in Spring Integration has been moved to the Extensions project.
 See https://github.com/spring-projects/spring-integration-extensions/tree/master/spring-integration-social-twitter[Spring Integration Social Twitter] for more information.
+
+[[x51.-jms]]
+=== JMS Support
+
+The `JmsSendingMessageHandler` now provides `deliveryModeExpression` and `timeToLiveExpression` options to determine respective QoS options for JMS message to send at runtime.
+The `DefaultJmsHeaderMapper` now allows to map inbound `JMSDeliveryMode` and `JMSExpiration` properties via setting to `true` respective `setMapInboundDeliveryMode()` and `setMapInboundExpiration()` options.
+
+See <<jms>> for more information.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4317

* Add `deliveryModeExpression` and `timeToLiveExpression` properties
to the `JmsSendingMessageHandler` and expose them in the Java DSL and
XML components
* Add `setMapInboundDeliveryMode()` and `setMapInboundExpiration()`
`boolean` properties (default `false`) to the `DefaultJmsHeaderMapper`
for transferring `JMSDeliveryMode` and `JMSExpiration` into appropriate
`JmsHeaders.DELIVERY_MODE` and `JmsHeaders.EXPIRATION` headers
* Upgrade to latest Kotlin and AssertK

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
