### PR TITLE
GH-2733: Fix Meter Memory Leak

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
@@ -555,8 +555,9 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 	protected abstract boolean doSend(Message<?> message, long timeout);
 
 	@Override
-	public void destroy() throws Exception {
+	public void destroy() throws Exception { // NOSONAR TODO: remove throws in 5.2
 		this.meters.forEach(MeterFacade::remove);
+		this.meters.clear();
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractPollableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractPollableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -233,7 +233,7 @@ public abstract class AbstractPollableChannel extends AbstractMessageChannel
 	protected abstract Message<?> doReceive(long timeout);
 
 	@Override
-	public void destroy() throws Exception {
+	public void destroy() throws Exception { // NOSONAR TODO: remove throws in 5.2
 		super.destroy();
 		if (this.receiveCounter != null) {
 			this.receiveCounter.remove();

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsCaptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsCaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -195,6 +195,19 @@ public class MicrometerMetricsCaptor implements MetricsCaptor {
 			this.timer.record(time, unit);
 		}
 
+		@Override
+		public int hashCode() {
+			return this.timer.hashCode();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (!MicroTimer.class.equals(obj.getClass())) {
+				return false;
+			}
+			return this.timer.equals(((MicroTimer) obj).timer);
+		}
+
 	}
 
 	protected static class MicroCounterBuilder implements CounterBuilder {
@@ -246,6 +259,19 @@ public class MicrometerMetricsCaptor implements MetricsCaptor {
 			this.counter.increment();
 		}
 
+		@Override
+		public int hashCode() {
+			return this.counter.hashCode();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (!MicroCounter.class.equals(obj.getClass())) {
+				return false;
+			}
+			return this.counter.equals(((MicroCounter) obj).counter);
+		}
+
 	}
 
 	protected static class MicroGaugeBuilder implements GaugeBuilder {
@@ -290,6 +316,19 @@ public class MicrometerMetricsCaptor implements MetricsCaptor {
 		@Override
 		protected Gauge getMeter() {
 			return this.gauge;
+		}
+
+		@Override
+		public int hashCode() {
+			return this.gauge.hashCode();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (!MicroGauge.class.equals(obj.getClass())) {
+				return false;
+			}
+			return this.gauge.equals(((MicroGauge) obj).gauge);
 		}
 
 	}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2733

`AbstractMessageChannel` exception meters caused a memory leak because they
are stored in a `Set` for destruction purposes but did not implement
`hashCode` and `equals`.

Add `hashCode()` and `equals()` to all meter facades, delegating to the
underlying Micrometer objects.

