### PR TITLE
Use RetrySynchronizationManager

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
@@ -296,6 +296,7 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 			}
 			catch (RuntimeException e) {
 				if (getErrorChannel() != null) {
+					setAttributesIfNecessary(message, null);
 					AmqpInboundGateway.this.messagingTemplate.send(getErrorChannel(), buildErrorMessage(null,
 							new ListenerExecutionFailedException("Message conversion failed", e, message)));
 				}

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
@@ -248,9 +248,12 @@ public class InboundEndpointTests {
 
 		});
 		adapter.afterPropertiesSet();
-		((ChannelAwareMessageListener) container.getMessageListener()).onMessage(null, null);
+		((ChannelAwareMessageListener) container.getMessageListener())
+				.onMessage(mock(org.springframework.amqp.core.Message.class), null);
 		assertNull(outputChannel.receive(0));
-		assertNotNull(errorChannel.receive(0));
+		Message<?> received = errorChannel.receive(0);
+		assertNotNull(received);
+		assertNotNull(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE));
 	}
 
 	@Test
@@ -276,14 +279,17 @@ public class InboundEndpointTests {
 
 			@Override
 			public Object fromMessage(org.springframework.amqp.core.Message message) throws MessageConversionException {
-				return null;
+				throw new MessageConversionException("intended");
 			}
 
 		});
 		adapter.afterPropertiesSet();
-		((ChannelAwareMessageListener) container.getMessageListener()).onMessage(null, null);
+		((ChannelAwareMessageListener) container.getMessageListener())
+				.onMessage(mock(org.springframework.amqp.core.Message.class), null);
 		assertNull(outputChannel.receive(0));
-		assertNotNull(errorChannel.receive(0));
+		Message<?> received = errorChannel.receive(0);
+		assertNotNull(received);
+		assertNotNull(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE));
 	}
 
 	@Test


### PR DESCRIPTION
Use the `RetrySynchronizationManager` instead of a `RetryListener`.

Fix `setAttributesIfNecessary` for gateway conversion errors (this, at least,
should be cherry-picked).
