### PR TITLE
GH-2770: AbstractMessageSource EvaluationContext

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractMessageSource.java
@@ -193,10 +193,12 @@ public abstract class AbstractMessageSource<T> extends AbstractExpressionEvaluat
 			catch (Exception e) {
 				throw new MessagingException("MessageSource returned unexpected type.", e);
 			}
-			message = getMessageBuilderFactory()
-					.withPayload(payload)
-					.copyHeaders(headers)
-					.build();
+			AbstractIntegrationMessageBuilder<T> builder = getMessageBuilderFactory()
+					.withPayload(payload);
+			if (!CollectionUtils.isEmpty(headers)) {
+				builder.copyHeaders(headers);
+			}
+			message = builder.build();
 		}
 		if (this.countsEnabled && message != null) {
 			if (this.metricsCaptor != null) {
@@ -220,10 +222,13 @@ public abstract class AbstractMessageSource<T> extends AbstractExpressionEvaluat
 		this.receiveCounter.increment();
 	}
 
+	@Nullable
 	private Map<String, Object> evaluateHeaders() {
-		return ExpressionEvalMap.from(this.headerExpressions)
-				.usingEvaluationContext(getEvaluationContext())
-				.build();
+		return this.headerExpressions.size() > 0
+				? ExpressionEvalMap.from(this.headerExpressions)
+					.usingEvaluationContext(getEvaluationContext())
+					.build()
+				: null;
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2770

Only create an evaluation context for header expressions if we actually
have header expressions.
