### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,15 +38,15 @@ allprojects {
 	}
 
 	ext.javadocLinks = [
-		'http://docs.oracle.com/javase/7/docs/api/',
-		'http://docs.oracle.com/javaee/6/api/',
-		'http://docs.spring.io/spring/docs/current/javadoc-api/',
-		'http://docs.spring.io/spring-amqp/docs/current/api/',
-		'http://docs.spring.io/spring-data-gemfire/docs/current/api/',
-		'http://docs.spring.io/spring-data/data-mongo/docs/current/api/',
-		'http://docs.spring.io/spring-data/data-redis/docs/current/api/',
-		'http://docs.spring.io/spring-social-twitter/docs/current/apidocs/',
-		'http://docs.spring.io/spring-ws/sites/2.0/apidocs/'
+		'https://docs.oracle.com/javase/7/docs/api/',
+		'https://docs.oracle.com/javaee/6/api/',
+		'https://docs.spring.io/spring/docs/current/javadoc-api/',
+		'https://docs.spring.io/spring-amqp/docs/current/api/',
+		'https://docs.spring.io/spring-data-gemfire/docs/current/api/',
+		'https://docs.spring.io/spring-data/data-mongo/docs/current/api/',
+		'https://docs.spring.io/spring-data/data-redis/docs/current/api/',
+		'https://docs.spring.io/spring-social-twitter/docs/current/apidocs/',
+		'https://docs.spring.io/spring-ws/sites/2.0/apidocs/'
 	] as String[]
 
 }

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = linkHomepage
 			organization {
 				name = 'SpringIO'
-				url = 'http://spring.io'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.oracle.com/javaee/6/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javaee/6/api/ ([https](https://docs.oracle.com/javaee/6/api/) result 200).
* http://docs.oracle.com/javase/7/docs/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/7/docs/api/ ([https](https://docs.oracle.com/javase/7/docs/api/) result 200).
* http://docs.spring.io/spring-amqp/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-amqp/docs/current/api/ ([https](https://docs.spring.io/spring-amqp/docs/current/api/) result 200).
* http://docs.spring.io/spring-data-gemfire/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data-gemfire/docs/current/api/ ([https](https://docs.spring.io/spring-data-gemfire/docs/current/api/) result 200).
* http://docs.spring.io/spring-data/data-mongo/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/data-mongo/docs/current/api/ ([https](https://docs.spring.io/spring-data/data-mongo/docs/current/api/) result 200).
* http://docs.spring.io/spring-data/data-redis/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/data-redis/docs/current/api/ ([https](https://docs.spring.io/spring-data/data-redis/docs/current/api/) result 200).
* http://docs.spring.io/spring-social-twitter/docs/current/apidocs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social-twitter/docs/current/apidocs/ ([https](https://docs.spring.io/spring-social-twitter/docs/current/apidocs/) result 200).
* http://docs.spring.io/spring-ws/sites/2.0/apidocs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-ws/sites/2.0/apidocs/ ([https](https://docs.spring.io/spring-ws/sites/2.0/apidocs/) result 200).
* http://docs.spring.io/spring/docs/current/javadoc-api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/ ([https](https://docs.spring.io/spring/docs/current/javadoc-api/) result 200).
* http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).