### PR TITLE
Use MergedAnnotations in MethodAnnPublisher

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/MethodNameMappingPublisherMetadataSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/MethodNameMappingPublisherMetadataSource.java
@@ -78,24 +78,6 @@ public class MethodNameMappingPublisherMetadataSource implements PublisherMetada
 	}
 
 	@Override
-	@Deprecated
-	public String getPayloadExpression(Method method) {
-		Expression expressionForPayload = getExpressionForPayload(method);
-		return expressionForPayload != null ? expressionForPayload.getExpressionString() : null;
-	}
-
-	@Override
-	@Deprecated
-	public Map<String, String> getHeaderExpressions(Method method) {
-		Map<String, Expression> expressionsForHeaders = getExpressionsForHeaders(method);
-		return expressionsForHeaders == null
-				? null
-				: expressionsForHeaders.entrySet()
-						.stream()
-						.collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getExpressionString()));
-	}
-
-	@Override
 	public Map<String, Expression> getExpressionsForHeaders(Method method) {
 		return this.headerExpressionMap
 				.entrySet()

--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherMetadataSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherMetadataSource.java
@@ -18,7 +18,6 @@ package org.springframework.integration.aop;
 
 import java.lang.reflect.Method;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
@@ -60,37 +59,13 @@ interface PublisherMetadataSource {
 	String getChannelName(Method method);
 
 	/**
-	 * Returns the expression string to be evaluated for creating the Message
-	 * payload.
-	 * @param method The Method.
-	 * @return The payload expression.
-	 * @deprecated since 5.0.4 in favor of {@link #getExpressionForPayload(Method)}
-	 */
-	@Deprecated
-	String getPayloadExpression(Method method);
-
-	/**
 	 * Returns the SpEL expression to be evaluated for creating the Message
 	 * payload.
 	 * @param method the Method.
 	 * @return rhe payload expression.
 	 * @since 5.0.4
 	 */
-	@SuppressWarnings("deprecation")
-	default Expression getExpressionForPayload(Method method) {
-		return EXPRESSION_PARSER.parseExpression(getPayloadExpression(method));
-	}
-
-	/**
-	 * Returns the map of expression strings to be evaluated for any headers
-	 * that should be set on the published Message. The keys in the Map are
-	 * header names, the values are the expression strings.
-	 * @param method The Method.
-	 * @return The header expressions.
-	 * @deprecated since 5.0.4 in favor of {@link #getExpressionsForHeaders(Method)}
-	 */
-	@Deprecated
-	Map<String, String> getHeaderExpressions(Method method);
+	Expression getExpressionForPayload(Method method);
 
 	/**
 	 * Returns the map of expression strings to be evaluated for any headers
@@ -99,13 +74,6 @@ interface PublisherMetadataSource {
 	 * @param method The Method.
 	 * @return The header expressions.
 	 */
-	@SuppressWarnings("deprecation")
-	default Map<String, Expression> getExpressionsForHeaders(Method method) {
-		return getHeaderExpressions(method)
-				.entrySet()
-				.stream()
-				.collect(Collectors.toMap(Map.Entry::getKey,
-						e -> EXPRESSION_PARSER.parseExpression(e.getValue())));
-	}
+	Map<String, Expression> getExpressionsForHeaders(Method method);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/SimplePublisherMetadataSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/SimplePublisherMetadataSource.java
@@ -55,12 +55,6 @@ public class SimplePublisherMetadataSource implements PublisherMetadataSource {
 	}
 
 	@Override
-	@Deprecated
-	public String getPayloadExpression(Method method) {
-		return this.payloadExpression.getExpressionString();
-	}
-
-	@Override
 	public Expression getExpressionForPayload(Method method) {
 		return this.payloadExpression;
 	}
@@ -71,16 +65,6 @@ public class SimplePublisherMetadataSource implements PublisherMetadataSource {
 						.stream()
 						.collect(Collectors.toMap(Map.Entry::getKey,
 								e -> EXPRESSION_PARSER.parseExpression(e.getValue())));
-	}
-
-	@Override
-	@Deprecated
-	public Map<String, String> getHeaderExpressions(Method method) {
-		return this.headerExpressions
-				.entrySet()
-				.stream()
-				.collect(Collectors.toMap(Map.Entry::getKey,
-						e -> e.getValue().getExpressionString()));
 	}
 
 	@Override

--- a/spring-integration-core/src/test/java/org/springframework/integration/aop/MessagePublishingInterceptorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aop/MessagePublishingInterceptorTests.java
@@ -73,15 +73,16 @@ public class MessagePublishingInterceptorTests {
 
 	@Test
 	public void demoMethodNameMappingExpressionSource() {
-		Map<String, String> expressionMap = new HashMap<String, String>();
+		Map<String, String> expressionMap = new HashMap<>();
 		expressionMap.put("test", "#return");
-		MethodNameMappingPublisherMetadataSource metadataSource = new MethodNameMappingPublisherMetadataSource(expressionMap);
-		Map<String, String> channelMap = new HashMap<String, String>();
+		MethodNameMappingPublisherMetadataSource metadataSource =
+				new MethodNameMappingPublisherMetadataSource(expressionMap);
+		Map<String, String> channelMap = new HashMap<>();
 		channelMap.put("test", "c");
 		metadataSource.setChannelMap(channelMap);
 
-		Map<String, Map<String, String>> headerExpressionMap = new HashMap<String, Map<String, String>>();
-		Map<String, String> headerExpressions = new HashMap<String, String>();
+		Map<String, Map<String, String>> headerExpressionMap = new HashMap<>();
+		Map<String, String> headerExpressions = new HashMap<>();
 		headerExpressions.put("bar", "#return");
 		headerExpressions.put("name", "'oleg'");
 		headerExpressionMap.put("test", headerExpressions);
@@ -126,21 +127,8 @@ public class MessagePublishingInterceptorTests {
 		}
 
 		@Override
-		@Deprecated
-		public String getPayloadExpression(Method method) {
-			return getExpressionForPayload(method)
-					.getExpressionString();
-		}
-
-		@Override
 		public Expression getExpressionForPayload(Method method) {
 			return EXPRESSION_PARSER.parseExpression("'test-' + #return");
-		}
-
-		@Override
-		@Deprecated
-		public Map<String, String> getHeaderExpressions(Method method) {
-			return null;
 		}
 
 		@Override


### PR DESCRIPTION
* For better performance and consistency use a `MergedAnnotations` in
the `MethodAnnotationPublisherMetadataSource` instead of
`AnnotatedElementUtils`
* Remove deprecated API from the `PublisherMetadataSource` hierarchy

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
