### PR TITLE
Use Context CL wherever it is applicable

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfigurer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfigurer.java
@@ -225,9 +225,8 @@ public class IntegrationManagementConfigurer
 		Assert.state(this.applicationContext != null, "'applicationContext' must not be null");
 		Assert.state(MANAGEMENT_CONFIGURER_NAME.equals(this.beanName), getClass().getSimpleName()
 				+ " bean name must be " + MANAGEMENT_CONFIGURER_NAME);
-		ClassLoader classLoader = IntegrationManagementConfigurer.class.getClassLoader();
 		if (ClassUtils.isPresent("io.micrometer.core.instrument.MeterRegistry",
-				classLoader)) {
+				this.applicationContext.getClassLoader())) {
 			this.metricsCaptor = MicrometerMetricsCaptor.loadCaptor(this.applicationContext);
 		}
 		if (this.metricsCaptor != null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/StandardHeaderEnricherParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/StandardHeaderEnricherParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,16 +36,18 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Fisher
  * @author Oleg Zhurakousky
+ * @author Artem Bilan
  */
 public class StandardHeaderEnricherParser extends HeaderEnricherParserSupport {
 
 	public StandardHeaderEnricherParser() {
-		this.addElementToHeaderMapping("reply-channel", MessageHeaders.REPLY_CHANNEL);
-		this.addElementToHeaderMapping("error-channel", MessageHeaders.ERROR_CHANNEL);
-		this.addElementToHeaderMapping("correlation-id", IntegrationMessageHeaderAccessor.CORRELATION_ID);
-		this.addElementToHeaderMapping("expiration-date", IntegrationMessageHeaderAccessor.EXPIRATION_DATE, Long.class);
-		this.addElementToHeaderMapping("priority", IntegrationMessageHeaderAccessor.PRIORITY, Integer.class);
-		this.addElementToHeaderMapping("routing-slip", IntegrationMessageHeaderAccessor.ROUTING_SLIP, Map.class);
+		addElementToHeaderMapping("reply-channel", MessageHeaders.REPLY_CHANNEL);
+		addElementToHeaderMapping("error-channel", MessageHeaders.ERROR_CHANNEL);
+		addElementToHeaderMapping("correlation-id", IntegrationMessageHeaderAccessor.CORRELATION_ID);
+		addElementToHeaderMapping("expiration-date", IntegrationMessageHeaderAccessor.EXPIRATION_DATE,
+				Long.class.getName());
+		addElementToHeaderMapping("priority", IntegrationMessageHeaderAccessor.PRIORITY, Integer.class.getName());
+		addElementToHeaderMapping("routing-slip", IntegrationMessageHeaderAccessor.ROUTING_SLIP, Map.class.getName());
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/scattergather/ScatterGatherHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/scattergather/ScatterGatherHandler.java
@@ -178,7 +178,7 @@ public class ScatterGatherHandler extends AbstractReplyProducingMessageHandler i
 
 	private void checkClass(Class<?> gathererClass, String className, String type) throws LinkageError {
 		try {
-			Class<?> clazz = ClassUtils.forName(className, getApplicationContext().getClassLoader());
+			Class<?> clazz = ClassUtils.forName(className, ClassUtils.getDefaultClassLoader());
 			Assert.isAssignable(clazz, gathererClass, "the '" + type + "' must be an " + className + " instance");
 		}
 		catch (ClassNotFoundException e) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/scattergather/ScatterGatherHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/scattergather/ScatterGatherHandler.java
@@ -177,13 +177,13 @@ public class ScatterGatherHandler extends AbstractReplyProducingMessageHandler i
 	}
 
 	private void checkClass(Class<?> gathererClass, String className, String type) throws LinkageError {
-		Class<?> clazz = null;
 		try {
-			clazz = ClassUtils.forName(className, getClass().getClassLoader());
+			Class<?> clazz = ClassUtils.forName(className, getApplicationContext().getClassLoader());
+			Assert.isAssignable(clazz, gathererClass, "the '" + type + "' must be an " + className + " instance");
 		}
-		catch (Exception e) {
+		catch (ClassNotFoundException e) {
+			throw new IllegalStateException("The class for '" + className + "' cannot be loaded", e);
 		}
-		Assert.isAssignable(clazz, gathererClass, "the '" + type + "' must be an " + className + " instance");
 	}
 
 }


### PR DESCRIPTION
* Use `ClassUtils.getDefaultClassLoader()` in the `IntegrationManagementConfigurer`
for checking a Micrometer presence from the `afterSingletonsInstantiated()`
* Use `ClassUtils.getDefaultClassLoader()` in the `ScatterGatherHandler`
to load required class
* Refactor `HeaderEnricherParserSupport` do not use CL at all.
The `TypedStringValue` will resolve a target type later by the
`BeanFactory`.
This way we honor a property placeholder behavior for the `type` XML
attribute

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
