### PR TITLE
GH-2752: RequestMapping: react only for our event

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/IntegrationRequestMappingHandlerMapping.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/IntegrationRequestMappingHandlerMapping.java
@@ -234,11 +234,6 @@ public final class IntegrationRequestMappingHandlerMapping extends RequestMappin
 		return createRequestMappingInfo(requestMappingAnnotation, getCustomTypeCondition(endpoint.getClass()));
 	}
 
-	@Override
-	public void afterPropertiesSet() {
-		// No-op in favor of onApplicationEvent
-	}
-
 	/**
 	 * {@link HttpRequestHandlingEndpointSupport}s may depend on auto-created
 	 * {@code requestChannel}s, so MVC Handlers detection should be postponed
@@ -247,9 +242,14 @@ public final class IntegrationRequestMappingHandlerMapping extends RequestMappin
 	 */
 	@Override
 	public void onApplicationEvent(ContextRefreshedEvent event) {
-		if (!this.initialized.getAndSet(true)) {
+		if (event.getApplicationContext().equals(getApplicationContext()) && !this.initialized.getAndSet(true)) {
 			super.afterPropertiesSet();
 		}
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		// No-op in favor of onApplicationEvent
 	}
 
 }

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/inbound/WebFluxIntegrationRequestMappingHandlerMapping.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/inbound/WebFluxIntegrationRequestMappingHandlerMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -191,7 +191,7 @@ public class WebFluxIntegrationRequestMappingHandlerMapping extends RequestMappi
 	 */
 	@Override
 	public void onApplicationEvent(ContextRefreshedEvent event) {
-		if (!this.initialized.getAndSet(true)) {
+		if (event.getApplicationContext().equals(getApplicationContext()) && !this.initialized.getAndSet(true)) {
 			super.afterPropertiesSet();
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2752

The logic in the `IntegrationRequestMappingHandlerMapping` fully depends
on the application context it has been registered with, therefore any
arbitrary `ContextRefreshedEvent` doesn't fit our requirements.
More over it may cause a problem with missed mappings when parent-child
configuration is used.

**Chery-pick to 5.1.x, 5.0.x & 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
