### PR TITLE
Extensible MicrometerMetricsCaptor and polishing

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerCustomMetricsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerCustomMetricsTests.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support.management.micrometer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.config.EnableIntegrationManagement;
+import org.springframework.integration.support.management.metrics.MetricsCaptor;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * @author Gary Russell
+ *
+ * @since 5.1
+ *
+ */
+@RunWith(SpringRunner.class)
+public class MicrometerCustomMetricsTests {
+
+	@Autowired
+	private ConfigurableApplicationContext context;
+
+	@Autowired
+	private MeterRegistry meterRegistry;
+
+	@Autowired
+	private QueueChannel queue;
+
+	@Test
+	public void testSend() throws Exception {
+		GenericMessage<String> message = new GenericMessage<>("foo");
+		this.queue.send(message);
+		this.queue.receive();
+		MeterRegistry registry = this.meterRegistry;
+		assertThat(registry.get("spring.integration.channels").gauge().value()).isEqualTo(3);
+
+		assertThat(registry.get("myTimer")
+				.tag("standardTimerName", "spring.integration.send")
+				.tag("name", "queue")
+				.tag("result", "success")
+				.timer().count()).isEqualTo(1);
+
+		assertThat(registry.get("myCounter")
+				.tag("standardCounterName", "spring.integration.receive")
+				.tag("name", "queue")
+				.tag("result", "success")
+				.counter().count()).isEqualTo(1);
+
+		// Test meter removal
+		this.context.close();
+		try {
+			registry.get("myTimer").timers();
+			fail("Expected MeterNotFoundException");
+		}
+		catch (MeterNotFoundException e) {
+			assertThat(e).hasMessageContaining("No meter with name 'myTimer' was found");
+		}
+		try {
+			registry.get("myCounter").counters();
+			fail("Expected MeterNotFoundException");
+		}
+		catch (MeterNotFoundException e) {
+			assertThat(e).hasMessageContaining("No meter with name 'myCounter' was found");
+		}
+	}
+
+	@Configuration
+	@EnableIntegration
+	@EnableIntegrationManagement
+	public static class Config {
+
+		@Bean
+		public MeterRegistry meterRegistry() {
+			return new SimpleMeterRegistry();
+		}
+
+		@Bean
+		public QueueChannel queue() {
+			return new QueueChannel();
+		}
+
+		@Bean(name = MicrometerMetricsCaptor.MICROMETER_CAPTOR_NAME)
+		public MetricsCaptor captor() {
+			return new CustomMetricsCaptor(meterRegistry());
+		}
+	}
+
+	static class CustomMetricsCaptor extends MicrometerMetricsCaptor {
+
+		CustomMetricsCaptor(MeterRegistry meterRegistry) {
+			super(meterRegistry);
+		}
+
+		@Override
+		public TimerBuilder timerBuilder(String name) {
+			return super.timerBuilder("myTimer")
+					.tag("standardTimerName", name);
+		}
+
+		@Override
+		public CounterBuilder counterBuilder(String name) {
+			return super.counterBuilder("myCounter")
+					.tag("standardCounterName", name);
+		}
+
+	}
+
+}
+

--- a/src/reference/asciidoc/metrics.adoc
+++ b/src/reference/asciidoc/metrics.adoc
@@ -157,6 +157,9 @@ In addition, there are three `Gauge` Meters:
 * `spring.integration.handlers`: The number of `MessageHandlers` in the application.
 * `spring.integration.sources`: The number of `MessageSources` in the application.
 
+It is possible to customize the names and tags of `Meters` created by integration components by providing a subclass of `MicrometerMetricsCaptor`.
+The https://github.com/spring-projects/spring-integration/blob/master/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerCustomMetricsTests.java[MicrometerCustomMetricsTests] test case shows a simple example of how to do that.
+You can also further customize the meters by overloading the `build()` methods on builder subclasses.
 
 [[mgmt-channel-features]]
 ==== `MessageChannel` Metric Features

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -200,3 +200,9 @@ Object name key values are now quoted if they contain any characters other than 
 e.g. `org.springframework.integration:type=MessageChannel,` `name="input:foo.myGroup.errors"`.
 This has the side effect that previously "allowed" names, with such characters, will now be quoted.
 e.g. `org.springframework.integration:type=MessageChannel,` `name="input#foo.myGroup.errors"`.
+
+[[x51.-micrometer]]
+=== Micrometer Support Changes
+
+It is now simpler to customize the standard Micrometer meters created by the framework.
+See <<micrometer-integration>> for more information.


### PR DESCRIPTION
- change `loadCaptor` to return any existing captor
- make builders and facades protected to allow subclassing
- change `AbstractMeter.getMeter()` to use generics
- add test case demonstrating meter name changes
- docs

