### PR TITLE
INT-4564: ACMH: Fix erroneous error log

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -112,7 +112,7 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 					this.expiryCallbacks.stream()
 							.anyMatch(UniqueExpiryCallback.class::isInstance);
 
-			if (!uniqueExpiryCallbackPresent && this.logger.isErrorEnabled()) {
+			if (uniqueExpiryCallbackPresent && this.logger.isErrorEnabled()) {
 				this.logger.error("Only one instance of 'UniqueExpiryCallback' can be registered in the " +
 						"'MessageGroupStore'. Use a separate 'MessageGroupStore' for each aggregator/resequencer.");
 			}

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandlerTests.java
@@ -349,6 +349,8 @@ public class AbstractCorrelatingMessageHandlerTests {
 			}
 		};
 		handler.setMessageStore(messageStore);
+		// test UniqueExpiryCallback error message
+		// new AggregatingMessageHandler(new DefaultAggregatingMessageGroupProcessor()).setMessageStore(messageStore);
 		handler.handleMessage(MessageBuilder.withPayload("foo")
 				.setCorrelationId(1)
 				.setSequenceNumber(1)


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4564

INT-4550 added an error log when multiple ACMHs were registered with the
same store; the error log logic was incorrect and the error was logged
when the first ACMH was registered.

