### PR TITLE
GH-2759: Fix CorrelationData.future

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
@@ -44,6 +44,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Gary Russell
@@ -479,8 +480,10 @@ public abstract class AbstractAmqpOutboundEndpoint extends AbstractReplyProducin
 			if (messageId == null) {
 				messageId = NO_ID;
 			}
-			correlationData = new CorrelationDataWrapper(messageId.toString(),
-					this.correlationDataGenerator.processMessage(requestMessage), requestMessage);
+			Object userData = this.correlationDataGenerator.processMessage(requestMessage);
+			if (userData != null) {
+				correlationData = new CorrelationDataWrapper(messageId.toString(), userData, requestMessage);
+			}
 		}
 		return correlationData;
 	}
@@ -604,6 +607,28 @@ public abstract class AbstractAmqpOutboundEndpoint extends AbstractReplyProducin
 			return this.message;
 		}
 
+		@Override
+		public SettableListenableFuture<Confirm> getFuture() {
+			if (this.userData instanceof CorrelationData) {
+				return ((CorrelationData) this.userData).getFuture();
+			}
+			else {
+				return super.getFuture();
+			}
+		}
+
+		@Override
+		public org.springframework.amqp.core.Message getReturnedMessage() {
+			return super.getReturnedMessage();
+		}
+
+		@Override
+		public void setReturnedMessage(org.springframework.amqp.core.Message returnedMessage) {
+			if (this.userData instanceof CorrelationData) {
+				((CorrelationData) this.userData).setReturnedMessage(returnedMessage);
+			}
+			super.setReturnedMessage(returnedMessage);
+		}
 	}
 
 }

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
@@ -618,11 +618,6 @@ public abstract class AbstractAmqpOutboundEndpoint extends AbstractReplyProducin
 		}
 
 		@Override
-		public org.springframework.amqp.core.Message getReturnedMessage() {
-			return super.getReturnedMessage();
-		}
-
-		@Override
 		public void setReturnedMessage(org.springframework.amqp.core.Message returnedMessage) {
 			if (this.userData instanceof CorrelationData) {
 				((CorrelationData) this.userData).setReturnedMessage(returnedMessage);

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
@@ -484,6 +484,10 @@ public abstract class AbstractAmqpOutboundEndpoint extends AbstractReplyProducin
 			if (userData != null) {
 				correlationData = new CorrelationDataWrapper(messageId.toString(), userData, requestMessage);
 			}
+			else {
+				this.logger.debug("'confirmCorrelationExpression' resolved to 'null'; "
+						+ "no publisher confirm will be sent to the ack or nack channel");
+			}
 		}
 		return correlationData;
 	}

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests-context.xml
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests-context.xml
@@ -70,6 +70,7 @@
 								   routing-key="#{queue.name + queue.name}"
 								   mapped-request-headers="foo*"
 								   amqp-template="amqpTemplateReturns"
+								   confirm-correlation-expression="headers['corrData']"
 								   return-channel="returnChannel" />
 
 	<int:channel id="returnRequestChannel"/>


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2759

The outbound endpoints wrap user correlation data in a wrapper.
If the user data is a `CorrelationData`, we must delegate methods
involving the `Future<?>` and `returnedMessage` to the user data.

**cherry-pick to 2.1 and switch AMQP to snapshots**

