### PR TITLE
Optimize DefaultSftpSessionFactory

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -361,11 +361,16 @@ public class DefaultSftpSessionFactory implements SessionFactory<LsEntry>, Share
 			this.sharedSessionLock.lock();
 		}
 		try {
+			boolean freshJschSession = false;
 			if (jschSession == null || !jschSession.isConnected()) {
 				jschSession = new JSchSessionWrapper(initJschSession());
+				freshJschSession = true;
 			}
 			sftpSession = new SftpSession(jschSession);
 			sftpSession.connect();
+			if (this.isSharedSession && freshJschSession) {
+				this.sharedJschSession = jschSession;
+			}
 		}
 		catch (Exception e) {
 			throw new IllegalStateException("failed to create SFTP Session", e);
@@ -374,9 +379,6 @@ public class DefaultSftpSessionFactory implements SessionFactory<LsEntry>, Share
 			if (this.sharedSessionLock != null) {
 				this.sharedSessionLock.unlock();
 			}
-		}
-		if (this.isSharedSession) {
-			this.sharedJschSession = jschSession;
 		}
 		jschSession.addChannel();
 		return sftpSession;


### PR DESCRIPTION
Related to https://build.spring.io/browse/INT-MASTERSPRING40-677/

Doesn't look like `DefaultSftpSessionFactory.getSession()` needs
locking around `sharedJschSession`

* change the logic in the `getSession()` to store a `sharedJschSession`
into the local variable and if it is `null` or not connected, create a
new `JSchSessionWrapper`, connect it and store to the `sharedJschSession`
back into the `sharedJschSession` property if `this.isSharedSession`.
This way we always deal with `sharedJschSession` anyway if it is valid
or create a new fresh one if that is invalid.
Without locking we always get an actual state of the `sharedJschSession`
and don't fall into the race condition when `sharedJschSession` is invalid,
but we can't connect to the SFTP channel from the `sftpSession.connect()`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
