### PR TITLE
Short-circuit methods for lambdas from annotation

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -515,8 +515,8 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 		}
 	}
 
-	protected boolean resolveAttributeToBoolean(String requiresReply) {
-		return Boolean.parseBoolean(this.beanFactory.resolveEmbeddedValue(requiresReply));
+	protected boolean resolveAttributeToBoolean(String attribute) {
+		return Boolean.parseBoolean(this.beanFactory.resolveEmbeddedValue(attribute));
 	}
 
 	@Nullable

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AggregatorAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AggregatorAnnotationPostProcessor.java
@@ -51,7 +51,6 @@ public class AggregatorAnnotationPostProcessor extends AbstractMethodAnnotationP
 	@Override
 	protected MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations) {
 		MethodInvokingMessageGroupProcessor processor = new MethodInvokingMessageGroupProcessor(bean, method);
-		processor.setBeanFactory(this.beanFactory);
 
 		MethodInvokingReleaseStrategy releaseStrategy = null;
 		Method releaseStrategyMethod = MessagingAnnotationUtils.findAnnotatedMethod(bean, ReleaseStrategy.class);
@@ -60,7 +59,8 @@ public class AggregatorAnnotationPostProcessor extends AbstractMethodAnnotationP
 		}
 
 		MethodInvokingCorrelationStrategy correlationStrategy = null;
-		Method correlationStrategyMethod = MessagingAnnotationUtils.findAnnotatedMethod(bean, CorrelationStrategy.class);
+		Method correlationStrategyMethod =
+				MessagingAnnotationUtils.findAnnotatedMethod(bean, CorrelationStrategy.class);
 		if (correlationStrategyMethod != null) {
 			correlationStrategy = new MethodInvokingCorrelationStrategy(bean, correlationStrategyMethod);
 		}
@@ -68,21 +68,21 @@ public class AggregatorAnnotationPostProcessor extends AbstractMethodAnnotationP
 		AggregatingMessageHandler handler = new AggregatingMessageHandler(processor, new SimpleMessageStore(),
 				correlationStrategy, releaseStrategy);
 
-		String discardChannelName = MessagingAnnotationUtils.resolveAttribute(annotations, "discardChannel", String.class);
+		String discardChannelName =
+				MessagingAnnotationUtils.resolveAttribute(annotations, "discardChannel", String.class);
 		if (StringUtils.hasText(discardChannelName)) {
 			handler.setDiscardChannelName(discardChannelName);
 		}
-		String outputChannelName = MessagingAnnotationUtils.resolveAttribute(annotations, "outputChannel", String.class);
+		String outputChannelName =
+				MessagingAnnotationUtils.resolveAttribute(annotations, "outputChannel", String.class);
 		if (StringUtils.hasText(outputChannelName)) {
 			handler.setOutputChannelName(outputChannelName);
 		}
 		String sendPartialResultsOnExpiry = MessagingAnnotationUtils.resolveAttribute(annotations,
 				"sendPartialResultsOnExpiry", String.class);
 		if (sendPartialResultsOnExpiry != null) {
-			handler.setSendPartialResultOnExpiry(
-					Boolean.parseBoolean(this.beanFactory.resolveEmbeddedValue(sendPartialResultsOnExpiry)));
+			handler.setSendPartialResultOnExpiry(resolveAttributeToBoolean(sendPartialResultsOnExpiry));
 		}
-		handler.setBeanFactory(this.beanFactory);
 		return handler;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessor.java
@@ -45,7 +45,7 @@ public class FilterAnnotationPostProcessor extends AbstractMethodAnnotationPostP
 
 	public FilterAnnotationPostProcessor(ConfigurableListableBeanFactory beanFactory) {
 		super(beanFactory);
-		this.messageHandlerAttributes.addAll(Arrays.<String>asList("discardChannel", "throwExceptionOnRejection",
+		this.messageHandlerAttributes.addAll(Arrays.asList("discardChannel", "throwExceptionOnRejection",
 				"adviceChain", "discardWithinAdvice"));
 	}
 
@@ -54,11 +54,11 @@ public class FilterAnnotationPostProcessor extends AbstractMethodAnnotationPostP
 	protected MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations) {
 		MessageSelector selector;
 		if (AnnotatedElementUtils.isAnnotated(method, Bean.class.getName())) {
-			Object target = this.resolveTargetBeanFromMethodWithBeanAnnotation(method);
+			Object target = resolveTargetBeanFromMethodWithBeanAnnotation(method);
 			if (target instanceof MessageSelector) {
 				selector = (MessageSelector) target;
 			}
-			else if (this.extractTypeIfPossible(target, MessageFilter.class) != null) {
+			else if (extractTypeIfPossible(target, MessageFilter.class) != null) {
 				checkMessageHandlerAttributes(resolveTargetBeanName(method), annotations);
 				return (MessageHandler) target;
 			}
@@ -74,31 +74,25 @@ public class FilterAnnotationPostProcessor extends AbstractMethodAnnotationPostP
 
 		MessageFilter filter = new MessageFilter(selector);
 
-		String discardWithinAdvice = MessagingAnnotationUtils.resolveAttribute(annotations, "discardWithinAdvice",
-				String.class);
+		String discardWithinAdvice =
+				MessagingAnnotationUtils.resolveAttribute(annotations, "discardWithinAdvice", String.class);
 		if (StringUtils.hasText(discardWithinAdvice)) {
-			discardWithinAdvice = this.beanFactory.resolveEmbeddedValue(discardWithinAdvice);
-			if (StringUtils.hasText(discardWithinAdvice)) {
-				filter.setDiscardWithinAdvice(Boolean.parseBoolean(discardWithinAdvice));
-			}
+			filter.setDiscardWithinAdvice(resolveAttributeToBoolean(discardWithinAdvice));
 		}
 
-
-		String throwExceptionOnRejection = MessagingAnnotationUtils.resolveAttribute(annotations,
-				"throwExceptionOnRejection", String.class);
+		String throwExceptionOnRejection =
+				MessagingAnnotationUtils.resolveAttribute(annotations, "throwExceptionOnRejection", String.class);
 		if (StringUtils.hasText(throwExceptionOnRejection)) {
-			String throwExceptionOnRejectionValue = this.beanFactory.resolveEmbeddedValue(throwExceptionOnRejection);
-			if (StringUtils.hasText(throwExceptionOnRejectionValue)) {
-				filter.setThrowExceptionOnRejection(Boolean.parseBoolean(throwExceptionOnRejectionValue));
-			}
+			filter.setThrowExceptionOnRejection(resolveAttributeToBoolean(throwExceptionOnRejection));
 		}
 
-		String discardChannelName = MessagingAnnotationUtils.resolveAttribute(annotations, "discardChannel", String.class);
+		String discardChannelName =
+				MessagingAnnotationUtils.resolveAttribute(annotations, "discardChannel", String.class);
 		if (StringUtils.hasText(discardChannelName)) {
 			filter.setDiscardChannelName(discardChannelName);
 		}
 
-		this.setOutputChannelIfPresent(annotations, filter);
+		setOutputChannelIfPresent(annotations, filter);
 		return filter;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessor.java
@@ -46,7 +46,7 @@ public class RouterAnnotationPostProcessor extends AbstractMethodAnnotationPostP
 
 	public RouterAnnotationPostProcessor(ConfigurableListableBeanFactory beanFactory) {
 		super(beanFactory);
-		this.messageHandlerAttributes.addAll(Arrays.<String>asList("defaultOutputChannel", "applySequence",
+		this.messageHandlerAttributes.addAll(Arrays.asList("defaultOutputChannel", "applySequence",
 				"ignoreSendFailures", "resolutionRequired", "channelMappings", "prefix", "suffix"));
 	}
 
@@ -54,12 +54,13 @@ public class RouterAnnotationPostProcessor extends AbstractMethodAnnotationPostP
 	protected MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations) {
 		AbstractMessageRouter router;
 		if (AnnotatedElementUtils.isAnnotated(method, Bean.class.getName())) {
-			Object target = this.resolveTargetBeanFromMethodWithBeanAnnotation(method);
-			router = this.extractTypeIfPossible(target, AbstractMessageRouter.class);
+			Object target = resolveTargetBeanFromMethodWithBeanAnnotation(method);
+			router = extractTypeIfPossible(target, AbstractMessageRouter.class);
 			if (router == null) {
 				if (target instanceof MessageHandler) {
-					Assert.isTrue(this.routerAttributesProvided(annotations), "'defaultOutputChannel', 'applySequence', " +
-							"'ignoreSendFailures', 'resolutionRequired', 'channelMappings', 'prefix' and 'suffix' " +
+					Assert.isTrue(routerAttributesProvided(annotations),
+							"'defaultOutputChannel', 'applySequence', 'ignoreSendFailures', 'resolutionRequired', " +
+									"'channelMappings', 'prefix' and 'suffix' " +
 							"can be applied to 'AbstractMessageRouter' implementations, but target handler is: " +
 							target.getClass());
 					return (MessageHandler) target;
@@ -84,26 +85,23 @@ public class RouterAnnotationPostProcessor extends AbstractMethodAnnotationPostP
 
 		String applySequence = MessagingAnnotationUtils.resolveAttribute(annotations, "applySequence", String.class);
 		if (StringUtils.hasText(applySequence)) {
-			router.setApplySequence(Boolean.parseBoolean(this.beanFactory.resolveEmbeddedValue(applySequence)));
+			router.setApplySequence(resolveAttributeToBoolean(applySequence));
 		}
 
 		String ignoreSendFailures = MessagingAnnotationUtils.resolveAttribute(annotations, "ignoreSendFailures",
 				String.class);
 		if (StringUtils.hasText(ignoreSendFailures)) {
-			router.setIgnoreSendFailures(Boolean.parseBoolean(this.beanFactory.resolveEmbeddedValue(ignoreSendFailures)));
+			router.setIgnoreSendFailures(resolveAttributeToBoolean(ignoreSendFailures));
 		}
 
-		if (this.routerAttributesProvided(annotations)) {
+		if (routerAttributesProvided(annotations)) {
 
 			MethodInvokingRouter methodInvokingRouter = (MethodInvokingRouter) router;
 
 			String resolutionRequired = MessagingAnnotationUtils.resolveAttribute(annotations, "resolutionRequired",
 					String.class);
 			if (StringUtils.hasText(resolutionRequired)) {
-				String resolutionRequiredValue = this.beanFactory.resolveEmbeddedValue(resolutionRequired);
-				if (StringUtils.hasText(resolutionRequiredValue)) {
-					methodInvokingRouter.setResolutionRequired(Boolean.parseBoolean(resolutionRequiredValue));
-				}
+				methodInvokingRouter.setResolutionRequired(resolveAttributeToBoolean(resolutionRequired));
 			}
 
 			String prefix = MessagingAnnotationUtils.resolveAttribute(annotations, "prefix", String.class);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/ServiceActivatorAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/ServiceActivatorAnnotationPostProcessor.java
@@ -20,12 +20,17 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.handler.LambdaMessageProcessor;
+import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.handler.ReplyProducingMessageHandlerWrapper;
 import org.springframework.integration.handler.ServiceActivatingHandler;
 import org.springframework.integration.util.MessagingAnnotationUtils;
@@ -63,7 +68,13 @@ public class ServiceActivatorAnnotationPostProcessor extends AbstractMethodAnnot
 					return new ReplyProducingMessageHandlerWrapper((MessageHandler) target);
 				}
 				else {
-					serviceActivator = new ServiceActivatingHandler(target);
+					MessageProcessor<?> messageProcessor = buildLambdaMessageProcessorForBeanMethod(method, target);
+					if (messageProcessor != null) {
+						serviceActivator = new ServiceActivatingHandler(messageProcessor);
+					}
+					else {
+						serviceActivator = new ServiceActivatingHandler(target);
+					}
 				}
 			}
 			else {
@@ -77,15 +88,15 @@ public class ServiceActivatorAnnotationPostProcessor extends AbstractMethodAnnot
 
 		String requiresReply = MessagingAnnotationUtils.resolveAttribute(annotations, "requiresReply", String.class);
 		if (StringUtils.hasText(requiresReply)) {
-			serviceActivator.setRequiresReply(Boolean.parseBoolean(this.beanFactory.resolveEmbeddedValue(requiresReply)));
+			serviceActivator.setRequiresReply(resolveAttributeToBoolean(requiresReply));
 		}
 
 		String isAsync = MessagingAnnotationUtils.resolveAttribute(annotations, "async", String.class);
 		if (StringUtils.hasText(isAsync)) {
-			serviceActivator.setAsync(Boolean.parseBoolean(this.beanFactory.resolveEmbeddedValue(isAsync)));
+			serviceActivator.setAsync(resolveAttributeToBoolean(isAsync));
 		}
 
-		this.setOutputChannelIfPresent(annotations, serviceActivator);
+		setOutputChannelIfPresent(annotations, serviceActivator);
 		return serviceActivator;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/ServiceActivatorAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/ServiceActivatorAnnotationPostProcessor.java
@@ -20,16 +20,12 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
-import org.springframework.integration.handler.LambdaMessageProcessor;
 import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.handler.ReplyProducingMessageHandlerWrapper;
 import org.springframework.integration.handler.ServiceActivatingHandler;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/SplitterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/SplitterAnnotationPostProcessor.java
@@ -43,7 +43,7 @@ public class SplitterAnnotationPostProcessor extends AbstractMethodAnnotationPos
 
 	public SplitterAnnotationPostProcessor(ConfigurableListableBeanFactory beanFactory) {
 		super(beanFactory);
-		this.messageHandlerAttributes.addAll(Arrays.<String>asList("outputChannel", "applySequence", "adviceChain"));
+		this.messageHandlerAttributes.addAll(Arrays.asList("outputChannel", "applySequence", "adviceChain"));
 	}
 
 	@Override
@@ -52,7 +52,7 @@ public class SplitterAnnotationPostProcessor extends AbstractMethodAnnotationPos
 
 		AbstractMessageSplitter splitter;
 		if (AnnotatedElementUtils.isAnnotated(method, Bean.class.getName())) {
-			Object target = this.resolveTargetBeanFromMethodWithBeanAnnotation(method);
+			Object target = resolveTargetBeanFromMethodWithBeanAnnotation(method);
 			splitter = this.extractTypeIfPossible(target, AbstractMessageSplitter.class);
 			if (splitter == null) {
 				if (target instanceof MessageHandler) {
@@ -74,10 +74,7 @@ public class SplitterAnnotationPostProcessor extends AbstractMethodAnnotationPos
 		}
 
 		if (StringUtils.hasText(applySequence)) {
-			String applySequenceValue = this.beanFactory.resolveEmbeddedValue(applySequence);
-			if (StringUtils.hasText(applySequenceValue)) {
-				splitter.setApplySequence(Boolean.parseBoolean(applySequenceValue));
-			}
+			splitter.setApplySequence(resolveAttributeToBoolean(applySequence));
 		}
 
 		this.setOutputChannelIfPresent(annotations, splitter);

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -3121,11 +3121,11 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	protected StandardIntegrationFlow get() {
 		if (this.integrationFlow == null) {
 			if (this.currentMessageChannel instanceof FixedSubscriberChannelPrototype) {
-				throw new BeanCreationException("The 'currentMessageChannel' (" + this.currentMessageChannel
-						+ ") is a prototype for 'FixedSubscriberChannel' which can't be created without " +
-						"'MessageHandler' "
-						+ "constructor argument. That means that '.fixedSubscriberChannel()' can't be the last "
-						+ "EIP-method in the 'IntegrationFlow' definition.");
+				throw new BeanCreationException("The 'currentMessageChannel' (" + this.currentMessageChannel +
+						") is a prototype for 'FixedSubscriberChannel' which can't be created without " +
+						"a 'MessageHandler' constructor argument. " +
+						"That means that '.fixedSubscriberChannel()' can't be the last " +
+						"EIP-method in the 'IntegrationFlow' definition.");
 			}
 
 			if (this.integrationComponents.size() == 1) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionCommandMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionCommandMessageProcessor.java
@@ -52,7 +52,7 @@ public class ExpressionCommandMessageProcessor extends AbstractMessageProcessor<
 	private final MethodFilter methodFilter;
 
 	public ExpressionCommandMessageProcessor() {
-		methodFilter = null;
+		this.methodFilter = null;
 	}
 
 	public ExpressionCommandMessageProcessor(@Nullable MethodFilter methodFilter) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionCommandMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionCommandMessageProcessor.java
@@ -48,7 +48,11 @@ import org.springframework.util.CollectionUtils;
  */
 public class ExpressionCommandMessageProcessor extends AbstractMessageProcessor<Object> {
 
+	@Nullable
+	private final MethodFilter methodFilter;
+
 	public ExpressionCommandMessageProcessor() {
+		methodFilter = null;
 	}
 
 	public ExpressionCommandMessageProcessor(@Nullable MethodFilter methodFilter) {
@@ -56,18 +60,19 @@ public class ExpressionCommandMessageProcessor extends AbstractMessageProcessor<
 	}
 
 	public ExpressionCommandMessageProcessor(@Nullable MethodFilter methodFilter, @Nullable BeanFactory beanFactory) {
+		this.methodFilter = methodFilter;
 		if (beanFactory != null) {
 			setBeanFactory(beanFactory);
-		}
-		if (methodFilter != null) {
-			MethodResolver methodResolver = new ExpressionCommandMethodResolver(methodFilter);
-			getEvaluationContext().setMethodResolvers(Collections.singletonList(methodResolver));
 		}
 	}
 
 	@Override
 	public final void setBeanFactory(BeanFactory beanFactory) {
 		super.setBeanFactory(beanFactory);
+		if (this.methodFilter != null) {
+			MethodResolver methodResolver = new ExpressionCommandMethodResolver(this.methodFilter);
+			getEvaluationContext().setMethodResolvers(Collections.singletonList(methodResolver));
+		}
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
@@ -17,10 +17,13 @@
 package org.springframework.integration.util;
 
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.springframework.lang.Nullable;
 import org.springframework.util.ReflectionUtils;
 
 /**
@@ -30,6 +33,13 @@ import org.springframework.util.ReflectionUtils;
  * @since 2.0
  */
 public abstract class ClassUtils {
+
+	/**
+	 * Map with primitive wrapper type as key and corresponding primitive
+	 * type as value, for example: Integer.class -> int.class.
+	 */
+	private static final Map<Class<?>, Class<?>> PRIMITIVE_WRAPPER_TYPE_MAP = new HashMap<>(8);
+
 
 	/**
 	 * The {@link Function#apply(Object)} method object.
@@ -74,6 +84,15 @@ public abstract class ClassUtils {
 	public static final Class<?> KOTLIN_FUNCTION_1_CLASS;
 
 	static {
+		PRIMITIVE_WRAPPER_TYPE_MAP.put(Boolean.class, boolean.class);
+		PRIMITIVE_WRAPPER_TYPE_MAP.put(Byte.class, byte.class);
+		PRIMITIVE_WRAPPER_TYPE_MAP.put(Character.class, char.class);
+		PRIMITIVE_WRAPPER_TYPE_MAP.put(Double.class, double.class);
+		PRIMITIVE_WRAPPER_TYPE_MAP.put(Float.class, float.class);
+		PRIMITIVE_WRAPPER_TYPE_MAP.put(Integer.class, int.class);
+		PRIMITIVE_WRAPPER_TYPE_MAP.put(Long.class, long.class);
+		PRIMITIVE_WRAPPER_TYPE_MAP.put(Short.class, short.class);
+
 		Class<?> genericSelectorClass = null;
 		try {
 			genericSelectorClass =
@@ -192,11 +211,10 @@ public abstract class ClassUtils {
 	 * returning the corresponding primitive type instead.
 	 * @param clazz the wrapper class to check
 	 * @return the corresponding primitive if the clazz is a wrapper, otherwise null
-	 * @deprecated since 5.2 in favor of {@link org.springframework.util.ClassUtils#resolvePrimitiveIfNecessary(Class)}
 	 */
-	@Deprecated
+	@Nullable
 	public static Class<?> resolvePrimitiveType(Class<?> clazz) {
-		return org.springframework.util.ClassUtils.resolvePrimitiveIfNecessary(clazz);
+		return PRIMITIVE_WRAPPER_TYPE_MAP.get(clazz);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
@@ -17,8 +17,6 @@
 package org.springframework.integration.util;
 
 import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -230,4 +228,5 @@ public abstract class ClassUtils {
 	public static boolean isKotlinFaction1(Class<?> aClass) {
 		return KOTLIN_FUNCTION_1_CLASS != null && KOTLIN_FUNCTION_1_CLASS.isAssignableFrom(aClass);
 	}
+
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -349,8 +349,7 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 		@Filter(inputChannel = "skippedChannel5")
 		@Profile("foo")
 		public MessageHandler skippedMessageHandler() {
-			return m -> {
-			};
+			return m -> { };
 		}
 
 		@Bean
@@ -384,14 +383,7 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 		@Bean
 		@ServiceActivator(inputChannel = "functionMessageServiceChannel")
 		public Function<Message<String>, String> messageFunctionAsService() {
-			return new Function<Message<String>, String>() { // Has to be interface for proper type inferring
-
-				@Override
-				public String apply(Message<String> m) {
-					return m.getPayload().toLowerCase();
-				}
-
-			};
+			return (message) -> message.getPayload().toLowerCase();
 		}
 
 		@Bean
@@ -408,14 +400,7 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 		@Bean
 		@ServiceActivator(inputChannel = "messageConsumerServiceChannel")
 		public Consumer<Message<?>> messageConsumerAsService() {
-			return new Consumer<Message<?>>() { // Has to be interface for proper type inferring
-
-				@Override
-				public void accept(Message<?> e) {
-					collector().add(e);
-				}
-
-			};
+			return collector()::add;
 		}
 
 	}

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
@@ -33,12 +33,12 @@ import javax.management.ObjectName;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.util.ClassUtils;
 import org.springframework.jmx.support.ObjectNameManager;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -212,8 +212,8 @@ public class OperationInvokingMessageHandler extends AbstractReplyProducingMessa
 			return true;
 		}
 		else {
-			Class<?> primitiveType = ClassUtils.resolvePrimitiveIfNecessary(valueClass);
-			return primitiveType.getName().equals(paramInfo.getType());
+			Class<?> primitiveType = ClassUtils.resolvePrimitiveType(valueClass);
+			return primitiveType != null && primitiveType.getName().equals(paramInfo.getType());
 		}
 	}
 

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
@@ -33,12 +33,12 @@ import javax.management.ObjectName;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
-import org.springframework.integration.util.ClassUtils;
 import org.springframework.jmx.support.ObjectNameManager;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -212,8 +212,8 @@ public class OperationInvokingMessageHandler extends AbstractReplyProducingMessa
 			return true;
 		}
 		else {
-			Class<?> primitiveType = ClassUtils.resolvePrimitiveType(valueClass);
-			return primitiveType != null && primitiveType.getName().equals(paramInfo.getType());
+			Class<?> primitiveType = ClassUtils.resolvePrimitiveIfNecessary(valueClass);
+			return primitiveType.getName().equals(paramInfo.getType());
 		}
 	}
 


### PR DESCRIPTION
When we have a `@ServiceActivator` or any other messaging annotations
on `Function` or `Consumer` `@Bean`s, there is a restriction when we
can't use lambdas because of target method argument type erasure in Java.

* Use a `@Bean` method return to determine the target function argument
type and wrap the call into the `LambdaMessageProcessor`.

In this case we call the target method directly after possible payload
conversion according expected generic type for `Function` or `Consumer`.
There is just no reason to go a `MessagingMethodInvokerHelper` route
for this lambda variants

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
