### PR TITLE
Fix MMIHelper for reinitialization

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
@@ -159,7 +159,7 @@ public class AggregatorParserTests {
 		Object handlerMethods = new DirectFieldAccessor(new DirectFieldAccessor(new DirectFieldAccessor(accessor
 				.getPropertyValue("outputProcessor")).getPropertyValue("processor")).getPropertyValue("delegate"))
 				.getPropertyValue("handlerMethods");
-		assertThat(handlerMethods).isNull();
+		assertThat(handlerMethods).isNotNull();
 		Object handlerMethod = new DirectFieldAccessor(new DirectFieldAccessor(new DirectFieldAccessor(accessor
 				.getPropertyValue("outputProcessor")).getPropertyValue("processor")).getPropertyValue("delegate"))
 				.getPropertyValue("handlerMethod");
@@ -244,7 +244,7 @@ public class AggregatorParserTests {
 		MessagingMethodInvokerHelper methodInvokerHelper =
 				TestUtils.getPropertyValue(releaseStrategy, "adapter.delegate", MessagingMethodInvokerHelper.class);
 		Object handlerMethods = TestUtils.getPropertyValue(methodInvokerHelper, "handlerMethods");
-		assertThat(handlerMethods).isNull();
+		assertThat(handlerMethods).isNotNull();
 		Object handlerMethod = TestUtils.getPropertyValue(methodInvokerHelper, "handlerMethod");
 		assertThat(handlerMethod.toString().contains("checkCompleteness")).isTrue();
 		input.send(createMessage(1L, "correlationId", 4, 0, null));
@@ -269,7 +269,7 @@ public class AggregatorParserTests {
 		DirectFieldAccessor releaseStrategyAccessor = new DirectFieldAccessor(new DirectFieldAccessor(new DirectFieldAccessor(releaseStrategy)
 				.getPropertyValue("adapter")).getPropertyValue("delegate"));
 		Object handlerMethods = releaseStrategyAccessor.getPropertyValue("handlerMethods");
-		assertThat(handlerMethods).isNull();
+		assertThat(handlerMethods).isNotNull();
 		Object handlerMethod = releaseStrategyAccessor.getPropertyValue("handlerMethod");
 		assertThat(handlerMethod.toString().contains("checkCompleteness")).isTrue();
 		input.send(createMessage(1L, "correlationId", 4, 0, null));

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -59,6 +59,7 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.config.EnableMessageHistory;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessageSelector;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.endpoint.AbstractEndpoint;
@@ -72,6 +73,8 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
@@ -228,6 +231,11 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 	public static class ContextConfiguration {
 
 		private static final ExpressionParser PARSER = new SpelExpressionParser();
+
+		@Bean(IntegrationContextUtils.MESSAGE_HANDLER_FACTORY_BEAN_NAME)
+		public MessageHandlerMethodFactory messageHandlerMethodFactory() {
+			return new DefaultMessageHandlerMethodFactory();
+		}
 
 		@Bean
 		public AtomicInteger counter() {


### PR DESCRIPTION
If we provide a custom `MessageHandlerMethodFactory`, the
`MessagingMethodInvokerHelper` obtains its bean and reinitialize a
`handlerMethod`, but it is done only for single, explicit
and provided method.
In case of `Function` or `Consumer` we use local names for methods to
extract, but this is not populated to properties of the
`MessagingMethodInvokerHelper`

* Change an internal `MessagingMethodInvokerHelper` logic to recreate
`InvocableHandlerMethod` instances based on the `MessageHandlerMethodFactory`
bean for all the methods scanned on the target.
* Populate a `handlerMethodsList` for the purpose above even if we have
only one candidate
* Fix `AggregatorParserTests` to reflect the current logic around
`handlerMethodsList`
* Prove that new logic works well with a custom `MessageHandlerMethodFactory`
bean in the `MessagingAnnotationsWithBeanAnnotationTests`

**Cherry-pick to 5.1.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
