### PR TITLE
Support non-Object types for WebFlux requests

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
@@ -30,6 +30,9 @@ import java.util.function.Supplier;
 
 import javax.xml.transform.Source;
 
+import org.reactivestreams.Publisher;
+
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
@@ -48,6 +51,7 @@ import org.springframework.integration.http.support.DefaultHttpHeaderMapper;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.MessageBuilderFactory;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.util.Assert;
@@ -74,7 +78,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public abstract class AbstractHttpRequestExecutingMessageHandler extends AbstractReplyProducingMessageHandler {
 
-	private static final List<HttpMethod> noBodyHttpMethods =
+	private static final List<HttpMethod> NO_BODY_HTTP_METHODS =
 			Arrays.asList(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.TRACE);
 
 	private final Map<String, Expression> uriVariableExpressions = new HashMap<>();
@@ -140,7 +144,7 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	 */
 	public void setHttpMethod(HttpMethod httpMethod) {
 		Assert.notNull(httpMethod, "'httpMethod' must not be null");
-		this.httpMethodExpression = new ValueExpression<HttpMethod>(httpMethod);
+		this.httpMethodExpression = new ValueExpression<>(httpMethod);
 	}
 
 	/**
@@ -193,7 +197,7 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	 */
 	public void setExpectedResponseType(Class<?> expectedResponseType) {
 		Assert.notNull(expectedResponseType, "'expectedResponseType' must not be null");
-		this.expectedResponseTypeExpression = new ValueExpression<Class<?>>(expectedResponseType);
+		setExpectedResponseTypeExpression(new ValueExpression<>(expectedResponseType));
 	}
 
 	/**
@@ -261,14 +265,14 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 
 	@Override
 	protected void doInit() {
-		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(this.getBeanFactory());
-		this.simpleEvaluationContext = ExpressionUtils.createSimpleEvaluationContext(this.getBeanFactory());
+		BeanFactory beanFactory = getBeanFactory();
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(beanFactory);
+		this.simpleEvaluationContext = ExpressionUtils.createSimpleEvaluationContext(beanFactory);
 	}
 
 	@Override
 	protected Object handleRequestMessage(Message<?> requestMessage) {
 		HttpMethod httpMethod = determineHttpMethod(requestMessage);
-
 		if (!shouldIncludeRequestBody(httpMethod) && this.extractPayloadExplicitlySet) {
 			if (logger.isWarnEnabled()) {
 				logger.warn("The 'extractPayload' attribute has no relevance for the current request " +
@@ -293,7 +297,8 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 				"'uriExpression' evaluation must result in a 'String' or 'URI' instance, not: "
 						+ (uri == null ? "null" : uri.getClass()));
 		Map<String, ?> uriVariables = determineUriVariables(requestMessage);
-		UriComponentsBuilder uriComponentsBuilder = uri instanceof String
+		UriComponentsBuilder uriComponentsBuilder =
+				uri instanceof String
 				? UriComponentsBuilder.fromUriString((String) uri)
 				: UriComponentsBuilder.fromUri((URI) uri);
 		UriComponents uriComponents = uriComponentsBuilder.buildAndExpand(uriVariables);
@@ -310,7 +315,7 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 			HttpHeaders httpHeaders = httpResponse.getHeaders();
 			Map<String, Object> headers = this.headerMapper.toHeaders(httpHeaders);
 			if (this.transferCookies) {
-				this.doConvertSetCookie(headers);
+				doConvertSetCookie(headers);
 			}
 
 			AbstractIntegrationMessageBuilder<?> replyBuilder = null;
@@ -355,8 +360,9 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 
 	private HttpEntity<?> generateHttpRequest(Message<?> message, HttpMethod httpMethod) {
 		Assert.notNull(message, "message must not be null");
-		return (this.extractPayload) ? this.createHttpEntityFromPayload(message, httpMethod)
-				: this.createHttpEntityFromMessage(message, httpMethod);
+		return this.extractPayload
+				? createHttpEntityFromPayload(message, httpMethod)
+				: createHttpEntityFromMessage(message, httpMethod);
 	}
 
 	private HttpEntity<?> createHttpEntityFromPayload(Message<?> message, HttpMethod httpMethod) {
@@ -371,16 +377,20 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 		}
 		// otherwise, we are creating a request with a body and need to deal with the content-type header as well
 		if (httpHeaders.getContentType() == null) {
-			MediaType contentType = (payload instanceof String)
-					? resolveContentType((String) payload, this.charset)
-					: resolveContentType(payload);
+			MediaType contentType =
+					payload instanceof String
+							? new MediaType("text", "plain", this.charset)
+							: resolveContentType(payload);
 			httpHeaders.setContentType(contentType);
 		}
-		if (MediaType.APPLICATION_FORM_URLENCODED.equals(httpHeaders.getContentType()) ||
-				MediaType.MULTIPART_FORM_DATA.equals(httpHeaders.getContentType())) {
-			if (!(payload instanceof MultiValueMap)) {
-				payload = this.convertToMultiValueMap((Map<?, ?>) payload);
-			}
+		if ((MediaType.APPLICATION_FORM_URLENCODED.equals(httpHeaders.getContentType()) ||
+				MediaType.MULTIPART_FORM_DATA.equals(httpHeaders.getContentType()))
+				&& !(payload instanceof MultiValueMap)) {
+
+			Assert.isInstanceOf(Map.class, payload,
+					() -> "For " + MediaType.APPLICATION_FORM_URLENCODED + " and " +
+							MediaType.MULTIPART_FORM_DATA + " media types the payload must be an instance of a Map.");
+			payload = convertToMultiValueMap((Map<?, ?>) payload);
 		}
 		return new HttpEntity<>(payload, httpHeaders);
 	}
@@ -412,8 +422,8 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 		else if (content instanceof Map) {
 			// We need to check separately for MULTIPART as well as URLENCODED simply because
 			// MultiValueMap<Object, Object> is actually valid content for serialization
-			if (this.isFormData((Map<Object, ?>) content)) {
-				if (this.isMultipart((Map<String, ?>) content)) {
+			if (isFormData((Map<Object, ?>) content)) {
+				if (isMultipart((Map<String, ?>) content)) {
 					contentType = MediaType.MULTIPART_FORM_DATA;
 				}
 				else {
@@ -421,22 +431,18 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 				}
 			}
 		}
-		if (contentType == null) {
+		if (contentType == null && !(content instanceof Publisher<?>)) {
 			contentType = new MediaType("application", "x-java-serialized-object");
 		}
 		return contentType;
 	}
 
 	private boolean shouldIncludeRequestBody(HttpMethod httpMethod) {
-		return !(CollectionUtils.containsInstance(noBodyHttpMethods, httpMethod));
-	}
-
-	private MediaType resolveContentType(String content, Charset charset) {
-		return new MediaType("text", "plain", charset);
+		return !(CollectionUtils.containsInstance(NO_BODY_HTTP_METHODS, httpMethod));
 	}
 
 	private MultiValueMap<Object, Object> convertToMultiValueMap(Map<?, ?> simpleMap) {
-		LinkedMultiValueMap<Object, Object> multipartValueMap = new LinkedMultiValueMap<Object, Object>();
+		LinkedMultiValueMap<Object, Object> multipartValueMap = new LinkedMultiValueMap<>();
 		for (Entry<?, ?> entry : simpleMap.entrySet()) {
 			Object key = entry.getKey();
 			Object value = entry.getValue();
@@ -444,13 +450,25 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 				value = Arrays.asList((Object[]) value);
 			}
 			if (value instanceof Collection) {
-				multipartValueMap.put(key, new ArrayList<Object>((Collection<?>) value));
+				multipartValueMap.put(key, new ArrayList<>((Collection<?>) value));
 			}
 			else {
 				multipartValueMap.add(key, value);
 			}
 		}
 		return multipartValueMap;
+	}
+
+	/**
+	 * If all keys and values are Strings, we'll consider the Map to be form data.
+	 */
+	private boolean isFormData(Map<Object, ?> map) {
+		for (Object key : map.keySet()) {
+			if (!(key instanceof String)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**
@@ -479,21 +497,9 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 		return false;
 	}
 
-	/**
-	 * If all keys and values are Strings, we'll consider the Map to be form data.
-	 */
-	private boolean isFormData(Map<Object, ?> map) {
-		for (Object key : map.keySet()) {
-			if (!(key instanceof String)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
 	private HttpMethod determineHttpMethod(Message<?> requestMessage) {
 		Object httpMethod = this.httpMethodExpression.getValue(this.evaluationContext, requestMessage);
-		Assert.state(httpMethod != null && (httpMethod instanceof String || httpMethod instanceof HttpMethod),
+		Assert.state((httpMethod instanceof String || httpMethod instanceof HttpMethod), () ->
 				"'httpMethodExpression' evaluation must result in an 'HttpMethod' enum or its String representation, " +
 						"not: " + (httpMethod == null ? "null" : httpMethod.getClass()));
 		if (httpMethod instanceof HttpMethod) {
@@ -511,28 +517,35 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	}
 
 	private Object determineExpectedResponseType(Message<?> requestMessage) {
-		Object expectedResponseType = null;
-		if (this.expectedResponseTypeExpression != null) {
-			expectedResponseType = this.expectedResponseTypeExpression.getValue(this.evaluationContext, requestMessage);
+		return evaluateTypeFromExpression(requestMessage, this.expectedResponseTypeExpression, "expectedResponseType");
+	}
+
+	@Nullable
+	protected Object evaluateTypeFromExpression(Message<?> requestMessage, @Nullable Expression expression,
+			String property) {
+
+		Object type = null;
+		if (expression != null) {
+			type = expression.getValue(this.evaluationContext, requestMessage);
 		}
-		if (expectedResponseType != null) {
-			Assert.state(expectedResponseType instanceof Class<?>
-							|| expectedResponseType instanceof String
-							|| expectedResponseType instanceof ParameterizedTypeReference,
-					"'expectedResponseType' can be an instance of 'Class<?>', 'String' " +
+		if (type != null) {
+			Class<?> typeClass = type.getClass();
+			Assert.state(type instanceof Class<?>
+							|| type instanceof String
+							|| type instanceof ParameterizedTypeReference,
+					() -> "The '" + property + "' can be an instance of 'Class<?>', 'String' " +
 							"or 'ParameterizedTypeReference<?>'; " +
-							"evaluation resulted in a" + expectedResponseType.getClass() + ".");
-			if (expectedResponseType instanceof String && StringUtils.hasText((String) expectedResponseType)) {
+							"evaluation resulted in a " + typeClass + ".");
+			if (type instanceof String && StringUtils.hasText((String) type)) {
 				try {
-					expectedResponseType = ClassUtils.forName((String) expectedResponseType,
-							getApplicationContext().getClassLoader());
+					type = ClassUtils.forName((String) type, getApplicationContext().getClassLoader());
 				}
 				catch (ClassNotFoundException e) {
-					throw new IllegalStateException("Cannot load class for name: " + expectedResponseType, e);
+					throw new IllegalStateException("Cannot load class for name: " + type, e);
 				}
 			}
 		}
-		return expectedResponseType;
+		return type;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParser.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParser.java
@@ -38,15 +38,7 @@ public class WebFluxOutboundGatewayParser extends HttpOutboundGatewayParser {
 	@Override
 	protected BeanDefinitionBuilder getBuilder(Element element, ParserContext parserContext) {
 		BeanDefinitionBuilder builder =
-				BeanDefinitionBuilder.genericBeanDefinition(WebFluxRequestExecutingMessageHandler.class);
-
-		String webClientRef = element.getAttribute("web-client");
-		if (StringUtils.hasText(webClientRef)) {
-			builder.getBeanDefinition()
-					.getConstructorArgumentValues()
-					.addIndexedArgumentValue(1, new RuntimeBeanReference(webClientRef));
-		}
-
+				WebFluxOutboundChannelAdapterParser.buildWebFluxRequestExecutingMessageHandler(element, parserContext);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-payload-to-flux");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "body-extractor");
 		return builder;

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParser.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParser.java
@@ -18,13 +18,10 @@ package org.springframework.integration.webflux.config;
 
 import org.w3c.dom.Element;
 
-import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.http.config.HttpOutboundGatewayParser;
-import org.springframework.integration.webflux.outbound.WebFluxRequestExecutingMessageHandler;
-import org.springframework.util.StringUtils;
 
 /**
  * Parser for the 'outbound-gateway' element of the webflux namespace.

--- a/spring-integration-webflux/src/main/resources/org/springframework/integration/webflux/config/spring-integration-webflux-5.2.xsd
+++ b/spring-integration-webflux/src/main/resources/org/springframework/integration/webflux/config/spring-integration-webflux-5.2.xsd
@@ -376,6 +376,29 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="publisher-element-type" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						The type for a request 'Publisher' elements.
+						This attribute cannot be provided if expected-response-type-expression has a value
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation>
+							<tool:expected-type type="java.lang.Class" />
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="publisher-element-type-expression" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation>
+						SpEL expression to determine the type for a request 'Publisher' elements against a request
+						message. The returned value of the expression could be an instance of java.lang.Class,
+						or java.lang.String representing a fully qualified class name, or 'ParameterizedTypeReference'.
+						This attribute cannot be provided if 'publisher-element-type' has a value
+					</xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 
@@ -510,6 +533,29 @@
 								A reference to an org.springframework.web.reactive.function.BodyExtractor bean
 								which is used to to extract the content from the response.
 								Must be used instead of 'expected-response-type(-expression)'
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="publisher-element-type" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								The type for a request 'Publisher' elements.
+								This attribute cannot be provided if expected-response-type-expression has a value
+							</xsd:documentation>
+							<xsd:appinfo>
+								<tool:annotation>
+									<tool:expected-type type="java.lang.Class" />
+								</tool:annotation>
+							</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="publisher-element-type-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								SpEL expression to determine the type for a request 'Publisher' elements against a request
+								message. The returned value of the expression could be an instance of java.lang.Class,
+								or java.lang.String representing a fully qualified class name, or 'ParameterizedTypeReference'.
+								This attribute cannot be provided if 'publisher-element-type' has a value
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParserTests-context.xml
@@ -13,7 +13,8 @@
 	<outbound-channel-adapter id="reactiveMinimalConfig" url="http://localhost/test1" channel="requests"/>
 
 	<outbound-channel-adapter id="reactiveWebClientConfig" url="http://localhost/test1" channel="requests"
-									   web-client="webClient"/>
+							  web-client="webClient"
+							  publisher-element-type="java.util.Date"/>
 
 	<beans:bean id="webClient" class="org.springframework.web.reactive.function.client.WebClient"
 				factory-method="create"/>

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParserTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParserTests.java
@@ -19,6 +19,7 @@ package org.springframework.integration.webflux.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.Charset;
+import java.util.Date;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -82,6 +83,9 @@ public class WebFluxOutboundChannelAdapterParserTests {
 	public void reactiveWebClientConfig() {
 		assertThat(TestUtils.getPropertyValue(this.reactiveWebClientConfig, "handler.webClient"))
 				.isSameAs(this.webClient);
+		assertThat(TestUtils.getPropertyValue(this.reactiveWebClientConfig,
+				"handler.publisherElementTypeExpression.value"))
+				.isSameAs(Date.class);
 	}
 
 }

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests-context.xml
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests-context.xml
@@ -37,7 +37,8 @@
 					  auto-startup="false"
 					  transfer-cookies="true"
 					  reply-payload-to-flux="true"
-					  body-extractor="bodyExtractor">
+					  body-extractor="bodyExtractor"
+					  publisher-element-type-expression="headers.elementType">
 		<uri-variable name="foo" expression="headers.bar"/>
 	</outbound-gateway>
 

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests.java
@@ -126,6 +126,8 @@ public class WebFluxOutboundGatewayParserTests {
 		assertThat(handlerAccessor.getPropertyValue("transferCookies")).isEqualTo(true);
 		assertThat(handlerAccessor.getPropertyValue("replyPayloadToFlux")).isEqualTo(true);
 		assertThat(handlerAccessor.getPropertyValue("bodyExtractor")).isSameAs(this.bodyExtractor);
+		assertThat(handlerAccessor.getPropertyValue("publisherElementTypeExpression.expression"))
+				.isEqualTo("headers.elementType");
 	}
 
 }

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/outbound/WebFluxRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/outbound/WebFluxRequestExecutingMessageHandlerTests.java
@@ -211,7 +211,7 @@ public class WebFluxRequestExecutingMessageHandlerTests {
 		reactiveHandler.setExpectedResponseType(String.class);
 		reactiveHandler.setReplyPayloadToFlux(true);
 
-		reactiveHandler.handleMessage(MessageBuilder.withPayload("hello, world").build());
+		reactiveHandler.handleMessage(MessageBuilder.withPayload(Mono.just("hello, world")).build());
 
 		Message<?> receive = replyChannel.receive(10_000);
 

--- a/src/reference/asciidoc/webflux.adoc
+++ b/src/reference/asciidoc/webflux.adoc
@@ -138,6 +138,11 @@ In addition a `BodyExtractor<?, ClientHttpResponse>` can be injected into the `W
 It can be used for low-level access to the `ClientHttpResponse` and more control over body and HTTP headers conversion.
 Spring Integration provides `ClientHttpResponseBodyExtractor` as a identity function to produce (downstream) the whole `ClientHttpResponse` and any other possible custom logic.
 
+Starting with version 5.2, the `WebFluxRequestExecutingMessageHandler` supports a reactive `Publisher`, `Resource` and `MultiValueMap` types as a request message payload.
+A respective `BodyInserter` is used internally to be populated into the `WebClient.RequestBodySpec`.
+When the payload is a reactive `Publisher`, a configured `publisherElementType` or `publisherElementTypeExpression` can be used to determine a type for the publisher's element type.
+The expression must be resolved to a `Class<?>`, `String` which is resolved to the target `Class<?>` or `ParameterizedTypeReference`.
+
 See <<http-outbound>> for more possible configuration options.
 
 [[webflux-namespace]]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -60,3 +60,9 @@ See <<note-nio>> for more information.
 
 The `AbstractMailReceiver` has now an `autoCloseFolder` option (`true` by default), to disable an automatic folder close after a fetch, but populate `IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE` header instead for downstream interaction.
 See <<mail-inbound>> for more information.
+
+[[x5.2-webflux]]
+==== WebFlux Changes
+
+The `WebFluxRequestExecutingMessageHandler` now supports a `Publisher`, `Resource` and `MultiValueMap` as a request message `payload`.
+See <<webflux>> for more information.


### PR DESCRIPTION
* Add the support for a `Publisher`, `Resource` and `MultiValueMap`
into the `WebFluxRequestExecutingMessageHandler`
* Along side with the `WebFluxRequestExecutingMessageHandler.setPublisherElementType`
and `WebFluxRequestExecutingMessageHandler.setPublisherElementTypeExpression`,
add XSD support for the `publisher-element-type(-expression)`, which
is used for the element type when request body is a `Publisher`
* Polishing for `AbstractHttpRequestExecutingMessageHandler`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
