### PR TITLE
INT-4538: Fix Splitter for ArrayNode.size()

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/Transformers.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/Transformers.java
@@ -117,6 +117,17 @@ public abstract class Transformers {
 		return toJson(jsonObjectMapper, null, contentType);
 	}
 
+	/**
+	 * Factory for the {@link ObjectToJsonTransformer} based on the provided {@link ObjectToJsonTransformer.ResultType}.
+	 * @param resultType the {@link ObjectToJsonTransformer.ResultType} to use.
+	 * Defaults to {@link ObjectToJsonTransformer.ResultType#STRING}.
+	 * @return the ObjectToJsonTransformer
+	 * @since 5.0.9
+	 */
+	public static ObjectToJsonTransformer toJson(ObjectToJsonTransformer.ResultType resultType) {
+		return toJson(null, resultType, null);
+	}
+
 	public static ObjectToJsonTransformer toJson(ObjectToJsonTransformer.ResultType resultType, String contentType) {
 		return toJson(null, resultType, contentType);
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/correlation/CorrelationHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/correlation/CorrelationHandlerTests.java
@@ -36,7 +36,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.aggregator.HeaderAttributeCorrelationStrategy;
 import org.springframework.integration.channel.QueueChannel;
@@ -45,7 +44,9 @@ import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.MessageChannelSpec;
 import org.springframework.integration.dsl.MessageChannels;
+import org.springframework.integration.dsl.Transformers;
 import org.springframework.integration.handler.MessageTriggerAction;
+import org.springframework.integration.json.ObjectToJsonTransformer;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -54,6 +55,8 @@ import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import com.fasterxml.jackson.databind.node.TextNode;
 
 /**
  * @author Artem Bilan
@@ -73,7 +76,6 @@ public class CorrelationHandlerTests {
 
 
 	@Autowired
-	@Qualifier("splitAggregateInput")
 	private MessageChannel splitAggregateInput;
 
 	@Autowired
@@ -114,7 +116,7 @@ public class CorrelationHandlerTests {
 
 	@Test
 	public void testSplitterAggregator() {
-		List<Character> payload = Arrays.asList('a', 'b', 'c', 'd', 'e');
+		List<String> payload = Arrays.asList("a", "b", "c", "d", "e");
 
 		QueueChannel replyChannel = new QueueChannel();
 		this.splitAggregateInput.send(MessageBuilder.withPayload(payload)
@@ -127,7 +129,8 @@ public class CorrelationHandlerTests {
 		@SuppressWarnings("unchecked")
 		List<Object> result = (List<Object>) receive.getPayload();
 		for (int i = 0; i < payload.size(); i++) {
-			assertEquals(payload.get(i), result.get(i));
+			assertThat(result.get(i), instanceOf(TextNode.class));
+			assertEquals(TextNode.valueOf(payload.get(i)), result.get(i));
 		}
 	}
 
@@ -204,6 +207,7 @@ public class CorrelationHandlerTests {
 		@Bean
 		public IntegrationFlow splitAggregateFlow() {
 			return IntegrationFlows.from("splitAggregateInput", true)
+					.transform(Transformers.toJson(ObjectToJsonTransformer.ResultType.NODE))
 					.split()
 					.channel(MessageChannels.executor(taskExecutor()))
 					.resequence()
@@ -260,7 +264,6 @@ public class CorrelationHandlerTests {
 		}
 
 		@Bean
-		@DependsOn("barrierFlow")
 		public IntegrationFlow releaseBarrierFlow(MessageTriggerAction barrierTriggerAction) {
 			return IntegrationFlows.from(releaseChannel())
 					.trigger(barrierTriggerAction,

--- a/src/reference/asciidoc/splitter.adoc
+++ b/src/reference/asciidoc/splitter.adoc
@@ -45,17 +45,17 @@ We recommend this approach, because it decouples the code from the Spring Integr
 
 ===== Iterators
 
-Starting with _version 4.1_, the `AbstractMessageSplitter` supports the `Iterator` type for the `value` to split.
+Starting with version 4.1, the `AbstractMessageSplitter` supports the `Iterator` type for the `value` to split.
 Note, in the case of an `Iterator` (or `Iterable`), we don't have access to the number of underlying items and the `SEQUENCE_SIZE` header is set to `0`.
 This means that the default `SequenceSizeReleaseStrategy` of an `<aggregator>` won't work and the group for the `CORRELATION_ID` from the `splitter` won't be released; it will remain as `incomplete`.
 In this case you should use an appropriate custom `ReleaseStrategy` or rely on `send-partial-result-on-expiry` together with `group-timeout` or a `MessageGroupStoreReaper`.
 
-Starting with _version 5.0_, the `AbstractMessageSplitter` provides `protected obtainSizeIfPossible()` methods to allow the determination of the size of the `Iterable` and `Iterator` objects if that is possible.
+Starting with version 5.0, the `AbstractMessageSplitter` provides `protected obtainSizeIfPossible()` methods to allow the determination of the size of the `Iterable` and `Iterator` objects if that is possible.
 For example `XPathMessageSplitter` can determine the size of the underlying `NodeList` object.
+And starting with version 5.0.9, this method also properly returns a size of the `com.fasterxml.jackson.core.TreeNode`.
 
 An `Iterator` object is useful to avoid the need for building an entire collection in the memory before splitting.
-For example, when underlying items are populated from some external system (e.g.
-DataBase or FTP `MGET`) using iterations or streams.
+For example, when underlying items are populated from some external system (e.g. DataBase or FTP `MGET`) using iterations or streams.
 
 ===== Stream and Flux
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4538

* Add support for Jackson `TreeNode.size()` in the `AbstractMessageSplitter`
* Add overloaded `Transformers.toJson(ObjectToJsonTransformer.ResultType)`
* Modify test to verify Jackson `ArrayNode` use-case with the splitter
and aggregator

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
