### PR TITLE
MessageHandlingException consistency

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/core/MessageProducer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/MessageProducer.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.core;
 
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageChannel;
 
 /**
@@ -49,6 +50,7 @@ public interface MessageProducer {
 	 * @return the channel.
 	 * @since 4.3
 	 */
+	@Nullable
 	MessageChannel getOutputChannel();
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageSourcePollingTemplate.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageSourcePollingTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@ import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.integration.acks.AckUtils;
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.core.MessageSource;
+import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.util.Assert;
 
 /**
@@ -56,7 +56,9 @@ public class MessageSourcePollingTemplate implements PollingOperations {
 			}
 			catch (Exception e) {
 				AckUtils.autoNack(ackCallback);
-				throw new MessageHandlingException(message, e);
+				throw IntegrationUtils.wrapInHandlingExceptionIfNecessary(message,
+						() -> "error occurred during handling message in 'MessageSourcePollingTemplate' ["
+								+ this + "]", e);
 			}
 			return true;
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageHandler.java
@@ -33,6 +33,7 @@ import org.springframework.integration.support.management.MessageHandlerMetrics;
 import org.springframework.integration.support.management.MetricsContext;
 import org.springframework.integration.support.management.Statistics;
 import org.springframework.integration.support.management.TrackableComponent;
+import org.springframework.integration.support.management.metrics.MeterFacade;
 import org.springframework.integration.support.management.metrics.MetricsCaptor;
 import org.springframework.integration.support.management.metrics.SampleFacade;
 import org.springframework.integration.support.management.metrics.TimerFacade;
@@ -338,7 +339,7 @@ public abstract class AbstractMessageHandler extends IntegrationObjectSupport
 
 	@Override
 	public void destroy() throws Exception {
-		this.timers.forEach(t -> t.remove());
+		this.timers.forEach(MeterFacade::remove);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.handler;
 
 import org.springframework.integration.util.AbstractExpressionEvaluator;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 
 /**
@@ -28,6 +29,7 @@ import org.springframework.messaging.Message;
  */
 public abstract class AbstractMessageProcessor<T> extends AbstractExpressionEvaluator implements MessageProcessor<T> {
 
+	@Nullable
 	public abstract T processMessage(Message<?> message);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -68,8 +68,10 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 
 	private boolean async;
 
+	@Nullable
 	private String outputChannelName;
 
+	@Nullable
 	private MessageChannel outputChannel;
 
 	private String[] notPropagatedHeaders;
@@ -205,6 +207,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	}
 
 	@Override
+	@Nullable
 	public MessageChannel getOutputChannel() {
 		if (this.outputChannelName != null) {
 			this.outputChannel = getChannelResolver().resolveDestination(this.outputChannelName);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.aopalliance.aop.Advice;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.integration.handler.advice.HandleMessageAdvice;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -137,6 +138,7 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 		}
 	}
 
+	@Nullable
 	protected Object doInvokeAdvisedRequestHandler(Message<?> message) {
 		return this.advisedRequestHandler.handleRequestMessage(message);
 	}
@@ -149,6 +151,7 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 	 * @param requestMessage The request message.
 	 * @return The result of handling the message, or {@code null}.
 	 */
+	@Nullable
 	protected abstract Object handleRequestMessage(Message<?> requestMessage);
 
 
@@ -166,6 +169,7 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 	 */
 	public interface RequestHandler {
 
+		@Nullable
 		Object handleRequestMessage(Message<?> requestMessage);
 
 		/**
@@ -189,6 +193,7 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 		}
 
 		@Override
+		@Nullable
 		public Object handleRequestMessage(Message<?> requestMessage) {
 			return AbstractReplyProducingMessageHandler.this.handleRequestMessage(requestMessage);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingPostProcessingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingPostProcessingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 
 package org.springframework.integration.handler;
 
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 3.0
  *
  */
@@ -42,6 +45,7 @@ public abstract class AbstractReplyProducingPostProcessingMessageHandler
 	}
 
 	@Override
+	@Nullable
 	protected final Object handleRequestMessage(Message<?> requestMessage) {
 		Object result = this.doHandleRequestMessage(requestMessage);
 		if (this.postProcessWithinAdvice || !this.hasAdviceChain()) {
@@ -51,6 +55,7 @@ public abstract class AbstractReplyProducingPostProcessingMessageHandler
 	}
 
 	@Override
+	@Nullable
 	protected final Object doInvokeAdvisedRequestHandler(Message<?> message) {
 		Object result = super.doInvokeAdvisedRequestHandler(message);
 		if (!this.postProcessWithinAdvice) {
@@ -59,6 +64,7 @@ public abstract class AbstractReplyProducingPostProcessingMessageHandler
 		return result;
 	}
 
+	@Nullable
 	protected abstract Object doHandleRequestMessage(Message<?> requestMessage);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/BeanNameMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/BeanNameMessageProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package org.springframework.integration.handler;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
-import org.springframework.util.Assert;
 
 /**
  * An "artificial" {@link MessageProcessor} for lazy-load of target bean by its name.
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
  * @param <T> the expected {@link #processMessage} result type.
  *
  * @author Artem Bilan
+ *
  * @since 5.0
  */
 public class BeanNameMessageProcessor<T> implements MessageProcessor<T>, BeanFactoryAware {
@@ -48,11 +49,11 @@ public class BeanNameMessageProcessor<T> implements MessageProcessor<T>, BeanFac
 
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-		Assert.notNull(beanFactory, "'beanFactory' must not be null");
 		this.beanFactory = beanFactory;
 	}
 
 	@Override
+	@Nullable
 	public T processMessage(Message<?> message) {
 		if (this.delegate == null) {
 			Object target = this.beanFactory.getBean(this.beanName);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DiscardingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DiscardingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.handler;
 
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 
@@ -32,6 +33,7 @@ public interface DiscardingMessageHandler extends MessageHandler {
 	 * Return the discard channel.
 	 * @return the channel.
 	 */
+	@Nullable
 	MessageChannel getDiscardChannel();
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionEvaluatingMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionEvaluatingMessageProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.handler;
 
 import org.springframework.expression.Expression;
 import org.springframework.expression.ParseException;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
@@ -28,6 +29,7 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ *
  * @since 2.0
  */
 public class ExpressionEvaluatingMessageProcessor<T> extends AbstractMessageProcessor<T> {
@@ -51,7 +53,7 @@ public class ExpressionEvaluatingMessageProcessor<T> extends AbstractMessageProc
 	 * @param expression The expression.
 	 * @param expectedType The expected type.
 	 */
-	public ExpressionEvaluatingMessageProcessor(Expression expression, Class<T> expectedType) {
+	public ExpressionEvaluatingMessageProcessor(Expression expression, @Nullable Class<T> expectedType) {
 		Assert.notNull(expression, "The expression must not be null");
 		try {
 			this.expression = expression;
@@ -84,7 +86,7 @@ public class ExpressionEvaluatingMessageProcessor<T> extends AbstractMessageProc
 	 * @param expectedType the expected result type.
 	 * @since 5.0
 	 */
-	public ExpressionEvaluatingMessageProcessor(String expression, Class<T> expectedType) {
+	public ExpressionEvaluatingMessageProcessor(String expression, @Nullable Class<T> expectedType) {
 		try {
 			this.expression = EXPRESSION_PARSER.parseExpression(expression);
 			this.expectedType = expectedType;

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.handler;
 
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 
 /**
@@ -37,6 +38,8 @@ import org.springframework.messaging.Message;
  * message-handling components. As such, it is subject to change.
  *
  * @author Mark Fisher
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 @FunctionalInterface
@@ -48,6 +51,7 @@ public interface MessageProcessor<T> {
 	 * @param message The message to process.
 	 * @return The result.
 	 */
+	@Nullable
 	T processMessage(Message<?> message);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,18 +34,18 @@ import org.springframework.util.Assert;
  */
 public class MethodInvokingMessageHandler extends AbstractMessageHandler implements Lifecycle {
 
-	private volatile MethodInvokingMessageProcessor<Object> processor;
+	private final MethodInvokingMessageProcessor<Object> processor;
 
-	private volatile String componentType;
+	private String componentType;
 
 	public MethodInvokingMessageHandler(Object object, Method method) {
 		Assert.isTrue(method.getReturnType().equals(void.class),
 				"MethodInvokingMessageHandler requires a void-returning method");
-		this.processor = new MethodInvokingMessageProcessor<Object>(object, method);
+		this.processor = new MethodInvokingMessageProcessor<>(object, method);
 	}
 
 	public MethodInvokingMessageHandler(Object object, String methodName) {
-		this.processor = new MethodInvokingMessageProcessor<Object>(object, methodName);
+		this.processor = new MethodInvokingMessageProcessor<>(object, methodName);
 	}
 
 	@Override
@@ -79,7 +79,7 @@ public class MethodInvokingMessageHandler extends AbstractMessageHandler impleme
 	}
 
 	@Override
-	protected void handleMessageInternal(Message<?> message) throws Exception {
+	protected void handleMessageInternal(Message<?> message) {
 		Object result = this.processor.processMessage(message);
 		if (result != null) {
 			throw new MessagingException(message, "the MethodInvokingMessageHandler method must "

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,9 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.Lifecycle;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.integration.handler.support.MessagingMethodInvokerHelper;
-import org.springframework.lang.NonNull;
+import org.springframework.integration.support.utils.IntegrationUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
 
 /**
  * A MessageProcessor implementation that invokes a method on a target Object.
@@ -69,7 +69,7 @@ public class MethodInvokingMessageProcessor<T> extends AbstractMessageProcessor<
 	}
 
 	@Override
-	public void setBeanFactory(@NonNull BeanFactory beanFactory) {
+	public void setBeanFactory(@Nullable BeanFactory beanFactory) {
 		super.setBeanFactory(beanFactory);
 		this.delegate.setBeanFactory(beanFactory);
 	}
@@ -101,12 +101,15 @@ public class MethodInvokingMessageProcessor<T> extends AbstractMessageProcessor<
 	}
 
 	@Override
+	@Nullable
 	public T processMessage(Message<?> message) {
 		try {
 			return this.delegate.process(message);
 		}
 		catch (Exception e) {
-			throw new MessageHandlingException(message, e);
+			throw IntegrationUtils.wrapInHandlingExceptionIfNecessary(message,
+					() -> "error occurred during processing message in 'MethodInvokingMessageProcessor' [" + this + "]",
+					e);
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.context.Lifecycle;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 
 /**
@@ -35,15 +36,15 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 
 
 	public ServiceActivatingHandler(final Object object) {
-		this(new MethodInvokingMessageProcessor<Object>(object, ServiceActivator.class));
+		this(new MethodInvokingMessageProcessor<>(object, ServiceActivator.class));
 	}
 
 	public ServiceActivatingHandler(Object object, Method method) {
-		this(new MethodInvokingMessageProcessor<Object>(object, method));
+		this(new MethodInvokingMessageProcessor<>(object, method));
 	}
 
 	public ServiceActivatingHandler(Object object, String methodName) {
-		this(new MethodInvokingMessageProcessor<Object>(object, methodName));
+		this(new MethodInvokingMessageProcessor<>(object, methodName));
 	}
 
 	public <T> ServiceActivatingHandler(MessageProcessor<T> processor) {
@@ -89,6 +90,7 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 	}
 
 	@Override
+	@Nullable
 	protected Object handleRequestMessage(Message<?> message) {
 		return this.processor.processMessage(message);
 	}
@@ -96,7 +98,7 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 	@Override
 	public String toString() {
 		return "ServiceActivator for [" + this.processor + "]"
-				+ (this.getComponentName() == null ? "" : " (" + this.getComponentName() + ")");
+				+ (getComponentName() == null ? "" : " (" + getComponentName() + ")");
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -84,7 +84,7 @@ import org.springframework.integration.util.ClassUtils;
 import org.springframework.integration.util.FixedMethodFilter;
 import org.springframework.integration.util.MessagingAnnotationUtils;
 import org.springframework.integration.util.UniqueMethodFilter;
-import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessageHeaders;
@@ -285,7 +285,7 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 	}
 
 	@Override
-	public void setBeanFactory(@NonNull BeanFactory beanFactory) {
+	public void setBeanFactory(BeanFactory beanFactory) {
 		super.setBeanFactory(beanFactory);
 		((DefaultMessageHandlerMethodFactory) this.messageHandlerMethodFactory).setBeanFactory(beanFactory);
 
@@ -308,11 +308,13 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 		}
 	}
 
+	@Nullable
 	public T process(Message<?> message) throws Exception {
 		ParametersWrapper parameters = new ParametersWrapper(message);
 		return processInternal(parameters);
 	}
 
+	@Nullable
 	public T process(Collection<Message<?>> messages, Map<String, Object> headers) throws Exception {
 		ParametersWrapper parameters = new ParametersWrapper(messages, headers);
 		return processInternal(parameters);
@@ -468,6 +470,7 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 	}
 
 	@SuppressWarnings("unchecked")
+	@Nullable
 	private T processInternal(ParametersWrapper parameters) throws Exception {
 		if (!this.initialized) {
 			initialize();

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/utils/IntegrationUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/utils/IntegrationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 the original author or authors.
+ * Copyright 2014-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @author Marius Bogoevici
+ * @author Artem Bilan
+ *
  * @since 4.0
  *
  */
@@ -113,7 +115,6 @@ public final class IntegrationUtils {
 
 	/**
 	 * Utility method for null-safe conversion from String to byte[]
-	 *
 	 * @param value the String to be converted
 	 * @param encoding the encoding
 	 * @return the byte[] corresponding to the given String and encoding, null if provided String argument was null
@@ -130,7 +131,6 @@ public final class IntegrationUtils {
 
 	/**
 	 * Utility method for null-safe conversion from byte[] to String
-	 *
 	 * @param bytes the byte[] to be converted
 	 * @param encoding the encoding
 	 * @return the String corresponding to the given byte[] and encoding, null if provided byte[] argument was null
@@ -151,19 +151,19 @@ public final class IntegrationUtils {
 	 * in a new {@link MessageDeliveryException} with the message.
 	 * @param message the message.
 	 * @param text a Supplier for the new exception's message text.
-	 * @param e the exception.
+	 * @param ex the exception.
 	 * @return the wrapper, if necessary, or the original exception.
 	 * @since 5.0.4
 	 */
 	public static RuntimeException wrapInDeliveryExceptionIfNecessary(Message<?> message, Supplier<String> text,
-			Exception e) {
+			Throwable ex) {
 
-		RuntimeException runtimeException = (e instanceof RuntimeException)
-				? (RuntimeException) e
-				: new MessageDeliveryException(message, text.get(), e);
-		if (!(e instanceof MessagingException) ||
-				((MessagingException) e).getFailedMessage() == null) {
-			runtimeException = new MessageDeliveryException(message, text.get(), e);
+		RuntimeException runtimeException = (ex instanceof RuntimeException)
+				? (RuntimeException) ex
+				: new MessageDeliveryException(message, text.get(), ex);
+		if (!(ex instanceof MessagingException) ||
+				((MessagingException) ex).getFailedMessage() == null) {
+			runtimeException = new MessageDeliveryException(message, text.get(), ex);
 		}
 		return runtimeException;
 	}
@@ -174,19 +174,19 @@ public final class IntegrationUtils {
 	 * in a new {@link MessageHandlingException} with the message.
 	 * @param message the message.
 	 * @param text a Supplier for the new exception's message text.
-	 * @param e the exception.
+	 * @param ex the exception.
 	 * @return the wrapper, if necessary, or the original exception.
 	 * @since 5.0.4
 	 */
 	public static RuntimeException wrapInHandlingExceptionIfNecessary(Message<?> message, Supplier<String> text,
-			Exception e) {
+			Throwable ex) {
 
-		RuntimeException runtimeException = (e instanceof RuntimeException)
-				? (RuntimeException) e
-				: new MessageHandlingException(message, text.get(), e);
-		if (!(e instanceof MessagingException) ||
-				((MessagingException) e).getFailedMessage() == null) {
-			runtimeException = new MessageHandlingException(message, text.get(), e);
+		RuntimeException runtimeException = (ex instanceof RuntimeException)
+				? (RuntimeException) ex
+				: new MessageHandlingException(message, text.get(), ex);
+		if (!(ex instanceof MessagingException) ||
+				((MessagingException) ex).getFailedMessage() == null) {
+			runtimeException = new MessageHandlingException(message, text.get(), ex);
 		}
 		return runtimeException;
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/LoggingChannelAdapterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/LoggingChannelAdapterParserTests.java
@@ -17,22 +17,21 @@
 package org.springframework.integration.config.xml;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.core.Ordered;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
+import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.handler.LoggingHandler;
 import org.springframework.integration.test.util.TestUtils;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author Mark Fisher
@@ -41,14 +40,15 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  *
  * @since 2.1
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 public class LoggingChannelAdapterParserTests {
 
-	@Autowired @Qualifier("logger.adapter")
+	@Autowired
+	@Qualifier("logger.adapter")
 	private EventDrivenConsumer loggerConsumer;
 
-	@Autowired @Qualifier("loggerWithExpression.adapter")
+	@Autowired
+	@Qualifier("loggerWithExpression.adapter")
 	private EventDrivenConsumer loggerWithExpression;
 
 
@@ -58,33 +58,30 @@ public class LoggingChannelAdapterParserTests {
 		assertThat(TestUtils.getPropertyValue(loggingHandler, "messageLogger.logger.name"))
 				.isEqualTo("org.springframework.integration.test.logger");
 		assertThat(TestUtils.getPropertyValue(loggingHandler, "order")).isEqualTo(1);
-		assertThat(TestUtils.getPropertyValue(loggingHandler, "level").toString()).isEqualTo("WARN");
-		assertThat(TestUtils.getPropertyValue(loggingHandler, "expression.expression")).isEqualTo("#root");
+		assertThat(TestUtils.getPropertyValue(loggingHandler, "level")).isEqualTo(LoggingHandler.Level.WARN);
+		assertThat(TestUtils.getPropertyValue(loggingHandler, "expression")).isInstanceOf(FunctionExpression.class);
 	}
 
 	@Test
 	public void verifyExpressionAndOtherDefaultConfig() {
-		LoggingHandler loggingHandler = TestUtils.getPropertyValue(loggerWithExpression, "handler", LoggingHandler.class);
+		LoggingHandler loggingHandler =
+				TestUtils.getPropertyValue(loggerWithExpression, "handler", LoggingHandler.class);
 		assertThat(TestUtils.getPropertyValue(loggingHandler, "messageLogger.logger.name"))
 				.isEqualTo("org.springframework.integration.handler.LoggingHandler");
 		assertThat(TestUtils.getPropertyValue(loggingHandler, "order")).isEqualTo(Ordered.LOWEST_PRECEDENCE);
-		assertThat(TestUtils.getPropertyValue(loggingHandler, "level").toString()).isEqualTo("INFO");
+		assertThat(TestUtils.getPropertyValue(loggingHandler, "level")).isEqualTo(LoggingHandler.Level.INFO);
 		assertThat(TestUtils.getPropertyValue(loggingHandler, "expression.expression")).isEqualTo("payload.foo");
 		assertThat(TestUtils.getPropertyValue(loggingHandler, "evaluationContext.beanResolver")).isNotNull();
 	}
 
 	@Test
 	public void failConfigLogFullMessageAndExpression() {
-		try {
-			new ClassPathXmlApplicationContext("LoggingChannelAdapterParserTests-fail-context.xml", this.getClass())
-					.close();
-			fail("BeanDefinitionParsingException expected");
-		}
-		catch (BeansException e) {
-			assertThat(e instanceof BeanDefinitionParsingException).isTrue();
-			assertThat(e.getMessage()
-					.contains("The 'expression' and 'log-full-message' attributes are mutually exclusive.")).isTrue();
-		}
+		assertThatExceptionOfType(BeanDefinitionParsingException.class)
+				.isThrownBy(() ->
+						new ClassPathXmlApplicationContext(
+								"LoggingChannelAdapterParserTests-fail-context.xml",
+								getClass()))
+				.withMessageContaining("The 'expression' and 'log-full-message' attributes are mutually exclusive.");
 	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -57,6 +57,7 @@ import org.springframework.integration.handler.MessageTriggerAction;
 import org.springframework.integration.support.locks.DefaultLockRegistry;
 import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.integration.support.locks.PassThruLockRegistry;
+import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.integration.util.WhileLockedProcessor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
@@ -526,7 +527,8 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 						timestamp);
 			}
 			catch (Exception e) {
-				throw new MessageHandlingException(requestMessage, "failed to write Message payload to file", e);
+				throw IntegrationUtils.wrapInHandlingExceptionIfNecessary(requestMessage,
+						() -> "failed to write Message payload to file", e);
 			}
 		}
 

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/ExpressionEvaluatingParameterSourceUtils.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/ExpressionEvaluatingParameterSourceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,38 +24,38 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.jpa.support.JpaParameter;
 import org.springframework.integration.util.AbstractExpressionEvaluator;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
  *
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.2
  *
  */
 final class ExpressionEvaluatingParameterSourceUtils {
 
 	private ExpressionEvaluatingParameterSourceUtils() {
-		throw new AssertionError();
 	}
 
 
 	/**
 	 * Utility method that converts a Collection of {@link JpaParameter} to
 	 * a Map containing only static parameters.
-	 *
 	 * @param jpaParameters Must not be null.
 	 * @return Map containing only the static parameters. Will never be null.
 	 */
 	public static Map<String, Object> convertStaticParameters(Collection<JpaParameter> jpaParameters) {
-
 		Assert.notNull(jpaParameters, "The Collection of jpaParameters must not be null.");
 
 		for (JpaParameter parameter : jpaParameters) {
 			Assert.notNull(parameter, "'jpaParameters' must not contain null values.");
 		}
 
-		final Map<String, Object> staticParameters = new HashMap<String, Object>();
+		final Map<String, Object> staticParameters = new HashMap<>();
 
 		for (JpaParameter parameter : jpaParameters) {
 			if (parameter.getValue() != null) {
@@ -78,6 +78,7 @@ final class ExpressionEvaluatingParameterSourceUtils {
 		}
 
 		@Override
+		@Nullable
 		public Object evaluateExpression(Expression expression, Object input) {
 			return super.evaluateExpression(expression, input);
 		}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/DefaultPahoMessageConverter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/DefaultPahoMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.util.Assert;
@@ -174,7 +173,6 @@ public class DefaultPahoMessageConverter implements MqttMessageConverter, BeanFa
 	/**
 	 * True if the converter should not convert the message payload to a String.
 	 * Ignored if a {@link BytesMessageMapper} is provided.
-	 *
 	 * @param payloadAsBytes The payloadAsBytes to set.
 	 * @see #setBytesMessageMapper(BytesMessageMapper)
 	 */
@@ -274,7 +272,8 @@ public class DefaultPahoMessageConverter implements MqttMessageConverter, BeanFa
 				return this.bytesMessageMapper.fromMessage(message);
 			}
 			catch (Exception e) {
-				throw new MessageHandlingException(message, "Failed to map outbound message", e);
+				throw IntegrationUtils.wrapInHandlingExceptionIfNecessary(message,
+						() -> "Failed to map outbound message", e);
 			}
 		}
 		else {

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2018 the original author or authors.
+ * Copyright 2007-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,8 @@ import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.redis.support.RedisHeaders;
+import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.util.Assert;
 import org.springframework.util.NumberUtils;
 
@@ -289,11 +289,11 @@ public class RedisStoreWritingMessageHandler extends AbstractMessageHandler {
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	protected void handleMessageInternal(Message<?> message) throws Exception {
+	protected void handleMessageInternal(Message<?> message) {
 		String key = this.keyExpression.getValue(this.evaluationContext, message, String.class);
 		Assert.hasText(key, () -> "Failed to determine a key for the Redis store based on the message: " + message);
 
-		RedisStore store = this.createStoreView(key);
+		RedisStore store = createStoreView(key);
 
 		Assert.state(this.initialized,
 				"handler not initialized - afterPropertiesSet() must be called before the first use");
@@ -314,8 +314,9 @@ public class RedisStoreWritingMessageHandler extends AbstractMessageHandler {
 				writeToProperties((RedisProperties) store, message);
 			}
 		}
-		catch (Exception e) {
-			throw new MessageHandlingException(message, "Failed to store Message data in Redis collection", e);
+		catch (Exception ex) {
+			throw IntegrationUtils.wrapInHandlingExceptionIfNecessary(message,
+					() -> "Failed to store Message data in Redis collection", ex);
 		}
 	}
 
@@ -488,7 +489,8 @@ public class RedisStoreWritingMessageHandler extends AbstractMessageHandler {
 			return 1d;
 		}
 		else {
-			Assert.isInstanceOf(Number.class, scoreHeader, "Header " + RedisHeaders.ZSET_SCORE + " must be a Number");
+			Assert.isInstanceOf(Number.class, scoreHeader,
+					() -> "Header " + RedisHeaders.ZSET_SCORE + " must be a Number");
 			Number score = (Number) scoreHeader;
 			return Double.valueOf(score.toString());
 		}

--- a/spring-integration-rmi/src/main/java/org/springframework/integration/rmi/RmiOutboundGateway.java
+++ b/spring-integration-rmi/src/main/java/org/springframework/integration/rmi/RmiOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ public class RmiOutboundGateway extends AbstractReplyProducingMessageHandler {
 		if (!(requestMessage.getPayload() instanceof Serializable)) {
 			throw new MessageHandlingException(requestMessage,
 					this.getComponentName() + " expects a Serializable payload type " +
-					"but encountered [" + requestMessage.getPayload().getClass().getName() + "]");
+							"but encountered [" + requestMessage.getPayload().getClass().getName() + "]");
 		}
 		try {
 			return this.proxy.exchange(requestMessage);
@@ -86,8 +86,8 @@ public class RmiOutboundGateway extends AbstractReplyProducingMessageHandler {
 			throw new MessageHandlingException(requestMessage, e);
 		}
 		catch (RemoteAccessException e) {
-			throw new MessageHandlingException(requestMessage, "Remote failure in RmiOutboundGateway: " +
-					this.getComponentName(), e);
+			throw new MessageHandlingException(requestMessage,
+					"Remote failure in RmiOutboundGateway: " + getComponentName(), e);
 		}
 	}
 

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/splitter/XPathMessageSplitter.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/splitter/XPathMessageSplitter.java
@@ -41,11 +41,11 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import org.springframework.integration.splitter.AbstractMessageSplitter;
+import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.integration.util.FunctionIterator;
 import org.springframework.integration.xml.DefaultXmlPayloadConverter;
 import org.springframework.integration.xml.XmlPayloadConverter;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.util.Assert;
 import org.springframework.xml.DocumentBuilderFactoryUtils;
@@ -221,11 +221,12 @@ public class XPathMessageSplitter extends AbstractMessageSplitter {
 			}
 			return result;
 		}
-		catch (ParserConfigurationException e) {
-			throw new MessageConversionException(message, "failed to create DocumentBuilder", e);
+		catch (ParserConfigurationException ex) {
+			throw new MessageConversionException(message, "failed to create DocumentBuilder", ex);
 		}
-		catch (Exception e) {
-			throw new MessageHandlingException(message, "failed to split Message payload", e);
+		catch (Exception ex) {
+			throw IntegrationUtils.wrapInHandlingExceptionIfNecessary(message,
+					() -> "Failed to split Message payload", ex);
 		}
 	}
 


### PR DESCRIPTION
* Use `IntegrationUtils.wrapInHandlingExceptionIfNecessary()` whenever
it is possible to avoid double wrapping into the `MessageHandlingException`
* Some code polishing for affected classes

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
