### PR TITLE
Fix stylesheet location for HTML Asciidoctor docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -781,7 +781,7 @@ asciidoctor {
 		toc2: '',
 		'compat-mode': '',
 		imagesdir: '',
-		stylesheet: '../../../src/reference/asciidoc/stylesheets/golo.css',
+		stylesheet: "${rootProject.projectDir}/src/reference/asciidoc/stylesheets/golo.css",
 		'source-highlighter': 'highlightjs'
 	]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -781,8 +781,7 @@ asciidoctor {
 		toc2: '',
 		'compat-mode': '',
 		imagesdir: '',
-		stylesdir: "stylesheets/",
-		stylesheet: 'golo.css',
+		stylesheet: '../../../src/reference/asciidoc/stylesheets/golo.css',
 		'source-highlighter': 'highlightjs'
 	]
 }

--- a/src/reference/asciidoc/index.adoc
+++ b/src/reference/asciidoc/index.adoc
@@ -1,6 +1,6 @@
 [[spring-integration-reference]]
 = Spring Integration Reference Manual
-:revnumber: {version}
+:revnumber: {project-version}
 :revdate: {localdate}
 :linkcss:
 :doctype: book


### PR DESCRIPTION
- also fix `{version}` to `{project-version}`.

(HTML5 doc is in `build/asciidoc/html5`).