### PR TITLE
INT-4571 Make MessageHandlerMethodFactory injectable

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  * @author Josh Long
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Oleg Zhurakousky
  */
 public abstract class IntegrationContextUtils {
 
@@ -104,6 +105,8 @@ public abstract class IntegrationContextUtils {
 	public static final String LIST_ARGUMENT_RESOLVERS_BEAN_NAME = "integrationListArgumentResolvers";
 
 	public static final String DISPOSABLES_BEAN_NAME = "integrationDisposableAutoCreatedBeans";
+
+	public static final String MESSAGE_HANDLER_FACTORY_BEAN_NAME = "integrationMessageHandlerMethodFactory";
 
 	/**
 	 * @param beanFactory BeanFactory for lookup, must not be null.

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/HandlerMethodArgumentResolversHolder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/HandlerMethodArgumentResolversHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,9 @@ import org.springframework.messaging.handler.invocation.HandlerMethodArgumentRes
  * @author Gary Russell
  *
  * @since 5.0
- *
+ * @deprecated as of 5.1.2. Instead simply configure your own MessageHandlerMethodFactory as a bean.
  */
+@Deprecated
 public class HandlerMethodArgumentResolversHolder {
 
 	private final List<HandlerMethodArgumentResolver> resolvers;


### PR DESCRIPTION
Make MessageHandlerMethodFactory injectable into MessagingMethodInvokerHelper
Allow 'handlerMethod' to be overriden
Deprecate HandlerMethodArgumentResolversHolder
Add 'integrationMessageHandlerMethodFactory' property to IntegrationContextUtils
Add test that actually validates that custom resolver gets picked up


===
Quick NOTE: With the current implementation of _MessagingMethodInvokerHelper_ by allowing injection of _MessageHandlerMethodFactory_ we effectively providing a mechanism for overriding the `handlerMethod` instance that was already created in the constructor. While at the moment I don’t see a valid  reason why it should be created in the constructor, an attempt to push it down to `initialize()` method ***only***  resulted in some test failures which were asserting for `handlerMethod` to NOT be null before `initialize()` is called. In other words attempting to do that would be a much greater change, but I would consider revisiting the internal implementation and see if it is necessary to create `handlerMethod` inside the constructor.

In any event, this PR basically maintains the status quo aside from the changes described in the commit message and simply looks IF `MESSAGE_HANDLER_FACTORY_BEAN_NAME` exists during initialization and if it does it overrides the existing `messageHandlerMethodFactory` as well as the instance of `handlerMethod`.
