### PR TITLE
INT-2277: Register ChResolver & ErrHandler beans

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationAdvisor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationAdvisor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.integration.annotation.Publisher;
-import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.util.Assert;
 
 /**
@@ -60,7 +59,8 @@ public class PublisherAnnotationAdvisor extends AbstractPointcutAdvisor implemen
 	@SuppressWarnings("unchecked")
 	public PublisherAnnotationAdvisor(Class<? extends Annotation>... publisherAnnotationTypes) {
 		this.publisherAnnotationTypes = new HashSet<>(Arrays.asList(publisherAnnotationTypes));
-		PublisherMetadataSource metadataSource = new MethodAnnotationPublisherMetadataSource(this.publisherAnnotationTypes);
+		PublisherMetadataSource metadataSource =
+				new MethodAnnotationPublisherMetadataSource(this.publisherAnnotationTypes);
 		this.interceptor = new MessagePublishingInterceptor(metadataSource);
 	}
 
@@ -81,7 +81,6 @@ public class PublisherAnnotationAdvisor extends AbstractPointcutAdvisor implemen
 
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) {
-		this.interceptor.setChannelResolver(new BeanFactoryChannelResolver(beanFactory));
 		this.interceptor.setBeanFactory(beanFactory);
 	}
 
@@ -168,6 +167,7 @@ public class PublisherAnnotationAdvisor extends AbstractPointcutAdvisor implemen
 		public MethodMatcher getMethodMatcher() {
 			return this.methodMatcher;
 		}
+
 	}
 
 
@@ -197,6 +197,7 @@ public class PublisherAnnotationAdvisor extends AbstractPointcutAdvisor implemen
 			return (specificMethod != method &&
 					(AnnotationUtils.getAnnotation(specificMethod, this.annotationType) != null));
 		}
+
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/ExecutorChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/ExecutorChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@ package org.springframework.integration.channel;
 
 import java.util.concurrent.Executor;
 
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.IntegrationProperties;
 import org.springframework.integration.dispatcher.LoadBalancingStrategy;
 import org.springframework.integration.dispatcher.RoundRobinLoadBalancingStrategy;
 import org.springframework.integration.dispatcher.UnicastingDispatcher;
-import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.util.ErrorHandlingTaskExecutor;
 import org.springframework.util.Assert;
 import org.springframework.util.ErrorHandler;
@@ -103,8 +103,7 @@ public class ExecutorChannel extends AbstractExecutorChannel {
 				+ "bean is fully initialized by the framework. Do not subscribe in a @Bean definition");
 		super.onInit();
 		if (!(this.executor instanceof ErrorHandlingTaskExecutor)) {
-			ErrorHandler errorHandler = new MessagePublishingErrorHandler(
-					new BeanFactoryChannelResolver(this.getBeanFactory()));
+			ErrorHandler errorHandler = IntegrationContextUtils.getErrorHandler(getBeanFactory());
 			this.executor = new ErrorHandlingTaskExecutor(this.executor, errorHandler);
 		}
 		UnicastingDispatcher unicastingDispatcher = new UnicastingDispatcher(this.executor);

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/MessagePublishingErrorHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/MessagePublishingErrorHandler.java
@@ -64,7 +64,7 @@ public class MessagePublishingErrorHandler extends ErrorMessagePublisher impleme
 	}
 
 
-	public void setDefaultErrorChannel(MessageChannel defaultErrorChannel) {
+	public void setDefaultErrorChannel(@Nullable MessageChannel defaultErrorChannel) {
 		setChannel(defaultErrorChannel);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/WireTap.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/WireTap.java
@@ -23,8 +23,8 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.context.Lifecycle;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessageSelector;
-import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedResource;
@@ -179,14 +179,12 @@ public class WireTap implements ChannelInterceptor, Lifecycle, VetoCapableInterc
 	}
 
 	private MessageChannel getChannel() {
-		if (this.channelName != null) {
-			synchronized (this) {
-				if (this.channelName != null) {
-					this.channel = new BeanFactoryChannelResolver(this.beanFactory)
-							.resolveDestination(this.channelName);
-					this.channelName = null;
-				}
-			}
+		String channelNameToUse = this.channelName;
+		if (channelNameToUse != null) {
+			this.channel =
+					IntegrationContextUtils.getChannelResolver(this.beanFactory)
+							.resolveDestination(channelNameToUse);
+			this.channelName = null;
 		}
 		return this.channel;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -51,6 +51,7 @@ import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.config.IntegrationConfigUtils;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.Orderable;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.endpoint.AbstractPollingEndpoint;
@@ -64,7 +65,6 @@ import org.springframework.integration.handler.ReplyProducingMessageHandlerWrapp
 import org.springframework.integration.handler.advice.HandleMessageAdvice;
 import org.springframework.integration.router.AbstractMessageRouter;
 import org.springframework.integration.scheduling.PollerMetadata;
-import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.util.MessagingAnnotationUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageChannel;
@@ -120,9 +120,10 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 		this.conversionService = this.beanFactory.getConversionService() != null
 				? this.beanFactory.getConversionService()
 				: DefaultConversionService.getSharedInstance();
-		this.channelResolver = new BeanFactoryChannelResolver(beanFactory);
-		this.annotationType = (Class<T>) GenericTypeResolver.resolveTypeArgument(this.getClass(),
-				MethodAnnotationPostProcessor.class);
+		this.channelResolver = IntegrationContextUtils.getChannelResolver(beanFactory);
+		this.annotationType =
+				(Class<T>) GenericTypeResolver.resolveTypeArgument(this.getClass(),
+						MethodAnnotationPostProcessor.class);
 		Disposables disposablesBean = null;
 		try {
 			disposablesBean = beanFactory.getBean(Disposables.class);

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
@@ -23,11 +23,15 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.expression.spel.support.SimpleEvaluationContext;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.config.IntegrationConfigUtils;
 import org.springframework.integration.metadata.MetadataStore;
+import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.core.DestinationResolver;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
+import org.springframework.util.ErrorHandler;
 
 /**
  * Utility methods for accessing common integration components from the BeanFactory.
@@ -44,9 +48,9 @@ public abstract class IntegrationContextUtils {
 
 	public static final String ERROR_CHANNEL_BEAN_NAME = "errorChannel";
 
-	public static final String ERROR_LOGGER_BEAN_NAME = "_org.springframework.integration.errorLogger";
-
 	public static final String NULL_CHANNEL_BEAN_NAME = "nullChannel";
+
+	public static final String ERROR_LOGGER_BEAN_NAME = "_org.springframework.integration.errorLogger";
 
 	public static final String METADATA_STORE_BEAN_NAME = "metadataStore";
 
@@ -106,6 +110,10 @@ public abstract class IntegrationContextUtils {
 	public static final String MESSAGE_HANDLER_FACTORY_BEAN_NAME = "integrationMessageHandlerMethodFactory";
 
 	public static final String LIST_MESSAGE_HANDLER_FACTORY_BEAN_NAME = "integrationListMessageHandlerMethodFactory";
+
+	public static final String CHANNEL_RESOLVER_BEAN_NAME = "integrationChannelResolver";
+
+	public static final String MESSAGE_PUBLISHING_ERROR_HANDLER_BEAN_NAME = "integrationMessagePublishingErrorHandler";
 
 	/**
 	 * @param beanFactory BeanFactory for lookup, must not be null.
@@ -210,6 +218,39 @@ public abstract class IntegrationContextUtils {
 			properties.putAll(IntegrationProperties.defaults());
 		}
 		return properties;
+	}
+
+	/**
+	 * Obtain a {@link DestinationResolver} registered with the
+	 * {@value #CHANNEL_RESOLVER_BEAN_NAME} bean name.
+	 * @param beanFactory BeanFactory for lookup, must not be null.
+	 * @return the instance of {@link DestinationResolver} bean whose name is
+	 * {@value #CHANNEL_RESOLVER_BEAN_NAME}.
+	 * @since 5.2
+	 */
+	@SuppressWarnings("unchecked")
+	public static DestinationResolver<MessageChannel> getChannelResolver(BeanFactory beanFactory) {
+		if (!beanFactory.containsBean(CHANNEL_RESOLVER_BEAN_NAME)) {
+			return new BeanFactoryChannelResolver(beanFactory);
+		}
+		return beanFactory.getBean(CHANNEL_RESOLVER_BEAN_NAME, DestinationResolver.class);
+	}
+
+	/**
+	 * Obtain an {@link ErrorHandler} registered with the
+	 * {@value #MESSAGE_PUBLISHING_ERROR_HANDLER_BEAN_NAME} bean name.
+	 * By default resolves to the {@link org.springframework.integration.channel.MessagePublishingErrorHandler}
+	 * with the {@value #CHANNEL_RESOLVER_BEAN_NAME} {@link DestinationResolver} bean.
+	 * @param beanFactory BeanFactory for lookup, must not be null.
+	 * @return the instance of {@link ErrorHandler} bean whose name is
+	 * {@value #MESSAGE_PUBLISHING_ERROR_HANDLER_BEAN_NAME}.
+	 * @since 5.2
+	 */
+	public static ErrorHandler getErrorHandler(BeanFactory beanFactory) {
+		if (!beanFactory.containsBean(MESSAGE_PUBLISHING_ERROR_HANDLER_BEAN_NAME)) {
+			return new MessagePublishingErrorHandler(getChannelResolver(beanFactory));
+		}
+		return beanFactory.getBean(MESSAGE_PUBLISHING_ERROR_HANDLER_BEAN_NAME, ErrorHandler.class);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
@@ -230,6 +230,7 @@ public abstract class IntegrationContextUtils {
 	 */
 	@SuppressWarnings("unchecked")
 	public static DestinationResolver<MessageChannel> getChannelResolver(BeanFactory beanFactory) {
+		Assert.notNull(beanFactory, "'beanFactory' must not be null");
 		if (!beanFactory.containsBean(CHANNEL_RESOLVER_BEAN_NAME)) {
 			return new BeanFactoryChannelResolver(beanFactory);
 		}
@@ -247,6 +248,7 @@ public abstract class IntegrationContextUtils {
 	 * @since 5.2
 	 */
 	public static ErrorHandler getErrorHandler(BeanFactory beanFactory) {
+		Assert.notNull(beanFactory, "'beanFactory' must not be null");
 		if (!beanFactory.containsBean(MESSAGE_PUBLISHING_ERROR_HANDLER_BEAN_NAME)) {
 			return new MessagePublishingErrorHandler(getChannelResolver(beanFactory));
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -37,7 +37,6 @@ import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
-import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.lang.Nullable;
@@ -228,7 +227,7 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 
 	protected DestinationResolver<MessageChannel> getChannelResolver() {
 		if (this.channelResolver == null) {
-			this.channelResolver = new BeanFactoryChannelResolver(this.beanFactory);
+			this.channelResolver = IntegrationContextUtils.getChannelResolver(this.beanFactory);
 		}
 		return this.channelResolver;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/ErrorMessagePublisher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/ErrorMessagePublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.support.DefaultErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageUtils;
-import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -97,7 +96,7 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 	public void setBeanFactory(BeanFactory beanFactory) {
 		Assert.notNull(beanFactory, "beanFactory must not be null");
 		if (this.channelResolver == null) {
-			this.channelResolver = new BeanFactoryChannelResolver(beanFactory);
+			this.channelResolver = IntegrationContextUtils.getChannelResolver(beanFactory);
 		}
 	}
 
@@ -183,8 +182,8 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 		else if (!(lastThrowable instanceof MessagingException)) {
 			Message<?> message = (Message<?>) context.getAttribute(ErrorMessageUtils.FAILED_MESSAGE_CONTEXT_KEY);
 			lastThrowable = message == null
-				? new MessagingException(lastThrowable.getMessage(), lastThrowable)
-				: new MessagingException(message, lastThrowable.getMessage(), lastThrowable);
+					? new MessagingException(lastThrowable.getMessage(), lastThrowable)
+					: new MessagingException(message, lastThrowable.getMessage(), lastThrowable);
 		}
 		return lastThrowable;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/MessagingTemplate.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/MessagingTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.IntegrationProperties;
-import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.core.GenericMessagingTemplate;
@@ -57,12 +56,12 @@ public class MessagingTemplate extends GenericMessagingTemplate {
 	}
 
 	/**
-	 * Overridden to set the destination resolver to a {@link BeanFactoryChannelResolver}.
+	 * Overridden to set the destination resolver to a {@code integrationChannelResolver} bean.
 	 */
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		this.beanFactory = beanFactory; //NOSONAR - non-sync is ok here
-		super.setDestinationResolver(new BeanFactoryChannelResolver(beanFactory));
+		setDestinationResolver(IntegrationContextUtils.getChannelResolver(beanFactory));
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveStreamsConsumer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveStreamsConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,10 @@ import org.reactivestreams.Subscription;
 
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.channel.MessageChannelReactiveUtils;
-import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.channel.NullChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.router.MessageRouter;
-import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
@@ -124,8 +123,7 @@ public class ReactiveStreamsConsumer extends AbstractEndpoint implements Integra
 	protected void onInit() {
 		super.onInit();
 		if (this.errorHandler == null) {
-			Assert.notNull(getBeanFactory(), "BeanFactory is required");
-			this.errorHandler = new MessagePublishingErrorHandler(new BeanFactoryChannelResolver(getBeanFactory()));
+			this.errorHandler = IntegrationContextUtils.getErrorHandler(getBeanFactory());
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -55,11 +55,11 @@ import org.springframework.expression.common.LiteralExpression;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.annotation.Gateway;
 import org.springframework.integration.annotation.GatewayHeader;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
-import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.support.management.TrackableComponent;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
@@ -384,12 +384,12 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 			}
 			BeanFactory beanFactory = this.getBeanFactory();
 			if (this.channelResolver == null && beanFactory != null) {
-				this.channelResolver = new BeanFactoryChannelResolver(beanFactory);
+				this.channelResolver = IntegrationContextUtils.getChannelResolver(beanFactory);
 			}
-			Class<?> proxyInterface = this.determineServiceInterface();
+			Class<?> proxyInterface = determineServiceInterface();
 			Method[] methods = ReflectionUtils.getUniqueDeclaredMethods(proxyInterface);
 			for (Method method : methods) {
-				MethodInvocationGateway gateway = this.createGatewayForMethod(method);
+				MethodInvocationGateway gateway = createGatewayForMethod(method);
 				this.gatewayMap.put(method, gateway);
 			}
 			this.serviceProxy = new ProxyFactory(proxyInterface, this)
@@ -451,7 +451,8 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 			}
 			else if (Future.class.isAssignableFrom(returnType)) {
 				if (logger.isDebugEnabled()) {
-					logger.debug("AsyncTaskExecutor submit*() return types are incompatible with the method return type; "
+					logger.debug("AsyncTaskExecutor submit*() return types are incompatible with the method return " +
+							"type; "
 							+ "running on calling thread; the downstream flow must return the required Future: "
 							+ returnType.getSimpleName());
 				}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueInboundGateway.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 the original author or authors.
+ * Copyright 2014-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.gateway.MessagingGatewaySupport;
 import org.springframework.integration.redis.event.RedisExceptionEvent;
-import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
 import org.springframework.integration.support.management.IntegrationManagedResource;
 import org.springframework.integration.util.ErrorHandlingTaskExecutor;
 import org.springframework.jmx.export.annotation.ManagedMetric;
@@ -152,8 +151,8 @@ public class RedisQueueInboundGateway extends MessagingGatewaySupport implements
 					+ this.getComponentType());
 		}
 		if (!(this.taskExecutor instanceof ErrorHandlingTaskExecutor) && this.getBeanFactory() != null) {
-			MessagePublishingErrorHandler errorHandler =
-					new MessagePublishingErrorHandler(new BeanFactoryChannelResolver(getBeanFactory()));
+			MessagePublishingErrorHandler errorHandler = new MessagePublishingErrorHandler();
+			errorHandler.setBeanFactory(getBeanFactory());
 			errorHandler.setDefaultErrorChannel(getErrorChannel());
 			this.taskExecutor = new ErrorHandlingTaskExecutor(this.taskExecutor, errorHandler);
 		}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-2277

To avoid extra objects at runtime and reuse a central configuration,
register `BeanFactoryChannelResolver` and `MessagePublishingErrorHandler`
bean via `DefaultConfiguringBeanFactoryPostProcessor`

* Use those beans whenever it is necessary via `IntegrationContextUtils`
factory methods against provided `BeanFactory`
* To avoid changes in the non-managed test, those new factories fall
back to a new instance if there is no an appropriate bean in the `beanFactory`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
