### PR TITLE
INT-4537: Fix RSConsumer for MockIntegrationCtx

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveStreamsConsumer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveStreamsConsumer.java
@@ -49,7 +49,7 @@ public class ReactiveStreamsConsumer extends AbstractEndpoint implements Integra
 
 	private final MessageChannel inputChannel;
 
-	private final MessageHandler messageHandler;
+	private final MessageHandler handler;
 
 	private final Publisher<Message<Object>> publisher;
 
@@ -83,10 +83,13 @@ public class ReactiveStreamsConsumer extends AbstractEndpoint implements Integra
 		this.subscriber = subscriber;
 		this.lifecycleDelegate = subscriber instanceof Lifecycle ? (Lifecycle) subscriber : null;
 		if (subscriber instanceof MessageHandlerSubscriber) {
-			this.messageHandler = ((MessageHandlerSubscriber) subscriber).messageHandler;
+			this.handler = ((MessageHandlerSubscriber) subscriber).messageHandler;
+		}
+		else if (subscriber instanceof MessageHandler) {
+			this.handler = (MessageHandler) subscriber;
 		}
 		else {
-			this.messageHandler = this.subscriber::onNext;
+			this.handler = this.subscriber::onNext;
 		}
 	}
 
@@ -101,11 +104,11 @@ public class ReactiveStreamsConsumer extends AbstractEndpoint implements Integra
 
 	@Override
 	public MessageChannel getOutputChannel() {
-		if (this.messageHandler instanceof MessageProducer) {
-			return ((MessageProducer) this.messageHandler).getOutputChannel();
+		if (this.handler instanceof MessageProducer) {
+			return ((MessageProducer) this.handler).getOutputChannel();
 		}
-		else if (this.messageHandler instanceof MessageRouter) {
-			return ((MessageRouter) this.messageHandler).getDefaultOutputChannel();
+		else if (this.handler instanceof MessageRouter) {
+			return ((MessageRouter) this.handler).getDefaultOutputChannel();
 		}
 		else {
 			return null;
@@ -114,7 +117,7 @@ public class ReactiveStreamsConsumer extends AbstractEndpoint implements Integra
 
 	@Override
 	public MessageHandler getHandler() {
-		return this.messageHandler;
+		return this.handler;
 	}
 
 	@Override

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -245,7 +245,7 @@ public class MyIntegrationTests {
 The `@SpringIntegrationTest` annotation populates a `MockIntegrationContext` bean, which you can autowire to the test class to access its methods.
 With the `noAutoStartup` option, the Spring Integration Test Framework prevents endpoints that are normally `autoStartup=true` from starting. The endpoints are matched to the provided patterns, which support the following simple pattern styles: `xxx*`, `*xxx`, `*xxx*`, and `xxx*yyy`.
 
-This is useful when we would like to not have real connections to the target systems from inbound channel adapters (for example an AMQP Inbound Gateway, JDBC Polling Channel Adapter, WebSocket Message Producer in client mode, and so on).
+This is useful when we would like do not have real connections to the target systems from inbound channel adapters (for example an AMQP Inbound Gateway, JDBC Polling Channel Adapter, WebSocket Message Producer in client mode, and so on).
 
 The `MockIntegrationContext` is meant to be used in the target test cases for modifications to beans in the real application context.
 For example, endpoints that have `autoStartup` overridden to `false` can be replaced with mocks, as the following example shows:
@@ -265,6 +265,21 @@ public void testMockMessageSource() {
 ----
 ====
 
+NOTE: The `mySourceEndpoint` refers here to the bean name of the `SourcePollingChannelAdapter` for which we replace the real `MessageSource` with our mock.
+Similarly the `MockIntegrationContext.substituteMessageHandlerFor()` expect a bean name for the `IntegrationConsumer`, which wraps a `MessageHandler` as an endpoint.
+
+After test is performed you can restore the state of endpoint beans to the real configuration using `MockIntegrationContext.resetBeans()`:
+
+====
+[source,java]
+----
+@After
+public void tearDown() {
+    this.mockIntegrationContext.resetBeans();
+}
+----
+====
+
 See the https://docs.spring.io/spring-integration/api/org/springframework/integration/test/context/MockIntegrationContext.html[Javadoc] for more information.
 
 [[testing-mocks]]
@@ -272,7 +287,7 @@ See the https://docs.spring.io/spring-integration/api/org/springframework/integr
 
 The `org.springframework.integration.test.mock` package offers tools and utilities for mocking, stubbing, and verification of activity on Spring Integration components.
 The mocking functionality is fully based on and compatible with the well known Mockito Framework.
-(The current Mockito transitive dependency is on version 2.5.x.)
+(The current Mockito transitive dependency is on version 2.5.x or higher.)
 
 ==== MockIntegration
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4537

Fixes spring-projects/spring-integration#2582

* Rename `ReactiveStreamsConsumer.messageHandler` property to the
`handler` for consistency with other `IntegrationConsumer` s
* Do not wrap `Subscriber` into the `MessageHandler` if that one is
already a `MessageHandler`
* Fix `MockIntegrationContext` for the logic around `ReactiveStreamsConsumer`
where it is not enough just replace a `handler`, but we also need to do
that with the `subscriber`.
Luckily the `MockMessageHandler` is also a Reactive `Subscriber`
* Clean up `MockIntegrationContext.beans` in the end of `resetBeans()`
* Improve `testing.adoc`

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
