### PR TITLE
Add default expressions for ExpEvalReqHAdvice

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ExpressionEvaluatingRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ExpressionEvaluatingRequestHandlerAdvice.java
@@ -24,12 +24,12 @@ import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.message.AdviceMessage;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.core.DestinationResolver;
 import org.springframework.messaging.support.ErrorMessage;
-import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -94,8 +94,7 @@ public class ExpressionEvaluatingRequestHandlerAdvice extends AbstractRequestHan
 	 * @param onSuccessExpression the SpEL expression.
 	 * @since 5.0
 	 */
-	public void setOnSuccessExpression(Expression onSuccessExpression) {
-		Assert.notNull(onSuccessExpression, "'onSuccessExpression' must not be null");
+	public void setOnSuccessExpression(@Nullable Expression onSuccessExpression) {
 		this.onSuccessExpression = onSuccessExpression;
 	}
 
@@ -128,8 +127,7 @@ public class ExpressionEvaluatingRequestHandlerAdvice extends AbstractRequestHan
 	 * @param onFailureExpression the SpEL expression.
 	 * @since 5.0
 	 */
-	public void setOnFailureExpression(Expression onFailureExpression) {
-		Assert.notNull(onFailureExpression, "'onFailureExpression' must not be null");
+	public void setOnFailureExpression(@Nullable Expression onFailureExpression) {
 		this.onFailureExpression = onFailureExpression;
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -1163,7 +1163,6 @@ public class EnableIntegrationTests {
 		@Bean
 		public Advice myHandlerAdvice() {
 			ExpressionEvaluatingRequestHandlerAdvice advice = new ExpressionEvaluatingRequestHandlerAdvice();
-			advice.setOnSuccessExpressionString("payload");
 			advice.setSuccessChannel(myHandlerSuccessChannel());
 			return advice;
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
@@ -644,7 +644,6 @@ public class IntegrationFlowTests {
 		@Bean
 		public Advice expressionAdvice() {
 			ExpressionEvaluatingRequestHandlerAdvice advice = new ExpressionEvaluatingRequestHandlerAdvice();
-			advice.setOnSuccessExpressionString("payload");
 			advice.setSuccessChannel(this.successChannel);
 			return advice;
 		}

--- a/src/reference/asciidoc/handler-advice.adoc
+++ b/src/reference/asciidoc/handler-advice.adoc
@@ -406,7 +406,7 @@ An additional property, called `inputMessage`, contains the original message sen
 A message sent to the `failureChannel` (when the handler throws an exception) is an `ErrorMessage` with a payload of `MessageHandlingExpressionEvaluatingAdviceException`.
 Like all `MessagingException` instances, this payload has `failedMessage` and `cause` properties, as well as an additional property called `evaluationResult`, which contains the result of the expression evaluation.
 
-NOTE: Starting with version 5.1.3, if channels are configured, but expressions are not provided, the default expression is used to evaluate to a `payload` of the message.
+NOTE: Starting with version 5.1.3, if channels are configured, but expressions are not provided, the default expression is used to evaluate to the `payload` of the message.
 
 When an exception is thrown in the scope of the advice, by default, that exception is thrown to the caller after any `failureExpression` is evaluated.
 If you wish to suppress throwing the exception, set the `trapException` property to `true`.

--- a/src/reference/asciidoc/handler-advice.adoc
+++ b/src/reference/asciidoc/handler-advice.adoc
@@ -406,6 +406,8 @@ An additional property, called `inputMessage`, contains the original message sen
 A message sent to the `failureChannel` (when the handler throws an exception) is an `ErrorMessage` with a payload of `MessageHandlingExpressionEvaluatingAdviceException`.
 Like all `MessagingException` instances, this payload has `failedMessage` and `cause` properties, as well as an additional property called `evaluationResult`, which contains the result of the expression evaluation.
 
+NOTE: Starting with version 5.1.3, if channels are configured, but expressions are not provided, the default expression is used to evaluate to a `payload` of the message.
+
 When an exception is thrown in the scope of the advice, by default, that exception is thrown to the caller after any `failureExpression` is evaluated.
 If you wish to suppress throwing the exception, set the `trapException` property to `true`.
 The following advice shows how to configure an advice with Java DSL:


### PR DESCRIPTION
https://stackoverflow.com/questions/54546728/how-to-handle-ftpoutboundadapter-connection-exception-in-spring-integration-flow

When channels are configured for the `ExpressionEvaluatingRequestHandlerAdvice`,
but no expressions, the logic is not performed.
In other words: we can evaluate expressions, when no channels,
but we  don't send messages to channels when no expressions.

* Provide default expressions to be evaluated to `payload`, when only
channels are provided.

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
