### PR TITLE
Upgrades to the latest dependencies and fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,9 +85,9 @@ subprojects { subproject ->
 
 	ext {
 		activeMqVersion = '5.15.3'
-		apacheSshdVersion = '1.7.0'
-		aspectjVersion = '1.9.0'
-		assertjVersion = '3.9.1'
+		apacheSshdVersion = '2.0.0'
+		aspectjVersion = '1.9.1'
+		assertjVersion = '3.11.1'
 		assertkVersion = '0.12'
 		boonVersion = '0.34'
 		commonsDbcp2Version = '2.2.0'
@@ -98,49 +98,49 @@ subprojects { subproject ->
 		eclipseLinkVersion = '2.7.1'
 		ftpServerVersion = '1.1.1'
 		googleJsr305Version = '3.0.2'
-		groovyVersion = '2.4.15'
-		guavaVersion = '20.0'
+		groovyVersion = '2.5.2'
+		guavaVersion = '26.0-jre'
 		hamcrestVersion = '1.3'
-		hazelcastVersion = '3.8'
-		hibernateVersion = '5.2.16.Final'
+		hazelcastVersion = '3.10.5'
+		hibernateVersion = '5.3.6.Final'
 		hsqldbVersion = '2.4.0'
 		h2Version = '1.4.197'
-		jackson2Version = '2.9.5'
+		jackson2Version = '2.9.6'
 		javaxActivationVersion = '1.1.1'
-		javaxMailVersion = '1.6.1'
+		javaxMailVersion = '1.6.2'
 		jmsApiVersion = '2.0.1'
 		jpa21ApiVersion = '1.0.0.Final'
-		jpaApiVersion = '2.1.1'
+		jpaApiVersion = '2.2.1'
 		jrubyVersion = '9.1.16.0'
 		jschVersion = '0.1.54'
 		jsonpathVersion = '2.4.0'
 		junit4Version = '4.12'
-		junitJupiterVersion = '5.1.1'
-		junitPlatformVersion = '1.1.1'
+		junitJupiterVersion = '5.3.1'
+		junitPlatformVersion = '1.3.1'
 		jythonVersion = '2.5.3'
 		kryoShadedVersion = '3.0.3'
-		lettuceVersion = '5.0.3.RELEASE'
-		log4jVersion = '2.11.0'
+		lettuceVersion = '5.1.0.RELEASE'
+		log4jVersion = '2.11.1'
 		micrometerVersion = '1.0.6'
-		mockitoVersion = '2.18.0'
+		mockitoVersion = '2.22.0'
 		mysqlVersion = '8.0.11'
 		pahoMqttClientVersion = '1.2.0'
 		postgresVersion = '42.0.0'
-		reactorNettyVersion = '0.8.0.M2'
-		reactorVersion = '3.2.0.M4'
+		reactorNettyVersion = '0.8.0.RELEASE'
+		reactorVersion = '3.2.0.RELEASE'
 		romeToolsVersion = '1.9.0'
 		servletApiVersion = '4.0.0'
-		smackVersion = '4.2.3'
-		springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '2.1.0.M2'
-		springDataJpaVersion = '2.1.0.RC2'
-		springDataMongoVersion = '2.1.0.RC2'
-		springDataRedisVersion = '2.1.0.RC2'
-		springGemfireVersion = '2.1.0.RC2'
-		springSecurityVersion = '5.1.0.RC1'
+		smackVersion = '4.3.0'
+		springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '2.1.0.BUILD-SNAPSHOT'
+		springDataJpaVersion = '2.1.0.BUILD-SNAPSHOT'
+		springDataMongoVersion = '2.1.0.BUILD-SNAPSHOT'
+		springDataRedisVersion = '2.1.0.BUILD-SNAPSHOT'
+		springGemfireVersion = '2.1.0.BUILD-SNAPSHOT'
+		springSecurityVersion = '5.1.0.BUILD-SNAPSHOT'
 		springRetryVersion = '1.2.2.RELEASE'
-		springVersion = project.hasProperty('springVersion') ? project.springVersion : '5.1.0.RC2'
-		springWsVersion = '3.0.2.RELEASE'
-		tomcatVersion = "9.0.7"
+		springVersion = project.hasProperty('springVersion') ? project.springVersion : '5.1.0.BUILD-SNAPSHOT'
+		springWsVersion = '3.0.3.RELEASE'
+		tomcatVersion = "9.0.12"
 		xmlUnitVersion = '1.6'
 		xstreamVersion = '1.4.10'
 	}
@@ -152,7 +152,7 @@ subprojects { subproject ->
 	}
 
 	jacoco {
-		toolVersion = "0.7.9"
+		toolVersion = "0.8.2"
 	}
 
 	// dependencies that are common across all java projects
@@ -411,6 +411,8 @@ project('spring-integration-groovy') {
 		compile "org.springframework:spring-context-support:$springVersion"
 
 		testCompile "org.springframework:spring-web:$springVersion"
+
+		testRuntime "org.codehaus.groovy:groovy-dateutil:$groovyVersion"
 	}
 }
 
@@ -423,8 +425,12 @@ project('spring-integration-http') {
 		compile ("com.rometools:rome:$romeToolsVersion", optional)
 
 		testCompile project(":spring-integration-security")
-		testCompile ("org.springframework.security:spring-security-config:$springSecurityVersion")
-		testCompile ("org.springframework.security:spring-security-test:$springSecurityVersion")
+		testCompile ("org.springframework.security:spring-security-config:$springSecurityVersion") {
+			exclude group: 'org.springframework'
+		}
+		testCompile ("org.springframework.security:spring-security-test:$springSecurityVersion") {
+			exclude group: 'org.springframework'
+		}
 	}
 }
 
@@ -569,9 +575,13 @@ project('spring-integration-security') {
 	description = 'Spring Integration Security Support'
 	dependencies {
 		compile project(":spring-integration-core")
-		compile("org.springframework.security:spring-security-core:$springSecurityVersion")
+		compile("org.springframework.security:spring-security-core:$springSecurityVersion") {
+			exclude group: 'org.springframework'
+		}
 
-		testCompile ("org.springframework.security:spring-security-config:$springSecurityVersion")
+		testCompile ("org.springframework.security:spring-security-config:$springSecurityVersion") {
+			exclude group: 'org.springframework'
+		}
 	}
 }
 
@@ -585,6 +595,7 @@ project('spring-integration-sftp') {
 		compile("javax.activation:activation:$javaxActivationVersion", optional)
 
 		testCompile "org.apache.sshd:sshd-core:$apacheSshdVersion"
+		testCompile "org.apache.sshd:sshd-sftp:$apacheSshdVersion"
 		testCompile project(":spring-integration-file").sourceSets.test.output
 	}
 }
@@ -637,8 +648,12 @@ project('spring-integration-webflux') {
 		compile ("io.projectreactor.netty:reactor-netty:$reactorNettyVersion" , optional)
 
 		testCompile "org.springframework:spring-webmvc:$springVersion"
-		testCompile ("org.springframework.security:spring-security-config:$springSecurityVersion")
-		testCompile ("org.springframework.security:spring-security-test:$springSecurityVersion")
+		testCompile ("org.springframework.security:spring-security-config:$springSecurityVersion") {
+			exclude group: 'org.springframework'
+		}
+		testCompile ("org.springframework.security:spring-security-test:$springSecurityVersion") {
+			exclude group: 'org.springframework'
+		}
 		testCompile "io.projectreactor:reactor-test:$reactorVersion"
 	}
 }

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.support.CorrelationData;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.beans.factory.BeanFactory;

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 package org.springframework.integration.amqp.outbound;
 
 import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.core.RabbitTemplate.ReturnCallback;
-import org.springframework.amqp.rabbit.support.CorrelationData;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.amqp.support.MappingUtils;

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AsyncAmqpOutboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AsyncAmqpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import org.springframework.amqp.core.AmqpMessageReturnedException;
 import org.springframework.amqp.core.AmqpReplyTimeoutException;
 import org.springframework.amqp.rabbit.AsyncRabbitTemplate;
 import org.springframework.amqp.rabbit.AsyncRabbitTemplate.RabbitMessageFuture;
-import org.springframework.amqp.rabbit.support.CorrelationData;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.integration.amqp.support.MappingUtils;
 import org.springframework.integration.handler.ReplyRequiredException;

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,9 +48,9 @@ import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.connection.PublisherCallbackChannelImpl;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.support.CorrelationData;
-import org.springframework.amqp.rabbit.support.PublisherCallbackChannelImpl;
 import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.DirectFieldAccessor;

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/OutboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/OutboundEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,9 +39,9 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.AsyncRabbitTemplate;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
-import org.springframework.amqp.rabbit.support.CorrelationData;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
 import org.springframework.integration.channel.NullChannel;

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayTests-context.xml
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayTests-context.xml
@@ -185,7 +185,7 @@
 					<bean class="org.springframework.integration.jpa.core.JpaExecutor">
 						<constructor-arg name="entityManager" ref="entityManager"/>
 						<property name="entityClass"        value="org.springframework.integration.jpa.test.entity.StudentDomain"/>
-						<property name="jpaQuery"           value="from Student s where s.firstName = ? and s.lastName=?"/>
+						<property name="jpaQuery"           value="from Student s where s.firstName = ?0 and s.lastName = ?1"/>
 						<property name="expectSingleResult" value="true"/>
 						<property name="jpaParameters" >
 							<util:list>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/SftpTestSupport.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/SftpTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,7 @@ package org.springframework.integration.sftp;
 import java.io.File;
 import java.util.Collections;
 
-import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
-import org.apache.sshd.server.Command;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory;
@@ -62,7 +60,7 @@ public class SftpTestSupport extends RemoteFileTestSupport {
 		server.setPasswordAuthenticator((username, password, session) -> true);
 		server.setPort(0);
 		server.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(new File("hostkey.ser")));
-		server.setSubsystemFactories(Collections.<NamedFactory<Command>>singletonList(new SftpSubsystemFactory()));
+		server.setSubsystemFactories(Collections.singletonList(new SftpSubsystemFactory()));
 		server.setFileSystemFactory(new VirtualFileSystemFactory(remoteTemporaryFolder.getRoot().toPath()));
 		server.start();
 		port = server.getPort();

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpServerTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpServerTests.java
@@ -34,8 +34,8 @@ import java.util.Collections;
 
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
-import org.apache.sshd.server.Command;
 import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory;
 import org.junit.Test;
@@ -104,7 +104,7 @@ public class SftpServerTests {
 			server.setPublickeyAuthenticator((username, key, session) -> key.equals(allowedKey));
 			server.setPort(0);
 			server.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(new File("hostkey.ser")));
-			server.setSubsystemFactories(Collections.<NamedFactory<Command>>singletonList(new SftpSubsystemFactory()));
+			server.setSubsystemFactories(Collections.singletonList(new SftpSubsystemFactory()));
 			final String pathname = System.getProperty("java.io.tmpdir") + File.separator + "sftptest" + File.separator;
 			new File(pathname).mkdirs();
 			server.setFileSystemFactory(new VirtualFileSystemFactory(Paths.get(pathname)));

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpSessionFactoryTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpSessionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,6 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.util.Collections;
 
-import org.apache.sshd.common.NamedFactory;
-import org.apache.sshd.server.Command;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory;
@@ -135,7 +133,8 @@ public class SftpSessionFactoryTests {
 			fail("expected Exception");
 		}
 		catch (IllegalStateException e) {
-			assertThat(e.getMessage(), startsWith("When a 'UserInfo' is provided, 'privateKeyPassphrase' is not allowed"));
+			assertThat(e
+					.getMessage(), startsWith("When a 'UserInfo' is provided, 'privateKeyPassphrase' is not allowed"));
 		}
 		f.setUserInfo(null);
 		assertEquals("foo", userInfo.getPassword());
@@ -213,7 +212,7 @@ public class SftpSessionFactoryTests {
 	private DefaultSftpSessionFactory createServerAndClient(SshServer server) throws IOException {
 		server.setPublickeyAuthenticator((username, key, session) -> true);
 		server.setPort(0);
-		server.setSubsystemFactories(Collections.<NamedFactory<Command>>singletonList(new SftpSubsystemFactory()));
+		server.setSubsystemFactories(Collections.singletonList(new SftpSubsystemFactory()));
 		server.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(new File("hostkey.ser")));
 		server.start();
 

--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/client/StompIntegrationTests.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/client/StompIntegrationTests.java
@@ -109,7 +109,7 @@ import org.springframework.web.socket.sockjs.client.WebSocketTransport;
  */
 @ContextConfiguration(classes = StompIntegrationTests.ClientConfig.class)
 @RunWith(SpringRunner.class)
-@DirtiesContext
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class StompIntegrationTests {
 
 	@Value("#{server.serverContext}")
@@ -197,7 +197,6 @@ public class StompIntegrationTests {
 
 	@Test
 	public void sendMessageToBrokerAndReceiveReplyViaTopic() throws Exception {
-
 		StompHeaderAccessor headers = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
 		headers.setSubscriptionId("subs1");
 		headers.setDestination("/topic/foo");
@@ -222,8 +221,7 @@ public class StompIntegrationTests {
 	}
 
 	@Test
-	public void sendSubscribeToControllerAndReceiveReply() throws Exception {
-
+	public void sendSubscribeToControllerAndReceiveReply() {
 		String destHeader = "/app/number";
 
 		StompHeaderAccessor headers = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
@@ -284,7 +282,6 @@ public class StompIntegrationTests {
 
 	@Test
 	public void sendMessageToGateway() throws Exception {
-
 		StompHeaderAccessor headers = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
 		headers.setSubscriptionId("subs1");
 		headers.setDestination("/user/queue/answer");
@@ -395,11 +392,12 @@ public class StompIntegrationTests {
 			producer.setOutputChannel(webSocketEvents());
 			return producer;
 		}
+
 	}
 
 	// WebSocket Server part
 
-	@Target({ ElementType.TYPE })
+	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	@Controller
 	private @interface IntegrationTestController {
@@ -429,6 +427,7 @@ public class StompIntegrationTests {
 		public String handleException(IllegalArgumentException ex) {
 			return "Got error: " + ex.getMessage();
 		}
+
 	}
 
 	@IntegrationTestController
@@ -444,6 +443,7 @@ public class StompIntegrationTests {
 		public int number() {
 			return 42;
 		}
+
 	}
 
 

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBean.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,7 +144,7 @@ public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnectio
 							.setPort(this.port);
 
 			if (StringUtils.hasText(this.resource)) {
-							builder.setResource(this.resource);
+				builder.setResource(this.resource);
 			}
 
 			if (StringUtils.hasText(this.serviceName)) {
@@ -192,7 +192,7 @@ public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnectio
 			}
 			catch (Exception e) {
 				throw new BeanInitializationException("failed to connect to XMPP service for "
-						+ connection.getServiceName(), e);
+						+ connection.getXMPPServiceDomain(), e);
 			}
 		}
 	}
@@ -229,26 +229,10 @@ public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnectio
 	}
 
 
-	@SuppressWarnings("deprecation")
 	private class LoggingConnectionListener implements ConnectionListener {
 
 		LoggingConnectionListener() {
 			super();
-		}
-
-		@Override
-		public void reconnectionSuccessful() {
-			logger.debug("Reconnection successful");
-		}
-
-		@Override
-		public void reconnectionFailed(Exception e) {
-			logger.debug("Reconnection failed", e);
-		}
-
-		@Override
-		public void reconnectingIn(int seconds) {
-			logger.debug("Reconnecting in " + seconds + " seconds");
 		}
 
 		@Override

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpointTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,10 +40,12 @@ import org.jivesoftware.smack.StanzaListener;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.tcp.XMPPTCPConnection;
+import org.jivesoftware.smack.tcp.XMPPTCPConnectionConfiguration;
 import org.jivesoftware.smack.util.PacketParserUtils;
 import org.jivesoftware.smackx.gcm.packet.GcmPacketExtension;
 import org.junit.Test;
 import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.stringprep.XmppStringprepException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.xmlpull.v1.XmlPullParser;
@@ -170,7 +172,8 @@ public class ChatMessageListeningEndpointTests {
 		Message smackMessage = new Message();
 		smackMessage.setBody("foo");
 
-		XmlPullParser xmlPullParser = PacketParserUtils.newXmppParser(new StringReader(smackMessage.toXML().toString()));
+		XmlPullParser xmlPullParser =
+				PacketParserUtils.newXmppParser(new StringReader(smackMessage.toXML(null).toString()));
 		xmlPullParser.next();
 		testXMPPConnection.parseAndProcessStanza(xmlPullParser);
 
@@ -196,7 +199,7 @@ public class ChatMessageListeningEndpointTests {
 		endpoint.setPayloadExpression(null);
 
 		smackMessage = new Message();
-		xmlPullParser = PacketParserUtils.newXmppParser(new StringReader(smackMessage.toXML().toString()));
+		xmlPullParser = PacketParserUtils.newXmppParser(new StringReader(smackMessage.toXML(null).toString()));
 		xmlPullParser.next();
 		testXMPPConnection.parseAndProcessStanza(xmlPullParser);
 
@@ -239,7 +242,8 @@ public class ChatMessageListeningEndpointTests {
 		endpoint.afterPropertiesSet();
 		endpoint.start();
 
-		XmlPullParser xmlPullParser = PacketParserUtils.newXmppParser(new StringReader(smackMessage.toXML().toString()));
+		XmlPullParser xmlPullParser =
+				PacketParserUtils.newXmppParser(new StringReader(smackMessage.toXML(null).toString()));
 		xmlPullParser.next();
 		testXMPPConnection.parseAndProcessStanza(xmlPullParser);
 
@@ -253,8 +257,8 @@ public class ChatMessageListeningEndpointTests {
 
 	private static class TestXMPPConnection extends XMPPTCPConnection {
 
-		TestXMPPConnection() {
-			super(null);
+		TestXMPPConnection() throws XmppStringprepException {
+			super(XMPPTCPConnectionConfiguration.builder().setXmppDomain("/foo").build());
 		}
 
 		@Override


### PR DESCRIPTION
* Spring AMQP 2.1 B-S and fix imports for moved classes
* Reactor GA
* SF-5.1 B-S and exclude `org.springframework` from all the
Spring Security dependencies
* the latest Hibernate and JPA and fix the test query for the
appropriate actual syntax
* latest SSHD and add required dependency for `sshd-sftp`
* latest Groovy and extra dependency for the `groovy-dateutil`
* latest Smack for XMPP and appropriate code fixes for compatibility
* Fix `StompIntegrationTests` to use `AFTER_EACH_TEST_METHOD`:
when session is disconnected on the server, we can't interact with it
anymore

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
