### PR TITLE
INT-4573: Fix logic in the OperationInvokingMH

### DIFF
--- a/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-5.2.xsd
+++ b/spring-integration-jmx/src/main/resources/org/springframework/integration/jmx/config/spring-integration-jmx-5.2.xsd
@@ -318,8 +318,8 @@
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="mbeanServerIdentifierType">
-				<xsd:attribute name="object-name" type="xsd:string" use="required" />
-				<xsd:attribute name="operation-name" type="xsd:string" use="required" />
+				<xsd:attribute name="object-name" type="xsd:string" />
+				<xsd:attribute name="operation-name" type="xsd:string" />
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingChannelAdapterParserTests-context.xml
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingChannelAdapterParserTests-context.xml
@@ -43,4 +43,6 @@
 				operation-name="testWithReturn"/>
 	</si:chain>
 
+	<jmx:operation-invoking-channel-adapter id="input2"/>
+
 </beans>

--- a/src/reference/asciidoc/jmx.adoc
+++ b/src/reference/asciidoc/jmx.adoc
@@ -184,7 +184,7 @@ You can also implement your own filter.
 
 The operation-invoking channel adapter enables message-driven invocation of any managed operation exposed by an MBean.
 Each invocation requires the operation name to be invoked and the object name of the target MBean.
-Both of these must be explicitly provided by adapter configuration, as the following example shows:
+Both of these must be explicitly provided by adapter configuration or via `JmxHeaders.OBJECT_NAME` and `JmxHeaders.OPERATION_NAME` message headers, respectively:
 
 ====
 [source,xml]


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4573

* Fix check order for headers first in the `resolveObjectName()` and
`resolveOperationName()`.
Then fallback to defaults configured on the `OperationInvokingMessageHandler`
* Remove also a deprecated API in the `OperationInvokingMessageHandler`
* Remove requirements for `object-name` and `operation-name` XML
attributes since those options can be provided in the request message
headers
* Fix `OperationInvokingChannelAdapterParserTests` for proper headers
resolution
* Mention `JmxHeaders.OBJECT_NAME` and `JmxHeaders.OPERATION_NAME`
headers in the `jmx.adoc`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
