### PR TITLE
Implement Lifecycle for IntegrationComponentSpec

### DIFF
--- a/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,11 +211,16 @@ public class HttpDslTests {
 		}
 
 		@Bean
+		public HttpRequestHandlerEndpointSpec httpService() {
+			return Http.inboundGateway("/service")
+					.requestMapping(r -> r.params("name"))
+					.errorChannel("httpProxyErrorFlow.input");
+		}
+
+		@Bean
 		public IntegrationFlow httpProxyFlow() {
 			return IntegrationFlows
-					.from(Http.inboundGateway("/service")
-							.requestMapping(r -> r.params("name"))
-							.errorChannel("httpProxyErrorFlow.input"))
+					.from(httpService())
 					.handle(Http.outboundGateway("/service/internal?{params}")
 									.uriVariable("params", "payload")
 									.expectedResponseType(String.class)


### PR DESCRIPTION
Since an `IntegrationComponentSpec` is a `FactoryBean`, all it's target
callbacks and lifecycle is controlled over a `FactoryBean`.

* Add `SmartLifecycle` for the `IntegrationComponentSpec` to delegate
lifecycle hooks to the `target` if necessary
* Refactor `IntegrationComponentSpec` to be an `AbstractFactoryBean`
which is a central place for the `FactoryBean`, `InitializingBean` and
`DisposableBean` interfaces

**Cherry-pick to 5.0.x**

See https://stackoverflow.com/questions/54314755/enpointspec-fails-in-spring-integration-java-dsl