### PR TITLE
GH-2777: Remote File Filter Improvements

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractFileListFilter.java
@@ -26,6 +26,7 @@ import java.util.List;
  *
  * @author Mark Fisher
  * @author Iwein Fuld
+ * @author Gary Russell
  */
 public abstract class AbstractFileListFilter<F> implements FileListFilter<F> {
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractFileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,11 +42,17 @@ public abstract class AbstractFileListFilter<F> implements FileListFilter<F> {
 		return accepted;
 	}
 
+	@Override
+	public boolean supportsSingleFileFiltering() {
+		return true;
+	}
+
 	/**
 	 * Subclasses must implement this method.
 	 * @param file The file.
 	 * @return true if the file passes the filter.
 	 */
+	@Override
 	public abstract boolean accept(F file);
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractMarkerFilePresentFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractMarkerFilePresentFileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,9 @@ import java.util.stream.Collectors;
 /**
  * A FileListFilter that only passes files matched by one or more {@link FileListFilter}
  * if a corresponding marker file is also present to indicate a file transfer is complete.
+ *
+ * Since they look at multiple files, they cannot be used for late filtering in the
+ * streaming message source.
  *
  * @author Gary Russell
  * @since 5.0

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentAcceptOnceFileListFilter.java
@@ -173,7 +173,7 @@ public abstract class AbstractPersistentAcceptOnceFileListFilter<F> extends Abst
 			try {
 				this.flushableStore.flush();
 			}
-			catch (IOException e) {
+			catch (@SuppressWarnings("unused") IOException e) {
 				// store's responsibility to log
 			}
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/ChainFileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,17 @@ public class ChainFileListFilter<F> extends CompositeFileListFilter<F> {
 			leftOver = fileFilter.filterFiles(fileArray);
 		}
 		return leftOver;
+	}
+
+	@Override
+	public boolean accept(F file) {
+		// we can't use stream().allMatch() because there is no guarantee of early exit
+		for (FileListFilter<F> filter : this.fileFilters) {
+			if (!filter.accept(file)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
@@ -63,7 +63,7 @@ public class CompositeFileListFilter<F>
 
 	public CompositeFileListFilter(Collection<? extends FileListFilter<F>> fileFilters) {
 		this.fileFilters = new LinkedHashSet<>(fileFilters);
-		this.allSupportAccept = fileFilters.stream().allMatch(f -> f.supportsSingleFileFiltering());
+		this.allSupportAccept = fileFilters.stream().allMatch(FileListFilter::supportsSingleFileFiltering);
 	}
 
 
@@ -115,7 +115,7 @@ public class CompositeFileListFilter<F>
 			}
 		}
 		this.fileFilters.addAll(filtersToAdd);
-		this.allSupportAccept &= filtersToAdd.stream().allMatch(f -> f.supportsSingleFileFiltering());
+		this.allSupportAccept &= filtersToAdd.stream().allMatch(FileListFilter::supportsSingleFileFiltering);
 		return this;
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
@@ -63,7 +63,7 @@ public class CompositeFileListFilter<F>
 
 	public CompositeFileListFilter(Collection<? extends FileListFilter<F>> fileFilters) {
 		this.fileFilters = new LinkedHashSet<>(fileFilters);
-		this.allSupportAccept = fileFilters.stream().allMatch(FileListFilter::supportsSingleFileFiltering);
+		this.allSupportAccept = fileFilters.stream().allMatch(FileListFilter<F>::supportsSingleFileFiltering);
 	}
 
 
@@ -86,8 +86,9 @@ public class CompositeFileListFilter<F>
 	 * @return this CompositeFileFilter instance with the added filters
 	 * @see #addFilters(Collection)
 	 */
-	@SuppressWarnings("unchecked")
-	public CompositeFileListFilter<F> addFilters(FileListFilter<F>... filters) {
+	@SafeVarargs
+	@SuppressWarnings("varargs")
+	public final CompositeFileListFilter<F> addFilters(FileListFilter<F>... filters) {
 		List<FileListFilter<F>> asList = Arrays.asList(filters);
 		return addFilters(asList);
 	}
@@ -115,7 +116,7 @@ public class CompositeFileListFilter<F>
 			}
 		}
 		this.fileFilters.addAll(filtersToAdd);
-		this.allSupportAccept &= filtersToAdd.stream().allMatch(FileListFilter::supportsSingleFileFiltering);
+		this.allSupportAccept &= filtersToAdd.stream().allMatch(FileListFilter<F>::supportsSingleFileFiltering);
 		return this;
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/CompositeFileListFilter.java
@@ -63,7 +63,7 @@ public class CompositeFileListFilter<F>
 
 	public CompositeFileListFilter(Collection<? extends FileListFilter<F>> fileFilters) {
 		this.fileFilters = new LinkedHashSet<>(fileFilters);
-		fileFilters.stream().allMatch(f -> f.supportsSingleFileFiltering());
+		this.allSupportAccept = fileFilters.stream().allMatch(f -> f.supportsSingleFileFiltering());
 	}
 
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/DiscardAwareFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/DiscardAwareFileListFilter.java
@@ -22,9 +22,10 @@ import org.springframework.lang.Nullable;
 
 /**
  * The {@link FileListFilter} modification which can accept a {@link Consumer}
- * which can be called when filter discards the file.
+ * which can be called when the filter discards the file.
  *
  * @author Artem Bilan
+ * @author Gary Russell
  *
  * @since 5.0.5
  */

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.file.filters;
 
+import java.lang.reflect.Array;
 import java.util.List;
 
 /**
@@ -37,5 +38,27 @@ public interface FileListFilter<F> {
 	 * @return The filtered files.
 	 */
 	List<F> filterFiles(F[] files);
+
+	/**
+	 * Filter a single file.
+	 * @param file the file.
+	 * @return true if the file passes the filter, false to filter.
+	 * @since 5.2
+	 */
+	default boolean accept(F file) {
+		@SuppressWarnings("unchecked")
+		F[] fileArray = (F[]) Array.newInstance(file.getClass(), 1);
+		fileArray[0] = file;
+		return filterFiles(fileArray).size() > 0;
+	}
+
+	/**
+	 * Indicates that this filter supports filtering a single file.
+	 * Default false.
+	 * @return true to allow external calls to {@link #accept(Object)}.
+	 */
+	default boolean supportsSingleFileFiltering() {
+		return false;
+	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileListFilter.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.file.filters;
 
-import java.lang.reflect.Array;
 import java.util.List;
 
 /**
@@ -46,16 +45,15 @@ public interface FileListFilter<F> {
 	 * @since 5.2
 	 */
 	default boolean accept(F file) {
-		@SuppressWarnings("unchecked")
-		F[] fileArray = (F[]) Array.newInstance(file.getClass(), 1);
-		fileArray[0] = file;
-		return filterFiles(fileArray).size() > 0;
+		throw new UnsupportedOperationException(
+				"Filters that return true in supportsSingleFileFiltering() must implement this method");
 	}
 
 	/**
 	 * Indicates that this filter supports filtering a single file.
 	 * Default false.
 	 * @return true to allow external calls to {@link #accept(Object)}.
+	 * @since 5.2
 	 */
 	default boolean supportsSingleFileFiltering() {
 		return false;

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileListFilter.java
@@ -24,6 +24,7 @@ import java.util.List;
  *
  * @author Iwein Fuld
  * @author Josh Long
+ * @author Gary Russell
  *
  * @since 1.0.0
  */

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileListFilter.java
@@ -39,10 +39,12 @@ public interface FileListFilter<F> {
 	List<F> filterFiles(F[] files);
 
 	/**
-	 * Filter a single file.
+	 * Filter a single file; only called externally if {@link #supportsSingleFileFiltering()}
+	 * returns true.
 	 * @param file the file.
 	 * @return true if the file passes the filter, false to filter.
 	 * @since 5.2
+	 * @see #supportsSingleFileFiltering()
 	 */
 	default boolean accept(F file) {
 		throw new UnsupportedOperationException(
@@ -51,9 +53,11 @@ public interface FileListFilter<F> {
 
 	/**
 	 * Indicates that this filter supports filtering a single file.
+	 * Filters that return true <b>must</b> override {@link #accept(Object)}.
 	 * Default false.
 	 * @return true to allow external calls to {@link #accept(Object)}.
 	 * @since 5.2
+	 * @see #accept(Object)
 	 */
 	default boolean supportsSingleFileFiltering() {
 		return false;

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/LastModifiedFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/LastModifiedFileListFilter.java
@@ -105,8 +105,8 @@ public class LastModifiedFileListFilter implements DiscardAwareFileListFilter<Fi
 	}
 
 	@Override
-	public void addDiscardCallback(@Nullable Consumer<File> discardCallback) {
-		this.discardCallback = discardCallback;
+	public void addDiscardCallback(@Nullable Consumer<File> discardCallbackToSet) {
+		this.discardCallback = discardCallbackToSet;
 	}
 
 	@Override
@@ -123,5 +123,22 @@ public class LastModifiedFileListFilter implements DiscardAwareFileListFilter<Fi
 		}
 		return list;
 	}
+
+	@Override
+	public boolean accept(File file) {
+		if (file.lastModified() / ONE_SECOND + this.age <= System.currentTimeMillis()) {
+			return true;
+		}
+		else if (this.discardCallback != null) {
+			this.discardCallback.accept(file);
+		}
+		return false;
+	}
+
+	@Override
+	public boolean supportsSingleFileFiltering() {
+		return true;
+	}
+
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/LastModifiedFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/LastModifiedFileListFilter.java
@@ -112,9 +112,8 @@ public class LastModifiedFileListFilter implements DiscardAwareFileListFilter<Fi
 	@Override
 	public List<File> filterFiles(File[] files) {
 		List<File> list = new ArrayList<>();
-		long now = System.currentTimeMillis() / ONE_SECOND;
 		for (File file : files) {
-			if (file.lastModified() / ONE_SECOND + this.age <= now) {
+			if (file.lastModified() / ONE_SECOND + this.age <= System.currentTimeMillis() / ONE_SECOND) {
 				list.add(file);
 			}
 			else if (this.discardCallback != null) {
@@ -126,7 +125,7 @@ public class LastModifiedFileListFilter implements DiscardAwareFileListFilter<Fi
 
 	@Override
 	public boolean accept(File file) {
-		if (file.lastModified() / ONE_SECOND + this.age <= System.currentTimeMillis()) {
+		if (file.lastModified() / ONE_SECOND + this.age <= System.currentTimeMillis() / ONE_SECOND) {
 			return true;
 		}
 		else if (this.discardCallback != null) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/LastModifiedFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/LastModifiedFileListFilter.java
@@ -112,8 +112,9 @@ public class LastModifiedFileListFilter implements DiscardAwareFileListFilter<Fi
 	@Override
 	public List<File> filterFiles(File[] files) {
 		List<File> list = new ArrayList<>();
+		long now = System.currentTimeMillis() / ONE_SECOND;
 		for (File file : files) {
-			if (file.lastModified() / ONE_SECOND + this.age <= System.currentTimeMillis() / ONE_SECOND) {
+			if (fileIsAged(file, now)) {
 				list.add(file);
 			}
 			else if (this.discardCallback != null) {
@@ -125,13 +126,17 @@ public class LastModifiedFileListFilter implements DiscardAwareFileListFilter<Fi
 
 	@Override
 	public boolean accept(File file) {
-		if (file.lastModified() / ONE_SECOND + this.age <= System.currentTimeMillis() / ONE_SECOND) {
+		if (fileIsAged(file, System.currentTimeMillis() / ONE_SECOND)) {
 			return true;
 		}
 		else if (this.discardCallback != null) {
 			this.discardCallback.accept(file);
 		}
 		return false;
+	}
+
+	private boolean fileIsAged(File file, long now) {
+		return file.lastModified() / ONE_SECOND + this.age <= now;
 	}
 
 	@Override

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
@@ -28,7 +28,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.Lifecycle;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
@@ -148,7 +147,7 @@ public abstract class AbstractRemoteFileStreamingMessageSource<F>
 
 	/**
 	 * Subclasses can override to perform initialization - called from
-	 * {@link InitializingBean#afterPropertiesSet()}.
+	 * {@link org.springframework.beans.factory.InitializingBean#afterPropertiesSet()}.
 	 */
 	protected void doInit() {
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
@@ -187,10 +187,16 @@ public abstract class AbstractRemoteFileStreamingMessageSource<F>
 		AbstractFileInfo<F> file = poll();
 		while (file != null) {
 			if (this.filter != null && this.filter.supportsSingleFileFiltering()
-					&& !this.filter.accept(file.getFileInfo())) {
-				file = poll();
+						&& !this.filter.accept(file.getFileInfo())) {
+
+					if (this.toBeReceived.size() > 0) { // don't re-fetch already filtered files
+						file = poll();
+					}
+					else {
+						file = null;
+					}
 			}
-			else {
+			if (file != null) {
 				try {
 					String remotePath = remotePath(file);
 					Session<?> session = this.remoteFileTemplate.getSession();

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -215,9 +215,9 @@ public abstract class AbstractInboundFileSynchronizer<F>
 	}
 
 
-	protected final void doSetRemoteDirectoryExpression(Expression remoteDirectoryExpression) {
-		Assert.notNull(remoteDirectoryExpression, "'remoteDirectoryExpression' must not be null");
-		this.remoteDirectoryExpression = remoteDirectoryExpression;
+	protected final void doSetRemoteDirectoryExpression(Expression expression) {
+		Assert.notNull(expression, "'remoteDirectoryExpression' must not be null");
+		this.remoteDirectoryExpression = expression;
 		evaluateRemoteDirectory();
 	}
 
@@ -229,8 +229,8 @@ public abstract class AbstractInboundFileSynchronizer<F>
 		doSetFilter(filter);
 	}
 
-	protected final void doSetFilter(@Nullable FileListFilter<F> filter) {
-		this.filter = filter;
+	protected final void doSetFilter(@Nullable FileListFilter<F> filterToSet) {
+		this.filter = filterToSet;
 	}
 
 	/**
@@ -339,6 +339,7 @@ public abstract class AbstractInboundFileSynchronizer<F>
 					}
 					else {
 						file = null;
+						copied--;
 					}
 				}
 				try {
@@ -373,8 +374,10 @@ public abstract class AbstractInboundFileSynchronizer<F>
 			filteredFiles = Arrays.asList(files);
 		}
 		if (maxFetchSize >= 0 && filteredFiles.size() > maxFetchSize) {
-			if (!filteringOneByOne && haveFilter) {
-				rollbackFromFileToListEnd(filteredFiles, filteredFiles.get(maxFetchSize));
+			if (!filteringOneByOne) {
+				if (haveFilter) {
+					rollbackFromFileToListEnd(filteredFiles, filteredFiles.get(maxFetchSize));
+				}
 				filteredFiles = filteredFiles.stream()
 						.limit(maxFetchSize)
 						.collect(Collectors.toList());

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -22,11 +22,11 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -325,19 +325,22 @@ public abstract class AbstractInboundFileSynchronizer<F>
 			files = FileUtils.purgeUnwantedElements(files, e -> !isFile(e), this.comparator);
 		}
 		if (!ObjectUtils.isEmpty(files)) {
-			List<F> filteredFiles = filterFiles(files);
-			if (maxFetchSize >= 0 && filteredFiles.size() > maxFetchSize) {
-				rollbackFromFileToListEnd(filteredFiles, filteredFiles.get(maxFetchSize));
-				List<F> newList = new ArrayList<>(maxFetchSize);
-				for (int i = 0; i < maxFetchSize; i++) {
-					newList.add(filteredFiles.get(i));
-				}
-				filteredFiles = newList;
-			}
+			boolean haveFilter = this.filter != null;
+			boolean filteringOneByOne = haveFilter && this.filter.supportsSingleFileFiltering();
+			List<F> filteredFiles = applyFilter(files, haveFilter, filteringOneByOne, maxFetchSize);
 
 			int copied = filteredFiles.size();
+			int accepted = 0;
 
 			for (F file : filteredFiles) {
+				if (filteringOneByOne) {
+					if ((maxFetchSize < 0 || accepted < maxFetchSize) && this.filter.accept(file)) {
+						accepted++;
+					}
+					else {
+						file = null;
+					}
+				}
 				try {
 					if (file != null && !copyFileToLocalDirectory(this.evaluatedRemoteDirectory, file,
 							localDirectory, session)) {
@@ -345,7 +348,12 @@ public abstract class AbstractInboundFileSynchronizer<F>
 					}
 				}
 				catch (RuntimeException | IOException e1) {
-					rollbackFromFileToListEnd(filteredFiles, file);
+					if (filteringOneByOne) {
+						resetFilterIfNecessary(file);
+					}
+					else {
+						rollbackFromFileToListEnd(filteredFiles, file);
+					}
 					throw e1;
 				}
 			}
@@ -354,6 +362,25 @@ public abstract class AbstractInboundFileSynchronizer<F>
 		else {
 			return 0;
 		}
+	}
+
+	private List<F> applyFilter(F[] files, boolean haveFilter, boolean filteringOneByOne, int maxFetchSize) {
+		List<F> filteredFiles;
+		if (!filteringOneByOne && haveFilter) {
+			filteredFiles = filterFiles(files);
+		}
+		else {
+			filteredFiles = Arrays.asList(files);
+		}
+		if (maxFetchSize >= 0 && filteredFiles.size() > maxFetchSize) {
+			if (!filteringOneByOne && haveFilter) {
+				rollbackFromFileToListEnd(filteredFiles, filteredFiles.get(maxFetchSize));
+				filteredFiles = filteredFiles.stream()
+						.limit(maxFetchSize)
+						.collect(Collectors.toList());
+			}
+		}
+		return filteredFiles;
 	}
 
 	protected void rollbackFromFileToListEnd(List<F> filteredFiles, F file) {
@@ -418,12 +445,8 @@ public abstract class AbstractInboundFileSynchronizer<F>
 				}
 				return true;
 			}
-			else if (this.filter instanceof ResettableFileListFilter) {
-				if (this.logger.isInfoEnabled()) {
-					this.logger.info("Reverting the remote file '" + remoteFile +
-							"' from the filter for a subsequent transfer attempt");
-				}
-				((ResettableFileListFilter<F>) this.filter).remove(remoteFile);
+			else {
+				resetFilterIfNecessary(remoteFile);
 			}
 		}
 		else if (this.logger.isWarnEnabled()) {
@@ -432,6 +455,16 @@ public abstract class AbstractInboundFileSynchronizer<F>
 		}
 
 		return false;
+	}
+
+	private void resetFilterIfNecessary(F remoteFile) {
+		if (this.filter instanceof ResettableFileListFilter) {
+			if (this.logger.isInfoEnabled()) {
+				this.logger.info("Removing the remote file '" + remoteFile +
+						"' from the filter for a subsequent transfer attempt");
+			}
+			((ResettableFileListFilter<F>) this.filter).remove(remoteFile);
+		}
 	}
 
 	private boolean copyRemoteContentToLocalFile(Session<F> session, String remoteFilePath, File localFile) {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/filters/LastModifiedFileListFilterTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/filters/LastModifiedFileListFilterTests.java
@@ -45,10 +45,12 @@ public class LastModifiedFileListFilterTests {
 		FileOutputStream fileOutputStream = new FileOutputStream(foo);
 		fileOutputStream.write("x".getBytes());
 		fileOutputStream.close();
-		assertThat(filter.filterFiles(new File[] { foo }).size()).isEqualTo(0);
+		assertThat(filter.filterFiles(new File[] { foo })).hasSize(0);
+		assertThat(filter.accept(foo)).isFalse();
 		// Make a file as of yesterday's
 		foo.setLastModified(System.currentTimeMillis() - 1000 * 60 * 60 * 24);
-		assertThat(filter.filterFiles(new File[] { foo }).size()).isEqualTo(1);
+		assertThat(filter.filterFiles(new File[] { foo })).hasSize(1);
+		assertThat(filter.accept(foo)).isTrue();
 	}
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
@@ -116,7 +116,6 @@ public class StreamingInboundTests {
 		Streamer streamer = new Streamer(new StringRemoteFileTemplate(sessionFactory), null);
 		streamer.setBeanFactory(mock(BeanFactory.class));
 		streamer.setRemoteDirectory("/foo");
-		streamer.setMaxFetchSize(1);
 		streamer.setFilter(new AcceptOnceFileListFilter<>());
 		streamer.afterPropertiesSet();
 		streamer.start();
@@ -133,10 +132,10 @@ public class StreamingInboundTests {
 		assertThat(received.getHeaders().get(FileHeaders.REMOTE_DIRECTORY)).isEqualTo("/foo");
 		assertThat(received.getHeaders().get(FileHeaders.REMOTE_FILE)).isEqualTo("bar");
 
-		// close after list, transform
-		verify(new IntegrationMessageHeaderAccessor(received).getCloseableResource(), times(4)).close();
+		// close after transform
+		verify(new IntegrationMessageHeaderAccessor(received).getCloseableResource(), times(3)).close();
 
-		verify(sessionFactory.getSession(), times(2)).list("/foo");
+		verify(sessionFactory.getSession()).list("/foo");
 	}
 
 	@Test
@@ -204,10 +203,9 @@ public class StreamingInboundTests {
 		streamer.start();
 		assertThat(streamer.receive()).isNotNull();
 		assertThat(TestUtils.getPropertyValue(streamer, "toBeReceived", BlockingQueue.class)).hasSize(1);
-		assertThat(streamer.metadataMap).hasSize(2);
+		assertThat(streamer.metadataMap).hasSize(1);
 		streamer.stop();
 		assertThat(TestUtils.getPropertyValue(streamer, "toBeReceived", BlockingQueue.class)).hasSize(0);
-		assertThat(streamer.metadataMap).hasSize(1);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -221,7 +219,7 @@ public class StreamingInboundTests {
 		assertThatExceptionOfType(UncheckedIOException.class)
 				.isThrownBy(streamer::receive);
 		assertThat(TestUtils.getPropertyValue(streamer, "toBeReceived", BlockingQueue.class)).hasSize(1);
-		assertThat(streamer.metadataMap).hasSize(1);
+		assertThat(streamer.metadataMap).hasSize(0);
 	}
 
 	public static class Streamer extends AbstractRemoteFileStreamingMessageSource<String> {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
@@ -35,6 +35,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 
@@ -45,6 +47,7 @@ import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.filters.AbstractPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.file.filters.AcceptOnceFileListFilter;
+import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.splitter.FileSplitter;
@@ -65,13 +68,33 @@ public class StreamingInboundTests {
 
 	private final StreamTransformer transformer = new StreamTransformer();
 
-	@SuppressWarnings("unchecked")
 	@Test
-	public void testAllData() throws Exception {
+	public void testAllDataNoFilter() throws IOException {
+		testAllData(null, true);
+	}
+
+	@Test
+	public void testAllDataSingleCapableFilter() throws IOException {
+		testAllData(null, false);
+	}
+
+	@Test
+	public void testAllDataBulkOnlyFilter() throws IOException {
+		testAllData(fs -> Stream.of(fs).collect(Collectors.toList()), false);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void testAllData(FileListFilter<String> filter, boolean nullFilter) throws IOException {
 		StringSessionFactory sessionFactory = new StringSessionFactory();
 		Streamer streamer = new Streamer(new StringRemoteFileTemplate(sessionFactory), null);
 		streamer.setBeanFactory(mock(BeanFactory.class));
 		streamer.setRemoteDirectory("/foo");
+		if (filter != null) {
+			streamer.setFilter(filter);
+		}
+		if (nullFilter) {
+			streamer.setFilter(null);
+		}
 		streamer.afterPropertiesSet();
 		streamer.start();
 		Message<byte[]> received = (Message<byte[]>) this.transformer.transform(streamer.receive());
@@ -225,6 +248,11 @@ public class StreamingInboundTests {
 	public static class Streamer extends AbstractRemoteFileStreamingMessageSource<String> {
 
 		ConcurrentHashMap<String, String> metadataMap = new ConcurrentHashMap<>();
+
+		protected Streamer(RemoteFileTemplate<String> template) {
+			super(template, null);
+			doSetFilter(null);
+		}
 
 		protected Streamer(RemoteFileTemplate<String> template, Comparator<String> comparator) {
 			super(template, comparator);

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
@@ -166,6 +166,7 @@ public class AbstractRemoteFileSynchronizerTests {
 
 	private AbstractInboundFileSynchronizingMessageSource<String> createSource(
 			AbstractInboundFileSynchronizer<String> sync) {
+
 		AbstractInboundFileSynchronizingMessageSource<String> source =
 				new AbstractInboundFileSynchronizingMessageSource<String>(sync) {
 

--- a/spring-integration-file/src/test/resources/log4j2-test.xml
+++ b/spring-integration-file/src/test/resources/log4j2-test.xml
@@ -6,8 +6,8 @@
 		</Console>
 	</Appenders>
 	<Loggers>
-		<Logger name="org.springframework.integration" level="trace"/>
-		<Logger name="org.springframework.integration.file" level="trace"/>
+		<Logger name="org.springframework.integration" level="warn"/>
+		<Logger name="org.springframework.integration.file" level="warn"/>
 		<Root level="warn">
 			<AppenderRef ref="STDOUT" />
 		</Root>

--- a/spring-integration-file/src/test/resources/log4j2-test.xml
+++ b/spring-integration-file/src/test/resources/log4j2-test.xml
@@ -6,8 +6,8 @@
 		</Console>
 	</Appenders>
 	<Loggers>
-		<Logger name="org.springframework.integration" level="warn"/>
-		<Logger name="org.springframework.integration.file" level="warn"/>
+		<Logger name="org.springframework.integration" level="trace"/>
+		<Logger name="org.springframework.integration.file" level="trace"/>
 		<Root level="warn">
 			<AppenderRef ref="STDOUT" />
 		</Root>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
@@ -124,10 +124,9 @@ public class FtpStreamingMessageSourceTests extends FtpTestSupport {
 		assertThat(received).isNotNull();
 		assertThat(received.getHeaders().get(FileHeaders.REMOTE_FILE_INFO)).isInstanceOf(FtpFileInfo.class);
 		assertThat(TestUtils.getPropertyValue(source, "toBeReceived", BlockingQueue.class)).hasSize(1);
-		assertThat(this.metadataMap).hasSize(2);
+		assertThat(this.metadataMap).hasSize(1);
 		this.adapter.stop();
 		assertThat(TestUtils.getPropertyValue(source, "toBeReceived", BlockingQueue.class)).isEmpty();
-		assertThat(this.metadataMap).hasSize(1);
 	}
 
 	@Test
@@ -166,7 +165,6 @@ public class FtpStreamingMessageSourceTests extends FtpTestSupport {
 		FtpStreamingMessageSource messageSource = new FtpStreamingMessageSource(this.config.template(),
 				Comparator.comparing(FTPFile::getName));
 		messageSource.setRemoteDirectory("ftpSource/");
-		messageSource.setMaxFetchSize(1);
 		messageSource.setBeanFactory(this.context);
 		return messageSource;
 	}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/RotatingServersTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/RotatingServersTests.java
@@ -31,7 +31,6 @@ import org.apache.commons.net.ftp.FTPFile;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -149,7 +148,6 @@ public class RotatingServersTests extends FtpTestSupport {
 	}
 
 	@Test
-	@Ignore //- need to debug this
 	public void testStreaming() throws Exception {
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(StreamingConfig.class);
 		StandardConfig config = ctx.getBean(StandardConfig.class);

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/RotatingServersTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/RotatingServersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.apache.commons.net.ftp.FTPFile;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -148,6 +149,7 @@ public class RotatingServersTests extends FtpTestSupport {
 	}
 
 	@Test
+	@Ignore //- need to debug this
 	public void testStreaming() throws Exception {
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(StreamingConfig.class);
 		StandardConfig config = ctx.getBean(StandardConfig.class);

--- a/spring-integration-ftp/src/test/resources/log4j2-test.xml
+++ b/spring-integration-ftp/src/test/resources/log4j2-test.xml
@@ -8,7 +8,7 @@
 	<Loggers>
 		<Logger name="org.springframework" level="warn"/>
 		<Logger name="org.springframework.integration" level="warn"/>
-		<Logger name="org.springframework.integration.file" level="warn"/>
+		<Logger name="org.springframework.integration.file" level="trace"/>
 		<Logger name="org.springframework.integration.ftp" level="warn"/>
 		<Logger name="org.apache.ftpserver" level="error"/>
 		<Root level="warn">

--- a/spring-integration-ftp/src/test/resources/log4j2-test.xml
+++ b/spring-integration-ftp/src/test/resources/log4j2-test.xml
@@ -8,7 +8,7 @@
 	<Loggers>
 		<Logger name="org.springframework" level="warn"/>
 		<Logger name="org.springframework.integration" level="warn"/>
-		<Logger name="org.springframework.integration.file" level="trace"/>
+		<Logger name="org.springframework.integration.file" level="warn"/>
 		<Logger name="org.springframework.integration.ftp" level="warn"/>
 		<Logger name="org.apache.ftpserver" level="error"/>
 		<Root level="warn">

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
@@ -169,7 +169,6 @@ public class SftpStreamingMessageSourceTests extends SftpTestSupport {
 				new SftpStreamingMessageSource(this.config.template(),
 						Comparator.comparing(LsEntry::getFilename));
 		messageSource.setRemoteDirectory("sftpSource/");
-		messageSource.setMaxFetchSize(1);
 		messageSource.setBeanFactory(this.context);
 		return messageSource;
 	}

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -461,7 +461,7 @@ public class FileReadingJavaApplication {
                   .transform(Files.toStringTransformer())
                   .channel("processFileChannel")
                   .get();
-        }
+    }
 
 }
 ----
@@ -482,15 +482,15 @@ Examples of such events include the following:
 ====
 [source,bash]
 ----
-[message=tail: cannot open `/tmp/somefile' for reading:
+[message=tail: cannot open '/tmp/somefile' for reading:
                No such file or directory, file=/tmp/somefile]
 
-[message=tail: `/tmp/somefile' has become accessible, file=/tmp/somefile]
+[message=tail: '/tmp/somefile' has become accessible, file=/tmp/somefile]
 
-[message=tail: `/tmp/somefile' has become inaccessible:
+[message=tail: '/tmp/somefile' has become inaccessible:
                No such file or directory, file=/tmp/somefile]
 
-[message=tail: `/tmp/somefile' has appeared;
+[message=tail: '/tmp/somefile' has appeared;
                following end of new file, file=/tmp/somefile]
 ----
 ====
@@ -1114,3 +1114,33 @@ public class FileSplitterApplication {
 }
 ----
 ====
+
+[[remote-persistent-flf]]
+=== Remote Persistent File List Filters
+
+Inbound and streaming inbound remote file channel adapters (`FTP`, `SFTP`, and other technologies) are configured with correponding implementations of `AbstractPersistentFileListFilter` by default, configured with an in-memory `MetadataStore`.
+To run in a cluster, these can be replaced with filters using a shared `MetadataStore` (see <<metadata-store>> for more information).
+These filters are used to prevent fetching the same file multiple times (unless it's modified time changes).
+Starting with version 5.2, a file is added to the filter immediately before the file is fetched (and reversed if the fetch fails).
+
+IMPORTANT: In the event of a catestrophic failure (such as power loss), it is possible that the file currently being fetched will remain in the filter and won't be re-fetched when restarting the application.
+In this case you would need to manually remove this file from the `MetadataStore`.
+
+In previous versions, the files were filtered before any were fetched, meaning that several files could be in this state after a catestrophic failure.
+
+In order to facilitate this new behavior, two new methods have been added to `FileListFilter`.
+
+====
+[source, java]
+----
+boolean accept(F file);
+
+boolean supportsSingleFileFiltering();
+----
+====
+
+If a filter returns `true` in `supportsSingleFileFiltering`, it **must** implement `accept()`.
+
+If a remote filter does not support single file filtering (such as the `AbstractMarkerFilePresentFileListFilter`), the adapters revert to the previous behavior.
+
+If multiple filters are in used (using a `CompositeFileListFilter` or `ChainFileListFilter`), then **all** of the delegate filters must support single file filtering in order for the composite filter to support it.

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -344,6 +344,8 @@ Unless your application removes files after processing, the adapter will re-proc
 
 Also, if you configure the `filter` to use a `FtpPersistentAcceptOnceFileListFilter` and the remote file timestamp changes (causing it to be re-fetched), the default local filter does not let this new file be processed.
 
+For more information about this filter, and how it is used, see <<remote-persistent-flf>>.
+
 You can use the `local-filter` attribute to configure the behavior of the local file system filter.
 Starting with version 4.3.8, a `FileSystemPersistentAcceptOnceFileListFilter` is configured by default.
 This filter stores the accepted file names and modified timestamp in an instance of the `MetadataStore` strategy (see <<metadata-store>>) and detects changes to the local file modified time.
@@ -622,6 +624,8 @@ By default, this filter is also applied with the filename pattern (or regex).
 If you need to allow duplicates, you can use `AcceptAllFileListFilter`.
 Any other use cases can be handled by `CompositeFileListFilter` (or `ChainFileListFilter`).
 The Java configuration (<<ftp-streaming-java,later in the document>>) shows one technique to remove the remote file after processing to avoid duplicates.
+
+For more information about the `FtpPersistentAcceptOnceFileListFilter`, and how it is used, see <<remote-persistent-flf>>.
 
 Use the `max-fetch-size` attribute to limit the number of files fetched on each poll when a fetch is necessary.
 Set it to `1` and use a persistent filter when running in a clustered environment.

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -371,7 +371,9 @@ Once the files have been retrieved, an additional filter is applied to the files
 By default, this is an`AcceptOnceFileListFilter`, which, as discussed in this section, retains state in memory and does not consider the file's modified time.
 Unless your application removes files after processing, the adapter re-processes the files on disk by default after an application restart.
 
-Also, if you configure the `filter` to use a `FtpPersistentAcceptOnceFileListFilter` and the remote file timestamp changes (causing it to be re-fetched), the default local filter does not allow this new file to be processed.
+Also, if you configure the `filter` to use a `SftpPersistentAcceptOnceFileListFilter` and the remote file timestamp changes (causing it to be re-fetched), the default local filter does not allow this new file to be processed.
+
+For more information about this filter, and how it is used, see <<remote-persistent-flf>>.
 
 You can use the `local-filter` attribute to configure the behavior of the local file system filter.
 Starting with version 4.3.8, a `FileSystemPersistentAcceptOnceFileListFilter` is configured by default.
@@ -621,6 +623,8 @@ By default, this filter is also applied together with the filename pattern (or r
 If you need to allow duplicates, you can use the `AcceptAllFileListFilter`.
 You can handle any other use cases by using `CompositeFileListFilter` (or `ChainFileListFilter`).
 The Java configuration <<sftp-streaming-java-config,shown later>> shows one technique to remove the remote file after processing, avoiding duplicates.
+
+For more information about the `SftpPersistentAcceptOnceFileListFilter`, and how it is used, see <<remote-persistent-flf>>.
 
 You can use the `max-fetch-size` attribute to limit the number of files fetched on each poll when a fetch is necessary.
 Set it to `1` and use a persistent filter when running in a clustered environment.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -10,7 +10,13 @@ If you are interested in more details, see the Issue Tracker tickets that were r
 [[x5.2-general]]
 === General Changes
 
-[[5.2-tcp]]
+[[x5.2-file]]
+==== File Changes
+
+Some improvements to filtering remote files have been made.
+See <<remote-persistent-flf>> for more information.
+
+[[x5.2-tcp]]
 ==== TCP Changes
 
 The length header used by the `ByteArrayLengthHeaderSerializer` can now include the length of the header in addition to the payload.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/2777

If the filter supports it, defer filtering until the last possible moment.
Then, the worst case scenario after a catestrophic failure (e.g. power loss),
would be that at most one file will be incorrectly filtered on restart.

**Do not merge - needs more test coverage and fix one broken test case**