### PR TITLE
GH-2731: Fix nested gateway error propagation

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/gateway/GatewayDslTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/gateway/GatewayDslTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.integration.MessageRejectedException;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlows;
+import org.springframework.integration.dsl.MessageChannels;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 5.1.3
+ */
+@SpringJUnitConfig
+public class GatewayDslTests {
+
+	@Autowired
+	@Qualifier("gatewayInput")
+	private MessageChannel gatewayInput;
+
+	@Autowired
+	@Qualifier("gatewayError")
+	private PollableChannel gatewayError;
+
+	@Test
+	void testGatewayFlow() {
+		PollableChannel replyChannel = new QueueChannel();
+		Message<String> message = MessageBuilder.withPayload("foo").setReplyChannel(replyChannel).build();
+
+		this.gatewayInput.send(message);
+
+		Message<?> receive = replyChannel.receive(10000);
+		assertThat(receive).isNotNull();
+		assertThat(receive.getPayload()).isEqualTo("From Gateway SubFlow: FOO");
+		assertThat(this.gatewayError.receive(1)).isNull();
+
+		message = MessageBuilder.withPayload("bar").setReplyChannel(replyChannel).build();
+
+		this.gatewayInput.send(message);
+
+		assertThat(replyChannel.receive(1)).isNull();
+
+		receive = this.gatewayError.receive(10000);
+		assertThat(receive).isNotNull();
+		assertThat(receive).isInstanceOf(ErrorMessage.class);
+		assertThat(receive.getPayload()).isInstanceOf(MessageRejectedException.class);
+		assertThat(((Exception) receive.getPayload()).getMessage()).contains("' rejected Message");
+	}
+
+	@Autowired
+	@Qualifier("nestedGatewayErrorPropagationFlow.input")
+	private MessageChannel nestedGatewayErrorPropagationFlowInput;
+
+	@Test
+	void testNestedGatewayErrorPropagation() {
+		assertThatThrownBy(() -> this.nestedGatewayErrorPropagationFlowInput.send(new GenericMessage<>("test")))
+				.hasCauseInstanceOf(RuntimeException.class)
+				.hasMessageContaining("intentional");
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class ContextConfiguration {
+
+		@Bean
+		public IntegrationFlow gatewayFlow() {
+			return IntegrationFlows.from("gatewayInput")
+					.gateway("gatewayRequest", g -> g.errorChannel("gatewayError").replyTimeout(10L))
+					.gateway((f) -> f.transform("From Gateway SubFlow: "::concat))
+					.get();
+		}
+
+		@Bean
+		public IntegrationFlow gatewayRequestFlow() {
+			return IntegrationFlows.from("gatewayRequest")
+					.filter("foo"::equals, (f) -> f.throwExceptionOnRejection(true))
+					.<String, String>transform(String::toUpperCase)
+					.get();
+		}
+
+		@Bean
+		public MessageChannel gatewayError() {
+			return MessageChannels.queue().get();
+		}
+
+
+		@Bean
+		public IntegrationFlow nestedGatewayErrorPropagationFlow(TaskExecutor taskExecutor) {
+			return f -> f
+					.gateway((gatewayFlow) -> gatewayFlow
+							.channel((c) -> c.executor(taskExecutor))
+							.gateway((nestedGatewayFlow) -> nestedGatewayFlow
+									.transform((m) -> {
+										throw new RuntimeException("intentional");
+									})));
+		}
+
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2731

When we have a nested gateway configuration, we are loosing the context
of the current request message in case of errors and downstream
`MessagingException` is just re-thrown as is with already not actual
`failedMessage` and its processed `errorChannel` header.

* Check for exception type and for the `errorChannel` header in the
current `requestMessage` before re-throwing as a new
`MessageHandlingException` in the `MessagingGatewaySupport.sendAndReceive()`
* Extract `.gateway()` tests into the separate `GatewayDslTests` class

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
