### PR TITLE
Fix mail lock race condition & Sonar smells

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -339,7 +339,7 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 
 	@Override
 	public Object[] receive() throws javax.mail.MessagingException {
-		this.folderReadLock.lock();
+		this.folderReadLock.lock(); // NOSONAR - guarded with the getReadHoldCount()
 		try {
 			try {
 				Folder folderToCheck = getFolder();

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.mail.Authenticator;
@@ -72,7 +71,7 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 
 	private final URLName url;
 
-	private final ReadWriteLock folderLock = new ReentrantReadWriteLock();
+	private final ReentrantReadWriteLock folderLock = new ReentrantReadWriteLock();
 
 	private final Lock folderReadLock = this.folderLock.readLock();
 
@@ -362,7 +361,9 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 			}
 		}
 		finally {
-			this.folderReadLock.unlock();
+			if (this.folderLock.getReadHoldCount() > 0) {
+				this.folderReadLock.unlock();
+			}
 		}
 	}
 
@@ -416,21 +417,16 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 	private Object extractContent(MimeMessage message, Map<String, Object> headers) {
 		Object content;
 		try {
-			MimeMessage theMessage;
+			MimeMessage theMessage = message;
 			if (this.simpleContent) {
 				theMessage = new IntegrationMimeMessage(message);
 			}
-			else {
-				theMessage = message;
-			}
 			content = theMessage.getContent();
 			if (content instanceof String) {
+				headers.put(MessageHeaders.CONTENT_TYPE, "text/plain");
 				String mailContentType = (String) headers.get(MailHeaders.CONTENT_TYPE);
 				if (mailContentType != null && mailContentType.toLowerCase().startsWith("text")) {
 					headers.put(MessageHeaders.CONTENT_TYPE, mailContentType);
-				}
-				else {
-					headers.put(MessageHeaders.CONTENT_TYPE, "text/plain");
 				}
 			}
 			else if (content instanceof InputStream) {

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
@@ -253,10 +253,15 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 
 		@Override
 		public void run() {
-			Folder folder = getFolder();
-			logger.debug("Canceling IDLE");
-			if (folder != null) {
-				folder.isOpen(); // resets idle state
+			try {
+				Folder folder = getFolder();
+				logger.debug("Canceling IDLE");
+				if (folder != null) {
+					folder.isOpen(); // resets idle state
+				}
+			}
+			catch (Exception ex) {
+				logger.error("Error during resetting idle state.", ex);
 			}
 		}
 

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
@@ -349,13 +349,13 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 						"System flag 'Flag.FLAGGED' will be used to prevent duplicates during email fetch.");
 				notFlagged = new NotTerm(new FlagTerm(new Flags(Flag.FLAGGED), true));
 			}
+
 			if (searchTerm == null) {
-				searchTerm = notFlagged;
+				return notFlagged;
 			}
 			else {
-				searchTerm = new AndTerm(searchTerm, notFlagged);
+				return new AndTerm(searchTerm, notFlagged);
 			}
-			return searchTerm;
 		}
 
 	}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
@@ -59,6 +59,8 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 
 	private static final int DEFAULT_CANCEL_IDLE_INTERVAL = 120000;
 
+	private static final String PROTOCOL = "imap";
+
 	private final MessageCountListener messageCountListener = new SimpleMessageCountListener();
 
 	private final IdleCanceler idleCanceler = new IdleCanceler();
@@ -77,17 +79,17 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 
 	public ImapMailReceiver() {
 		super();
-		this.setProtocol("imap");
+		setProtocol(PROTOCOL);
 	}
 
 	public ImapMailReceiver(String url) {
 		super(url);
 		if (url != null) {
-			Assert.isTrue(url.toLowerCase().startsWith("imap"),
+			Assert.isTrue(url.toLowerCase().startsWith(PROTOCOL),
 					"URL must start with 'imap' for the IMAP Mail receiver.");
 		}
 		else {
-			this.setProtocol("imap");
+			setProtocol(PROTOCOL);
 		}
 	}
 
@@ -126,7 +128,7 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 	 * @since 3.0.5
 	 */
 	public void setCancelIdleInterval(long cancelIdleInterval) {
-		this.cancelIdleInterval = cancelIdleInterval * 1000;
+		this.cancelIdleInterval = cancelIdleInterval * 1000; // NOSONAR - convert seconds to milliseconds
 	}
 
 	@Override
@@ -140,7 +142,7 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 			this.isInternalScheduler = true;
 		}
 		Properties javaMailProperties = getJavaMailProperties();
-		for (String name : new String[]{"imap", "imaps"}) {
+		for (String name : new String[] { PROTOCOL, "imaps" }) {
 			String peek = "mail." + name + ".peek";
 			if (javaMailProperties.getProperty(peek) == null) {
 				javaMailProperties.setProperty(peek, "true");
@@ -154,6 +156,9 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 		if (this.isInternalScheduler) {
 			((ThreadPoolTaskScheduler) this.scheduler).shutdown();
 		}
+		if (this.pingTask != null) {
+			this.pingTask.cancel(true);
+		}
 	}
 
 	/**
@@ -162,18 +167,16 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 	 * @throws MessagingException Any MessagingException.
 	 */
 	public void waitForNewMessages() throws MessagingException {
-		this.openFolder();
-		Folder folder = this.getFolder();
+		openFolder();
+		Folder folder = getFolder();
 		Assert.state(folder instanceof IMAPFolder,
-				"folder is not an instance of [" + IMAPFolder.class.getName() + "]");
+				() -> "folder is not an instance of [" + IMAPFolder.class.getName() + "]");
 		IMAPFolder imapFolder = (IMAPFolder) folder;
 		if (imapFolder.hasNewMessages()) {
 			return;
 		}
-		else if (!folder.getPermanentFlags().contains(Flags.Flag.RECENT)) {
-			if (searchForNewMessages().length > 0) {
-				return;
-			}
+		else if (!folder.getPermanentFlags().contains(Flags.Flag.RECENT) && searchForNewMessages().length > 0) {
+			return;
 		}
 		imapFolder.addMessageCountListener(this.messageCountListener);
 		try {
@@ -203,11 +206,11 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 	 */
 	@Override
 	protected Message[] searchForNewMessages() throws MessagingException {
-		Flags supportedFlags = this.getFolder().getPermanentFlags();
-		SearchTerm searchTerm = this.compileSearchTerms(supportedFlags);
-		Folder folder = this.getFolder();
-		if (folder.isOpen()) {
-			return nullSafeMessages(searchTerm != null ? folder.search(searchTerm) : folder.getMessages());
+		Folder folderToUse = getFolder();
+		Flags supportedFlags = folderToUse.getPermanentFlags();
+		SearchTerm searchTerm = compileSearchTerms(supportedFlags);
+		if (folderToUse.isOpen()) {
+			return nullSafeMessages(searchTerm != null ? folderToUse.search(searchTerm) : folderToUse.getMessages());
 		}
 		throw new MessagingException("Folder is closed");
 	}
@@ -250,16 +253,13 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 
 		@Override
 		public void run() {
-			try {
-				Folder folder = getFolder();
-				logger.debug("Canceling IDLE");
-				if (folder != null) {
-					folder.isOpen(); // resets idle state
-				}
-			}
-			catch (Exception ignore) {
+			Folder folder = getFolder();
+			logger.debug("Canceling IDLE");
+			if (folder != null) {
+				folder.isOpen(); // resets idle state
 			}
 		}
+
 	}
 
 	/**
@@ -327,26 +327,33 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 			}
 
 			if (!recentFlagSupported) {
-				NotTerm notFlagged = null;
-				if (folder.getPermanentFlags().contains(Flags.Flag.USER)) {
+				searchTerm = applyTermsWhenNoRecentFlag(folder, searchTerm);
+			}
+			return searchTerm;
+		}
+
+		private SearchTerm applyTermsWhenNoRecentFlag(Folder folder, SearchTerm searchTerm) {
+			NotTerm notFlagged = null;
+			if (folder.getPermanentFlags().contains(Flag.USER)) {
+				if (logger.isDebugEnabled()) {
 					logger.debug("This email server does not support RECENT flag, but it does support " +
 							"USER flags which will be used to prevent duplicates during email fetch." +
 							" This receiver instance uses flag: " + getUserFlag());
-					Flags siFlags = new Flags();
-					siFlags.add(getUserFlag());
-					notFlagged = new NotTerm(new FlagTerm(siFlags, true));
 				}
-				else {
-					logger.debug("This email server does not support RECENT or USER flags. " +
-							"System flag 'Flag.FLAGGED' will be used to prevent duplicates during email fetch.");
-					notFlagged = new NotTerm(new FlagTerm(new Flags(Flags.Flag.FLAGGED), true));
-				}
-				if (searchTerm == null) {
-					searchTerm = notFlagged;
-				}
-				else {
-					searchTerm = new AndTerm(searchTerm, notFlagged);
-				}
+				Flags siFlags = new Flags();
+				siFlags.add(getUserFlag());
+				notFlagged = new NotTerm(new FlagTerm(siFlags, true));
+			}
+			else {
+				logger.debug("This email server does not support RECENT or USER flags. " +
+						"System flag 'Flag.FLAGGED' will be used to prevent duplicates during email fetch.");
+				notFlagged = new NotTerm(new FlagTerm(new Flags(Flag.FLAGGED), true));
+			}
+			if (searchTerm == null) {
+				searchTerm = notFlagged;
+			}
+			else {
+				searchTerm = new AndTerm(searchTerm, notFlagged);
 			}
 			return searchTerm;
 		}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailTransportUtils.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailTransportUtils.java
@@ -57,17 +57,6 @@ public abstract class MailTransportUtils {
 		}
 	}
 
-	//    /**
-	//     * Close the given JavaMail Folder and ignore any thrown exception. This is
-	//     * useful for typical <code>finally</code> blocks in manual JavaMail code.
-	//     *
-	//     * @param folder the JavaMail Folder to close (may be <code>null</code>)
-	//     */
-	//
-	//    public static void closeFolder(Folder folder) {
-	//        closeFolder(folder, false);
-	//    }
-
 	/**
 	 * Close the given JavaMail Folder and ignore any thrown exception. This is
 	 * useful for typical <code>finally</code> blocks in manual JavaMail code.

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailTransportUtils.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailTransportUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2018 the original author or authors.
+ * Copyright 2007-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,16 +31,17 @@ import org.springframework.util.StringUtils;
  *
  * @author Arjen Poutsma
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public abstract class MailTransportUtils {
 
-	private static final Log logger = LogFactory.getLog(MailTransportUtils.class);
+	private static final Log LOGGER = LogFactory.getLog(MailTransportUtils.class);
 
 
 	/**
-	 * Close the given JavaMail Service and ignore any thrown exception. This is useful for typical <code>finally</code>
+	 * Close the given JavaMail Service and ignore any thrown exception. This is useful for typical
+	 * <code>finally</code>
 	 * blocks in manual JavaMail code.
-	 *
 	 * @param service the JavaMail Service to close (may be <code>null</code>)
 	 * @see javax.mail.Transport
 	 * @see javax.mail.Store
@@ -51,26 +52,25 @@ public abstract class MailTransportUtils {
 				service.close();
 			}
 			catch (MessagingException ex) {
-				logger.debug("Could not close JavaMail Service", ex);
+				LOGGER.debug("Could not close JavaMail Service", ex);
 			}
 		}
 	}
 
-//    /**
-//     * Close the given JavaMail Folder and ignore any thrown exception. This is
-//     * useful for typical <code>finally</code> blocks in manual JavaMail code.
-//     *
-//     * @param folder the JavaMail Folder to close (may be <code>null</code>)
-//     */
-//
-//    public static void closeFolder(Folder folder) {
-//        closeFolder(folder, false);
-//    }
+	//    /**
+	//     * Close the given JavaMail Folder and ignore any thrown exception. This is
+	//     * useful for typical <code>finally</code> blocks in manual JavaMail code.
+	//     *
+	//     * @param folder the JavaMail Folder to close (may be <code>null</code>)
+	//     */
+	//
+	//    public static void closeFolder(Folder folder) {
+	//        closeFolder(folder, false);
+	//    }
 
 	/**
 	 * Close the given JavaMail Folder and ignore any thrown exception. This is
 	 * useful for typical <code>finally</code> blocks in manual JavaMail code.
-	 *
 	 * @param folder  the JavaMail Folder to close (may be <code>null</code>)
 	 * @param expunge whether all deleted messages should be expunged from the folder
 	 */
@@ -80,11 +80,7 @@ public abstract class MailTransportUtils {
 				folder.close(expunge);
 			}
 			catch (MessagingException ex) {
-				logger.debug("Could not close JavaMail Folder", ex);
-			}
-			catch (NullPointerException ex) {
-				// JavaMail prior to 1.4.1 may throw this
-				logger.debug("Could not close JavaMail Folder", ex);
+				LOGGER.debug("Could not close JavaMail Folder", ex);
 			}
 		}
 	}
@@ -92,7 +88,6 @@ public abstract class MailTransportUtils {
 	/**
 	 * Returns a string representation of the given {@link URLName}, where the
 	 * password has been protected.
-	 *
 	 * @param name The URL name.
 	 * @return The result with password protection.
 	 */
@@ -104,7 +99,7 @@ public abstract class MailTransportUtils {
 		int port = name.getPort();
 		String file = name.getFile();
 		String ref = name.getRef();
-		StringBuffer tempURL = new StringBuffer();
+		StringBuilder tempURL = new StringBuilder();
 		if (protocol != null) {
 			tempURL.append(protocol).append(':');
 		}
@@ -121,7 +116,7 @@ public abstract class MailTransportUtils {
 				tempURL.append(host);
 			}
 			if (port != -1) {
-				tempURL.append(':').append(Integer.toString(port));
+				tempURL.append(':').append(port);
 			}
 			if (StringUtils.hasLength(file)) {
 				tempURL.append('/');

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/Pop3MailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/Pop3MailReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.mail;
 
+import javax.mail.Folder;
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import javax.mail.URLName;
@@ -32,18 +33,20 @@ import org.springframework.util.Assert;
  */
 public class Pop3MailReceiver extends AbstractMailReceiver {
 
+	public static final String PROTOCOL = "pop3";
+
 	public Pop3MailReceiver() {
 		super();
-		this.setProtocol("pop3");
+		setProtocol(PROTOCOL);
 	}
 
 	public Pop3MailReceiver(String url) {
 		super(url);
 		if (url != null) {
-			Assert.isTrue(url.startsWith("pop3"), "url must start with 'pop3'");
+			Assert.isTrue(url.startsWith(PROTOCOL), "url must start with 'pop3'");
 		}
 		else {
-			this.setProtocol("pop3");
+			setProtocol(PROTOCOL);
 		}
 	}
 
@@ -53,22 +56,22 @@ public class Pop3MailReceiver extends AbstractMailReceiver {
 	}
 
 	public Pop3MailReceiver(String host, int port, String username, String password) {
-		super(new URLName("pop3", host, port, "INBOX", username, password));
+		super(new URLName(PROTOCOL, host, port, "INBOX", username, password));
 	}
 
 
 	@Override
 	protected Message[] searchForNewMessages() throws MessagingException {
-		int messageCount = this.getFolder().getMessageCount();
+		Folder folderToUse = getFolder();
+		int messageCount = folderToUse.getMessageCount();
 		if (messageCount == 0) {
 			return new Message[0];
 		}
-		return this.getFolder().getMessages();
+		return folderToUse.getMessages();
 	}
 
 	/**
 	 * Deletes the given messages from this receiver's folder, and closes it to expunge deleted messages.
-	 *
 	 * @param messages the messages to delete
 	 * @throws MessagingException in case of JavaMail errors
 	 */
@@ -76,8 +79,9 @@ public class Pop3MailReceiver extends AbstractMailReceiver {
 	protected void deleteMessages(Message[] messages) throws MessagingException {
 		super.deleteMessages(messages);
 		// expunge deleted mails, and make sure we've retrieved them before closing the folder
-		for (int i = 0; i < messages.length; i++) {
-			new MimeMessage((MimeMessage) messages[i]);
+		for (Message message : messages) {
+			new MimeMessage((MimeMessage) message);
 		}
 	}
+
 }

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/dsl/ImapIdleChannelAdapterSpec.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/dsl/ImapIdleChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 the original author or authors.
+ * Copyright 2014-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class ImapIdleChannelAdapterSpec
 
 	private final List<Advice> adviceChain = new LinkedList<>();
 
-	protected final boolean externalReceiver;
+	protected final boolean externalReceiver; // NOSONAR
 
 	private boolean sessionProvided;
 
@@ -106,7 +106,8 @@ public class ImapIdleChannelAdapterSpec
 	}
 
 	private void assertReceiver() {
-		Assert.state(!this.externalReceiver, "An external 'receiver' [" + this.receiver + "] can't be modified.");
+		Assert.state(!this.externalReceiver,
+				() -> "An external 'receiver' [" + this.receiver + "] can't be modified.");
 	}
 
 	/**
@@ -118,7 +119,7 @@ public class ImapIdleChannelAdapterSpec
 	 * @see FunctionExpression
 	 */
 	public ImapIdleChannelAdapterSpec selector(Function<MimeMessage, Boolean> selectorFunction) {
-		return selectorExpression(new FunctionExpression<MimeMessage>(selectorFunction));
+		return selectorExpression(new FunctionExpression<>(selectorFunction));
 	}
 
 	/**
@@ -277,6 +278,7 @@ public class ImapIdleChannelAdapterSpec
 	 */
 	public ImapIdleChannelAdapterSpec transactionSynchronizationFactory(
 			TransactionSynchronizationFactory transactionSynchronizationFactory) {
+
 		this.target.setTransactionSynchronizationFactory(transactionSynchronizationFactory);
 		return this;
 	}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/dsl/MailInboundChannelAdapterSpec.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/dsl/MailInboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 the original author or authors.
+ * Copyright 2014-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 5.0
  */
 public abstract class
@@ -52,9 +53,9 @@ MailInboundChannelAdapterSpec<S extends MailInboundChannelAdapterSpec<S, R>, R e
 		extends MessageSourceSpec<S, MailReceivingMessageSource>
 		implements ComponentsRegistration {
 
-	protected final R receiver;
+	protected final R receiver; // NOSONAR
 
-	protected final boolean externalReceiver;
+	protected final boolean externalReceiver; // NOSONAR
 
 	private boolean sessionProvided;
 
@@ -81,7 +82,8 @@ MailInboundChannelAdapterSpec<S extends MailInboundChannelAdapterSpec<S, R>, R e
 	}
 
 	protected void assertReceiver() {
-		Assert.state(!this.externalReceiver, "An external 'receiver' [" + this.receiver + "] can't be modified.");
+		Assert.state(!this.externalReceiver,
+				() -> "An external 'receiver' [" + this.receiver + "] can't be modified.");
 	}
 
 	/**
@@ -107,7 +109,7 @@ MailInboundChannelAdapterSpec<S extends MailInboundChannelAdapterSpec<S, R>, R e
 	 */
 	public S selector(Function<MimeMessage, Boolean> selectorFunction) {
 		assertReceiver();
-		this.receiver.setSelectorExpression(new FunctionExpression<MimeMessage>(selectorFunction));
+		this.receiver.setSelectorExpression(new FunctionExpression<>(selectorFunction));
 		return _this();
 	}
 
@@ -227,8 +229,7 @@ MailInboundChannelAdapterSpec<S extends MailInboundChannelAdapterSpec<S, R>, R e
 	 * {@link javax.mail.Multipart} content is rendered as a byte[] in the payload.
 	 * Otherwise, leave as a {@link javax.mail.Part}. These objects are not suitable for
 	 * downstream serialization. Default: true.
-	 * <p>
-	 * This has no effect if there is no header mapper, in that case the payload is the
+	 * <p> This has no effect if there is no header mapper, in that case the payload is the
 	 * {@link MimeMessage}.
 	 * @param embeddedPartsAsBytes the embeddedPartsAsBytes to set.
 	 * @return the spec.

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/MailToStringTransformer.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/MailToStringTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,26 +33,27 @@ import org.springframework.util.Assert;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class MailToStringTransformer extends AbstractMailMessageTransformer<String> {
 
-	private volatile String charset = "UTF-8";
-
+	private String charset = "UTF-8";
 
 	/**
 	 * Specify the name of the Charset to use when converting from bytes.
 	 * The default is UTF-8.
-	 *
 	 * @param charset The charset.
 	 */
 	public void setCharset(String charset) {
 		Assert.notNull(charset, "charset must not be null");
-		Assert.isTrue(Charset.isSupported(charset), "unsupported charset '" + charset + "'");
+		Assert.isTrue(Charset.isSupported(charset), () -> "unsupported charset '" + charset + "'");
 		this.charset = charset;
 	}
 
 	@Override
-	protected AbstractIntegrationMessageBuilder<String> doTransform(javax.mail.Message mailMessage) throws Exception {
+	protected AbstractIntegrationMessageBuilder<String> doTransform(javax.mail.Message mailMessage)
+			throws Exception { // NOSONAR
+
 		Object content = mailMessage.getContent();
 		if (content instanceof String) {
 			return this.getMessageBuilderFactory().withPayload((String) content);


### PR DESCRIPTION
https://build.spring.io/browse/INT-MASTERSPRING40-599/

* The `folderReadLock` might not be re-locked when `openFolder()`
throws an exception
* Fix all the Sonar smells for mail module
* Optimize all the dynamic `Assert` messages to `Supplier`
* Refactor `MailReceiverFactoryBean` to be based on the `AbstractFactoryBean`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
