### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'idea'
 
 buildscript {
 	repositories {
-		maven { url 'http://repo.springsource.org/plugins-release' }
+		maven { url 'https://repo.springsource.org/plugins-release' }
 	}
 	dependencies {
 		classpath 'io.spring.gradle:docbook-reference-plugin:0.3.1'
@@ -13,7 +13,7 @@ buildscript {
 }
 
 ext {
-	linkHomepage = 'http://www.springintegration.org/'
+	linkHomepage = 'https://www.springsource.org/spring-integration/'
 	linkCi       = 'https://build.springsource.org/browse/INT'
 	linkIssue    = 'https://jira.springsource.org/browse/INT'
 	linkScmUrl           = 'https://github.com/spring-projects/spring-integration'
@@ -26,10 +26,10 @@ allprojects {
 
 	repositories {
 		if (project.hasProperty('springVersion') && getProperty('springVersion').endsWith('BUILD-SNAPSHOT')) {
-			maven { url 'http://repo.spring.io/libs-snapshot' }
+			maven { url 'https://repo.spring.io/libs-snapshot' }
 		}
-		maven { url 'http://repo.spring.io/libs-milestone' }
-		maven { url 'http://repo.spring.io/plugins-release' }
+		maven { url 'https://repo.spring.io/libs-milestone' }
+		maven { url 'https://repo.spring.io/plugins-release' }
 		mavenCentral()
 	}
 }
@@ -91,8 +91,8 @@ subprojects { subproject ->
 		}
 	}
 
-	// See http://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
-	// and http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
+	// See https://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
+	// and https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
 	configurations {
 		jacoco //Configuration Group used by Sonar to provide Code Coverage using JaCoCo
 		javaAgentSpringInstrument //Configuration Group used by the JPA Adapter during test execution

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'SpringSource'
-				url = 'http://springsource.org'
+				url = 'https://springsource.org'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://repo.springsource.org/plugins-release with 1 occurrences migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).
* http://springsource.org with 1 occurrences migrated to:  
  https://springsource.org ([https](https://springsource.org) result 301).
* http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html with 1 occurrences migrated to:  
  https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html ([https](https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html) result 301).
* http://www.gradle.org/docs/current/userguide/dependency_management.html with 1 occurrences migrated to:  
  https://www.gradle.org/docs/current/userguide/dependency_management.html ([https](https://www.gradle.org/docs/current/userguide/dependency_management.html) result 301).
* http://www.springintegration.org/ (301) with 1 occurrences migrated to:  
  https://www.springsource.org/spring-integration/ ([https](https://www.springintegration.org/) result 301).
* http://repo.spring.io/libs-milestone with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/plugins-release with 1 occurrences migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).