### PR TITLE
correcting the link from java-dsl-gateway to dsl

### DIFF
--- a/src/reference/asciidoc/gateway.adoc
+++ b/src/reference/asciidoc/gateway.adoc
@@ -857,4 +857,4 @@ At that time, the calling thread starts waiting for the reply.
 If the flow was completely synchronous, the reply is immediately available.
 For asynchronous flows, the thread waits for up to this time.
 
-See <<java-dsl-gateway>> in the Java DSL chapter for options to define gateways through `IntegrationFlows`.
+See <<dsl>> in the Java DSL chapter for options to define gateways through `IntegrationFlows`.


### PR DESCRIPTION
java-dsl-gateway doesnt seem to exist

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
