### PR TITLE
INT-4535: Fix @SpringIntegrationTest for caching

### DIFF
--- a/spring-integration-test/src/main/java/org/springframework/integration/test/context/MockIntegrationContextCustomizer.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/context/MockIntegrationContextCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,11 +54,27 @@ class MockIntegrationContextCustomizer implements ContextCustomizer {
 				new RootBeanDefinition(MockIntegrationContext.class));
 
 		String endpointsInitializer = Introspector.decapitalize(IntegrationEndpointsInitializer.class.getSimpleName());
+
 		registry.registerBeanDefinition(endpointsInitializer,
 				BeanDefinitionBuilder.genericBeanDefinition(IntegrationEndpointsInitializer.class)
 						.addConstructorArgValue(this.springIntegrationTest)
 						.getBeanDefinition());
 
+	}
+
+	@Override
+	public int hashCode() {
+		return this.springIntegrationTest.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null || obj.getClass() != getClass()) {
+			return false;
+		}
+
+		MockIntegrationContextCustomizer customizer = (MockIntegrationContextCustomizer) obj;
+		return this.springIntegrationTest.equals(customizer.springIntegrationTest);
 	}
 
 }

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/context/MockIntegrationContextCustomizerFactory.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/context/MockIntegrationContextCustomizerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,11 +37,12 @@ class MockIntegrationContextCustomizerFactory implements ContextCustomizerFactor
 	@Override
 	public ContextCustomizer createContextCustomizer(Class<?> testClass,
 			List<ContextConfigurationAttributes> configAttributes) {
+
 		SpringIntegrationTest springIntegrationTest =
 				AnnotatedElementUtils.findMergedAnnotation(testClass, SpringIntegrationTest.class);
+
 		return springIntegrationTest != null
-				?
-				new MockIntegrationContextCustomizer(springIntegrationTest)
+				? new MockIntegrationContextCustomizer(springIntegrationTest)
 				: null;
 	}
 

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/mock/CachedSpringIntegrationTestAnnotationTests.java
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/mock/CachedSpringIntegrationTestAnnotationTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.test.mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.test.context.SpringIntegrationTest;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 5.0.9
+ */
+@SpringJUnitConfig
+@SpringIntegrationTest
+public abstract class CachedSpringIntegrationTestAnnotationTests {
+
+	private static int beanFactoryPostProcessorCallCounter;
+
+	public static class SpringIntegrationTestAnnotationCaching1Tests
+			extends CachedSpringIntegrationTestAnnotationTests {
+
+		@Test
+		public void testSingleApplicationContext() {
+			assertThat(beanFactoryPostProcessorCallCounter).isEqualTo(1);
+		}
+
+	}
+
+	public static class SpringIntegrationTestAnnotationCaching2Tests
+			extends CachedSpringIntegrationTestAnnotationTests {
+
+		@Test
+		public void testSingleApplicationContext() {
+			assertThat(beanFactoryPostProcessorCallCounter).isEqualTo(1);
+		}
+
+	}
+
+	@Configuration
+	public static class ContextConfiguration {
+
+		@Bean
+		public static BeanFactoryPostProcessor tesBeanFactoryPostProcessor() {
+			return beanFactory -> beanFactoryPostProcessorCallCounter++;
+		}
+
+	}
+
+}

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/mock/MockMessageHandlerTests.java
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/mock/MockMessageHandlerTests.java
@@ -60,6 +60,7 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -72,6 +73,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = MockMessageHandlerTests.Config.class)
 @SpringIntegrationTest
+@DirtiesContext
 public class MockMessageHandlerTests {
 
 	@Autowired


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4535

For the proper Spring Test Context caching support, the `ContextCustomizer`
must implement `hashCode()` and `equals()` methods

* Add `hashCode()` and `equals()` into the `MockIntegrationContextCustomizer`
* Ensure that caching works as excepted with the
`CachedSpringIntegrationTestAnnotationTests` its two sub-classes

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
