### PR TITLE
URL Cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <html lang="en-US">
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="http://spring.io/projects/spring-integration">
-  <meta http-equiv="refresh" content="0; url=http://spring.io/projects/spring-integration">
+  <link rel="canonical" href="https://spring.io/projects/spring-integration">
+  <meta http-equiv="refresh" content="0; url=https://spring.io/projects/spring-integration">
   <meta name="robots" content="noindex">
   <h1>Redirecting&hellip;</h1>
-  <a href="http://spring.io/projects/spring-integration">Click here if you are not redirected.</a>
-  <script>location="http://spring.io/projects/spring-integration"</script>
+  <a href="https://spring.io/projects/spring-integration">Click here if you are not redirected.</a>
+  <script>location="https://spring.io/projects/spring-integration"</script>
 </html>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://spring.io/projects/spring-integration with 4 occurrences migrated to:  
  https://spring.io/projects/spring-integration ([https](https://spring.io/projects/spring-integration) result 200).