### PR TITLE
Make IOS.setTaskScheduler() as public

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.locks.Lock;
 
 import org.aopalliance.aop.Advice;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.BeanFactory;
@@ -57,7 +55,6 @@ import org.springframework.integration.util.UUIDConverter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageDeliveryException;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 
@@ -95,8 +92,6 @@ import org.springframework.util.CollectionUtils;
  */
 public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageProducingHandler
 		implements DiscardingMessageHandler, DisposableBean, ApplicationEventPublisherAware, Lifecycle {
-
-	protected final Log logger = LogFactory.getLog(getClass());
 
 	private final Comparator<Message<?>> sequenceNumberComparator = new MessageSequenceComparator();
 
@@ -286,11 +281,6 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		this.popSequence = popSequence;
 	}
 
-	@Override
-	public void setTaskScheduler(TaskScheduler taskScheduler) {
-		super.setTaskScheduler(taskScheduler);
-	}
-
 	protected boolean isReleaseLockBeforeSend() {
 		return this.releaseLockBeforeSend;
 	}
@@ -444,7 +434,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 	}
 
 	@Override
-	protected void handleMessageInternal(Message<?> message) throws Exception {
+	protected void handleMessageInternal(Message<?> message) throws InterruptedException {
 		Object correlationKey = this.correlationStrategy.getCorrelationKey(message);
 		Assert.state(correlationKey != null,
 				"Null correlation not allowed.  Maybe the CorrelationStrategy is failing?");

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/DefaultHeaderChannelRegistry.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/DefaultHeaderChannelRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.support.channel.HeaderChannelRegistry;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 
 /**
@@ -53,11 +52,11 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 
 	private static final int DEFAULT_REAPER_DELAY = 60000;
 
-	protected static final AtomicLong id = new AtomicLong();
+	protected static final AtomicLong id = new AtomicLong(); // NOSONAR
 
-	protected final Map<String, MessageChannelWrapper> channels = new ConcurrentHashMap<>();
+	protected final Map<String, MessageChannelWrapper> channels = new ConcurrentHashMap<>(); // NOSONAR
 
-	protected final String uuid = UUID.randomUUID().toString() + ":";
+	protected final String uuid = UUID.randomUUID().toString() + ":"; // NOSONAR
 
 	private boolean removeOnGet;
 
@@ -109,11 +108,6 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 	}
 
 	@Override
-	public void setTaskScheduler(TaskScheduler taskScheduler) {
-		super.setTaskScheduler(taskScheduler);
-	}
-
-	@Override
 	public final int size() {
 		return this.channels.size();
 	}
@@ -157,16 +151,18 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 	}
 
 	@Override
+	@Nullable
 	public Object channelToChannelName(@Nullable Object channel) {
 		return channelToChannelName(channel, this.reaperDelay);
 	}
 
 	@Override
+	@Nullable
 	public Object channelToChannelName(@Nullable Object channel, long timeToLive) {
 		if (!this.running && !this.explicitlyStopped && this.getTaskScheduler() != null) {
 			start();
 		}
-		if (channel != null && channel instanceof MessageChannel) {
+		if (channel instanceof MessageChannel) {
 			String name = this.uuid + id.incrementAndGet();
 			this.channels.put(name, new MessageChannelWrapper((MessageChannel) channel,
 					System.currentTimeMillis() + timeToLive));
@@ -181,6 +177,7 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 	}
 
 	@Override
+	@Nullable
 	public MessageChannel channelNameToChannel(@Nullable String name) {
 		if (name != null) {
 			MessageChannelWrapper messageChannelWrapper;

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -205,6 +205,20 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 		return this.beanFactory;
 	}
 
+	/**
+	 * Configure a {@link TaskScheduler} for those components which logic relies
+	 * on the scheduled tasks.
+	 * If not provided, falls back to the global {@code taskScheduler} bean
+	 * in the application context, provided by the Spring Integration infrastructure.
+	 * @param taskScheduler the {@link TaskScheduler} to use.
+	 * @since 5.1.3
+	 * @see #getTaskScheduler()
+	 */
+	public void setTaskScheduler(TaskScheduler taskScheduler) {
+		Assert.notNull(taskScheduler, "taskScheduler must not be null");
+		this.taskScheduler = taskScheduler;
+	}
+
 	protected TaskScheduler getTaskScheduler() {
 		if (this.taskScheduler == null && this.beanFactory != null) {
 			this.taskScheduler = IntegrationContextUtils.getTaskScheduler(this.beanFactory);
@@ -217,11 +231,6 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 			this.channelResolver = new BeanFactoryChannelResolver(this.beanFactory);
 		}
 		return this.channelResolver;
-	}
-
-	protected void setTaskScheduler(TaskScheduler taskScheduler) {
-		Assert.notNull(taskScheduler, "taskScheduler must not be null");
-		this.taskScheduler = taskScheduler;
 	}
 
 	public ConversionService getConversionService() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
@@ -119,7 +119,7 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 	}
 
 	@Override
-	public void destroy() {
+	public void destroy() throws Exception { // NOSONAR TODO: remove throws in 5.2
 		if (this.roleController != null) {
 			this.roleController.removeLifecycle(this);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.context.IntegrationProperties;
 import org.springframework.integration.support.SmartLifecycleRoleController;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.util.StringUtils;
 
@@ -56,9 +55,9 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 
 	private volatile boolean running;
 
-	protected final ReentrantLock lifecycleLock = new ReentrantLock();
+	protected final ReentrantLock lifecycleLock = new ReentrantLock(); // NOSONAR
 
-	protected final Condition lifecycleCondition = this.lifecycleLock.newCondition();
+	protected final Condition lifecycleCondition = this.lifecycleLock.newCondition(); // NOSONAR
 
 	private String role;
 
@@ -87,11 +86,6 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 
 	public String getRole() {
 		return this.role;
-	}
-
-	@Override
-	public void setTaskScheduler(TaskScheduler taskScheduler) {
-		super.setTaskScheduler(taskScheduler);
 	}
 
 	@Override
@@ -125,7 +119,7 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 	}
 
 	@Override
-	public void destroy() throws Exception {
+	public void destroy() {
 		if (this.roleController != null) {
 			this.roleController.removeLifecycle(this);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -48,6 +48,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.core.DestinationResolver;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
@@ -142,7 +143,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 	 */
 	public DelayHandler(String messageGroupId, TaskScheduler taskScheduler) {
 		this(messageGroupId);
-		this.setTaskScheduler(taskScheduler);
+		setTaskScheduler(taskScheduler);
 	}
 
 	/**
@@ -272,11 +273,9 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 		if (this.delayedMessageErrorChannel != null) {
 			return this.delayedMessageErrorChannel;
 		}
-		if (this.delayedMessageErrorChannelName != null) {
-			if (getChannelResolver() != null) {
-				this.delayedMessageErrorChannel = getChannelResolver()
-						.resolveDestination(this.delayedMessageErrorChannelName);
-			}
+		DestinationResolver<MessageChannel> channelResolver = getChannelResolver();
+		if (this.delayedMessageErrorChannelName != null && channelResolver != null) {
+			this.delayedMessageErrorChannel = channelResolver.resolveDestination(this.delayedMessageErrorChannelName);
 		}
 		return this.delayedMessageErrorChannel;
 	}
@@ -516,11 +515,9 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 			}
 			handleMessageInternal(message);
 		}
-		else {
-			if (logger.isDebugEnabled()) {
-				logger.debug("No message in the Message Store to release: " + message +
-						". Likely another instance has already released it.");
-			}
+		else if (logger.isDebugEnabled()) {
+			logger.debug("No message in the Message Store to release: " + message +
+					". Likely another instance has already released it.");
 		}
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -342,15 +342,6 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 	}
 
 	/**
-	 * Configure a {@link TaskScheduler} for flush operations.
-	 * @param taskScheduler the {@link TaskScheduler} to use.
-	 */
-	@Override
-	public void setTaskScheduler(TaskScheduler taskScheduler) { // NOSONAR
-		super.setTaskScheduler(taskScheduler);
-	}
-
-	/**
 	 * Set a {@link MessageFlushPredicate} to use when flushing files when
 	 * {@link FileExistsMode#APPEND_NO_FLUSH} is being used.
 	 * See {@link #trigger(Message)}.

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsInboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsInboundGateway.java
@@ -101,7 +101,12 @@ public class JmsInboundGateway extends MessagingGatewaySupport implements Dispos
 	@Override
 	public void destroy() {
 		this.endpoint.destroy();
-		super.destroy();
+		try {
+			super.destroy();
+		}
+		catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
 	}
 
 	@Override

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsInboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ public class JmsInboundGateway extends MessagingGatewaySupport implements Dispos
 	}
 
 	@Override
-	public void destroy() throws Exception {
+	public void destroy() {
 		this.endpoint.destroy();
 		super.destroy();
 	}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsMessageDrivenEndpoint.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsMessageDrivenEndpoint.java
@@ -218,7 +218,12 @@ public class JmsMessageDrivenEndpoint extends MessageProducerSupport
 			this.stop();
 		}
 		this.listenerContainer.destroy();
-		super.destroy();
+		try {
+			super.destroy();
+		}
+		catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
 	}
 
 	@Override

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsMessageDrivenEndpoint.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsMessageDrivenEndpoint.java
@@ -36,7 +36,8 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Artem Bilan
  */
-public class JmsMessageDrivenEndpoint extends MessageProducerSupport implements DisposableBean, OrderlyShutdownCapable {
+public class JmsMessageDrivenEndpoint extends MessageProducerSupport
+		implements DisposableBean, OrderlyShutdownCapable {
 
 	private final AbstractMessageListenerContainer listenerContainer;
 
@@ -73,7 +74,7 @@ public class JmsMessageDrivenEndpoint extends MessageProducerSupport implements 
 			ChannelPublishingJmsMessageListener listener, boolean externalContainer) {
 		Assert.notNull(listenerContainer, "listener container must not be null");
 		Assert.notNull(listener, "listener must not be null");
-		if (logger.isWarnEnabled() && listenerContainer.getMessageListener() != null) {
+		if (listenerContainer.getMessageListener() != null) {
 			logger.warn("The provided listener container already has a MessageListener implementation, " +
 					"but it will be overridden by the provided ChannelPublishingJmsMessageListener.");
 		}
@@ -212,7 +213,7 @@ public class JmsMessageDrivenEndpoint extends MessageProducerSupport implements 
 	}
 
 	@Override
-	public void destroy() throws Exception {
+	public void destroy() {
 		if (this.isRunning()) {
 			this.stop();
 		}

--- a/spring-integration-rmi/src/main/java/org/springframework/integration/rmi/RmiInboundGateway.java
+++ b/spring-integration-rmi/src/main/java/org/springframework/integration/rmi/RmiInboundGateway.java
@@ -139,11 +139,11 @@ public class RmiInboundGateway extends MessagingGatewaySupport
 
 	@Override
 	public void destroy() {
-		super.destroy();
 		try {
+			super.destroy();
 			this.exporter.destroy();
 		}
-		catch (RemoteException e) {
+		catch (Exception e) {
 			throw new IllegalStateException(e);
 		}
 	}

--- a/spring-integration-rmi/src/main/java/org/springframework/integration/rmi/RmiInboundGateway.java
+++ b/spring-integration-rmi/src/main/java/org/springframework/integration/rmi/RmiInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,9 +138,14 @@ public class RmiInboundGateway extends MessagingGatewaySupport
 	}
 
 	@Override
-	public void destroy() throws Exception {
+	public void destroy() {
 		super.destroy();
-		this.exporter.destroy();
+		try {
+			this.exporter.destroy();
+		}
+		catch (RemoteException e) {
+			throw new IllegalStateException(e);
+		}
 	}
 
 }


### PR DESCRIPTION
* Make `IntegrationObjectSupport.setTaskScheduler()` as `public` and
remove all the overrides for visibility
* Fix Sonar smells for all the affected classes

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
