### PR TITLE
Add Duration overloads to Pollers factory

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/Pollers.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/Pollers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.dsl;
 
+import java.time.Duration;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
@@ -29,6 +30,7 @@ import org.springframework.scheduling.support.PeriodicTrigger;
  * variants.
  *
  * @author Artem Bilan
+ * @author Gary Russell
  *
  * @since 5.0
  */
@@ -38,6 +40,10 @@ public final class Pollers {
 		return new PollerSpec(trigger);
 	}
 
+	public static PollerSpec fixedRate(Duration period) {
+		return fixedRate(period.toMillis());
+	}
+
 	public static PollerSpec fixedRate(long period) {
 		return fixedRate(period, null);
 	}
@@ -45,6 +51,11 @@ public final class Pollers {
 	public static PollerSpec fixedRate(long period, TimeUnit timeUnit) {
 		return fixedRate(period, timeUnit, 0);
 	}
+
+	public static PollerSpec fixedRate(Duration period, Duration initialDelay) {
+		return fixedRate(period.toMillis(), initialDelay.toMillis());
+	}
+
 	public static PollerSpec fixedRate(long period, long initialDelay) {
 		return periodicTrigger(period, null, true, initialDelay);
 	}
@@ -53,8 +64,16 @@ public final class Pollers {
 		return periodicTrigger(period, timeUnit, true, initialDelay);
 	}
 
+	public static PollerSpec fixedDelay(Duration period) {
+		return fixedDelay(period.toMillis());
+	}
+
 	public static PollerSpec fixedDelay(long period) {
 		return fixedDelay(period, null);
+	}
+
+	public static PollerSpec fixedDelay(Duration period, Duration initialDelay) {
+		return fixedDelay(period.toMillis(), initialDelay.toMillis());
 	}
 
 	public static PollerSpec fixedDelay(long period, TimeUnit timeUnit) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/PollersTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/PollersTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.scheduling.support.PeriodicTrigger;
+
+/**
+ * @author Gary Russell
+ * @since 5.1.4
+ *
+ */
+public class PollersTests {
+
+	@Test
+	public void testDurations() {
+		PeriodicTrigger trigger = (PeriodicTrigger) Pollers.fixedDelay(Duration.ofMinutes(1L)).get().getTrigger();
+		assertThat(trigger.getPeriod()).isEqualTo(60_000L);
+		assertThat(trigger.getTimeUnit()).isEqualTo(TimeUnit.MILLISECONDS);
+		assertThat(trigger.isFixedRate()).isFalse();
+		trigger = (PeriodicTrigger) Pollers.fixedDelay(Duration.ofMinutes(1L), Duration.ofSeconds(10L))
+				.get().getTrigger();
+		assertThat(trigger.getPeriod()).isEqualTo(60_000L);
+		assertThat(trigger.getInitialDelay()).isEqualTo(10_000L);
+		assertThat(trigger.getTimeUnit()).isEqualTo(TimeUnit.MILLISECONDS);
+		assertThat(trigger.isFixedRate()).isFalse();
+		trigger = (PeriodicTrigger) Pollers.fixedRate(Duration.ofMinutes(1L)).get().getTrigger();
+		assertThat(trigger.getPeriod()).isEqualTo(60_000L);
+		assertThat(trigger.getTimeUnit()).isEqualTo(TimeUnit.MILLISECONDS);
+		assertThat(trigger.isFixedRate()).isTrue();
+		trigger = (PeriodicTrigger) Pollers.fixedRate(Duration.ofMinutes(1L), Duration.ofSeconds(10L))
+				.get().getTrigger();
+		assertThat(trigger.getPeriod()).isEqualTo(60_000L);
+		assertThat(trigger.getInitialDelay()).isEqualTo(10_000L);
+		assertThat(trigger.getTimeUnit()).isEqualTo(TimeUnit.MILLISECONDS);
+		assertThat(trigger.isFixedRate()).isTrue();
+	}
+
+}


### PR DESCRIPTION
- test adds coverage to all time-based factory methods

