### PR TITLE
INT-4543: JacksonJsonObjectMapper: fix toJsonNode

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonObjectMapper.java
@@ -114,7 +114,10 @@ public class Jackson2JsonObjectMapper extends AbstractJacksonJsonObjectMapper<Js
 			}
 		}
 		catch (JsonParseException e) {
-			// The input might not be valid JSON, fallback to TextNode with ObjectMapper.valueToTree()
+			if (!(json instanceof String) && !(json instanceof byte[])) {
+				throw e;
+			}
+			// Otherwise the input might not be valid JSON, fallback to TextNode with ObjectMapper.valueToTree()
 		}
 
 		return this.objectMapper.valueToTree(json);

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,8 +91,28 @@ public class Jackson2JsonObjectMapper extends AbstractJacksonJsonObjectMapper<Js
 	}
 
 	@Override
-	public JsonNode toJsonNode(Object value) throws Exception {
-		return this.objectMapper.valueToTree(value);
+	public JsonNode toJsonNode(Object json) throws Exception {
+		if (json instanceof String) {
+			return this.objectMapper.readTree((String) json);
+		}
+		else if (json instanceof byte[]) {
+			return this.objectMapper.readTree((byte[]) json);
+		}
+		else if (json instanceof File) {
+			return this.objectMapper.readTree((File) json);
+		}
+		else if (json instanceof URL) {
+			return this.objectMapper.readTree((URL) json);
+		}
+		else if (json instanceof InputStream) {
+			return this.objectMapper.readTree((InputStream) json);
+		}
+		else if (json instanceof Reader) {
+			return this.objectMapper.readTree((Reader) json);
+		}
+		else {
+			return this.objectMapper.valueToTree(json);
+		}
 	}
 
 	@Override
@@ -137,7 +157,8 @@ public class Jackson2JsonObjectMapper extends AbstractJacksonJsonObjectMapper<Js
 		JavaType contentClassType = this.createJavaType(javaTypes, JsonHeaders.CONTENT_TYPE_ID);
 		if (classType.getKeyType() == null) {
 			return this.objectMapper.getTypeFactory()
-					.constructCollectionType((Class<? extends Collection<?>>) classType.getRawClass(), contentClassType);
+					.constructCollectionType((Class<? extends Collection<?>>) classType
+							.getRawClass(), contentClassType);
 		}
 
 		JavaType keyClassType = this.createJavaType(javaTypes, JsonHeaders.KEY_TYPE_ID);

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
@@ -46,6 +46,7 @@ import org.springframework.messaging.support.GenericMessage;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Mark Fisher
@@ -58,38 +59,42 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class ObjectToJsonTransformerTests {
 
 	@Test
-	public void simpleStringPayload() throws Exception {
+	public void simpleStringPayload() {
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
-		String result = (String) transformer.transform(new GenericMessage<String>("foo")).getPayload();
+		String result = (String) transformer.transform(new GenericMessage<>("foo")).getPayload();
 		assertEquals("\"foo\"", result);
 	}
 
 	@Test
-	public void withDefaultContentType() throws Exception {
+	public void withDefaultContentType() {
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
-		Message<?> result = transformer.transform(new GenericMessage<String>("foo"));
+		Message<?> result = transformer.transform(new GenericMessage<>("foo"));
 		assertEquals(ObjectToJsonTransformer.JSON_CONTENT_TYPE, result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test
-	public void withProvidedContentType() throws Exception {
+	public void withProvidedContentType() {
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
-		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "text/xml").build();
+		Message<?> message = MessageBuilder.withPayload("foo")
+				.setHeader(MessageHeaders.CONTENT_TYPE, "text/xml")
+				.build();
 		Message<?> result = transformer.transform(message);
 		assertEquals("text/xml", result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test
-	public void withProvidedContentTypeWithOverride() throws Exception {
+	public void withProvidedContentTypeWithOverride() {
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		transformer.setContentType(ObjectToJsonTransformer.JSON_CONTENT_TYPE);
-		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "text/xml").build();
+		Message<?> message = MessageBuilder.withPayload("foo")
+				.setHeader(MessageHeaders.CONTENT_TYPE, "text/xml")
+				.build();
 		Message<?> result = transformer.transform(message);
 		assertEquals(ObjectToJsonTransformer.JSON_CONTENT_TYPE, result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test
-	public void withProvidedContentTypeAsEmptyString() throws Exception {
+	public void withProvidedContentTypeAsEmptyString() {
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		transformer.setContentType("");
 		Message<?> message = MessageBuilder.withPayload("foo").build();
@@ -98,24 +103,26 @@ public class ObjectToJsonTransformerTests {
 	}
 
 	@Test
-	public void withProvidedContentTypeAsEmptyStringDoesNotOverride() throws Exception {
+	public void withProvidedContentTypeAsEmptyStringDoesNotOverride() {
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		transformer.setContentType("");
-		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "text/xml").build();
+		Message<?> message = MessageBuilder.withPayload("foo")
+				.setHeader(MessageHeaders.CONTENT_TYPE, "text/xml")
+				.build();
 		Message<?> result = transformer.transform(message);
 		assertEquals("text/xml", result.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void withProvidedContentTypeAsNull() throws Exception {
+	public void withProvidedContentTypeAsNull() {
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		transformer.setContentType(null);
 	}
 
 	@Test
-	public void simpleIntegerPayload() throws Exception {
+	public void simpleIntegerPayload() {
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
-		String result = (String) transformer.transform(new GenericMessage<Integer>(123)).getPayload();
+		String result = (String) transformer.transform(new GenericMessage<>(123)).getPayload();
 		assertEquals("123", result);
 	}
 
@@ -128,12 +135,12 @@ public class ObjectToJsonTransformerTests {
 	}
 
 	@Test
-	public void objectPayload() throws Exception {
+	public void objectPayload() {
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer();
 		TestAddress address = new TestAddress(123, "Main Street");
 		TestPerson person = new TestPerson("John", "Doe", 42);
 		person.setAddress(address);
-		String result = (String) transformer.transform(new GenericMessage<TestPerson>(person)).getPayload();
+		String result = (String) transformer.transform(new GenericMessage<>(person)).getPayload();
 		assertTrue(result.contains("\"firstName\":\"John\""));
 		assertTrue(result.contains("\"lastName\":\"Doe\""));
 		assertTrue(result.contains("\"age\":42"));
@@ -146,13 +153,13 @@ public class ObjectToJsonTransformerTests {
 	}
 
 	@Test
-	public void objectPayloadWithCustomObjectMapper() throws Exception {
+	public void objectPayloadWithCustomObjectMapper() {
 		ObjectMapper customMapper = new ObjectMapper();
 		customMapper.configure(JsonGenerator.Feature.QUOTE_FIELD_NAMES, Boolean.FALSE);
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer(new Jackson2JsonObjectMapper(customMapper));
 		TestPerson person = new TestPerson("John", "Doe", 42);
 		person.setAddress(new TestAddress(123, "Main Street"));
-		String result = (String) transformer.transform(new GenericMessage<TestPerson>(person)).getPayload();
+		String result = (String) transformer.transform(new GenericMessage<>(person)).getPayload();
 		assertTrue(result.contains("firstName:\"John\""));
 		assertTrue(result.contains("lastName:\"Doe\""));
 		assertTrue(result.contains("age:42"));
@@ -193,11 +200,11 @@ public class ObjectToJsonTransformerTests {
 	}
 
 	@Test
-	public void testBoonJsonObjectMapper() throws Exception {
+	public void testBoonJsonObjectMapper() {
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer(new BoonJsonObjectMapper());
 		TestPerson person = new TestPerson("John", "Doe", 42);
 		person.setAddress(new TestAddress(123, "Main Street"));
-		String result = (String) transformer.transform(new GenericMessage<TestPerson>(person)).getPayload();
+		String result = (String) transformer.transform(new GenericMessage<>(person)).getPayload();
 		assertTrue(result.contains("\"firstName\":\"John\""));
 		assertTrue(result.contains("\"lastName\":\"Doe\""));
 		assertTrue(result.contains("\"age\":42"));
@@ -210,12 +217,12 @@ public class ObjectToJsonTransformerTests {
 	}
 
 	@Test
-	public void testBoonJsonObjectMapper_toNode() throws Exception {
+	public void testBoonJsonObjectMapper_toNode() {
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer(new BoonJsonObjectMapper(),
 				ObjectToJsonTransformer.ResultType.NODE);
 		TestPerson person = new TestPerson("John", "Doe", 42);
 		person.setAddress(new TestAddress(123, "Main Street"));
-		Object payload = transformer.transform(new GenericMessage<TestPerson>(person)).getPayload();
+		Object payload = transformer.transform(new GenericMessage<>(person)).getPayload();
 		assertThat(payload, instanceOf(Map.class));
 
 		SpelExpressionParser parser = new SpelExpressionParser();
@@ -225,6 +232,17 @@ public class ObjectToJsonTransformerTests {
 		String value = expression.getValue(evaluationContext, payload, String.class);
 
 		assertEquals("John: Main Street", value);
+	}
+
+	@Test
+	public void testJsonStringAndJsonNode() {
+		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer(ObjectToJsonTransformer.ResultType.NODE);
+		Object result = transformer.transform(new GenericMessage<>("{\"foo\": \"FOO\", \"bar\": 1}")).getPayload();
+		assertThat(result, instanceOf(ObjectNode.class));
+		ObjectNode objectNode = (ObjectNode) result;
+		assertEquals(2, objectNode.size());
+		assertEquals("FOO", objectNode.path("foo").textValue());
+		assertEquals(1, objectNode.path("bar").intValue());
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
@@ -47,6 +47,7 @@ import org.springframework.messaging.support.GenericMessage;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 /**
  * @author Mark Fisher
@@ -243,6 +244,10 @@ public class ObjectToJsonTransformerTests {
 		assertEquals(2, objectNode.size());
 		assertEquals("FOO", objectNode.path("foo").textValue());
 		assertEquals(1, objectNode.path("bar").intValue());
+
+		result = transformer.transform(new GenericMessage<>("foo")).getPayload();
+		assertThat(result, instanceOf(TextNode.class));
+		assertEquals("foo", ((TextNode) result).textValue());
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4543

When inbound payload is type of `String`, `byte[]`, `File`, `URL`,
`InputStream` or `Reader`, we have to use an `ObjectMapper.readTree()`
function.
For all other types the `valueToTree()` should be used as a fallback

**Cherry-pick to 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
