### PR TITLE
Fix complexity for DefaultHttpHeaderMapper

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
@@ -188,9 +188,7 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	 * be returned as a payload of the reply Message.
 	 * To take advantage of the HttpMessageConverters
 	 * registered on this adapter, provide a different type).
-	 *
 	 * @param expectedResponseType The expected type.
-	 *
 	 * Also see {@link #setExpectedResponseTypeExpression(Expression)}
 	 */
 	public void setExpectedResponseType(Class<?> expectedResponseType) {
@@ -221,7 +219,6 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	/**
 	 * Set the Map of URI variable expressions to evaluate against the outbound message
 	 * when replacing the variable placeholders in a URI template.
-	 *
 	 * @param uriVariableExpressions The URI variable expressions.
 	 */
 	public void setUriVariableExpressions(Map<String, Expression> uriVariableExpressions) {
@@ -235,7 +232,6 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	 * Set the {@link Expression} to evaluate against the outbound message; the expression
 	 * must evaluate to a Map of URI variable expressions to evaluate against the outbound message
 	 * when replacing the variable placeholders in a URI template.
-	 *
 	 * @param uriVariablesExpression The URI variables expression.
 	 */
 	public void setUriVariablesExpression(Expression uriVariablesExpression) {
@@ -246,7 +242,6 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	 * Set to true if you wish 'Set-Cookie' headers in responses to be
 	 * transferred as 'Cookie' headers in subsequent interactions for
 	 * a message.
-	 *
 	 * @param transferCookies the transferCookies to set.
 	 */
 	public void setTransferCookies(boolean transferCookies) {
@@ -343,14 +338,14 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	private void doConvertSetCookie(Map<String, Object> headers) {
 		String keyName = null;
 		for (String key : headers.keySet()) {
-			if (key.equalsIgnoreCase(DefaultHttpHeaderMapper.SET_COOKIE)) {
+			if (key.equalsIgnoreCase(HttpHeaders.SET_COOKIE)) {
 				keyName = key;
 				break;
 			}
 		}
 		if (keyName != null) {
 			Object cookies = headers.remove(keyName);
-			headers.put(DefaultHttpHeaderMapper.COOKIE, cookies);
+			headers.put(HttpHeaders.COOKIE, cookies);
 			if (logger.isDebugEnabled()) {
 				logger.debug("Converted Set-Cookie header to Cookie for: "
 						+ cookies);
@@ -562,7 +557,6 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 				.usingEvaluationContext(evaluationContextToUse)
 				.withRoot(requestMessage)
 				.build();
-
 	}
 
 }

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -61,11 +61,11 @@ import org.springframework.web.client.RestTemplate;
  * @since 2.0
  */
 public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecutingMessageHandler {
+
 	private final RestTemplate restTemplate;
 
 	/**
 	 * Create a handler that will send requests to the provided URI.
-	 *
 	 * @param uri The URI.
 	 */
 	public HttpRequestExecutingMessageHandler(URI uri) {
@@ -74,7 +74,6 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 
 	/**
 	 * Create a handler that will send requests to the provided URI.
-	 *
 	 * @param uri The URI.
 	 */
 	public HttpRequestExecutingMessageHandler(String uri) {
@@ -83,7 +82,6 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 
 	/**
 	 * Create a handler that will send requests to the provided URI Expression.
-	 *
 	 * @param uriExpression The URI expression.
 	 */
 	public HttpRequestExecutingMessageHandler(Expression uriExpression) {
@@ -142,9 +140,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 
 	/**
 	 * Set the {@link ClientHttpRequestFactory} for the underlying {@link RestTemplate}.
-	 *
 	 * @param requestFactory The request factory.
-	 *
 	 * @see RestTemplate#setRequestFactory(ClientHttpRequestFactory)
 	 */
 	public void setRequestFactory(ClientHttpRequestFactory requestFactory) {
@@ -154,6 +150,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	@Override
 	protected Object exchange(Supplier<URI> uriSupplier, HttpMethod httpMethod, HttpEntity<?> httpRequest,
 			Object expectedResponseType, Message<?> requestMessage) {
+
 		URI uri = uriSupplier.get();
 		ResponseEntity<?> httpResponse;
 		try {
@@ -162,14 +159,13 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 						(ParameterizedTypeReference<?>) expectedResponseType);
 			}
 			else {
-				httpResponse = this.restTemplate.exchange(uri, httpMethod, httpRequest,
-						(Class<?>) expectedResponseType);
+				httpResponse = this.restTemplate.exchange(uri, httpMethod, httpRequest, (Class<?>) expectedResponseType);
 			}
 			return getReply(httpResponse);
 		}
 		catch (RestClientException e) {
-			throw new MessageHandlingException(requestMessage,
-					"HTTP request execution failed for URI [" + uri + "]", e);
+			throw new MessageHandlingException(requestMessage, "HTTP request execution failed for URI [" + uri + "]", e);
 		}
 	}
+
 }

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -20,7 +20,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.text.MessageFormat;
-import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -37,6 +36,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -52,6 +53,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.utils.IntegrationUtils;
+import org.springframework.integration.util.JavaUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -75,202 +78,420 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 
 	private static final String UNUSED = "unused";
 
-	protected final Log logger = LogFactory.getLog(getClass());
+	protected final Log logger = LogFactory.getLog(getClass()); // NOSONAR - final
 
-	public static final String ACCEPT = "Accept";
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#ACCEPT}
+	 */
+	@Deprecated
+	public static final String ACCEPT = HttpHeaders.ACCEPT;
 
-	public static final String ACCEPT_CHARSET = "Accept-Charset";
+	private static final String ACCEPT_LOWER = "accept";
 
-	public static final String ACCEPT_ENCODING = "Accept-Encoding";
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#ACCEPT_CHARSET}
+	 */
+	@Deprecated
+	public static final String ACCEPT_CHARSET = HttpHeaders.ACCEPT_CHARSET;
 
-	public static final String ACCEPT_LANGUAGE = "Accept-Language";
+	private static final String ACCEPT_CHARSET_LOWER = "accept-charset";
 
-	public static final String ACCEPT_RANGES = "Accept-Ranges";
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#ACCEPT_ENCODING}
+	 */
+	@Deprecated
+	public static final String ACCEPT_ENCODING = HttpHeaders.ACCEPT_ENCODING;
 
-	public static final String AGE = "Age";
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#ACCEPT_LANGUAGE}
+	 */
+	@Deprecated
+	public static final String ACCEPT_LANGUAGE = HttpHeaders.ACCEPT_LANGUAGE;
 
-	public static final String ALLOW = "Allow";
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#ACCEPT_RANGES}
+	 */
+	@Deprecated
+	public static final String ACCEPT_RANGES = HttpHeaders.ACCEPT_RANGES;
 
-	public static final String AUTHORIZATION = "Authorization";
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#AGE}
+	 */
+	@Deprecated
+	public static final String AGE = HttpHeaders.AGE;
 
-	public static final String CACHE_CONTROL = "Cache-Control";
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#ALLOW}
+	 */
+	@Deprecated
+	public static final String ALLOW = HttpHeaders.ALLOW;
 
-	public static final String CONNECTION = "Connection";
+	private static final String ALLOW_LOWER = "allow";
 
-	public static final String CONTENT_ENCODING = "Content-Encoding";
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#AUTHORIZATION}
+	 */
+	@Deprecated
+	public static final String AUTHORIZATION = HttpHeaders.AUTHORIZATION;
 
-	public static final String CONTENT_LANGUAGE = "Content-Language";
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#CACHE_CONTROL}
+	 */
+	@Deprecated
+	public static final String CACHE_CONTROL = HttpHeaders.CACHE_CONTROL;
 
-	public static final String CONTENT_LENGTH = "Content-Length";
+	private static final String CACHE_CONTROL_LOWER = "cache-control";
 
-	public static final String CONTENT_LOCATION = "Content-Location";
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#CONNECTION}
+	 */
+	@Deprecated
+	public static final String CONNECTION = HttpHeaders.CONNECTION;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#CONTENT_ENCODING}
+	 */
+	@Deprecated
+	public static final String CONTENT_ENCODING = HttpHeaders.CONTENT_ENCODING;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#CONTENT_LANGUAGE}
+	 */
+	@Deprecated
+	public static final String CONTENT_LANGUAGE = HttpHeaders.CONTENT_LANGUAGE;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#CONTENT_LENGTH}
+	 */
+	@Deprecated
+	public static final String CONTENT_LENGTH = HttpHeaders.CONTENT_LENGTH;
+
+	private static final String CONTENT_LENGTH_LOWER = "content-length";
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#CONTENT_LOCATION}
+	 */
+	@Deprecated
+	public static final String CONTENT_LOCATION = HttpHeaders.CONTENT_LOCATION;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#CONTENT_RANGE}
+	 */
+	@Deprecated
+	public static final String CONTENT_RANGE = HttpHeaders.CONTENT_RANGE;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#CONTENT_TYPE}
+	 */
+	@Deprecated
+	public static final String CONTENT_TYPE = HttpHeaders.CONTENT_TYPE;
+
+	private static final String CONTENT_TYPE_LOWER = "content-type";
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#CONTENT_DISPOSITION}
+	 */
+	@Deprecated
+	public static final String CONTENT_DISPOSITION = HttpHeaders.CONTENT_DISPOSITION;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#COOKIE}
+	 */
+	@Deprecated
+	public static final String COOKIE = HttpHeaders.COOKIE;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#DATE}
+	 */
+	@Deprecated
+	public static final String DATE = HttpHeaders.DATE;
+
+	private static final String DATE_LOWER = "date";
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#ETAG}
+	 */
+	@Deprecated
+	public static final String ETAG = HttpHeaders.ETAG;
+
+	private static final String ETAG_LOWER = "etag";
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#EXPECT}
+	 */
+	@Deprecated
+	public static final String EXPECT = HttpHeaders.EXPECT;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#EXPIRES}
+	 */
+	@Deprecated
+	public static final String EXPIRES = HttpHeaders.EXPIRES;
+
+	private static final String EXPIRES_LOWER = "expires";
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#FROM}
+	 */
+	@Deprecated
+	public static final String FROM = HttpHeaders.FROM;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#HOST}
+	 */
+	@Deprecated
+	public static final String HOST = HttpHeaders.HOST;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#IF_MATCH}
+	 */
+	@Deprecated
+	public static final String IF_MATCH = HttpHeaders.IF_MATCH;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#IF_MODIFIED_SINCE}
+	 */
+	@Deprecated
+	public static final String IF_MODIFIED_SINCE = HttpHeaders.IF_MODIFIED_SINCE;
+
+	private static final String IF_MODIFIED_SINCE_LOWER = "if-modified-since";
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#IF_NONE_MATCH}
+	 */
+	@Deprecated
+	public static final String IF_NONE_MATCH = HttpHeaders.IF_NONE_MATCH;
+
+	private static final String IF_NONE_MATCH_LOWER = "if-none-match";
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#IF_RANGE}
+	 */
+	@Deprecated
+	public static final String IF_RANGE = HttpHeaders.IF_RANGE;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#IF_UNMODIFIED_SINCE}
+	 */
+	@Deprecated
+	public static final String IF_UNMODIFIED_SINCE = HttpHeaders.IF_UNMODIFIED_SINCE;
+
+	private static final String IF_UNMODIFIED_SINCE_LOWER = "if-unmodified-since";
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#LAST_MODIFIED}
+	 */
+	@Deprecated
+	public static final String LAST_MODIFIED = HttpHeaders.LAST_MODIFIED;
+
+	private static final String LAST_MODIFIED_LOWER = "last-modified";
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#LOCATION}
+	 */
+	@Deprecated
+	public static final String LOCATION = HttpHeaders.LOCATION;
+
+	private static final String LOCATION_LOWER = "location";
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#MAX_FORWARDS}
+	 */
+	@Deprecated
+	public static final String MAX_FORWARDS = HttpHeaders.MAX_FORWARDS;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#PRAGMA}
+	 */
+	@Deprecated
+	public static final String PRAGMA = HttpHeaders.PRAGMA;
+
+	private static final String PRAGMA_LOWER = "pragma";
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#PROXY_AUTHENTICATE}
+	 */
+	@Deprecated
+	public static final String PROXY_AUTHENTICATE = HttpHeaders.PROXY_AUTHENTICATE;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#PROXY_AUTHORIZATION}
+	 */
+	@Deprecated
+	public static final String PROXY_AUTHORIZATION = HttpHeaders.PROXY_AUTHORIZATION;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#RANGE}
+	 */
+	@Deprecated
+	public static final String RANGE = HttpHeaders.RANGE;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#REFERER}
+	 */
+	@Deprecated
+	public static final String REFERER = HttpHeaders.REFERER;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#RETRY_AFTER}
+	 */
+	@Deprecated
+	public static final String RETRY_AFTER = HttpHeaders.RETRY_AFTER;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#SERVER}
+	 */
+	@Deprecated
+	public static final String SERVER = HttpHeaders.SERVER;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#SET_COOKIE}
+	 */
+	@Deprecated
+	public static final String SET_COOKIE = HttpHeaders.SET_COOKIE;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#TE}
+	 */
+	@Deprecated
+	public static final String TE = HttpHeaders.TE;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#TRAILER}
+	 */
+	@Deprecated
+	public static final String TRAILER = HttpHeaders.TRAILER;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#UPGRADE}
+	 */
+	@Deprecated
+	public static final String UPGRADE = HttpHeaders.UPGRADE;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#USER_AGENT}
+	 */
+	@Deprecated
+	public static final String USER_AGENT = HttpHeaders.USER_AGENT;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#VARY}
+	 */
+	@Deprecated
+	public static final String VARY = HttpHeaders.VARY;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#VIA}
+	 */
+	@Deprecated
+	public static final String VIA = HttpHeaders.VIA;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#WARNING}
+	 */
+	@Deprecated
+	public static final String WARNING = HttpHeaders.WARNING;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#WWW_AUTHENTICATE}
+	 */
+	@Deprecated
+	public static final String WWW_AUTHENTICATE = HttpHeaders.WWW_AUTHENTICATE;
+
+	/**
+	 * @deprecated since 5.2 in favor of {@link HttpHeaders#TRANSFER_ENCODING}
+	 */
+	@Deprecated
+	public static final String TRANSFER_ENCODING = HttpHeaders.TRANSFER_ENCODING;
 
 	public static final String CONTENT_MD5 = "Content-MD5";
 
-	public static final String CONTENT_RANGE = "Content-Range";
-
-	public static final String CONTENT_TYPE = "Content-Type";
-
-	public static final String CONTENT_DISPOSITION = "Content-Disposition";
-
-	public static final String COOKIE = "Cookie";
-
-	public static final String DATE = "Date";
-
-	public static final String ETAG = "ETag";
-
-	public static final String EXPECT = "Expect";
-
-	public static final String EXPIRES = "Expires";
-
-	public static final String FROM = "From";
-
-	public static final String HOST = "Host";
-
-	public static final String IF_MATCH = "If-Match";
-
-	public static final String IF_MODIFIED_SINCE = "If-Modified-Since";
-
-	public static final String IF_NONE_MATCH = "If-None-Match";
-
-	public static final String IF_RANGE = "If-Range";
-
-	public static final String IF_UNMODIFIED_SINCE = "If-Unmodified-Since";
-
-	public static final String LAST_MODIFIED = "Last-Modified";
-
-	public static final String LOCATION = "Location";
-
-	public static final String MAX_FORWARDS = "Max-Forwards";
-
-	public static final String PRAGMA = "Pragma";
-
-	public static final String PROXY_AUTHENTICATE = "Proxy-Authenticate";
-
-	public static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
-
-	public static final String RANGE = "Range";
-
-	public static final String REFERER = "Referer";
-
 	public static final String REFRESH = "Refresh";
 
-	public static final String RETRY_AFTER = "Retry-After";
-
-	public static final String SERVER = "Server";
-
-	public static final String SET_COOKIE = "Set-Cookie";
-
-	public static final String TE = "TE";
-
-	public static final String TRAILER = "Trailer";
-
-	public static final String UPGRADE = "Upgrade";
-
-	public static final String USER_AGENT = "User-Agent";
-
-	public static final String VARY = "Vary";
-
-	public static final String VIA = "Via";
-
-	public static final String WARNING = "Warning";
-
-	public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
-
-	public static final String TRANSFER_ENCODING = "Transfer-Encoding";
-
 	private static final String[] HTTP_REQUEST_HEADER_NAMES = new String[] {
-			ACCEPT,
-			ACCEPT_CHARSET,
-			ACCEPT_ENCODING,
-			ACCEPT_LANGUAGE,
-			ACCEPT_RANGES,
-			AUTHORIZATION,
-			CACHE_CONTROL,
-			CONNECTION,
-			CONTENT_LENGTH,
-			CONTENT_TYPE,
-			COOKIE,
-			DATE,
-			EXPECT,
-			FROM,
-			HOST,
-			IF_MATCH,
-			IF_MODIFIED_SINCE,
-			IF_NONE_MATCH,
-			IF_RANGE,
-			IF_UNMODIFIED_SINCE,
-			MAX_FORWARDS,
-			PRAGMA,
-			PROXY_AUTHORIZATION,
-			RANGE,
-			REFERER,
-			TE,
-			UPGRADE,
-			USER_AGENT,
-			VIA,
-			WARNING
+			HttpHeaders.ACCEPT,
+			HttpHeaders.ACCEPT_CHARSET,
+			HttpHeaders.ACCEPT_ENCODING,
+			HttpHeaders.ACCEPT_LANGUAGE,
+			HttpHeaders.ACCEPT_RANGES,
+			HttpHeaders.AUTHORIZATION,
+			HttpHeaders.CACHE_CONTROL,
+			HttpHeaders.CONNECTION,
+			HttpHeaders.CONTENT_LENGTH,
+			HttpHeaders.CONTENT_TYPE,
+			HttpHeaders.COOKIE,
+			HttpHeaders.DATE,
+			HttpHeaders.EXPECT,
+			HttpHeaders.FROM,
+			HttpHeaders.HOST,
+			HttpHeaders.IF_MATCH,
+			HttpHeaders.IF_MODIFIED_SINCE,
+			HttpHeaders.IF_NONE_MATCH,
+			HttpHeaders.IF_RANGE,
+			HttpHeaders.IF_UNMODIFIED_SINCE,
+			HttpHeaders.MAX_FORWARDS,
+			HttpHeaders.PRAGMA,
+			HttpHeaders.PROXY_AUTHORIZATION,
+			HttpHeaders.RANGE,
+			HttpHeaders.REFERER,
+			HttpHeaders.TE,
+			HttpHeaders.UPGRADE,
+			HttpHeaders.USER_AGENT,
+			HttpHeaders.VIA,
+			HttpHeaders.WARNING
 	};
 
 	private static final Set<String> HTTP_REQUEST_HEADER_NAMES_LOWER = new HashSet<>();
 
 	private static final String[] HTTP_RESPONSE_HEADER_NAMES = new String[] {
-			ACCEPT_RANGES,
-			AGE,
-			ALLOW,
-			CACHE_CONTROL,
-			CONNECTION,
-			CONTENT_ENCODING,
-			CONTENT_LANGUAGE,
-			CONTENT_LENGTH,
-			CONTENT_LOCATION,
+			HttpHeaders.ACCEPT_RANGES,
+			HttpHeaders.AGE,
+			HttpHeaders.ALLOW,
+			HttpHeaders.CACHE_CONTROL,
+			HttpHeaders.CONNECTION,
+			HttpHeaders.CONTENT_ENCODING,
+			HttpHeaders.CONTENT_LANGUAGE,
+			HttpHeaders.CONTENT_LENGTH,
+			HttpHeaders.CONTENT_LOCATION,
 			CONTENT_MD5,
-			CONTENT_RANGE,
-			CONTENT_TYPE,
-			CONTENT_DISPOSITION,
-			TRANSFER_ENCODING,
-			DATE,
-			ETAG,
-			EXPIRES,
-			LAST_MODIFIED,
-			LOCATION,
-			PRAGMA,
-			PROXY_AUTHENTICATE,
+			HttpHeaders.CONTENT_RANGE,
+			HttpHeaders.CONTENT_TYPE,
+			HttpHeaders.CONTENT_DISPOSITION,
+			HttpHeaders.TRANSFER_ENCODING,
+			HttpHeaders.DATE,
+			HttpHeaders.ETAG,
+			HttpHeaders.EXPIRES,
+			HttpHeaders.LAST_MODIFIED,
+			HttpHeaders.LOCATION,
+			HttpHeaders.PRAGMA,
+			HttpHeaders.PROXY_AUTHENTICATE,
 			REFRESH,
-			RETRY_AFTER,
-			SERVER,
-			SET_COOKIE,
-			TRAILER,
-			VARY,
-			VIA,
-			WARNING,
-			WWW_AUTHENTICATE
+			HttpHeaders.RETRY_AFTER,
+			HttpHeaders.SERVER,
+			HttpHeaders.SET_COOKIE,
+			HttpHeaders.TRAILER,
+			HttpHeaders.VARY,
+			HttpHeaders.VIA,
+			HttpHeaders.WARNING,
+			HttpHeaders.WWW_AUTHENTICATE
 	};
 
-	private static final Set<String> HTTP_RESPONSE_HEADER_NAMES_LOWER = new HashSet<String>();
+	private static final Set<String> HTTP_RESPONSE_HEADER_NAMES_LOWER = new HashSet<>();
 
 	private static final String[] HTTP_REQUEST_HEADER_NAMES_OUTBOUND_EXCLUSIONS = new String[0];
 
-	private static final String[] HTTP_RESPONSE_HEADER_NAMES_INBOUND_EXCLUSIONS = new String[] {
-			CONTENT_LENGTH, TRANSFER_ENCODING
-	};
+	private static final String[] HTTP_RESPONSE_HEADER_NAMES_INBOUND_EXCLUSIONS =
+			{ HttpHeaders.CONTENT_LENGTH, HttpHeaders.TRANSFER_ENCODING };
 
 	public static final String HTTP_REQUEST_HEADER_NAME_PATTERN = "HTTP_REQUEST_HEADERS";
 
 	public static final String HTTP_RESPONSE_HEADER_NAME_PATTERN = "HTTP_RESPONSE_HEADERS";
 
-	// Copy of 'org.springframework.http.HttpHeaders#GMT'
-	private static final ZoneId GMT = ZoneId.of("GMT");
-
-	// Copy of 'org.springframework.http.HttpHeaders#DATE_FORMATTER'
-	protected static final DateTimeFormatter DATE_FORMATTER =
-			DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(GMT);
-
 	// Copy of 'org.springframework.http.HttpHeaders#DATE_FORMATS'
-	protected static final DateTimeFormatter[] DATE_FORMATS = new DateTimeFormatter[] {
+	protected static final DateTimeFormatter[] DATE_FORMATS = {
 			DateTimeFormatter.RFC_1123_DATE_TIME,
 			DateTimeFormatter.ofPattern("EEEE, dd-MMM-yy HH:mm:ss zz", Locale.US),
-			DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss yyyy", Locale.US).withZone(GMT)
+			DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss yyyy", Locale.US).withZone(ZoneId.of("GMT")) // NOSONAR
 	};
 
 	static {
@@ -321,15 +542,17 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	 * {@link DefaultHttpHeaderMapper#setUserDefinedHeaderPrefix(String)}. The default is 'X-'.
 	 * @param outboundHeaderNames The outbound header names.
 	 */
-	public void setOutboundHeaderNames(String[] outboundHeaderNames) { //NOSONAR - false positive
+	public void setOutboundHeaderNames(String... outboundHeaderNames) {
 		if (HTTP_REQUEST_HEADER_NAMES == outboundHeaderNames) {
 			this.isDefaultOutboundMapper = true;
 		}
 		else if (HTTP_RESPONSE_HEADER_NAMES == outboundHeaderNames) {
 			this.isDefaultInboundMapper = true;
 		}
-		this.outboundHeaderNames = outboundHeaderNames != null ?
-				Arrays.copyOf(outboundHeaderNames, outboundHeaderNames.length) : new String[0];
+		this.outboundHeaderNames =
+				outboundHeaderNames != null
+						? Arrays.copyOf(outboundHeaderNames, outboundHeaderNames.length)
+						: new String[0];
 		String[] outboundHeaderNamesLower = new String[this.outboundHeaderNames.length];
 		for (int i = 0; i < this.outboundHeaderNames.length; i++) {
 			if (HTTP_REQUEST_HEADER_NAME_PATTERN.equals(this.outboundHeaderNames[i])
@@ -357,9 +580,11 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	 * that is an empty String.
 	 * @param inboundHeaderNames The inbound header names.
 	 */
-	public void setInboundHeaderNames(String[] inboundHeaderNames) { //NOSONAR - false positive
-		this.inboundHeaderNames = inboundHeaderNames != null ?
-				Arrays.copyOf(inboundHeaderNames, inboundHeaderNames.length) : new String[0];
+	public void setInboundHeaderNames(String... inboundHeaderNames) {
+		this.inboundHeaderNames =
+				inboundHeaderNames != null
+						? Arrays.copyOf(inboundHeaderNames, inboundHeaderNames.length)
+						: new String[0];
 		this.inboundHeaderNamesLower = new String[this.inboundHeaderNames.length];
 		for (int i = 0; i < this.inboundHeaderNames.length; i++) {
 			if (HTTP_REQUEST_HEADER_NAME_PATTERN.equals(this.inboundHeaderNames[i])
@@ -409,6 +634,13 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 		this.userDefinedHeaderPrefix = (userDefinedHeaderPrefix != null) ? userDefinedHeaderPrefix : "";
 	}
 
+	@Override
+	public void afterPropertiesSet() {
+		if (this.beanFactory != null) {
+			this.conversionService = IntegrationUtils.getConversionService(this.beanFactory);
+		}
+	}
+
 	/**
 	 * Map from the integration MessageHeaders to an HttpHeaders instance.
 	 * Depending on which type of adapter is using this mapper, the HttpHeaders might be
@@ -421,26 +653,453 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 		}
 		for (Entry<String, Object> entry : headers.entrySet()) {
 			String name = entry.getKey();
+			Object value = entry.getValue();
 			String lowerName = name.toLowerCase();
-			if (shouldMapOutboundHeader(lowerName)) {
-				Object value = entry.getValue();
-				if (value != null) {
-					if (!HTTP_REQUEST_HEADER_NAMES_LOWER.contains(lowerName) &&
-							!HTTP_RESPONSE_HEADER_NAMES_LOWER.contains(lowerName) &&
-							!MessageHeaders.CONTENT_TYPE.equalsIgnoreCase(name)) {
-						// prefix the user-defined header names if not already prefixed
-
-						name =
-								StringUtils.startsWithIgnoreCase(name, this.userDefinedHeaderPrefix)
-										? name
-										: this.userDefinedHeaderPrefix + name;
-					}
-					if (this.logger.isDebugEnabled()) {
-						this.logger.debug(MessageFormat.format("setting headerName=[{0}], value={1}", name, value));
-					}
-					setHttpHeader(target, name, value);
+			if (value != null && shouldMapOutboundHeader(lowerName)) {
+				if (!HTTP_REQUEST_HEADER_NAMES_LOWER.contains(lowerName) &&
+						!HTTP_RESPONSE_HEADER_NAMES_LOWER.contains(lowerName) &&
+						!MessageHeaders.CONTENT_TYPE.equalsIgnoreCase(name)) {
+					// prefix the user-defined header names if not already prefixed
+					name =
+							StringUtils.startsWithIgnoreCase(name, this.userDefinedHeaderPrefix)
+									? name
+									: this.userDefinedHeaderPrefix + name;
 				}
+				if (this.logger.isDebugEnabled()) {
+					this.logger.debug(MessageFormat.format("setting headerName=[{0}], value={1}", name, value));
+				}
+				setHttpHeader(target, name, value);
 			}
+		}
+	}
+
+	private void setHttpHeader(HttpHeaders target, String name, Object value) {
+		AtomicBoolean headerSet = new AtomicBoolean();
+
+		JavaUtils.INSTANCE
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.ACCEPT, name, headerSet), target, value,
+						this::setAccept)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.ACCEPT_CHARSET, name, headerSet), target, value,
+						this::setAcceptCharset)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.ALLOW, name, headerSet), target, value,
+						this::setAllow)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.CACHE_CONTROL, name, headerSet), target, value,
+						this::setCacheControl)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.CONTENT_LENGTH, name, headerSet), target, value,
+						this::setContentLength)
+				.acceptIfCondition(checkStandardHeaderToSet(MessageHeaders.CONTENT_TYPE, name, headerSet), target,
+						value, this::setContentType)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.DATE, name, headerSet), target, value,
+						this::setDate)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.ETAG, name, headerSet), target, value,
+						this::setETag)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.EXPIRES, name, headerSet), target, value,
+						this::setExpires)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.IF_MODIFIED_SINCE, name, headerSet), target,
+						value, this::setIfModifiedSince)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.IF_UNMODIFIED_SINCE, name, headerSet), target,
+						value, this::setIfUnmodifiedSince)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.IF_NONE_MATCH, name, headerSet), target, value,
+						this::setIfNoneMatch)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.LAST_MODIFIED, name, headerSet), target, value,
+						this::setLastModified)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.LOCATION, name, headerSet), target, value,
+						this::setLocation)
+				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.PRAGMA, name, headerSet), target, value,
+						this::setPragma);
+
+		if (!headerSet.get()) {
+			if (value instanceof String) {
+				target.set(name, (String) value);
+			}
+			else if (value instanceof String[]) {
+				target.addAll(name, Arrays.asList((String[]) value));
+			}
+			else if (value instanceof Iterable<?>) {
+				setIterableHeader(target, name, value);
+			}
+			else {
+				setPlainHeader(target, name, value);
+			}
+		}
+	}
+
+	private boolean checkStandardHeaderToSet(String headerName, String actualName, AtomicBoolean headerSet) {
+		boolean setHeader = headerName.equalsIgnoreCase(actualName);
+		headerSet.compareAndSet(false, setHeader);
+		return setHeader;
+	}
+
+	private void setAccept(HttpHeaders target, Object value) {
+		if (value instanceof Collection<?>) {
+			Collection<?> values = (Collection<?>) value;
+			if (!CollectionUtils.isEmpty(values)) {
+				List<MediaType> acceptableMediaTypes = new ArrayList<>();
+				for (Object type : values) {
+					if (type instanceof MediaType) {
+						acceptableMediaTypes.add((MediaType) type);
+					}
+					else if (type instanceof String) {
+						acceptableMediaTypes.addAll(MediaType.parseMediaTypes((String) type));
+					}
+					else {
+						throwIllegalArgumentForUnexpectedValue(
+								"Expected MediaType or String value for 'Accept' header value, but received: ", type);
+
+					}
+				}
+				target.setAccept(acceptableMediaTypes);
+			}
+		}
+		else if (value instanceof MediaType) {
+			target.setAccept(Collections.singletonList((MediaType) value));
+		}
+		else if (value instanceof String[]) {
+			target.setAccept(MediaType.parseMediaTypes(Arrays.asList((String[]) value)));
+		}
+		else if (value instanceof String) {
+			target.setAccept(MediaType.parseMediaTypes((String) value));
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue(
+					"Expected MediaType or String value for 'Accept' header value, but received: ", value);
+		}
+	}
+
+	private void setAcceptCharset(HttpHeaders target, Object value) {
+		List<Charset> acceptableCharsets = null;
+		if (value instanceof Collection<?>) {
+			acceptableCharsets =
+					((Collection<?>) value).stream()
+							.map((charset) -> {
+								if (charset instanceof Charset) {
+									return (Charset) charset;
+								}
+								else if (charset instanceof String) {
+									return Charset.forName((String) charset);
+								}
+								else {
+									throwIllegalArgumentForUnexpectedValue(
+											"Expected Charset or String value for 'Accept-Charset' header value, " +
+													"but received: ", charset);
+									return null;
+								}
+							})
+							.collect(Collectors.toList());
+		}
+		else if (value instanceof Charset[] || value instanceof String[]) {
+			acceptableCharsets =
+					Arrays.stream(ObjectUtils.toObjectArray(value))
+							.map((charset) -> charset instanceof String ? Charset.forName((String) charset) : charset)
+							.map(Charset.class::cast)
+							.collect(Collectors.toList());
+		}
+		else if (value instanceof Charset) {
+			acceptableCharsets = Collections.singletonList((Charset) value);
+		}
+		else if (value instanceof String) {
+			acceptableCharsets =
+					StringUtils.commaDelimitedListToSet((String) value)
+							.stream()
+							.map((charset) -> Charset.forName(charset.trim()))
+							.collect(Collectors.toList());
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue(
+					"Expected Charset or String value for 'Accept-Charset' header value, but received: ", value);
+		}
+
+		if (!CollectionUtils.isEmpty(acceptableCharsets)) {
+			target.setAcceptCharset(acceptableCharsets);
+		}
+	}
+
+	private void setAllow(HttpHeaders target, Object value) {
+		Set<HttpMethod> allowedMethods = null;
+		if (value instanceof Collection<?>) {
+			allowedMethods =
+					((Collection<?>) value).stream()
+							.map((method) -> {
+								if (method instanceof HttpMethod) {
+									return (HttpMethod) method;
+								}
+								else if (method instanceof String) {
+									return HttpMethod.valueOf((String) method);
+								}
+								else {
+									throwIllegalArgumentForUnexpectedValue(
+											"Expected HttpMethod or String value for 'Allow' header value, " +
+													"but received: ", method);
+									return null;
+								}
+							})
+							.collect(Collectors.toSet());
+		}
+		else if (value instanceof HttpMethod) {
+			allowedMethods = Collections.singleton((HttpMethod) value);
+		}
+		else if (value instanceof HttpMethod[]) {
+			allowedMethods = new HashSet<>(Arrays.asList((HttpMethod[]) value));
+		}
+		else if (value instanceof String || value instanceof String[]) {
+			String[] values =
+					(value instanceof String[])
+							? (String[]) value
+							: StringUtils.delimitedListToStringArray((String) value, ",", " ");
+			allowedMethods =
+					Arrays.stream(values)
+							.map(HttpMethod::valueOf)
+							.collect(Collectors.toSet());
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue(
+					"Expected HttpMethod or String value for 'Allow' header value, but received: ", value);
+		}
+
+		if (!CollectionUtils.isEmpty(allowedMethods)) {
+			target.setAllow(allowedMethods);
+		}
+	}
+
+	private void setCacheControl(HttpHeaders target, Object value) {
+		if (value instanceof String) {
+			target.setCacheControl((String) value);
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue(
+					"Expected String value for 'Cache-Control' header value, but received: ", value);
+		}
+	}
+
+	private void setContentLength(HttpHeaders target, Object value) {
+		if (value instanceof Number) {
+			target.setContentLength(((Number) value).longValue());
+		}
+		else if (value instanceof String) {
+			target.setContentLength(Long.parseLong((String) value));
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue(
+					"Expected Number or String value for 'Content-Length' header value, but received: ", value);
+		}
+	}
+
+	private void setContentType(HttpHeaders target, Object value) {
+		if (value instanceof MediaType) {
+			target.setContentType((MediaType) value);
+		}
+		else if (value instanceof String) {
+			target.setContentType(MediaType.parseMediaType((String) value));
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue(
+					"Expected MediaType or String value for 'Content-Type' header value, but received: ", value);
+		}
+	}
+
+	private void setDate(HttpHeaders target, Object value) {
+		if (value instanceof Date) {
+			target.setDate(((Date) value).getTime());
+		}
+		else if (value instanceof Number) {
+			target.setDate(((Number) value).longValue());
+		}
+		else if (value instanceof String) {
+			try {
+				target.setDate(Long.parseLong((String) value));
+			}
+			catch (@SuppressWarnings(UNUSED) NumberFormatException e) {
+				target.setDate(getFirstDate((String) value, HttpHeaders.DATE));
+			}
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue(
+					"Expected Date, Number, or String value for 'Date' header value, but received: ", value);
+		}
+	}
+
+	private void setETag(HttpHeaders target, Object value) {
+		if (value instanceof String) {
+			target.setETag((String) value);
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue("Expected String value for 'ETag' header value, but received: ",
+					value);
+		}
+	}
+
+	private void setExpires(HttpHeaders target, Object value) {
+		if (value instanceof Date) {
+			target.setExpires(((Date) value).getTime());
+		}
+		else if (value instanceof Number) {
+			target.setExpires(((Number) value).longValue());
+		}
+		else if (value instanceof String) {
+			try {
+				target.setExpires(Long.parseLong((String) value));
+			}
+			catch (@SuppressWarnings(UNUSED) NumberFormatException e) {
+				target.setExpires(getFirstDate((String) value, HttpHeaders.EXPIRES));
+			}
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue(
+					"Expected Date, Number, or String value for 'Expires' header value, but received: ", value);
+		}
+	}
+
+	private void setIfModifiedSince(HttpHeaders target, Object value) {
+		if (value instanceof Date) {
+			target.setIfModifiedSince(((Date) value).getTime());
+		}
+		else if (value instanceof Number) {
+			target.setIfModifiedSince(((Number) value).longValue());
+		}
+		else if (value instanceof String) {
+			try {
+				target.setIfModifiedSince(Long.parseLong((String) value));
+			}
+			catch (@SuppressWarnings(UNUSED) NumberFormatException e) {
+				target.setIfModifiedSince(getFirstDate((String) value, HttpHeaders.IF_MODIFIED_SINCE));
+			}
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue(
+					"Expected Date, Number, or String value for 'If-Modified-Since' header value, but received: ",
+					value);
+		}
+	}
+
+	private void setIfUnmodifiedSince(HttpHeaders target, Object value) {
+		if (value instanceof Date) {
+			target.setIfUnmodifiedSince(((Date) value).getTime());
+		}
+		else if (value instanceof Number) {
+			target.setIfUnmodifiedSince(((Number) value).longValue());
+		}
+		else if (value instanceof String) {
+			try {
+				target.setIfUnmodifiedSince(Long.parseLong((String) value));
+			}
+			catch (@SuppressWarnings(UNUSED) NumberFormatException e) {
+				target.setIfUnmodifiedSince(getFirstDate((String) value, HttpHeaders.IF_UNMODIFIED_SINCE));
+			}
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue(
+					"Expected Date, Number, or String value for 'If-Unmodified-Since' header value, but received: ",
+					value);
+		}
+	}
+
+	private void setIfNoneMatch(HttpHeaders target, Object value) {
+		if (value instanceof String) {
+			target.setIfNoneMatch((String) value);
+		}
+		else if (value instanceof String[]) {
+			target.setIfNoneMatch(StringUtils.arrayToCommaDelimitedString((String[]) value));
+		}
+		else if (value instanceof Collection) {
+			Collection<?> values = (Collection<?>) value;
+			if (!CollectionUtils.isEmpty(values)) {
+				List<String> ifNoneMatchList = new ArrayList<>();
+				for (Object next : values) {
+					if (next instanceof String) {
+						ifNoneMatchList.add((String) next);
+					}
+					else {
+						throwIllegalArgumentForUnexpectedValue(
+								"Expected String value for 'If-None-Match' header value, but received: ", value);
+					}
+				}
+				target.setIfNoneMatch(ifNoneMatchList);
+			}
+		}
+	}
+
+	private void setLastModified(HttpHeaders target, Object value) {
+		if (value instanceof Date) {
+			target.setLastModified(((Date) value).getTime());
+		}
+		else if (value instanceof Number) {
+			target.setLastModified(((Number) value).longValue());
+		}
+		else if (value instanceof String) {
+			try {
+				target.setLastModified(Long.parseLong((String) value));
+			}
+			catch (@SuppressWarnings(UNUSED) NumberFormatException e) {
+				target.setLastModified(getFirstDate((String) value, HttpHeaders.LAST_MODIFIED));
+			}
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue(
+					"Expected Date, Number, or String value for 'Last-Modified' header value, but received: ", value);
+		}
+	}
+
+	private void setLocation(HttpHeaders target, Object value) {
+		if (value instanceof URI) {
+			target.setLocation((URI) value);
+		}
+		else if (value instanceof String) {
+			try {
+				target.setLocation(new URI((String) value));
+			}
+			catch (URISyntaxException e) {
+				throw new IllegalArgumentException(e);
+			}
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue(
+					"Expected URI or String value for 'Location' header value, but received: ", value);
+		}
+	}
+
+	private void setPragma(HttpHeaders target, Object value) {
+		if (value instanceof String) {
+			target.setPragma((String) value);
+		}
+		else {
+			throwIllegalArgumentForUnexpectedValue("Expected String value for 'Pragma' header value, but received: ",
+					value);
+		}
+	}
+
+	private void throwIllegalArgumentForUnexpectedValue(String message, @Nullable Object value) {
+		throw new IllegalArgumentException(message + (value != null ? value.getClass() : null));
+	}
+
+	private void setIterableHeader(HttpHeaders target, String name, Object value) {
+		for (Object next : (Iterable<?>) value) {
+			String convertedValue;
+			if (next instanceof String) {
+				convertedValue = (String) next;
+			}
+			else {
+				convertedValue = convertToString(value);
+			}
+			if (StringUtils.hasText(convertedValue)) {
+				target.add(name, convertedValue);
+			}
+			else {
+				this.logger.warn("Element of the header '" + name + "' with value '" + value +
+						"' will not be set since it is not a String and no Converter is available. " +
+						"Consider registering a Converter with ConversionService (e.g., <int:converter>)");
+			}
+		}
+	}
+
+	private void setPlainHeader(HttpHeaders target, String name, Object value) {
+		String convertedValue = convertToString(value);
+		if (StringUtils.hasText(convertedValue)) {
+			target.set(name, convertedValue);
+		}
+		else {
+			this.logger.warn("Header '" + name + "' with value '" + value +
+					"' will not be set since it is not a String and no Converter is available. " +
+					"Consider registering a Converter with ConversionService (e.g., <int:converter>)");
 		}
 	}
 
@@ -452,8 +1111,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	@Override
 	public Map<String, Object> toHeaders(HttpHeaders source) {
 		if (this.logger.isDebugEnabled()) {
-			this.logger.debug(MessageFormat.format("inboundHeaderNames={0}",
-					CollectionUtils.arrayToList(this.inboundHeaderNames)));
+			this.logger.debug("inboundHeaderNames=" + Arrays.toString(this.inboundHeaderNames));
 		}
 		Map<String, Object> target = new HashMap<>();
 		Set<String> headerNames = source.keySet();
@@ -462,50 +1120,111 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 			if (shouldMapInboundHeader(lowerName)) {
 				if (!HTTP_REQUEST_HEADER_NAMES_LOWER.contains(lowerName)
 						&& !HTTP_RESPONSE_HEADER_NAMES_LOWER.contains(lowerName)) {
-					String prefixedName = StringUtils.startsWithIgnoreCase(name, this.userDefinedHeaderPrefix)
-							? name
-							: this.userDefinedHeaderPrefix + name;
-					Object value = source.containsKey(prefixedName)
-							? getHttpHeader(source, prefixedName)
-							: getHttpHeader(source, name);
-					if (value != null) {
-						if (this.logger.isDebugEnabled()) {
-							this.logger.debug(MessageFormat.format("setting headerName=[{0}], value={1}", name, value));
-						}
-						setMessageHeader(target, name, value);
-					}
+					populateUserDefinedHeader(source, target, name);
 				}
 				else {
-					Object value = getHttpHeader(source, name);
-					if (value != null) {
-						if (this.logger.isDebugEnabled()) {
-							this.logger.debug(MessageFormat.format("setting headerName=[{0}], value={1}", name, value));
-						}
-						if (CONTENT_TYPE.equalsIgnoreCase(name)) {
-							name = MessageHeaders.CONTENT_TYPE;
-						}
-						setMessageHeader(target, name, value);
-					}
+					populateStandardHeader(source, target, name);
 				}
 			}
 		}
 		return target;
 	}
 
-	@Override
-	public void afterPropertiesSet() {
-		if (this.beanFactory != null) {
-			this.conversionService = IntegrationUtils.getConversionService(this.beanFactory);
+	private void populateUserDefinedHeader(HttpHeaders source, Map<String, Object> target, String name) {
+		String prefixedName = StringUtils.startsWithIgnoreCase(name, this.userDefinedHeaderPrefix)
+				? name
+				: this.userDefinedHeaderPrefix + name;
+		Object value = source.containsKey(prefixedName)
+				? getHttpHeader(source, prefixedName)
+				: getHttpHeader(source, name);
+		if (value != null) {
+			setMessageHeader(target, name, value);
 		}
 	}
 
-	protected final boolean containsElementIgnoreCase(String[] headerNames, String name) {
-		for (String headerName : headerNames) {
-			if (headerName.equalsIgnoreCase(name)) {
-				return true;
+	private void populateStandardHeader(HttpHeaders source, Map<String, Object> target, String name) {
+		Object value = getHttpHeader(source, name);
+		if (value != null) {
+			setMessageHeader(target,
+					HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(name) ? MessageHeaders.CONTENT_TYPE : name, value);
+		}
+	}
+
+	protected Object getHttpHeader(HttpHeaders source, String name) { // NOSONAR
+		switch (name.toLowerCase()) {
+			case ACCEPT_LOWER:
+				return source.getAccept();
+			case ACCEPT_CHARSET_LOWER:
+				return source.getAcceptCharset();
+			case ALLOW_LOWER:
+				return source.getAllow();
+			case CACHE_CONTROL_LOWER:
+				String cacheControl = source.getCacheControl();
+				return (StringUtils.hasText(cacheControl)) ? cacheControl : null;
+			case CONTENT_LENGTH_LOWER:
+				long contentLength = source.getContentLength();
+				return (contentLength > -1) ? contentLength : null;
+			case CONTENT_TYPE_LOWER:
+				return source.getContentType();
+			case DATE_LOWER:
+				long date = source.getDate();
+				return (date > -1) ? date : null;
+			case ETAG_LOWER:
+				String eTag = source.getETag();
+				return (StringUtils.hasText(eTag)) ? eTag : null;
+			case EXPIRES_LOWER:
+				long expires = source.getExpires();
+				return (expires > -1) ? expires : null;
+			case IF_NONE_MATCH_LOWER:
+				return source.getIfNoneMatch();
+			case IF_MODIFIED_SINCE_LOWER:
+				long modifiedSince = source.getIfModifiedSince();
+				return (modifiedSince > -1) ? modifiedSince : null;
+			case IF_UNMODIFIED_SINCE_LOWER:
+				long unmodifiedSince = source.getIfUnmodifiedSince();
+				return (unmodifiedSince > -1) ? unmodifiedSince : null;
+			case LAST_MODIFIED_LOWER:
+				long lastModified = source.getLastModified();
+				return (lastModified > -1) ? lastModified : null;
+			case LOCATION_LOWER:
+				return source.getLocation();
+			case PRAGMA_LOWER:
+				String pragma = source.getPragma();
+				return (StringUtils.hasText(pragma)) ? pragma : null;
+			default:
+				return source.get(name);
+		}
+	}
+
+	private void setMessageHeader(Map<String, Object> target, String name, Object value) {
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug(MessageFormat.format("setting headerName=[{0}], value={1}", name, value));
+		}
+		if (ObjectUtils.isArray(value)) {
+			Object[] values = ObjectUtils.toObjectArray(value);
+			if (!ObjectUtils.isEmpty(values)) {
+				if (values.length == 1) {
+					target.put(name, values);
+				}
+				else {
+					target.put(name, values[0]);
+				}
 			}
 		}
-		return false;
+		else if (value instanceof Collection<?>) {
+			Collection<?> values = (Collection<?>) value;
+			if (!CollectionUtils.isEmpty(values)) {
+				if (values.size() == 1) {
+					target.put(name, values.iterator().next());
+				}
+				else {
+					target.put(name, values);
+				}
+			}
+		}
+		else if (value != null) {
+			target.put(name, value);
+		}
 	}
 
 	private boolean shouldMapOutboundHeader(String headerName) {
@@ -553,27 +1272,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	private boolean shouldMapHeader(String headerName, String[] patterns) {
 		if (patterns != null && patterns.length > 0) {
 			for (String pattern : patterns) {
-				if (PatternMatchUtils.simpleMatch(pattern, headerName)) {
-					if (this.logger.isDebugEnabled()) {
-						this.logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}",
-								headerName, pattern));
-					}
-					return true;
-				}
-				else if (HTTP_REQUEST_HEADER_NAME_PATTERN.equals(pattern)
-						&& HTTP_REQUEST_HEADER_NAMES_LOWER.contains(headerName)) {
-					if (this.logger.isDebugEnabled()) {
-						this.logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}",
-								headerName, pattern));
-					}
-					return true;
-				}
-				else if (HTTP_RESPONSE_HEADER_NAME_PATTERN.equals(pattern)
-						&& HTTP_RESPONSE_HEADER_NAMES_LOWER.contains(headerName)) {
-					if (this.logger.isDebugEnabled()) {
-						this.logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}",
-								headerName, pattern));
-					}
+				if (matchHeaderForPattern(headerName, pattern)) {
 					return true;
 				}
 			}
@@ -584,491 +1283,34 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 		return false;
 	}
 
-	private void setHttpHeader(HttpHeaders target, String name, Object value) {
-		if (ACCEPT.equalsIgnoreCase(name)) {
-			if (value instanceof Collection<?>) {
-				Collection<?> values = (Collection<?>) value;
-				if (!CollectionUtils.isEmpty(values)) {
-					List<MediaType> acceptableMediaTypes = new ArrayList<>();
-					for (Object type : values) {
-						if (type instanceof MediaType) {
-							acceptableMediaTypes.add((MediaType) type);
-						}
-						else if (type instanceof String) {
-							acceptableMediaTypes.addAll(MediaType.parseMediaTypes((String) type));
-						}
-						else {
-							Class<?> clazz = (type != null) ? type.getClass() : null;
-							throw new IllegalArgumentException(
-									"Expected MediaType or String value for 'Accept' header value, but received: "
-											+ clazz);
-						}
-					}
-					target.setAccept(acceptableMediaTypes);
-				}
+	private boolean matchHeaderForPattern(String headerName, String pattern) {
+		if (PatternMatchUtils.simpleMatch(pattern, headerName)) {
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}",
+						headerName, pattern));
 			}
-			else if (value instanceof MediaType) {
-				target.setAccept(Collections.singletonList((MediaType) value));
-			}
-			else if (value instanceof String[]) {
-				List<MediaType> acceptableMediaTypes = new ArrayList<>();
-				for (String next : (String[]) value) {
-					acceptableMediaTypes.add(MediaType.parseMediaType(next));
-				}
-				target.setAccept(acceptableMediaTypes);
-			}
-			else if (value instanceof String) {
-				target.setAccept(MediaType.parseMediaTypes((String) value));
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected MediaType or String value for 'Accept' header value, but received: " + clazz);
-			}
+			return true;
 		}
-		else if (ACCEPT_CHARSET.equalsIgnoreCase(name)) {
-			if (value instanceof Collection<?>) {
-				Collection<?> values = (Collection<?>) value;
-				if (!CollectionUtils.isEmpty(values)) {
-					List<Charset> acceptableCharsets = new ArrayList<>();
-					for (Object charset : values) {
-						if (charset instanceof Charset) {
-							acceptableCharsets.add((Charset) charset);
-						}
-						else if (charset instanceof String) {
-							acceptableCharsets.add(Charset.forName((String) charset));
-						}
-						else {
-							Class<?> clazz = (charset != null) ? charset.getClass() : null;
-							throw new IllegalArgumentException(
-									"Expected Charset or String value for 'Accept-Charset' header value, but received: "
-											+ clazz);
-						}
-					}
-					target.setAcceptCharset(acceptableCharsets);
-				}
+		else if (HTTP_REQUEST_HEADER_NAME_PATTERN.equals(pattern)
+				&& HTTP_REQUEST_HEADER_NAMES_LOWER.contains(headerName)) {
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}",
+						headerName, pattern));
 			}
-			else if (value instanceof Charset[] || value instanceof String[]) {
-				List<Charset> acceptableCharsets = new ArrayList<>();
-				Object[] values = ObjectUtils.toObjectArray(value);
-				for (Object charset : values) {
-					if (charset instanceof Charset) {
-						acceptableCharsets.add((Charset) charset);
-					}
-					else if (charset instanceof String) {
-						acceptableCharsets.add(Charset.forName((String) charset));
-					}
-				}
-				target.setAcceptCharset(acceptableCharsets);
-			}
-			else if (value instanceof Charset) {
-				target.setAcceptCharset(Collections.singletonList((Charset) value));
-			}
-			else if (value instanceof String) {
-				String[] charsets = StringUtils.commaDelimitedListToStringArray((String) value);
-				List<Charset> acceptableCharsets = new ArrayList<>();
-				for (String charset : charsets) {
-					acceptableCharsets.add(Charset.forName(charset.trim()));
-				}
-				target.setAcceptCharset(acceptableCharsets);
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected Charset or String value for 'Accept-Charset' header value, but received: " + clazz);
-			}
+			return true;
 		}
-		else if (ALLOW.equalsIgnoreCase(name)) {
-			if (value instanceof Collection<?>) {
-				Collection<?> values = (Collection<?>) value;
-				if (!CollectionUtils.isEmpty(values)) {
-					Set<HttpMethod> allowedMethods = new HashSet<>();
-					for (Object method : values) {
-						if (method instanceof HttpMethod) {
-							allowedMethods.add((HttpMethod) method);
-						}
-						else if (method instanceof String) {
-							allowedMethods.add(HttpMethod.valueOf((String) method));
-						}
-						else {
-							Class<?> clazz = (method != null) ? method.getClass() : null;
-							throw new IllegalArgumentException(
-									"Expected HttpMethod or String value for 'Allow' header value, but received: "
-											+ clazz);
-						}
-					}
-					target.setAllow(allowedMethods);
-				}
+		else if (HTTP_RESPONSE_HEADER_NAME_PATTERN.equals(pattern)
+				&& HTTP_RESPONSE_HEADER_NAMES_LOWER.contains(headerName)) {
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug(MessageFormat.format("headerName=[{0}] WILL be mapped, matched pattern={1}",
+						headerName, pattern));
 			}
-			else {
-				if (value instanceof HttpMethod) {
-					target.setAllow(Collections.singleton((HttpMethod) value));
-				}
-				else if (value instanceof HttpMethod[]) {
-					Set<HttpMethod> allowedMethods = new HashSet<>();
-					Collections.addAll(allowedMethods, (HttpMethod[]) value);
-					target.setAllow(allowedMethods);
-				}
-				else if (value instanceof String || value instanceof String[]) {
-					String[] values = (value instanceof String[]) ? (String[]) value
-							: StringUtils.commaDelimitedListToStringArray((String) value);
-					Set<HttpMethod> allowedMethods = new HashSet<>();
-					for (String next : values) {
-						allowedMethods.add(HttpMethod.valueOf(next.trim()));
-					}
-					target.setAllow(allowedMethods);
-				}
-				else {
-					Class<?> clazz = (value != null) ? value.getClass() : null;
-					throw new IllegalArgumentException(
-							"Expected HttpMethod or String value for 'Allow' header value, but received: " + clazz);
-				}
-			}
+			return true;
 		}
-		else if (CACHE_CONTROL.equalsIgnoreCase(name)) {
-			if (value instanceof String) {
-				target.setCacheControl((String) value);
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected String value for 'Cache-Control' header value, but received: " + clazz);
-			}
-		}
-		else if (CONTENT_LENGTH.equalsIgnoreCase(name)) {
-			if (value instanceof Number) {
-				target.setContentLength(((Number) value).longValue());
-			}
-			else if (value instanceof String) {
-				target.setContentLength(Long.parseLong((String) value));
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected Number or String value for 'Content-Length' header value, but received: " + clazz);
-			}
-		}
-		else if (MessageHeaders.CONTENT_TYPE.equalsIgnoreCase(name)) {
-			if (value instanceof MediaType) {
-				target.setContentType((MediaType) value);
-			}
-			else if (value instanceof String) {
-				target.setContentType(MediaType.parseMediaType((String) value));
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected MediaType or String value for 'Content-Type' header value, but received: " + clazz);
-			}
-		}
-		else if (DATE.equalsIgnoreCase(name)) {
-			if (value instanceof Date) {
-				target.setDate(((Date) value).getTime());
-			}
-			else if (value instanceof Number) {
-				target.setDate(((Number) value).longValue());
-			}
-			else if (value instanceof String) {
-				try {
-					target.setDate(Long.parseLong((String) value));
-				}
-				catch (@SuppressWarnings(UNUSED) NumberFormatException e) {
-					target.setDate(getFirstDate((String) value, DATE));
-				}
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected Date, Number, or String value for 'Date' header value, but received: " + clazz);
-			}
-		}
-		else if (ETAG.equalsIgnoreCase(name)) {
-			if (value instanceof String) {
-				target.setETag((String) value);
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected String value for 'ETag' header value, but received: " + clazz);
-			}
-		}
-		else if (EXPIRES.equalsIgnoreCase(name)) {
-			if (value instanceof Date) {
-				target.setExpires(((Date) value).getTime());
-			}
-			else if (value instanceof Number) {
-				target.setExpires(((Number) value).longValue());
-			}
-			else if (value instanceof String) {
-				try {
-					target.setExpires(Long.parseLong((String) value));
-				}
-				catch (@SuppressWarnings(UNUSED) NumberFormatException e) {
-					target.setExpires(getFirstDate((String) value, EXPIRES));
-				}
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected Date, Number, or String value for 'Expires' header value, but received: " + clazz);
-			}
-		}
-		else if (IF_MODIFIED_SINCE.equalsIgnoreCase(name)) {
-			if (value instanceof Date) {
-				target.setIfModifiedSince(((Date) value).getTime());
-			}
-			else if (value instanceof Number) {
-				target.setIfModifiedSince(((Number) value).longValue());
-			}
-			else if (value instanceof String) {
-				try {
-					target.setIfModifiedSince(Long.parseLong((String) value));
-				}
-				catch (@SuppressWarnings(UNUSED) NumberFormatException e) {
-					target.setIfModifiedSince(getFirstDate((String) value, IF_MODIFIED_SINCE));
-				}
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected Date, Number, or String value for 'If-Modified-Since' header value, but received: "
-								+ clazz);
-			}
-		}
-		else if (IF_UNMODIFIED_SINCE.equalsIgnoreCase(name)) {
-			String ifUnmodifiedSinceValue;
-			if (value instanceof Date) {
-				ifUnmodifiedSinceValue = formatDate(((Date) value).getTime());
-			}
-			else if (value instanceof Number) {
-				ifUnmodifiedSinceValue = formatDate(((Number) value).longValue());
-			}
-			else if (value instanceof String) {
-				try {
-					ifUnmodifiedSinceValue = formatDate(Long.parseLong((String) value));
-				}
-				catch (@SuppressWarnings(UNUSED) NumberFormatException e) {
-					long longValue = getFirstDate((String) value, IF_UNMODIFIED_SINCE);
-					ifUnmodifiedSinceValue = formatDate(longValue);
-				}
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected Date, Number, or String value for 'If-Unmodified-Since' header value, but received: "
-								+ clazz);
-			}
-			target.set(IF_UNMODIFIED_SINCE, ifUnmodifiedSinceValue);
-		}
-		else if (IF_NONE_MATCH.equalsIgnoreCase(name)) {
-			if (value instanceof String) {
-				target.setIfNoneMatch((String) value);
-			}
-			else if (value instanceof String[]) {
-				String delmitedString = StringUtils.arrayToCommaDelimitedString((String[]) value);
-				target.setIfNoneMatch(delmitedString);
-			}
-			else if (value instanceof Collection) {
-				Collection<?> values = (Collection<?>) value;
-				if (!CollectionUtils.isEmpty(values)) {
-					List<String> ifNoneMatchList = new ArrayList<>();
-					for (Object next : values) {
-						if (next instanceof String) {
-							ifNoneMatchList.add((String) next);
-						}
-						else {
-							Class<?> clazz = (next != null) ? next.getClass() : null;
-							throw new IllegalArgumentException(
-									"Expected String value for 'If-None-Match' header value, but received: " + clazz);
-						}
-					}
-					target.setIfNoneMatch(ifNoneMatchList);
-				}
-			}
-		}
-		else if (LAST_MODIFIED.equalsIgnoreCase(name)) {
-			if (value instanceof Date) {
-				target.setLastModified(((Date) value).getTime());
-			}
-			else if (value instanceof Number) {
-				target.setLastModified(((Number) value).longValue());
-			}
-			else if (value instanceof String) {
-				try {
-					target.setLastModified(Long.parseLong((String) value));
-				}
-				catch (@SuppressWarnings(UNUSED) NumberFormatException e) {
-					target.setLastModified(getFirstDate((String) value, LAST_MODIFIED));
-				}
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected Date, Number, or String value for 'Last-Modified' header value, but received: "
-								+ clazz);
-			}
-		}
-		else if (LOCATION.equalsIgnoreCase(name)) {
-			if (value instanceof URI) {
-				target.setLocation((URI) value);
-			}
-			else if (value instanceof String) {
-				try {
-					target.setLocation(new URI((String) value));
-				}
-				catch (URISyntaxException e) {
-					throw new IllegalArgumentException(e);
-				}
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected URI or String value for 'Location' header value, but received: " + clazz);
-			}
-		}
-		else if (PRAGMA.equalsIgnoreCase(name)) {
-			if (value instanceof String) {
-				target.setPragma((String) value);
-			}
-			else {
-				Class<?> clazz = (value != null) ? value.getClass() : null;
-				throw new IllegalArgumentException(
-						"Expected String value for 'Pragma' header value, but received: " + clazz);
-			}
-		}
-		else if (value instanceof String) {
-			target.set(name, (String) value);
-		}
-		else if (value instanceof String[]) {
-			for (String next : (String[]) value) {
-				target.add(name, next);
-			}
-		}
-		else if (value instanceof Iterable<?>) {
-			for (Object next : (Iterable<?>) value) {
-				String convertedValue;
-				if (next instanceof String) {
-					convertedValue = (String) next;
-				}
-				else {
-					convertedValue = convertToString(value);
-				}
-				if (StringUtils.hasText(convertedValue)) {
-					target.add(name, convertedValue);
-				}
-				else {
-					this.logger.warn("Element of the header '" + name + "' with value '" + value +
-							"' will not be set since it is not a String and no Converter is available. " +
-							"Consider registering a Converter with ConversionService (e.g., <int:converter>)");
-				}
-			}
-		}
-		else {
-			String convertedValue = convertToString(value);
-			if (StringUtils.hasText(convertedValue)) {
-				target.set(name, convertedValue);
-			}
-			else {
-				this.logger.warn("Header '" + name + "' with value '" + value +
-						"' will not be set since it is not a String and no Converter is available. " +
-						"Consider registering a Converter with ConversionService (e.g., <int:converter>)");
-			}
-		}
+		return false;
 	}
 
-	protected Object getHttpHeader(HttpHeaders source, String name) {
-		if (ACCEPT.equalsIgnoreCase(name)) {
-			return source.getAccept();
-		}
-		else if (ACCEPT_CHARSET.equalsIgnoreCase(name)) {
-			return source.getAcceptCharset();
-		}
-		else if (ALLOW.equalsIgnoreCase(name)) {
-			return source.getAllow();
-		}
-		else if (CACHE_CONTROL.equalsIgnoreCase(name)) {
-			String cacheControl = source.getCacheControl();
-			return (StringUtils.hasText(cacheControl)) ? cacheControl : null;
-		}
-		else if (CONTENT_LENGTH.equalsIgnoreCase(name)) {
-			long contentLength = source.getContentLength();
-			return (contentLength > -1) ? contentLength : null;
-		}
-		else if (CONTENT_TYPE.equalsIgnoreCase(name)) {
-			return source.getContentType();
-		}
-		else if (DATE.equalsIgnoreCase(name)) {
-			long date = source.getDate();
-			return (date > -1) ? date : null;
-		}
-		else if (ETAG.equalsIgnoreCase(name)) {
-			String eTag = source.getETag();
-			return (StringUtils.hasText(eTag)) ? eTag : null;
-		}
-		else if (EXPIRES.equalsIgnoreCase(name)) {
-			try {
-				long expires = source.getExpires();
-				return (expires > -1) ? expires : null;
-			}
-			catch (Exception e) {
-				this.logger.debug(e.getMessage());
-				// According to RFC 2616
-				return null;
-			}
-		}
-		else if (IF_NONE_MATCH.equalsIgnoreCase(name)) {
-			return source.getIfNoneMatch();
-		}
-		else if (IF_MODIFIED_SINCE.equalsIgnoreCase(name)) {
-			long modifiedSince = source.getIfModifiedSince();
-			return (modifiedSince > -1) ? modifiedSince : null;
-		}
-		else if (IF_UNMODIFIED_SINCE.equalsIgnoreCase(name)) {
-			String unmodifiedSince = source.getFirst(IF_UNMODIFIED_SINCE);
-			return unmodifiedSince != null ? getFirstDate(unmodifiedSince, IF_UNMODIFIED_SINCE) : null;
-		}
-		else if (LAST_MODIFIED.equalsIgnoreCase(name)) {
-			long lastModified = source.getLastModified();
-			return (lastModified > -1) ? lastModified : null;
-		}
-		else if (LOCATION.equalsIgnoreCase(name)) {
-			return source.getLocation();
-		}
-		else if (PRAGMA.equalsIgnoreCase(name)) {
-			String pragma = source.getPragma();
-			return (StringUtils.hasText(pragma)) ? pragma : null;
-		}
-		return source.get(name);
-	}
-
-	private void setMessageHeader(Map<String, Object> target, String name, Object value) {
-		if (ObjectUtils.isArray(value)) {
-			Object[] values = ObjectUtils.toObjectArray(value);
-			if (!ObjectUtils.isEmpty(values)) {
-				if (values.length == 1) {
-					target.put(name, values);
-				}
-				else {
-					target.put(name, values[0]);
-				}
-			}
-		}
-		else if (value instanceof Collection<?>) {
-			Collection<?> values = (Collection<?>) value;
-			if (!CollectionUtils.isEmpty(values)) {
-				if (values.size() == 1) {
-					target.put(name, values.iterator().next());
-				}
-				else {
-					target.put(name, values);
-				}
-			}
-		}
-		else if (value != null) {
-			target.put(name, value);
-		}
-	}
-
+	@Nullable
 	protected String convertToString(Object value) {
 		if (this.conversionService != null &&
 				this.conversionService.canConvert(TypeDescriptor.forObject(value),
@@ -1081,7 +1323,11 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 
 	// Utility methods
 
-	protected long getFirstDate(String headerValue, String headerName) {
+	protected static boolean containsElementIgnoreCase(String[] headerNames, String name) {
+		return Arrays.stream(headerNames).anyMatch(headerName -> headerName.equalsIgnoreCase(name));
+	}
+
+	protected static long getFirstDate(String headerValue, String headerName) {
 		for (DateTimeFormatter dateFormatter : DATE_FORMATS) {
 			try {
 				return ZonedDateTime.parse(headerValue, dateFormatter)
@@ -1095,12 +1341,6 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 
 		throw new IllegalArgumentException("Cannot parse date value '" + headerValue + "' for '" + headerName
 				+ "' header");
-	}
-
-	protected static String formatDate(long date) {
-		Instant instant = Instant.ofEpochMilli(date);
-		ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(instant, GMT);
-		return DATE_FORMATTER.format(zonedDateTime);
 	}
 
 	/**

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -789,11 +789,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 				}
 			}
 		}
-		else if (value instanceof Charset) {
-			acceptableCharsets = Collections.singletonList((Charset) value);
-		}
-		else if (value instanceof Charset[]) {
-			acceptableCharsets = Arrays.asList((Charset[]) value);
+		else if (value instanceof Charset || value instanceof Charset[]) {
+			acceptableCharsets = Arrays.asList((Charset[]) ObjectUtils.toObjectArray(value));
 		}
 		else if (value instanceof String || value instanceof String[]) {
 			String[] values = arrayFromValue(value);
@@ -830,11 +827,8 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 				}
 			}
 		}
-		else if (value instanceof HttpMethod) {
-			allowedMethods = Collections.singleton((HttpMethod) value);
-		}
-		else if (value instanceof HttpMethod[]) {
-			allowedMethods = new LinkedHashSet<>(Arrays.asList((HttpMethod[]) value));
+		else if (value instanceof HttpMethod || value instanceof HttpMethod[]) {
+			allowedMethods = new LinkedHashSet<>(Arrays.asList((HttpMethod[]) ObjectUtils.toObjectArray(value)));
 		}
 		else if (value instanceof String || value instanceof String[]) {
 			String[] values = arrayFromValue(value);

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -31,13 +31,13 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -53,7 +53,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.utils.IntegrationUtils;
-import org.springframework.integration.util.JavaUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
@@ -86,15 +85,11 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	@Deprecated
 	public static final String ACCEPT = HttpHeaders.ACCEPT;
 
-	private static final String ACCEPT_LOWER = "accept";
-
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#ACCEPT_CHARSET}
 	 */
 	@Deprecated
 	public static final String ACCEPT_CHARSET = HttpHeaders.ACCEPT_CHARSET;
-
-	private static final String ACCEPT_CHARSET_LOWER = "accept-charset";
 
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#ACCEPT_ENCODING}
@@ -126,8 +121,6 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	@Deprecated
 	public static final String ALLOW = HttpHeaders.ALLOW;
 
-	private static final String ALLOW_LOWER = "allow";
-
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#AUTHORIZATION}
 	 */
@@ -139,8 +132,6 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	 */
 	@Deprecated
 	public static final String CACHE_CONTROL = HttpHeaders.CACHE_CONTROL;
-
-	private static final String CACHE_CONTROL_LOWER = "cache-control";
 
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#CONNECTION}
@@ -166,8 +157,6 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	@Deprecated
 	public static final String CONTENT_LENGTH = HttpHeaders.CONTENT_LENGTH;
 
-	private static final String CONTENT_LENGTH_LOWER = "content-length";
-
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#CONTENT_LOCATION}
 	 */
@@ -185,8 +174,6 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	 */
 	@Deprecated
 	public static final String CONTENT_TYPE = HttpHeaders.CONTENT_TYPE;
-
-	private static final String CONTENT_TYPE_LOWER = "content-type";
 
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#CONTENT_DISPOSITION}
@@ -206,15 +193,11 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	@Deprecated
 	public static final String DATE = HttpHeaders.DATE;
 
-	private static final String DATE_LOWER = "date";
-
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#ETAG}
 	 */
 	@Deprecated
 	public static final String ETAG = HttpHeaders.ETAG;
-
-	private static final String ETAG_LOWER = "etag";
 
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#EXPECT}
@@ -227,8 +210,6 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	 */
 	@Deprecated
 	public static final String EXPIRES = HttpHeaders.EXPIRES;
-
-	private static final String EXPIRES_LOWER = "expires";
 
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#FROM}
@@ -254,15 +235,11 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	@Deprecated
 	public static final String IF_MODIFIED_SINCE = HttpHeaders.IF_MODIFIED_SINCE;
 
-	private static final String IF_MODIFIED_SINCE_LOWER = "if-modified-since";
-
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#IF_NONE_MATCH}
 	 */
 	@Deprecated
 	public static final String IF_NONE_MATCH = HttpHeaders.IF_NONE_MATCH;
-
-	private static final String IF_NONE_MATCH_LOWER = "if-none-match";
 
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#IF_RANGE}
@@ -276,23 +253,17 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	@Deprecated
 	public static final String IF_UNMODIFIED_SINCE = HttpHeaders.IF_UNMODIFIED_SINCE;
 
-	private static final String IF_UNMODIFIED_SINCE_LOWER = "if-unmodified-since";
-
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#LAST_MODIFIED}
 	 */
 	@Deprecated
 	public static final String LAST_MODIFIED = HttpHeaders.LAST_MODIFIED;
 
-	private static final String LAST_MODIFIED_LOWER = "last-modified";
-
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#LOCATION}
 	 */
 	@Deprecated
 	public static final String LOCATION = HttpHeaders.LOCATION;
-
-	private static final String LOCATION_LOWER = "location";
 
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#MAX_FORWARDS}
@@ -305,8 +276,6 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	 */
 	@Deprecated
 	public static final String PRAGMA = HttpHeaders.PRAGMA;
-
-	private static final String PRAGMA_LOWER = "pragma";
 
 	/**
 	 * @deprecated since 5.2 in favor of {@link HttpHeaders#PROXY_AUTHENTICATE}
@@ -407,6 +376,36 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	public static final String CONTENT_MD5 = "Content-MD5";
 
 	public static final String REFRESH = "Refresh";
+
+	private static final String ACCEPT_LOWER = "accept";
+
+	private static final String ACCEPT_CHARSET_LOWER = "accept-charset";
+
+	private static final String ALLOW_LOWER = "allow";
+
+	private static final String CACHE_CONTROL_LOWER = "cache-control";
+
+	private static final String CONTENT_LENGTH_LOWER = "content-length";
+
+	private static final String CONTENT_TYPE_LOWER = "content-type";
+
+	private static final String DATE_LOWER = "date";
+
+	private static final String ETAG_LOWER = "etag";
+
+	private static final String EXPIRES_LOWER = "expires";
+
+	private static final String IF_MODIFIED_SINCE_LOWER = "if-modified-since";
+
+	private static final String IF_NONE_MATCH_LOWER = "if-none-match";
+
+	private static final String IF_UNMODIFIED_SINCE_LOWER = "if-unmodified-since";
+
+	private static final String LAST_MODIFIED_LOWER = "last-modified";
+
+	private static final String LOCATION_LOWER = "location";
+
+	private static final String PRAGMA_LOWER = "pragma";
 
 	private static final String[] HTTP_REQUEST_HEADER_NAMES = new String[] {
 			HttpHeaders.ACCEPT,
@@ -673,61 +672,67 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 		}
 	}
 
-	private void setHttpHeader(HttpHeaders target, String name, Object value) {
-		AtomicBoolean headerSet = new AtomicBoolean();
-
-		JavaUtils.INSTANCE
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.ACCEPT, name, headerSet), target, value,
-						this::setAccept)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.ACCEPT_CHARSET, name, headerSet), target, value,
-						this::setAcceptCharset)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.ALLOW, name, headerSet), target, value,
-						this::setAllow)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.CACHE_CONTROL, name, headerSet), target, value,
-						this::setCacheControl)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.CONTENT_LENGTH, name, headerSet), target, value,
-						this::setContentLength)
-				.acceptIfCondition(checkStandardHeaderToSet(MessageHeaders.CONTENT_TYPE, name, headerSet), target,
-						value, this::setContentType)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.DATE, name, headerSet), target, value,
-						this::setDate)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.ETAG, name, headerSet), target, value,
-						this::setETag)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.EXPIRES, name, headerSet), target, value,
-						this::setExpires)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.IF_MODIFIED_SINCE, name, headerSet), target,
-						value, this::setIfModifiedSince)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.IF_UNMODIFIED_SINCE, name, headerSet), target,
-						value, this::setIfUnmodifiedSince)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.IF_NONE_MATCH, name, headerSet), target, value,
-						this::setIfNoneMatch)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.LAST_MODIFIED, name, headerSet), target, value,
-						this::setLastModified)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.LOCATION, name, headerSet), target, value,
-						this::setLocation)
-				.acceptIfCondition(checkStandardHeaderToSet(HttpHeaders.PRAGMA, name, headerSet), target, value,
-						this::setPragma);
-
-		if (!headerSet.get()) {
-			if (value instanceof String) {
-				target.set(name, (String) value);
-			}
-			else if (value instanceof String[]) {
-				target.addAll(name, Arrays.asList((String[]) value));
-			}
-			else if (value instanceof Iterable<?>) {
-				setIterableHeader(target, name, value);
-			}
-			else {
-				setPlainHeader(target, name, value);
-			}
+	private void setHttpHeader(HttpHeaders target, String name, Object value) { // NOSONAR
+		switch (name.toLowerCase()) {
+			case ACCEPT_LOWER:
+				setAccept(target, value);
+				break;
+			case ACCEPT_CHARSET_LOWER:
+				setAcceptCharset(target, value);
+				break;
+			case ALLOW_LOWER:
+				setAllow(target, value);
+				break;
+			case CACHE_CONTROL_LOWER:
+				setCacheControl(target, value);
+				break;
+			case CONTENT_LENGTH_LOWER:
+				setContentLength(target, value);
+				break;
+			case "contenttype": // Lower case for MessageHeaders.CONTENT_TYPE
+				setContentType(target, value);
+				break;
+			case DATE_LOWER:
+				setDate(target, value);
+				break;
+			case ETAG_LOWER:
+				setETag(target, value);
+				break;
+			case EXPIRES_LOWER:
+				setExpires(target, value);
+				break;
+			case IF_MODIFIED_SINCE_LOWER:
+				setIfModifiedSince(target, value);
+				break;
+			case IF_UNMODIFIED_SINCE_LOWER:
+				setIfUnmodifiedSince(target, value);
+				break;
+			case IF_NONE_MATCH_LOWER:
+				setIfNoneMatch(target, value);
+				break;
+			case LAST_MODIFIED_LOWER:
+				setLastModified(target, value);
+				break;
+			case LOCATION_LOWER:
+				setLocation(target, value);
+				break;
+			case PRAGMA_LOWER:
+				setPragma(target, value);
+				break;
+			default:
+				if (value instanceof String) {
+					target.set(name, (String) value);
+				}
+				else if (value instanceof String[]) {
+					target.addAll(name, Arrays.asList((String[]) value));
+				}
+				else if (value instanceof Iterable<?>) {
+					setIterableHeader(target, name, value);
+				}
+				else {
+					setPlainHeader(target, name, value);
+				}
 		}
-	}
-
-	private boolean checkStandardHeaderToSet(String headerName, String actualName, AtomicBoolean headerSet) {
-		boolean setHeader = headerName.equalsIgnoreCase(actualName);
-		headerSet.compareAndSet(false, setHeader);
-		return setHeader;
 	}
 
 	private void setAccept(HttpHeaders target, Object value) {
@@ -769,40 +774,33 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	private void setAcceptCharset(HttpHeaders target, Object value) {
 		List<Charset> acceptableCharsets = null;
 		if (value instanceof Collection<?>) {
-			acceptableCharsets =
-					((Collection<?>) value).stream()
-							.map((charset) -> {
-								if (charset instanceof Charset) {
-									return (Charset) charset;
-								}
-								else if (charset instanceof String) {
-									return Charset.forName((String) charset);
-								}
-								else {
-									throwIllegalArgumentForUnexpectedValue(
-											"Expected Charset or String value for 'Accept-Charset' header value, " +
-													"but received: ", charset);
-									return null;
-								}
-							})
-							.collect(Collectors.toList());
-		}
-		else if (value instanceof Charset[] || value instanceof String[]) {
-			acceptableCharsets =
-					Arrays.stream(ObjectUtils.toObjectArray(value))
-							.map((charset) -> charset instanceof String ? Charset.forName((String) charset) : charset)
-							.map(Charset.class::cast)
-							.collect(Collectors.toList());
+			acceptableCharsets = new LinkedList<>();
+			for (Object charset : (Collection<?>) value) {
+				if (charset instanceof Charset) {
+					acceptableCharsets.add((Charset) charset);
+				}
+				else if (charset instanceof String) {
+					acceptableCharsets.add(Charset.forName((String) charset));
+				}
+				else {
+					throwIllegalArgumentForUnexpectedValue(
+							"Expected Charset or String value for 'Accept-Charset' header value, " +
+									"but received: ", charset);
+				}
+			}
 		}
 		else if (value instanceof Charset) {
 			acceptableCharsets = Collections.singletonList((Charset) value);
 		}
-		else if (value instanceof String) {
-			acceptableCharsets =
-					StringUtils.commaDelimitedListToSet((String) value)
-							.stream()
-							.map((charset) -> Charset.forName(charset.trim()))
-							.collect(Collectors.toList());
+		else if (value instanceof Charset[]) {
+			acceptableCharsets = Arrays.asList((Charset[]) value);
+		}
+		else if (value instanceof String || value instanceof String[]) {
+			String[] values = arrayFromValue(value);
+			acceptableCharsets = new LinkedList<>();
+			for (String charset : values) {
+				acceptableCharsets.add(Charset.forName(charset));
+			}
 		}
 		else {
 			throwIllegalArgumentForUnexpectedValue(
@@ -817,39 +815,33 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	private void setAllow(HttpHeaders target, Object value) {
 		Set<HttpMethod> allowedMethods = null;
 		if (value instanceof Collection<?>) {
-			allowedMethods =
-					((Collection<?>) value).stream()
-							.map((method) -> {
-								if (method instanceof HttpMethod) {
-									return (HttpMethod) method;
-								}
-								else if (method instanceof String) {
-									return HttpMethod.valueOf((String) method);
-								}
-								else {
-									throwIllegalArgumentForUnexpectedValue(
-											"Expected HttpMethod or String value for 'Allow' header value, " +
-													"but received: ", method);
-									return null;
-								}
-							})
-							.collect(Collectors.toSet());
+			allowedMethods = new LinkedHashSet<>();
+			for (Object method : (Collection<?>) value) {
+				if (method instanceof HttpMethod) {
+					allowedMethods.add((HttpMethod) method);
+				}
+				else if (method instanceof String) {
+					allowedMethods.add(HttpMethod.valueOf((String) method));
+				}
+				else {
+					throwIllegalArgumentForUnexpectedValue(
+							"Expected HttpMethod or String value for 'Allow' header value, " +
+									"but received: ", method);
+				}
+			}
 		}
 		else if (value instanceof HttpMethod) {
 			allowedMethods = Collections.singleton((HttpMethod) value);
 		}
 		else if (value instanceof HttpMethod[]) {
-			allowedMethods = new HashSet<>(Arrays.asList((HttpMethod[]) value));
+			allowedMethods = new LinkedHashSet<>(Arrays.asList((HttpMethod[]) value));
 		}
 		else if (value instanceof String || value instanceof String[]) {
-			String[] values =
-					(value instanceof String[])
-							? (String[]) value
-							: StringUtils.delimitedListToStringArray((String) value, ",", " ");
-			allowedMethods =
-					Arrays.stream(values)
-							.map(HttpMethod::valueOf)
-							.collect(Collectors.toSet());
+			String[] values = arrayFromValue(value);
+			allowedMethods = new LinkedHashSet<>();
+			for (String method : values) {
+				allowedMethods.add(HttpMethod.valueOf(method));
+			}
 		}
 		else {
 			throwIllegalArgumentForUnexpectedValue(
@@ -859,6 +851,12 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 		if (!CollectionUtils.isEmpty(allowedMethods)) {
 			target.setAllow(allowedMethods);
 		}
+	}
+
+	private String[] arrayFromValue(Object value) {
+		return value instanceof String[]
+				? (String[]) value
+				: StringUtils.delimitedListToStringArray((String) value, ",", " ");
 	}
 
 	private void setCacheControl(HttpHeaders target, Object value) {
@@ -1324,7 +1322,12 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	// Utility methods
 
 	protected static boolean containsElementIgnoreCase(String[] headerNames, String name) {
-		return Arrays.stream(headerNames).anyMatch(headerName -> headerName.equalsIgnoreCase(name));
+		for (String headerName : headerNames) {
+			if (headerName.equalsIgnoreCase(name)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	protected static long getFirstDate(String headerValue, String headerName) {

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageInboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageInboundTests.java
@@ -75,7 +75,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAllow().size()).isEqualTo(1);
+		assertThat(headers.getAllow()).hasSize(1);
 		assertThat(headers.getAllow().iterator().next()).isEqualTo(HttpMethod.GET);
 	}
 
@@ -87,7 +87,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAllow().size()).isEqualTo(1);
+		assertThat(headers.getAllow()).hasSize(1);
 		assertThat(headers.getAllow().iterator().next()).isEqualTo(HttpMethod.GET);
 	}
 
@@ -99,7 +99,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAllow().size()).isEqualTo(1);
+		assertThat(headers.getAllow()).hasSize(1);
 		assertThat(headers.getAllow().iterator().next()).isEqualTo(HttpMethod.GET);
 	}
 
@@ -301,12 +301,12 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 	@Test
 	public void validateTransferEncodingMappedFromHttpHeaders() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setInboundHeaderNames(new String[] { "Transfer-Encoding" });
+		mapper.setInboundHeaderNames("Transfer-Encoding");
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("Transfer-Encoding", "chunked");
 
 		Map<String, ?> result = mapper.toHeaders(headers);
-		assertThat(result.size()).isEqualTo(1);
+		assertThat(result).hasSize(1);
 		assertThat(result.get("Transfer-Encoding")).isEqualTo("chunked");
 
 	}
@@ -329,23 +329,23 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 	@Test
 	public void validateCustomHeaderNamesMappedToHttpHeaders() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[] { "foo", "bar" });
+		mapper.setOutboundHeaderNames("foo", "bar");
 		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("foo", "abc");
 		messageHeaders.put("bar", "123");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
 		assertThat(headers.size()).isEqualTo(2);
-		assertThat(headers.get("foo").size()).isEqualTo(1);
+		assertThat(headers.get("foo")).hasSize(1);
 		assertThat(headers.getFirst("foo")).isEqualTo("abc");
-		assertThat(headers.get("bar").size()).isEqualTo(1);
+		assertThat(headers.get("bar")).hasSize(1);
 		assertThat(headers.getFirst("bar")).isEqualTo("123");
 	}
 
 	@Test
 	public void validateCustomHeaderNamePatternsMappedToHttpHeaders() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[] { "x*", "*z", "a*f" });
+		mapper.setOutboundHeaderNames("x*", "*z", "a*f");
 		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("x1", "x1-value");
 		messageHeaders.put("1x", "1x-value");
@@ -361,18 +361,18 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 		assertThat(headers.get("z1")).isNull();
 		assertThat(headers.get("abc")).isNull();
 		assertThat(headers.get("def")).isNull();
-		assertThat(headers.get("x1").size()).isEqualTo(1);
+		assertThat(headers.get("x1")).hasSize(1);
 		assertThat(headers.getFirst("x1")).isEqualTo("x1-value");
-		assertThat(headers.get("1z").size()).isEqualTo(1);
+		assertThat(headers.get("1z")).hasSize(1);
 		assertThat(headers.getFirst("1z")).isEqualTo("1z-value");
-		assertThat(headers.get("abcdef").size()).isEqualTo(1);
+		assertThat(headers.get("abcdef")).hasSize(1);
 		assertThat(headers.getFirst("abcdef")).isEqualTo("abcdef-value");
 	}
 
 	@Test
 	public void validateCustomHeaderNamePatternsAndStandardResponseHeadersMappedToHttpHeaders() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[] { "foo*", "HTTP_RESPONSE_HEADERS" });
+		mapper.setOutboundHeaderNames("foo*", "HTTP_RESPONSE_HEADERS");
 		mapper.setUserDefinedHeaderPrefix("X-");
 		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("foobar", "abc");
@@ -383,7 +383,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 		assertThat(headers.size()).isEqualTo(2);
 		assertThat(headers.getAccept().isEmpty()).isTrue();
 		assertThat(headers.getContentType()).isEqualTo(MediaType.TEXT_XML);
-		assertThat(headers.get("X-foobar").size()).isEqualTo(1);
+		assertThat(headers.get("X-foobar")).hasSize(1);
 		assertThat(headers.getFirst("X-foobar")).isEqualTo("abc");
 	}
 
@@ -391,7 +391,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 	public void validateCustomHeaderNamePatternsAndStandardResponseHeadersMappedToHttpHeadersWithCustomPrefix() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
 		mapper.setUserDefinedHeaderPrefix("Z-");
-		mapper.setOutboundHeaderNames(new String[] { "foo*", "HTTP_RESPONSE_HEADERS" });
+		mapper.setOutboundHeaderNames("foo*", "HTTP_RESPONSE_HEADERS");
 		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("foobar", "abc");
 		messageHeaders.put("Accept", "text/html");
@@ -401,7 +401,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 		assertThat(headers.size()).isEqualTo(2);
 		assertThat(headers.getAccept().isEmpty()).isTrue();
 		assertThat(headers.getContentType()).isEqualTo(MediaType.TEXT_XML);
-		assertThat(headers.get("Z-foobar").size()).isEqualTo(1);
+		assertThat(headers.get("Z-foobar")).hasSize(1);
 		assertThat(headers.getFirst("Z-foobar")).isEqualTo("abc");
 	}
 
@@ -409,7 +409,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 	public void validateCustomHeaderNamePatternsAndStandardResponseHeadersMappedToHttpHeadersWithCustomPrefixEmptyString() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
 		mapper.setUserDefinedHeaderPrefix("");
-		mapper.setOutboundHeaderNames(new String[] { "foo*", "HTTP_RESPONSE_HEADERS" });
+		mapper.setOutboundHeaderNames("foo*", "HTTP_RESPONSE_HEADERS");
 		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("foobar", "abc");
 		messageHeaders.put("Accept", "text/html");
@@ -419,7 +419,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 		assertThat(headers.size()).isEqualTo(2);
 		assertThat(headers.getAccept().isEmpty()).isTrue();
 		assertThat(headers.getContentType()).isEqualTo(MediaType.TEXT_XML);
-		assertThat(headers.get("foobar").size()).isEqualTo(1);
+		assertThat(headers.get("foobar")).hasSize(1);
 		assertThat(headers.getFirst("foobar")).isEqualTo("abc");
 	}
 
@@ -427,7 +427,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 	public void validateCustomHeaderNamePatternsAndStandardResponseHeadersMappedToHttpHeadersWithCustomPrefixNull() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
 		mapper.setUserDefinedHeaderPrefix(null);
-		mapper.setOutboundHeaderNames(new String[] { "foo*", "HTTP_RESPONSE_HEADERS" });
+		mapper.setOutboundHeaderNames("foo*", "HTTP_RESPONSE_HEADERS");
 		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("foobar", "abc");
 		messageHeaders.put("Accept", "text/html");
@@ -437,14 +437,14 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 		assertThat(headers.size()).isEqualTo(2);
 		assertThat(headers.getAccept().isEmpty()).isTrue();
 		assertThat(headers.getContentType()).isEqualTo(MediaType.TEXT_XML);
-		assertThat(headers.get("foobar").size()).isEqualTo(1);
+		assertThat(headers.get("foobar")).hasSize(1);
 		assertThat(headers.getFirst("foobar")).isEqualTo("abc");
 	}
 
 	@Test
 	public void validateCustomHeaderNamesMappedFromHttpHeaders() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setInboundHeaderNames(new String[] { "foo", "bar" });
+		mapper.setInboundHeaderNames("foo", "bar");
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("foo", "abc");
 		headers.set("bar", "123");
@@ -457,7 +457,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 	@Test
 	public void validateCustomHeaderNamePatternsMappedFromHttpHeaders() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setInboundHeaderNames(new String[] { "x*", "*z", "a*f" });
+		mapper.setInboundHeaderNames("x*", "*z", "a*f");
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("x1", "x1-value");
 		headers.set("1x", "1x-value");
@@ -482,13 +482,13 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 			throws URISyntaxException {
 
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setInboundHeaderNames(new String[] { "foo*", "HTTP_REQUEST_HEADERS" });
+		mapper.setInboundHeaderNames("foo*", "HTTP_REQUEST_HEADERS");
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("foobar", "abc");
 		headers.setAccept(Collections.singletonList(MediaType.TEXT_XML));
 		headers.setLocation(new URI("http://www.example.org"));
 		Map<String, ?> result = mapper.toHeaders(headers);
-		assertThat(result.size()).isEqualTo(2);
+		assertThat(result).hasSize(2);
 		assertThat(result.get("Location")).isNull();
 		assertThat(result.get("foobar")).isEqualTo("abc");
 		assertThat(result.get("Accept")).isEqualTo(MediaType.TEXT_XML);
@@ -497,7 +497,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 	@Test
 	public void validateCustomHeadersWithNonStringValuesAndNoConverter() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[] { "customHeader*" });
+		mapper.setOutboundHeaderNames("customHeader*");
 
 		HttpHeaders headers = new HttpHeaders();
 		Map<String, Object> messageHeaders = new HashMap<>();
@@ -513,7 +513,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 	@Test
 	public void validateCustomHeadersWithNonStringValuesAndDefaultConverterOnly() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[] { "customHeader*" });
+		mapper.setOutboundHeaderNames("customHeader*");
 		ConversionService cs = new DefaultConversionService();
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 		beanFactory.registerSingleton("integrationConversionService", cs);
@@ -534,7 +534,7 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 	@Test
 	public void validateCustomHeadersWithNonStringValuesAndDefaultConverterWithCustomConverter() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[] { "customHeader*" });
+		mapper.setOutboundHeaderNames("customHeader*");
 		GenericConversionService cs = new DefaultConversionService();
 		cs.addConverter(new TestClassConverter());
 		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
@@ -48,6 +48,7 @@ import org.springframework.util.StopWatch;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Gary Russell
+ *
  * @since 2.0.1
  */
 public class DefaultHttpHeaderMapperFromMessageOutboundTests {
@@ -56,7 +57,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void validateAcceptHeaderWithNoSlash() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Accept", "bar");
 		HttpHeaders headers = new HttpHeaders();
 
@@ -66,7 +67,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateAcceptHeaderSingleString() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Accept", "bar/foo");
 
 		HttpHeaders headers = new HttpHeaders();
@@ -79,7 +80,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateAcceptHeaderSingleMediaType() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Accept", new MediaType("bar", "foo"));
 
 		HttpHeaders headers = new HttpHeaders();
@@ -92,12 +93,12 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateAcceptHeaderMultipleAsDelimitedString() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Accept", "bar/foo, text/xml");
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAccept().size()).isEqualTo(2);
+		assertThat(headers.getAccept()).hasSize(2);
 		assertThat(headers.getAccept().get(0).toString()).isEqualTo("bar/foo");
 		assertThat(headers.getAccept().get(1).toString()).isEqualTo("text/xml");
 	}
@@ -105,12 +106,12 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateAcceptHeaderMultipleAsStringArray() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("Accept", new String[] {"bar/foo", "text/xml"});
+		Map<String, Object> messageHeaders = new HashMap<>();
+		messageHeaders.put("Accept", new String[] { "bar/foo", "text/xml" });
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAccept().size()).isEqualTo(2);
+		assertThat(headers.getAccept()).hasSize(2);
 		assertThat(headers.getAccept().get(0).toString()).isEqualTo("bar/foo");
 		assertThat(headers.getAccept().get(1).toString()).isEqualTo("text/xml");
 	}
@@ -118,12 +119,12 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateAcceptHeaderMultipleAsStringCollection() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Accept", Arrays.asList("bar/foo", "text/xml"));
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAccept().size()).isEqualTo(2);
+		assertThat(headers.getAccept()).hasSize(2);
 		assertThat(headers.getAccept().get(0).toString()).isEqualTo("bar/foo");
 		assertThat(headers.getAccept().get(1).toString()).isEqualTo("text/xml");
 	}
@@ -131,25 +132,25 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateAcceptHeaderMultipleAsStringCollectionCaseInsensitive() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("acCePt", Arrays.asList("bar/foo", "text/xml"));
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAccept().size()).isEqualTo(2);
+		assertThat(headers.getAccept()).hasSize(2);
 		assertThat(headers.getAccept().get(0).toString()).isEqualTo("bar/foo");
 		assertThat(headers.getAccept().get(1).toString()).isEqualTo("text/xml");
 	}
 
 	@Test
-	public void validateAcceptHeaderMultipleAsMediatypeCollection() {
+	public void validateAcceptHeaderMultipleAsMediaTypeCollection() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Accept", Arrays.asList(new MediaType("bar", "foo"), new MediaType("text", "xml")));
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAccept().size()).isEqualTo(2);
+		assertThat(headers.getAccept()).hasSize(2);
 		assertThat(headers.getAccept().get(0).toString()).isEqualTo("bar/foo");
 		assertThat(headers.getAccept().get(1).toString()).isEqualTo("text/xml");
 	}
@@ -159,7 +160,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test(expected = UnsupportedCharsetException.class)
 	public void validateAcceptCharsetHeaderWithWrongCharset() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Accept-Charset", "foo");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -168,36 +169,36 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateAcceptCharsetHeaderSingleString() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Accept-Charset", "UTF-8");
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAcceptCharset().size()).isEqualTo(1);
+		assertThat(headers.getAcceptCharset()).hasSize(1);
 		assertThat(headers.getAcceptCharset().get(0).displayName()).isEqualTo("UTF-8");
 	}
 
 	@Test
 	public void validateAcceptCharsetHeaderSingleCharset() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Accept-Charset", Charset.forName("UTF-8"));
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAcceptCharset().size()).isEqualTo(1);
+		assertThat(headers.getAcceptCharset()).hasSize(1);
 		assertThat(headers.getAcceptCharset().get(0).displayName()).isEqualTo("UTF-8");
 	}
 
 	@Test
 	public void validateAcceptCharsetHeaderMultipleAsDelimitedString() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Accept-Charset", "UTF-8, ISO-8859-1");
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAcceptCharset().size()).isEqualTo(2);
+		assertThat(headers.getAcceptCharset()).hasSize(2);
 		// validate contains since the order is not enforced
 		assertThat(headers.getAcceptCharset().contains(Charset.forName("UTF-8"))).isTrue();
 		assertThat(headers.getAcceptCharset().contains(Charset.forName("ISO-8859-1"))).isTrue();
@@ -206,12 +207,12 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateAcceptCharsetHeaderMultipleAsStringArray() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("Accept-Charset", new String[] {"UTF-8", "ISO-8859-1"});
+		Map<String, Object> messageHeaders = new HashMap<>();
+		messageHeaders.put("Accept-Charset", new String[] { "UTF-8", "ISO-8859-1" });
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAcceptCharset().size()).isEqualTo(2);
+		assertThat(headers.getAcceptCharset()).hasSize(2);
 		// validate contains since the order is not enforced
 		assertThat(headers.getAcceptCharset().contains(Charset.forName("UTF-8"))).isTrue();
 		assertThat(headers.getAcceptCharset().contains(Charset.forName("ISO-8859-1"))).isTrue();
@@ -220,12 +221,12 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateAcceptCharsetHeaderMultipleAsCharsetArray() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("Accept-Charset", new Charset[] {Charset.forName("UTF-8"), Charset.forName("ISO-8859-1")});
+		Map<String, Object> messageHeaders = new HashMap<>();
+		messageHeaders.put("Accept-Charset", new Charset[] { Charset.forName("UTF-8"), Charset.forName("ISO-8859-1") });
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAcceptCharset().size()).isEqualTo(2);
+		assertThat(headers.getAcceptCharset()).hasSize(2);
 		// validate contains since the order is not enforced
 		assertThat(headers.getAcceptCharset().contains(Charset.forName("UTF-8"))).isTrue();
 		assertThat(headers.getAcceptCharset().contains(Charset.forName("ISO-8859-1"))).isTrue();
@@ -234,12 +235,12 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateAcceptCharsetHeaderMultipleAsCollectionOfStrings() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Accept-Charset", Arrays.asList("UTF-8", "ISO-8859-1"));
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAcceptCharset().size()).isEqualTo(2);
+		assertThat(headers.getAcceptCharset()).hasSize(2);
 		// validate contains since the order is not enforced
 		assertThat(headers.getAcceptCharset().contains(Charset.forName("UTF-8"))).isTrue();
 		assertThat(headers.getAcceptCharset().contains(Charset.forName("ISO-8859-1"))).isTrue();
@@ -248,12 +249,12 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateAcceptCharsetHeaderMultipleAsCollectionOfCharsets() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Accept-Charset", Arrays.asList(Charset.forName("UTF-8"), Charset.forName("ISO-8859-1")));
 		HttpHeaders headers = new HttpHeaders();
 
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.getAcceptCharset().size()).isEqualTo(2);
+		assertThat(headers.getAcceptCharset()).hasSize(2);
 		// validate contains since the order is not enforced
 		assertThat(headers.getAcceptCharset().contains(Charset.forName("UTF-8"))).isTrue();
 		assertThat(headers.getAcceptCharset().contains(Charset.forName("ISO-8859-1"))).isTrue();
@@ -264,7 +265,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateCacheControl() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Cache-Control", "foo");
 		HttpHeaders headers = new HttpHeaders();
 
@@ -277,7 +278,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateContentLengthAsString() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Content-Length", "1");
 		HttpHeaders headers = new HttpHeaders();
 
@@ -288,7 +289,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateContentLengthAsNumber() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Content-Length", 1);
 		HttpHeaders headers = new HttpHeaders();
 
@@ -299,7 +300,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test(expected = NumberFormatException.class)
 	public void validateContentLengthAsNonNumericString() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Content-Length", "foo");
 		HttpHeaders headers = new HttpHeaders();
 
@@ -311,7 +312,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void validateContentTypeWrongValue() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put(MessageHeaders.CONTENT_TYPE, "foo");
 		HttpHeaders headers = new HttpHeaders();
 
@@ -321,7 +322,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateContentTypeAsString() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Content-Type", "text/html");
 		HttpHeaders headers = new HttpHeaders();
 
@@ -333,7 +334,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateContentTypeAsMediaType() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put(MessageHeaders.CONTENT_TYPE, new MediaType("text", "html"));
 		HttpHeaders headers = new HttpHeaders();
 
@@ -347,7 +348,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateDateAsNumber() throws ParseException {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Date", 12345678);
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -360,7 +361,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateDateAsString() throws ParseException {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Date", "12345678");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -373,7 +374,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateDateAsDate() throws ParseException {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Date", new Date(12345678));
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -388,7 +389,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateIfModifiedSinceAsNumber() throws ParseException {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("If-Modified-Since", 12345678);
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -402,7 +403,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateIfModifiedSinceAsString() throws ParseException {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("If-Modified-Since", "12345678");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -416,7 +417,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	@Test
 	public void validateIfModifiedSinceAsDate() throws ParseException {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("If-Modified-Since", new Date(12345678));
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -430,74 +431,74 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	// If-None-Match
 
 	@Test
-	public void validateIfNoneMatch() throws ParseException {
+	public void validateIfNoneMatch() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("If-None-Match", "\"1234567\"");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
 
-		assertThat(headers.getIfNoneMatch().size()).isEqualTo(1);
+		assertThat(headers.getIfNoneMatch()).hasSize(1);
 		assertThat(headers.getIfNoneMatch().get(0)).isEqualTo("\"1234567\"");
 	}
 
 	@Test
-	public void validateIfNoneMatchAsDelimitedString() throws ParseException {
+	public void validateIfNoneMatchAsDelimitedString() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("If-None-Match", "\"123,4567\", \"123\"");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
 
-		assertThat(headers.getIfNoneMatch().size()).isEqualTo(2);
+		assertThat(headers.getIfNoneMatch()).hasSize(2);
 		assertThat(headers.getIfNoneMatch().get(0)).isEqualTo("\"123,4567\"");
 		assertThat(headers.getIfNoneMatch().get(1)).isEqualTo("\"123\"");
 	}
 
 	@Test
-	public void validateIfNoneMatchAsStringArray() throws ParseException {
+	public void validateIfNoneMatchAsStringArray() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
-		messageHeaders.put("If-None-Match", new String[] {"\"1234567\"", "\"123\""});
+		Map<String, Object> messageHeaders = new HashMap<>();
+		messageHeaders.put("If-None-Match", new String[] { "\"1234567\"", "\"123\"" });
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
 
-		assertThat(headers.getIfNoneMatch().size()).isEqualTo(2);
+		assertThat(headers.getIfNoneMatch()).hasSize(2);
 		assertThat(headers.getIfNoneMatch().get(0)).isEqualTo("\"1234567\"");
 		assertThat(headers.getIfNoneMatch().get(1)).isEqualTo("\"123\"");
 	}
 
 	@Test
-	public void validateIfNoneMatchAsCommaDelimitedString() throws ParseException {
+	public void validateIfNoneMatchAsCommaDelimitedString() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("If-None-Match", "\"123.4567\", \"123\"");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
 
-		assertThat(headers.getIfNoneMatch().size()).isEqualTo(2);
+		assertThat(headers.getIfNoneMatch()).hasSize(2);
 		assertThat(headers.getIfNoneMatch().get(0)).isEqualTo("\"123.4567\"");
 		assertThat(headers.getIfNoneMatch().get(1)).isEqualTo("\"123\"");
 	}
 
 	@Test
-	public void validateIfNoneMatchAsStringCollection() throws ParseException {
+	public void validateIfNoneMatchAsStringCollection() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("If-None-Match", Arrays.asList("\"1234567\"", "\"123\""));
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
 
-		assertThat(headers.getIfNoneMatch().size()).isEqualTo(2);
+		assertThat(headers.getIfNoneMatch()).hasSize(2);
 		assertThat(headers.getIfNoneMatch().get(0)).isEqualTo("\"1234567\"");
 		assertThat(headers.getIfNoneMatch().get(1)).isEqualTo("\"123\"");
 	}
 
 	// Pragma tests
 	@Test
-	public void validatePragma() throws ParseException {
+	public void validatePragma() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Pragma", "foo");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -506,9 +507,9 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 
 	// Transfer-Encoding tests
 	@Test
-	public void validateTransferEncoding() throws ParseException {
+	public void validateTransferEncoding() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Transfer-Encoding", "chunked");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -516,20 +517,20 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateTransferEncodingToHeaders() throws ParseException {
+	public void validateTransferEncodingToHeaders() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 
 		HttpHeaders httpHeaders = new HttpHeaders();
 		httpHeaders.set("Transfer-Encoding", "chunked");
 
 		Map<String, ?> messageHeaders = mapper.toHeaders(httpHeaders);
-		assertThat(messageHeaders.size()).isEqualTo(1);
+		assertThat(messageHeaders).hasSize(1);
 
 	}
 
 	@Test
 	@Ignore
-	public void perf() throws ParseException {
+	public void perf() {
 		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
 
 		HttpHeaders httpHeaders = new HttpHeaders();
@@ -554,9 +555,9 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	// Custom headers
 
 	@Test
-	public void validateCustomHeaderWithNoHeaderNames() throws ParseException {
+	public void validateCustomHeaderWithNoHeaderNames() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("foo", "foo");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
@@ -565,24 +566,24 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void validateCustomHeaderWithHeaderNames() throws ParseException {
+	public void validateCustomHeaderWithHeaderNames() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[] {"foo"});
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		mapper.setOutboundHeaderNames("foo");
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("foo", "foo");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
 		assertThat(headers.get("X-foo")).isNull();
 		assertThat(headers.get("foo")).isNotNull();
-		assertThat(headers.get("foo").size() == 1).isTrue();
+		assertThat(headers.get("foo")).hasSize(1);
 		assertThat(headers.get("foo").get(0)).isEqualTo("foo");
 	}
 
 	@Test
-	public void validateCustomHeaderWithHeaderNamePatterns() throws ParseException {
+	public void validateCustomHeaderWithHeaderNamePatterns() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[] {"x*", "*z", "a*f"});
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		mapper.setOutboundHeaderNames("x*", "*z", "a*f");
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("x1", "x1-value");
 		messageHeaders.put("1x", "1x-value");
 		messageHeaders.put("z1", "z1-value");
@@ -592,80 +593,80 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 		messageHeaders.put("abcdef", "abcdef-value");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.size()).isEqualTo(3);
+		assertThat(headers).hasSize(3);
 		assertThat(headers.get("1x")).isNull();
 		assertThat(headers.get("z1")).isNull();
 		assertThat(headers.get("abc")).isNull();
 		assertThat(headers.get("def")).isNull();
-		assertThat(headers.get("x1").size()).isEqualTo(1);
+		assertThat(headers.get("x1")).hasSize(1);
 		assertThat(headers.getFirst("x1")).isEqualTo("x1-value");
-		assertThat(headers.get("1z").size()).isEqualTo(1);
+		assertThat(headers.get("1z")).hasSize(1);
 		assertThat(headers.getFirst("1z")).isEqualTo("1z-value");
-		assertThat(headers.get("abcdef").size()).isEqualTo(1);
+		assertThat(headers.get("abcdef")).hasSize(1);
 		assertThat(headers.getFirst("abcdef")).isEqualTo("abcdef-value");
 	}
 
 	@Test
-	public void validateCustomHeaderWithHeaderNamePatternsAndStandardRequestHeaders() throws ParseException {
+	public void validateCustomHeaderWithHeaderNamePatternsAndStandardRequestHeaders() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[] {"foo*", "HTTP_REQUEST_HEADERS"});
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		mapper.setOutboundHeaderNames("foo*", "HTTP_REQUEST_HEADERS");
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("foobar", "abc");
 		messageHeaders.put("Content-Type", "text/html");
 		messageHeaders.put("Accept", "text/xml");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.size()).isEqualTo(3);
-		assertThat(headers.get("foobar").size()).isEqualTo(1);
+		assertThat(headers).hasSize(3);
+		assertThat(headers.get("foobar")).hasSize(1);
 		assertThat(headers.getFirst("foobar")).isEqualTo("abc");
 		assertThat(headers.getContentType().toString()).isEqualTo("text/html");
-		assertThat(headers.getAccept().size()).isEqualTo(1);
+		assertThat(headers.getAccept()).hasSize(1);
 		assertThat(headers.getAccept().get(0)).isEqualTo(MediaType.TEXT_XML);
 	}
 
 	@Test
-	public void validateCustomHeaderWithHeaderNamePatternsAndStandardResponseHeaders() throws ParseException {
+	public void validateCustomHeaderWithHeaderNamePatternsAndStandardResponseHeaders() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setInboundHeaderNames(new String[] {"foo*", "HTTP_RESPONSE_HEADERS"});
+		mapper.setInboundHeaderNames("foo*", "HTTP_RESPONSE_HEADERS");
 		HttpHeaders httpHeaders = new HttpHeaders();
 		httpHeaders.set("foobar", "abc");
 		httpHeaders.setContentType(MediaType.TEXT_HTML);
 		httpHeaders.setAccept(Collections.singletonList(MediaType.TEXT_HTML));
 		Map<String, ?> messageHeaders = mapper.toHeaders(httpHeaders);
-		assertThat(messageHeaders.size()).isEqualTo(2);
+		assertThat(messageHeaders).hasSize(2);
 		assertThat(messageHeaders.get("Accept")).isNull();
 		assertThat(messageHeaders.get("foobar")).isEqualTo("abc");
 		assertThat(messageHeaders.get(MessageHeaders.CONTENT_TYPE).toString()).isEqualTo("text/html");
 	}
 
 	@Test
-	public void validateCustomHeaderWithStandardPrefix() throws Exception {
+	public void validateCustomHeaderWithStandardPrefix() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setInboundHeaderNames(new String[] {"X-Foo"});
+		mapper.setInboundHeaderNames("X-Foo");
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("x-foo", "x-foo-value");
 		Map<String, ?> result = mapper.toHeaders(headers);
-		assertThat(result.size()).isEqualTo(1);
+		assertThat(result).hasSize(1);
 		assertThat(result.get("x-foo")).isEqualTo("x-foo-value");
 	}
 
 	@Test
-	public void validateCustomHeaderWithStandardPrefixSameCase() throws Exception {
+	public void validateCustomHeaderWithStandardPrefixSameCase() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setInboundHeaderNames(new String[] {"X-Foo"});
+		mapper.setInboundHeaderNames("X-Foo");
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("X-Foo", "x-foo-value");
 		Map<String, ?> result = mapper.toHeaders(headers);
-		assertThat(result.size()).isEqualTo(1);
+		assertThat(result).hasSize(1);
 		assertThat(result.get("X-Foo")).isEqualTo("x-foo-value");
 	}
 
 	@Test
-	public void validateCustomHeaderCaseInsensitivity() throws ParseException {
+	public void validateCustomHeaderCaseInsensitivity() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
-		mapper.setOutboundHeaderNames(new String[] {"*", "HTTP_REQUEST_HEADERS"});
+		mapper.setOutboundHeaderNames("*", "HTTP_REQUEST_HEADERS");
 		mapper.setUserDefinedHeaderPrefix("X-");
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("foobar", "abc");
 		messageHeaders.put("X-bar", "xbar");
 		messageHeaders.put("x-baz", "xbaz");
@@ -674,12 +675,12 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
 		assertThat(headers.size()).isEqualTo(5);
-		assertThat(headers.get("X-foobar").size()).isEqualTo(1);
-		assertThat(headers.get("x-foobar").size()).isEqualTo(1);
-		assertThat(headers.get("X-bar").size()).isEqualTo(1);
-		assertThat(headers.get("x-bar").size()).isEqualTo(1);
-		assertThat(headers.get("X-baz").size()).isEqualTo(1);
-		assertThat(headers.get("x-baz").size()).isEqualTo(1);
+		assertThat(headers.get("X-foobar")).hasSize(1);
+		assertThat(headers.get("x-foobar")).hasSize(1);
+		assertThat(headers.get("X-bar")).hasSize(1);
+		assertThat(headers.get("x-bar")).hasSize(1);
+		assertThat(headers.get("X-baz")).hasSize(1);
+		assertThat(headers.get("x-baz")).hasSize(1);
 	}
 
 	@Test
@@ -687,7 +688,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 		DefaultHttpHeaderMapper mapper = DefaultHttpHeaderMapper.outboundMapper();
 		// not suppressed on outbound request, by default
 		mapper.setExcludedOutboundStandardRequestHeaderNames("Content-Length");
-		Map<String, Object> messageHeaders = new HashMap<String, Object>();
+		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("Content-Length", 4);
 
 		HttpHeaders headers = new HttpHeaders();
@@ -704,7 +705,7 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void testInt2995IfModifiedSince() throws Exception {
+	public void testInt2995IfModifiedSince() {
 		Date ifModifiedSince = new Date();
 		SimpleDateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss yyyy", Locale.US);
 		dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
@@ -720,12 +721,12 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 	}
 
 	@Test
-	public void testContentDispositionHeader() throws Exception {
+	public void testContentDispositionHeader() {
 		HttpHeaders headers = new HttpHeaders();
 		String headerValue = "attachment; filename=\"test.txt\"";
 		headers.set("Content-Disposition", headerValue);
 		Map<String, Object> messageHeaders = DefaultHttpHeaderMapper.outboundMapper().toHeaders(headers);
-		assertThat(messageHeaders.size()).isEqualTo(1);
+		assertThat(messageHeaders).hasSize(1);
 		assertThat(messageHeaders.get("Content-Disposition")).isEqualTo(headerValue);
 	}
 


### PR DESCRIPTION
* Deprecate `DefaultHttpHeaderMapper` constants which are fully
Spring Web `HttpHeaders` constants
* Introduce lowercase constants for `getHttpHeader()` switch
* Reuse `HttpHeaders` API as much as possible
* Simplify logic in some methods to break them to smaller methods

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
