### PR TITLE
GH-2754: Add channel-based mapping to RouterSpec

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/RouterSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/RouterSpec.java
@@ -116,9 +116,9 @@ public final class RouterSpec<K, R extends AbstractMappingMessageRouter>
 	 * @return the router spec.
 	 * @see AbstractMappingMessageRouter#setChannelMapping(String, String)
 	 */
-	public RouterSpec<K, R> channelMapping(K key, final String channelName) {
+	public RouterSpec<K, R> channelMapping(K key, String channelName) {
 		Assert.notNull(key, "'key' must not be null");
-		Assert.hasText(channelName, "'channelName' must not be null");
+		Assert.hasText(channelName, "'channelName' must not be empty");
 		if (key instanceof String) {
 			this.handler.setChannelMapping((String) key, channelName);
 		}
@@ -137,6 +137,26 @@ public final class RouterSpec<K, R extends AbstractMappingMessageRouter>
 
 			});
 		}
+		return _this();
+	}
+
+	/**
+	 * The router mapping configuration based on the provided generic key
+	 * and  {@link MessageChannel} bean.
+	 * The {@link MessageChannel} must be instance of {@link NamedComponent}
+	 * for proper target router mapping based on the bean name.
+	 * @param key the key.
+	 * @param channel the {@link MessageChannel} instance to use.
+	 * @return the router spec.
+	 * @see AbstractMappingMessageRouter#setChannelMapping(String, String)
+	 * @since 5.2
+	 */
+	public RouterSpec<K, R> channelMapping(K key, final MessageChannel channel) {
+		Assert.notNull(key, "'key' must not be null");
+		Assert.notNull(channel, "'channel' must not be null");
+		Assert.isInstanceOf(NamedComponent.class, channel,
+				() -> "The routing channel '" + channel + " must be instance of 'NamedComponent'.");
+		this.mappingProvider.addMapping(key, (NamedComponent) channel);
 		return _this();
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
@@ -89,7 +89,7 @@ public class RouterTests {
 	public void testRouter() {
 		this.beanFactory.containsBean("routeFlow.subFlow#0.channel#0");
 
-		int[] payloads = new int[] { 1, 2, 3, 4, 5, 6 };
+		int[] payloads = { 1, 2, 3, 4, 5, 6 };
 
 		for (int payload : payloads) {
 			this.routerInput.send(new GenericMessage<>(payload));
@@ -124,7 +124,7 @@ public class RouterTests {
 		@SuppressWarnings("unchecked")
 		List<Integer> results = (List<Integer>) payload;
 
-		assertThat(results.toArray(new Integer[results.size()])).isEqualTo(new Integer[] { 3, 4, 9, 8, 15, 12 });
+		assertThat(results).containsExactly(3, 4, 9, 8, 15, 12);
 	}
 
 	@Autowired
@@ -606,7 +606,7 @@ public class RouterTests {
 		public IntegrationFlow routeFlow() {
 			return IntegrationFlows.from("routerInput")
 					.<Integer, Boolean>route(p -> p % 2 == 0,
-							m -> m.channelMapping(true, "evenChannel")
+							m -> m.channelMapping(true, evenChannel())
 									.subFlowMapping(false, f ->
 											f.<Integer>handle((p, h) -> p * 3))
 									.defaultOutputToParentFlow())
@@ -928,6 +928,5 @@ public class RouterTests {
 		}
 
 	}
-
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2754

For better end-user experience when we have `@Bean` declared for a
channel it is good to have a `MessageChannel` based
`RouterSpec.channelMapping` for possible traceability and code
navigation in the IDE

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
