### PR TITLE
INT-4559: JDBC Gateway: return List for maxRows>1

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParser.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,24 +71,6 @@ public class JdbcOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element,
 				"request-prepared-statement-setter");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "row-mapper");
-
-
-		// TODO remove deprecated option in the next version
-		boolean hasMaxRowsPerPoll = element.hasAttribute("max-rows-per-poll");
-		boolean hasMaxRows = element.hasAttribute("max-rows");
-
-		if (hasMaxRowsPerPoll) {
-			parserContext.getReaderContext()
-					.warning("The 'max-rows-per-poll' is deprecated in favor of 'max-rows'", element);
-
-			IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "max-rows-per-poll");
-
-			if (hasMaxRows) {
-				parserContext.getReaderContext()
-						.warning("The 'max-rows' has a precedence over 'max-rows-per-poll'", element);
-			}
-		}
-
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "max-rows");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "keys-generated");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcPollingChannelAdapterParser.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/config/JdbcPollingChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,25 +74,7 @@ public class JdbcPollingChannelAdapterParser extends AbstractPollingInboundChann
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "row-mapper");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "update-sql-parameter-source-factory");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "select-sql-parameter-source");
-
-		// TODO remove deprecated option in the next version
-		boolean hasMaxRowsPerPoll = element.hasAttribute("max-rows-per-poll");
-		boolean hasMaxRows = element.hasAttribute("max-rows");
-
-		if (hasMaxRowsPerPoll) {
-			parserContext.getReaderContext()
-					.warning("The 'max-rows-per-poll' is deprecated in favor of 'max-rows'", element);
-
-			IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "max-rows-per-poll");
-
-			if (hasMaxRows) {
-				parserContext.getReaderContext()
-						.warning("The 'max-rows' has a precedence over 'max-rows-per-poll'", element);
-			}
-		}
-
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "max-rows");
-
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "update", "updateSql");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "update-per-row");
 

--- a/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-5.2.xsd
+++ b/spring-integration-jdbc/src/main/resources/org/springframework/integration/jdbc/config/spring-integration-jdbc-5.2.xsd
@@ -367,18 +367,6 @@
 							</xsd:appinfo>
 						</xsd:annotation>
 					</xsd:attribute>
-					<xsd:attribute name="max-rows-per-poll" type="xsd:string">
-						<xsd:annotation>
-							<xsd:documentation>
-								[DEPRECATED] When using a select query, you can set a
-								custom limit regarding the number of rows
-								extracted. Otherwise by default only the first
-								row will be extracted into the outgoing message.
-								If set to '0' all rows are extracted.
-								Deprecated since 5.1 in favor of 'max-rows'.
-							</xsd:documentation>
-						</xsd:annotation>
-					</xsd:attribute>
 					<xsd:attribute name="max-rows" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/handlingMapPayloadJdbcOutboundGatewayTest.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/handlingMapPayloadJdbcOutboundGatewayTest.xml
@@ -26,6 +26,7 @@
 	<si:chain input-channel="jdbcOutboundGatewayInsideChain" output-channel="replyChannel">
 		<outbound-gateway id="jdbc-outbound-gateway-within-chain" query="select * from foos where id=:headers[id]"
 						  update="insert into foos (id, status, name) values (:headers[id], 0, :payload[foo])"
+						  max-rows="2"
 						  data-source="dataSource" requires-reply="false"/>
 
 	</si:chain>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4559

* Return a single item from result only if
`maxRows == null || maxRows == 1`
* Remove deprecated `max-rows-per-poll` from the
`JdbcOutboundGateway.java` and its XSD and parsers

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
