### PR TITLE
GH-2695: Add proxy option to @EnablePublisher

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationBeanPostProcessor.java
@@ -81,7 +81,7 @@ public class PublisherAnnotationBeanPostProcessor extends AbstractBeanFactoryAwa
 		catch (NoUniqueBeanDefinitionException ex) {
 			throw new BeanCreationNotAllowedException(this.name,
 					"Only one 'PublisherAnnotationBeanPostProcessor' bean can be defined in the application context." +
-							" Consider do not use '@EnablePublisher' (or '<int:enable-publisher>') if you declare" +
+							" Do not use '@EnablePublisher' (or '<int:enable-publisher>') if you declare a" +
 							" 'PublisherAnnotationBeanPostProcessor' bean definition manually. " +
 							"Bean names found: " + ex.getBeanNamesFound());
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/EnablePublisher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/EnablePublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 the original author or authors.
+ * Copyright 2014-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AliasFor;
 
 /**
- * Provides the registration for the {@link org.springframework.integration.aop.PublisherAnnotationBeanPostProcessor}
+ * Provides the registration for the
+ * {@link org.springframework.integration.aop.PublisherAnnotationBeanPostProcessor}
  * to allow the use of the {@link org.springframework.integration.annotation.Publisher} annotation.
- * In addition the {@code default-publisher-channel} name can be configured as the {@code value} of this annotation.
+ * In addition the {@code default-publisher-channel} name can be configured as
+ * the {@link #defaultChannel()} of this annotation.
  *
  * @author Artem Bilan
  *
@@ -40,7 +44,39 @@ import org.springframework.context.annotation.Import;
 public @interface EnablePublisher {
 
 	/**
-	 * @return the {@code default-publisher-channel} name.
+	 * Alias for the {@link #defaultChannel()} attribute.
+	 * The {@code default-publisher-channel} name.
+	 * @return the channel bean name.
 	 */
+	@AliasFor("defaultChannel")
 	String value() default "";
+
+	/**
+	 * The {@code default-publisher-channel} name.
+	 * @return the channel bean name.
+	 * @since 5.1.3
+	 */
+	@AliasFor("value")
+	String defaultChannel() default "";
+
+	/**
+	 * Indicate whether subclass-based (CGLIB) proxies are to be created as opposed
+	 * to standard Java interface-based proxies.
+	 * @return whether proxy target class or not.
+	 * @since 5.1.3
+	 */
+	boolean proxyTargetClass() default false;
+
+	/**
+	 * Indicate the order in which the
+	 * {@link org.springframework.integration.aop.PublisherAnnotationBeanPostProcessor}
+	 * should be applied.
+	 * <p>The default is {@link Ordered#LOWEST_PRECEDENCE} in order to run
+	 * after all other post-processors, so that it can add an advisor to
+	 * existing proxies rather than double-proxy.
+	 * @return the order for the bean post-processor.
+	 * @since 5.1.3
+	 */
+	int order() default Ordered.LOWEST_PRECEDENCE;
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AnnotationConfigParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AnnotationConfigParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.config.xml;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.w3c.dom.Element;
@@ -40,8 +40,6 @@ public class AnnotationConfigParser implements BeanDefinitionParser {
 
 	@Override
 	public BeanDefinition parse(final Element element, ParserContext parserContext) {
-		IntegrationRegistrar integrationRegistrar = new IntegrationRegistrar();
-
 		StandardAnnotationMetadata importingClassMetadata =
 				new StandardAnnotationMetadata(Object.class) {
 
@@ -51,8 +49,13 @@ public class AnnotationConfigParser implements BeanDefinitionParser {
 							Element enablePublisherElement =
 									DomUtils.getChildElementByTagName(element, "enable-publisher");
 							if (enablePublisherElement != null) {
-								return Collections.singletonMap("value",
+								Map<String, Object> attributes = new HashMap<>();
+								attributes.put("defaultChannel",
 										enablePublisherElement.getAttribute("default-publisher-channel"));
+								attributes.put("proxyTargetClass",
+										enablePublisherElement.getAttribute("proxy-target-class"));
+								attributes.put("order", enablePublisherElement.getAttribute("order"));
+								return attributes;
 							}
 							else {
 								return null;
@@ -65,7 +68,7 @@ public class AnnotationConfigParser implements BeanDefinitionParser {
 
 				};
 
-		integrationRegistrar.registerBeanDefinitions(importingClassMetadata, parserContext.getRegistry());
+		new IntegrationRegistrar().registerBeanDefinitions(importingClassMetadata, parserContext.getRegistry());
 
 		return null;
 	}

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration-5.1.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration-5.1.xsd
@@ -35,6 +35,30 @@
 								</xsd:appinfo>
 							</xsd:annotation>
 						</xsd:attribute>
+						<xsd:attribute name="proxy-target-class" default="false">
+							<xsd:annotation>
+								<xsd:documentation>
+									Indicate whether subclass-based (CGLIB) proxies are to be created as opposed
+									to standard Java interface-based proxies.
+								</xsd:documentation>
+							</xsd:annotation>
+							<xsd:simpleType>
+								<xsd:union memberTypes="xsd:boolean xsd:string" />
+							</xsd:simpleType>
+						</xsd:attribute>
+						<xsd:attribute name="order" default="2147483647">
+							<xsd:annotation>
+								<xsd:documentation>
+									Indicate the order in which the
+									'org.springframework.integration.aop.PublisherAnnotationBeanPostProcessor'
+									should be applied.
+									Defaults to 'org.springframework.core.Ordered.LOWEST_PRECEDENCE'.
+								</xsd:documentation>
+							</xsd:annotation>
+							<xsd:simpleType>
+								<xsd:union memberTypes="xsd:integer xsd:string" />
+							</xsd:simpleType>
+						</xsd:attribute>
 					</xsd:complexType>
 				</xsd:element>
 			</xsd:sequence>

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests-context.xml
@@ -15,7 +15,7 @@
 	<message-history tracked-components="publishedChannel,input,annotationTestService*"/>
 
 	<annotation-config>
-		<enable-publisher default-publisher-channel="publishedChannel"/>
+		<enable-publisher default-publisher-channel="publishedChannel" proxy-target-class="true" order="2147483646"/>
 	</annotation-config>
 
 	<channel-interceptor pattern="none">

--- a/src/reference/asciidoc/message-publishing.adoc
+++ b/src/reference/asciidoc/message-publishing.adoc
@@ -142,6 +142,8 @@ public class IntegrationConfiguration {
 ----
 ====
 
+Starting with version 5.1.3, the `<int:enable-publisher>` component, as well as `@EnablePublisher` annotation are supplied with the `proxy-target-class` and `order` attributes for tuning a `ProxyFactory` configuration.
+
 Similar to other Spring annotations (`@Component`, `@Scheduled`, and so on), you can also use `@Publisher` as a meta-annotation.
 This means that you can define your own annotations that are treated in the same way as the `@Publisher` itself.
 The following example shows how to do so:
@@ -321,7 +323,7 @@ Another way of handling this type of scenario is with a wire-tap. See <<channel-
 In the preceding sections, we looked at the message-publishing feature, which constructs and publishes messages as by-products of method invocations.
 However, in those cases, you are still responsible for invoking the method.
 Spring Integration 2.0 added support for scheduled message producers and publishers with the new `expression` attribute on the 'inbound-channel-adapter' element.
-You can schedul based on several triggers, any one of which can be configured on the 'poller' element.
+You can schedule based on several triggers, any one of which can be configured on the 'poller' element.
 Currently, we support `cron`, `fixed-rate`, `fixed-delay` and any custom trigger implemented by you and referenced by the 'trigger' attribute value.
 
 As mentioned earlier, support for scheduled producers and publishers is provided via the `<inbound-channel-adapter>` XML element.

--- a/src/reference/asciidoc/message-publishing.adoc
+++ b/src/reference/asciidoc/message-publishing.adoc
@@ -142,7 +142,7 @@ public class IntegrationConfiguration {
 ----
 ====
 
-Starting with version 5.1.3, the `<int:enable-publisher>` component, as well as `@EnablePublisher` annotation are supplied with the `proxy-target-class` and `order` attributes for tuning a `ProxyFactory` configuration.
+Starting with version 5.1.3, the `<int:enable-publisher>` component, as well as the `@EnablePublisher` annotation have the `proxy-target-class` and `order` attributes for tuning the `ProxyFactory` configuration.
 
 Similar to other Spring annotations (`@Component`, `@Scheduled`, and so on), you can also use `@Publisher` as a meta-annotation.
 This means that you can define your own annotations that are treated in the same way as the `@Publisher` itself.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -119,6 +119,7 @@ See <<aggregator>> for more information.
 ==== @Publisher annotation changes
 
 Starting with version 5.1, you must explicitly turn on the `@Publisher` AOP functionality by using `@EnablePublisher` or by using the `<int:enable-publisher>` child element on `<int:annotation-config>`.
+Also the `proxy-target-class` and `order` attributes have been added for tuning the `ProxyFactory` configuration.
 
 See <<publisher-annotation>> for more information.
 


### PR DESCRIPTION
Fixes spring-projects/spring-integration#2695

To configure a `proxyTargetClass=true` we need declare a
`PublisherAnnotationBeanPostProcessor` bean manually, but that may cause
a confuse when `@EnablePublisher` is still present.
So, target service is proxied twice

* Expose `proxyTargetClass` and `order` into the `@EnablePublisher`
and `<enable-publisher>`
* Refactor `PublisherAnnotationBeanPostProcessor` to extend an
`AbstractBeanFactoryAwareAdvisingPostProcessor` to avoid AOP boilerplate
code altogether
* Add assertion into the `PublisherAnnotationBeanPostProcessor` to be
sure that only one of its instance is present in the application context

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
