### PR TITLE
RemoteFTempl: InputStream.close() in the finally

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -391,11 +391,18 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 	@Override
 	public boolean get(final String remotePath, final InputStreamCallback callback) {
 		Assert.notNull(remotePath, "'remotePath' cannot be null");
-		return this.execute(session -> {
-			InputStream inputStream = session.readRaw(remotePath);
-			callback.doWithInputStream(inputStream);
-			inputStream.close();
-			return session.finalizeRaw();
+		return execute(session -> {
+			InputStream inputStream = null;
+			try {
+				inputStream = session.readRaw(remotePath);
+				callback.doWithInputStream(inputStream);
+				return session.finalizeRaw();
+			}
+			finally {
+				if (inputStream != null) {
+					inputStream.close();
+				}
+			}
 		});
 	}
 


### PR DESCRIPTION
If exception happens in the `callback.doWithInputStream(inputStream)`,
we don't close the `inputStream = session.readRaw(remotePath)`.

* Move the `InputStream.close()` to the `finally` block of the
`SessionCallback` action in the `RemoteFileTemplate.get()`

**Cherry-pick to 5.0.x and 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
