### PR TITLE
Adding ChainFileListFilter constructors to behave like CompositeFileL…

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
@@ -19,6 +19,7 @@ package org.springframework.integration.file.filters;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Collection;
 
 import org.springframework.util.Assert;
 
@@ -31,7 +32,7 @@ import org.springframework.util.Assert;
  *
  * @author Artem Bilan
  * @author Gary Russell
- *
+ * @author Cengis KOCAURLU
  * @since 4.3.7
  *
  */
@@ -40,15 +41,15 @@ public class ChainFileListFilter<F> extends CompositeFileListFilter<F> {
 	* @inheritDoc
 	*/
 	public ChainFileListFilter() {
-    	super();
-    }
+  	super();
+  }
 
 	/**
 	* @inheritDoc
 	*/
-    public ChainFileListFilter(Collection<? extends FileListFilter<F>> fileFilters) {
-        super(fileFilters);
-    }
+  public ChainFileListFilter(Collection<? extends FileListFilter<F>> fileFilters) {
+    super(fileFilters);
+  }
 
 	@Override
 	public List<F> filterFiles(F[] files) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
@@ -18,8 +18,8 @@ package org.springframework.integration.file.filters;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 
 import org.springframework.util.Assert;
 
@@ -41,15 +41,15 @@ public class ChainFileListFilter<F> extends CompositeFileListFilter<F> {
 	* @inheritDoc
 	*/
 	public ChainFileListFilter() {
-  	super();
-  }
+		super();
+	}
 
 	/**
 	* @inheritDoc
 	*/
-  public ChainFileListFilter(Collection<? extends FileListFilter<F>> fileFilters) {
-    super(fileFilters);
-  }
+	public ChainFileListFilter(Collection<? extends FileListFilter<F>> fileFilters) {
+		super(fileFilters);
+	}
 
 	@Override
 	public List<F> filterFiles(F[] files) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
@@ -32,22 +32,17 @@ import org.springframework.util.Assert;
  *
  * @author Artem Bilan
  * @author Gary Russell
- * @author Cengis KOCAURLU
+ * @author Cengis Kocaurlu
  *
  * @since 4.3.7
  *
  */
 public class ChainFileListFilter<F> extends CompositeFileListFilter<F> {
-	/**
-	* {@inheritDoc}
-	*/
+
 	public ChainFileListFilter() {
 		super();
 	}
 
-	/**
-	* {@inheritDoc}
-	*/
 	public ChainFileListFilter(Collection<? extends FileListFilter<F>> fileFilters) {
 		super(fileFilters);
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
@@ -36,6 +36,19 @@ import org.springframework.util.Assert;
  *
  */
 public class ChainFileListFilter<F> extends CompositeFileListFilter<F> {
+	/**
+	* @inheritDoc
+	*/
+	public ChainFileListFilter() {
+    	super();
+    }
+
+	/**
+	* @inheritDoc
+	*/
+    public ChainFileListFilter(Collection<? extends FileListFilter<F>> fileFilters) {
+        super(fileFilters);
+    }
 
 	@Override
 	public List<F> filterFiles(F[] files) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Cengis KOCAURLU
+ *
  * @since 4.3.7
  *
  */

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
@@ -52,7 +52,7 @@ public class ChainFileListFilter<F> extends CompositeFileListFilter<F> {
 		Assert.notNull(files, "'files' should not be null");
 		List<F> leftOver = Arrays.asList(files);
 		for (FileListFilter<F> fileFilter : this.fileFilters) {
-			if (leftOver.size() == 0) {
+			if (leftOver.isEmpty()) {
 				break;
 			}
 			@SuppressWarnings("unchecked")

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
@@ -38,14 +38,14 @@ import org.springframework.util.Assert;
  */
 public class ChainFileListFilter<F> extends CompositeFileListFilter<F> {
 	/**
-	* @inheritDoc
+	* {@inheritDoc}
 	*/
 	public ChainFileListFilter() {
 		super();
 	}
 
 	/**
-	* @inheritDoc
+	* {@inheritDoc}
 	*/
 	public ChainFileListFilter(Collection<? extends FileListFilter<F>> fileFilters) {
 		super(fileFilters);

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/filters/ChainFileListFilterIntegrationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/filters/ChainFileListFilterIntegrationTests.java
@@ -31,9 +31,11 @@ import org.junit.Test;
  */
 public class ChainFileListFilterIntegrationTests {
 
+	public static final String PATTERN_ANY_TEXT_FILES = "*.txt";
+
 	private File[] noFiles = new File[0];
 
-	private File[] oneFile = new File[] { new MockOldFile("file.txt") };
+	private File[] oneFile = new File[]{new MockOldFile("file.txt")};
 
 	@Test
 	public void singleModifiedFilterNoFiles() throws IOException {
@@ -47,7 +49,7 @@ public class ChainFileListFilterIntegrationTests {
 	@Test
 	public void singlePatternFilter() throws IOException {
 		try (ChainFileListFilter<File> chain = new ChainFileListFilter<>()) {
-			chain.addFilter(new SimplePatternFileListFilter("*.txt"));
+			chain.addFilter(new SimplePatternFileListFilter(PATTERN_ANY_TEXT_FILES));
 			List<File> result = chain.filterFiles(oneFile);
 			assertEquals(1, result.size());
 		}
@@ -65,7 +67,7 @@ public class ChainFileListFilterIntegrationTests {
 	@Test
 	public void patternThenModifiedFilters() throws IOException {
 		try (ChainFileListFilter<File> chain = new ChainFileListFilter<>()) {
-			chain.addFilter(new SimplePatternFileListFilter("*.txt"));
+			chain.addFilter(new SimplePatternFileListFilter(PATTERN_ANY_TEXT_FILES));
 			chain.addFilter(new LastModifiedFileListFilter());
 			List<File> result = chain.filterFiles(oneFile);
 			assertEquals(1, result.size());
@@ -76,7 +78,16 @@ public class ChainFileListFilterIntegrationTests {
 	public void modifiedThenPatternFilters() throws IOException {
 		try (ChainFileListFilter<File> chain = new ChainFileListFilter<>()) {
 			chain.addFilter(new LastModifiedFileListFilter());
-			chain.addFilter(new SimplePatternFileListFilter("*.txt"));
+			chain.addFilter(new SimplePatternFileListFilter(PATTERN_ANY_TEXT_FILES));
+			List<File> result = chain.filterFiles(oneFile);
+			assertEquals(1, result.size());
+		}
+	}
+
+	//https://github.com/spring-projects/spring-integration/issues/2569
+	@Test
+	public void initializeFilterByConstructor() throws IOException {
+		try (ChainFileListFilter<File> chain = new ChainFileListFilter<>(Arrays.asList(new SimplePatternFileListFilter(PATTERN_ANY_TEXT_FILES)))) {
 			List<File> result = chain.filterFiles(oneFile);
 			assertEquals(1, result.size());
 		}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/filters/ChainFileListFilterIntegrationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/filters/ChainFileListFilterIntegrationTests.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/filters/ChainFileListFilterIntegrationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/filters/ChainFileListFilterIntegrationTests.java
@@ -26,12 +26,13 @@ import org.junit.Test;
 
 /**
  * @author Aaron Grant
+ * @author Cengis Kocaurlu
  *
  * @since 4.3.8
  */
 public class ChainFileListFilterIntegrationTests {
 
-	public static final String PATTERN_ANY_TEXT_FILES = "*.txt";
+	private static final String PATTERN_ANY_TEXT_FILES = "*.txt";
 
 	private File[] noFiles = new File[0];
 


### PR DESCRIPTION
…istFilter

Fixing https://github.com/spring-projects/spring-integration/issues/2569
Adding constructors in ChainFileListFilter matching super, so this class behave like CompositeFileListFilter when using XML flow configuration.

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
