### PR TITLE
INT-4530: Remove Meters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ subprojects { subproject ->
 		kryoShadedVersion = '3.0.3'
 		lettuceVersion = '5.1.0.RELEASE'
 		log4jVersion = '2.11.1'
-		micrometerVersion = '1.0.6'
+		micrometerVersion = '1.1.0-SNAPSHOT'
 		mockitoVersion = '2.22.0'
 		mysqlVersion = '8.0.11'
 		pahoMqttClientVersion = '1.2.0'

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PollableAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PollableAmqpChannel.java
@@ -352,4 +352,12 @@ public class PollableAmqpChannel extends AbstractAmqpChannel
 		return this.executorInterceptorsSize > 0;
 	}
 
+	@Override
+	public void destroy() throws Exception {
+		super.destroy();
+		if (this.receiveCounter != null) {
+			this.receiveCounter.remove();
+		}
+	}
+
 }

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests.java
@@ -177,7 +177,7 @@ public class AmqpOutboundEndpointTests {
 				.setHeader(AmqpHeaders.CONTENT_TYPE, "application/json")
 				.build();
 		this.ctRequestChannel.send(message);
-		org.springframework.amqp.core.Message m = template.receive();
+		org.springframework.amqp.core.Message m = receive(template);
 		assertNotNull(m);
 		assertEquals("\"hello\"", new String(m.getBody(), "UTF-8"));
 		assertEquals("application/json", m.getMessageProperties().getContentType());
@@ -186,13 +186,24 @@ public class AmqpOutboundEndpointTests {
 		message = MessageBuilder.withPayload("hello")
 				.build();
 		this.ctRequestChannel.send(message);
-		m = template.receive();
+		m = receive(template);
 		assertNotNull(m);
 		assertEquals("hello", new String(m.getBody(), "UTF-8"));
 		assertEquals("text/plain", m.getMessageProperties().getContentType());
 		while (template.receive() != null) {
 			// drain
 		}
+	}
+
+	private org.springframework.amqp.core.Message receive(RabbitTemplate template) throws Exception {
+		int n = 0;
+		org.springframework.amqp.core.Message message = template.receive();
+		while (message == null && n++ < 100) {
+			Thread.sleep(100);
+			message = template.receive();
+		}
+		assertNotNull(message);
+		return message;
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/NullChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/NullChannel.java
@@ -273,4 +273,11 @@ public class NullChannel implements PollableChannel, MessageChannelMetrics,
 		return (this.beanName != null) ? this.beanName : super.toString();
 	}
 
+	@Override
+	public void destroy() throws Exception {
+		if (this.successTimer != null) {
+			this.successTimer.remove();
+		}
+	}
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -51,7 +51,6 @@ import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.config.IntegrationConfigUtils;
-import org.springframework.integration.config.annotation.MessagingAnnotationPostProcessor.Disposables;
 import org.springframework.integration.context.Orderable;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.endpoint.AbstractPollingEndpoint;
@@ -190,7 +189,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 			this.beanFactory.registerSingleton(handlerBeanName, handler);
 			handler = (MessageHandler) this.beanFactory.initializeBean(handler, handlerBeanName);
 			if (handler instanceof DisposableBean && this.disposables != null) {
-				this.disposables.addOne((DisposableBean) handler);
+				this.disposables.add((DisposableBean) handler);
 			}
 		}
 
@@ -313,7 +312,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 					this.beanFactory.registerSingleton(inputChannelName, inputChannel);
 					inputChannel = (MessageChannel) this.beanFactory.initializeBean(inputChannel, inputChannelName);
 					if (this.disposables != null) {
-						this.disposables.addOne((DisposableBean) inputChannel);
+						this.disposables.add((DisposableBean) inputChannel);
 					}
 				}
 				else {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -34,6 +34,7 @@ import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.DefaultBeanFactoryPointcutAdvisor;
 import org.springframework.aop.support.NameMatchMethodPointcut;
 import org.springframework.aop.support.NameMatchMethodPointcutAdvisor;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionValidationException;
@@ -50,6 +51,7 @@ import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.config.IntegrationConfigUtils;
+import org.springframework.integration.config.annotation.MessagingAnnotationPostProcessor.Disposables;
 import org.springframework.integration.context.Orderable;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.endpoint.AbstractPollingEndpoint;
@@ -108,6 +110,8 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 	protected final Class<T> annotationType;
 
+	protected final Disposables disposables; // NOSONAR
+
 	@SuppressWarnings("unchecked")
 	public AbstractMethodAnnotationPostProcessor(ConfigurableListableBeanFactory beanFactory) {
 		Assert.notNull(beanFactory, "'beanFactory' must not be null");
@@ -123,6 +127,14 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 		this.channelResolver = new BeanFactoryChannelResolver(beanFactory);
 		this.annotationType = (Class<T>) GenericTypeResolver.resolveTypeArgument(this.getClass(),
 				MethodAnnotationPostProcessor.class);
+		Disposables disposables = null;
+		try {
+			disposables = beanFactory.getBean(Disposables.class);
+		}
+		catch (Exception e) {
+			// NOSONAR - only for test cases
+		}
+		this.disposables = disposables;
 	}
 
 
@@ -177,6 +189,9 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 			}
 			this.beanFactory.registerSingleton(handlerBeanName, handler);
 			handler = (MessageHandler) this.beanFactory.initializeBean(handler, handlerBeanName);
+			if (handler instanceof DisposableBean && this.disposables != null) {
+				this.disposables.addOne((DisposableBean) handler);
+			}
 		}
 
 		if (AnnotatedElementUtils.isAnnotated(method, IdempotentReceiver.class.getName())
@@ -297,6 +312,9 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 					inputChannel = new DirectChannel();
 					this.beanFactory.registerSingleton(inputChannelName, inputChannel);
 					inputChannel = (MessageChannel) this.beanFactory.initializeBean(inputChannel, inputChannelName);
+					if (this.disposables != null) {
+						this.disposables.addOne((DisposableBean) inputChannel);
+					}
 				}
 				else {
 					throw e;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/Disposables.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/Disposables.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.config.annotation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.beans.factory.DisposableBean;
+
+/**
+ * A container for a collection of {@link DisposableBean} it is, itself a
+ * {@link DisposableBean} and will dispose of its contained beans when it is destroyed.
+ * Intended for any {@link DisposableBean} that is registered as a singleton in which
+ * case, the container does not automatically dispose of them.
+ *
+ * @author Gary Russell
+ * @since 5.1
+ *
+ */
+class Disposables implements DisposableBean {
+
+	private final List<DisposableBean> disposables = new ArrayList<>();
+
+	public void add(DisposableBean... disposables) {
+		this.disposables.addAll(Arrays.asList(disposables));
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		this.disposables.forEach(d -> {
+			try {
+				d.destroy();
+			}
+			catch (Exception e) {
+				// NOSONAR
+			}
+		});
+	}
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
@@ -131,6 +131,9 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 			this.beanFactory.registerSingleton(messageSourceBeanName, methodInvokingMessageSource);
 			messageSource = (MessageSource<?>) this.beanFactory
 					.initializeBean(methodInvokingMessageSource, messageSourceBeanName);
+			if (this.disposables != null) {
+				this.disposables.addOne(methodInvokingMessageSource);
+			}
 		}
 		return messageSource;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
@@ -132,7 +132,7 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 			messageSource = (MessageSource<?>) this.beanFactory
 					.initializeBean(methodInvokingMessageSource, messageSourceBeanName);
 			if (this.disposables != null) {
-				this.disposables.addOne(methodInvokingMessageSource);
+				this.disposables.add(methodInvokingMessageSource);
 			}
 		}
 		return messageSource;

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
@@ -99,6 +99,8 @@ public abstract class IntegrationContextUtils {
 
 	public static final String LIST_ARGUMENT_RESOLVERS_BEAN_NAME = "integrationListArgumentResolvers";
 
+	public static final String DISPOSABLES_BEAN_NAME = "integrationDisposableAutoCreatedBeans";
+
 	/**
 	 * @param beanFactory BeanFactory for lookup, must not be null.
 	 * @return The {@link MetadataStore} bean whose name is "metadataStore".

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractMessageSource.java
@@ -233,4 +233,11 @@ public abstract class AbstractMessageSource<T> extends AbstractExpressionEvaluat
 	 */
 	protected abstract Object doReceive();
 
+	@Override
+	public void destroy() throws Exception {
+		if (this.receiveCounter != null) {
+			this.receiveCounter.remove();
+		}
+	}
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationManagement.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.support.management;
 
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.integration.support.management.metrics.MetricsCaptor;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedOperation;
@@ -27,7 +28,7 @@ import org.springframework.jmx.export.annotation.ManagedOperation;
  * @since 4.2
  *
  */
-public interface IntegrationManagement {
+public interface IntegrationManagement extends DisposableBean {
 
 	String METER_PREFIX = "spring.integration.";
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/LifecycleMessageHandlerMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/LifecycleMessageHandlerMetrics.java
@@ -187,4 +187,9 @@ public class LifecycleMessageHandlerMetrics implements MessageHandlerMetrics, Li
 		return this.delegate.getOverrides();
 	}
 
+	@Override
+	public void destroy() throws Exception {
+		this.delegate.destroy();
+	}
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/LifecycleMessageSourceMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/LifecycleMessageSourceMetrics.java
@@ -126,4 +126,9 @@ public class LifecycleMessageSourceMetrics implements MessageSourceMetrics, Life
 		return this.delegate.getOverrides();
 	}
 
+	@Override
+	public void destroy() throws Exception {
+		this.delegate.destroy();
+	}
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/MessageSourceMetrics.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/MessageSourceMetrics.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.support.management;
 
-import org.springframework.integration.support.management.metrics.CounterFacade;
 import org.springframework.jmx.export.annotation.ManagedMetric;
 import org.springframework.jmx.support.MetricType;
 
@@ -49,17 +48,5 @@ public interface MessageSourceMetrics extends IntegrationManagement {
 	void setManagedType(String source);
 
 	String getManagedType();
-
-	/**
-	 * Set a micrometer counter to count messages produced.
-	 * @param counter the counter.
-	 * @since 5.0.2
-	 * @deprecated in favor of built-in counter registration via {@code MeterRegistry} callbacks.
-	 * Will be remove in the next release.
-	 */
-	@Deprecated
-	default void setCounter(CounterFacade counter) {
-		// no op
-	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/metrics/GaugeFacade.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/metrics/GaugeFacade.java
@@ -21,6 +21,6 @@ package org.springframework.integration.support.management.metrics;
  * @since 5.0.4
  *
  */
-public interface GaugeFacade {
+public interface GaugeFacade extends MeterFacade {
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/metrics/MeterFacade.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/metrics/MeterFacade.java
@@ -16,13 +16,25 @@
 
 package org.springframework.integration.support.management.metrics;
 
+import org.springframework.lang.Nullable;
+
 /**
+ * Facade for Meters.
+ *
  * @author Gary Russell
- * @since 5.0.4
+ * @since 5.1
  *
  */
-public interface CounterFacade extends MeterFacade {
+public interface MeterFacade {
 
-	void increment();
+	/**
+	 * Remove this meter facade.
+	 * @param <T> the type of meter removed.
+	 * @return the facade that was removed, or null.
+	 */
+	@Nullable
+	default <T extends MeterFacade> T remove() {
+		return null;
+	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/metrics/MetricsCaptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/metrics/MetricsCaptor.java
@@ -59,6 +59,17 @@ public interface MetricsCaptor {
 	SampleFacade start();
 
 	/**
+	 * Remove a meter facade.
+	 * @param facade the facade to remove.
+	 * @return the removed facade, or null.
+	 * @since 5.1
+	 */
+	@Nullable
+	default MeterFacade removeMeter(MeterFacade facade) {
+		return null;
+	}
+
+	/**
 	 * A builder for a timer.
 	 */
 	interface TimerBuilder {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/metrics/TimerFacade.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/metrics/TimerFacade.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
  * @since 5.0.4
  *
  */
-public interface TimerFacade {
+public interface TimerFacade extends MeterFacade {
 
 	void record(long time, TimeUnit unit);
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessorChannelCreationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessorChannelCreationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,12 +25,14 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
 
 import org.junit.Test;
 
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.messaging.MessageChannel;
@@ -46,7 +48,8 @@ public class MessagingAnnotationPostProcessorChannelCreationTests {
 
 	@Test
 	public void testAutoCreateChannel() {
-		ConfigurableListableBeanFactory beanFactory = mock(ConfigurableListableBeanFactory.class);
+		ConfigurableListableBeanFactory beanFactory = mock(ConfigurableListableBeanFactory.class,
+				withSettings().extraInterfaces(BeanDefinitionRegistry.class));
 		given(beanFactory.getBean("channel", MessageChannel.class)).willThrow(NoSuchBeanDefinitionException.class);
 		willAnswer(invocation -> invocation.getArgument(0))
 				.given(beanFactory).initializeBean(any(DirectChannel.class), eq("channel"));
@@ -61,7 +64,8 @@ public class MessagingAnnotationPostProcessorChannelCreationTests {
 
 	@Test
 	public void testDontCreateChannelWhenChannelHasBadDefinition() {
-		ConfigurableListableBeanFactory beanFactory = mock(ConfigurableListableBeanFactory.class);
+		ConfigurableListableBeanFactory beanFactory = mock(ConfigurableListableBeanFactory.class,
+				withSettings().extraInterfaces(BeanDefinitionRegistry.class));
 		given(beanFactory.getBean("channel", MessageChannel.class)).willThrow(BeanCreationException.class);
 		willAnswer(invocation -> invocation.getArgument(0))
 				.given(beanFactory).initializeBean(any(DirectChannel.class), eq("channel"));

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsTests.java
@@ -45,10 +45,10 @@ import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 /**
@@ -58,7 +58,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
  *
  */
 @RunWith(SpringRunner.class)
-@DirtiesContext
 public class MicrometerMetricsTests {
 
 	@Autowired
@@ -86,7 +85,7 @@ public class MicrometerMetricsTests {
 	private NullChannel nullChannel;
 
 	@Test
-	public void testSend() {
+	public void testSend() throws Exception {
 		GenericMessage<String> message = new GenericMessage<>("foo");
 		this.channel.send(message);
 		try {
@@ -170,6 +169,38 @@ public class MicrometerMetricsTests {
 				.tag("name", "newChannel")
 				.tag("result", "success")
 				.timer().count()).isEqualTo(1);
+
+		// Test meter removal
+		registry.get("spring.integration.send")
+			.tag("name", "newChannel")
+			.tag("result", "success")
+			.timer();
+		newChannel.destroy();
+		try {
+			registry.get("spring.integration.send")
+				.tag("name", "newChannel")
+				.tag("result", "success")
+				.timer();
+			fail("Expected MeterNotFoundException");
+		}
+		catch (MeterNotFoundException e) {
+			// NOSONAR
+		}
+		this.context.close();
+		try {
+			registry.get("spring.integration.send").timers();
+			fail("Expected MeterNotFoundException");
+		}
+		catch (MeterNotFoundException e) {
+			// NOSONAR
+		}
+		try {
+			registry.get("spring.integration.receive").counters();
+			fail("Expected MeterNotFoundException");
+		}
+		catch (MeterNotFoundException e) {
+			// NOSONAR
+		}
 	}
 
 	@Configuration

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsTests.java
@@ -184,7 +184,8 @@ public class MicrometerMetricsTests {
 			fail("Expected MeterNotFoundException");
 		}
 		catch (MeterNotFoundException e) {
-			// NOSONAR
+			assertThat(e).hasMessageContaining("A meter with name 'spring.integration.send' was found");
+			assertThat(e).hasMessageContaining("No meters have a tag 'name' with value 'newChannel'");
 		}
 		this.context.close();
 		try {
@@ -192,14 +193,14 @@ public class MicrometerMetricsTests {
 			fail("Expected MeterNotFoundException");
 		}
 		catch (MeterNotFoundException e) {
-			// NOSONAR
+			assertThat(e).hasMessageContaining("No meter with name 'spring.integration.send' was found");
 		}
 		try {
 			registry.get("spring.integration.receive").counters();
 			fail("Expected MeterNotFoundException");
 		}
 		catch (MeterNotFoundException e) {
-			// NOSONAR
+			assertThat(e).hasMessageContaining("No meter with name 'spring.integration.receive' was found");
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4530

- implement `DisposableBean` in all meter-aware components
- remove meters in `destroy()`
- manually destroy annotation components created by `registerSingleton()`
  - changing these beans to register as bean definitions caused some subtle
    initialization side-effects; given we are post-RC, I felt it was too late
    to make such a large change
  - also CPXAC is not a `GenericApplicationContext`
  - hence a bean is registered to destroy them manually

