### PR TITLE
Fix race condition around `sharedJschSession`

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -355,6 +355,7 @@ public class DefaultSftpSessionFactory implements SessionFactory<LsEntry>, Share
 				"either a password or a private key is required");
 		try {
 			JSchSessionWrapper jschSession;
+			SftpSession sftpSession;
 			if (this.isSharedSession) {
 				this.sharedSessionLock.readLock().lock();
 				try {
@@ -377,17 +378,19 @@ public class DefaultSftpSessionFactory implements SessionFactory<LsEntry>, Share
 							this.sharedSessionLock.writeLock().unlock();
 						}
 					}
+					jschSession = this.sharedJschSession;
+					sftpSession = new SftpSession(jschSession);
+					sftpSession.connect();
 				}
 				finally {
 					this.sharedSessionLock.readLock().unlock();
 				}
-				jschSession = this.sharedJschSession;
 			}
 			else {
 				jschSession = new JSchSessionWrapper(initJschSession());
+				sftpSession = new SftpSession(jschSession);
+				sftpSession.connect();
 			}
-			SftpSession sftpSession = new SftpSession(jschSession);
-			sftpSession.connect();
 			jschSession.addChannel();
 			return sftpSession;
 		}


### PR DESCRIPTION
https://build.spring.io/browse/INT-MASTER-1481

The `SftpSession.connect()` may lead to race condition when we try to
open the `channel`, but `JschSession` is closed already.
It may happen in cases when we have `DefaultSftpSessionFactory`
configured for the `isSharedSession` and that shared session may be
closed by another thread before we reach the `channel.connect()`,
because we already have left the `this.sharedSessionLock` blocking path

**Cherry-pick to 5.1.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
