### PR TITLE
INT-4539: Fix Java DSL for prototype beans

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationComponentSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationComponentSpec.java
@@ -63,7 +63,7 @@ public abstract class IntegrationComponentSpec<S extends IntegrationComponentSpe
 	/**
 	 * @return the configured component.
 	 */
-	public final T get() {
+	public T get() {
 		if (this.target == null) {
 			this.target = doGet();
 		}
@@ -71,18 +71,13 @@ public abstract class IntegrationComponentSpec<S extends IntegrationComponentSpe
 	}
 
 	@Override
-	public T getObject() throws Exception {
+	public T getObject() {
 		return get();
 	}
 
 	@Override
 	public Class<?> getObjectType() {
 		return get().getClass();
-	}
-
-	@Override
-	public boolean isSingleton() {
-		return true;
 	}
 
 	@Override


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4539

The `IntegrationFlowBeanPostProcessor` doesn't check for prototype beans
and just override them in the application context with the singletons

* Since we can't in the DSL understand if provided object is a prototype
or not, we try to check for its bean definition by possible bean name.
Use `NamedComponent` for possible bean name to check.
* Remove `final` from the `IntegrationComponentSpec.get()` since its
result is not visible for CGI proxies when it is declared as a `@Bean`
and subsequent `getObject()` produces a new internal object
* Verify prototype beans with new test in the `IntegrationFlowTests`

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
