### PR TITLE
INT-4541: Fix Reactive MessagingGateway Errors

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -628,12 +628,23 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 							this.messageCount.incrementAndGet();
 						}
 					})
-					.<Message<?>>map(replyMessage ->
-							MessageBuilder.fromMessage(replyMessage)
-									.setHeader(MessageHeaders.REPLY_CHANNEL, originalReplyChannelHeader)
-									.setHeader(MessageHeaders.ERROR_CHANNEL, originalErrorChannelHeader)
-									.build())
-
+					.<Message<?>>map(replyMessage -> {
+							if (!error && replyMessage instanceof ErrorMessage) {
+								ErrorMessage em = (ErrorMessage) replyMessage;
+								if (em.getPayload() instanceof MessagingException) {
+									throw (MessagingException) em.getPayload();
+								}
+								else {
+									throw new MessagingException(requestMessage, em.getPayload());
+								}
+							}
+							else {
+								return MessageBuilder.fromMessage(replyMessage)
+										.setHeader(MessageHeaders.REPLY_CHANNEL, originalReplyChannelHeader)
+										.setHeader(MessageHeaders.ERROR_CHANNEL, originalErrorChannelHeader)
+										.build();
+							}
+					})
 					.onErrorResume(t -> error ? Mono.error(t) : handleSendError(requestMessage, t));
 		});
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4541

Add test case to reproduce.

The gateway correctly sets up the `errorChannel` header so that a downstream
`MPEH` will send exceptions back to the gateway, but the `map()` function
did not check for an error message.

Check for an error message and throw the payload so that the `onErrorResume`
will route to the error channel.

