### PR TITLE
Make `RSocketOutboundGateway` for server side 

### DIFF
--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/ClientRSocketConnector.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/ClientRSocketConnector.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.rsocket;
+
+import java.net.URI;
+import java.util.function.Consumer;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.messaging.rsocket.RSocketRequester;
+import org.springframework.messaging.rsocket.RSocketStrategies;
+import org.springframework.util.Assert;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+
+import io.rsocket.Payload;
+import io.rsocket.RSocket;
+import io.rsocket.RSocketFactory;
+import io.rsocket.transport.ClientTransport;
+import io.rsocket.transport.netty.client.TcpClientTransport;
+import io.rsocket.transport.netty.client.WebsocketClientTransport;
+import io.rsocket.util.DefaultPayload;
+import io.rsocket.util.EmptyPayload;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+
+/**
+ * A client connector to the RSocket server.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.2
+ *
+ * @see RSocketFactory.ClientRSocketFactory
+ * @see RSocketRequester
+ */
+public class ClientRSocketConnector implements InitializingBean, DisposableBean {
+
+	private final ClientTransport clientTransport;
+
+	private MimeType dataMimeType = MimeTypeUtils.TEXT_PLAIN;
+
+	private Payload connectPayload = EmptyPayload.INSTANCE;
+
+	private RSocketStrategies rsocketStrategies = RSocketStrategies.builder().build();
+
+	private Consumer<RSocketFactory.ClientRSocketFactory> factoryConfigurer = (clientRSocketFactory) -> { };
+
+	private Mono<RSocket> rsocketMono;
+
+	public ClientRSocketConnector(String host, int port) {
+		this(TcpClientTransport.create(host, port));
+	}
+
+	public ClientRSocketConnector(URI uri) {
+		this(WebsocketClientTransport.create(uri));
+	}
+
+	public ClientRSocketConnector(ClientTransport clientTransport) {
+		Assert.notNull(clientTransport, "'clientTransport' must not be null");
+		this.clientTransport = clientTransport;
+	}
+
+	public void setDataMimeType(MimeType dataMimeType) {
+		Assert.notNull(dataMimeType, "'dataMimeType' must not be null");
+		this.dataMimeType = dataMimeType;
+	}
+
+	public void setFactoryConfigurer(Consumer<RSocketFactory.ClientRSocketFactory> factoryConfigurer) {
+		Assert.notNull(factoryConfigurer, "'factoryConfigurer' must not be null");
+		this.factoryConfigurer = factoryConfigurer;
+	}
+
+	public void setRSocketStrategies(RSocketStrategies rsocketStrategies) {
+		Assert.notNull(rsocketStrategies, "'rsocketStrategies' must not be null");
+		this.rsocketStrategies = rsocketStrategies;
+	}
+
+	public void setConnectRoute(String connectRoute) {
+		this.connectPayload = DefaultPayload.create("", connectRoute);
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		RSocketFactory.ClientRSocketFactory clientFactory =
+				RSocketFactory.connect()
+						.dataMimeType(this.dataMimeType.toString());
+		this.factoryConfigurer.accept(clientFactory);
+		clientFactory.setupPayload(this.connectPayload);
+		this.rsocketMono = clientFactory.transport(this.clientTransport).start();
+	}
+
+	public void connect() {
+		this.rsocketMono.cache().subscribe();
+	}
+
+	public Mono<RSocketRequester> getRSocketRequester() {
+		return this.rsocketMono
+				.map(rsocket -> RSocketRequester.create(rsocket, this.dataMimeType, this.rsocketStrategies))
+				.cache();
+	}
+
+	@Override
+	public void destroy() {
+		this.rsocketMono
+				.doOnNext(Disposable::dispose)
+				.subscribe();
+	}
+
+}

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/config/package-info.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/config/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides classes for RSocket XML namespace parsing and configuration support.
+ */
+package org.springframework.integration.rsocket.config;

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/inbound/package-info.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/inbound/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides classes representing inbound RSocket components.
+ */
+package org.springframework.integration.rsocket.inbound;

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/package-info.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Provides common classes for RSocket components.
+ */
+package org.springframework.integration.rsocket;


### PR DESCRIPTION
* Introduce a `ClientRSocketConnector` to represent a common logic for
client side connection and management an obtained `RSocket`
* Rework the `RSocketOutboundGateway` to perform similar RSocket request
logic on the server side as well.
* Refactor `RSocketOutboundGatewayIntegrationTests` to demonstrate that
RSocket requests work the same way from the server side as well.
For this reason a `CommonConfig` has been extracted with the same
`RSocketOutboundGateway` configuration reuse on both server and client
sides.
