### PR TITLE
Optimize performance when many new connections arrive

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
@@ -205,7 +205,7 @@ public class TcpNioServerConnectionFactory extends AbstractServerConnectionFacto
 		// accept connections in a for loop until no new connection is ready
 		for (;;) {
 			SocketChannel channel = server.accept();
-			if(channel == null) {
+			if (channel == null) {
 				return;
 			}
 			if (isShuttingDown()) {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
@@ -203,10 +203,11 @@ public class TcpNioServerConnectionFactory extends AbstractServerConnectionFacto
 		logger.debug("New accept");
 		// when many new connections arrive, we should
 		// accept connections in a for loop until no new connection is ready
-		for(;;){
+		for (;;) {
 			SocketChannel channel = server.accept();
-			if(channel == null)
+			if(channel == null) {
 				return;
+			}
 			if (isShuttingDown()) {
 				if (logger.isInfoEnabled()) {
 					logger.info("New connection from " + channel.socket().getInetAddress().getHostAddress()


### PR DESCRIPTION
When many new connections arrive at once, we should accept as soon as possible.  accept connections in a for loop until no new connection is ready

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
