### PR TITLE
Fix BeanFactory propagation for MMInvokerHelper

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -98,17 +98,17 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 	protected static final String SEND_TIMEOUT_ATTRIBUTE = "sendTimeout";
 
-	protected final Log logger = LogFactory.getLog(this.getClass());
+	protected final Log logger = LogFactory.getLog(this.getClass()); // NOSONAR
 
-	protected final List<String> messageHandlerAttributes = new ArrayList<>();
+	protected final List<String> messageHandlerAttributes = new ArrayList<>(); // NOSONAR
 
-	protected final ConfigurableListableBeanFactory beanFactory;
+	protected final ConfigurableListableBeanFactory beanFactory; // NOSONAR
 
-	protected final ConversionService conversionService;
+	protected final ConversionService conversionService; // NOSONAR
 
-	protected final DestinationResolver<MessageChannel> channelResolver;
+	protected final DestinationResolver<MessageChannel> channelResolver; // NOSONAR
 
-	protected final Class<T> annotationType;
+	protected final Class<T> annotationType; // NOSONAR
 
 	protected final Disposables disposables; // NOSONAR
 
@@ -192,7 +192,8 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 		if (AnnotatedElementUtils.isAnnotated(method, IdempotentReceiver.class.getName())
 				&& !AnnotatedElementUtils.isAnnotated(method, Bean.class.getName())) {
-			String[] interceptors = AnnotationUtils.getAnnotation(method, IdempotentReceiver.class).value(); // NOSONAR never null
+			String[] interceptors =
+					AnnotationUtils.getAnnotation(method, IdempotentReceiver.class).value(); // NOSONAR never null
 			for (String interceptor : interceptors) {
 				DefaultBeanFactoryPointcutAdvisor advisor = new DefaultBeanFactoryPointcutAdvisor();
 				advisor.setAdviceBeanName(interceptor);
@@ -281,9 +282,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 				else if (adviceChainBean instanceof Collection) {
 					@SuppressWarnings("unchecked")
 					Collection<Advice> adviceChainEntries = (Collection<Advice>) adviceChainBean;
-					for (Advice advice : adviceChainEntries) {
-						adviceChain.add(advice);
-					}
+					adviceChain.addAll(adviceChainEntries);
 				}
 				else {
 					throw new IllegalArgumentException("Invalid advice chain type:" +
@@ -346,7 +345,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 	}
 
 	protected void configurePollingEndpoint(AbstractPollingEndpoint pollingEndpoint, List<Annotation> annotations) {
-		PollerMetadata pollerMetadata = null;
+		PollerMetadata pollerMetadata;
 		Poller[] pollers = MessagingAnnotationUtils.resolveAttribute(annotations, "poller", Poller[].class);
 		if (!ObjectUtils.isEmpty(pollers)) {
 			Assert.state(pollers.length == 1,

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/BeanNameMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/BeanNameMessageProcessor.java
@@ -56,7 +56,10 @@ public class BeanNameMessageProcessor<T> implements MessageProcessor<T>, BeanFac
 	public T processMessage(Message<?> message) {
 		if (this.delegate == null) {
 			Object target = this.beanFactory.getBean(this.beanName);
-			this.delegate = new MethodInvokingMessageProcessor<>(target, this.methodName);
+			MethodInvokingMessageProcessor<T> methodInvokingMessageProcessor =
+					new MethodInvokingMessageProcessor<>(target, this.methodName);
+			methodInvokingMessageProcessor.setBeanFactory(this.beanFactory);
+			this.delegate = methodInvokingMessageProcessor;
 		}
 		return this.delegate.processMessage(message);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -398,9 +398,7 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 	}
 
 	private boolean isProvidedMessageHandlerFactoryBean() {
-		BeanFactory beanFactory = getBeanFactory();
-		return beanFactory != null
-				&& beanFactory.containsBean(IntegrationContextUtils.MESSAGE_HANDLER_FACTORY_BEAN_NAME);
+		return getBeanFactory().containsBean(IntegrationContextUtils.MESSAGE_HANDLER_FACTORY_BEAN_NAME);
 	}
 
 	private void createHandlerMethod() {
@@ -1163,9 +1161,8 @@ public class MessagingMethodInvokerHelper<T> extends AbstractExpressionEvaluator
 					}
 					if (annotationType.equals(Payloads.class)) {
 						Assert.isTrue(this.canProcessMessageList,
-								"The @Payloads annotation can only be applied if method handler " +
-										"canProcessMessageList" +
-										".");
+								"The @Payloads annotation can only be applied " +
+										"if method handler canProcessMessageList.");
 						Assert.isTrue(Collection.class.isAssignableFrom(parameterType),
 								"The @Payloads annotation can only be applied to a Collection-typed parameter.");
 						sb.append("messages.![payload");

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
@@ -28,6 +28,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.integration.core.MessageSelector;
 import org.springframework.integration.filter.ExpressionEvaluatingSelector;
@@ -97,9 +99,8 @@ public class RecipientListRouter extends AbstractMessageRouter
 		Assert.notEmpty(recipients, "'recipients' must not be empty");
 		Queue<Recipient> newRecipients = new ConcurrentLinkedQueue<>(recipients);
 
-		if (getBeanFactory() != null) {
-			newRecipients.forEach(recipient -> recipient.setChannelResolver(getChannelResolver()));
-		}
+		newRecipients.forEach(this::setupRecipient);
+
 		if (logger.isDebugEnabled()) {
 			logger.debug("Channel Recipients: " + this.recipients + " replaced with: " + newRecipients);
 		}
@@ -145,9 +146,7 @@ public class RecipientListRouter extends AbstractMessageRouter
 				new ExpressionEvaluatingSelector(selectorExpression);
 		expressionEvaluatingSelector.setBeanFactory(getBeanFactory());
 		Recipient recipient = new Recipient(channelName, expressionEvaluatingSelector);
-		if (getBeanFactory() != null) {
-			recipient.setChannelResolver(getChannelResolver());
-		}
+		setupRecipient(recipient);
 		recipients.add(recipient);
 	}
 
@@ -164,9 +163,7 @@ public class RecipientListRouter extends AbstractMessageRouter
 	private void addRecipient(String channelName, MessageSelector selector, Queue<Recipient> recipients) {
 		Assert.hasText(channelName, "'channelName' must not be empty.");
 		Recipient recipient = new Recipient(channelName, selector);
-		if (getBeanFactory() != null) {
-			recipient.setChannelResolver(getChannelResolver());
-		}
+		setupRecipient(recipient);
 		recipients.add(recipient);
 	}
 
@@ -176,10 +173,18 @@ public class RecipientListRouter extends AbstractMessageRouter
 
 	public void addRecipient(MessageChannel channel, MessageSelector selector) {
 		Recipient recipient = new Recipient(channel, selector);
-		if (getBeanFactory() != null) {
-			recipient.setChannelResolver(getChannelResolver());
-		}
+		setupRecipient(recipient);
 		this.recipients.add(recipient);
+	}
+
+	private void setupRecipient(Recipient recipient) {
+		BeanFactory beanFactory = getBeanFactory();
+		if (beanFactory != null) {
+			recipient.setChannelResolver(getChannelResolver());
+			if (recipient.selector instanceof BeanFactoryAware) {
+				((BeanFactoryAware) recipient.selector).setBeanFactory(beanFactory);
+			}
+		}
 	}
 
 	@Override
@@ -225,14 +230,14 @@ public class RecipientListRouter extends AbstractMessageRouter
 		for (String key : keys) {
 			Assert.notNull(key, "channelName can't be null.");
 			if (StringUtils.hasText(recipientMappings.getProperty(key))) {
-				this.addRecipient(key, recipientMappings.getProperty(key));
+				addRecipient(key, recipientMappings.getProperty(key));
 			}
 			else {
-				this.addRecipient(key);
+				addRecipient(key);
 			}
 		}
 		if (logger.isDebugEnabled()) {
-			logger.debug("Channel Recipients:" + originalRecipients	+ " replaced with:" + this.recipients);
+			logger.debug("Channel Recipients:" + originalRecipients + " replaced with:" + this.recipients);
 		}
 	}
 
@@ -259,7 +264,7 @@ public class RecipientListRouter extends AbstractMessageRouter
 	@Override
 	protected void onInit() {
 		super.onInit();
-		this.recipients.forEach(recipient -> recipient.setChannelResolver(getChannelResolver()));
+		this.recipients.forEach(this::setupRecipient);
 	}
 
 	public static class Recipient {

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelationStrategyAdapterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/CorrelationStrategyAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
 package org.springframework.integration.aggregator;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
@@ -28,6 +30,7 @@ import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Dave Syer
+ * @author Artem Bilan
  *
  */
 public class CorrelationStrategyAdapterTests {
@@ -43,13 +46,16 @@ public class CorrelationStrategyAdapterTests {
 	public void testMethodName() {
 		MethodInvokingCorrelationStrategy adapter =
 				new MethodInvokingCorrelationStrategy(new SimpleMessageCorrelator(), "getKey");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		assertEquals("b", adapter.getCorrelationKey(message));
 	}
 
 	@Test
 	public void testCorrelationStrategyAdapterObjectMethod() {
-		MethodInvokingCorrelationStrategy adapter = new MethodInvokingCorrelationStrategy(new SimpleMessageCorrelator(),
+		MethodInvokingCorrelationStrategy adapter =
+				new MethodInvokingCorrelationStrategy(new SimpleMessageCorrelator(),
 				ReflectionUtils.findMethod(SimpleMessageCorrelator.class, "getKey", Message.class));
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		assertEquals("b", adapter.getCorrelationKey(message));
 	}
 
@@ -57,6 +63,7 @@ public class CorrelationStrategyAdapterTests {
 	public void testCorrelationStrategyAdapterPojoMethod() {
 		MethodInvokingCorrelationStrategy adapter =
 				new MethodInvokingCorrelationStrategy(new SimplePojoCorrelator(), "getKey");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		assertEquals("foo", adapter.getCorrelationKey(message));
 	}
 
@@ -64,6 +71,7 @@ public class CorrelationStrategyAdapterTests {
 	public void testHeaderPojoMethod() {
 		MethodInvokingCorrelationStrategy adapter =
 				new MethodInvokingCorrelationStrategy(new SimpleHeaderCorrelator(), "getKey");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		assertEquals("b", adapter.getCorrelationKey(message));
 	}
 
@@ -71,6 +79,7 @@ public class CorrelationStrategyAdapterTests {
 	public void testHeadersPojoMethod() {
 		MethodInvokingCorrelationStrategy adapter = new MethodInvokingCorrelationStrategy(new MultiHeaderCorrelator(),
 				ReflectionUtils.findMethod(MultiHeaderCorrelator.class, "getKey", String.class, String.class));
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		assertEquals("bd", adapter.getCorrelationKey(message));
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingReleaseStrategyTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/MethodInvokingReleaseStrategyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.aggregator;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
@@ -23,9 +25,9 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.Assert;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.store.MessageGroup;
@@ -44,104 +46,125 @@ public class MethodInvokingReleaseStrategyTests {
 	public void testTrueConvertedProperly() {
 		MethodInvokingReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new AlwaysTrueReleaseStrategy(),
 				"checkCompleteness");
-		Assert.assertTrue(adapter.canRelease(createListOfMessages(0)));
+		adapter.setBeanFactory(mock(BeanFactory.class));
+		assertTrue(adapter.canRelease(createListOfMessages(0)));
 	}
 
 	@Test
 	public void testFalseConvertedProperly() {
 		MethodInvokingReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new AlwaysFalseReleaseStrategy(),
 				"checkCompleteness");
-		Assert.assertTrue(!adapter.canRelease(createListOfMessages(0)));
+		adapter.setBeanFactory(mock(BeanFactory.class));
+		assertFalse(adapter.canRelease(createListOfMessages(0)));
 	}
 
 	@Test
 	public void testAdapterWithNonParameterizedMessageListBasedMethod() {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			public boolean checkCompletenessOnNonParameterizedListOfMessages(List<Message<?>> messages) {
-				Assert.assertTrue(messages.size() > 0);
-				return messages.size() > new IntegrationMessageHeaderAccessor(messages.iterator().next()).getSequenceSize();
+				assertTrue(messages.size() > 0);
+				return messages.size() >
+						new IntegrationMessageHeaderAccessor(messages.iterator().next()).getSequenceSize();
 			}
+
 		}
-		ReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
+		MethodInvokingReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
 				"checkCompletenessOnNonParameterizedListOfMessages");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		MessageGroup messages = createListOfMessages(3);
-		Assert.assertTrue(adapter.canRelease(messages));
+		assertTrue(adapter.canRelease(messages));
 	}
 
 	@Test
 	public void testAdapterWithWildcardParametrizedMessageBasedMethod() {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			public boolean checkCompletenessOnListOfMessagesParametrizedWithWildcard(List<Message<?>> messages) {
-				Assert.assertTrue(messages.size() > 0);
-				return messages.size() > new IntegrationMessageHeaderAccessor(messages.iterator().next()).getSequenceSize();
+				assertTrue(messages.size() > 0);
+				return messages.size() >
+						new IntegrationMessageHeaderAccessor(messages.iterator().next()).getSequenceSize();
 			}
+
 		}
-		ReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
+		MethodInvokingReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
 				"checkCompletenessOnListOfMessagesParametrizedWithWildcard");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		MessageGroup messages = createListOfMessages(3);
-		Assert.assertTrue(adapter.canRelease(messages));
+		assertTrue(adapter.canRelease(messages));
 	}
 
 	@Test
 	public void testAdapterWithTypeParametrizedMessageBasedMethod() {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			public boolean checkCompletenessOnListOfMessagesParametrizedWithString(List<Message<String>> messages) {
-				Assert.assertTrue(messages.size() > 0);
-				return messages.size() > new IntegrationMessageHeaderAccessor(messages.iterator().next()).getSequenceSize();
+				assertTrue(messages.size() > 0);
+				return messages.size() > new IntegrationMessageHeaderAccessor(messages.iterator().next())
+						.getSequenceSize();
 			}
+
 		}
-		ReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
+		MethodInvokingReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
 				"checkCompletenessOnListOfMessagesParametrizedWithString");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		MessageGroup messages = createListOfMessages(3);
-		Assert.assertTrue(adapter.canRelease(messages));
+		assertTrue(adapter.canRelease(messages));
 	}
 
 	@Test
 	public void testAdapterWithPojoBasedMethod() {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			// Example for the case when completeness is checked on the structure of
 			// the data
 			public boolean checkCompletenessOnListOfStrings(List<String> messages) {
-				StringBuffer buffer = new StringBuffer();
+				StringBuilder buffer = new StringBuilder();
 				for (String content : messages) {
 					buffer.append(content);
 				}
 				return buffer.length() >= 9;
 			}
+
 		}
-		ReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
+		MethodInvokingReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
 				"checkCompletenessOnListOfStrings");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		MessageGroup messages = createListOfMessages(3);
-		Assert.assertTrue(adapter.canRelease(messages));
+		assertTrue(adapter.canRelease(messages));
 	}
 
 	@Test
 	public void testAdapterWithPojoBasedMethodReturningObject() {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			// Example for the case when completeness is checked on the structure of
 			// the data
 			public boolean checkCompletenessOnListOfStrings(List<String> messages) {
-				StringBuffer buffer = new StringBuffer();
+				StringBuilder buffer = new StringBuilder();
 				for (String content : messages) {
 					buffer.append(content);
 				}
 				return buffer.length() >= 9;
 			}
+
 		}
-		ReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
+		MethodInvokingReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
 				"checkCompletenessOnListOfStrings");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		MessageGroup messages = createListOfMessages(3);
-		Assert.assertTrue(adapter.canRelease(messages));
+		assertTrue(adapter.canRelease(messages));
 	}
 
 	@Test(expected = IllegalStateException.class)
 	public void testAdapterWithWrongMethodName() {
 		class TestReleaseStrategy {
+
 		}
 		new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), "methodThatDoesNotExist");
 	}
@@ -149,23 +172,29 @@ public class MethodInvokingReleaseStrategyTests {
 	@Test(expected = IllegalStateException.class)
 	public void testInvalidParameterTypeUsingMethodName() {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			public boolean invalidParameterType(Date invalid) {
 				return true;
 			}
+
 		}
-		ReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), "invalidParameterType");
+		MethodInvokingReleaseStrategy adapter =
+				new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), "invalidParameterType");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		MessageGroup messages = createListOfMessages(3);
-		Assert.assertTrue(adapter.canRelease(messages));
+		assertTrue(adapter.canRelease(messages));
 	}
 
 	@Test(expected = IllegalStateException.class)
 	public void testTooManyParametersUsingMethodName() {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			public boolean tooManyParameters(List<?> c1, List<?> c2) {
 				return false;
 			}
+
 		}
 		new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), "tooManyParameters");
 	}
@@ -173,10 +202,12 @@ public class MethodInvokingReleaseStrategyTests {
 	@Test
 	public void testNotEnoughParametersUsingMethodName() {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			public boolean notEnoughParameters() {
 				return false;
 			}
+
 		}
 		new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), "notEnoughParameters");
 	}
@@ -184,10 +215,12 @@ public class MethodInvokingReleaseStrategyTests {
 	@Test
 	public void testNotEnoughParametersUsingMethodObject() throws SecurityException, NoSuchMethodException {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			public boolean notEnoughParameters() {
 				return false;
 			}
+
 		}
 		new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), TestReleaseStrategy.class.getMethod(
 				"notEnoughParameters"));
@@ -196,36 +229,46 @@ public class MethodInvokingReleaseStrategyTests {
 	@Test
 	public void testListSubclassParameterUsingMethodName() {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			public boolean listSubclassParameter(LinkedList<?> l1) {
 				return true;
 			}
+
 		}
-		ReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), "listSubclassParameter");
+		MethodInvokingReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
+				"listSubclassParameter");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		MessageGroup messages = createListOfMessages(3);
-		Assert.assertTrue(adapter.canRelease(messages));
+		assertTrue(adapter.canRelease(messages));
 	}
 
 	@Test(expected = ConversionFailedException.class)
 	public void testWrongReturnType() throws SecurityException, NoSuchMethodError {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			public String wrongReturnType(List<Message<?>> messages) {
 				return "foo";
 			}
+
 		}
-		ReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), "wrongReturnType");
+		MethodInvokingReleaseStrategy adapter =
+				new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), "wrongReturnType");
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		MessageGroup messages = createListOfMessages(3);
-		Assert.assertTrue(adapter.canRelease(messages));
+		assertTrue(adapter.canRelease(messages));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testTooManyParametersUsingMethodObject() throws SecurityException, NoSuchMethodException {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			public boolean tooManyParameters(List<?> c1, List<?> c2) {
 				return false;
 			}
+
 		}
 		new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), TestReleaseStrategy.class.getMethod(
 				"tooManyParameters", List.class, List.class));
@@ -234,15 +277,18 @@ public class MethodInvokingReleaseStrategyTests {
 	@Test
 	public void testListSubclassParameterUsingMethodObject() throws SecurityException, NoSuchMethodException {
 		class TestReleaseStrategy {
+
 			@SuppressWarnings("unused")
 			public boolean listSubclassParameter(LinkedList<?> l1) {
 				return true;
 			}
+
 		}
-		ReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
-				TestReleaseStrategy.class.getMethod("listSubclassParameter", new Class<?>[] { LinkedList.class }));
+		MethodInvokingReleaseStrategy adapter = new MethodInvokingReleaseStrategy(new TestReleaseStrategy(),
+				TestReleaseStrategy.class.getMethod("listSubclassParameter", LinkedList.class));
+		adapter.setBeanFactory(mock(BeanFactory.class));
 		MessageGroup messages = createListOfMessages(3);
-		Assert.assertTrue(adapter.canRelease(messages));
+		assertTrue(adapter.canRelease(messages));
 	}
 
 	@Test(expected = IllegalStateException.class)
@@ -258,36 +304,41 @@ public class MethodInvokingReleaseStrategyTests {
 
 		MethodInvokingReleaseStrategy wrongReturnType =
 				new MethodInvokingReleaseStrategy(new TestReleaseStrategy(), TestReleaseStrategy.class.getMethod(
-						"wrongReturnType", new Class<?>[] {List.class}));
+						"wrongReturnType", List.class));
+		wrongReturnType.setBeanFactory(mock(BeanFactory.class));
 		wrongReturnType.canRelease(mock(MessageGroup.class));
 	}
 
 	private static MessageGroup createListOfMessages(int size) {
-		List<Message<?>> messages = new ArrayList<Message<?>>();
+		List<Message<?>> messages = new ArrayList<>();
 		if (size > 0) {
-			messages.add(new GenericMessage<String>("123"));
+			messages.add(new GenericMessage<>("123"));
 		}
 		if (size > 1) {
-			messages.add(new GenericMessage<String>("456"));
+			messages.add(new GenericMessage<>("456"));
 		}
 		if (size > 2) {
-			messages.add(new GenericMessage<String>("789"));
+			messages.add(new GenericMessage<>("789"));
 		}
 		return new SimpleMessageGroup(messages, "ABC");
 	}
 
 	@SuppressWarnings("unused")
 	private static class AlwaysTrueReleaseStrategy {
+
 		public boolean checkCompleteness(List<Message<?>> messages) {
 			return true;
 		}
+
 	}
 
 	@SuppressWarnings("unused")
 	private static class AlwaysFalseReleaseStrategy {
+
 		public boolean checkCompleteness(List<Message<?>> messages) {
 			return false;
 		}
+
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/bus/DirectChannelSubscriptionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/bus/DirectChannelSubscriptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,16 +65,15 @@ public class DirectChannelSubscriptionTests {
 
 	@Test
 	public void sendAndReceiveForRegisteredEndpoint() {
-		TestApplicationContext context = TestUtils.createTestApplicationContext();
 		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(new TestBean(), "handle");
 		serviceActivator.setOutputChannel(this.targetChannel);
+		context.registerBean("testServiceActivator", serviceActivator);
 		EventDrivenConsumer endpoint = new EventDrivenConsumer(this.sourceChannel, serviceActivator);
 		context.registerEndpoint("testEndpoint", endpoint);
 		context.refresh();
-		this.sourceChannel.send(new GenericMessage<String>("foo"));
+		this.sourceChannel.send(new GenericMessage<>("foo"));
 		Message<?> response = this.targetChannel.receive();
 		assertEquals("foo!", response.getPayload());
-		context.stop();
 	}
 
 	@Test
@@ -88,7 +87,6 @@ public class DirectChannelSubscriptionTests {
 		this.sourceChannel.send(new GenericMessage<>("foo"));
 		Message<?> response = this.targetChannel.receive();
 		assertEquals("foo-from-annotated-endpoint", response.getPayload());
-		this.context.stop();
 	}
 
 	@Test(expected = MessagingException.class)
@@ -104,12 +102,7 @@ public class DirectChannelSubscriptionTests {
 		EventDrivenConsumer endpoint = new EventDrivenConsumer(sourceChannel, handler);
 		this.context.registerEndpoint("testEndpoint", endpoint);
 		this.context.refresh();
-		try {
-			this.sourceChannel.send(new GenericMessage<>("foo"));
-		}
-		finally {
-			this.context.stop();
-		}
+		this.sourceChannel.send(new GenericMessage<>("foo"));
 	}
 
 	@Test(expected = MessagingException.class)
@@ -122,12 +115,7 @@ public class DirectChannelSubscriptionTests {
 		FailingTestEndpoint endpoint = new FailingTestEndpoint();
 		postProcessor.postProcessAfterInitialization(endpoint, "testEndpoint");
 		this.context.refresh();
-		try {
-			this.sourceChannel.send(new GenericMessage<String>("foo"));
-		}
-		finally {
-			this.context.stop();
-		}
+		this.sourceChannel.send(new GenericMessage<>("foo"));
 	}
 
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveStreamsConsumerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveStreamsConsumerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ public class ReactiveStreamsConsumerTests {
 		};
 
 		MessageHandler testSubscriber = new MethodInvokingMessageHandler(messageHandler, (String) null);
-
+		((MethodInvokingMessageHandler) testSubscriber).setBeanFactory(mock(BeanFactory.class));
 		ReactiveStreamsConsumer reactiveConsumer = new ReactiveStreamsConsumer(testChannel, testSubscriber);
 		reactiveConsumer.setBeanFactory(mock(BeanFactory.class));
 		reactiveConsumer.afterPropertiesSet();

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/CustomMessagingAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/CustomMessagingAnnotationTests.java
@@ -146,6 +146,7 @@ public class CustomMessagingAnnotationTests {
 					LoggingHandler.Level.class);
 			LoggingHandler loggingHandler = new LoggingHandler(level.name());
 			MethodInvokingMessageProcessor<String> processor = new MethodInvokingMessageProcessor<>(bean, method);
+			processor.setBeanFactory(this.beanFactory);
 			loggingHandler.setLogExpression(new FunctionExpression<>(processor::processMessage));
 			return loggingHandler;
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +45,7 @@ import org.springframework.messaging.support.GenericMessage;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class FilterAnnotationPostProcessorTests {
@@ -64,6 +66,10 @@ public class FilterAnnotationPostProcessorTests {
 		postProcessor.afterPropertiesSet();
 	}
 
+	@After
+	public void tearDown() {
+		this.context.close();
+	}
 
 	@Test
 	public void filterAnnotationWithBooleanPrimitive() {
@@ -108,7 +114,7 @@ public class FilterAnnotationPostProcessorTests {
 	@Test
 	public void filterAnnotationWithAdviceArray() {
 		TestAdvice advice = new TestAdvice();
-		context.registerBean("adviceChain", new TestAdvice[] {advice});
+		context.registerBean("adviceChain", new TestAdvice[] { advice });
 		testValidFilter(new TestFilterWithAdviceDiscardWithin());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
 		assertSame(advice, TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class).get(0));
@@ -119,10 +125,10 @@ public class FilterAnnotationPostProcessorTests {
 	public void filterAnnotationWithAdviceArrayTwice() {
 		TestAdvice advice1 = new TestAdvice();
 		TestAdvice advice2 = new TestAdvice();
-		context.registerBean("adviceChain1", new TestAdvice[] {advice1, advice2});
+		context.registerBean("adviceChain1", new TestAdvice[] { advice1, advice2 });
 		TestAdvice advice3 = new TestAdvice();
 		TestAdvice advice4 = new TestAdvice();
-		context.registerBean("adviceChain2", new TestAdvice[] {advice3, advice4});
+		context.registerBean("adviceChain2", new TestAdvice[] { advice3, advice4 });
 		testValidFilter(new TestFilterWithAdviceDiscardWithinTwice());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
 		List<?> adviceList = TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class);
@@ -137,7 +143,7 @@ public class FilterAnnotationPostProcessorTests {
 	@Test
 	public void filterAnnotationWithAdviceCollection() {
 		TestAdvice advice = new TestAdvice();
-		context.registerBean("adviceChain", Arrays.asList(new TestAdvice[] {advice}));
+		context.registerBean("adviceChain", Collections.singletonList(advice));
 		testValidFilter(new TestFilterWithAdviceDiscardWithin());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
 		assertSame(advice, TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class).get(0));
@@ -148,10 +154,10 @@ public class FilterAnnotationPostProcessorTests {
 	public void filterAnnotationWithAdviceCollectionTwice() {
 		TestAdvice advice1 = new TestAdvice();
 		TestAdvice advice2 = new TestAdvice();
-		context.registerBean("adviceChain1", new TestAdvice[] {advice1, advice2});
+		context.registerBean("adviceChain1", new TestAdvice[] { advice1, advice2 });
 		TestAdvice advice3 = new TestAdvice();
 		TestAdvice advice4 = new TestAdvice();
-		context.registerBean("adviceChain2", new TestAdvice[] {advice3, advice4});
+		context.registerBean("adviceChain2", new TestAdvice[] { advice3, advice4 });
 		testValidFilter(new TestFilterWithAdviceDiscardWithinTwice());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
 		List<?> adviceList = TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class);
@@ -184,10 +190,10 @@ public class FilterAnnotationPostProcessorTests {
 	private void testValidFilter(Object filter) {
 		postProcessor.postProcessAfterInitialization(filter, "testFilter");
 		context.refresh();
-		inputChannel.send(new GenericMessage<String>("good"));
+		inputChannel.send(new GenericMessage<>("good"));
 		Message<?> passed = outputChannel.receive(0);
 		assertNotNull(passed);
-		inputChannel.send(new GenericMessage<String>("bad"));
+		inputChannel.send(new GenericMessage<>("bad"));
 		assertNull(outputChannel.receive(0));
 		context.stop();
 	}
@@ -216,7 +222,7 @@ public class FilterAnnotationPostProcessorTests {
 	@MessageEndpoint
 	public static class TestFilterWithAdviceDiscardWithinTwice {
 
-		@Filter(inputChannel = "input", outputChannel = "output", adviceChain = {"adviceChain1", "adviceChain2"})
+		@Filter(inputChannel = "input", outputChannel = "output", adviceChain = { "adviceChain1", "adviceChain2" })
 		public boolean filter(String s) {
 			return !s.contains("bad");
 		}
@@ -231,6 +237,7 @@ public class FilterAnnotationPostProcessorTests {
 		public boolean filter(String s) {
 			return !s.contains("bad");
 		}
+
 	}
 
 	@MessageEndpoint

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,10 +72,11 @@ public class MessagingAnnotationPostProcessorTests {
 		assertTrue(context.containsBean("testBean.test.serviceActivator"));
 		Object endpoint = context.getBean("testBean.test.serviceActivator");
 		assertTrue(endpoint instanceof AbstractEndpoint);
+		context.close();
 	}
 
 	@Test
-	public void serviceActivatorInApplicationContext() throws Exception {
+	public void serviceActivatorInApplicationContext() {
 		AbstractApplicationContext context = new ClassPathXmlApplicationContext(
 				"serviceActivatorAnnotationPostProcessorTests.xml", this.getClass());
 		MessageChannel inputChannel = (MessageChannel) context.getBean("inputChannel");
@@ -87,8 +88,10 @@ public class MessagingAnnotationPostProcessorTests {
 	}
 
 	@Test
-	public void testSimpleHandler() throws InterruptedException {
-		AbstractApplicationContext context = new ClassPathXmlApplicationContext("simpleAnnotatedEndpointTests.xml", this.getClass());
+	public void testSimpleHandler() {
+		AbstractApplicationContext context = new ClassPathXmlApplicationContext("simpleAnnotatedEndpointTests.xml",
+				this
+				.getClass());
 		context.start();
 		MessageChannel inputChannel = (MessageChannel) context.getBean("inputChannel");
 		PollableChannel outputChannel = (PollableChannel) context.getBean("outputChannel");
@@ -106,26 +109,26 @@ public class MessagingAnnotationPostProcessorTests {
 	}
 
 	@Test
-	public void messageAsMethodParameter() throws InterruptedException {
+	public void messageAsMethodParameter() {
 		AbstractApplicationContext context = new ClassPathXmlApplicationContext(
 				"messageParameterAnnotatedEndpointTests.xml", this.getClass());
 		context.start();
 		MessageChannel inputChannel = (MessageChannel) context.getBean("inputChannel");
 		PollableChannel outputChannel = (PollableChannel) context.getBean("outputChannel");
-		inputChannel.send(new GenericMessage<String>("world"));
+		inputChannel.send(new GenericMessage<>("world"));
 		Message<?> message = outputChannel.receive(1000);
 		assertEquals("hello world", message.getPayload());
 		context.close();
 	}
 
 	@Test
-	public void typeConvertingHandler() throws InterruptedException {
+	public void typeConvertingHandler() {
 		AbstractApplicationContext context = new ClassPathXmlApplicationContext(
 				"typeConvertingEndpointTests.xml", this.getClass());
 		context.start();
 		MessageChannel inputChannel = (MessageChannel) context.getBean("inputChannel");
 		PollableChannel outputChannel = (PollableChannel) context.getBean("outputChannel");
-		inputChannel.send(new GenericMessage<String>("123"));
+		inputChannel.send(new GenericMessage<>("123"));
 		Message<?> message = outputChannel.receive(1000);
 		assertEquals(246, message.getPayload());
 		context.close();
@@ -148,7 +151,7 @@ public class MessagingAnnotationPostProcessorTests {
 		latch.await(1000, TimeUnit.MILLISECONDS);
 		assertEquals(0, latch.getCount());
 		assertEquals("foo", testBean.getMessageText());
-		context.stop();
+		context.close();
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -179,10 +182,10 @@ public class MessagingAnnotationPostProcessorTests {
 		Message<?> reply = outputChannel.receive(0);
 		assertNotNull(reply);
 
-		eventBus.send(new GenericMessage<String>("foo"));
+		eventBus.send(new GenericMessage<>("foo"));
 		assertTrue(bean.getInvoked());
 
-		context.stop();
+		context.close();
 	}
 
 	@Test
@@ -199,10 +202,10 @@ public class MessagingAnnotationPostProcessorTests {
 		Object proxy = proxyFactory.getProxy();
 		postProcessor.postProcessAfterInitialization(proxy, "proxy");
 		context.refresh();
-		inputChannel.send(new GenericMessage<String>("world"));
+		inputChannel.send(new GenericMessage<>("world"));
 		Message<?> message = outputChannel.receive(1000);
 		assertEquals("hello world", message.getPayload());
-		context.stop();
+		context.close();
 	}
 
 	@Test
@@ -217,10 +220,10 @@ public class MessagingAnnotationPostProcessorTests {
 		postProcessor.afterPropertiesSet();
 		postProcessor.postProcessAfterInitialization(new SimpleAnnotatedEndpointSubclass(), "subclass");
 		context.refresh();
-		inputChannel.send(new GenericMessage<String>("world"));
+		inputChannel.send(new GenericMessage<>("world"));
 		Message<?> message = outputChannel.receive(1000);
 		assertEquals("hello world", message.getPayload());
-		context.stop();
+		context.close();
 	}
 
 	@Test
@@ -237,10 +240,10 @@ public class MessagingAnnotationPostProcessorTests {
 		Object proxy = proxyFactory.getProxy();
 		postProcessor.postProcessAfterInitialization(proxy, "proxy");
 		context.refresh();
-		inputChannel.send(new GenericMessage<String>("world"));
+		inputChannel.send(new GenericMessage<>("world"));
 		Message<?> message = outputChannel.receive(1000);
 		assertEquals("hello world", message.getPayload());
-		context.stop();
+		context.close();
 	}
 
 	@Test
@@ -255,10 +258,10 @@ public class MessagingAnnotationPostProcessorTests {
 		postProcessor.afterPropertiesSet();
 		postProcessor.postProcessAfterInitialization(new SimpleAnnotatedEndpointImplementation(), "impl");
 		context.refresh();
-		inputChannel.send(new GenericMessage<String>("ABC"));
+		inputChannel.send(new GenericMessage<>("ABC"));
 		Message<?> message = outputChannel.receive(1000);
 		assertEquals("test-ABC", message.getPayload());
-		context.stop();
+		context.close();
 	}
 
 	@Test
@@ -273,10 +276,10 @@ public class MessagingAnnotationPostProcessorTests {
 		postProcessor.afterPropertiesSet();
 		postProcessor.postProcessAfterInitialization(new SimpleAnnotatedEndpointImplementation(), "impl");
 		context.refresh();
-		inputChannel.send(new GenericMessage<String>("ABC"));
+		inputChannel.send(new GenericMessage<>("ABC"));
 		Message<?> message = outputChannel.receive(1000);
 		assertEquals("test-ABC", message.getPayload());
-		context.stop();
+		context.close();
 	}
 
 	@Test
@@ -293,10 +296,10 @@ public class MessagingAnnotationPostProcessorTests {
 		Object proxy = proxyFactory.getProxy();
 		postProcessor.postProcessAfterInitialization(proxy, "proxy");
 		context.refresh();
-		inputChannel.send(new GenericMessage<String>("ABC"));
+		inputChannel.send(new GenericMessage<>("ABC"));
 		Message<?> message = outputChannel.receive(1000);
 		assertEquals("test-ABC", message.getPayload());
-		context.stop();
+		context.close();
 	}
 
 	@Test
@@ -312,10 +315,10 @@ public class MessagingAnnotationPostProcessorTests {
 		TransformerAnnotationTestBean testBean = new TransformerAnnotationTestBean();
 		postProcessor.postProcessAfterInitialization(testBean, "testBean");
 		context.refresh();
-		inputChannel.send(new GenericMessage<String>("foo"));
+		inputChannel.send(new GenericMessage<>("foo"));
 		Message<?> reply = outputChannel.receive(0);
 		assertEquals("FOO", reply.getPayload());
-		context.stop();
+		context.close();
 	}
 
 
@@ -340,16 +343,20 @@ public class MessagingAnnotationPostProcessorTests {
 			this.messageText = input;
 			latch.countDown();
 		}
+
 	}
 
 
 	public static class SimpleAnnotatedEndpointSubclass extends AnnotatedTestService {
+
 	}
 
 
 	@MessageEndpoint
 	public interface SimpleAnnotatedEndpointInterface {
+
 		String test(String input);
+
 	}
 
 
@@ -358,8 +365,9 @@ public class MessagingAnnotationPostProcessorTests {
 		@Override
 		@ServiceActivator(inputChannel = "inputChannel", outputChannel = "outputChannel")
 		public String test(String input) {
-			return "test-"  + input;
+			return "test-" + input;
 		}
+
 	}
 
 
@@ -381,6 +389,7 @@ public class MessagingAnnotationPostProcessorTests {
 		public Boolean getInvoked() {
 			return invoked.get();
 		}
+
 	}
 
 
@@ -391,6 +400,7 @@ public class MessagingAnnotationPostProcessorTests {
 		public String transformBefore(String input) {
 			return input.toUpperCase();
 		}
+
 	}
 
 	public static class ServiceActivatorAdvice extends AbstractRequestHandlerAdvice {
@@ -406,6 +416,7 @@ public class MessagingAnnotationPostProcessorTests {
 	@Retention(RetentionPolicy.RUNTIME)
 	@ServiceActivator(inputChannel = "eventBus")
 	public static @interface EventHandler {
+
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -61,6 +62,10 @@ public class RouterAnnotationPostProcessorTests {
 		context.registerChannel("stringChannel", stringChannel);
 	}
 
+	@After
+	public void tearDown() {
+		this.context.close();
+	}
 
 	@Test
 	public void testRouter() {
@@ -70,7 +75,7 @@ public class RouterAnnotationPostProcessorTests {
 		TestRouter testRouter = new TestRouter();
 		postProcessor.postProcessAfterInitialization(testRouter, "test");
 		context.refresh();
-		inputChannel.send(new GenericMessage<String>("foo"));
+		inputChannel.send(new GenericMessage<>("foo"));
 		Message<?> replyMessage = outputChannel.receive(0);
 		assertEquals("foo", replyMessage.getPayload());
 		context.stop();
@@ -90,7 +95,7 @@ public class RouterAnnotationPostProcessorTests {
 		assertEquals(Collections.singletonList("foo"), replyMessage.getPayload());
 
 		// The SpEL ReflectiveMethodExecutor does a conversion of a single value to a List
-		routingChannel.send(new GenericMessage<Integer>(2));
+		routingChannel.send(new GenericMessage<>(2));
 		replyMessage = integerChannel.receive(0);
 		assertEquals(2, replyMessage.getPayload());
 		context.stop();

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/SplitterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/SplitterAnnotationPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -55,16 +56,20 @@ public class SplitterAnnotationPostProcessorTests {
 		context.registerChannel("output", outputChannel);
 	}
 
+	@After
+	public void tearDown() {
+		this.context.close();
+	}
 
 	@Test
-	public void testSplitterAnnotation() throws InterruptedException {
+	public void testSplitterAnnotation() {
 		MessagingAnnotationPostProcessor postProcessor = new MessagingAnnotationPostProcessor();
 		postProcessor.setBeanFactory(context.getBeanFactory());
 		postProcessor.afterPropertiesSet();
 		TestSplitter splitter = new TestSplitter();
 		postProcessor.postProcessAfterInitialization(splitter, "testSplitter");
 		context.refresh();
-		inputChannel.send(new GenericMessage<String>("this.is.a.test"));
+		inputChannel.send(new GenericMessage<>("this.is.a.test"));
 		Message<?> message1 = outputChannel.receive(500);
 		assertNotNull(message1);
 		assertEquals("this", message1.getPayload());

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/CorrelationIdTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/CorrelationIdTests.java
@@ -18,9 +18,11 @@ package org.springframework.integration.endpoint;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
@@ -45,6 +47,8 @@ public class CorrelationIdTests {
 		QueueChannel outputChannel = new QueueChannel(1);
 		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(new TestBean(), "upperCase");
 		serviceActivator.setOutputChannel(outputChannel);
+		serviceActivator.setBeanFactory(mock(BeanFactory.class));
+		serviceActivator.afterPropertiesSet();
 		EventDrivenConsumer endpoint = new EventDrivenConsumer(inputChannel, serviceActivator);
 		endpoint.start();
 		assertTrue(inputChannel.send(message));
@@ -60,16 +64,18 @@ public class CorrelationIdTests {
 		QueueChannel outputChannel = new QueueChannel(1);
 		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(new TestBean(), "upperCase");
 		serviceActivator.setOutputChannel(outputChannel);
+		serviceActivator.setBeanFactory(mock(BeanFactory.class));
+		serviceActivator.afterPropertiesSet();
 		EventDrivenConsumer endpoint = new EventDrivenConsumer(inputChannel, serviceActivator);
 		endpoint.start();
 		assertTrue(inputChannel.send(message));
 		Message<?> reply = outputChannel.receive(0);
-		assertEquals(new IntegrationMessageHeaderAccessor(message).getCorrelationId(), new IntegrationMessageHeaderAccessor(reply).getCorrelationId());
-		assertTrue(new IntegrationMessageHeaderAccessor(message).getCorrelationId().equals(new IntegrationMessageHeaderAccessor(reply).getCorrelationId()));
+		assertEquals(new IntegrationMessageHeaderAccessor(message).getCorrelationId(),
+				new IntegrationMessageHeaderAccessor(reply).getCorrelationId());
 	}
 
 	@Test
-	public void testCorrelationNotPassedFromRequestHeaderIfAlreadySetByHandler() throws Exception {
+	public void testCorrelationNotPassedFromRequestHeaderIfAlreadySetByHandler() {
 		Object correlationId = "123-ABC";
 		Message<String> message = MessageBuilder.withPayload("test")
 				.setCorrelationId(correlationId).build();
@@ -77,6 +83,8 @@ public class CorrelationIdTests {
 		QueueChannel outputChannel = new QueueChannel(1);
 		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(new TestBean(), "createMessage");
 		serviceActivator.setOutputChannel(outputChannel);
+		serviceActivator.setBeanFactory(mock(BeanFactory.class));
+		serviceActivator.afterPropertiesSet();
 		EventDrivenConsumer endpoint = new EventDrivenConsumer(inputChannel, serviceActivator);
 		endpoint.start();
 		assertTrue(inputChannel.send(message));
@@ -91,6 +99,8 @@ public class CorrelationIdTests {
 		QueueChannel outputChannel = new QueueChannel(1);
 		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(new TestBean(), "createMessage");
 		serviceActivator.setOutputChannel(outputChannel);
+		serviceActivator.setBeanFactory(mock(BeanFactory.class));
+		serviceActivator.afterPropertiesSet();
 		EventDrivenConsumer endpoint = new EventDrivenConsumer(inputChannel, serviceActivator);
 		endpoint.start();
 		assertTrue(inputChannel.send(message));
@@ -105,6 +115,8 @@ public class CorrelationIdTests {
 		MethodInvokingSplitter splitter = new MethodInvokingSplitter(
 				new TestBean(), TestBean.class.getMethod("split", String.class));
 		splitter.setOutputChannel(testChannel);
+		splitter.setBeanFactory(mock(BeanFactory.class));
+		splitter.afterPropertiesSet();
 		splitter.handleMessage(message);
 		Message<?> reply1 = testChannel.receive(100);
 		Message<?> reply2 = testChannel.receive(100);
@@ -114,20 +126,23 @@ public class CorrelationIdTests {
 
 	@Test
 	public void testCorrelationIdWithSplitterWhenValueSetOnIncomingMessage() throws Exception {
-
 		final String correlationIdForTest = "#FOR_TEST#";
 		Message<?> message = MessageBuilder.withPayload("test1,test2").setCorrelationId(correlationIdForTest).build();
 		QueueChannel testChannel = new QueueChannel();
 		MethodInvokingSplitter splitter = new MethodInvokingSplitter(
 				new TestBean(), TestBean.class.getMethod("split", String.class));
 		splitter.setOutputChannel(testChannel);
+		splitter.setBeanFactory(mock(BeanFactory.class));
+		splitter.afterPropertiesSet();
 		splitter.handleMessage(message);
 		Message<?> reply1 = testChannel.receive(100);
 		Message<?> reply2 = testChannel.receive(100);
 		assertEquals(message.getHeaders().getId(), new IntegrationMessageHeaderAccessor(reply1).getCorrelationId());
 		assertEquals(message.getHeaders().getId(), new IntegrationMessageHeaderAccessor(reply2).getCorrelationId());
-		assertTrue("Sequence details missing", reply1.getHeaders().containsKey(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS));
-		assertTrue("Sequence details missing", reply2.getHeaders().containsKey(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS));
+		assertTrue("Sequence details missing",
+				reply1.getHeaders().containsKey(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS));
+		assertTrue("Sequence details missing",
+				reply2.getHeaders().containsKey(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS));
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorMethodResolutionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ServiceActivatorMethodResolutionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@ package org.springframework.integration.endpoint;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
 
 import java.util.Date;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.gateway.RequestReplyExchanger;
@@ -36,6 +38,7 @@ import org.springframework.messaging.support.GenericMessage;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class ServiceActivatorMethodResolutionTests {
 
@@ -45,7 +48,10 @@ public class ServiceActivatorMethodResolutionTests {
 		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(testBean);
 		QueueChannel outputChannel = new QueueChannel();
 		serviceActivator.setOutputChannel(outputChannel);
-		serviceActivator.handleMessage(new GenericMessage<String>("foo"));
+		serviceActivator.setBeanFactory(mock(BeanFactory.class));
+		serviceActivator.afterPropertiesSet();
+
+		serviceActivator.handleMessage(new GenericMessage<>("foo"));
 		Message<?> result = outputChannel.receive(0);
 		assertEquals("FOO", result.getPayload());
 	}
@@ -62,7 +68,10 @@ public class ServiceActivatorMethodResolutionTests {
 		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(testBean);
 		QueueChannel outputChannel = new QueueChannel();
 		serviceActivator.setOutputChannel(outputChannel);
-		serviceActivator.handleMessage(new GenericMessage<String>("foo"));
+		serviceActivator.setBeanFactory(mock(BeanFactory.class));
+		serviceActivator.afterPropertiesSet();
+
+		serviceActivator.handleMessage(new GenericMessage<>("foo"));
 		Message<?> result = outputChannel.receive(0);
 		assertEquals("FOO", result.getPayload());
 	}
@@ -76,13 +85,7 @@ public class ServiceActivatorMethodResolutionTests {
 
 	@Test
 	public void testRequestReplyExchanger() {
-		RequestReplyExchanger testBean = new RequestReplyExchanger() {
-
-			@Override
-			public Message<?> exchange(Message<?> request) {
-				return request;
-			}
-		};
+		RequestReplyExchanger testBean = request -> request;
 
 		final Message<?> test = new GenericMessage<Object>("foo");
 
@@ -95,6 +98,8 @@ public class ServiceActivatorMethodResolutionTests {
 				return null;
 			}
 		};
+		serviceActivator.setBeanFactory(mock(BeanFactory.class));
+		serviceActivator.afterPropertiesSet();
 
 		serviceActivator.handleMessage(test);
 	}
@@ -120,6 +125,8 @@ public class ServiceActivatorMethodResolutionTests {
 		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(testBean);
 		PollableChannel outputChannel = new QueueChannel();
 		serviceActivator.setOutputChannel(outputChannel);
+		serviceActivator.setBeanFactory(mock(BeanFactory.class));
+		serviceActivator.afterPropertiesSet();
 
 		Message<?> test = new GenericMessage<Object>(new Date());
 		serviceActivator.handleMessage(test);
@@ -151,6 +158,8 @@ public class ServiceActivatorMethodResolutionTests {
 		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(testBean);
 		PollableChannel outputChannel = new QueueChannel();
 		serviceActivator.setOutputChannel(outputChannel);
+		serviceActivator.setBeanFactory(mock(BeanFactory.class));
+		serviceActivator.afterPropertiesSet();
 
 		Message<?> test = new GenericMessage<Object>(new Date());
 		serviceActivator.handleMessage(test);
@@ -187,6 +196,8 @@ public class ServiceActivatorMethodResolutionTests {
 		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(testBean);
 		PollableChannel outputChannel = new QueueChannel();
 		serviceActivator.setOutputChannel(outputChannel);
+		serviceActivator.setBeanFactory(mock(BeanFactory.class));
+		serviceActivator.afterPropertiesSet();
 
 		Message<?> test = new GenericMessage<Object>(new Date());
 		serviceActivator.handleMessage(test);
@@ -223,6 +234,8 @@ public class ServiceActivatorMethodResolutionTests {
 		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(testBean);
 		PollableChannel outputChannel = new QueueChannel();
 		serviceActivator.setOutputChannel(outputChannel);
+		serviceActivator.setBeanFactory(mock(BeanFactory.class));
+		serviceActivator.afterPropertiesSet();
 
 		Message<?> test = new GenericMessage<Object>(new Date());
 		serviceActivator.handleMessage(test);
@@ -239,6 +252,9 @@ public class ServiceActivatorMethodResolutionTests {
 		ServiceActivatingHandler serviceActivator = new ServiceActivatingHandler(testBean);
 		QueueChannel outputChannel = new QueueChannel();
 		serviceActivator.setOutputChannel(outputChannel);
+		serviceActivator.setBeanFactory(mock(BeanFactory.class));
+		serviceActivator.afterPropertiesSet();
+
 		serviceActivator.handleMessage(new GenericMessage<>(new KafkaNull()));
 		Message<?> result = outputChannel.receive(0);
 		assertEquals("gotNull", result.getPayload());

--- a/spring-integration-core/src/test/java/org/springframework/integration/filter/MethodInvokingSelectorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/filter/MethodInvokingSelectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,13 @@ package org.springframework.integration.filter;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 
@@ -30,62 +32,72 @@ import org.springframework.messaging.support.GenericMessage;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
+ * @author Artem Bilan
  */
 public class MethodInvokingSelectorTests {
 
 	@Test
 	public void acceptedWithMethodName() {
 		MethodInvokingSelector selector = new MethodInvokingSelector(new TestBean(), "acceptString");
-		assertTrue(selector.accept(new GenericMessage<String>("should accept")));
+		selector.setBeanFactory(mock(BeanFactory.class));
+		assertTrue(selector.accept(new GenericMessage<>("should accept")));
 	}
 
 	@Test
 	public void acceptedWithMethodReference() throws Exception {
 		TestBean testBean = new TestBean();
-		Method method = testBean.getClass().getMethod("acceptString", new Class<?>[] { Message.class });
+		Method method = testBean.getClass().getMethod("acceptString", Message.class);
 		MethodInvokingSelector selector = new MethodInvokingSelector(testBean, method);
-		assertTrue(selector.accept(new GenericMessage<String>("should accept")));
+		selector.setBeanFactory(mock(BeanFactory.class));
+		assertTrue(selector.accept(new GenericMessage<>("should accept")));
 	}
 
 	@Test
 	public void rejectedWithMethodName() {
 		MethodInvokingSelector selector = new MethodInvokingSelector(new TestBean(), "acceptString");
-		assertFalse(selector.accept(new GenericMessage<Integer>(99)));
+		selector.setBeanFactory(mock(BeanFactory.class));
+		assertFalse(selector.accept(new GenericMessage<>(99)));
 	}
 
 	@Test
 	public void rejectedWithMethodReference() throws Exception {
 		TestBean testBean = new TestBean();
-		Method method = testBean.getClass().getMethod("acceptString", new Class<?>[] { Message.class });
+		Method method = testBean.getClass().getMethod("acceptString", Message.class);
 		MethodInvokingSelector selector = new MethodInvokingSelector(testBean, method);
-		assertFalse(selector.accept(new GenericMessage<Integer>(99)));
+		selector.setBeanFactory(mock(BeanFactory.class));
+		assertFalse(selector.accept(new GenericMessage<>(99)));
 	}
 
 	@Test
 	public void noArgMethodWithMethodName() {
 		MethodInvokingSelector selector = new MethodInvokingSelector(new TestBean(), "noArgs");
-		selector.accept(new GenericMessage<String>("test"));
+		selector.setBeanFactory(mock(BeanFactory.class));
+		assertTrue(selector.accept(new GenericMessage<>("test")));
 	}
 
 	@Test
 	public void noArgMethodWithMethodReference() throws Exception {
 		TestBean testBean = new TestBean();
-		Method method = testBean.getClass().getMethod("noArgs", new Class<?>[] {});
-		new MethodInvokingSelector(testBean, method);
+		Method method = testBean.getClass().getMethod("noArgs");
+		MethodInvokingSelector selector = new MethodInvokingSelector(testBean, method);
+		selector.setBeanFactory(mock(BeanFactory.class));
+		assertTrue(selector.accept(new GenericMessage<>("test")));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void voidReturningMethodWithMethodName() {
 		MethodInvokingSelector selector = new MethodInvokingSelector(new TestBean(), "returnVoid");
-		selector.accept(new GenericMessage<String>("test"));
+		selector.setBeanFactory(mock(BeanFactory.class));
+		selector.accept(new GenericMessage<>("test"));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void voidReturningMethodWithMethodReference() throws Exception {
 		TestBean testBean = new TestBean();
-		Method method = testBean.getClass().getMethod("returnVoid", new Class<?>[] { Message.class });
+		Method method = testBean.getClass().getMethod("returnVoid", Message.class);
 		MethodInvokingSelector selector = new MethodInvokingSelector(testBean, method);
-		selector.accept(new GenericMessage<String>("test"));
+		selector.setBeanFactory(mock(BeanFactory.class));
+		selector.accept(new GenericMessage<>("test"));
 	}
 
 
@@ -106,6 +118,7 @@ public class MethodInvokingSelectorTests {
 		public boolean noArgs() {
 			return true;
 		}
+
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyFactoryBeanTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -389,8 +389,8 @@ public class GatewayProxyFactoryBeanTests {
 		}
 		catch (Exception e) {
 			assertThat(e, instanceOf(BeanInitializationException.class));
-			assertThat(e
-					.getMessage(), containsString("Messaging Gateway cannot override 'id' and 'timestamp' read-only headers"));
+			assertThat(e.getMessage(),
+					containsString("Messaging Gateway cannot override 'id' and 'timestamp' read-only headers"));
 		}
 	}
 
@@ -406,8 +406,8 @@ public class GatewayProxyFactoryBeanTests {
 		}
 		catch (Exception e) {
 			assertThat(e, instanceOf(BeanInitializationException.class));
-			assertThat(e
-					.getMessage(), containsString("Messaging Gateway cannot override 'id' and 'timestamp' read-only headers"));
+			assertThat(e.getMessage(),
+					containsString("Messaging Gateway cannot override 'id' and 'timestamp' read-only headers"));
 		}
 	}
 
@@ -423,48 +423,48 @@ public class GatewayProxyFactoryBeanTests {
 		}
 		catch (Exception e) {
 			assertThat(e, instanceOf(BeanInitializationException.class));
-			assertThat(e
-					.getMessage(), containsString("Messaging Gateway cannot override 'id' and 'timestamp' read-only headers"));
+			assertThat(e.getMessage(),
+					containsString("Messaging Gateway cannot override 'id' and 'timestamp' read-only headers"));
 		}
 	}
 
-//	@Test
-//	public void testHistory() throws Exception {
-//		GenericApplicationContext context = new GenericApplicationContext();
-//		context.getBeanFactory().registerSingleton("historyWriter", new MessageHistoryWriter());
-//		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
-//		proxyFactory.setBeanFactory(context);
-//		proxyFactory.setBeanName("testGateway");
-//		DirectChannel channel = new DirectChannel();
-//		channel.setBeanName("testChannel");
-//		channel.setBeanFactory(context);
-//		channel.afterPropertiesSet();
-//		BridgeHandler bridgeHandler = new BridgeHandler();
-//		bridgeHandler.setBeanFactory(context);
-//		bridgeHandler.afterPropertiesSet();
-//		bridgeHandler.setBeanName("testBridge");
-//		EventDrivenConsumer consumer = new EventDrivenConsumer(channel, bridgeHandler);
-//		consumer.setBeanFactory(context);
-//		consumer.afterPropertiesSet();
-//		consumer.start();
-//		proxyFactory.setDefaultRequestChannel(channel);
-//		proxyFactory.setServiceInterface(TestEchoService.class);
-//		proxyFactory.afterPropertiesSet();
-//		TestEchoService proxy = (TestEchoService) proxyFactory.getObject();
-//		Message<?> message = proxy.echo("test");
-//		Iterator<MessageHistoryEvent> historyIterator = message.getHeaders().getHistory().iterator();
-//		MessageHistoryEvent event1 = historyIterator.next();
-//		MessageHistoryEvent event2 = historyIterator.next();
-//		MessageHistoryEvent event3 = historyIterator.next();
-//
-//		//assertEquals("echo", event1.getAttribute("method", String.class));
-//		assertEquals("gateway", event1.getType());
-//		assertEquals("testGateway", event1.getName());
-//		assertEquals("channel", event2.getType());
-//		assertEquals("testChannel", event2.getName());
-//		assertEquals("bridge", event3.getType());
-//		assertEquals("testBridge", event3.getName());
-//	}
+	//	@Test
+	//	public void testHistory() throws Exception {
+	//		GenericApplicationContext context = new GenericApplicationContext();
+	//		context.getBeanFactory().registerSingleton("historyWriter", new MessageHistoryWriter());
+	//		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
+	//		proxyFactory.setBeanFactory(context);
+	//		proxyFactory.setBeanName("testGateway");
+	//		DirectChannel channel = new DirectChannel();
+	//		channel.setBeanName("testChannel");
+	//		channel.setBeanFactory(context);
+	//		channel.afterPropertiesSet();
+	//		BridgeHandler bridgeHandler = new BridgeHandler();
+	//		bridgeHandler.setBeanFactory(context);
+	//		bridgeHandler.afterPropertiesSet();
+	//		bridgeHandler.setBeanName("testBridge");
+	//		EventDrivenConsumer consumer = new EventDrivenConsumer(channel, bridgeHandler);
+	//		consumer.setBeanFactory(context);
+	//		consumer.afterPropertiesSet();
+	//		consumer.start();
+	//		proxyFactory.setDefaultRequestChannel(channel);
+	//		proxyFactory.setServiceInterface(TestEchoService.class);
+	//		proxyFactory.afterPropertiesSet();
+	//		TestEchoService proxy = (TestEchoService) proxyFactory.getObject();
+	//		Message<?> message = proxy.echo("test");
+	//		Iterator<MessageHistoryEvent> historyIterator = message.getHeaders().getHistory().iterator();
+	//		MessageHistoryEvent event1 = historyIterator.next();
+	//		MessageHistoryEvent event2 = historyIterator.next();
+	//		MessageHistoryEvent event3 = historyIterator.next();
+	//
+	//		//assertEquals("echo", event1.getAttribute("method", String.class));
+	//		assertEquals("gateway", event1.getType());
+	//		assertEquals("testGateway", event1.getName());
+	//		assertEquals("channel", event2.getType());
+	//		assertEquals("testChannel", event2.getName());
+	//		assertEquals("bridge", event3.getType());
+	//		assertEquals("testBridge", event3.getName());
+	//	}
 
 	@Test
 	public void autowiredGateway() {
@@ -474,6 +474,7 @@ public class GatewayProxyFactoryBeanTests {
 	@Test
 	public void testOverriddenMethod() {
 		GatewayProxyFactoryBean gpfb = new GatewayProxyFactoryBean(InheritChild.class);
+		gpfb.setBeanFactory(mock(BeanFactory.class));
 		gpfb.afterPropertiesSet();
 		Map<Method, MessagingGatewaySupport> gateways = gpfb.getGateways();
 		assertThat(gateways.size(), equalTo(2));

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,8 @@ public class DelayHandlerTests {
 
 	private final ResultHandler resultHandler = new ResultHandler();
 
+	private TestApplicationContext context = TestUtils.createTestApplicationContext();
+
 	@Before
 	public void setup() {
 		input.setBeanName("input");
@@ -104,7 +106,8 @@ public class DelayHandlerTests {
 
 	@After
 	public void tearDown() {
-		taskScheduler.destroy();
+		this.context.close();
+		this.taskScheduler.destroy();
 	}
 
 	private void setDelayExpression() {
@@ -113,10 +116,9 @@ public class DelayHandlerTests {
 	}
 
 	private void startDelayerHandler() {
-		delayHandler.afterPropertiesSet();
-		TestApplicationContext ac = TestUtils.createTestApplicationContext();
-		delayHandler.setApplicationContext(ac);
-		delayHandler.onApplicationEvent(new ContextRefreshedEvent(ac));
+		this.delayHandler.setApplicationContext(this.context);
+		this.delayHandler.afterPropertiesSet();
+		this.delayHandler.onApplicationEvent(new ContextRefreshedEvent(this.context));
 	}
 
 	@Test
@@ -466,6 +468,7 @@ public class DelayHandlerTests {
 		this.delayHandler.onApplicationEvent(contextRefreshedEvent);
 		this.delayHandler.onApplicationEvent(contextRefreshedEvent);
 		Mockito.verify(this.delayHandler, Mockito.times(1)).reschedulePersistedMessages();
+		ac.close();
 	}
 
 	@Test(expected = MessageHandlingException.class)
@@ -473,7 +476,7 @@ public class DelayHandlerTests {
 		this.setDelayExpression();
 		this.delayHandler.setIgnoreExpressionFailures(false);
 		startDelayerHandler();
-		this.delayHandler.handleMessage(new GenericMessage<String>("test"));
+		this.delayHandler.handleMessage(new GenericMessage<>("test"));
 	}
 
 	@Test //INT-3560

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingHeaderEnricherTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingHeaderEnricherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,6 +29,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.transformer.HeaderEnricher;
@@ -49,6 +51,7 @@ public class MethodInvokingHeaderEnricherTests {
 	public void emptyHeadersOnRequest() {
 		TestBean testBean = new TestBean();
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testBean, "process");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		HeaderEnricher enricher = new HeaderEnricher();
 		enricher.setMessageProcessor(processor);
 		enricher.setDefaultOverwrite(true);
@@ -63,6 +66,7 @@ public class MethodInvokingHeaderEnricherTests {
 	public void overwriteFalseByDefault() {
 		TestBean testBean = new TestBean();
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testBean, "process");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		HeaderEnricher enricher = new HeaderEnricher();
 		enricher.setMessageProcessor(processor);
 		Message<?> message = MessageBuilder.withPayload("test").setHeader("bar", "XYZ").build();
@@ -76,6 +80,7 @@ public class MethodInvokingHeaderEnricherTests {
 	public void overwriteFalseExplicit() {
 		TestBean testBean = new TestBean();
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testBean, "process");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		HeaderEnricher enricher = new HeaderEnricher();
 		enricher.setMessageProcessor(processor);
 		enricher.setDefaultOverwrite(false);
@@ -90,6 +95,7 @@ public class MethodInvokingHeaderEnricherTests {
 	public void overwriteTrue() {
 		TestBean testBean = new TestBean();
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testBean, "process");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		HeaderEnricher enricher = new HeaderEnricher();
 		enricher.setMessageProcessor(processor);
 		enricher.setDefaultOverwrite(true);

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorAnnotationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -38,6 +39,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
@@ -69,13 +71,14 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void multiThreadsUUIDToStringConversion() throws Exception {
 		Method method = TestService.class.getMethod("headerId", String.class, String.class);
 		final MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		ExecutorService exec = Executors.newFixedThreadPool(100);
-		processor.processMessage(new GenericMessage<String>("foo"));
+		processor.processMessage(new GenericMessage<>("foo"));
 		for (int i = 0; i < 100; i++) {
 			exec.execute(new Runnable() {
 
 				public void run() {
-					Object result = processor.processMessage(new GenericMessage<String>("foo"));
+					Object result = processor.processMessage(new GenericMessage<>("foo"));
 					assertNotNull(result);
 				}
 			});
@@ -89,7 +92,8 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void optionalHeader() throws Exception {
 		Method method = TestService.class.getMethod("optionalHeader", Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
-		Object result = processor.processMessage(new GenericMessage<String>("foo"));
+		processor.setBeanFactory(mock(BeanFactory.class));
+		Object result = processor.processMessage(new GenericMessage<>("foo"));
 		assertNull(result);
 	}
 
@@ -97,16 +101,18 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void requiredHeaderNotProvided() throws Exception {
 		Method method = TestService.class.getMethod("requiredHeader", Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
-		processor.processMessage(new GenericMessage<String>("foo"));
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.processMessage(new GenericMessage<>("foo"));
 	}
 
 	@Test(expected = MessageHandlingException.class)
 	public void requiredHeaderNotProvidedOnSecondMessage() throws Exception {
 		Method method = TestService.class.getMethod("requiredHeader", Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<String> messageWithHeader = MessageBuilder.withPayload("foo")
 				.setHeader("num", 123).build();
-		GenericMessage<String> messageWithoutHeader = new GenericMessage<String>("foo");
+		GenericMessage<String> messageWithoutHeader = new GenericMessage<>("foo");
 
 		processor.processMessage(messageWithHeader);
 		processor.processMessage(messageWithoutHeader);
@@ -118,6 +124,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 		Message<String> message = MessageBuilder.withPayload("foo")
 				.setHeader("num", 123).build();
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Object result = processor.processMessage(message);
 		assertEquals(123, result);
 	}
@@ -126,6 +133,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageWithOptionalAndRequiredHeaderAndOnlyOptionalHeaderProvided() throws Exception {
 		Method method = TestService.class.getMethod("optionalAndRequiredHeader", String.class, Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("foo")
 				.setHeader("prop", "bar").build();
 		processor.processMessage(message);
@@ -135,6 +143,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageWithOptionalAndRequiredHeaderAndOnlyRequiredHeaderProvided() throws Exception {
 		Method method = TestService.class.getMethod("optionalAndRequiredHeader", String.class, Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("foo")
 				.setHeader("num", 123).build();
 		Object result = processor.processMessage(message);
@@ -145,6 +154,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageWithOptionalAndRequiredHeaderAndBothHeadersProvided() throws Exception {
 		Method method = TestService.class.getMethod("optionalAndRequiredHeader", String.class, Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("foo")
 				.setHeader("num", 123)
 				.setHeader("prop", "bar")
@@ -157,6 +167,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageWithPropertiesMethodAndHeadersAnnotation() throws Exception {
 		Method method = TestService.class.getMethod("propertiesHeaders", Properties.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("test")
 				.setHeader("prop1", "foo").setHeader("prop2", "bar").build();
 		assertFalse(TestUtils.getPropertyValue(processor, "delegate.handlerMethod.spelOnly", Boolean.class));
@@ -180,6 +191,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageWithPropertiesAndObjectMethod() throws Exception {
 		Method method = TestService.class.getMethod("propertiesHeadersAndPayload", Properties.class, Object.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("test")
 				.setHeader("prop1", "foo").setHeader("prop2", "bar").build();
 		Object result = processor.processMessage(message);
@@ -193,6 +205,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageWithMapAndObjectMethod() throws Exception {
 		Method method = TestService.class.getMethod("mapHeadersAndPayload", Map.class, Object.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("test")
 				.setHeader("prop1", "foo").setHeader("prop2", "bar").build();
 		Map<?, ?> result = (Map<?, ?>) processor.processMessage(message);
@@ -208,6 +221,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageWithPropertiesMethodAndPropertiesPayload() throws Exception {
 		Method method = TestService.class.getMethod("propertiesPayload", Properties.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Properties payload = new Properties();
 		payload.setProperty("prop1", "foo");
 		payload.setProperty("prop2", "bar");
@@ -223,6 +237,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageWithMapMethodAndHeadersAnnotation() throws Exception {
 		Method method = TestService.class.getMethod("mapHeaders", Map.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("test")
 				.setHeader("attrib1", 123)
 				.setHeader("attrib2", 456).build();
@@ -235,7 +250,8 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageWithMapMethodAndMapPayload() throws Exception {
 		Method method = TestService.class.getMethod("mapPayload", Map.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
-		Map<String, Integer> payload = new HashMap<String, Integer>();
+		processor.setBeanFactory(mock(BeanFactory.class));
+		Map<String, Integer> payload = new HashMap<>();
 		payload.put("attrib1", 88);
 		payload.put("attrib2", 99);
 		Message<Map<String, Integer>> message = MessageBuilder.withPayload(payload)
@@ -252,6 +268,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 		Message<?> message = this.getMessage();
 		Method method = TestService.class.getMethod("headerAnnotationWithExpression", String.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Object result = processor.processMessage(message);
 		Assert.assertEquals("monday", result);
 	}
@@ -261,6 +278,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 		Message<?> message = MessageBuilder.withPayload("foo").build();
 		Method method = TestService.class.getMethod("irrelevantAnnotation", String.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Object result = processor.processMessage(message);
 		assertEquals("foo", result);
 	}
@@ -275,20 +293,22 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 				String.class,
 				Map.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Object[] parameters = (Object[]) processor.processMessage(message);
-		Assert.assertNotNull(parameters);
-		Assert.assertTrue(parameters.length == 5);
-		Assert.assertTrue(parameters[0].equals("monday"));
-		Assert.assertTrue(parameters[1].equals("September"));
-		Assert.assertTrue(parameters[2].equals(employee));
-		Assert.assertTrue(parameters[3].equals("oleg"));
-		Assert.assertTrue(parameters[4] instanceof Map);
+		assertNotNull(parameters);
+		assertEquals(5, parameters.length);
+		assertEquals("monday", parameters[0]);
+		assertEquals("September", parameters[1]);
+		assertEquals(parameters[2], employee);
+		assertEquals("oleg", parameters[3]);
+		assertTrue(parameters[4] instanceof Map);
 	}
 
 	@Test
 	public void fromMessageToPayload() throws Exception {
 		Method method = TestService.class.getMethod("mapOnly", Map.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<Employee> message = MessageBuilder.withPayload(employee).setHeader("number", "jkl").build();
 		Object result = processor.processMessage(message);
 		Assert.assertTrue(result instanceof Map);
@@ -299,6 +319,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageToPayloadArg() throws Exception {
 		Method method = TestService.class.getMethod("payloadAnnotationFirstName", String.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<Employee> message = MessageBuilder.withPayload(employee).setHeader("number", "jkl").build();
 		Object result = processor.processMessage(message);
 		Assert.assertTrue(result instanceof String);
@@ -309,6 +330,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageToPayloadArgs() throws Exception {
 		Method method = TestService.class.getMethod("payloadAnnotationFullName", String.class, String.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<Employee> message = MessageBuilder.withPayload(employee).setHeader("number", "jkl").build();
 		Object result = processor.processMessage(message);
 		Assert.assertEquals("oleg zhurakousky", result);
@@ -318,6 +340,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageToPayloadArgsHeaderArgs() throws Exception {
 		Method method = TestService.class.getMethod("payloadArgAndHeaderArg", String.class, String.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<Employee> message = MessageBuilder.withPayload(employee).setHeader("day", "monday").build();
 		Object result = processor.processMessage(message);
 		Assert.assertEquals("olegmonday", result);
@@ -327,6 +350,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageInvalidMethodWithMultipleMappingAnnotations() throws Exception {
 		Method method = MultipleMappingAnnotationTestBean.class.getMethod("test", String.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<?> message = MessageBuilder.withPayload("payload").setHeader("foo", "bar").build();
 		processor.processMessage(message);
 	}
@@ -335,6 +359,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageToHeadersWithExpressions() throws Exception {
 		Method method = TestService.class.getMethod("headersWithExpressions", String.class, String.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Employee employee = new Employee("John", "Doe");
 		Message<?> message = MessageBuilder.withPayload("payload").setHeader("emp", employee).build();
 		Object result = processor.processMessage(message);
@@ -345,6 +370,7 @@ public class MethodInvokingMessageProcessorAnnotationTests {
 	public void fromMessageToHyphenatedHeaderName() throws Exception {
 		Method method = TestService.class.getMethod("headerNameWithHyphen", String.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testService, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<?> message = MessageBuilder.withPayload("payload").setHeader("foo-bar", "abc").build();
 		Object result = processor.processMessage(message);
 		assertEquals("ABC", result);

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -151,10 +151,11 @@ public class MethodInvokingMessageProcessorTests {
 				}
 
 				@Override
-				public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception {
+				public Object resolveArgument(MethodParameter parameter, Message<?> message) {
 					String[] names = ((String) message.getPayload()).split(" ");
 					return new Person(names[0], names[1]);
 				}
+
 			};
 			f.setArgumentResolvers(Collections.singletonList(resolver));
 			f.afterPropertiesSet();
@@ -170,7 +171,7 @@ public class MethodInvokingMessageProcessorTests {
 			}
 
 			public String toString() {
-				return "Person: " + name;
+				return "Person: " + this.name;
 			}
 
 		}
@@ -198,6 +199,7 @@ public class MethodInvokingMessageProcessorTests {
 		}
 
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new B(), "myMethod");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<?> message = (Message<?>) processor.processMessage(new GenericMessage<>(""));
 		assertEquals("A", message.getHeaders().get("A"));
 	}
@@ -228,6 +230,7 @@ public class MethodInvokingMessageProcessorTests {
 		}
 
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new B(), "myMethod");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<?> message = (Message<?>) processor.processMessage(new GenericMessage<>(""));
 		assertEquals("B", message.getHeaders().get("B"));
 	}
@@ -297,7 +300,8 @@ public class MethodInvokingMessageProcessorTests {
 	public void payloadAsMethodParameterAndObjectAsReturnValue() {
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
 				"acceptPayloadAndReturnObject");
-		Object result = processor.processMessage(new GenericMessage<>("testing"));
+		processor.setBeanFactory(mock(BeanFactory.class));
+		Object result = processor.processMessage(new GenericMessage<String>("testing"));
 		assertEquals("testing-1", result);
 	}
 
@@ -305,7 +309,8 @@ public class MethodInvokingMessageProcessorTests {
 	public void testPayloadCoercedToString() {
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
 				"acceptPayloadAndReturnObject");
-		Object result = processor.processMessage(new GenericMessage<>(123456789));
+		processor.setBeanFactory(mock(BeanFactory.class));
+		Object result = processor.processMessage(new GenericMessage<Integer>(123456789));
 		assertEquals("123456789-1", result);
 	}
 
@@ -313,6 +318,7 @@ public class MethodInvokingMessageProcessorTests {
 	public void payloadAsMethodParameterAndMessageAsReturnValue() {
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
 				"acceptPayloadAndReturnMessage");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<?> result = (Message<?>) processor.processMessage(new GenericMessage<>("testing"));
 		assertEquals("testing-2", result.getPayload());
 	}
@@ -321,7 +327,8 @@ public class MethodInvokingMessageProcessorTests {
 	public void messageAsMethodParameterAndObjectAsReturnValue() {
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
 				"acceptMessageAndReturnObject");
-		Object result = processor.processMessage(new GenericMessage<>("testing"));
+		processor.setBeanFactory(mock(BeanFactory.class));
+		Object result = processor.processMessage(new GenericMessage<String>("testing"));
 		assertEquals("testing-3", result);
 	}
 
@@ -329,6 +336,7 @@ public class MethodInvokingMessageProcessorTests {
 	public void messageAsMethodParameterAndMessageAsReturnValue() {
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
 				"acceptMessageAndReturnMessage");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<?> result = (Message<?>) processor.processMessage(new GenericMessage<>("testing"));
 		assertEquals("testing-4", result.getPayload());
 	}
@@ -337,6 +345,7 @@ public class MethodInvokingMessageProcessorTests {
 	public void messageSubclassAsMethodParameterAndMessageAsReturnValue() {
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
 				"acceptMessageSubclassAndReturnMessage");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<?> result = (Message<?>) processor.processMessage(new GenericMessage<>("testing"));
 		assertEquals("testing-5", result.getPayload());
 	}
@@ -345,7 +354,8 @@ public class MethodInvokingMessageProcessorTests {
 	public void messageSubclassAsMethodParameterAndMessageSubclassAsReturnValue() {
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
 				"acceptMessageSubclassAndReturnMessageSubclass");
-		Message<?> result = (Message<?>) processor.processMessage(new GenericMessage<>("testing"));
+		processor.setBeanFactory(mock(BeanFactory.class));
+		Message<?> result = (Message<?>) processor.processMessage(new GenericMessage<String>("testing"));
 		assertEquals("testing-6", result.getPayload());
 	}
 
@@ -353,6 +363,7 @@ public class MethodInvokingMessageProcessorTests {
 	public void payloadAndHeaderAnnotationMethodParametersAndObjectAsReturnValue() {
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
 				"acceptPayloadAndHeaderAndReturnObject");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<?> request = MessageBuilder.withPayload("testing").setHeader("number", 123).build();
 		Object result = processor.processMessage(request);
 		assertEquals("testing-123", result);
@@ -360,8 +371,9 @@ public class MethodInvokingMessageProcessorTests {
 
 	@Test
 	public void testVoidMethodsIncludedByDefault() {
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
-				"testVoidReturningMethods");
+		MethodInvokingMessageProcessor processor =
+				new MethodInvokingMessageProcessor(new TestBean(), "testVoidReturningMethods");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		assertNull(processor.processMessage(MessageBuilder.withPayload("Something").build()));
 		assertEquals(12, processor.processMessage(MessageBuilder.withPayload(12).build()));
 	}
@@ -371,6 +383,7 @@ public class MethodInvokingMessageProcessorTests {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("messageOnly", Message.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Object result = processor.processMessage(new GenericMessage<>("foo"));
 		assertEquals("foo", result);
 	}
@@ -380,6 +393,7 @@ public class MethodInvokingMessageProcessorTests {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("integerMethod", Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Object result = processor.processMessage(new GenericMessage<>(123));
 		assertEquals(123, result);
 	}
@@ -389,7 +403,8 @@ public class MethodInvokingMessageProcessorTests {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("integerMethod", Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
-		Object result = processor.processMessage(new GenericMessage<String>("456"));
+		processor.setBeanFactory(mock(BeanFactory.class));
+		Object result = processor.processMessage(new GenericMessage<>("456"));
 		assertEquals(456, result);
 	}
 
@@ -398,13 +413,15 @@ public class MethodInvokingMessageProcessorTests {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("integerMethod", Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
-		processor.processMessage(new GenericMessage<String>("foo"));
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.processMessage(new GenericMessage<>("foo"));
 	}
 
 	@Test
 	public void filterSelectsAnnotationMethodsOnly() {
 		OverloadedMethodBean bean = new OverloadedMethodBean();
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, ServiceActivator.class);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		processor.processMessage(MessageBuilder.withPayload(123).build());
 		assertNotNull(bean.lastArg);
 		assertEquals(String.class, bean.lastArg.getClass());
@@ -417,7 +434,8 @@ public class MethodInvokingMessageProcessorTests {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("integerMethod", Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
-		assertEquals("foo", processor.processMessage(new GenericMessage<String>("foo")));
+		processor.setBeanFactory(mock(BeanFactory.class));
+		assertEquals("foo", processor.processMessage(new GenericMessage<>("foo")));
 	}
 
 	@Test
@@ -426,7 +444,8 @@ public class MethodInvokingMessageProcessorTests {
 		TestErrorService service = new TestErrorService();
 		Method method = service.getClass().getMethod("error", String.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
-		assertEquals("foo", processor.processMessage(new GenericMessage<String>("foo")));
+		processor.setBeanFactory(mock(BeanFactory.class));
+		assertEquals("foo", processor.processMessage(new GenericMessage<>("foo")));
 	}
 
 	@Test
@@ -435,7 +454,8 @@ public class MethodInvokingMessageProcessorTests {
 		TestErrorService service = new TestErrorService();
 		Method method = service.getClass().getMethod("checked", String.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
-		assertEquals("foo", processor.processMessage(new GenericMessage<String>("foo")));
+		processor.setBeanFactory(mock(BeanFactory.class));
+		assertEquals("foo", processor.processMessage(new GenericMessage<>("foo")));
 	}
 
 	@Test
@@ -445,7 +465,8 @@ public class MethodInvokingMessageProcessorTests {
 		Method method = TestErrorService.class.getMethod("checked", String.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
 		processor.setUseSpelInvoker(true);
-		processor.processMessage(new GenericMessage<String>("foo"));
+		processor.setBeanFactory(mock(BeanFactory.class));
+		processor.processMessage(new GenericMessage<>("foo"));
 	}
 
 	@Test
@@ -453,6 +474,7 @@ public class MethodInvokingMessageProcessorTests {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("messageAndHeader", Message.class, Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("foo").setHeader("number", 42).build();
 		Object result = processor.processMessage(message);
 		assertEquals("foo-42", result);
@@ -463,8 +485,12 @@ public class MethodInvokingMessageProcessorTests {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("twoHeaders", String.class, Integer.class);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
-		Message<String> message = MessageBuilder.withPayload("foo").setHeader("prop", "bar").setHeader("number", 42)
-				.build();
+		processor.setBeanFactory(mock(BeanFactory.class));
+		Message<String> message =
+				MessageBuilder.withPayload("foo")
+						.setHeader("prop", "bar")
+						.setHeader("number", 42)
+						.build();
 		Object result = processor.processMessage(message);
 		assertEquals("bar-42", result);
 	}
@@ -493,6 +519,8 @@ public class MethodInvokingMessageProcessorTests {
 
 	private void optionalAndRequiredWithAnnotatedMethodGuts(MethodInvokingMessageProcessor processor,
 			boolean compiled) {
+
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("foo")
 				.setHeader("num", 42)
 				.build();
@@ -545,6 +573,8 @@ public class MethodInvokingMessageProcessorTests {
 
 	private void optionalAndRequiredDottedWithAnnotatedMethodGuts(MethodInvokingMessageProcessor processor,
 			boolean compiled) {
+
+		processor.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("hello")
 				.setHeader("dot2", new DotBean())
 				.build();
@@ -577,6 +607,7 @@ public class MethodInvokingMessageProcessorTests {
 	public void testOverloadedNonVoidReturningMethodsWithExactMatchForType() {
 		AmbiguousMethodBean bean = new AmbiguousMethodBean();
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, "foo");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		processor.processMessage(MessageBuilder.withPayload("true").build());
 		assertNotNull(bean.lastArg);
 		assertEquals(String.class, bean.lastArg.getClass());
@@ -621,13 +652,14 @@ public class MethodInvokingMessageProcessorTests {
 		}
 
 		MessagingMethodInvokerHelper helper = new MessagingMethodInvokerHelper(new Foo(), (String) null, false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 		assertEquals("4", helper.process(new GenericMessage<Object>(2L)));
 		assertEquals("1", helper.process(new GenericMessage<Object>(1)));
 		assertEquals("foo", helper.process(new GenericMessage<Object>(new Date())));
 	}
 
 	@Test
-	public void testInt3199GettersAmbiguity() throws Exception {
+	public void testInt3199GettersAmbiguity() {
 
 		class Foo {
 
@@ -678,6 +710,7 @@ public class MethodInvokingMessageProcessorTests {
 		Foo targetObject = new Foo();
 
 		MessagingMethodInvokerHelper helper = new MessagingMethodInvokerHelper(targetObject, (String) null, false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 		assertEquals("foo", helper.process(new GenericMessage<Object>("foo")));
 		assertEquals(1, helper.process(new GenericMessage<Object>(1)));
 		assertEquals(targetObject, helper.process(new GenericMessage<Object>(targetObject)));
@@ -708,6 +741,7 @@ public class MethodInvokingMessageProcessorTests {
 		Foo targetObject = new Foo();
 
 		MessagingMethodInvokerHelper helper = new MessagingMethodInvokerHelper(targetObject, (String) null, false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 		assertEquals("foo", helper.process(new GenericMessage<Object>("foo")));
 		assertEquals(1, helper.process(new GenericMessage<Object>(1)));
 		assertEquals(targetObject, helper.process(new GenericMessage<Object>(targetObject)));
@@ -739,6 +773,7 @@ public class MethodInvokingMessageProcessorTests {
 		Foo targetObject = new Foo();
 
 		MessagingMethodInvokerHelper helper = new MessagingMethodInvokerHelper(targetObject, (String) null, false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 		assertEquals("foo", helper.process(new GenericMessage<Object>("foo")));
 		assertEquals("FOO", helper.process(new GenericMessage<Object>(targetObject)));
 	}
@@ -747,6 +782,7 @@ public class MethodInvokingMessageProcessorTests {
 	public void testIneligible() {
 		IneligibleMethodBean bean = new IneligibleMethodBean();
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, "foo");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		processor.processMessage(MessageBuilder.withPayload("true").build());
 		assertNotNull(bean.lastArg);
 		assertEquals(String.class, bean.lastArg.getClass());
@@ -757,7 +793,7 @@ public class MethodInvokingMessageProcessorTests {
 	public void testOptionalArgs() throws Exception {
 		class Foo {
 
-			private final Map<String, Object> arguments = new LinkedHashMap<String, Object>();
+			private final Map<String, Object> arguments = new LinkedHashMap<>();
 
 			@SuppressWarnings("unused")
 			public void optionalHeaders(Optional<String> foo, @Header(value = "foo", required = false) String foo1,
@@ -772,6 +808,7 @@ public class MethodInvokingMessageProcessorTests {
 		Foo targetObject = new Foo();
 
 		MessagingMethodInvokerHelper helper = new MessagingMethodInvokerHelper(targetObject, (String) null, false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 
 		helper.process(new GenericMessage<>(Optional.empty()));
 		assertNull(targetObject.arguments.get("foo"));
@@ -795,8 +832,9 @@ public class MethodInvokingMessageProcessorTests {
 
 		}
 
-		MessagingMethodInvokerHelper helper = new MessagingMethodInvokerHelper(new Foo(), ServiceActivator.class,
-				false);
+		MessagingMethodInvokerHelper helper =
+				new MessagingMethodInvokerHelper(new Foo(), ServiceActivator.class, false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 
 		assertEquals("FOO", helper.process(new GenericMessage<>("foo")));
 		assertEquals("BAR", helper.process(new GenericMessage<>("bar")));
@@ -809,6 +847,7 @@ public class MethodInvokingMessageProcessorTests {
 
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
 		processor.setUseSpelInvoker(true);
+		processor.setBeanFactory(mock(BeanFactory.class));
 
 		Message<Integer> message = MessageBuilder.withPayload(42).build();
 
@@ -823,6 +862,7 @@ public class MethodInvokingMessageProcessorTests {
 		stopWatch.stop();
 
 		processor = new MethodInvokingMessageProcessor(service, method);
+		processor.setBeanFactory(mock(BeanFactory.class));
 
 		stopWatch.start("Invocable");
 		for (int i = 0; i < count; i++) {
@@ -834,6 +874,7 @@ public class MethodInvokingMessageProcessorTests {
 
 		processor = new MethodInvokingMessageProcessor(service, method);
 		processor.setUseSpelInvoker(true);
+		processor.setBeanFactory(mock(BeanFactory.class));
 
 		stopWatch.start("Compiled SpEL");
 		for (int i = 0; i < count; i++) {
@@ -858,7 +899,7 @@ public class MethodInvokingMessageProcessorTests {
 		}
 
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new A(), "myMethod");
-
+		processor.setBeanFactory(mock(BeanFactory.class));
 		try {
 			processor.processMessage(new GenericMessage<>("foo"));
 		}
@@ -896,6 +937,7 @@ public class MethodInvokingMessageProcessorTests {
 		service = (MessageHandler) proxyFactory.getProxy(getClass().getClassLoader());
 
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, "handleMessage");
+		processor.setBeanFactory(mock(BeanFactory.class));
 
 		processor.processMessage(new GenericMessage<>("foo"));
 
@@ -931,6 +973,7 @@ public class MethodInvokingMessageProcessorTests {
 		GenericMessage<String> testMessage = new GenericMessage<>("foo");
 
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, "handle");
+		processor.setBeanFactory(mock(BeanFactory.class));
 
 		processor.processMessage(testMessage);
 
@@ -942,8 +985,10 @@ public class MethodInvokingMessageProcessorTests {
 	@Test
 	public void testUseSpelInvoker() throws Exception {
 		UseSpelInvokerBean bean = new UseSpelInvokerBean();
-		MessagingMethodInvokerHelper<?> helper = new MessagingMethodInvokerHelper<>(bean,
-				UseSpelInvokerBean.class.getDeclaredMethod("foo", String.class), false);
+		MessagingMethodInvokerHelper<?> helper =
+				new MessagingMethodInvokerHelper<>(bean,
+						UseSpelInvokerBean.class.getDeclaredMethod("foo", String.class), false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 		Message<?> message = new GenericMessage<>("Test");
 		helper.process(message);
 		assertEquals(SpelCompilerMode.OFF,
@@ -951,24 +996,28 @@ public class MethodInvokingMessageProcessorTests {
 
 		helper = new MessagingMethodInvokerHelper<>(bean,
 				UseSpelInvokerBean.class.getDeclaredMethod("bar", String.class), false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 		helper.process(message);
 		assertEquals(SpelCompilerMode.IMMEDIATE,
 				TestUtils.getPropertyValue(helper, "handlerMethod.expression.configuration.compilerMode"));
 
 		helper = new MessagingMethodInvokerHelper<>(bean,
 				UseSpelInvokerBean.class.getDeclaredMethod("baz", String.class), false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 		helper.process(message);
 		assertEquals(SpelCompilerMode.MIXED,
 				TestUtils.getPropertyValue(helper, "handlerMethod.expression.configuration.compilerMode"));
 
 		helper = new MessagingMethodInvokerHelper<>(bean,
 				UseSpelInvokerBean.class.getDeclaredMethod("qux", String.class), false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 		helper.process(message);
 		assertEquals(SpelCompilerMode.OFF,
 				TestUtils.getPropertyValue(helper, "handlerMethod.expression.configuration.compilerMode"));
 
 		helper = new MessagingMethodInvokerHelper<>(bean,
 				UseSpelInvokerBean.class.getDeclaredMethod("fiz", String.class), false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 		try {
 			helper.process(message);
 		}
@@ -993,11 +1042,13 @@ public class MethodInvokingMessageProcessorTests {
 
 		// Check other CTORs
 		helper = new MessagingMethodInvokerHelper<>(bean, "bar", false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 		helper.process(message);
 		assertEquals(SpelCompilerMode.IMMEDIATE,
 				TestUtils.getPropertyValue(helper, "handlerMethod.expression.configuration.compilerMode"));
 
 		helper = new MessagingMethodInvokerHelper<>(bean, ServiceActivator.class, false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 		helper.process(message);
 		assertEquals(SpelCompilerMode.MIXED,
 				TestUtils.getPropertyValue(helper, "handlerMethod.expression.configuration.compilerMode"));
@@ -1006,10 +1057,13 @@ public class MethodInvokingMessageProcessorTests {
 	@Test
 	public void testSingleMethodJson() throws Exception {
 		SingleMethodJsonWithSpELBean bean = new SingleMethodJsonWithSpELBean();
-		MessagingMethodInvokerHelper<?> helper = new MessagingMethodInvokerHelper<>(bean,
-				SingleMethodJsonWithSpELBean.class.getDeclaredMethod("foo",
-						SingleMethodJsonWithSpELBean.Foo.class),
-				false);
+		MessagingMethodInvokerHelper<?> helper =
+				new MessagingMethodInvokerHelper<>(bean,
+						SingleMethodJsonWithSpELBean.class.getDeclaredMethod("foo",
+								SingleMethodJsonWithSpELBean.Foo.class),
+						false);
+		helper.setBeanFactory(mock(BeanFactory.class));
+
 		Message<?> message = new GenericMessage<>("{\"bar\":\"bar\"}",
 				Collections.singletonMap(MessageHeaders.CONTENT_TYPE, "application/json"));
 		helper.process(message);
@@ -1021,6 +1075,7 @@ public class MethodInvokingMessageProcessorTests {
 		SingleMethodJsonWithSpELMessageWildBean bean = new SingleMethodJsonWithSpELMessageWildBean();
 		MessagingMethodInvokerHelper<?> helper = new MessagingMethodInvokerHelper<>(bean,
 				SingleMethodJsonWithSpELMessageWildBean.class.getDeclaredMethod("foo", Message.class), false);
+		helper.setBeanFactory(mock(BeanFactory.class));
 		Message<?> message = new GenericMessage<>("baz",
 				Collections.singletonMap(MessageHeaders.CONTENT_TYPE, "application/json"));
 		helper.process(message);
@@ -1032,6 +1087,8 @@ public class MethodInvokingMessageProcessorTests {
 		SingleMethodJsonWithSpELMessageFooBean bean = new SingleMethodJsonWithSpELMessageFooBean();
 		MessagingMethodInvokerHelper<?> helper = new MessagingMethodInvokerHelper<>(bean,
 				SingleMethodJsonWithSpELMessageFooBean.class.getDeclaredMethod("foo", Message.class), false);
+		helper.setBeanFactory(mock(BeanFactory.class));
+
 		Message<?> message = new GenericMessage<>("{\"bar\":\"bar\"}",
 				Collections.singletonMap(MessageHeaders.CONTENT_TYPE, "application/json"));
 		helper.process(message);
@@ -1043,6 +1100,8 @@ public class MethodInvokingMessageProcessorTests {
 		SingleMethodJsonWithSpELMessageWildBean bean = new SingleMethodJsonWithSpELMessageWildBean();
 		MessagingMethodInvokerHelper<?> helper = new MessagingMethodInvokerHelper<>(bean,
 				SingleMethodJsonWithSpELMessageWildBean.class.getDeclaredMethod("foo", Message.class), false);
+		helper.setBeanFactory(mock(BeanFactory.class));
+
 		Message<?> message = new GenericMessage<>("{\"bar\":\"baz\"}",
 				Collections.singletonMap(MessageHeaders.CONTENT_TYPE, "application/json"));
 		helper.process(message);

--- a/spring-integration-core/src/test/java/org/springframework/integration/splitter/MethodInvokingSplitterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/splitter/MethodInvokingSplitterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.splitter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.junit.Test;
 
 import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.annotation.Splitter;
 import org.springframework.integration.channel.QueueChannel;
@@ -53,7 +55,7 @@ public class MethodInvokingSplitterTests {
 	@Test
 	public void splitStringToStringArray() throws Exception {
 		GenericMessage<String> message = new GenericMessage<>("foo.bar");
-		MethodInvokingSplitter splitter = this.getSplitter("stringToStringArray");
+		MethodInvokingSplitter splitter = getSplitter("stringToStringArray");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
 		splitter.handleMessage(message);
@@ -69,7 +71,7 @@ public class MethodInvokingSplitterTests {
 	@Test
 	public void splitStringToStringList() throws Exception {
 		GenericMessage<String> message = new GenericMessage<>("foo.bar");
-		MethodInvokingSplitter splitter = this.getSplitter("stringToStringList");
+		MethodInvokingSplitter splitter = getSplitter("stringToStringList");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
 		splitter.handleMessage(message);
@@ -85,7 +87,7 @@ public class MethodInvokingSplitterTests {
 	@Test
 	public void splitMessageToStringArray() throws Exception {
 		GenericMessage<String> message = new GenericMessage<>("foo.bar");
-		MethodInvokingSplitter splitter = this.getSplitter("messageToStringArray");
+		MethodInvokingSplitter splitter = getSplitter("messageToStringArray");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
 		splitter.handleMessage(message);
@@ -101,7 +103,7 @@ public class MethodInvokingSplitterTests {
 	@Test
 	public void splitMessageToStringList() throws Exception {
 		GenericMessage<String> message = new GenericMessage<>("foo.bar");
-		MethodInvokingSplitter splitter = this.getSplitter("messageToStringList");
+		MethodInvokingSplitter splitter = getSplitter("messageToStringList");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
 		splitter.handleMessage(message);
@@ -117,7 +119,7 @@ public class MethodInvokingSplitterTests {
 	@Test
 	public void splitMessageToMessageArray() throws Exception {
 		GenericMessage<String> message = new GenericMessage<>("foo.bar");
-		MethodInvokingSplitter splitter = this.getSplitter("messageToMessageArray");
+		MethodInvokingSplitter splitter = getSplitter("messageToMessageArray");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
 		splitter.handleMessage(message);
@@ -154,6 +156,8 @@ public class MethodInvokingSplitterTests {
 		MethodInvokingSplitter splitter = new MethodInvokingSplitter(testBean, "messageToMessageBuilderList");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
+		splitter.setBeanFactory(mock(BeanFactory.class));
+		splitter.afterPropertiesSet();
 		splitter.handleMessage(message);
 		List<Message<?>> replies = replyChannel.clear();
 		Message<?> reply1 = replies.get(0);
@@ -202,9 +206,9 @@ public class MethodInvokingSplitterTests {
 	}
 
 	@Test
-	public void splitStringToStringArrayConfiguredByMethodName() {
+	public void splitStringToStringArrayConfiguredByMethodName() throws Exception {
 		GenericMessage<String> message = new GenericMessage<>("foo.bar");
-		MethodInvokingSplitter splitter = new MethodInvokingSplitter(testBean, "stringToStringArray");
+		MethodInvokingSplitter splitter = getSplitter("stringToStringArray");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
 		splitter.handleMessage(message);
@@ -218,9 +222,9 @@ public class MethodInvokingSplitterTests {
 	}
 
 	@Test
-	public void splitStringToStringListConfiguredByMethodName() {
+	public void splitStringToStringListConfiguredByMethodName() throws Exception {
 		GenericMessage<String> message = new GenericMessage<>("foo.bar");
-		MethodInvokingSplitter splitter = new MethodInvokingSplitter(testBean, "stringToStringList");
+		MethodInvokingSplitter splitter = getSplitter("stringToStringList");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
 		splitter.handleMessage(message);
@@ -239,6 +243,8 @@ public class MethodInvokingSplitterTests {
 		MethodInvokingSplitter splitter = new MethodInvokingSplitter(testBean, "messageToStringArray");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
+		splitter.setBeanFactory(mock(BeanFactory.class));
+		splitter.afterPropertiesSet();
 		splitter.handleMessage(message);
 		List<Message<?>> replies = replyChannel.clear();
 		Message<?> reply1 = replies.get(0);
@@ -250,9 +256,9 @@ public class MethodInvokingSplitterTests {
 	}
 
 	@Test
-	public void splitMessageToStringListConfiguredByMethodName() {
+	public void splitMessageToStringListConfiguredByMethodName() throws Exception {
 		GenericMessage<String> message = new GenericMessage<>("foo.bar");
-		MethodInvokingSplitter splitter = new MethodInvokingSplitter(testBean, "messageToStringList");
+		MethodInvokingSplitter splitter = getSplitter("messageToStringList");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
 		splitter.handleMessage(message);
@@ -266,9 +272,9 @@ public class MethodInvokingSplitterTests {
 	}
 
 	@Test
-	public void splitMessageToMessageArrayConfiguredByMethodName() {
+	public void splitMessageToMessageArrayConfiguredByMethodName() throws Exception {
 		GenericMessage<String> message = new GenericMessage<>("foo.bar");
-		MethodInvokingSplitter splitter = new MethodInvokingSplitter(testBean, "messageToMessageArray");
+		MethodInvokingSplitter splitter = getSplitter("messageToMessageArray");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
 		splitter.handleMessage(message);
@@ -282,9 +288,9 @@ public class MethodInvokingSplitterTests {
 	}
 
 	@Test
-	public void splitMessageToMessageListConfiguredByMethodName() {
+	public void splitMessageToMessageListConfiguredByMethodName() throws Exception {
 		GenericMessage<String> message = new GenericMessage<>("foo.bar");
-		MethodInvokingSplitter splitter = new MethodInvokingSplitter(testBean, "messageToMessageList");
+		MethodInvokingSplitter splitter = getSplitter("messageToMessageList");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
 		splitter.handleMessage(message);
@@ -298,9 +304,9 @@ public class MethodInvokingSplitterTests {
 	}
 
 	@Test
-	public void splitStringToMessageArrayConfiguredByMethodName() {
+	public void splitStringToMessageArrayConfiguredByMethodName() throws Exception {
 		GenericMessage<String> message = new GenericMessage<>("foo.bar");
-		MethodInvokingSplitter splitter = new MethodInvokingSplitter(testBean, "stringToMessageArray");
+		MethodInvokingSplitter splitter = getSplitter("stringToMessageArray");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
 		splitter.handleMessage(message);
@@ -319,6 +325,8 @@ public class MethodInvokingSplitterTests {
 		MethodInvokingSplitter splitter = new MethodInvokingSplitter(testBean, "stringToMessageList");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
+		splitter.setBeanFactory(mock(BeanFactory.class));
+		splitter.afterPropertiesSet();
 		splitter.handleMessage(message);
 		List<Message<?>> replies = replyChannel.clear();
 		Message<?> reply1 = replies.get(0);
@@ -337,11 +345,14 @@ public class MethodInvokingSplitterTests {
 			public List<String> split(List<String> list) {
 				return list;
 			}
+
 		}
 		GenericMessage<List<?>> message = new GenericMessage<>(Arrays.asList("foo", "bar"));
 		MethodInvokingSplitter splitter = new MethodInvokingSplitter(new ListSplitter(), "split");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
+		splitter.setBeanFactory(mock(BeanFactory.class));
+		splitter.afterPropertiesSet();
 		splitter.handleMessage(message);
 		List<Message<?>> replies = replyChannel.clear();
 		Message<?> reply1 = replies.get(0);
@@ -378,6 +389,8 @@ public class MethodInvokingSplitterTests {
 		MethodInvokingSplitter splitter = new MethodInvokingSplitter(new StreamSplitter(), "split");
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
+		splitter.setBeanFactory(mock(BeanFactory.class));
+		splitter.afterPropertiesSet();
 		splitter.handleMessage(message);
 		List<Message<?>> replies = replyChannel.clear();
 		Message<?> reply1 = replies.get(0);
@@ -453,6 +466,8 @@ public class MethodInvokingSplitterTests {
 		MethodInvokingSplitter splitter = new MethodInvokingSplitter(testBean, splittingMethod);
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
+		splitter.setBeanFactory(mock(BeanFactory.class));
+		splitter.afterPropertiesSet();
 		splitter.handleMessage(message);
 		List<Message<?>> replies = replyChannel.clear();
 		Message<?> reply1 = replies.get(0);
@@ -476,6 +491,8 @@ public class MethodInvokingSplitterTests {
 		MethodInvokingSplitter splitter = new MethodInvokingSplitter(annotatedBean);
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
+		splitter.setBeanFactory(mock(BeanFactory.class));
+		splitter.afterPropertiesSet();
 		splitter.handleMessage(message);
 		List<Message<?>> replies = replyChannel.clear();
 		Message<?> reply1 = replies.get(0);
@@ -498,6 +515,8 @@ public class MethodInvokingSplitterTests {
 		MethodInvokingSplitter splitter = new MethodInvokingSplitter(testBean);
 		QueueChannel replyChannel = new QueueChannel();
 		splitter.setOutputChannel(replyChannel);
+		splitter.setBeanFactory(mock(BeanFactory.class));
+		splitter.afterPropertiesSet();
 		splitter.handleMessage(message);
 		List<Message<?>> replies = replyChannel.clear();
 		Message<?> reply1 = replies.get(0);
@@ -516,7 +535,10 @@ public class MethodInvokingSplitterTests {
 	private MethodInvokingSplitter getSplitter(String methodName) throws Exception {
 		Class<?> paramType = methodName.startsWith("message") ? Message.class : String.class;
 		Method splittingMethod = this.testBean.getClass().getMethod(methodName, paramType);
-		return new MethodInvokingSplitter(testBean, splittingMethod);
+		MethodInvokingSplitter methodInvokingSplitter = new MethodInvokingSplitter(this.testBean, splittingMethod);
+		methodInvokingSplitter.setBeanFactory(mock(BeanFactory.class));
+		methodInvokingSplitter.afterPropertiesSet();
+		return methodInvokingSplitter;
 	}
 
 	public static class SplitterTestBean {

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/MethodInvokingTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/MethodInvokingTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,14 @@ package org.springframework.integration.transformer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
 import java.util.Properties;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.annotation.Transformer;
 import org.springframework.integration.handler.MethodInvokingMessageProcessor;
 import org.springframework.integration.support.MessageBuilder;
@@ -34,6 +36,7 @@ import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public class MethodInvokingTransformerTests {
 
@@ -42,15 +45,17 @@ public class MethodInvokingTransformerTests {
 		TestBean testBean = new TestBean();
 		Method testMethod = testBean.getClass().getMethod("exclaim", String.class);
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, testMethod);
-		Message<?> message = new GenericMessage<String>("foo");
+		transformer.setBeanFactory(mock(BeanFactory.class));
+		Message<?> message = new GenericMessage<>("foo");
 		Message<?> result = transformer.transform(message);
 		assertEquals("FOO!", result.getPayload());
 	}
 
 	@Test
-	public void simplePayloadConfiguredWithMethodName() throws Exception {
+	public void simplePayloadConfiguredWithMethodName() {
 		TestBean testBean = new TestBean();
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, "exclaim");
+		transformer.setBeanFactory(mock(BeanFactory.class));
 		Message<?> message = new GenericMessage<String>("foo");
 		Message<?> result = transformer.transform(message);
 		assertEquals("FOO!", result.getPayload());
@@ -61,16 +66,18 @@ public class MethodInvokingTransformerTests {
 		TestBean testBean = new TestBean();
 		Method testMethod = testBean.getClass().getMethod("exclaim", String.class);
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, testMethod);
-		Message<?> message = new GenericMessage<Integer>(123);
+		transformer.setBeanFactory(mock(BeanFactory.class));
+		Message<?> message = new GenericMessage<>(123);
 		Message<?> result = transformer.transform(message);
 		assertEquals("123!", result.getPayload());
 	}
 
 	@Test
-	public void typeConversionConfiguredWithMethodName() throws Exception {
+	public void typeConversionConfiguredWithMethodName() {
 		TestBean testBean = new TestBean();
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, "exclaim");
-		Message<?> message = new GenericMessage<Integer>(123);
+		transformer.setBeanFactory(mock(BeanFactory.class));
+		Message<?> message = new GenericMessage<>(123);
 		Message<?> result = transformer.transform(message);
 		assertEquals("123!", result.getPayload());
 	}
@@ -85,10 +92,10 @@ public class MethodInvokingTransformerTests {
 	}
 
 	@Test(expected = MessageHandlingException.class)
-	public void typeConversionFailureConfiguredWithMethodName() throws Exception {
+	public void typeConversionFailureConfiguredWithMethodName() {
 		TestBean testBean = new TestBean();
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, "exclaim");
-		Message<?> message = new GenericMessage<TestBean>(new TestBean());
+		Message<?> message = new GenericMessage<>(new TestBean());
 		transformer.transform(message);
 	}
 
@@ -97,6 +104,7 @@ public class MethodInvokingTransformerTests {
 		TestBean testBean = new TestBean();
 		Method testMethod = testBean.getClass().getMethod("headerTest", String.class, Integer.class);
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, testMethod);
+		transformer.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("foo")
 				.setHeader("number", 123).build();
 		Message<?> result = transformer.transform(message);
@@ -104,9 +112,10 @@ public class MethodInvokingTransformerTests {
 	}
 
 	@Test
-	public void headerAnnotationConfiguredWithMethodName() throws Exception {
+	public void headerAnnotationConfiguredWithMethodName() {
 		TestBean testBean = new TestBean();
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, "headerTest");
+		transformer.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("foo")
 				.setHeader("number", 123).build();
 		Message<?> result = transformer.transform(message);
@@ -128,6 +137,7 @@ public class MethodInvokingTransformerTests {
 		TestBean testBean = new TestBean();
 		Method testMethod = testBean.getClass().getMethod("optionalHeaderTest", String.class, Integer.class);
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, testMethod);
+		transformer.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("foo").setHeader("number", 99).build();
 		Message<?> result = transformer.transform(message);
 		assertEquals("foo99", result.getPayload());
@@ -138,6 +148,7 @@ public class MethodInvokingTransformerTests {
 		TestBean testBean = new TestBean();
 		Method testMethod = testBean.getClass().getMethod("optionalHeaderTest", String.class, Integer.class);
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, testMethod);
+		transformer.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("foo").build();
 		Message<?> result = transformer.transform(message);
 		assertEquals("foonull", result.getPayload());
@@ -148,15 +159,17 @@ public class MethodInvokingTransformerTests {
 		TestBean testBean = new TestBean();
 		Method testMethod = testBean.getClass().getMethod("messageReturnValueTest", Message.class);
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, testMethod);
+		transformer.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("test").build();
 		Message<?> result = transformer.transform(message);
 		assertEquals("test", result.getPayload());
 	}
 
 	@Test
-	public void messageReturnValueConfiguredWithMethodName() throws Exception {
+	public void messageReturnValueConfiguredWithMethodName() {
 		TestBean testBean = new TestBean();
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, "messageReturnValueTest");
+		transformer.setBeanFactory(mock(BeanFactory.class));
 		Message<String> message = MessageBuilder.withPayload("test").build();
 		Message<?> result = transformer.transform(message);
 		assertEquals("test", result.getPayload());
@@ -168,10 +181,11 @@ public class MethodInvokingTransformerTests {
 		TestBean testBean = new TestBean();
 		Method testMethod = testBean.getClass().getMethod("propertyPayloadTest", Properties.class);
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, testMethod);
+		transformer.setBeanFactory(mock(BeanFactory.class));
 		Properties props = new Properties();
 		props.setProperty("prop1", "bad");
 		props.setProperty("prop3", "baz");
-		Message<Properties> message = new GenericMessage<Properties>(props);
+		Message<Properties> message = new GenericMessage<>(props);
 		Message<Properties> result = (Message<Properties>) transformer.transform(message);
 		assertEquals(Properties.class, result.getPayload().getClass());
 		Properties payload = result.getPayload();
@@ -185,13 +199,14 @@ public class MethodInvokingTransformerTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	public void propertiesPayloadConfiguredWithMethodName() throws Exception {
+	public void propertiesPayloadConfiguredWithMethodName() {
 		TestBean testBean = new TestBean();
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, "propertyPayloadTest");
+		transformer.setBeanFactory(mock(BeanFactory.class));
 		Properties props = new Properties();
 		props.setProperty("prop1", "bad");
 		props.setProperty("prop3", "baz");
-		Message<Properties> message = new GenericMessage<Properties>(props);
+		Message<Properties> message = new GenericMessage<>(props);
 		Message<Properties> result = (Message<Properties>) transformer.transform(message);
 		assertEquals(Properties.class, result.getPayload().getClass());
 		Properties payload = result.getPayload();
@@ -207,12 +222,13 @@ public class MethodInvokingTransformerTests {
 	public void nullReturningMethod() {
 		TestBean testBean = new TestBean();
 		MethodInvokingTransformer transformer = new MethodInvokingTransformer(testBean, "nullReturnValueTest");
-		GenericMessage<String> message = new GenericMessage<String>("test");
+		transformer.setBeanFactory(mock(BeanFactory.class));
+		GenericMessage<String> message = new GenericMessage<>("test");
 		Message<?> result = transformer.transform(message);
 		assertNull(result);
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test // this changed in 2.0 see INT-785 and INT-1130
 	public void headerEnricherConfiguredWithMethodReference() throws Exception {
 		TestBean testBean = new TestBean();
@@ -220,6 +236,7 @@ public class MethodInvokingTransformerTests {
 		HeaderEnricher transformer = new HeaderEnricher();
 		transformer.setDefaultOverwrite(true);
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testBean, testMethod);
+		processor.setBeanFactory(mock(BeanFactory.class));
 		transformer.setMessageProcessor(processor);
 		Message<String> message = MessageBuilder.withPayload("test")
 				.setHeader("prop1", "bad")
@@ -231,12 +248,14 @@ public class MethodInvokingTransformerTests {
 		assertEquals("baz", result.getHeaders().get("prop3"));
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test // this changed in 2.0 see INT-785 and INT-1130
-	public void headerEnricherConfiguredWithMethodName() throws Exception {
+	public void headerEnricherConfiguredWithMethodName() {
 		TestBean testBean = new TestBean();
 		HeaderEnricher transformer = new HeaderEnricher();
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(testBean, "propertyEnricherTest");
+		MethodInvokingMessageProcessor processor =
+				new MethodInvokingMessageProcessor(testBean, "propertyEnricherTest");
+		processor.setBeanFactory(mock(BeanFactory.class));
 		transformer.setMessageProcessor(processor);
 		transformer.setDefaultOverwrite(true);
 		Message<String> message = MessageBuilder.withPayload("test")

--- a/spring-integration-core/src/test/java/org/springframework/integration/util/BeanFactoryTypeConverterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/util/BeanFactoryTypeConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ public class BeanFactoryTypeConverterTests {
 		Collection<Integer> converted = (Collection<Integer>) typeConverter.convertValue(1234,
 				TypeDescriptor.valueOf(Integer.class),
 				TypeDescriptor.forObject(new ArrayList<>(Arrays.asList(1))));
-		assertEquals(Arrays.asList(1234), converted);
+		assertEquals(Collections.singletonList(1234), converted);
 	}
 
 	@Test
@@ -192,7 +192,7 @@ public class BeanFactoryTypeConverterTests {
 
 		Set<Foo> fooSet = new HashSet<>();
 		fooSet.add(new Foo());
-		Map<String, Set<Foo>> fooMap = new HashMap<String, Set<Foo>>();
+		Map<String, Set<Foo>> fooMap = new HashMap<>();
 		fooMap.put("foo", fooSet);
 		foos = new HashMap<>();
 		foos.put("foo", fooMap);
@@ -204,6 +204,7 @@ public class BeanFactoryTypeConverterTests {
 		MethodInvokingMessageProcessor<Service> processor = new	MethodInvokingMessageProcessor<>(service, "handle");
 		processor.setConversionService(conversionService);
 		processor.setUseSpelInvoker(true);
+		processor.setBeanFactory(beanFactory);
 		ServiceActivatingHandler handler = new ServiceActivatingHandler(processor);
 		QueueChannel replyChannel = new QueueChannel();
 		handler.setOutputChannel(replyChannel);
@@ -231,6 +232,7 @@ public class BeanFactoryTypeConverterTests {
 		MethodInvokingMessageProcessor<Service> processor = new	MethodInvokingMessageProcessor<>(service, "handle");
 		processor.setConversionService(conversionService);
 		processor.setUseSpelInvoker(true);
+		processor.setBeanFactory(beanFactory);
 		ServiceActivatingHandler handler = new ServiceActivatingHandler(processor);
 		QueueChannel replyChannel = new QueueChannel();
 		handler.setOutputChannel(replyChannel);

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducerTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,6 +170,8 @@ public class ApplicationEventListeningMessageProducerTests {
 		Message<?> message3 = channel.receive(20);
 		assertNotNull(message3);
 		assertEquals("received: event2", message3.getPayload());
+
+		ctx.close();
 	}
 
 	@Test
@@ -180,7 +182,7 @@ public class ApplicationEventListeningMessageProducerTests {
 		adapter.start();
 		Message<?> message1 = channel.receive(0);
 		assertNull(message1);
-		adapter.onApplicationEvent(new MessagingEvent(new GenericMessage<String>("test")));
+		adapter.onApplicationEvent(new MessagingEvent(new GenericMessage<>("test")));
 		Message<?> message2 = channel.receive(20);
 		assertNotNull(message2);
 		assertEquals("test", message2.getPayload());
@@ -194,7 +196,7 @@ public class ApplicationEventListeningMessageProducerTests {
 		adapter.start();
 		Message<?> message1 = channel.receive(0);
 		assertNull(message1);
-		adapter.onApplicationEvent(new TestMessagingEvent(new GenericMessage<String>("test")));
+		adapter.onApplicationEvent(new TestMessagingEvent(new GenericMessage<>("test")));
 		Message<?> message2 = channel.receive(20);
 		assertNotNull(message2);
 		assertEquals("test", message2.getPayload());
@@ -204,6 +206,7 @@ public class ApplicationEventListeningMessageProducerTests {
 	public void anyApplicationEventCausesExceptionWithErrorHandling() {
 		DirectChannel channel = new DirectChannel();
 		channel.subscribe(new AbstractReplyProducingMessageHandler() {
+
 			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				throw new RuntimeException("Failed");
@@ -223,7 +226,7 @@ public class ApplicationEventListeningMessageProducerTests {
 	}
 
 	@Test
-	@SuppressWarnings({"unchecked", "serial"})
+	@SuppressWarnings({ "unchecked", "serial" })
 	public void testInt2935CheckRetrieverCache() {
 		GenericApplicationContext ctx = TestUtils.createTestApplicationContext();
 		ConfigurableListableBeanFactory beanFactory = ctx.getBeanFactory();
@@ -278,6 +281,7 @@ public class ApplicationEventListeningMessageProducerTests {
 		}
 
 		ctx.publishEvent(new ApplicationEvent("Some event") {
+
 		});
 
 		assertEquals(4, listenerCounter.get());

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
@@ -632,6 +632,8 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		SubscribableChannel channel = new DirectChannel();
 		adapter.setOutputChannel(channel);
 		ServiceActivatingHandler handler = new ServiceActivatingHandler(new FailingService());
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.afterPropertiesSet();
 		channel.subscribe(handler);
 		QueueChannel errorChannel = new QueueChannel();
 		adapter.setErrorChannel(errorChannel);

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,9 +31,12 @@ import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
@@ -45,6 +48,7 @@ import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.MessageStore;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
@@ -58,6 +62,18 @@ import com.mongodb.MongoClient;
  * @author Artem Bilan
  */
 public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvailableTests {
+
+	protected final GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
+
+	@Before
+	public void setup() {
+		this.testApplicationContext.refresh();
+	}
+
+	@After
+	public void tearDown() {
+		this.testApplicationContext.close();
+	}
 
 	@Test
 	@MongoDbAvailable

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,11 @@ import java.util.Properties;
 import java.util.UUID;
 
 import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
 import org.springframework.integration.channel.DirectChannel;
@@ -42,6 +45,7 @@ import org.springframework.integration.store.MessageStore;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.MutableMessage;
 import org.springframework.integration.support.MutableMessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.ErrorMessage;
@@ -59,6 +63,17 @@ import com.mongodb.MongoClient;
  */
 public abstract class AbstractMongoDbMessageStoreTests extends MongoDbAvailableTests {
 
+	protected final GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
+
+	@Before
+	public void setup() {
+		this.testApplicationContext.refresh();
+	}
+
+	@After
+	public void tearDown() {
+		this.testApplicationContext.close();
+	}
 
 	@Test
 	@MongoDbAvailable

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.mongodb.MongoDbFactory;
@@ -40,7 +39,6 @@ import org.springframework.integration.mongodb.rules.MongoDbAvailable;
 import org.springframework.integration.store.AbstractMessageGroupStore;
 import org.springframework.integration.store.MessageStore;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.util.StopWatch;
@@ -58,9 +56,7 @@ public class ConfigurableMongoDbMessageGroupStoreTests extends AbstractMongoDbMe
 	protected ConfigurableMongoDbMessageStore getMessageGroupStore() throws Exception {
 		MongoDbFactory mongoDbFactory = new SimpleMongoDbFactory(new MongoClient(), "test");
 		ConfigurableMongoDbMessageStore mongoDbMessageStore = new ConfigurableMongoDbMessageStore(mongoDbFactory);
-		GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
-		testApplicationContext.refresh();
-		mongoDbMessageStore.setApplicationContext(testApplicationContext);
+		mongoDbMessageStore.setApplicationContext(this.testApplicationContext);
 		mongoDbMessageStore.afterPropertiesSet();
 		return mongoDbMessageStore;
 	}
@@ -79,7 +75,7 @@ public class ConfigurableMongoDbMessageGroupStoreTests extends AbstractMongoDbMe
 	@Test
 	@Ignore("The performance test. Enough slow. Also needs the release strategy changed to size() == 1000")
 	@MongoDbAvailable
-	public void messageGroupStoreLazyLoadPerformance() throws Exception {
+	public void messageGroupStoreLazyLoadPerformance() {
 		cleanupCollections(new SimpleMongoDbFactory(new MongoClient(), "test"));
 
 		StopWatch watch = new StopWatch("Lazy-Load Performance");

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,9 @@
 package org.springframework.integration.mongodb.store;
 
 
-import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
 import org.springframework.integration.store.MessageStore;
-import org.springframework.integration.test.util.TestUtils;
 
 import com.mongodb.MongoClient;
 
@@ -35,9 +33,7 @@ public class ConfigurableMongoDbMessageStoreTests extends AbstractMongoDbMessage
 	protected MessageStore getMessageStore() throws Exception {
 		MongoDbFactory mongoDbFactory = new SimpleMongoDbFactory(new MongoClient(), "test");
 		ConfigurableMongoDbMessageStore mongoDbMessageStore = new ConfigurableMongoDbMessageStore(mongoDbFactory);
-		GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
-		testApplicationContext.refresh();
-		mongoDbMessageStore.setApplicationContext(testApplicationContext);
+		mongoDbMessageStore.setApplicationContext(this.testApplicationContext);
 		mongoDbMessageStore.afterPropertiesSet();
 		return mongoDbMessageStore;
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageStoreClaimCheckIntegrationTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageStoreClaimCheckIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.Serializable;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.context.support.GenericApplicationContext;
@@ -40,6 +42,18 @@ import com.mongodb.MongoClient;
  * @author Artem Bilan
  */
 public class MongoDbMessageStoreClaimCheckIntegrationTests extends MongoDbAvailableTests {
+
+	private final GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
+
+	@Before
+	public void setup() {
+		this.testApplicationContext.refresh();
+	}
+
+	@After
+	public void tearDown() {
+		this.testApplicationContext.close();
+	}
 
 	@Test
 	@MongoDbAvailable
@@ -84,9 +98,7 @@ public class MongoDbMessageStoreClaimCheckIntegrationTests extends MongoDbAvaila
 	public void stringPayloadConfigurable() throws Exception {
 		MongoDbFactory mongoDbFactory = new SimpleMongoDbFactory(new MongoClient(), "test");
 		ConfigurableMongoDbMessageStore messageStore = new ConfigurableMongoDbMessageStore(mongoDbFactory);
-		GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
-		testApplicationContext.refresh();
-		messageStore.setApplicationContext(testApplicationContext);
+		messageStore.setApplicationContext(this.testApplicationContext);
 		messageStore.afterPropertiesSet();
 		ClaimCheckInTransformer checkin = new ClaimCheckInTransformer(messageStore);
 		ClaimCheckOutTransformer checkout = new ClaimCheckOutTransformer(messageStore);
@@ -104,9 +116,7 @@ public class MongoDbMessageStoreClaimCheckIntegrationTests extends MongoDbAvaila
 	public void objectPayloadConfigurable() throws Exception {
 		MongoDbFactory mongoDbFactory = new SimpleMongoDbFactory(new MongoClient(), "test");
 		ConfigurableMongoDbMessageStore messageStore = new ConfigurableMongoDbMessageStore(mongoDbFactory);
-		GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
-		testApplicationContext.refresh();
-		messageStore.setApplicationContext(testApplicationContext);
+		messageStore.setApplicationContext(this.testApplicationContext);
 		messageStore.afterPropertiesSet();
 		ClaimCheckInTransformer checkin = new ClaimCheckInTransformer(messageStore);
 		ClaimCheckOutTransformer checkout = new ClaimCheckOutTransformer(messageStore);
@@ -127,7 +137,9 @@ public class MongoDbMessageStoreClaimCheckIntegrationTests extends MongoDbAvaila
 	static class Beverage implements Serializable {
 
 		private String name;
+
 		private int shots;
+
 		private boolean iced;
 
 		@SuppressWarnings("unused")

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/util/TestUtils.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/util/TestUtils.java
@@ -52,6 +52,8 @@ import org.springframework.util.StringUtils;
  */
 public abstract class TestUtils {
 
+	private static final Log LOGGER = LogFactory.getLog(TestUtils.class);
+
 	/**
 	 * Obtain a value for the property from the provide object.
 	 * Supports nested properties via period delimiter.
@@ -114,6 +116,11 @@ public abstract class TestUtils {
 		scheduler.setErrorHandler(errorHandler);
 		registerBean("taskScheduler", scheduler, context);
 		registerBean("integrationConversionService", new DefaultFormattingConversionService(), context);
+		registerBean("errorChannel",
+				(MessageChannel) (message, timeout) -> {
+					LOGGER.error(message);
+					return true;
+				}, context);
 		return context;
 	}
 

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/xpath/XPathUtils.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/xpath/XPathUtils.java
@@ -62,12 +62,12 @@ public final class XPathUtils {
 	private static final List<String> RESULT_TYPES =
 			Arrays.asList(STRING, BOOLEAN, NUMBER, NODE, NODE_LIST, DOCUMENT_LIST);
 
-	private static final XmlPayloadConverter converter = new DefaultXmlPayloadConverter();
+	private static final XmlPayloadConverter CONVERTER = new DefaultXmlPayloadConverter();
 
-	private static final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactoryUtils.newInstance();
+	private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactoryUtils.newInstance();
 
 	static {
-		documentBuilderFactory.setNamespaceAware(true);
+		DOCUMENT_BUILDER_FACTORY.setNamespaceAware(true);
 	}
 
 	/**
@@ -97,7 +97,7 @@ public final class XPathUtils {
 		}
 
 		XPathExpression expression = XPathExpressionFactory.createXPathExpression(xpath);
-		Node node = converter.convertToNode(object);
+		Node node = CONVERTER.convertToNode(object);
 
 		if (resultType == null) {
 			return (T) expression.evaluateAsString(node);
@@ -111,7 +111,7 @@ public final class XPathUtils {
 				List<Node> nodeList = (List<Node>) XPathEvaluationType.NODE_LIST_RESULT.evaluateXPath(expression,
 						node);
 				try {
-					DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+					DocumentBuilder documentBuilder = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
 					List<Node> documents = new ArrayList<>(nodeList.size());
 					for (Node n : nodeList) {
 						Document document = documentBuilder.newDocument();


### PR DESCRIPTION
* Remove check for `null` in the
`MessagingMethodInvokerHelper.isProvidedMessageHandlerFactoryBean()`
* Fix `RecipientListRouter` for `BeanFactory` propagation to the
`Recipient.selector`
* Fix tests for `BeanFactory` population and propagation
* Add `errorChannel` into the `TestUtils.createTestApplicationContext()`
* Fix some Sonar smell, including new reported

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
