### PR TITLE
GH-2820: Close session in FtpRemFileTempl.exists

### DIFF
--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpRemoteFileTemplate.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpRemoteFileTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ public class FtpRemoteFileTemplate extends RemoteFileTemplate<FTPFile> {
 						return !ObjectUtils.isEmpty(names);
 
 					case NLST_AND_DIRS:
-						return getSession().exists(path);
+						return FtpRemoteFileTemplate.super.exists(path);
 
 					default:
 						throw new IllegalStateException("Unsupported 'existsMode': " +


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/2820

The current `FtpRemoteFileTemplate.exists()` implementation obtains a
`Session` for the `NLST_AND_DIRS` mode, but doesn't close it.

* Fix the `FtpRemoteFileTemplate.exists()` method to delegate to `super`
for the proper interaction with a `Session`

**Cherry-pick to 5.1.x, 5.0.x & 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
