### PR TITLE
INT-4386: Support Instant in schedule expressions

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationEvaluationContextFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationEvaluationContextFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.expression.BeanResolver;
 import org.springframework.expression.PropertyAccessor;
 import org.springframework.expression.TypeLocator;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.expression.spel.support.StandardTypeLocator;
 import org.springframework.integration.context.IntegrationContextUtils;
 
 /**
@@ -65,7 +66,7 @@ import org.springframework.integration.context.IntegrationContextUtils;
 public class IntegrationEvaluationContextFactoryBean extends AbstractEvaluationContextFactoryBean
 		implements FactoryBean<StandardEvaluationContext> {
 
-	private volatile TypeLocator typeLocator;
+	private TypeLocator typeLocator;
 
 	private BeanResolver beanResolver;
 
@@ -87,10 +88,19 @@ public class IntegrationEvaluationContextFactoryBean extends AbstractEvaluationC
 	}
 
 	@Override
-	public StandardEvaluationContext getObject() throws Exception {
+	public StandardEvaluationContext getObject() {
 		StandardEvaluationContext evaluationContext = new StandardEvaluationContext();
 		if (this.typeLocator != null) {
 			evaluationContext.setTypeLocator(this.typeLocator);
+		}
+
+		TypeLocator typeLocator = evaluationContext.getTypeLocator();
+		if (typeLocator instanceof StandardTypeLocator) {
+			/*
+			 * Register the 'java.time' package so its classes don't need a FQCN,
+			 * for example ' T(Instant).now().plusSeconds(5)'.
+			 */
+			((StandardTypeLocator) typeLocator).registerImport("java.time");
 		}
 
 		evaluationContext.setBeanResolver(this.beanResolver);

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/DelayHandlerTests.java
@@ -50,6 +50,7 @@ import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.IntegrationEvaluationContextFactoryBean;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
@@ -93,13 +94,16 @@ public class DelayHandlerTests {
 
 	@Before
 	public void setup() {
+		this.context.registerBean(IntegrationContextUtils.INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME,
+				new IntegrationEvaluationContextFactoryBean());
+		this.context.refresh();
 		input.setBeanName("input");
 		output.setBeanName("output");
 		taskScheduler = new ThreadPoolTaskScheduler();
 		taskScheduler.afterPropertiesSet();
 		delayHandler = new DelayHandler(DELAYER_MESSAGE_GROUP_ID, taskScheduler);
 		delayHandler.setOutputChannel(output);
-		delayHandler.setBeanFactory(mock(BeanFactory.class));
+		delayHandler.setBeanFactory(this.context);
 		input.subscribe(delayHandler);
 		output.subscribe(resultHandler);
 	}
@@ -230,6 +234,18 @@ public class DelayHandlerTests {
 		waitForLatch(10000);
 		assertSame(message.getPayload(), resultHandler.lastMessage.getPayload());
 		assertNotSame(Thread.currentThread(), resultHandler.lastThread);
+	}
+
+	@Test
+	public void delayHeaderIsInstantInTheFutureAndDefaultDelayWouldTimeout() {
+		this.delayHandler.setDefaultDelay(5000);
+		this.delayHandler.setDelayExpressionString("T(Instant).now().plusMillis(150)");
+		startDelayerHandler();
+		Message<?> message = new GenericMessage<>("test");
+		this.input.send(message);
+		waitForLatch(10000);
+		assertSame(message.getPayload(), this.resultHandler.lastMessage.getPayload());
+		assertNotSame(Thread.currentThread(), this.resultHandler.lastThread);
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4386

* Expose `java.time` in the `IntegrationEvaluationContextFactoryBean`
ot simply a `T()` SpEL operator
* Add `Instant` result evaluation to the `delayExpression`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
