### PR TITLE
INT-4531: Use Object key in (S)FTP rotating server advice

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/aop/RotatingServerAdvice.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/aop/RotatingServerAdvice.java
@@ -219,18 +219,18 @@ public class RotatingServerAdvice extends AbstractMessageSourceAdvice {
 	 */
 	public static class KeyDirectory {
 
-		private final String key;
+		private final Object key;
 
 		private final String directory;
 
-		public KeyDirectory(String key, String directory) {
+		public KeyDirectory(Object key, String directory) {
 			Assert.notNull(key, "key cannot be null");
 			Assert.notNull(directory, "directory cannot be null");
 			this.key = key;
 			this.directory = directory;
 		}
 
-		public String getKey() {
+		public Object getKey() {
 			return this.key;
 		}
 
@@ -240,7 +240,7 @@ public class RotatingServerAdvice extends AbstractMessageSourceAdvice {
 
 		@Override
 		public String toString() {
-			return "KeyDirectory [key=" + this.key + ", directory=" + this.directory + "]";
+			return "KeyDirectory [key=" + this.key.toString() + ", directory=" + this.directory + "]";
 		}
 
 	}


### PR DESCRIPTION
Small fix for https://jira.spring.io/browse/INT-4531.
The `DelegatingSessionFactory` uses plain `Object`s as key types whereas the default `RotatingServerAdvice` does not. This PR just changes the datatype from `String` to `Object`.