### PR TITLE
Changed an Assert error message to make the requirements clearer

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
@@ -80,6 +80,7 @@ import org.springframework.util.Assert;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Steven Pearce
  */
 public class FileReadingMessageSource extends AbstractMessageSource<File>
 		implements Lifecycle {
@@ -334,10 +335,10 @@ public class FileReadingMessageSource extends AbstractMessageSource<File>
 			this.scanner = new WatchServiceDirectoryScanner();
 		}
 
-		// Check that the local filter and locker options are _NOT_ set if an external scanner has been set.
+		// Check that the filter and locker options are _NOT_ set if an external scanner has been set.
 		// The external scanner is responsible for the filter and locker options in that case.
 		Assert.state(!(this.scannerExplicitlySet && (this.filter != null || this.locker != null)),
-				"When using an external scanner the local 'filter' and 'locker' options should not be used. Instead, set these options on the external DirectoryScanner: "
+				"When using an external scanner the 'filter' and 'locker' options should not be used. Instead, set these options on the external DirectoryScanner: "
 						+ this.scanner);
 		if (this.filter != null) {
 			this.scanner.setFilter(this.filter);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
@@ -67,6 +67,11 @@ import org.springframework.util.Assert;
  * a known suffix), composed with the default {@link AcceptOnceFileListFilter}
  * would allow for this.
  * <p>
+ * If a external {@link DirectoryScanner} is used, then the {@link FileLocker}
+ * and {@link FileListFilter} objects should be set on the external
+ * {@link DirectoryScanner}, not the instance of FileReadingMessageSource. An
+ * {@link IllegalStateException} will result otherwise.
+ * <p>
  * A {@link Comparator} can be used to ensure internal ordering of the Files in
  * a {@link PriorityBlockingQueue}. This does not provide the same guarantees as
  * a {@link ResequencingMessageGroupProcessor}, but in cases where writing files

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
@@ -334,8 +334,10 @@ public class FileReadingMessageSource extends AbstractMessageSource<File>
 			this.scanner = new WatchServiceDirectoryScanner();
 		}
 
+		// Check that the local filter and locker options are _NOT_ set if an external scanner has been set.
+		// The external scanner is responsible for the filter and locker options in that case.
 		Assert.state(!(this.scannerExplicitlySet && (this.filter != null || this.locker != null)),
-				"The 'filter' and 'locker' options must be present on the provided external 'scanner': "
+				"When using an external scanner the local 'filter' and 'locker' options should not be used. Instead, set these options on the external DirectoryScanner: "
 						+ this.scanner);
 		if (this.filter != null) {
 			this.scanner.setFilter(this.filter);


### PR DESCRIPTION
Changed an Assert error message to make the requirements when using an external scanner clearer, and added some explanatory comments.

Discussed in #2568 

