### PR TITLE
Add caught exception as suppressed in SftpSession

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -208,14 +208,18 @@ public class SftpSession implements Session<LsEntry> {
 				}
 			}
 			catch (IOException ioex) {
-				throw new NestedIOException("Failed to delete file " + pathTo, ioex);
+				NestedIOException nioex = new NestedIOException("Failed to delete file " + pathTo, ioex);
+				nioex.addSuppressed(sftpex);
+				throw nioex;
 			}
 			try {
 				// attempt to rename again
 				this.channel.rename(pathFrom, pathTo);
 			}
 			catch (SftpException sftpex2) {
-				throw new NestedIOException("failed to rename from " + pathFrom + " to " + pathTo, sftpex2);
+				NestedIOException nioex2 = new NestedIOException("failed to rename from " + pathFrom + " to " + pathTo, sftpex2);
+				nioex2.addSuppressed(sftpex);
+				throw nioex2;
 			}
 		}
 		if (this.logger.isDebugEnabled()) {


### PR DESCRIPTION
The `org.springframework.integration.sftp.session.SftpSession#rename` method catches an instance of `SftpException` but does not actually use it.

This makes is harder to troubleshoot issues as this exception cannot be accessed by the callers.

This commit adds this exception as "suppressed" to the exceptions that can be thrown by this method.