### PR TITLE
Defensive MBeanExporterHelper Registration

### DIFF
--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/JmxIntegrationConfigurationInitializer.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/JmxIntegrationConfigurationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.integration.monitor.IntegrationMBeanExporter;
  * The JMX Integration infrastructure {@code beanFactory} initializer.
  *
  * @author Artem Bilan
+ * @author Gary Russell
  * @since 4.0
  */
 public class JmxIntegrationConfigurationInitializer implements IntegrationConfigurationInitializer {
@@ -39,7 +40,8 @@ public class JmxIntegrationConfigurationInitializer implements IntegrationConfig
 	}
 
 	private void registerMBeanExporterHelperIfNecessary(ConfigurableListableBeanFactory beanFactory) {
-		if (beanFactory.getBeanNamesForType(IntegrationMBeanExporter.class, false, false).length > 0) {
+		if (!beanFactory.containsBean(MBEAN_EXPORTER_HELPER_BEAN_NAME)
+				&& beanFactory.getBeanNamesForType(IntegrationMBeanExporter.class, false, false).length > 0) {
 			((BeanDefinitionRegistry) beanFactory).registerBeanDefinition(MBEAN_EXPORTER_HELPER_BEAN_NAME,
 					new RootBeanDefinition(MBeanExporterHelper.class));
 		}


### PR DESCRIPTION
If the initializer is somehow called more than once, context
initialization will fail with default Boot 2.1 settings, which
do not allow bean overrides.
