### PR TITLE
INT-4540: Use MessageHeaders in GenericHandler

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/GenericHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/GenericHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.handler;
 
-import java.util.Map;
+import org.springframework.messaging.MessageHeaders;
 
 /**
  * A functional interface to specify {@link org.springframework.messaging.MessageHandler}
@@ -36,6 +36,6 @@ import java.util.Map;
 @FunctionalInterface
 public interface GenericHandler<P> {
 
-	Object handle(P payload, Map<String, Object> headers);
+	Object handle(P payload, MessageHeaders headers);
 
 }

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/dsl/IntegrationFlowEventsTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/dsl/IntegrationFlowEventsTests.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.BeforeClass;
@@ -49,6 +48,7 @@ import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.SimpleMessageStore;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
@@ -148,7 +148,7 @@ public class IntegrationFlowEventsTests {
 						}
 
 						@Override
-						public Object handle(Integer p, Map<String, Object> h) {
+						public Object handle(Integer p, MessageHeaders h) {
 							return p * 2;
 						}
 

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/dsl/WebFluxDslTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/dsl/WebFluxDslTests.java
@@ -370,7 +370,7 @@ public class WebFluxDslTests {
 							.requestMapping(m -> m.produces(MediaType.TEXT_EVENT_STREAM_VALUE))
 							.mappedResponseHeaders("*"))
 					.enrichHeaders(Collections.singletonMap("aHeader", new String[] { "foo", "bar", "baz" }))
-					.handle((p, h) -> Flux.fromArray((String[]) h.get("aHeader")))
+					.handle((p, h) -> Flux.fromArray(h.get("aHeader", String[].class)))
 					.get();
 		}
 

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -476,7 +476,7 @@ Similar lambda configurations are provided for the `resequence()` EIP method.
 The `.handle()` EIP method's goal is to invoke any `MessageHandler` implementation or any method on some POJO.
 Another option is to define an "`activity`" by using lambda expressions.
 Consequently, we introduced a generic `GenericHandler<P>` functional interface.
-Its `handle` method requires two arguments: `P payload` and `Map<String, Object> headers`.
+Its `handle` method requires two arguments: `P payload` and `MessageHeaders headers` (starting with version 5.1).
 Having that, we can define a flow as follows:
 
 ====

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -41,6 +41,8 @@ This avoid confusion with `log()` which is treated as a one-way end flow compone
 
 A generated bean name for any `NamedComponent` within an integration flow is now based on the component type for better readability from visual tools, logs analyzers and metrics collectors.
 
+The `GenericHandler.handle()` now excepts a `MessageHeaders` type for the second argument.
+
 [[x5.1-dispatcher-exceptions]]
 ==== Dispatcher Exceptions
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4540

For better end-user experience use a `MessageHeaders` in the
`GenericHandler` instead of plain `Map<String, Object>`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
