### PR TITLE
[DO NOT MERGE YET] Convert JUnit asserts to AssertJ

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/ChannelTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/ChannelTests.java
@@ -16,13 +16,8 @@
 
 package org.springframework.integration.amqp.channel;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
@@ -34,9 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import org.springframework.amqp.core.AmqpTemplate;
@@ -79,9 +72,6 @@ public class ChannelTests {
 	@ClassRule
 	public static final BrokerRunning brokerIsRunning =
 			BrokerRunning.isRunningWithEmptyQueues("pollableWithEP", "withEP", "testConvertFail");
-
-	@Rule
-	public ExpectedException exception = ExpectedException.none();
 
 	@Autowired
 	private PublishSubscribeAmqpChannel channel;
@@ -136,8 +126,8 @@ public class ChannelTests {
 		this.pubSubWithEP.destroy();
 		this.withEP.destroy();
 		this.pollableWithEP.destroy();
-		assertEquals(0,
-				TestUtils.getPropertyValue(connectionFactory, "connectionListener.delegates", Collection.class).size());
+		assertThat(TestUtils.getPropertyValue(connectionFactory, "connectionListener.delegates", Collection.class)
+				.size()).isEqualTo(0);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -147,7 +137,8 @@ public class ChannelTests {
 		final Object consumersMonitor = TestUtils.getPropertyValue(channel, "container.consumersMonitor");
 		int n = 0;
 		while (n++ < 100) {
-			Set<BlockingQueueConsumer> consumers = TestUtils.getPropertyValue(channel, "container.consumers", Set.class);
+			Set<BlockingQueueConsumer> consumers = TestUtils
+					.getPropertyValue(channel, "container.consumers", Set.class);
 			synchronized (consumersMonitor) {
 				if (!consumers.isEmpty()) {
 					BlockingQueueConsumer newConsumer = consumers.iterator().next();
@@ -158,7 +149,7 @@ public class ChannelTests {
 			}
 			Thread.sleep(100);
 		}
-		assertTrue("Failed to restart consumer", n < 100);
+		assertThat(n < 100).as("Failed to restart consumer").isTrue();
 	}
 
 	/*
@@ -177,21 +168,21 @@ public class ChannelTests {
 		channel.afterPropertiesSet();
 		channel.onCreate(null);
 
-		assertNotNull(admin.getQueueProperties("implicit"));
+		assertThat(admin.getQueueProperties("implicit")).isNotNull();
 
 		admin.deleteQueue("explicit");
 		channel.setQueueName("explicit");
 		channel.afterPropertiesSet();
 		channel.onCreate(null);
 
-		assertNotNull(admin.getQueueProperties("explicit"));
+		assertThat(admin.getQueueProperties("explicit")).isNotNull();
 
 		admin.deleteQueue("explicit");
 		admin.declareQueue(new Queue("explicit", false)); // verify no declaration if exists with non-standard props
 		channel.afterPropertiesSet();
 		channel.onCreate(null);
 
-		assertNotNull(admin.getQueueProperties("explicit"));
+		assertThat(admin.getQueueProperties("explicit")).isNotNull();
 		admin.deleteQueue("explicit");
 	}
 
@@ -203,7 +194,7 @@ public class ChannelTests {
 		channelFactoryBean.setBeanName("testChannel");
 		channelFactoryBean.afterPropertiesSet();
 		AbstractAmqpChannel channel = channelFactoryBean.getObject();
-		assertThat(channel, instanceOf(PointToPointSubscribableAmqpChannel.class));
+		assertThat(channel).isInstanceOf(PointToPointSubscribableAmqpChannel.class);
 
 		channelFactoryBean = new AmqpChannelFactoryBean();
 		channelFactoryBean.setBeanFactory(mock(BeanFactory.class));
@@ -212,7 +203,7 @@ public class ChannelTests {
 		channelFactoryBean.setPubSub(true);
 		channelFactoryBean.afterPropertiesSet();
 		channel = channelFactoryBean.getObject();
-		assertThat(channel, instanceOf(PublishSubscribeAmqpChannel.class));
+		assertThat(channel).isInstanceOf(PublishSubscribeAmqpChannel.class);
 
 		RabbitAdmin rabbitAdmin = new RabbitAdmin(this.connectionFactory);
 		rabbitAdmin.deleteQueue("testChannel");
@@ -225,24 +216,24 @@ public class ChannelTests {
 		Message<?> message = MessageBuilder.withPayload(foo).setHeader("baz", "qux").build();
 		this.pollableWithEP.send(message);
 		Message<?> received = this.pollableWithEP.receive(10000);
-		assertNotNull(received);
-		assertThat(received.getPayload(), equalTo(foo));
-		assertThat(received.getHeaders().get("baz"), equalTo("qux"));
+		assertThat(received).isNotNull();
+		assertThat(received.getPayload()).isEqualTo(foo);
+		assertThat(received.getHeaders().get("baz")).isEqualTo("qux");
 
 		this.withEP.send(message);
 		received = this.out.receive(10000);
-		assertNotNull(received);
-		assertThat(received.getPayload(), equalTo(foo));
-		assertThat(received.getHeaders().get("baz"), equalTo("qux"));
+		assertThat(received).isNotNull();
+		assertThat(received.getPayload()).isEqualTo(foo);
+		assertThat(received.getHeaders().get("baz")).isEqualTo("qux");
 
 		this.pubSubWithEP.send(message);
 		received = this.out.receive(10000);
-		assertNotNull(received);
-		assertThat(received.getPayload(), equalTo(foo));
-		assertThat(received.getHeaders().get("baz"), equalTo("qux"));
+		assertThat(received).isNotNull();
+		assertThat(received.getPayload()).isEqualTo(foo);
+		assertThat(received.getHeaders().get("baz")).isEqualTo("qux");
 
-		assertSame(this.mapperIn, TestUtils.getPropertyValue(this.pollableWithEP, "inboundHeaderMapper"));
-		assertSame(this.mapperOut, TestUtils.getPropertyValue(this.pollableWithEP, "outboundHeaderMapper"));
+		assertThat(TestUtils.getPropertyValue(this.pollableWithEP, "inboundHeaderMapper")).isSameAs(this.mapperIn);
+		assertThat(TestUtils.getPropertyValue(this.pollableWithEP, "outboundHeaderMapper")).isSameAs(this.mapperOut);
 	}
 
 	@Test
@@ -257,9 +248,9 @@ public class ChannelTests {
 				MessageListener.class);
 		willThrow(new MessageConversionException("foo", new IllegalStateException("bar")))
 				.given(messageConverter).fromMessage(any(org.springframework.amqp.core.Message.class));
-		this.exception.expect(MessageConversionException.class);
-		this.exception.expectCause(instanceOf(IllegalStateException.class));
-		listener.onMessage(mock(org.springframework.amqp.core.Message.class));
+		assertThatThrownBy(() -> listener.onMessage(mock(org.springframework.amqp.core.Message.class)))
+				.isInstanceOf(MessageConversionException.class)
+				.hasCauseInstanceOf(IllegalStateException.class);
 	}
 
 	public static class Foo {

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
@@ -16,11 +16,8 @@
 
 package org.springframework.integration.amqp.channel;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -87,8 +84,8 @@ public class DispatcherHasNoSubscribersTests {
 			fail("Exception expected");
 		}
 		catch (MessageDeliveryException e) {
-			assertThat(e.getMessage(),
-					containsString("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'."));
+			assertThat(e.getMessage())
+					.contains("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'.");
 		}
 	}
 
@@ -135,19 +132,18 @@ public class DispatcherHasNoSubscribersTests {
 	}
 
 	private void verifyLogReceived(final List<String> logList) {
-		assertTrue("Failed to get expected exception", logList.size() > 0);
+		assertThat(logList.size() > 0).as("Failed to get expected exception").isTrue();
 		boolean expectedExceptionFound = false;
 		while (logList.size() > 0) {
 			String message = logList.remove(0);
-			assertNotNull("Failed to get expected exception", message);
+			assertThat(message).as("Failed to get expected exception").isNotNull();
 			if (message.startsWith("Dispatcher has no subscribers")) {
 				expectedExceptionFound = true;
-				assertThat(message,
-						containsString("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'."));
+				assertThat(message).contains("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'.");
 				break;
 			}
 		}
-		assertTrue("Failed to get expected exception", expectedExceptionFound);
+		assertThat(expectedExceptionFound).as("Failed to get expected exception").isTrue();
 	}
 
 }

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests.java
@@ -16,14 +16,7 @@
 
 package org.springframework.integration.amqp.config;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -73,30 +66,33 @@ public class AmqpChannelParserTests {
 	public void interceptor() {
 		MessageChannel channel = context.getBean("channelWithInterceptor", MessageChannel.class);
 		List<?> interceptorList = TestUtils.getPropertyValue(channel, "interceptors.interceptors", List.class);
-		assertEquals(1, interceptorList.size());
-		assertEquals(TestInterceptor.class, interceptorList.get(0).getClass());
-		assertEquals(Integer.MAX_VALUE, TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers", Integer.class).intValue());
+		assertThat(interceptorList.size()).isEqualTo(1);
+		assertThat(interceptorList.get(0).getClass()).isEqualTo(TestInterceptor.class);
+		assertThat(TestUtils.getPropertyValue(
+				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers", Integer.class).intValue())
+				.isEqualTo(Integer.MAX_VALUE);
 		channel = context.getBean("pubSub", MessageChannel.class);
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertSame(mbf, TestUtils.getPropertyValue(channel, "container.messageListener.messageBuilderFactory"));
-		assertTrue(TestUtils.getPropertyValue(channel, "container.missingQueuesFatal", Boolean.class));
-		assertFalse(TestUtils.getPropertyValue(channel, "container.transactional", Boolean.class));
-		assertFalse(TestUtils.getPropertyValue(channel, "amqpTemplate.transactional", Boolean.class));
-		assertThat(TestUtils.getPropertyValue(channel, "container"), instanceOf(SimpleMessageListenerContainer.class));
+		assertThat(TestUtils.getPropertyValue(channel, "container.messageListener.messageBuilderFactory"))
+				.isSameAs(mbf);
+		assertThat(TestUtils.getPropertyValue(channel, "container.missingQueuesFatal", Boolean.class)).isTrue();
+		assertThat(TestUtils.getPropertyValue(channel, "container.transactional", Boolean.class)).isFalse();
+		assertThat(TestUtils.getPropertyValue(channel, "amqpTemplate.transactional", Boolean.class)).isFalse();
+		assertThat(TestUtils.getPropertyValue(channel, "container")).isInstanceOf(SimpleMessageListenerContainer.class);
 	}
 
 	@Test
 	public void subscriberLimit() {
 		MessageChannel channel = context.getBean("channelWithSubscriberLimit", MessageChannel.class);
-		assertEquals(1, TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers", Integer.class).intValue());
-		assertFalse(TestUtils.getPropertyValue(channel, "container.missingQueuesFatal", Boolean.class));
-		assertFalse(TestUtils.getPropertyValue(channel, "container.transactional", Boolean.class));
-		assertTrue(TestUtils.getPropertyValue(channel, "amqpTemplate.transactional", Boolean.class));
-		assertFalse(TestUtils.getPropertyValue(channel, "extractPayload", Boolean.class));
-		assertThat(TestUtils.getPropertyValue(channel, "container"), instanceOf(DirectMessageListenerContainer.class));
-		assertEquals(2, TestUtils.getPropertyValue(channel, "container.consumersPerQueue"));
+		assertThat(TestUtils.getPropertyValue(
+				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers", Integer.class).intValue())
+				.isEqualTo(1);
+		assertThat(TestUtils.getPropertyValue(channel, "container.missingQueuesFatal", Boolean.class)).isFalse();
+		assertThat(TestUtils.getPropertyValue(channel, "container.transactional", Boolean.class)).isFalse();
+		assertThat(TestUtils.getPropertyValue(channel, "amqpTemplate.transactional", Boolean.class)).isTrue();
+		assertThat(TestUtils.getPropertyValue(channel, "extractPayload", Boolean.class)).isFalse();
+		assertThat(TestUtils.getPropertyValue(channel, "container")).isInstanceOf(DirectMessageListenerContainer.class);
+		assertThat(TestUtils.getPropertyValue(channel, "container.consumersPerQueue")).isEqualTo(2);
 	}
 
 	@Test
@@ -104,19 +100,19 @@ public class AmqpChannelParserTests {
 		checkExtract(this.pollableWithEP);
 		checkExtract(this.withEP);
 		checkExtract(this.pubSubWithEP);
-		assertEquals(MessageDeliveryMode.NON_PERSISTENT,
-				TestUtils.getPropertyValue(this.withEP, "defaultDeliveryMode"));
-		assertFalse(TestUtils.getPropertyValue(this.withEP, "headersMappedLast", Boolean.class));
-		assertNull(TestUtils.getPropertyValue(this.pollableWithEP, "defaultDeliveryMode"));
-		assertTrue(TestUtils.getPropertyValue(this.pollableWithEP, "headersMappedLast", Boolean.class));
+		assertThat(TestUtils.getPropertyValue(this.withEP, "defaultDeliveryMode"))
+				.isEqualTo(MessageDeliveryMode.NON_PERSISTENT);
+		assertThat(TestUtils.getPropertyValue(this.withEP, "headersMappedLast", Boolean.class)).isFalse();
+		assertThat(TestUtils.getPropertyValue(this.pollableWithEP, "defaultDeliveryMode")).isNull();
+		assertThat(TestUtils.getPropertyValue(this.pollableWithEP, "headersMappedLast", Boolean.class)).isTrue();
 	}
 
 	private void checkExtract(AbstractAmqpChannel channel) {
-		assertThat(TestUtils.getPropertyValue(channel, "outboundHeaderMapper").toString(),
-				containsString("Mock for AmqpHeaderMapper"));
-		assertThat(TestUtils.getPropertyValue(channel, "inboundHeaderMapper").toString(),
-				containsString("Mock for AmqpHeaderMapper"));
-		assertTrue(TestUtils.getPropertyValue(channel, "extractPayload", Boolean.class));
+		assertThat(TestUtils.getPropertyValue(channel, "outboundHeaderMapper").toString())
+				.contains("Mock for AmqpHeaderMapper");
+		assertThat(TestUtils.getPropertyValue(channel, "inboundHeaderMapper").toString())
+				.contains("Mock for AmqpHeaderMapper");
+		assertThat(TestUtils.getPropertyValue(channel, "extractPayload", Boolean.class)).isTrue();
 	}
 
 	private static class TestInterceptor implements ChannelInterceptor {

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests.java
@@ -16,13 +16,7 @@
 
 package org.springframework.integration.amqp.config;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,33 +60,36 @@ public class AmqpInboundChannelAdapterParserTests {
 	public void verifyIdAsChannel() {
 		Object channel = context.getBean("rabbitInbound");
 		Object adapter = context.getBean("rabbitInbound.adapter");
-		assertEquals(DirectChannel.class, channel.getClass());
-		assertEquals(AmqpInboundChannelAdapter.class, adapter.getClass());
-		assertEquals(Boolean.TRUE, TestUtils.getPropertyValue(adapter, "autoStartup"));
-		assertEquals(Integer.MAX_VALUE / 2, TestUtils.getPropertyValue(adapter, "phase"));
-		assertTrue(TestUtils.getPropertyValue(adapter, "messageListenerContainer.missingQueuesFatal", Boolean.class));
-		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer"),
-				instanceOf(SimpleMessageListenerContainer.class));
+		assertThat(channel.getClass()).isEqualTo(DirectChannel.class);
+		assertThat(adapter.getClass()).isEqualTo(AmqpInboundChannelAdapter.class);
+		assertThat(TestUtils.getPropertyValue(adapter, "autoStartup")).isEqualTo(Boolean.TRUE);
+		assertThat(TestUtils.getPropertyValue(adapter, "phase")).isEqualTo(Integer.MAX_VALUE / 2);
+		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer.missingQueuesFatal", Boolean.class))
+				.isTrue();
+		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer"))
+				.isInstanceOf(SimpleMessageListenerContainer.class);
 	}
 
 	@Test
 	public void verifyDMCC() {
 		Object adapter = context.getBean("dmlc.adapter");
-		assertEquals(AmqpInboundChannelAdapter.class, adapter.getClass());
-		assertFalse(TestUtils.getPropertyValue(adapter, "messageListenerContainer.missingQueuesFatal", Boolean.class));
-		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer"),
-				instanceOf(DirectMessageListenerContainer.class));
-		assertEquals(2, TestUtils.getPropertyValue(adapter, "messageListenerContainer.consumersPerQueue"));
+		assertThat(adapter.getClass()).isEqualTo(AmqpInboundChannelAdapter.class);
+		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer.missingQueuesFatal", Boolean.class))
+				.isFalse();
+		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer"))
+				.isInstanceOf(DirectMessageListenerContainer.class);
+		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer.consumersPerQueue")).isEqualTo(2);
 	}
 
 	@Test
 	public void verifyLifeCycle() {
 		Object adapter = context.getBean("autoStartFalse.adapter");
-		assertEquals(Boolean.FALSE, TestUtils.getPropertyValue(adapter, "autoStartup"));
-		assertEquals(123, TestUtils.getPropertyValue(adapter, "phase"));
-		assertEquals(AcknowledgeMode.NONE,
-				TestUtils.getPropertyValue(adapter, "messageListenerContainer.acknowledgeMode"));
-		assertFalse(TestUtils.getPropertyValue(adapter, "messageListenerContainer.missingQueuesFatal", Boolean.class));
+		assertThat(TestUtils.getPropertyValue(adapter, "autoStartup")).isEqualTo(Boolean.FALSE);
+		assertThat(TestUtils.getPropertyValue(adapter, "phase")).isEqualTo(123);
+		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer.acknowledgeMode"))
+				.isEqualTo(AcknowledgeMode.NONE);
+		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer.missingQueuesFatal", Boolean.class))
+				.isFalse();
 	}
 
 	@Test
@@ -116,12 +113,12 @@ public class AmqpInboundChannelAdapterParserTests {
 		listener.onMessage(amqpMessage, null);
 		QueueChannel requestChannel = context.getBean("requestChannel", QueueChannel.class);
 		org.springframework.messaging.Message<?> siMessage = requestChannel.receive(0);
-		assertEquals("foo", siMessage.getHeaders().get("foo"));
-		assertNull(siMessage.getHeaders().get("bar"));
-		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_ENCODING));
-		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CLUSTER_ID));
-		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.APP_ID));
-		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE));
+		assertThat(siMessage.getHeaders().get("foo")).isEqualTo("foo");
+		assertThat(siMessage.getHeaders().get("bar")).isNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.CONTENT_ENCODING)).isNotNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.CLUSTER_ID)).isNotNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.APP_ID)).isNotNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE)).isNotNull();
 	}
 
 	@Test
@@ -145,12 +142,12 @@ public class AmqpInboundChannelAdapterParserTests {
 		listener.onMessage(amqpMessage, null);
 		QueueChannel requestChannel = context.getBean("requestChannel", QueueChannel.class);
 		org.springframework.messaging.Message<?> siMessage = requestChannel.receive(0);
-		assertEquals("foo", siMessage.getHeaders().get("foo"));
-		assertNull(siMessage.getHeaders().get("bar"));
-		assertNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_ENCODING));
-		assertNull(siMessage.getHeaders().get(AmqpHeaders.CLUSTER_ID));
-		assertNull(siMessage.getHeaders().get(AmqpHeaders.APP_ID));
-		assertNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE));
+		assertThat(siMessage.getHeaders().get("foo")).isEqualTo("foo");
+		assertThat(siMessage.getHeaders().get("bar")).isNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.CONTENT_ENCODING)).isNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.CLUSTER_ID)).isNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.APP_ID)).isNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE)).isNull();
 	}
 
 	@Test
@@ -175,12 +172,12 @@ public class AmqpInboundChannelAdapterParserTests {
 
 		QueueChannel requestChannel = context.getBean("requestChannel", QueueChannel.class);
 		org.springframework.messaging.Message<?> siMessage = requestChannel.receive(0);
-		assertNull(siMessage.getHeaders().get("foo"));
-		assertNull(siMessage.getHeaders().get("bar"));
-		assertNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_ENCODING));
-		assertNull(siMessage.getHeaders().get(AmqpHeaders.CLUSTER_ID));
-		assertNull(siMessage.getHeaders().get(AmqpHeaders.APP_ID));
-		assertNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE));
+		assertThat(siMessage.getHeaders().get("foo")).isNull();
+		assertThat(siMessage.getHeaders().get("bar")).isNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.CONTENT_ENCODING)).isNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.CLUSTER_ID)).isNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.APP_ID)).isNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE)).isNull();
 	}
 
 	@Test
@@ -204,12 +201,12 @@ public class AmqpInboundChannelAdapterParserTests {
 		listener.onMessage(amqpMessage, null);
 		QueueChannel requestChannel = context.getBean("requestChannel", QueueChannel.class);
 		org.springframework.messaging.Message<?> siMessage = requestChannel.receive(0);
-		assertNotNull(siMessage.getHeaders().get("bar"));
-		assertNotNull(siMessage.getHeaders().get("foo"));
-		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_ENCODING));
-		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CLUSTER_ID));
-		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.APP_ID));
-		assertNotNull(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE));
+		assertThat(siMessage.getHeaders().get("bar")).isNotNull();
+		assertThat(siMessage.getHeaders().get("foo")).isNotNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.CONTENT_ENCODING)).isNotNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.CLUSTER_ID)).isNotNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.APP_ID)).isNotNull();
+		assertThat(siMessage.getHeaders().get(AmqpHeaders.CONTENT_TYPE)).isNotNull();
 	}
 
 	@Test
@@ -219,8 +216,8 @@ public class AmqpInboundChannelAdapterParserTests {
 					this.getClass()).close();
 		}
 		catch (BeanDefinitionParsingException e) {
-			assertTrue(e.getMessage().startsWith("Configuration problem: The 'header-mapper' attribute " +
-					"is mutually exclusive with 'mapped-request-headers' or 'mapped-reply-headers'"));
+			assertThat(e.getMessage().startsWith("Configuration problem: The 'header-mapper' attribute " +
+					"is mutually exclusive with 'mapped-request-headers' or 'mapped-reply-headers'")).isTrue();
 		}
 	}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests.java
@@ -16,10 +16,7 @@
 
 package org.springframework.integration.amqp.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.isNull;
 
 import java.lang.reflect.Field;
@@ -72,28 +69,31 @@ public class AmqpInboundGatewayParserTests {
 		MessageConverter gatewayConverter = TestUtils.getPropertyValue(gateway, "amqpMessageConverter", MessageConverter.class);
 		MessageConverter templateConverter = TestUtils.getPropertyValue(gateway, "amqpTemplate.messageConverter", MessageConverter.class);
 		TestConverter testConverter = context.getBean("testConverter", TestConverter.class);
-		assertSame(testConverter, gatewayConverter);
-		assertSame(testConverter, templateConverter);
-		assertEquals(Boolean.TRUE, TestUtils.getPropertyValue(gateway, "autoStartup"));
-		assertEquals(0, TestUtils.getPropertyValue(gateway, "phase"));
-		assertEquals(Long.valueOf(1234L), TestUtils.getPropertyValue(gateway, "replyTimeout", Long.class));
-		assertEquals(Long.valueOf(1234L), TestUtils.getPropertyValue(gateway, "messagingTemplate.receiveTimeout", Long.class));
-		assertTrue(TestUtils.getPropertyValue(gateway, "messageListenerContainer.missingQueuesFatal", Boolean.class));
+		assertThat(gatewayConverter).isSameAs(testConverter);
+		assertThat(templateConverter).isSameAs(testConverter);
+		assertThat(TestUtils.getPropertyValue(gateway, "autoStartup")).isEqualTo(Boolean.TRUE);
+		assertThat(TestUtils.getPropertyValue(gateway, "phase")).isEqualTo(0);
+		assertThat(TestUtils.getPropertyValue(gateway, "replyTimeout", Long.class)).isEqualTo(Long.valueOf(1234L));
+		assertThat(TestUtils.getPropertyValue(gateway, "messagingTemplate.receiveTimeout", Long.class))
+				.isEqualTo(Long.valueOf(1234L));
+		assertThat(TestUtils.getPropertyValue(gateway, "messageListenerContainer.missingQueuesFatal", Boolean.class))
+				.isTrue();
 	}
 
 	@Test
 	public void verifyLifeCycle() {
 		Object gateway = context.getBean("autoStartFalseGateway");
-		assertEquals(Boolean.FALSE, TestUtils.getPropertyValue(gateway, "autoStartup"));
-		assertEquals(123, TestUtils.getPropertyValue(gateway, "phase"));
-		assertFalse(TestUtils.getPropertyValue(gateway, "messageListenerContainer.missingQueuesFatal", Boolean.class));
+		assertThat(TestUtils.getPropertyValue(gateway, "autoStartup")).isEqualTo(Boolean.FALSE);
+		assertThat(TestUtils.getPropertyValue(gateway, "phase")).isEqualTo(123);
+		assertThat(TestUtils.getPropertyValue(gateway, "messageListenerContainer.missingQueuesFatal", Boolean.class))
+				.isFalse();
 		Object amqpTemplate = context.getBean("amqpTemplate");
-		assertSame(amqpTemplate, TestUtils.getPropertyValue(gateway, "amqpTemplate"));
+		assertThat(TestUtils.getPropertyValue(gateway, "amqpTemplate")).isSameAs(amqpTemplate);
 		Address defaultReplyTo = TestUtils.getPropertyValue(gateway, "defaultReplyTo", Address.class);
 		Address expected = new Address("fooExchange/barRoutingKey");
-		assertEquals(expected.getExchangeName(), defaultReplyTo.getExchangeName());
-		assertEquals(expected.getRoutingKey(), defaultReplyTo.getRoutingKey());
-		assertEquals(expected, defaultReplyTo);
+		assertThat(defaultReplyTo.getExchangeName()).isEqualTo(expected.getExchangeName());
+		assertThat(defaultReplyTo.getRoutingKey()).isEqualTo(expected.getRoutingKey());
+		assertThat(defaultReplyTo).isEqualTo(expected);
 	}
 
 	@Test
@@ -117,7 +117,7 @@ public class AmqpInboundGatewayParserTests {
 			Object[] args = invocation.getArguments();
 			Message amqpReplyMessage = (Message) args[2];
 			MessageProperties properties = amqpReplyMessage.getMessageProperties();
-			assertEquals("bar", properties.getHeaders().get("bar"));
+			assertThat(properties.getHeaders().get("bar")).isEqualTo("bar");
 			return null;
 		}).when(amqpTemplate).send(Mockito.any(String.class), Mockito.any(String.class),
 				Mockito.any(Message.class), isNull());
@@ -150,8 +150,8 @@ public class AmqpInboundGatewayParserTests {
 					this.getClass()).close();
 		}
 		catch (BeanDefinitionParsingException e) {
-			assertTrue(e.getMessage().startsWith("Configuration problem: The 'header-mapper' attribute " +
-					"is mutually exclusive with 'mapped-request-headers' or 'mapped-reply-headers'"));
+			assertThat(e.getMessage().startsWith("Configuration problem: The 'header-mapper' attribute " +
+					"is mutually exclusive with 'mapped-request-headers' or 'mapped-reply-headers'")).isTrue();
 		}
 	}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
@@ -16,13 +16,8 @@
 
 package org.springframework.integration.amqp.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -107,14 +102,14 @@ public class AmqpOutboundChannelAdapterParserTests {
 	public void verifyIdAsChannel() {
 		Object channel = context.getBean("rabbitOutbound");
 		Object adapter = context.getBean("rabbitOutbound.adapter");
-		assertEquals(DirectChannel.class, channel.getClass());
-		assertEquals(EventDrivenConsumer.class, adapter.getClass());
+		assertThat(channel.getClass()).isEqualTo(DirectChannel.class);
+		assertThat(adapter.getClass()).isEqualTo(EventDrivenConsumer.class);
 		MessageHandler handler = TestUtils.getPropertyValue(adapter, "handler", MessageHandler.class);
-		assertTrue(handler instanceof NamedComponent);
-		assertEquals("amqp:outbound-channel-adapter", ((NamedComponent) handler).getComponentType());
+		assertThat(handler instanceof NamedComponent).isTrue();
+		assertThat(((NamedComponent) handler).getComponentType()).isEqualTo("amqp:outbound-channel-adapter");
 		handler.handleMessage(new GenericMessage<String>("foo"));
-		assertEquals(1, adviceCalled);
-		assertTrue(TestUtils.getPropertyValue(handler, "lazyConnect", Boolean.class));
+		assertThat(adviceCalled).isEqualTo(1);
+		assertThat(TestUtils.getPropertyValue(handler, "lazyConnect", Boolean.class)).isTrue();
 	}
 
 	@Test
@@ -123,12 +118,12 @@ public class AmqpOutboundChannelAdapterParserTests {
 
 		AmqpOutboundEndpoint endpoint = TestUtils.getPropertyValue(eventDrivenConsumer, "handler",
 				AmqpOutboundEndpoint.class);
-		assertNotNull(TestUtils.getPropertyValue(endpoint, "defaultDeliveryMode"));
-		assertFalse(TestUtils.getPropertyValue(endpoint, "lazyConnect", Boolean.class));
-		assertEquals("42",
-				TestUtils.getPropertyValue(endpoint, "delayExpression", org.springframework.expression.Expression.class)
-						.getExpressionString());
-		assertFalse(TestUtils.getPropertyValue(endpoint, "headersMappedLast", Boolean.class));
+		assertThat(TestUtils.getPropertyValue(endpoint, "defaultDeliveryMode")).isNotNull();
+		assertThat(TestUtils.getPropertyValue(endpoint, "lazyConnect", Boolean.class)).isFalse();
+		assertThat(TestUtils
+				.getPropertyValue(endpoint, "delayExpression", org.springframework.expression.Expression.class)
+				.getExpressionString()).isEqualTo("42");
+		assertThat(TestUtils.getPropertyValue(endpoint, "headersMappedLast", Boolean.class)).isFalse();
 
 		Field amqpTemplateField = ReflectionUtils.findField(AmqpOutboundEndpoint.class, "amqpTemplate");
 		amqpTemplateField.setAccessible(true);
@@ -140,11 +135,12 @@ public class AmqpOutboundChannelAdapterParserTests {
 			Object[] args = invocation.getArguments();
 			org.springframework.amqp.core.Message amqpMessage = (org.springframework.amqp.core.Message) args[2];
 			MessageProperties properties = amqpMessage.getMessageProperties();
-			assertEquals("foo", properties.getHeaders().get("foo"));
-			assertEquals("foobar", properties.getHeaders().get("foobar"));
-			assertNull(properties.getHeaders().get("bar"));
-			assertEquals(shouldBePersistent.get() ? MessageDeliveryMode.PERSISTENT
-					: MessageDeliveryMode.NON_PERSISTENT, properties.getDeliveryMode());
+			assertThat(properties.getHeaders().get("foo")).isEqualTo("foo");
+			assertThat(properties.getHeaders().get("foobar")).isEqualTo("foobar");
+			assertThat(properties.getHeaders().get("bar")).isNull();
+			assertThat(properties.getDeliveryMode()).isEqualTo(shouldBePersistent.get() ?
+					MessageDeliveryMode.PERSISTENT
+					: MessageDeliveryMode.NON_PERSISTENT);
 			return null;
 		})
 				.when(amqpTemplate).send(Mockito.any(String.class), Mockito.any(String.class),
@@ -178,9 +174,9 @@ public class AmqpOutboundChannelAdapterParserTests {
 				AmqpOutboundEndpoint.class);
 		NullChannel nullChannel = context.getBean(NullChannel.class);
 		MessageChannel ackChannel = context.getBean("ackChannel", MessageChannel.class);
-		assertSame(ackChannel, TestUtils.getPropertyValue(endpoint, "confirmAckChannel"));
-		assertSame(nullChannel, TestUtils.getPropertyValue(endpoint, "confirmNackChannel"));
-		assertSame(context.getBean("ems"), TestUtils.getPropertyValue(endpoint, "errorMessageStrategy"));
+		assertThat(TestUtils.getPropertyValue(endpoint, "confirmAckChannel")).isSameAs(ackChannel);
+		assertThat(TestUtils.getPropertyValue(endpoint, "confirmNackChannel")).isSameAs(nullChannel);
+		assertThat(TestUtils.getPropertyValue(endpoint, "errorMessageStrategy")).isSameAs(context.getBean("ems"));
 	}
 
 	@SuppressWarnings("rawtypes")
@@ -191,7 +187,7 @@ public class AmqpOutboundChannelAdapterParserTests {
 		List chainHandlers = TestUtils.getPropertyValue(eventDrivenConsumer, "handler.handlers", List.class);
 
 		AmqpOutboundEndpoint endpoint = (AmqpOutboundEndpoint) chainHandlers.get(0);
-		assertNull(TestUtils.getPropertyValue(endpoint, "defaultDeliveryMode"));
+		assertThat(TestUtils.getPropertyValue(endpoint, "defaultDeliveryMode")).isNull();
 
 		Field amqpTemplateField = ReflectionUtils.findField(AmqpOutboundEndpoint.class, "amqpTemplate");
 		amqpTemplateField.setAccessible(true);
@@ -202,8 +198,8 @@ public class AmqpOutboundChannelAdapterParserTests {
 			Object[] args = invocation.getArguments();
 			org.springframework.amqp.core.Message amqpMessage = (org.springframework.amqp.core.Message) args[2];
 			MessageProperties properties = amqpMessage.getMessageProperties();
-			assertEquals("hello", new String(amqpMessage.getBody()));
-			assertEquals(MessageDeliveryMode.PERSISTENT, properties.getDeliveryMode());
+			assertThat(new String(amqpMessage.getBody())).isEqualTo("hello");
+			assertThat(properties.getDeliveryMode()).isEqualTo(MessageDeliveryMode.PERSISTENT);
 			return null;
 		})
 				.when(amqpTemplate).send(Mockito.any(String.class), Mockito.any(String.class),
@@ -226,9 +222,9 @@ public class AmqpOutboundChannelAdapterParserTests {
 			fail("Expected BeanDefinitionParsingException");
 		}
 		catch (BeansException e) {
-			assertTrue(e instanceof BeanDefinitionParsingException);
-			assertTrue(e.getMessage().contains("The 'channel' attribute isn't allowed for " +
-					"'amqp:outbound-channel-adapter' when it is used as a nested element"));
+			assertThat(e instanceof BeanDefinitionParsingException).isTrue();
+			assertThat(e.getMessage().contains("The 'channel' attribute isn't allowed for " +
+					"'amqp:outbound-channel-adapter' when it is used as a nested element")).isTrue();
 		}
 	}
 
@@ -292,8 +288,8 @@ public class AmqpOutboundChannelAdapterParserTests {
 					this.getClass()).close();
 		}
 		catch (BeanDefinitionParsingException e) {
-			assertTrue(e.getMessage().startsWith("Configuration problem: The 'header-mapper' attribute " +
-					"is mutually exclusive with 'mapped-request-headers' or 'mapped-reply-headers'"));
+			assertThat(e.getMessage().startsWith("Configuration problem: The 'header-mapper' attribute " +
+					"is mutually exclusive with 'mapped-request-headers' or 'mapped-reply-headers'")).isTrue();
 		}
 	}
 
@@ -301,9 +297,9 @@ public class AmqpOutboundChannelAdapterParserTests {
 	public void testInt2971AmqpOutboundChannelAdapterWithCustomHeaderMapper() {
 		AmqpHeaderMapper headerMapper = TestUtils.getPropertyValue(this.amqpMessageHandlerWithCustomHeaderMapper,
 				"headerMapper", AmqpHeaderMapper.class);
-		assertSame(this.context.getBean("customHeaderMapper"), headerMapper);
-		assertTrue(TestUtils.getPropertyValue(this.amqpMessageHandlerWithCustomHeaderMapper,
-				"headersMappedLast", Boolean.class));
+		assertThat(headerMapper).isSameAs(this.context.getBean("customHeaderMapper"));
+		assertThat(TestUtils.getPropertyValue(this.amqpMessageHandlerWithCustomHeaderMapper,
+				"headersMappedLast", Boolean.class)).isTrue();
 	}
 
 	@Test

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/OutboundGatewayIntegrationTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/OutboundGatewayIntegrationTests.java
@@ -16,8 +16,7 @@
 
 package org.springframework.integration.amqp.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -58,8 +57,8 @@ public class OutboundGatewayIntegrationTests {
 		String payload = "foo";
 		this.toRabbit.send(new GenericMessage<String>(payload));
 		Message<?> receive = this.fromRabbit.receive(10000);
-		assertNotNull(receive);
-		assertEquals(payload.toUpperCase(), receive.getPayload());
+		assertThat(receive).isNotNull();
+		assertThat(receive.getPayload()).isEqualTo(payload.toUpperCase());
 	}
 
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/OutboundGatewayTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/OutboundGatewayTests.java
@@ -16,9 +16,7 @@
 
 package org.springframework.integration.amqp.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -67,16 +65,16 @@ public class OutboundGatewayTests {
 
 	@Test
 	public void testVanillaConfiguration() throws Exception {
-		assertTrue(context.getBeanFactory().containsBeanDefinition("vanilla"));
+		assertThat(context.getBeanFactory().containsBeanDefinition("vanilla")).isTrue();
 		context.getBean("vanilla");
 	}
 
 	@Test
 	public void testExpressionBasedConfiguration() throws Exception {
-		assertTrue(context.getBeanFactory().containsBeanDefinition("expression"));
+		assertThat(context.getBeanFactory().containsBeanDefinition("expression")).isTrue();
 		Object target = context.getBean("expression");
-		assertNotNull(ReflectionTestUtils.getField(ReflectionTestUtils.getField(target, "handler"),
-				"routingKeyGenerator"));
+		assertThat(ReflectionTestUtils.getField(ReflectionTestUtils.getField(target, "handler"),
+				"routingKeyGenerator")).isNotNull();
 	}
 
 	@Test
@@ -103,12 +101,12 @@ public class OutboundGatewayTests {
 		endpoint.setBeanFactory(context);
 		endpoint.afterPropertiesSet();
 		Message<?> message = new GenericMessage<String>("Hello, world!");
-		assertEquals("foobar", TestUtils.getPropertyValue(endpoint, "routingKeyGenerator", MessageProcessor.class)
-				.processMessage(message));
-		assertEquals("barbar", TestUtils.getPropertyValue(endpoint, "exchangeNameGenerator", MessageProcessor.class)
-				.processMessage(message));
-		assertEquals("bazbar", TestUtils.getPropertyValue(endpoint, "correlationDataGenerator", MessageProcessor.class)
-				.processMessage(message));
+		assertThat(TestUtils.getPropertyValue(endpoint, "routingKeyGenerator", MessageProcessor.class)
+				.processMessage(message)).isEqualTo("foobar");
+		assertThat(TestUtils.getPropertyValue(endpoint, "exchangeNameGenerator", MessageProcessor.class)
+				.processMessage(message)).isEqualTo("barbar");
+		assertThat(TestUtils.getPropertyValue(endpoint, "correlationDataGenerator", MessageProcessor.class)
+				.processMessage(message)).isEqualTo("bazbar");
 	}
 
 }

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/dsl/AmqpTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/dsl/AmqpTests.java
@@ -16,13 +16,7 @@
 
 package org.springframework.integration.amqp.dsl;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -112,11 +106,11 @@ public class AmqpTests {
 
 	@Test
 	public void testAmqpInboundGatewayFlow() {
-		assertNotNull(this.amqpInboundGatewayContainer);
-		assertSame(this.amqpTemplate, TestUtils.getPropertyValue(this.amqpInboundGateway, "amqpTemplate"));
+		assertThat(this.amqpInboundGatewayContainer).isNotNull();
+		assertThat(TestUtils.getPropertyValue(this.amqpInboundGateway, "amqpTemplate")).isSameAs(this.amqpTemplate);
 
 		Object result = this.amqpTemplate.convertSendAndReceive(this.amqpQueue.getName(), "world");
-		assertEquals("HELLO WORLD", result);
+		assertThat(result).isEqualTo("HELLO WORLD");
 
 		this.amqpInboundGateway.stop();
 		//INTEXT-209
@@ -125,7 +119,7 @@ public class AmqpTests {
 		this.amqpTemplate.convertAndSend(this.amqpQueue.getName(), "world");
 		((RabbitTemplate) this.amqpTemplate).setReceiveTimeout(10000);
 		result = this.amqpTemplate.receiveAndConvert("defaultReplyTo");
-		assertEquals("HELLO WORLD", result);
+		assertThat(result).isEqualTo("HELLO WORLD");
 	}
 
 	@Autowired
@@ -153,8 +147,8 @@ public class AmqpTests {
 		}
 		while (i < 10);
 
-		assertNotNull(receive);
-		assertEquals("HELLO THROUGH THE AMQP", receive.getPayload());
+		assertThat(receive).isNotNull();
+		assertThat(receive.getPayload()).isEqualTo("HELLO THROUGH THE AMQP");
 
 		((Lifecycle) this.amqpOutboundInput).stop();
 	}
@@ -165,8 +159,8 @@ public class AmqpTests {
 				this.rabbitConnectionFactory)
 				.autoStartup(false)
 				.templateChannelTransacted(true));
-		assertTrue(TestUtils.getPropertyValue(flow, "currentMessageChannel.amqpTemplate.transactional",
-				Boolean.class));
+		assertThat(TestUtils.getPropertyValue(flow, "currentMessageChannel.amqpTemplate.transactional",
+				Boolean.class)).isTrue();
 	}
 
 	@Autowired
@@ -181,8 +175,8 @@ public class AmqpTests {
 				.build());
 
 		Message<?> receive = replyChannel.receive(10000);
-		assertNotNull(receive);
-		assertEquals("HELLO ASYNC GATEWAY", receive.getPayload());
+		assertThat(receive).isNotNull();
+		assertThat(receive.getPayload()).isEqualTo("HELLO ASYNC GATEWAY");
 
 		this.asyncOutboundGateway.stop();
 	}
@@ -197,19 +191,19 @@ public class AmqpTests {
 	@Test
 	public void testInboundMessagingExceptionFlow() {
 		this.amqpTemplate.convertAndSend("si.dsl.exception.test", "foo");
-		assertNotNull(this.amqpTemplate.receive("si.dsl.exception.test.dlq", 30_000));
-		assertNull(this.lefe.get());
-		assertNotNull(this.raw.get());
+		assertThat(this.amqpTemplate.receive("si.dsl.exception.test.dlq", 30_000)).isNotNull();
+		assertThat(this.lefe.get()).isNull();
+		assertThat(this.raw.get()).isNotNull();
 		this.raw.set(null);
 	}
 
 	@Test
 	public void testInboundConversionExceptionFlow() {
 		this.amqpTemplate.convertAndSend("si.dsl.conv.exception.test", "foo");
-		assertNotNull(this.amqpTemplate.receive("si.dsl.conv.exception.test.dlq", 30_000));
-		assertNotNull(this.lefe.get());
-		assertThat(this.lefe.get().getCause(), instanceOf(MessageConversionException.class));
-		assertNotNull(this.raw.get());
+		assertThat(this.amqpTemplate.receive("si.dsl.conv.exception.test.dlq", 30_000)).isNotNull();
+		assertThat(this.lefe.get()).isNotNull();
+		assertThat(this.lefe.get().getCause()).isInstanceOf(MessageConversionException.class);
+		assertThat(this.raw.get()).isNotNull();
 		this.raw.set(null);
 		this.lefe.set(null);
 	}
@@ -225,11 +219,11 @@ public class AmqpTests {
 
 	@Test
 	public void unitTestChannel() {
-		assertEquals(MessageDeliveryMode.NON_PERSISTENT,
-				TestUtils.getPropertyValue(this.unitChannel, "defaultDeliveryMode"));
-		assertSame(this.mapperIn, TestUtils.getPropertyValue(this.unitChannel, "inboundHeaderMapper"));
-		assertSame(this.mapperOut, TestUtils.getPropertyValue(this.unitChannel, "outboundHeaderMapper"));
-		assertTrue(TestUtils.getPropertyValue(this.unitChannel, "extractPayload", Boolean.class));
+		assertThat(TestUtils.getPropertyValue(this.unitChannel, "defaultDeliveryMode"))
+				.isEqualTo(MessageDeliveryMode.NON_PERSISTENT);
+		assertThat(TestUtils.getPropertyValue(this.unitChannel, "inboundHeaderMapper")).isSameAs(this.mapperIn);
+		assertThat(TestUtils.getPropertyValue(this.unitChannel, "outboundHeaderMapper")).isSameAs(this.mapperOut);
+		assertThat(TestUtils.getPropertyValue(this.unitChannel, "extractPayload", Boolean.class)).isTrue();
 	}
 
 	@Configuration

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpMessageSourceIntegrationTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpMessageSourceIntegrationTests.java
@@ -16,11 +16,7 @@
 
 package org.springframework.integration.amqp.inbound;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -126,16 +122,16 @@ public class AmqpMessageSourceIntegrationTests {
 		template.convertAndSend(DSL_QUEUE, "bar");
 		template.convertAndSend(INTERCEPT_QUEUE, "baz");
 		template.convertAndSend(NOAUTOACK_QUEUE, "qux");
-		assertTrue(this.config.latch.await(10, TimeUnit.SECONDS));
-		assertThat(this.config.received, equalTo("foo"));
+		assertThat(this.config.latch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.received).isEqualTo("foo");
 		Message dead = template.receive(DLQ, 10_000);
-		assertNotNull(dead);
-		assertThat(this.config.fromDsl, equalTo("bar"));
-		assertThat(this.config.fromInterceptedSource, equalTo("BAZ"));
-		assertNull(template.receive(NOAUTOACK_QUEUE));
-		assertThat(this.config.requeueLatch.getCount(), equalTo(1L));
+		assertThat(dead).isNotNull();
+		assertThat(this.config.fromDsl).isEqualTo("bar");
+		assertThat(this.config.fromInterceptedSource).isEqualTo("BAZ");
+		assertThat(template.receive(NOAUTOACK_QUEUE)).isNull();
+		assertThat(this.config.requeueLatch.getCount()).isEqualTo(1L);
 		this.config.callback.acknowledge(Status.REQUEUE);
-		assertTrue(this.config.requeueLatch.await(10, TimeUnit.SECONDS));
+		assertThat(this.config.requeueLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Configuration

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpMessageSourceTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpMessageSourceTests.java
@@ -16,9 +16,7 @@
 
 package org.springframework.integration.amqp.inbound;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.willReturn;
@@ -72,9 +70,9 @@ public class AmqpMessageSourceTests {
 		AmqpMessageSource source = new AmqpMessageSource(ccf, "foo");
 		source.setRawMessageHeader(true);
 		Message<?> received = source.receive();
-		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE),
-				instanceOf(org.springframework.amqp.core.Message.class));
-		assertThat(received.getHeaders().get(AmqpHeaders.CONSUMER_QUEUE), equalTo("foo"));
+		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE))
+				.isInstanceOf(org.springframework.amqp.core.Message.class);
+		assertThat(received.getHeaders().get(AmqpHeaders.CONSUMER_QUEUE)).isEqualTo("foo");
 		// make sure channel is not cached
 		org.springframework.amqp.rabbit.connection.Connection conn = ccf.createConnection();
 		Channel notCached = conn.createChannel(false); // should not have been "closed"

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
@@ -17,18 +17,6 @@
 package org.springframework.integration.amqp.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -125,10 +113,10 @@ public class InboundEndpointTests {
 		listener.onMessage(amqpMessage, rabbitChannel);
 
 		Message<?> result = channel.receive(1000);
-		assertEquals(payload, result.getPayload());
+		assertThat(result.getPayload()).isEqualTo(payload);
 
-		assertSame(rabbitChannel, result.getHeaders().get(AmqpHeaders.CHANNEL));
-		assertEquals(123L, result.getHeaders().get(AmqpHeaders.DELIVERY_TAG));
+		assertThat(result.getHeaders().get(AmqpHeaders.CHANNEL)).isSameAs(rabbitChannel);
+		assertThat(result.getHeaders().get(AmqpHeaders.DELIVERY_TAG)).isEqualTo(123L);
 	}
 
 	@Test
@@ -161,7 +149,7 @@ public class InboundEndpointTests {
 
 		Message<?> result = new JsonToObjectTransformer().transform(receive);
 
-		assertEquals(payload, result.getPayload());
+		assertThat(result.getPayload()).isEqualTo(payload);
 	}
 
 	@Test
@@ -179,8 +167,8 @@ public class InboundEndpointTests {
 		final Channel rabbitChannel = mock(Channel.class);
 
 		channel.subscribe(new MessageTransformingHandler(message -> {
-			assertSame(rabbitChannel, message.getHeaders().get(AmqpHeaders.CHANNEL));
-			assertEquals(123L, message.getHeaders().get(AmqpHeaders.DELIVERY_TAG));
+			assertThat(message.getHeaders().get(AmqpHeaders.CHANNEL)).isSameAs(rabbitChannel);
+			assertThat(message.getHeaders().get(AmqpHeaders.DELIVERY_TAG)).isEqualTo(123L);
 			return MessageBuilder.fromMessage(message)
 					.setHeader(JsonHeaders.TYPE_ID, "foo")
 					.setHeader(JsonHeaders.CONTENT_TYPE_ID, "bar")
@@ -197,13 +185,13 @@ public class InboundEndpointTests {
 			org.springframework.amqp.core.Message message =
 					invocation.getArgument(2);
 			Map<String, Object> headers = message.getMessageProperties().getHeaders();
-			assertTrue(headers.containsKey(JsonHeaders.TYPE_ID.replaceFirst(JsonHeaders.PREFIX, "")));
-			assertNotEquals("foo", headers.get(JsonHeaders.TYPE_ID.replaceFirst(JsonHeaders.PREFIX, "")));
-			assertFalse(headers.containsKey(JsonHeaders.CONTENT_TYPE_ID.replaceFirst(JsonHeaders.PREFIX, "")));
-			assertFalse(headers.containsKey(JsonHeaders.KEY_TYPE_ID.replaceFirst(JsonHeaders.PREFIX, "")));
-			assertFalse(headers.containsKey(JsonHeaders.TYPE_ID));
-			assertFalse(headers.containsKey(JsonHeaders.KEY_TYPE_ID));
-			assertFalse(headers.containsKey(JsonHeaders.CONTENT_TYPE_ID));
+			assertThat(headers.containsKey(JsonHeaders.TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isTrue();
+			assertThat(headers.get(JsonHeaders.TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isNotEqualTo("foo");
+			assertThat(headers.containsKey(JsonHeaders.CONTENT_TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isFalse();
+			assertThat(headers.containsKey(JsonHeaders.KEY_TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isFalse();
+			assertThat(headers.containsKey(JsonHeaders.TYPE_ID)).isFalse();
+			assertThat(headers.containsKey(JsonHeaders.KEY_TYPE_ID)).isFalse();
+			assertThat(headers.containsKey(JsonHeaders.CONTENT_TYPE_ID)).isFalse();
 			sendLatch.countDown();
 			return null;
 		}).when(rabbitTemplate)
@@ -227,7 +215,7 @@ public class InboundEndpointTests {
 		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
 		listener.onMessage(amqpMessage, rabbitChannel);
 
-		assertTrue(sendLatch.await(10, TimeUnit.SECONDS));
+		assertThat(sendLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -349,15 +337,15 @@ public class InboundEndpointTests {
 		listener.onMessage(org.springframework.amqp.core.MessageBuilder.withBody("foo".getBytes())
 				.andProperties(new MessageProperties()).build(), null);
 		Message<?> errorMessage = errors.receive(0);
-		assertNotNull(errorMessage);
-		assertThat(errorMessage.getPayload(), instanceOf(MessagingException.class));
+		assertThat(errorMessage).isNotNull();
+		assertThat(errorMessage.getPayload()).isInstanceOf(MessagingException.class);
 		MessagingException payload = (MessagingException) errorMessage.getPayload();
-		assertThat(payload.getMessage(), containsString("Dispatcher has no"));
-		assertThat(StaticMessageHeaderAccessor.getDeliveryAttempt(payload.getFailedMessage()).get(), equalTo(3));
+		assertThat(payload.getMessage()).contains("Dispatcher has no");
+		assertThat(StaticMessageHeaderAccessor.getDeliveryAttempt(payload.getFailedMessage()).get()).isEqualTo(3);
 		org.springframework.amqp.core.Message amqpMessage = errorMessage.getHeaders()
 			.get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE, org.springframework.amqp.core.Message.class);
-		assertThat(amqpMessage, notNullValue());
-		assertNull(errors.receive(0));
+		assertThat(amqpMessage).isNotNull();
+		assertThat(errors.receive(0)).isNull();
 	}
 
 	@Test
@@ -376,15 +364,15 @@ public class InboundEndpointTests {
 		listener.onMessage(org.springframework.amqp.core.MessageBuilder.withBody("foo".getBytes())
 				.andProperties(new MessageProperties()).build(), null);
 		Message<?> errorMessage = errors.receive(0);
-		assertNotNull(errorMessage);
-		assertThat(errorMessage.getPayload(), instanceOf(MessagingException.class));
+		assertThat(errorMessage).isNotNull();
+		assertThat(errorMessage.getPayload()).isInstanceOf(MessagingException.class);
 		MessagingException payload = (MessagingException) errorMessage.getPayload();
-		assertThat(payload.getMessage(), containsString("Dispatcher has no"));
-		assertThat(StaticMessageHeaderAccessor.getDeliveryAttempt(payload.getFailedMessage()).get(), equalTo(3));
+		assertThat(payload.getMessage()).contains("Dispatcher has no");
+		assertThat(StaticMessageHeaderAccessor.getDeliveryAttempt(payload.getFailedMessage()).get()).isEqualTo(3);
 		org.springframework.amqp.core.Message amqpMessage = errorMessage.getHeaders()
 			.get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE, org.springframework.amqp.core.Message.class);
-		assertThat(amqpMessage, notNullValue());
-		assertNull(errors.receive(0));
+		assertThat(amqpMessage).isNotNull();
+		assertThat(errors.receive(0)).isNull();
 	}
 
 	public static class Foo {

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/ManualAckTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/ManualAckTests.java
@@ -16,9 +16,7 @@
 
 package org.springframework.integration.amqp.inbound;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import org.junit.Rule;
@@ -89,16 +87,16 @@ public class ManualAckTests {
 		adapter.start();
 		this.template.convertAndSend("Hello, world");
 		Message<?> out = bar.receive(5000);
-		assertNotNull(out);
-		assertEquals(1, out.getPayload());
+		assertThat(out).isNotNull();
+		assertThat(out.getPayload()).isEqualTo(1);
 		out = bar.receive(5000);
-		assertNotNull(out);
-		assertEquals(2, out.getPayload());
+		assertThat(out).isNotNull();
+		assertThat(out.getPayload()).isEqualTo(2);
 		out = bar.receive(5000);
-		assertNotNull(out);
-		assertEquals(3, out.getPayload());
+		assertThat(out).isNotNull();
+		assertThat(out.getPayload()).isEqualTo(3);
 		out = bar.receive(1000);
-		assertNull(out);
+		assertThat(out).isNull();
 		adapter.stop();
 	}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests.java
@@ -16,11 +16,7 @@
 
 package org.springframework.integration.amqp.outbound;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -108,24 +104,24 @@ public class AmqpOutboundEndpointTests {
 				.build();
 		this.pcRequestChannel.send(message);
 		Message<?> ack = this.ackChannel.receive(10000);
-		assertNotNull(ack);
-		assertEquals("foo", ack.getPayload());
-		assertEquals(Boolean.TRUE, ack.getHeaders().get(AmqpHeaders.PUBLISH_CONFIRM));
+		assertThat(ack).isNotNull();
+		assertThat(ack.getPayload()).isEqualTo("foo");
+		assertThat(ack.getHeaders().get(AmqpHeaders.PUBLISH_CONFIRM)).isEqualTo(Boolean.TRUE);
 
 		org.springframework.amqp.core.Message received = this.amqpTemplateConfirms.receive(this.queue.getName());
-		assertEquals("\"hello\"", new String(received.getBody(), "UTF-8"));
-		assertEquals("application/json", received.getMessageProperties().getContentType());
-		assertEquals("java.lang.String", received.getMessageProperties().getHeaders()
-				.get(JsonHeaders.TYPE_ID.replaceFirst(JsonHeaders.PREFIX, "")));
+		assertThat(new String(received.getBody(), "UTF-8")).isEqualTo("\"hello\"");
+		assertThat(received.getMessageProperties().getContentType()).isEqualTo("application/json");
+		assertThat(received.getMessageProperties().getHeaders()
+				.get(JsonHeaders.TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isEqualTo("java.lang.String");
 
 		// test whole message is correlation
 		message = MessageBuilder.withPayload("hello")
 				.build();
 		this.pcMessageCorrelationRequestChannel.send(message);
 		ack = ackChannel.receive(10000);
-		assertNotNull(ack);
-		assertSame(message.getPayload(), ack.getPayload());
-		assertEquals(Boolean.TRUE, ack.getHeaders().get(AmqpHeaders.PUBLISH_CONFIRM));
+		assertThat(ack).isNotNull();
+		assertThat(ack.getPayload()).isSameAs(message.getPayload());
+		assertThat(ack.getHeaders().get(AmqpHeaders.PUBLISH_CONFIRM)).isEqualTo(Boolean.TRUE);
 
 		while (this.amqpTemplateConfirms.receive(this.queue.getName()) != null) {
 			// drain
@@ -139,9 +135,9 @@ public class AmqpOutboundEndpointTests {
 				.build();
 		this.pcRequestChannelForAdapter.send(message);
 		Message<?> ack = this.ackChannel.receive(10000);
-		assertNotNull(ack);
-		assertEquals("foo", ack.getPayload());
-		assertEquals(Boolean.TRUE, ack.getHeaders().get(AmqpHeaders.PUBLISH_CONFIRM));
+		assertThat(ack).isNotNull();
+		assertThat(ack.getPayload()).isEqualTo("foo");
+		assertThat(ack.getHeaders().get(AmqpHeaders.PUBLISH_CONFIRM)).isEqualTo(Boolean.TRUE);
 	}
 
 	@Test
@@ -150,8 +146,8 @@ public class AmqpOutboundEndpointTests {
 		Message<?> message = MessageBuilder.withPayload("hello").build();
 		this.returnRequestChannel.send(message);
 		Message<?> returned = returnChannel.receive(10000);
-		assertNotNull(returned);
-		assertEquals(message.getPayload(), returned.getPayload());
+		assertThat(returned).isNotNull();
+		assertThat(returned.getPayload()).isEqualTo(message.getPayload());
 	}
 
 	@Test
@@ -159,11 +155,11 @@ public class AmqpOutboundEndpointTests {
 		Message<?> message = MessageBuilder.withPayload("hello").build();
 		this.returnRequestChannel.send(message);
 		Message<?> returned = returnChannel.receive(10000);
-		assertNotNull(returned);
-		assertThat(returned, instanceOf(ErrorMessage.class));
-		assertThat(returned.getPayload(), instanceOf(ReturnedAmqpMessageException.class));
+		assertThat(returned).isNotNull();
+		assertThat(returned).isInstanceOf(ErrorMessage.class);
+		assertThat(returned.getPayload()).isInstanceOf(ReturnedAmqpMessageException.class);
 		ReturnedAmqpMessageException payload = (ReturnedAmqpMessageException) returned.getPayload();
-		assertEquals(message.getPayload(), payload.getFailedMessage().getPayload());
+		assertThat(payload.getFailedMessage().getPayload()).isEqualTo(message.getPayload());
 	}
 
 	@Test
@@ -178,18 +174,18 @@ public class AmqpOutboundEndpointTests {
 				.build();
 		this.ctRequestChannel.send(message);
 		org.springframework.amqp.core.Message m = receive(template);
-		assertNotNull(m);
-		assertEquals("\"hello\"", new String(m.getBody(), "UTF-8"));
-		assertEquals("application/json", m.getMessageProperties().getContentType());
-		assertEquals("java.lang.String",
-				m.getMessageProperties().getHeaders().get(JsonHeaders.TYPE_ID.replaceFirst(JsonHeaders.PREFIX, "")));
+		assertThat(m).isNotNull();
+		assertThat(new String(m.getBody(), "UTF-8")).isEqualTo("\"hello\"");
+		assertThat(m.getMessageProperties().getContentType()).isEqualTo("application/json");
+		assertThat(m.getMessageProperties().getHeaders().get(JsonHeaders.TYPE_ID.replaceFirst(JsonHeaders.PREFIX, "")))
+				.isEqualTo("java.lang.String");
 		message = MessageBuilder.withPayload("hello")
 				.build();
 		this.ctRequestChannel.send(message);
 		m = receive(template);
-		assertNotNull(m);
-		assertEquals("hello", new String(m.getBody(), "UTF-8"));
-		assertEquals("text/plain", m.getMessageProperties().getContentType());
+		assertThat(m).isNotNull();
+		assertThat(new String(m.getBody(), "UTF-8")).isEqualTo("hello");
+		assertThat(m.getMessageProperties().getContentType()).isEqualTo("text/plain");
 		while (template.receive() != null) {
 			// drain
 		}
@@ -202,7 +198,7 @@ public class AmqpOutboundEndpointTests {
 			Thread.sleep(100);
 			message = template.receive();
 		}
-		assertNotNull(message);
+		assertThat(message).isNotNull();
 		return message;
 	}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/OutboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/OutboundEndpointTests.java
@@ -16,11 +16,7 @@
 
 package org.springframework.integration.amqp.outbound;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -76,19 +72,19 @@ public class OutboundEndpointTests {
 		endpoint.handleMessage(new GenericMessage<>("foo"));
 		ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
 		verify(amqpTemplate).send(eq("foo"), eq("bar"), captor.capture(), isNull());
-		assertThat(captor.getValue().getMessageProperties().getDelay(), equalTo(42));
+		assertThat(captor.getValue().getMessageProperties().getDelay()).isEqualTo(42);
 		endpoint.setExpectReply(true);
 		endpoint.setOutputChannel(new NullChannel());
 		endpoint.handleMessage(new GenericMessage<>("foo"));
 		verify(amqpTemplate).sendAndReceive(eq("foo"), eq("bar"), captor.capture(), isNull());
-		assertThat(captor.getValue().getMessageProperties().getDelay(), equalTo(42));
+		assertThat(captor.getValue().getMessageProperties().getDelay()).isEqualTo(42);
 
 		endpoint.setDelay(23);
 		endpoint.setRoutingKey("baz");
 		endpoint.afterPropertiesSet();
 		endpoint.handleMessage(new GenericMessage<>("foo"));
 		verify(amqpTemplate).sendAndReceive(eq("foo"), eq("baz"), captor.capture(), isNull());
-		assertThat(captor.getValue().getMessageProperties().getDelay(), equalTo(23));
+		assertThat(captor.getValue().getMessageProperties().getDelay()).isEqualTo(23);
 	}
 
 	@Test
@@ -111,7 +107,7 @@ public class OutboundEndpointTests {
 		ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
 		gateway.handleMessage(new GenericMessage<>("foo"));
 		verify(amqpTemplate).sendAndReceive(eq("foo"), eq("bar"), captor.capture());
-		assertThat(captor.getValue().getMessageProperties().getDelay(), equalTo(42));
+		assertThat(captor.getValue().getMessageProperties().getDelay()).isEqualTo(42);
 	}
 
 	@Test
@@ -130,8 +126,8 @@ public class OutboundEndpointTests {
 				.setHeader(MessageHeaders.CONTENT_TYPE, "bar")
 				.build();
 		endpoint.handleMessage(message);
-		assertNotNull(amqpMessage.get());
-		assertEquals("bar", amqpMessage.get().getMessageProperties().getContentType());
+		assertThat(amqpMessage.get()).isNotNull();
+		assertThat(amqpMessage.get().getMessageProperties().getContentType()).isEqualTo("bar");
 	}
 
 	@Test
@@ -156,9 +152,9 @@ public class OutboundEndpointTests {
 				.setReplyChannel(new QueueChannel())
 				.build();
 		endpoint.handleMessage(message);
-		assertNotNull(amqpMessage.get());
-		assertEquals("bar", amqpMessage.get().getMessageProperties().getContentType());
-		assertNull(amqpMessage.get().getMessageProperties().getHeaders().get(MessageHeaders.REPLY_CHANNEL));
+		assertThat(amqpMessage.get()).isNotNull();
+		assertThat(amqpMessage.get().getMessageProperties().getContentType()).isEqualTo("bar");
+		assertThat(amqpMessage.get().getMessageProperties().getHeaders().get(MessageHeaders.REPLY_CHANNEL)).isNull();
 	}
 
 	/**

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/BoundRabbitChannelAdviceIntegrationTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/BoundRabbitChannelAdviceIntegrationTests.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.amqp.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willReturn;
@@ -75,8 +74,8 @@ public class BoundRabbitChannelAdviceIntegrationTests {
 			return i.callRealMethod();
 		}).given(logger).debug(anyString());
 		this.gate.send("a,b,c");
-		assertTrue(this.config.latch.await(10, TimeUnit.SECONDS));
-		assertTrue(latch.await(10, TimeUnit.SECONDS));
+		assertThat(this.config.latch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.received).containsExactly("A", "B", "C");
 	}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapperTests.java
@@ -17,9 +17,7 @@
 package org.springframework.integration.amqp.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import java.util.Date;
@@ -103,27 +101,27 @@ public class DefaultAmqpHeaderMapperTests {
 				fail("Unexpected header in properties.headers: " + headerKey);
 			}
 		}
-		assertEquals("test.appId", amqpProperties.getAppId());
-		assertEquals("test.clusterId", amqpProperties.getClusterId());
-		assertEquals("test.contentEncoding", amqpProperties.getContentEncoding());
-		assertEquals(99L, amqpProperties.getContentLength());
-		assertEquals("test.contentType", amqpProperties.getContentType());
-		assertEquals(testCorrelationId, amqpProperties.getCorrelationId());
-		assertEquals(Integer.valueOf(1234), amqpProperties.getDelay());
-		assertEquals(MessageDeliveryMode.NON_PERSISTENT, amqpProperties.getDeliveryMode());
-		assertEquals(1234L, amqpProperties.getDeliveryTag());
-		assertEquals("test.expiration", amqpProperties.getExpiration());
-		assertEquals(new Integer(42), amqpProperties.getMessageCount());
-		assertEquals("test.messageId", amqpProperties.getMessageId());
-		assertEquals("test.receivedExchange", amqpProperties.getReceivedExchange());
-		assertEquals("test.receivedRoutingKey", amqpProperties.getReceivedRoutingKey());
-		assertEquals("test.replyTo", amqpProperties.getReplyTo());
-		assertEquals(testTimestamp, amqpProperties.getTimestamp());
-		assertEquals("test.type", amqpProperties.getType());
-		assertEquals("test.userId", amqpProperties.getUserId());
+		assertThat(amqpProperties.getAppId()).isEqualTo("test.appId");
+		assertThat(amqpProperties.getClusterId()).isEqualTo("test.clusterId");
+		assertThat(amqpProperties.getContentEncoding()).isEqualTo("test.contentEncoding");
+		assertThat(amqpProperties.getContentLength()).isEqualTo(99L);
+		assertThat(amqpProperties.getContentType()).isEqualTo("test.contentType");
+		assertThat(amqpProperties.getCorrelationId()).isEqualTo(testCorrelationId);
+		assertThat(amqpProperties.getDelay()).isEqualTo(Integer.valueOf(1234));
+		assertThat(amqpProperties.getDeliveryMode()).isEqualTo(MessageDeliveryMode.NON_PERSISTENT);
+		assertThat(amqpProperties.getDeliveryTag()).isEqualTo(1234L);
+		assertThat(amqpProperties.getExpiration()).isEqualTo("test.expiration");
+		assertThat(amqpProperties.getMessageCount()).isEqualTo(new Integer(42));
+		assertThat(amqpProperties.getMessageId()).isEqualTo("test.messageId");
+		assertThat(amqpProperties.getReceivedExchange()).isEqualTo("test.receivedExchange");
+		assertThat(amqpProperties.getReceivedRoutingKey()).isEqualTo("test.receivedRoutingKey");
+		assertThat(amqpProperties.getReplyTo()).isEqualTo("test.replyTo");
+		assertThat(amqpProperties.getTimestamp()).isEqualTo(testTimestamp);
+		assertThat(amqpProperties.getType()).isEqualTo("test.type");
+		assertThat(amqpProperties.getUserId()).isEqualTo("test.userId");
 
-		assertNull(amqpProperties.getHeaders().get(MessageHeaders.ERROR_CHANNEL));
-		assertNull(amqpProperties.getHeaders().get(MessageHeaders.REPLY_CHANNEL));
+		assertThat(amqpProperties.getHeaders().get(MessageHeaders.ERROR_CHANNEL)).isNull();
+		assertThat(amqpProperties.getHeaders().get(MessageHeaders.REPLY_CHANNEL)).isNull();
 	}
 
 	@Test
@@ -138,14 +136,14 @@ public class DefaultAmqpHeaderMapperTests {
 		MessageProperties amqpProperties = new MessageProperties();
 		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
 
-		assertEquals("text/html", amqpProperties.getContentType());
+		assertThat(amqpProperties.getContentType()).isEqualTo("text/html");
 
 		headerMap.put(AmqpHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON);
 		integrationHeaders = new MessageHeaders(headerMap);
 		amqpProperties = new MessageProperties();
 		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
 
-		assertEquals(MimeTypeUtils.APPLICATION_JSON_VALUE, amqpProperties.getContentType());
+		assertThat(amqpProperties.getContentType()).isEqualTo(MimeTypeUtils.APPLICATION_JSON_VALUE);
 	}
 
 	@Test
@@ -160,7 +158,7 @@ public class DefaultAmqpHeaderMapperTests {
 		MessageProperties amqpProperties = new MessageProperties();
 		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
 
-		assertEquals("text/html", amqpProperties.getContentType());
+		assertThat(amqpProperties.getContentType()).isEqualTo("text/html");
 	}
 
 
@@ -193,26 +191,26 @@ public class DefaultAmqpHeaderMapperTests {
 		amqpProperties.setHeader(AmqpHeaders.SPRING_REPLY_CORRELATION, "test.correlation");
 		amqpProperties.setHeader(AmqpHeaders.SPRING_REPLY_TO_STACK, "test.replyTo2");
 		Map<String, Object> headerMap = headerMapper.toHeadersFromReply(amqpProperties);
-		assertEquals("test.appId", headerMap.get(AmqpHeaders.APP_ID));
-		assertEquals("test.clusterId", headerMap.get(AmqpHeaders.CLUSTER_ID));
-		assertEquals("test.contentEncoding", headerMap.get(AmqpHeaders.CONTENT_ENCODING));
-		assertEquals(99L, headerMap.get(AmqpHeaders.CONTENT_LENGTH));
-		assertEquals("test.contentType", headerMap.get(AmqpHeaders.CONTENT_TYPE));
-		assertEquals(testCorrelationId, headerMap.get(AmqpHeaders.CORRELATION_ID));
-		assertEquals(MessageDeliveryMode.NON_PERSISTENT, headerMap.get(AmqpHeaders.RECEIVED_DELIVERY_MODE));
-		assertEquals(1234L, headerMap.get(AmqpHeaders.DELIVERY_TAG));
-		assertEquals("test.expiration", headerMap.get(AmqpHeaders.EXPIRATION));
-		assertEquals(42, headerMap.get(AmqpHeaders.MESSAGE_COUNT));
-		assertEquals("test.messageId", headerMap.get(AmqpHeaders.MESSAGE_ID));
-		assertEquals(4567, headerMap.get(AmqpHeaders.RECEIVED_DELAY));
-		assertEquals("test.receivedExchange", headerMap.get(AmqpHeaders.RECEIVED_EXCHANGE));
-		assertEquals("test.receivedRoutingKey", headerMap.get(AmqpHeaders.RECEIVED_ROUTING_KEY));
-		assertEquals("test.replyTo", headerMap.get(AmqpHeaders.REPLY_TO));
-		assertEquals(testTimestamp, headerMap.get(AmqpHeaders.TIMESTAMP));
-		assertEquals("test.type", headerMap.get(AmqpHeaders.TYPE));
-		assertEquals("test.userId", headerMap.get(AmqpHeaders.RECEIVED_USER_ID));
-		assertEquals("test.correlation", headerMap.get(AmqpHeaders.SPRING_REPLY_CORRELATION));
-		assertEquals("test.replyTo2", headerMap.get(AmqpHeaders.SPRING_REPLY_TO_STACK));
+		assertThat(headerMap.get(AmqpHeaders.APP_ID)).isEqualTo("test.appId");
+		assertThat(headerMap.get(AmqpHeaders.CLUSTER_ID)).isEqualTo("test.clusterId");
+		assertThat(headerMap.get(AmqpHeaders.CONTENT_ENCODING)).isEqualTo("test.contentEncoding");
+		assertThat(headerMap.get(AmqpHeaders.CONTENT_LENGTH)).isEqualTo(99L);
+		assertThat(headerMap.get(AmqpHeaders.CONTENT_TYPE)).isEqualTo("test.contentType");
+		assertThat(headerMap.get(AmqpHeaders.CORRELATION_ID)).isEqualTo(testCorrelationId);
+		assertThat(headerMap.get(AmqpHeaders.RECEIVED_DELIVERY_MODE)).isEqualTo(MessageDeliveryMode.NON_PERSISTENT);
+		assertThat(headerMap.get(AmqpHeaders.DELIVERY_TAG)).isEqualTo(1234L);
+		assertThat(headerMap.get(AmqpHeaders.EXPIRATION)).isEqualTo("test.expiration");
+		assertThat(headerMap.get(AmqpHeaders.MESSAGE_COUNT)).isEqualTo(42);
+		assertThat(headerMap.get(AmqpHeaders.MESSAGE_ID)).isEqualTo("test.messageId");
+		assertThat(headerMap.get(AmqpHeaders.RECEIVED_DELAY)).isEqualTo(4567);
+		assertThat(headerMap.get(AmqpHeaders.RECEIVED_EXCHANGE)).isEqualTo("test.receivedExchange");
+		assertThat(headerMap.get(AmqpHeaders.RECEIVED_ROUTING_KEY)).isEqualTo("test.receivedRoutingKey");
+		assertThat(headerMap.get(AmqpHeaders.REPLY_TO)).isEqualTo("test.replyTo");
+		assertThat(headerMap.get(AmqpHeaders.TIMESTAMP)).isEqualTo(testTimestamp);
+		assertThat(headerMap.get(AmqpHeaders.TYPE)).isEqualTo("test.type");
+		assertThat(headerMap.get(AmqpHeaders.RECEIVED_USER_ID)).isEqualTo("test.userId");
+		assertThat(headerMap.get(AmqpHeaders.SPRING_REPLY_CORRELATION)).isEqualTo("test.correlation");
+		assertThat(headerMap.get(AmqpHeaders.SPRING_REPLY_TO_STACK)).isEqualTo("test.replyTo2");
 	}
 
 	@Test
@@ -225,7 +223,7 @@ public class DefaultAmqpHeaderMapperTests {
 		String testCorrelationId = "foo";
 		amqpProperties.setCorrelationId(testCorrelationId);
 		Map<String, Object> headerMap = headerMapper.toHeadersFromReply(amqpProperties);
-		assertEquals(testCorrelationId, headerMap.get(AmqpHeaders.CORRELATION_ID));
+		assertThat(headerMap.get(AmqpHeaders.CORRELATION_ID)).isEqualTo(testCorrelationId);
 	}
 
 
@@ -236,8 +234,8 @@ public class DefaultAmqpHeaderMapperTests {
 		amqpProperties.setConsumerTag("consumerTag");
 		amqpProperties.setConsumerQueue("consumerQueue");
 		Map<String, Object> headerMap = headerMapper.toHeadersFromRequest(amqpProperties);
-		assertEquals("consumerTag", headerMap.get(AmqpHeaders.CONSUMER_TAG));
-		assertEquals("consumerQueue", headerMap.get(AmqpHeaders.CONSUMER_QUEUE));
+		assertThat(headerMap.get(AmqpHeaders.CONSUMER_TAG)).isEqualTo("consumerTag");
+		assertThat(headerMap.get(AmqpHeaders.CONSUMER_QUEUE)).isEqualTo("consumerQueue");
 	}
 
 	@Test
@@ -248,7 +246,7 @@ public class DefaultAmqpHeaderMapperTests {
 		MessageHeaders integrationHeaders = new MessageHeaders(headerMap);
 		MessageProperties amqpProperties = new MessageProperties();
 		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
-		assertNull(amqpProperties.getHeaders().get(MessageHeaders.ID));
+		assertThat(amqpProperties.getHeaders().get(MessageHeaders.ID)).isNull();
 	}
 
 	@Test
@@ -259,7 +257,7 @@ public class DefaultAmqpHeaderMapperTests {
 		MessageHeaders integrationHeaders = new MessageHeaders(headerMap);
 		MessageProperties amqpProperties = new MessageProperties();
 		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
-		assertNull(amqpProperties.getHeaders().get(MessageHeaders.TIMESTAMP));
+		assertThat(amqpProperties.getHeaders().get(MessageHeaders.TIMESTAMP)).isNull();
 	}
 
 	@Test // INT-2090
@@ -272,9 +270,9 @@ public class DefaultAmqpHeaderMapperTests {
 		headerMap.put("__TypeId__", "java.lang.Integer");
 		MessageHeaders integrationHeaders = new MessageHeaders(headerMap);
 		headerMapper.fromHeadersToRequest(integrationHeaders, amqpProperties);
-		assertEquals("java.lang.String", amqpProperties.getHeaders().get("__TypeId__"));
+		assertThat(amqpProperties.getHeaders().get("__TypeId__")).isEqualTo("java.lang.String");
 		Object result = converter.fromMessage(new Message("123".getBytes(), amqpProperties));
-		assertEquals(String.class, result.getClass());
+		assertThat(result.getClass()).isEqualTo(String.class);
 	}
 
 	@Test
@@ -285,31 +283,31 @@ public class DefaultAmqpHeaderMapperTests {
 		amqpProperties.getHeaders().put("foo", "bar");
 		amqpProperties.getHeaders().put("x-foo", "bar");
 		Map<String, Object> headers = mapper.toHeadersFromRequest(amqpProperties);
-		assertNull(headers.get(AmqpHeaders.DELIVERY_MODE));
-		assertEquals(MessageDeliveryMode.NON_PERSISTENT, headers.get(AmqpHeaders.RECEIVED_DELIVERY_MODE));
-		assertEquals("bar", headers.get("foo"));
-		assertEquals("bar", headers.get("x-foo"));
+		assertThat(headers.get(AmqpHeaders.DELIVERY_MODE)).isNull();
+		assertThat(headers.get(AmqpHeaders.RECEIVED_DELIVERY_MODE)).isEqualTo(MessageDeliveryMode.NON_PERSISTENT);
+		assertThat(headers.get("foo")).isEqualTo("bar");
+		assertThat(headers.get("x-foo")).isEqualTo("bar");
 
 		amqpProperties = new MessageProperties();
 		headers.put(AmqpHeaders.DELIVERY_MODE, MessageDeliveryMode.NON_PERSISTENT);
 		mapper.fromHeadersToReply(new MessageHeaders(headers), amqpProperties);
-		assertEquals(MessageDeliveryMode.NON_PERSISTENT, amqpProperties.getDeliveryMode());
-		assertEquals("bar", amqpProperties.getHeaders().get("foo"));
-		assertNull(amqpProperties.getHeaders().get("x-foo"));
+		assertThat(amqpProperties.getDeliveryMode()).isEqualTo(MessageDeliveryMode.NON_PERSISTENT);
+		assertThat(amqpProperties.getHeaders().get("foo")).isEqualTo("bar");
+		assertThat(amqpProperties.getHeaders().get("x-foo")).isNull();
 
 		mapper = DefaultAmqpHeaderMapper.outboundMapper();
 		mapper.fromHeadersToRequest(new MessageHeaders(headers), amqpProperties);
-		assertEquals(MessageDeliveryMode.NON_PERSISTENT, amqpProperties.getDeliveryMode());
-		assertEquals("bar", amqpProperties.getHeaders().get("foo"));
-		assertNull(amqpProperties.getHeaders().get("x-foo"));
+		assertThat(amqpProperties.getDeliveryMode()).isEqualTo(MessageDeliveryMode.NON_PERSISTENT);
+		assertThat(amqpProperties.getHeaders().get("foo")).isEqualTo("bar");
+		assertThat(amqpProperties.getHeaders().get("x-foo")).isNull();
 
 		amqpProperties.setReceivedDeliveryMode(MessageDeliveryMode.NON_PERSISTENT);
 		amqpProperties.setHeader("x-death", "foo");
 		headers = mapper.toHeadersFromReply(amqpProperties);
-		assertEquals(MessageDeliveryMode.NON_PERSISTENT, headers.get(AmqpHeaders.RECEIVED_DELIVERY_MODE));
-		assertNull(headers.get(AmqpHeaders.DELIVERY_MODE));
-		assertEquals("bar", headers.get("foo"));
-		assertEquals("foo", headers.get("x-death"));
+		assertThat(headers.get(AmqpHeaders.RECEIVED_DELIVERY_MODE)).isEqualTo(MessageDeliveryMode.NON_PERSISTENT);
+		assertThat(headers.get(AmqpHeaders.DELIVERY_MODE)).isNull();
+		assertThat(headers.get("foo")).isEqualTo("bar");
+		assertThat(headers.get("x-death")).isEqualTo("foo");
 	}
 
 }

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/JsonConverterCompatibilityTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/JsonConverterCompatibilityTests.java
@@ -16,8 +16,7 @@
 
 package org.springframework.integration.amqp.support;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.After;
 import org.junit.Before;
@@ -77,7 +76,7 @@ public class JsonConverterCompatibilityTests {
 		});
 
 		Object received = this.rabbitTemplate.receiveAndConvert(JSON_TESTQ);
-		assertThat(received, instanceOf(Foo.class));
+		assertThat(received).isInstanceOf(Foo.class);
 	}
 
 	public static class Foo {

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/MappingUtilsTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/MappingUtilsTests.java
@@ -16,9 +16,8 @@
 
 package org.springframework.integration.amqp.support;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.junit.Test;
 
@@ -48,23 +47,23 @@ public class MappingUtilsTests {
 		boolean headersMappedLast = false;
 		org.springframework.amqp.core.Message mapped = MappingUtils.mapMessage(requestMessage, converter, headerMapper,
 				defaultDeliveryMode, headersMappedLast);
-		assertThat(mapped.getMessageProperties().getContentType(), equalTo("text/plain"));
+		assertThat(mapped.getMessageProperties().getContentType()).isEqualTo("text/plain");
 
 		headersMappedLast = true;
 		mapped = MappingUtils.mapMessage(requestMessage, converter, headerMapper,
 				defaultDeliveryMode, headersMappedLast);
-		assertThat(mapped.getMessageProperties().getContentType(), equalTo("my/ct"));
+		assertThat(mapped.getMessageProperties().getContentType()).isEqualTo("my/ct");
 
 		ContentTypeDelegatingMessageConverter ctdConverter = new ContentTypeDelegatingMessageConverter();
 		ctdConverter.addDelegate("my/ct", converter);
 		mapped = MappingUtils.mapMessage(requestMessage, ctdConverter, headerMapper,
 				defaultDeliveryMode, headersMappedLast);
-		assertThat(mapped.getMessageProperties().getContentType(), equalTo("my/ct"));
+		assertThat(mapped.getMessageProperties().getContentType()).isEqualTo("my/ct");
 
 		headersMappedLast = false;
 		mapped = MappingUtils.mapMessage(requestMessage, ctdConverter, headerMapper,
 				defaultDeliveryMode, headersMappedLast);
-		assertThat(mapped.getMessageProperties().getContentType(), equalTo("text/plain"));
+		assertThat(mapped.getMessageProperties().getContentType()).isEqualTo("text/plain");
 
 		headersMappedLast = true;
 		requestMessage = MessageBuilder.withPayload("foo")
@@ -76,8 +75,8 @@ public class MappingUtilsTests {
 			fail("Expected IllegalArgumentException");
 		}
 		catch (IllegalArgumentException e) {
-			assertThat(e.getMessage(),
-					equalTo("contentType header must be a MimeType or String, found: java.lang.Integer"));
+			assertThat(e.getMessage())
+					.isEqualTo("contentType header must be a MimeType or String, found: java.lang.Integer");
 		}
 	}
 


### PR DESCRIPTION
* Apply for AMQP module
* Manually replace an `ExpectedException` JUnit rule to the
`assertThatThrownBy()` in the `ChannelTests` since Hamcrest imports
have been removed

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
