### PR TITLE
GH-2728: AMQP Manual acks and conversion errors

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/EndpointUtils.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/EndpointUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.amqp.support;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
+
+import com.rabbitmq.client.Channel;
+
+/**
+ * Utility methods for messaging endpoints.
+ *
+ * @author Gary Russell
+ * @since 5.1.3
+ *
+ */
+public final class EndpointUtils {
+
+	private static final String LEFE_MESSAGE = "Message conversion failed";
+
+	private EndpointUtils() {
+		super();
+	}
+
+	/**
+	 * Return an {@link ListenerExecutionFailedException} or a {@link ManualAckListenerExecutionFailedException}
+	 * depending on whether isManualAck is false or true.
+	 * @param message the failed message.
+	 * @param channel the channel.
+	 * @param isManualAck true if the container uses manual acknowledgment.
+	 * @param e the exception.
+	 * @return the exception.
+	 */
+	public static ListenerExecutionFailedException errorMessagePayload(final Message message,
+			Channel channel, boolean isManualAck, Exception e) {
+
+		return isManualAck
+				? new ManualAckListenerExecutionFailedException(LEFE_MESSAGE, e, message, channel,
+						message.getMessageProperties().getDeliveryTag())
+				: new ListenerExecutionFailedException(LEFE_MESSAGE, e, message);
+	}
+
+}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/ManualAckListenerExecutionFailedException.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/ManualAckListenerExecutionFailedException.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.amqp.support;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.listener.exception.ListenerExecutionFailedException;
+
+import com.rabbitmq.client.Channel;
+
+/**
+ * A {@link ListenerExecutionFailedException} enhanced with the channel and delivery tag.
+ * Used for conversion errors when using manual acks.
+ *
+ * @author Gary Russell
+ * @since 5.1.3
+ *
+ */
+public class ManualAckListenerExecutionFailedException extends ListenerExecutionFailedException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Channel channel;
+
+	private final long deliveryTag;
+
+	public ManualAckListenerExecutionFailedException(String msg, Throwable cause, Message failedMessage,
+			Channel channel, long deliveryTag) {
+
+		super(msg, cause, failedMessage);
+		this.channel = channel;
+		this.deliveryTag = deliveryTag;
+	}
+
+	public Channel getChannel() {
+		return this.channel;
+	}
+
+	public long getDeliveryTag() {
+		return this.deliveryTag;
+	}
+
+}

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -1081,6 +1081,20 @@ public class AmqpAsyncApplication {
 ----
 ====
 
+[[amqp-conversion-inbound]]
+=== Inbound Message Conversion
+
+Inbound messages, arriving at the channel adapter or gateway, are converted to the `spring-messaging` `Message<?>` payload using a message converter.
+By default, a `SimpleMessageConverter` is used, which handles java serialization and text.
+Headers are mapped using the `DefaultHeaderMapper.inboundMapper()` by default.
+If a conversion error occurs, and there is no error channel defined, the exception is thrown to the container and handled by the listener container's error handler.
+The default error handler treats conversion errors as fatal and the message will be rejected (and routed to a dead-letter exchange, if the queue is so configured).
+If an error channel is defined, the `ErrorMessage` payload is a `ListenerExecutionFailedException` with properties `failedMessage` (the Spring AMQP message that could not be converted) and the `cause`.
+If the container `AcknowledgeMode` is `AUTO` (the default) and the error flow consumes the error without throwing an exception, the original message will be acknowledged.
+If the error flow throws an exception, the exception type, in conjunction with the container's error handler, will determine whether or not the message is requeued.
+If the container is configured with `AcknowledgeMode.MANUAL`, the payload is a `ManualAckListenerExecutionFailedException` with additional properties `channel` and `deliveryTag`.
+This enables the error flow to call `basicAck` or `basicNack` (or `basicReject`) for the message, to control its disposition.
+
 [[content-type-conversion-outbound]]
 === Outbound Message Conversion
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -144,6 +144,10 @@ See the note near the bottom of <<amqp-message-headers>> for more information.
 The `contentType` header is now correctly mapped as an entry in the general headers map.
 See <<amqp-content-type>> for more information.
 
+Starting with version 5.1.3, if a message conversion exception occurs when using manual acknowledgments, and an error channel is defined, the payload is a `ManualAckListenerExecutionFailedException` with additional `channel` and `deliveryTag` properties.
+This enables the error flow to ack/nack the original message.
+See <<amqp-conversion-inbound>> for more information.
+
 [[x5.1-jdbc]]
 === JDBC Changes
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/2728

Provide access to the channel and delivery tag in the `ErrorMessage` when
using `AcknowledgeMode.MANUAL`.
